### PR TITLE
chore: Bump to version 0.44.2 to start release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,112 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v0.44.2] - 2023-01-19
+
+### Added
+* feat: add behavior tests for blocking buffer reader by @WenyXu in https://github.com/apache/opendal/pull/3872
+* feat(services): add pcloud support by @hoslo in https://github.com/apache/opendal/pull/3892
+* feat(services/hdfs): Atomic write for hdfs by @shbhmrzd in https://github.com/apache/opendal/pull/3875
+* feat(services/hdfs): add atomic_write_dir to hdfsconfig debug by @shbhmrzd in https://github.com/apache/opendal/pull/3902
+* feat: add MongodbConfig by @zjregee in https://github.com/apache/opendal/pull/3906
+* RFC-3898: Concurrent Writer by @WenyXu in https://github.com/apache/opendal/pull/3898
+* feat(services): add yandex disk support by @hoslo in https://github.com/apache/opendal/pull/3918
+* feat: implement concurrent `MultipartUploadWriter` by @WenyXu in https://github.com/apache/opendal/pull/3915
+* feat: add concurrent writer behavior tests by @WenyXu in https://github.com/apache/opendal/pull/3920
+* feat: implement concurrent `RangeWriter` by @WenyXu in https://github.com/apache/opendal/pull/3923
+* feat: add `concurrent` and `buffer` parameters into FuzzInput by @WenyXu in https://github.com/apache/opendal/pull/3921
+* feat(fuzz): add azblob as test service by @suyanhanx in https://github.com/apache/opendal/pull/3931
+* feat(services/webhdfs): Implement write with append by @hoslo in https://github.com/apache/opendal/pull/3937
+* feat(core/bench): Add benchmark for concurrent write by @Xuanwo in https://github.com/apache/opendal/pull/3942
+* feat(oio): add block_write support by @hoslo in https://github.com/apache/opendal/pull/3945
+* feat(services/webhdfs): Implement multi write via CONCAT by @hoslo in https://github.com/apache/opendal/pull/3939
+* feat(core): Allow retry in concurrent write operations by @Xuanwo in https://github.com/apache/opendal/pull/3958
+* feat(services/ghac): Add workaround for AWS S3 based GHES by @Xuanwo in https://github.com/apache/opendal/pull/3985
+* feat: Implement path cache and refactor gdrive by @Xuanwo in https://github.com/apache/opendal/pull/3975
+* feat(services): add hdfs native layout by @shbhmrzd in https://github.com/apache/opendal/pull/3933
+* feat(services/s3): Return error if credential is empty after loaded by @Xuanwo in https://github.com/apache/opendal/pull/4000
+* feat(services/gdrive): Use trash instead of permanently deletes by @Xuanwo in https://github.com/apache/opendal/pull/4002
+* feat(services): add koofr support by @hoslo in https://github.com/apache/opendal/pull/3981
+* feat(icloud): Add basic Apple iCloud Drive support by @bokket in https://github.com/apache/opendal/pull/3980
+
+### Changed
+* refactor: Merge compose_{read,write} into enum_utils by @Xuanwo in https://github.com/apache/opendal/pull/3871
+* refactor(services/ftp): Impl parse_error instead of From<Error> by @bokket in https://github.com/apache/opendal/pull/3891
+* docs: very minor English wording fix in error message by @gabrielgrant in https://github.com/apache/opendal/pull/3900
+* refactor(services/rocksdb): Impl parse_error instead of From<Error> by @suyanhanx in https://github.com/apache/opendal/pull/3903
+* refactor: Re-organize the layout of tests by @Xuanwo in https://github.com/apache/opendal/pull/3904
+* refactor(services/etcd): Impl parse_error instead of From<Error> by @suyanhanx in https://github.com/apache/opendal/pull/3910
+* refactor(services/sftp): Impl parse_error instead of From<Error> by @G-XD in https://github.com/apache/opendal/pull/3914
+* refactor!: Bump MSRV to 1.75 by @Xuanwo in https://github.com/apache/opendal/pull/3851
+* refactor(services/redis): Impl parse_error instead of From<Error> by @suyanhanx in https://github.com/apache/opendal/pull/3938
+* refactor!: Revert the bump of MSRV to 1.75 by @Xuanwo in https://github.com/apache/opendal/pull/3952
+* refactor(services/onedrive): Add OnedriveConfig to implement ConfigDeserializer by @Borber in https://github.com/apache/opendal/pull/3954
+* refactor(service/dropbox): Add DropboxConfig by @howiieyu in https://github.com/apache/opendal/pull/3961
+* refactor: Polish internal types and remove not needed deps by @Xuanwo in https://github.com/apache/opendal/pull/3964
+* refactor: Add concurrent error test for BlockWrite by @Xuanwo in https://github.com/apache/opendal/pull/3968
+* refactor: Remove not needed types in icloud by @Xuanwo in https://github.com/apache/opendal/pull/4021
+
+### Fixed
+* fix: Bump pyo3 to fix false positive of unnecessary_fallible_conversions by @Xuanwo in https://github.com/apache/opendal/pull/3873
+* fix(core): Handling content encoding correctly by @Xuanwo in https://github.com/apache/opendal/pull/3907
+* fix: fix RangeWriter incorrect `next_offset` by @WenyXu in https://github.com/apache/opendal/pull/3927
+* fix(oio::BlockWrite): fix write_once case by @hoslo in https://github.com/apache/opendal/pull/3953
+* fix: Don't retry close if concurrent > 1 to avoid content lost by @Xuanwo in https://github.com/apache/opendal/pull/3957
+* fix(doc): fix rfc typos by @howiieyu in https://github.com/apache/opendal/pull/3971
+* fix: Don't call wake_by_ref in OperatorFuture by @Xuanwo in https://github.com/apache/opendal/pull/4003
+* fix: async fn resumed after initiate part failed by @Xuanwo in https://github.com/apache/opendal/pull/4013
+* fix(pcloud,seafile): use get_basename and get_parent by @hoslo in https://github.com/apache/opendal/pull/4020
+* fix(ci): remove pr author from review candidates by @dqhl76 in https://github.com/apache/opendal/pull/4023
+
+### Docs
+* docs(bindings/python): drop unnecessary patchelf by @tisonkun in https://github.com/apache/opendal/pull/3889
+* docs: Polish core's quick start by @Xuanwo in https://github.com/apache/opendal/pull/3896
+* docs(gcs): correct the description of credential by @WenyXu in https://github.com/apache/opendal/pull/3928
+* docs: Add 0.44.1 download link by @Xuanwo in https://github.com/apache/opendal/pull/3929
+* docs(release): how to clean up old releases by @tisonkun in https://github.com/apache/opendal/pull/3934
+* docs(website): polish download page by @suyanhanx in https://github.com/apache/opendal/pull/3932
+* docs: improve user verify words by @tisonkun in https://github.com/apache/opendal/pull/3941
+* docs: fix incorrect word used by @zegevlier in https://github.com/apache/opendal/pull/3944
+* docs: improve wording for community pages by @tisonkun in https://github.com/apache/opendal/pull/3978
+* docs(bindings/nodejs): copyright in footer by @suyanhanx in https://github.com/apache/opendal/pull/3986
+* docs(bindings/nodejs): build docs locally doc by @suyanhanx in https://github.com/apache/opendal/pull/3987
+* docs: Fix missing word in download by @Xuanwo in https://github.com/apache/opendal/pull/3993
+* docs(bindings/java): copyright in footer by @G-XD in https://github.com/apache/opendal/pull/3996
+* docs(website): update footer by @suyanhanx in https://github.com/apache/opendal/pull/4008
+* docs: add trademark information to every possible published readme by @PsiACE in https://github.com/apache/opendal/pull/4014
+* docs(website): replace podling to project in website by @morristai in https://github.com/apache/opendal/pull/4015
+* docs: Update release guide to adapt as a new TLP by @Xuanwo in https://github.com/apache/opendal/pull/4011
+* docs: Add WebHDFS version compatibility details by @shbhmrzd in https://github.com/apache/opendal/pull/4024
+
+### CI
+* build(deps): bump actions/download-artifact from 3 to 4 by @dependabot in https://github.com/apache/opendal/pull/3885
+* build(deps): bump once_cell from 1.18.0 to 1.19.0 by @dependabot in https://github.com/apache/opendal/pull/3880
+* build(deps): bump napi-derive from 2.14.2 to 2.14.6 by @dependabot in https://github.com/apache/opendal/pull/3879
+* build(deps): bump url from 2.4.1 to 2.5.0 by @dependabot in https://github.com/apache/opendal/pull/3876
+* build(deps): bump mlua from 0.8.10 to 0.9.2 by @oowl in https://github.com/apache/opendal/pull/3890
+* ci: Disable supabase tests for our test org has been paused by @Xuanwo in https://github.com/apache/opendal/pull/3908
+* ci: Downgrade artifact actions until regression addressed by @Xuanwo in https://github.com/apache/opendal/pull/3935
+* ci: Refactor fuzz to integrate with test planner by @Xuanwo in https://github.com/apache/opendal/pull/3936
+* ci: Pick random reviewers from committer list by @Xuanwo in https://github.com/apache/opendal/pull/4001
+
+### Chore
+* chore: update release related docs and script by @dqhl76 in https://github.com/apache/opendal/pull/3870
+* chore(NOTICE): update copyright to year 2024 by @suyanhanx in https://github.com/apache/opendal/pull/3894
+* chore: Format code to make readers happy by @Xuanwo in https://github.com/apache/opendal/pull/3912
+* chore: Remove unused dep async-compat by @Xuanwo in https://github.com/apache/opendal/pull/3947
+* chore: display project logo on Rust docs by @tisonkun in https://github.com/apache/opendal/pull/3983
+* chore: improve trademarks in bindings docs by @tisonkun in https://github.com/apache/opendal/pull/3984
+* chore: use Apache OpenDAL™ in the first and most prominent mention by @tisonkun in https://github.com/apache/opendal/pull/3988
+* chore: add more information for javadocs by @tisonkun in https://github.com/apache/opendal/pull/3989
+* chore: precise footer by @tisonkun in https://github.com/apache/opendal/pull/3997
+* chore: use full form name when necessary by @tisonkun in https://github.com/apache/opendal/pull/3998
+* chore(bindings/python): Enable sftp service by default for unix platform by @Zheaoli in https://github.com/apache/opendal/pull/4006
+* chore: remove disclaimer by @suyanhanx in https://github.com/apache/opendal/pull/4009
+* chore: Remove incubating from releases by @Xuanwo in https://github.com/apache/opendal/pull/4010
+* chore: trim incubator prefix everywhere by @tisonkun in https://github.com/apache/opendal/pull/4016
+* chore: fixup doc link in release_java.yml by @tisonkun in https://github.com/apache/opendal/pull/4019
+* chore: simplify reviewer candidates logic by @tisonkun in https://github.com/apache/opendal/pull/4017
+
 ## [v0.44.1] - 2023-12-31
 
 ### Added
@@ -3234,6 +3340,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 Hello, OpenDAL!
 
+[v0.44.2]: https://github.com/apache/opendal/compare/v0.44.1...v0.44.2
 [v0.44.1]: https://github.com/apache/opendal/compare/v0.44.0...v0.44.1
 [v0.44.0]: https://github.com/apache/opendal/compare/v0.43.0...v0.44.0
 [v0.43.0]: https://github.com/apache/opendal/compare/v0.42.0...v0.43.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "dav-server-opendalfs"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "oay"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_opendal"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4582,7 +4582,7 @@ dependencies = [
 
 [[package]]
 name = "oli"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4614,7 +4614,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "anyhow",
  "async-backtrace",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-cpp"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-hs"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "chrono",
  "log",
@@ -4760,7 +4760,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-java"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "anyhow",
  "jni",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-nodejs"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "futures",
  "napi",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-python"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "futures",
  "opendal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.67"
-version = "0.44.1"
+version = "0.44.2"
 
 [workspace.dependencies]
 opendal = { version = "0.44", path = "core" }

--- a/bin/oay/DEPENDENCIES.rust.tsv
+++ b/bin/oay/DEPENDENCIES.rust.tsv
@@ -13,7 +13,6 @@ anstyle-query@1.0.0		X							X
 anstyle-wincon@3.0.1		X							X					
 anyhow@1.0.75		X							X					
 arc-swap@1.6.0		X							X					
-async-compat@0.2.3		X							X					
 async-trait@0.1.75		X							X					
 autocfg@1.1.0		X							X					
 awaitable@0.4.0									X					
@@ -48,7 +47,7 @@ cpufeatures@0.2.11		X							X
 crunchy@0.2.2									X					
 crypto-common@0.1.6		X							X					
 dav-server@0.5.7		X												
-dav-server-opendalfs@0.44.1		X												
+dav-server-opendalfs@0.44.2		X												
 der@0.7.8		X							X					
 deranged@0.3.9		X							X					
 derive_destructure2@0.1.2		X							X					
@@ -63,7 +62,7 @@ fastrand@1.9.0		X							X
 fastrand@2.0.1		X							X					
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
-form_urlencoded@1.2.0		X							X					
+form_urlencoded@1.2.1		X							X					
 futures@0.3.29		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
@@ -95,7 +94,7 @@ hyper@0.14.27									X
 hyper-rustls@0.24.2		X						X	X					
 iana-time-zone@0.1.58		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
-idna@0.4.0		X							X					
+idna@0.5.0		X							X					
 indexmap@2.1.0		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
@@ -127,10 +126,10 @@ num-integer@0.1.45		X							X
 num-iter@0.1.43		X							X					
 num-traits@0.2.17		X							X					
 num_cpus@1.16.0		X							X					
-oay@0.44.1		X												
+oay@0.44.2		X												
 object@0.32.1		X							X					
-once_cell@1.18.0		X							X					
-opendal@0.44.1		X												
+once_cell@1.19.0		X							X					
+opendal@0.44.2		X												
 openssh@0.10.1		X							X					
 openssh-sftp-client@0.14.1									X					
 openssh-sftp-client-lowlevel@0.6.0									X					
@@ -145,7 +144,7 @@ parking_lot@0.12.1		X							X
 parking_lot_core@0.9.9		X							X					
 pem@3.0.2									X					
 pem-rfc7468@0.7.0		X							X					
-percent-encoding@2.3.0		X							X					
+percent-encoding@2.3.1		X							X					
 pin-project@1.1.3		X							X					
 pin-project-internal@1.1.3		X							X					
 pin-project-lite@0.2.13		X							X					
@@ -253,7 +252,7 @@ unicode-bidi@0.3.13		X							X
 unicode-ident@1.0.12		X							X			X		
 unicode-normalization@0.1.22		X							X					
 untrusted@0.9.0								X						
-url@2.4.1		X							X					
+url@2.5.0		X							X					
 utf8parse@0.2.1		X							X					
 uuid@1.6.1		X							X					
 valuable@0.1.0									X					

--- a/bin/ofs/DEPENDENCIES.rust.tsv
+++ b/bin/ofs/DEPENDENCIES.rust.tsv
@@ -7,7 +7,6 @@ android-tzdata@0.1.1		X							X
 android_system_properties@0.1.5		X							X					
 anyhow@1.0.75		X							X					
 arc-swap@1.6.0		X							X					
-async-compat@0.2.3		X							X					
 async-trait@0.1.75		X							X					
 autocfg@1.1.0		X							X					
 awaitable@0.4.0									X					
@@ -50,7 +49,7 @@ fastrand@1.9.0		X							X
 fastrand@2.0.1		X							X					
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
-form_urlencoded@1.2.0		X							X					
+form_urlencoded@1.2.1		X							X					
 fuse3@0.6.1									X					
 futures@0.3.29		X							X					
 futures-channel@0.3.30		X							X					
@@ -78,7 +77,7 @@ hyper@0.14.27									X
 hyper-rustls@0.24.2		X						X	X					
 iana-time-zone@0.1.58		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
-idna@0.4.0		X							X					
+idna@0.5.0		X							X					
 indexmap@2.1.0		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
@@ -108,8 +107,8 @@ num-traits@0.2.17		X							X
 num_cpus@1.16.0		X							X					
 object@0.32.1		X							X					
 ofs@0.0.1		X												
-once_cell@1.18.0		X							X					
-opendal@0.44.1		X												
+once_cell@1.19.0		X							X					
+opendal@0.44.2		X												
 openssh@0.10.1		X							X					
 openssh-sftp-client@0.14.1									X					
 openssh-sftp-client-lowlevel@0.6.0									X					
@@ -123,7 +122,7 @@ parking_lot@0.12.1		X							X
 parking_lot_core@0.9.9		X							X					
 pem@3.0.2									X					
 pem-rfc7468@0.7.0		X							X					
-percent-encoding@2.3.0		X							X					
+percent-encoding@2.3.1		X							X					
 pin-project@1.1.3		X							X					
 pin-project-internal@1.1.3		X							X					
 pin-project-lite@0.2.13		X							X					
@@ -210,7 +209,7 @@ unicode-bidi@0.3.13		X							X
 unicode-ident@1.0.12		X							X			X		
 unicode-normalization@0.1.22		X							X					
 untrusted@0.9.0								X						
-url@2.4.1		X							X					
+url@2.5.0		X							X					
 uuid@1.6.1		X							X					
 valuable@0.1.0									X					
 vec-strings@0.4.8									X					

--- a/bin/oli/DEPENDENCIES.rust.tsv
+++ b/bin/oli/DEPENDENCIES.rust.tsv
@@ -13,7 +13,6 @@ anstyle-query@1.0.0		X							X
 anstyle-wincon@3.0.1		X							X					
 anyhow@1.0.75		X							X					
 arc-swap@1.6.0		X							X					
-async-compat@0.2.3		X							X					
 async-trait@0.1.75		X							X					
 autocfg@1.1.0		X							X					
 awaitable@0.4.0									X					
@@ -60,7 +59,7 @@ fastrand@1.9.0		X							X
 fastrand@2.0.1		X							X					
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
-form_urlencoded@1.2.0		X							X					
+form_urlencoded@1.2.1		X							X					
 futures@0.3.29		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
@@ -89,7 +88,7 @@ hyper@0.14.27									X
 hyper-rustls@0.24.2		X						X	X					
 iana-time-zone@0.1.58		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
-idna@0.4.0		X							X					
+idna@0.5.0		X							X					
 indexmap@2.1.0		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
@@ -118,9 +117,9 @@ num-iter@0.1.43		X							X
 num-traits@0.2.17		X							X					
 num_cpus@1.16.0		X							X					
 object@0.32.1		X							X					
-oli@0.44.1		X												
-once_cell@1.18.0		X							X					
-opendal@0.44.1		X												
+oli@0.44.2		X												
+once_cell@1.19.0		X							X					
+opendal@0.44.2		X												
 openssh@0.10.1		X							X					
 openssh-sftp-client@0.14.1									X					
 openssh-sftp-client-lowlevel@0.6.0									X					
@@ -134,7 +133,7 @@ parking_lot@0.12.1		X							X
 parking_lot_core@0.9.9		X							X					
 pem@3.0.2									X					
 pem-rfc7468@0.7.0		X							X					
-percent-encoding@2.3.0		X							X					
+percent-encoding@2.3.1		X							X					
 pin-project@1.1.3		X							X					
 pin-project-internal@1.1.3		X							X					
 pin-project-lite@0.2.13		X							X					
@@ -230,7 +229,7 @@ unicode-bidi@0.3.13		X							X
 unicode-ident@1.0.12		X							X			X		
 unicode-normalization@0.1.22		X							X					
 untrusted@0.9.0								X						
-url@2.4.1		X							X					
+url@2.5.0		X							X					
 utf8parse@0.2.1		X							X					
 uuid@1.6.1		X							X					
 valuable@0.1.0									X					

--- a/bindings/c/Cargo.lock
+++ b/bindings/c/Cargo.lock
@@ -898,7 +898,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-c"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "bytes",
  "cbindgen",

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.67"
-version = "0.44.1"
+version = "0.44.2"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -4,7 +4,6 @@ adler@1.0.2	X	X						X
 android-tzdata@0.1.1		X						X					
 android_system_properties@0.1.5		X						X					
 anyhow@1.0.77		X						X					
-async-compat@0.2.3		X						X					
 async-trait@0.1.75		X						X					
 atty@0.2.14								X					
 autocfg@1.1.0		X						X					
@@ -83,7 +82,6 @@ lazy_static@1.4.0		X						X
 libc@0.2.151		X						X					
 libm@0.2.8		X						X					
 linux-raw-sys@0.4.12		X	X					X					
-lock_api@0.4.11		X						X					
 log@0.4.20		X						X					
 md-5@0.10.6		X						X					
 memchr@2.7.1								X				X	
@@ -98,13 +96,11 @@ num-traits@0.2.17		X						X
 num_cpus@1.16.0		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.44.1		X											
-opendal-c@0.44.1		X											
+opendal@0.44.2		X											
+opendal-c@0.44.2		X											
 openssl-probe@0.1.5		X						X					
 ordered-multimap@0.7.1								X					
 os_str_bytes@6.6.1		X						X					
-parking_lot@0.12.1		X						X					
-parking_lot_core@0.9.9		X						X					
 pem@3.0.3								X					
 pem-rfc7468@0.7.0		X						X					
 percent-encoding@2.3.1		X						X					
@@ -137,7 +133,6 @@ rustls-pemfile@1.0.4		X					X	X
 rustls-webpki@0.101.7							X						
 ryu@1.0.16		X			X								
 schannel@0.1.23								X					
-scopeguard@1.2.0		X						X					
 sct@0.7.1		X					X	X					
 security-framework@2.9.2		X						X					
 security-framework-sys@2.9.1		X						X					

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 cmake_minimum_required(VERSION 3.10)
-project(opendal-cpp VERSION 0.44.1 LANGUAGES CXX)
+project(opendal-cpp VERSION 0.44.2 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/bindings/cpp/DEPENDENCIES.rust.tsv
+++ b/bindings/cpp/DEPENDENCIES.rust.tsv
@@ -7,7 +7,6 @@ android-tzdata@0.1.1		X							X
 android_system_properties@0.1.5		X							X					
 anyhow@1.0.75		X							X					
 arc-swap@1.6.0		X							X					
-async-compat@0.2.3		X							X					
 async-trait@0.1.75		X							X					
 autocfg@1.1.0		X							X					
 awaitable@0.4.0									X					
@@ -53,7 +52,7 @@ fastrand@1.9.0		X							X
 fastrand@2.0.1		X							X					
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
-form_urlencoded@1.2.0		X							X					
+form_urlencoded@1.2.1		X							X					
 futures@0.3.29		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
@@ -80,7 +79,7 @@ hyper@0.14.27									X
 hyper-rustls@0.24.2		X						X	X					
 iana-time-zone@0.1.58		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
-idna@0.4.0		X							X					
+idna@0.5.0		X							X					
 indexmap@2.1.0		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
@@ -109,9 +108,9 @@ num-iter@0.1.43		X							X
 num-traits@0.2.17		X							X					
 num_cpus@1.16.0		X							X					
 object@0.32.1		X							X					
-once_cell@1.18.0		X							X					
-opendal@0.44.1		X												
-opendal-cpp@0.44.1		X												
+once_cell@1.19.0		X							X					
+opendal@0.44.2		X												
+opendal-cpp@0.44.2		X												
 openssh@0.10.1		X							X					
 openssh-sftp-client@0.14.1									X					
 openssh-sftp-client-lowlevel@0.6.0									X					
@@ -125,7 +124,7 @@ parking_lot@0.12.1		X							X
 parking_lot_core@0.9.9		X							X					
 pem@3.0.2									X					
 pem-rfc7468@0.7.0		X							X					
-percent-encoding@2.3.0		X							X					
+percent-encoding@2.3.1		X							X					
 pin-project@1.1.3		X							X					
 pin-project-internal@1.1.3		X							X					
 pin-project-lite@0.2.13		X							X					
@@ -215,7 +214,7 @@ unicode-ident@1.0.12		X							X			X
 unicode-normalization@0.1.22		X							X					
 unicode-width@0.1.11		X							X					
 untrusted@0.9.0								X						
-url@2.4.1		X							X					
+url@2.5.0		X							X					
 uuid@1.6.1		X							X					
 valuable@0.1.0									X					
 vec-strings@0.4.8									X					

--- a/bindings/dotnet/DEPENDENCIES.rust.tsv
+++ b/bindings/dotnet/DEPENDENCIES.rust.tsv
@@ -7,7 +7,6 @@ android-tzdata@0.1.1		X							X
 android_system_properties@0.1.5		X							X					
 anyhow@1.0.75		X							X					
 arc-swap@1.6.0		X							X					
-async-compat@0.2.3		X							X					
 async-trait@0.1.75		X							X					
 autocfg@1.1.0		X							X					
 awaitable@0.4.0									X					
@@ -48,7 +47,7 @@ fastrand@1.9.0		X							X
 fastrand@2.0.1		X							X					
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
-form_urlencoded@1.2.0		X							X					
+form_urlencoded@1.2.1		X							X					
 futures@0.3.29		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
@@ -75,7 +74,7 @@ hyper@0.14.27									X
 hyper-rustls@0.24.2		X						X	X					
 iana-time-zone@0.1.58		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
-idna@0.4.0		X							X					
+idna@0.5.0		X							X					
 indexmap@2.1.0		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
@@ -103,8 +102,8 @@ num-iter@0.1.43		X							X
 num-traits@0.2.17		X							X					
 num_cpus@1.16.0		X							X					
 object@0.32.1		X							X					
-once_cell@1.18.0		X							X					
-opendal@0.44.1		X												
+once_cell@1.19.0		X							X					
+opendal@0.44.2		X												
 opendal-dotnet@0.1.0		X												
 openssh@0.10.1		X							X					
 openssh-sftp-client@0.14.1									X					
@@ -119,7 +118,7 @@ parking_lot@0.12.1		X							X
 parking_lot_core@0.9.9		X							X					
 pem@3.0.2									X					
 pem-rfc7468@0.7.0		X							X					
-percent-encoding@2.3.0		X							X					
+percent-encoding@2.3.1		X							X					
 pin-project@1.1.3		X							X					
 pin-project-internal@1.1.3		X							X					
 pin-project-lite@0.2.13		X							X					
@@ -206,7 +205,7 @@ unicode-bidi@0.3.13		X							X
 unicode-ident@1.0.12		X							X			X		
 unicode-normalization@0.1.22		X							X					
 untrusted@0.9.0								X						
-url@2.4.1		X							X					
+url@2.5.0		X							X					
 uuid@1.6.1		X							X					
 valuable@0.1.0									X					
 vec-strings@0.4.8									X					

--- a/bindings/haskell/DEPENDENCIES.rust.tsv
+++ b/bindings/haskell/DEPENDENCIES.rust.tsv
@@ -7,7 +7,6 @@ android-tzdata@0.1.1		X							X
 android_system_properties@0.1.5		X							X					
 anyhow@1.0.75		X							X					
 arc-swap@1.6.0		X							X					
-async-compat@0.2.3		X							X					
 async-trait@0.1.75		X							X					
 autocfg@1.1.0		X							X					
 awaitable@0.4.0									X					
@@ -48,7 +47,7 @@ fastrand@1.9.0		X							X
 fastrand@2.0.1		X							X					
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
-form_urlencoded@1.2.0		X							X					
+form_urlencoded@1.2.1		X							X					
 futures@0.3.29		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
@@ -75,7 +74,7 @@ hyper@0.14.27									X
 hyper-rustls@0.24.2		X						X	X					
 iana-time-zone@0.1.58		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
-idna@0.4.0		X							X					
+idna@0.5.0		X							X					
 indexmap@2.1.0		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
@@ -103,9 +102,9 @@ num-iter@0.1.43		X							X
 num-traits@0.2.17		X							X					
 num_cpus@1.16.0		X							X					
 object@0.32.1		X							X					
-once_cell@1.18.0		X							X					
-opendal@0.44.1		X												
-opendal-hs@0.44.1		X												
+once_cell@1.19.0		X							X					
+opendal@0.44.2		X												
+opendal-hs@0.44.2		X												
 openssh@0.10.1		X							X					
 openssh-sftp-client@0.14.1									X					
 openssh-sftp-client-lowlevel@0.6.0									X					
@@ -119,7 +118,7 @@ parking_lot@0.12.1		X							X
 parking_lot_core@0.9.9		X							X					
 pem@3.0.2									X					
 pem-rfc7468@0.7.0		X							X					
-percent-encoding@2.3.0		X							X					
+percent-encoding@2.3.1		X							X					
 pin-project@1.1.3		X							X					
 pin-project-internal@1.1.3		X							X					
 pin-project-lite@0.2.13		X							X					
@@ -206,7 +205,7 @@ unicode-bidi@0.3.13		X							X
 unicode-ident@1.0.12		X							X			X		
 unicode-normalization@0.1.22		X							X					
 untrusted@0.9.0								X						
-url@2.4.1		X							X					
+url@2.5.0		X							X					
 uuid@1.6.1		X							X					
 valuable@0.1.0									X					
 vec-strings@0.4.8									X					

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -7,7 +7,6 @@ android-tzdata@0.1.1		X							X
 android_system_properties@0.1.5		X							X					
 anyhow@1.0.75		X							X					
 arc-swap@1.6.0		X							X					
-async-compat@0.2.3		X							X					
 async-trait@0.1.75		X							X					
 autocfg@1.1.0		X							X					
 awaitable@0.4.0									X					
@@ -50,7 +49,7 @@ fastrand@1.9.0		X							X
 fastrand@2.0.1		X							X					
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
-form_urlencoded@1.2.0		X							X					
+form_urlencoded@1.2.1		X							X					
 futures@0.3.29		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
@@ -77,7 +76,7 @@ hyper@0.14.27									X
 hyper-rustls@0.24.2		X						X	X					
 iana-time-zone@0.1.58		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
-idna@0.4.0		X							X					
+idna@0.5.0		X							X					
 indexmap@2.1.0		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
@@ -107,9 +106,9 @@ num-iter@0.1.43		X							X
 num-traits@0.2.17		X							X					
 num_cpus@1.16.0		X							X					
 object@0.32.1		X							X					
-once_cell@1.18.0		X							X					
-opendal@0.44.1		X												
-opendal-java@0.44.1		X												
+once_cell@1.19.0		X							X					
+opendal@0.44.2		X												
+opendal-java@0.44.2		X												
 openssh@0.10.1		X							X					
 openssh-sftp-client@0.14.1									X					
 openssh-sftp-client-lowlevel@0.6.0									X					
@@ -123,7 +122,7 @@ parking_lot@0.12.1		X							X
 parking_lot_core@0.9.9		X							X					
 pem@3.0.2									X					
 pem-rfc7468@0.7.0		X							X					
-percent-encoding@2.3.0		X							X					
+percent-encoding@2.3.1		X							X					
 pin-project@1.1.3		X							X					
 pin-project-internal@1.1.3		X							X					
 pin-project-lite@0.2.13		X							X					
@@ -211,7 +210,7 @@ unicode-bidi@0.3.13		X							X
 unicode-ident@1.0.12		X							X			X		
 unicode-normalization@0.1.22		X							X					
 untrusted@0.9.0								X						
-url@2.4.1		X							X					
+url@2.5.0		X							X					
 uuid@1.6.1		X							X					
 valuable@0.1.0									X					
 vec-strings@0.4.8									X					

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal-java</artifactId>
-    <version>0.44.1</version>
+    <version>0.44.2</version>
 
     <name>Apache OpenDAL™</name>
     <description>

--- a/bindings/lua/DEPENDENCIES.rust.tsv
+++ b/bindings/lua/DEPENDENCIES.rust.tsv
@@ -2,12 +2,12 @@ crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	B
 addr2line@0.21.0		X							X					
 adler@1.0.2	X	X							X					
 ahash@0.8.6		X							X					
+aho-corasick@1.1.2									X				X	
 allocator-api2@0.2.16		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
 anyhow@1.0.75		X							X					
 arc-swap@1.6.0		X							X					
-async-compat@0.2.3		X							X					
 async-trait@0.1.75		X							X					
 autocfg@1.1.0		X							X					
 awaitable@0.4.0									X					
@@ -19,7 +19,7 @@ base64ct@1.6.0		X							X
 bitflags@1.3.2		X							X					
 bitflags@2.4.1		X							X					
 block-buffer@0.10.4		X							X					
-bstr@0.2.17		X							X					
+bstr@1.8.0		X							X					
 bumpalo@3.14.0		X							X					
 byteorder@1.5.0									X				X	
 bytes@1.5.0									X					
@@ -43,13 +43,14 @@ dirs@5.0.1		X							X
 dirs-sys@0.4.1		X							X					
 dlv-list@0.5.2		X							X					
 dotenvy@0.15.7									X					
+either@1.9.0		X							X					
 encoding_rs@0.8.33		X			X				X					
 equivalent@1.0.1		X							X					
 fastrand@1.9.0		X							X					
 fastrand@2.0.1		X							X					
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
-form_urlencoded@1.2.0		X							X					
+form_urlencoded@1.2.1		X							X					
 futures@0.3.29		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
@@ -76,10 +77,11 @@ hyper@0.14.27									X
 hyper-rustls@0.24.2		X						X	X					
 iana-time-zone@0.1.58		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
-idna@0.4.0		X							X					
+idna@0.5.0		X							X					
 indexmap@2.1.0		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
+itertools@0.11.0		X							X					
 itoa@1.0.9		X							X					
 jobserver@0.1.27		X							X					
 js-sys@0.3.66		X							X					
@@ -96,8 +98,9 @@ memchr@2.6.4									X				X
 mime@0.3.17		X							X					
 miniz_oxide@0.7.1		X							X					X
 mio@0.8.9									X					
-mlua@0.8.10									X					
-mlua_derive@0.8.0									X					
+mlua@0.9.2									X					
+mlua-sys@0.4.0									X					
+mlua_derive@0.9.0									X					
 num-bigint@0.4.4		X							X					
 num-bigint-dig@0.8.4		X							X					
 num-derive@0.3.3		X							X					
@@ -106,8 +109,8 @@ num-iter@0.1.43		X							X
 num-traits@0.2.17		X							X					
 num_cpus@1.16.0		X							X					
 object@0.32.1		X							X					
-once_cell@1.18.0		X							X					
-opendal@0.44.1		X												
+once_cell@1.19.0		X							X					
+opendal@0.44.2		X												
 opendal-lua@0.1.0		X												
 openssh@0.10.1		X							X					
 openssh-sftp-client@0.14.1									X					
@@ -122,7 +125,7 @@ parking_lot@0.12.1		X							X
 parking_lot_core@0.9.9		X							X					
 pem@3.0.2									X					
 pem-rfc7468@0.7.0		X							X					
-percent-encoding@2.3.0		X							X					
+percent-encoding@2.3.1		X							X					
 pin-project@1.1.3		X							X					
 pin-project-internal@1.1.3		X							X					
 pin-project-lite@0.2.13		X							X					
@@ -132,6 +135,8 @@ pkcs8@0.10.2		X							X
 pkg-config@0.3.27		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.17		X							X					
+proc-macro-error@1.0.4		X							X					
+proc-macro-error-attr@1.0.4		X							X					
 proc-macro2@1.0.69		X							X					
 quick-xml@0.30.0									X					
 quick-xml@0.31.0									X					
@@ -141,6 +146,9 @@ rand_chacha@0.3.1		X							X
 rand_core@0.6.4		X							X					
 redox_syscall@0.4.1									X					
 redox_users@0.4.4									X					
+regex@1.10.2		X							X					
+regex-automata@0.4.3		X							X					
+regex-syntax@0.8.2		X							X					
 reqsign@0.14.6		X												
 reqwest@0.11.22		X							X					
 ring@0.17.5											X			
@@ -211,7 +219,7 @@ unicode-bidi@0.3.13		X							X
 unicode-ident@1.0.12		X							X			X		
 unicode-normalization@0.1.22		X							X					
 untrusted@0.9.0								X						
-url@2.4.1		X							X					
+url@2.5.0		X							X					
 uuid@1.6.1		X							X					
 valuable@0.1.0									X					
 vec-strings@0.4.8									X					

--- a/bindings/nodejs/DEPENDENCIES.rust.tsv
+++ b/bindings/nodejs/DEPENDENCIES.rust.tsv
@@ -8,7 +8,6 @@ android-tzdata@0.1.1		X							X
 android_system_properties@0.1.5		X							X					
 anyhow@1.0.75		X							X					
 arc-swap@1.6.0		X							X					
-async-compat@0.2.3		X							X					
 async-trait@0.1.75		X							X					
 autocfg@1.1.0		X							X					
 awaitable@0.4.0									X					
@@ -51,7 +50,7 @@ fastrand@1.9.0		X							X
 fastrand@2.0.1		X							X					
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
-form_urlencoded@1.2.0		X							X					
+form_urlencoded@1.2.1		X							X					
 futures@0.3.29		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
@@ -78,7 +77,7 @@ hyper@0.14.27									X
 hyper-rustls@0.24.2		X						X	X					
 iana-time-zone@0.1.58		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
-idna@0.4.0		X							X					
+idna@0.5.0		X							X					
 indexmap@2.1.0		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
@@ -101,8 +100,8 @@ miniz_oxide@0.7.1		X							X					X
 mio@0.8.9									X					
 napi@2.14.1									X					
 napi-build@2.1.0									X					
-napi-derive@2.14.2									X					
-napi-derive-backend@1.0.55									X					
+napi-derive@2.14.6									X					
+napi-derive-backend@1.0.58									X					
 napi-sys@2.3.0									X					
 num-bigint@0.4.4		X							X					
 num-bigint-dig@0.8.4		X							X					
@@ -112,9 +111,9 @@ num-iter@0.1.43		X							X
 num-traits@0.2.17		X							X					
 num_cpus@1.16.0		X							X					
 object@0.32.1		X							X					
-once_cell@1.18.0		X							X					
-opendal@0.44.1		X												
-opendal-nodejs@0.44.1		X												
+once_cell@1.19.0		X							X					
+opendal@0.44.2		X												
+opendal-nodejs@0.44.2		X												
 openssh@0.10.1		X							X					
 openssh-sftp-client@0.14.1									X					
 openssh-sftp-client-lowlevel@0.6.0									X					
@@ -128,7 +127,7 @@ parking_lot@0.12.1		X							X
 parking_lot_core@0.9.9		X							X					
 pem@3.0.2									X					
 pem-rfc7468@0.7.0		X							X					
-percent-encoding@2.3.0		X							X					
+percent-encoding@2.3.1		X							X					
 pin-project@1.1.3		X							X					
 pin-project-internal@1.1.3		X							X					
 pin-project-lite@0.2.13		X							X					
@@ -220,7 +219,7 @@ unicode-ident@1.0.12		X							X			X
 unicode-normalization@0.1.22		X							X					
 unicode-segmentation@1.10.1		X							X					
 untrusted@0.9.0								X						
-url@2.4.1		X							X					
+url@2.5.0		X							X					
 uuid@1.6.1		X							X					
 valuable@0.1.0									X					
 vec-strings@0.4.8									X					

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-arm64",
   "repository": "git@github.com/apache/opendal.git",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-x64",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "darwin"

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-gnu",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-musl",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-arm64-msvc",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "OpenDAL Contributors <dev@opendal.apache.org>",
-  "version": "0.44.1",
+  "version": "0.44.2",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",

--- a/bindings/ocaml/Cargo.lock
+++ b/bindings/ocaml/Cargo.lock
@@ -39,19 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
 
 [[package]]
-name = "async-compat"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68a707c1feb095d8c07f8a65b9f506b117d30af431cab89374357de7c11461b"
-dependencies = [
- "futures-core",
- "futures-io",
- "once_cell",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,16 +652,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
-name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,10 +847,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "anyhow",
- "async-compat",
  "async-trait",
  "backon",
  "base64",
@@ -886,9 +862,7 @@ dependencies = [
  "log",
  "md-5",
  "once_cell",
- "parking_lot",
  "percent-encoding",
- "pin-project",
  "quick-xml 0.30.0",
  "reqsign",
  "reqwest",
@@ -922,29 +896,6 @@ checksum = "a4d6a8c22fc714f0c2373e6091bf6f5e9b37b1bc0b1184874b7e0a4e303d318f"
 dependencies = [
  "dlv-list",
  "hashbrown",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1103,15 +1054,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -1295,12 +1237,6 @@ checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"

--- a/bindings/ocaml/DEPENDENCIES.rust.tsv
+++ b/bindings/ocaml/DEPENDENCIES.rust.tsv
@@ -4,7 +4,6 @@ adler@1.0.2	X	X						X
 android-tzdata@0.1.1		X						X				
 android_system_properties@0.1.5		X						X				
 anyhow@1.0.76		X						X				
-async-compat@0.2.3		X						X				
 async-trait@0.1.75		X						X				
 autocfg@1.1.0		X						X				
 backon@0.4.1		X										
@@ -72,7 +71,6 @@ jsonwebtoken@9.2.0								X
 lazy_static@1.4.0		X						X				
 libc@0.2.151		X						X				
 libm@0.2.8		X						X				
-lock_api@0.4.11		X						X				
 log@0.4.20		X						X				
 md-5@0.10.6		X						X				
 memchr@2.6.4								X			X	
@@ -93,12 +91,10 @@ ocaml-interop@0.8.8								X
 ocaml-sys@0.22.3							X					
 ocaml-sys@0.23.0							X					
 once_cell@1.19.0		X						X				
-opendal@0.44.1		X										
+opendal@0.44.2		X										
 opendal-ocaml@0.0.0		X										
 openssl-probe@0.1.5		X						X				
 ordered-multimap@0.7.1								X				
-parking_lot@0.12.1		X						X				
-parking_lot_core@0.9.9		X						X				
 pem@3.0.3								X				
 pem-rfc7468@0.7.0		X						X				
 percent-encoding@2.3.1		X						X				
@@ -117,7 +113,6 @@ quote@1.0.33		X						X
 rand@0.8.5		X						X				
 rand_chacha@0.3.1		X						X				
 rand_core@0.6.4		X						X				
-redox_syscall@0.4.1								X				
 reqsign@0.14.6		X										
 reqwest@0.11.23		X						X				
 ring@0.17.7									X			
@@ -130,7 +125,6 @@ rustls-pemfile@1.0.4		X					X	X
 rustls-webpki@0.101.7							X					
 ryu@1.0.16		X			X							
 schannel@0.1.22								X				
-scopeguard@1.2.0		X						X				
 sct@0.7.1		X					X	X				
 security-framework@2.9.2		X						X				
 security-framework-sys@2.9.1		X						X				

--- a/bindings/php/Cargo.lock
+++ b/bindings/php/Cargo.lock
@@ -59,19 +59,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
 
 [[package]]
-name = "async-compat"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68a707c1feb095d8c07f8a65b9f506b117d30af431cab89374357de7c11461b"
-dependencies = [
- "futures-core",
- "futures-io",
- "once_cell",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,10 +1153,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "anyhow",
- "async-compat",
  "async-trait",
  "backon",
  "base64",
@@ -1182,9 +1168,7 @@ dependencies = [
  "log",
  "md-5",
  "once_cell",
- "parking_lot",
  "percent-encoding",
- "pin-project",
  "quick-xml 0.30.0",
  "reqsign",
  "reqwest",

--- a/bindings/php/DEPENDENCIES.rust.tsv
+++ b/bindings/php/DEPENDENCIES.rust.tsv
@@ -5,7 +5,6 @@ aes@0.8.3		X						X
 android-tzdata@0.1.1		X						X				
 android_system_properties@0.1.5		X						X				
 anyhow@1.0.76		X						X				
-async-compat@0.2.3		X						X				
 async-trait@0.1.75		X						X				
 autocfg@1.1.0		X						X				
 backon@0.4.1		X										
@@ -121,7 +120,7 @@ num-iter@0.1.43		X						X
 num-traits@0.2.17		X						X				
 object@0.32.1		X						X				
 once_cell@1.19.0		X						X				
-opendal@0.44.1		X										
+opendal@0.44.2		X										
 opendal-php@0.1.0		X										
 openssl@0.10.61		X										
 openssl-macros@0.1.1		X						X				

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -7,7 +7,6 @@ android-tzdata@0.1.1		X							X
 android_system_properties@0.1.5		X							X					
 anyhow@1.0.75		X							X					
 arc-swap@1.6.0		X							X					
-async-compat@0.2.3		X							X					
 async-trait@0.1.75		X							X					
 autocfg@1.1.0		X							X					
 awaitable@0.4.0									X					
@@ -48,7 +47,7 @@ fastrand@1.9.0		X							X
 fastrand@2.0.1		X							X					
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
-form_urlencoded@1.2.0		X							X					
+form_urlencoded@1.2.1		X							X					
 futures@0.3.29		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
@@ -76,7 +75,7 @@ hyper@0.14.27									X
 hyper-rustls@0.24.2		X						X	X					
 iana-time-zone@0.1.58		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
-idna@0.4.0		X							X					
+idna@0.5.0		X							X					
 indexmap@2.1.0		X							X					
 indoc@2.0.4		X							X					
 instant@0.1.12					X									
@@ -106,9 +105,9 @@ num-iter@0.1.43		X							X
 num-traits@0.2.17		X							X					
 num_cpus@1.16.0		X							X					
 object@0.32.1		X							X					
-once_cell@1.18.0		X							X					
-opendal@0.44.1		X												
-opendal-python@0.44.1		X												
+once_cell@1.19.0		X							X					
+opendal@0.44.2		X												
+opendal-python@0.44.2		X												
 openssh@0.10.1		X							X					
 openssh-sftp-client@0.14.1									X					
 openssh-sftp-client-lowlevel@0.6.0									X					
@@ -122,7 +121,7 @@ parking_lot@0.12.1		X							X
 parking_lot_core@0.9.9		X							X					
 pem@3.0.2									X					
 pem-rfc7468@0.7.0		X							X					
-percent-encoding@2.3.0		X							X					
+percent-encoding@2.3.1		X							X					
 pin-project@1.1.3		X							X					
 pin-project-internal@1.1.3		X							X					
 pin-project-lite@0.2.13		X							X					
@@ -132,12 +131,12 @@ pkcs8@0.10.2		X							X
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.17		X							X					
 proc-macro2@1.0.69		X							X					
-pyo3@0.20.0		X							X					
+pyo3@0.20.1		X							X					
 pyo3-asyncio@0.20.0		X												
-pyo3-build-config@0.20.0		X							X					
-pyo3-ffi@0.20.0		X							X					
-pyo3-macros@0.20.0		X							X					
-pyo3-macros-backend@0.20.0		X							X					
+pyo3-build-config@0.20.1		X							X					
+pyo3-ffi@0.20.1		X							X					
+pyo3-macros@0.20.1		X							X					
+pyo3-macros-backend@0.20.1		X							X					
 quick-xml@0.30.0									X					
 quick-xml@0.31.0									X					
 quote@1.0.33		X							X					
@@ -217,7 +216,7 @@ unicode-ident@1.0.12		X							X			X
 unicode-normalization@0.1.22		X							X					
 unindent@0.2.3		X							X					
 untrusted@0.9.0								X						
-url@2.4.1		X							X					
+url@2.5.0		X							X					
 uuid@1.6.1		X							X					
 valuable@0.1.0									X					
 vec-strings@0.4.8									X					

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -7,7 +7,6 @@ android-tzdata@0.1.1		X							X
 android_system_properties@0.1.5		X							X					
 anyhow@1.0.75		X							X					
 arc-swap@1.6.0		X							X					
-async-compat@0.2.3		X							X					
 async-trait@0.1.75		X							X					
 autocfg@1.1.0		X							X					
 awaitable@0.4.0									X					
@@ -48,7 +47,7 @@ fastrand@1.9.0		X							X
 fastrand@2.0.1		X							X					
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
-form_urlencoded@1.2.0		X							X					
+form_urlencoded@1.2.1		X							X					
 futures@0.3.29		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
@@ -75,7 +74,7 @@ hyper@0.14.27									X
 hyper-rustls@0.24.2		X						X	X					
 iana-time-zone@0.1.58		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
-idna@0.4.0		X							X					
+idna@0.5.0		X							X					
 indexmap@2.1.0		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
@@ -103,8 +102,8 @@ num-iter@0.1.43		X							X
 num-traits@0.2.17		X							X					
 num_cpus@1.16.0		X							X					
 object@0.32.1		X							X					
-once_cell@1.18.0		X							X					
-opendal@0.44.1		X												
+once_cell@1.19.0		X							X					
+opendal@0.44.2		X												
 openssh@0.10.1		X							X					
 openssh-sftp-client@0.14.1									X					
 openssh-sftp-client-lowlevel@0.6.0									X					
@@ -118,7 +117,7 @@ parking_lot@0.12.1		X							X
 parking_lot_core@0.9.9		X							X					
 pem@3.0.2									X					
 pem-rfc7468@0.7.0		X							X					
-percent-encoding@2.3.0		X							X					
+percent-encoding@2.3.1		X							X					
 pin-project@1.1.3		X							X					
 pin-project-internal@1.1.3		X							X					
 pin-project-lite@0.2.13		X							X					
@@ -205,7 +204,7 @@ unicode-bidi@0.3.13		X							X
 unicode-ident@1.0.12		X							X			X		
 unicode-normalization@0.1.22		X							X					
 untrusted@0.9.0								X						
-url@2.4.1		X							X					
+url@2.5.0		X							X					
 uuid@1.6.1		X							X					
 valuable@0.1.0									X					
 vec-strings@0.4.8									X					

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -8,7 +8,6 @@ android-tzdata@0.1.1		X							X
 android_system_properties@0.1.5		X							X					
 anyhow@1.0.75		X							X					
 arc-swap@1.6.0		X							X					
-async-compat@0.2.3		X							X					
 async-trait@0.1.75		X							X					
 autocfg@1.1.0		X							X					
 awaitable@0.4.0									X					
@@ -36,7 +35,7 @@ cpufeatures@0.2.11		X							X
 crunchy@0.2.2									X					
 crypto-common@0.1.6		X							X					
 dav-server@0.5.7		X												
-dav-server-opendalfs@0.44.1		X												
+dav-server-opendalfs@0.44.2		X												
 der@0.7.8		X							X					
 deranged@0.3.9		X							X					
 derive_destructure2@0.1.2		X							X					
@@ -51,7 +50,7 @@ fastrand@1.9.0		X							X
 fastrand@2.0.1		X							X					
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
-form_urlencoded@1.2.0		X							X					
+form_urlencoded@1.2.1		X							X					
 futures@0.3.29		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
@@ -81,7 +80,7 @@ hyper@0.14.27									X
 hyper-rustls@0.24.2		X						X	X					
 iana-time-zone@0.1.58		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
-idna@0.4.0		X							X					
+idna@0.5.0		X							X					
 indexmap@2.1.0		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
@@ -111,8 +110,8 @@ num-iter@0.1.43		X							X
 num-traits@0.2.17		X							X					
 num_cpus@1.16.0		X							X					
 object@0.32.1		X							X					
-once_cell@1.18.0		X							X					
-opendal@0.44.1		X												
+once_cell@1.19.0		X							X					
+opendal@0.44.2		X												
 openssh@0.10.1		X							X					
 openssh-sftp-client@0.14.1									X					
 openssh-sftp-client-lowlevel@0.6.0									X					
@@ -126,7 +125,7 @@ parking_lot@0.12.1		X							X
 parking_lot_core@0.9.9		X							X					
 pem@3.0.2									X					
 pem-rfc7468@0.7.0		X							X					
-percent-encoding@2.3.0		X							X					
+percent-encoding@2.3.1		X							X					
 pin-project@1.1.3		X							X					
 pin-project-internal@1.1.3		X							X					
 pin-project-lite@0.2.13		X							X					
@@ -217,7 +216,7 @@ unicode-bidi@0.3.13		X							X
 unicode-ident@1.0.12		X							X			X		
 unicode-normalization@0.1.22		X							X					
 untrusted@0.9.0								X						
-url@2.4.1		X							X					
+url@2.5.0		X							X					
 uuid@1.6.1		X							X					
 valuable@0.1.0									X					
 vec-strings@0.4.8									X					

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -7,7 +7,6 @@ android-tzdata@0.1.1		X							X
 android_system_properties@0.1.5		X							X					
 anyhow@1.0.75		X							X					
 arc-swap@1.6.0		X							X					
-async-compat@0.2.3		X							X					
 async-trait@0.1.75		X							X					
 autocfg@1.1.0		X							X					
 awaitable@0.4.0									X					
@@ -50,7 +49,7 @@ fastrand@1.9.0		X							X
 fastrand@2.0.1		X							X					
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
-form_urlencoded@1.2.0		X							X					
+form_urlencoded@1.2.1		X							X					
 futures@0.3.29		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
@@ -79,7 +78,7 @@ hyper@0.14.27									X
 hyper-rustls@0.24.2		X						X	X					
 iana-time-zone@0.1.58		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
-idna@0.4.0		X							X					
+idna@0.5.0		X							X					
 indexmap@2.1.0		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
@@ -109,9 +108,9 @@ num-traits@0.2.17		X							X
 num_cpus@1.16.0		X							X					
 object@0.32.1		X							X					
 object_store@0.7.1		X							X					
-object_store_opendal@0.44.1		X												
-once_cell@1.18.0		X							X					
-opendal@0.44.1		X												
+object_store_opendal@0.44.2		X												
+once_cell@1.19.0		X							X					
+opendal@0.44.2		X												
 openssh@0.10.1		X							X					
 openssh-sftp-client@0.14.1									X					
 openssh-sftp-client-lowlevel@0.6.0									X					
@@ -125,7 +124,7 @@ parking_lot@0.12.1		X							X
 parking_lot_core@0.9.9		X							X					
 pem@3.0.2									X					
 pem-rfc7468@0.7.0		X							X					
-percent-encoding@2.3.0		X							X					
+percent-encoding@2.3.1		X							X					
 pin-project@1.1.3		X							X					
 pin-project-internal@1.1.3		X							X					
 pin-project-lite@0.2.13		X							X					
@@ -215,7 +214,7 @@ unicode-bidi@0.3.13		X							X
 unicode-ident@1.0.12		X							X			X		
 unicode-normalization@0.1.22		X							X					
 untrusted@0.9.0								X						
-url@2.4.1		X							X					
+url@2.5.0		X							X					
 uuid@1.6.1		X							X					
 valuable@0.1.0									X					
 vec-strings@0.4.8									X					


### PR DESCRIPTION
# What's changed

## [v0.44.2] - 2023-01-19

### Added
* feat: add behavior tests for blocking buffer reader by @WenyXu in https://github.com/apache/opendal/pull/3872
* feat(services): add pcloud support by @hoslo in https://github.com/apache/opendal/pull/3892
* feat(services/hdfs): Atomic write for hdfs by @shbhmrzd in https://github.com/apache/opendal/pull/3875
* feat(services/hdfs): add atomic_write_dir to hdfsconfig debug by @shbhmrzd in https://github.com/apache/opendal/pull/3902
* feat: add MongodbConfig by @zjregee in https://github.com/apache/opendal/pull/3906
* RFC-3898: Concurrent Writer by @WenyXu in https://github.com/apache/opendal/pull/3898
* feat(services): add yandex disk support by @hoslo in https://github.com/apache/opendal/pull/3918
* feat: implement concurrent `MultipartUploadWriter` by @WenyXu in https://github.com/apache/opendal/pull/3915
* feat: add concurrent writer behavior tests by @WenyXu in https://github.com/apache/opendal/pull/3920
* feat: implement concurrent `RangeWriter` by @WenyXu in https://github.com/apache/opendal/pull/3923
* feat: add `concurrent` and `buffer` parameters into FuzzInput by @WenyXu in https://github.com/apache/opendal/pull/3921
* feat(fuzz): add azblob as test service by @suyanhanx in https://github.com/apache/opendal/pull/3931
* feat(services/webhdfs): Implement write with append by @hoslo in https://github.com/apache/opendal/pull/3937
* feat(core/bench): Add benchmark for concurrent write by @Xuanwo in https://github.com/apache/opendal/pull/3942
* feat(oio): add block_write support by @hoslo in https://github.com/apache/opendal/pull/3945
* feat(services/webhdfs): Implement multi write via CONCAT by @hoslo in https://github.com/apache/opendal/pull/3939
* feat(core): Allow retry in concurrent write operations by @Xuanwo in https://github.com/apache/opendal/pull/3958
* feat(services/ghac): Add workaround for AWS S3 based GHES by @Xuanwo in https://github.com/apache/opendal/pull/3985
* feat: Implement path cache and refactor gdrive by @Xuanwo in https://github.com/apache/opendal/pull/3975
* feat(services): add hdfs native layout by @shbhmrzd in https://github.com/apache/opendal/pull/3933
* feat(services/s3): Return error if credential is empty after loaded by @Xuanwo in https://github.com/apache/opendal/pull/4000
* feat(services/gdrive): Use trash instead of permanently deletes by @Xuanwo in https://github.com/apache/opendal/pull/4002
* feat(services): add koofr support by @hoslo in https://github.com/apache/opendal/pull/3981
* feat(icloud): Add basic Apple iCloud Drive support by @bokket in https://github.com/apache/opendal/pull/3980

### Changed
* refactor: Merge compose_{read,write} into enum_utils by @Xuanwo in https://github.com/apache/opendal/pull/3871
* refactor(services/ftp): Impl parse_error instead of From<Error> by @bokket in https://github.com/apache/opendal/pull/3891
* docs: very minor English wording fix in error message by @gabrielgrant in https://github.com/apache/opendal/pull/3900
* refactor(services/rocksdb): Impl parse_error instead of From<Error> by @suyanhanx in https://github.com/apache/opendal/pull/3903
* refactor: Re-organize the layout of tests by @Xuanwo in https://github.com/apache/opendal/pull/3904
* refactor(services/etcd): Impl parse_error instead of From<Error> by @suyanhanx in https://github.com/apache/opendal/pull/3910
* refactor(services/sftp): Impl parse_error instead of From<Error> by @G-XD in https://github.com/apache/opendal/pull/3914
* refactor!: Bump MSRV to 1.75 by @Xuanwo in https://github.com/apache/opendal/pull/3851
* refactor(services/redis): Impl parse_error instead of From<Error> by @suyanhanx in https://github.com/apache/opendal/pull/3938
* refactor!: Revert the bump of MSRV to 1.75 by @Xuanwo in https://github.com/apache/opendal/pull/3952
* refactor(services/onedrive): Add OnedriveConfig to implement ConfigDeserializer by @Borber in https://github.com/apache/opendal/pull/3954
* refactor(service/dropbox): Add DropboxConfig by @howiieyu in https://github.com/apache/opendal/pull/3961
* refactor: Polish internal types and remove not needed deps by @Xuanwo in https://github.com/apache/opendal/pull/3964
* refactor: Add concurrent error test for BlockWrite by @Xuanwo in https://github.com/apache/opendal/pull/3968
* refactor: Remove not needed types in icloud by @Xuanwo in https://github.com/apache/opendal/pull/4021

### Fixed
* fix: Bump pyo3 to fix false positive of unnecessary_fallible_conversions by @Xuanwo in https://github.com/apache/opendal/pull/3873
* fix(core): Handling content encoding correctly by @Xuanwo in https://github.com/apache/opendal/pull/3907
* fix: fix RangeWriter incorrect `next_offset` by @WenyXu in https://github.com/apache/opendal/pull/3927
* fix(oio::BlockWrite): fix write_once case by @hoslo in https://github.com/apache/opendal/pull/3953
* fix: Don't retry close if concurrent > 1 to avoid content lost by @Xuanwo in https://github.com/apache/opendal/pull/3957
* fix(doc): fix rfc typos by @howiieyu in https://github.com/apache/opendal/pull/3971
* fix: Don't call wake_by_ref in OperatorFuture by @Xuanwo in https://github.com/apache/opendal/pull/4003
* fix: async fn resumed after initiate part failed by @Xuanwo in https://github.com/apache/opendal/pull/4013
* fix(pcloud,seafile): use get_basename and get_parent by @hoslo in https://github.com/apache/opendal/pull/4020
* fix(ci): remove pr author from review candidates by @dqhl76 in https://github.com/apache/opendal/pull/4023

### Docs
* docs(bindings/python): drop unnecessary patchelf by @tisonkun in https://github.com/apache/opendal/pull/3889
* docs: Polish core's quick start by @Xuanwo in https://github.com/apache/opendal/pull/3896
* docs(gcs): correct the description of credential by @WenyXu in https://github.com/apache/opendal/pull/3928
* docs: Add 0.44.1 download link by @Xuanwo in https://github.com/apache/opendal/pull/3929
* docs(release): how to clean up old releases by @tisonkun in https://github.com/apache/opendal/pull/3934
* docs(website): polish download page by @suyanhanx in https://github.com/apache/opendal/pull/3932
* docs: improve user verify words by @tisonkun in https://github.com/apache/opendal/pull/3941
* docs: fix incorrect word used by @zegevlier in https://github.com/apache/opendal/pull/3944
* docs: improve wording for community pages by @tisonkun in https://github.com/apache/opendal/pull/3978
* docs(bindings/nodejs): copyright in footer by @suyanhanx in https://github.com/apache/opendal/pull/3986
* docs(bindings/nodejs): build docs locally doc by @suyanhanx in https://github.com/apache/opendal/pull/3987
* docs: Fix missing word in download by @Xuanwo in https://github.com/apache/opendal/pull/3993
* docs(bindings/java): copyright in footer by @G-XD in https://github.com/apache/opendal/pull/3996
* docs(website): update footer by @suyanhanx in https://github.com/apache/opendal/pull/4008
* docs: add trademark information to every possible published readme by @PsiACE in https://github.com/apache/opendal/pull/4014
* docs(website): replace podling to project in website by @morristai in https://github.com/apache/opendal/pull/4015
* docs: Update release guide to adapt as a new TLP by @Xuanwo in https://github.com/apache/opendal/pull/4011
* docs: Add WebHDFS version compatibility details by @shbhmrzd in https://github.com/apache/opendal/pull/4024

### CI
* build(deps): bump actions/download-artifact from 3 to 4 by @dependabot in https://github.com/apache/opendal/pull/3885
* build(deps): bump once_cell from 1.18.0 to 1.19.0 by @dependabot in https://github.com/apache/opendal/pull/3880
* build(deps): bump napi-derive from 2.14.2 to 2.14.6 by @dependabot in https://github.com/apache/opendal/pull/3879
* build(deps): bump url from 2.4.1 to 2.5.0 by @dependabot in https://github.com/apache/opendal/pull/3876
* build(deps): bump mlua from 0.8.10 to 0.9.2 by @oowl in https://github.com/apache/opendal/pull/3890
* ci: Disable supabase tests for our test org has been paused by @Xuanwo in https://github.com/apache/opendal/pull/3908
* ci: Downgrade artifact actions until regression addressed by @Xuanwo in https://github.com/apache/opendal/pull/3935
* ci: Refactor fuzz to integrate with test planner by @Xuanwo in https://github.com/apache/opendal/pull/3936
* ci: Pick random reviewers from committer list by @Xuanwo in https://github.com/apache/opendal/pull/4001

### Chore
* chore: update release related docs and script by @dqhl76 in https://github.com/apache/opendal/pull/3870
* chore(NOTICE): update copyright to year 2024 by @suyanhanx in https://github.com/apache/opendal/pull/3894
* chore: Format code to make readers happy by @Xuanwo in https://github.com/apache/opendal/pull/3912
* chore: Remove unused dep async-compat by @Xuanwo in https://github.com/apache/opendal/pull/3947
* chore: display project logo on Rust docs by @tisonkun in https://github.com/apache/opendal/pull/3983
* chore: improve trademarks in bindings docs by @tisonkun in https://github.com/apache/opendal/pull/3984
* chore: use Apache OpenDAL™ in the first and most prominent mention by @tisonkun in https://github.com/apache/opendal/pull/3988
* chore: add more information for javadocs by @tisonkun in https://github.com/apache/opendal/pull/3989
* chore: precise footer by @tisonkun in https://github.com/apache/opendal/pull/3997
* chore: use full form name when necessary by @tisonkun in https://github.com/apache/opendal/pull/3998
* chore(bindings/python): Enable sftp service by default for unix platform by @Zheaoli in https://github.com/apache/opendal/pull/4006
* chore: remove disclaimer by @suyanhanx in https://github.com/apache/opendal/pull/4009
* chore: Remove incubating from releases by @Xuanwo in https://github.com/apache/opendal/pull/4010
* chore: trim incubator prefix everywhere by @tisonkun in https://github.com/apache/opendal/pull/4016
* chore: fixup doc link in release_java.yml by @tisonkun in https://github.com/apache/opendal/pull/4019
* chore: simplify reviewer candidates logic by @tisonkun in https://github.com/apache/opendal/pull/4017

## New Contributors
* @bokket made their first contribution in https://github.com/apache/opendal/pull/3891
* @gabrielgrant made their first contribution in https://github.com/apache/opendal/pull/3900
* @zjregee made their first contribution in https://github.com/apache/opendal/pull/3906
* @zegevlier made their first contribution in https://github.com/apache/opendal/pull/3944
* @Borber made their first contribution in https://github.com/apache/opendal/pull/3954
* @howiieyu made their first contribution in https://github.com/apache/opendal/pull/3961