### PR TITLE
feat(layers/dtrace): Support User Statically-Defined Tracing(aka USDT) on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4650,6 +4650,7 @@ dependencies = [
  "percent-encoding",
  "persy",
  "pretty_assertions",
+ "probe",
  "prometheus",
  "prometheus-client",
  "prost 0.11.9",
@@ -5388,6 +5389,12 @@ dependencies = [
  "autocfg",
  "indexmap 1.9.3",
 ]
+
+[[package]]
+name = "probe"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e2d2444b730c8f027344c60f9e1f1554d7a3342df9bdd425142ed119a6e5a3"
 
 [[package]]
 name = "proc-macro-crate"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -110,6 +110,8 @@ layers-throttle = ["dep:governor"]
 layers-await-tree = ["dep:await-tree"]
 # Enable layers async-backtrace support.
 layers-async-backtrace = ["dep:async-backtrace"]
+# Enable dtrace support.
+layers-dtrace=["dep:probe"]
 layers-blocking = ["internal-tokio-rt"]
 
 services-alluxio = []
@@ -362,6 +364,8 @@ prometheus = { version = "0.13", features = ["process"], optional = true }
 prometheus-client = { version = "0.22.0", optional = true }
 # for layers-tracing
 tracing = { version = "0.1", optional = true }
+# for layers-dtrace
+probe = { version = "0.5.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/core/src/layers/dtrace.rs
+++ b/core/src/layers/dtrace.rs
@@ -347,7 +347,12 @@ impl<R: oio::BlockingRead> oio::BlockingRead for DtraceLayerWarpper<R> {
         probe_lazy!(opendal, blocking_next_start, c_path.as_ptr());
         self.inner.next().map(|res| match res {
             Ok(bytes) => {
-                probe_lazy!(opendal, blocking_next_complete_ok, c_path.as_ptr(), bytes.len());
+                probe_lazy!(
+                    opendal,
+                    blocking_next_complete_ok,
+                    c_path.as_ptr(),
+                    bytes.len()
+                );
                 Ok(bytes)
             }
             Err(e) => {

--- a/core/src/layers/dtrace.rs
+++ b/core/src/layers/dtrace.rs
@@ -15,13 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use async_trait::async_trait;
-use std::fmt::Debug;
-use std::fmt::Formatter;
-
+use crate::raw::Accessor;
 use crate::raw::*;
 use crate::*;
+use async_trait::async_trait;
+use bytes::Bytes;
+use probe::probe_lazy;
 use std::ffi::CString;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::io;
+use std::task::Context;
+use std::task::Poll;
 
 /// Support User Statically-Defined Tracing(aka USDT) on Linux
 ///
@@ -42,7 +47,7 @@ use std::ffi::CString;
 ///     builder.root("/tmp");
 ///
 ///     // `Accessor` provides the low level APIs, we will use `Operator` normally.
-///     let op: Operator = Operator::new(builder)?.layer(DTraceLayer{}).finish();
+///     let op: Operator = Operator::new(builder)?.layer(DtraceLayer::default()).finish();
 ///     
 ///     let path="/tmp/test.txt";
 ///     for _ in 1..100000{
@@ -82,9 +87,9 @@ use std::ffi::CString;
 ///   stapsdt              0x0000003c       NT_STAPSDT (SystemTap probe descriptors)
 /// ```
 #[derive(Default, Debug, Clone)]
-pub struct DTraceLayer {}
+pub struct DtraceLayer {}
 
-impl<A: Accessor> Layer<A> for DTraceLayer {
+impl<A: Accessor> Layer<A> for DtraceLayer {
     type LayeredAccessor = DTraceAccessor<A>;
     fn layer(&self, inner: A) -> Self::LayeredAccessor {
         DTraceAccessor { inner }
@@ -107,62 +112,72 @@ impl<A: Accessor> Debug for DTraceAccessor<A> {
 #[async_trait]
 impl<A: Accessor> LayeredAccessor for DTraceAccessor<A> {
     type Inner = A;
-    type Reader = A::Reader;
-    type BlockingReader = A::BlockingReader;
-    type Writer = A::Writer;
-    type BlockingWriter = A::BlockingWriter;
+    type Reader = DtraceLayerWarpper<A::Reader>;
+    type BlockingReader = DtraceLayerWarpper<A::BlockingReader>;
+    type Writer = DtraceLayerWarpper<A::Writer>;
+    type BlockingWriter = DtraceLayerWarpper<A::BlockingWriter>;
     type Lister = A::Lister;
     type BlockingLister = A::BlockingLister;
+
     fn inner(&self) -> &Self::Inner {
         &self.inner
     }
 
     async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         let c_path = CString::new(path).unwrap();
-        probe::probe_lazy!(opendal, create_dir_start, c_path.as_ptr());
-        let create_res = self.inner.create_dir(path, args).await;
-        probe::probe_lazy!(opendal, create_dir_end, c_path.as_ptr());
-        create_res
+        probe_lazy!(opendal, create_dir_start, c_path.as_ptr());
+        let result = self.inner.create_dir(path, args).await;
+        probe_lazy!(opendal, create_dir_end, c_path.as_ptr());
+        result
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let c_path = CString::new(path).unwrap();
-        probe::probe_lazy!(opendal, read_start, c_path.as_ptr());
-        let read_res = self.inner.read(path, args).await;
-        probe::probe_lazy!(opendal, read_end, c_path.as_ptr());
-        read_res
+        probe_lazy!(opendal, fetch_reader_start, c_path.as_ptr());
+        let result = self
+            .inner
+            .read(path, args)
+            .await
+            .map(|(rp, r)| (rp, DtraceLayerWarpper::new(r, &path.to_string())));
+        probe_lazy!(opendal, fetch_reader_end, c_path.as_ptr());
+        result
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         let c_path = CString::new(path).unwrap();
-        probe::probe_lazy!(opendal, write_start, c_path.as_ptr());
-        let write_res = self.inner.write(path, args).await;
-        probe::probe_lazy!(opendal, write_end, c_path.as_ptr());
-        write_res
+        probe_lazy!(opendal, fetch_writer_start, c_path.as_ptr());
+        let result = self
+            .inner
+            .write(path, args)
+            .await
+            .map(|(rp, r)| (rp, DtraceLayerWarpper::new(r, &path.to_string())));
+
+        probe_lazy!(opendal, fetch_writer_end, c_path.as_ptr());
+        result
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
         let c_path = CString::new(path).unwrap();
-        probe::probe_lazy!(opendal, stat_start, c_path.as_ptr());
-        let stat_res = self.inner.stat(path, args).await;
-        probe::probe_lazy!(opendal, stat_end, c_path.as_ptr());
-        stat_res
+        probe_lazy!(opendal, stat_start, c_path.as_ptr());
+        let result = self.inner.stat(path, args).await;
+        probe_lazy!(opendal, stat_end, c_path.as_ptr());
+        result
     }
 
     async fn delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
         let c_path = CString::new(path).unwrap();
-        probe::probe_lazy!(opendal, delete_start, c_path.as_ptr());
-        let delete_res = self.inner.delete(path, args).await;
-        probe::probe_lazy!(opendal, delete_end, c_path.as_ptr());
-        delete_res
+        probe_lazy!(opendal, delete_start, c_path.as_ptr());
+        let result = self.inner.delete(path, args).await;
+        probe_lazy!(opendal, delete_end, c_path.as_ptr());
+        result
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
         let c_path = CString::new(path).unwrap();
-        probe::probe_lazy!(opendal, list_start, c_path.as_ptr());
-        let list_res = self.inner.list(path, args).await;
-        probe::probe_lazy!(opendal, list_end, c_path.as_ptr());
-        list_res
+        probe_lazy!(opendal, list_start, c_path.as_ptr());
+        let result = self.inner.list(path, args).await;
+        probe_lazy!(opendal, list_end, c_path.as_ptr());
+        result
     }
 
     async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
@@ -171,57 +186,255 @@ impl<A: Accessor> LayeredAccessor for DTraceAccessor<A> {
 
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
         let c_path = CString::new(path).unwrap();
-        probe::probe_lazy!(opendal, presign_start, c_path.as_ptr());
+        probe_lazy!(opendal, presign_start, c_path.as_ptr());
         let result = self.inner.presign(path, args).await;
-        probe::probe_lazy!(opendal, presign_end, c_path.as_ptr());
+        probe_lazy!(opendal, presign_end, c_path.as_ptr());
         result
     }
 
     fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         let c_path = CString::new(path).unwrap();
-        probe::probe_lazy!(opendal, blocking_create_dir_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_create_dir_start, c_path.as_ptr());
         let result = self.inner.blocking_create_dir(path, args);
-        probe::probe_lazy!(opendal, blocking_create_dir_end, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_create_dir_end, c_path.as_ptr());
         result
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
         let c_path = CString::new(path).unwrap();
-        probe::probe_lazy!(opendal, blocking_read_start, c_path.as_ptr());
-        let result = self.inner.blocking_read(path, args);
-        probe::probe_lazy!(opendal, blocking_read_end, c_path.as_ptr());
+        probe_lazy!(opendal, fetch_blocking_reader_start, c_path.as_ptr());
+        let result = self
+            .inner
+            .blocking_read(path, args)
+            .map(|(rp, r)| (rp, DtraceLayerWarpper::new(r, &path.to_string())));
+        probe_lazy!(opendal, fetch_blocking_reader_end, c_path.as_ptr());
         result
     }
 
     fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
         let c_path = CString::new(path).unwrap();
-        probe::probe_lazy!(opendal, blocking_write_start, c_path.as_ptr());
-        let result = self.inner.blocking_write(path, args);
-        probe::probe_lazy!(opendal, blocking_write_end, c_path.as_ptr());
+        probe_lazy!(opendal, fetch_blocking_writer_start, c_path.as_ptr());
+        let result = self
+            .inner
+            .blocking_write(path, args)
+            .map(|(rp, r)| (rp, DtraceLayerWarpper::new(r, &path.to_string())));
+        probe_lazy!(opendal, fetch_blocking_writer_end, c_path.as_ptr());
         result
     }
 
     fn blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
         let c_path = CString::new(path).unwrap();
-        probe::probe_lazy!(opendal, blocking_stat_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_stat_start, c_path.as_ptr());
         let result = self.inner.blocking_stat(path, args);
-        probe::probe_lazy!(opendal, blocking_stat_end, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_stat_end, c_path.as_ptr());
         result
     }
 
     fn blocking_delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
         let c_path = CString::new(path).unwrap();
-        probe::probe_lazy!(opendal, blocking_delete_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_delete_start, c_path.as_ptr());
         let result = self.inner.blocking_delete(path, args);
-        probe::probe_lazy!(opendal, blocking_delete_end, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_delete_end, c_path.as_ptr());
         result
     }
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingLister)> {
         let c_path = CString::new(path).unwrap();
-        probe::probe_lazy!(opendal, blocking_list_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_list_start, c_path.as_ptr());
         let result = self.inner.blocking_list(path, args);
-        probe::probe_lazy!(opendal, blocking_list_end, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_list_end, c_path.as_ptr());
         result
+    }
+}
+
+pub struct DtraceLayerWarpper<R> {
+    inner: R,
+    path: String,
+}
+
+impl<R> DtraceLayerWarpper<R> {
+    pub fn new(inner: R, path: &String) -> Self {
+        Self {
+            inner,
+            path: path.to_string(),
+        }
+    }
+}
+
+impl<R: oio::Read> oio::Read for DtraceLayerWarpper<R> {
+    fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
+        let c_path = CString::new(self.path.clone()).unwrap();
+        probe_lazy!(opendal, poll_read_start, c_path.as_ptr());
+        self.inner.poll_read(cx, buf).map(|res| match res {
+            Ok(bytes) => {
+                probe_lazy!(opendal, poll_read_complete_success, c_path.as_ptr(), bytes);
+                Ok(bytes)
+            }
+            Err(e) => {
+                probe_lazy!(opendal, poll_read_complete_failed, c_path.as_ptr());
+                Err(e)
+            }
+        })
+    }
+    fn poll_seek(&mut self, cx: &mut Context<'_>, pos: io::SeekFrom) -> Poll<Result<u64>> {
+        let c_path = CString::new(self.path.clone()).unwrap();
+        probe_lazy!(opendal, poll_seek_start, c_path.as_ptr());
+        self.inner.poll_seek(cx, pos).map(|res| match res {
+            Ok(n) => {
+                probe_lazy!(opendal, poll_seek_complete_success, c_path.as_ptr(), n);
+                Ok(n)
+            }
+            Err(e) => {
+                probe_lazy!(opendal, poll_seek_complete_failed, c_path.as_ptr());
+                Err(e)
+            }
+        })
+    }
+
+    fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
+        let c_path = CString::new(self.path.clone()).unwrap();
+        probe_lazy!(opendal, poll_next_start, c_path.as_ptr());
+        self.inner.poll_next(cx).map(|res| match res {
+            Some(Ok(bytes)) => {
+                probe_lazy!(
+                    opendal,
+                    poll_next_complete_success,
+                    c_path.as_ptr(),
+                    bytes.len()
+                );
+                Some(Ok(bytes))
+            }
+            Some(Err(e)) => {
+                probe_lazy!(opendal, poll_next_complete_failed, c_path.as_ptr());
+                Some(Err(e))
+            }
+            None => {
+                probe_lazy!(opendal, poll_next_complete, c_path.as_ptr());
+                None
+            }
+        })
+    }
+}
+
+impl<R: oio::BlockingRead> oio::BlockingRead for DtraceLayerWarpper<R> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let c_path = CString::new(self.path.clone()).unwrap();
+        probe_lazy!(opendal, read_start, c_path.as_ptr());
+        self.inner
+            .read(buf)
+            .map(|n| {
+                probe_lazy!(opendal, read_complete_success, c_path.as_ptr(), n);
+                n
+            })
+            .map_err(|e| {
+                probe_lazy!(opendal, read_complete_failed, c_path.as_ptr());
+                e
+            })
+    }
+
+    fn seek(&mut self, pos: io::SeekFrom) -> Result<u64> {
+        let c_path = CString::new(self.path.clone()).unwrap();
+        probe_lazy!(opendal, seek_start, c_path.as_ptr());
+        self.inner
+            .seek(pos)
+            .map(|res| {
+                probe_lazy!(opendal, seek_complete_success, c_path.as_ptr(), res);
+                res
+            })
+            .map_err(|e| {
+                probe_lazy!(opendal, seek_complete_failed, c_path.as_ptr());
+                e
+            })
+    }
+
+    fn next(&mut self) -> Option<Result<Bytes>> {
+        let c_path = CString::new(self.path.clone()).unwrap();
+        probe_lazy!(opendal, next_start, c_path.as_ptr());
+        self.inner.next().map(|res| match res {
+            Ok(bytes) => {
+                probe_lazy!(opendal, next_complete_success, c_path.as_ptr(), bytes.len());
+                Ok(bytes)
+            }
+            Err(e) => {
+                probe_lazy!(opendal, next_complete_failed, c_path.as_ptr());
+                Err(e)
+            }
+        })
+    }
+}
+
+impl<R: oio::Write> oio::Write for DtraceLayerWarpper<R> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+        let c_path = CString::new(self.path.clone()).unwrap();
+        probe_lazy!(opendal, poll_write_start, c_path.as_ptr());
+        self.inner
+            .poll_write(cx, bs)
+            .map_ok(|n| {
+                probe_lazy!(opendal, poll_write_complete_success, c_path.as_ptr(), n);
+                n
+            })
+            .map_err(|err| {
+                probe_lazy!(opendal, poll_write_complete_failed, c_path.as_ptr());
+                err
+            })
+    }
+
+    fn poll_abort(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        let c_path = CString::new(self.path.clone()).unwrap();
+        probe_lazy!(opendal, poll_abort_start, c_path.as_ptr());
+        self.inner
+            .poll_abort(cx)
+            .map_ok(|_| {
+                probe_lazy!(opendal, poll_abort_complete_success, c_path.as_ptr());
+            })
+            .map_err(|err| {
+                probe_lazy!(opendal, poll_abort_complete_failed, c_path.as_ptr());
+                err
+            })
+    }
+
+    fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        let c_path = CString::new(self.path.clone()).unwrap();
+        probe_lazy!(opendal, poll_close_start, c_path.as_ptr());
+        self.inner
+            .poll_close(cx)
+            .map_ok(|_| {
+                probe_lazy!(opendal, poll_close_complete_success, c_path.as_ptr());
+            })
+            .map_err(|err| {
+                probe_lazy!(opendal, poll_close_complete_failed, c_path.as_ptr());
+                err
+            })
+    }
+}
+
+impl<R: oio::BlockingWrite> oio::BlockingWrite for DtraceLayerWarpper<R> {
+    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+        let c_path = CString::new(self.path.clone()).unwrap();
+        probe_lazy!(opendal, write_start, c_path.as_ptr());
+        self.inner
+            .write(bs)
+            .map(|n| {
+                probe_lazy!(opendal, write_complete_success, c_path.as_ptr(), n);
+                n
+            })
+            .map_err(|err| {
+                probe_lazy!(opendal, write_complete_failed, c_path.as_ptr());
+                err
+            })
+    }
+
+    fn close(&mut self) -> Result<()> {
+        let c_path = CString::new(self.path.clone()).unwrap();
+        probe_lazy!(opendal, close_start, c_path.as_ptr());
+        self.inner
+            .close()
+            .map(|_| {
+                probe_lazy!(opendal, close_complete_success, c_path.as_ptr());
+            })
+            .map_err(|err| {
+                probe_lazy!(opendal, close_complete_failed, c_path.as_ptr());
+                err
+            })
     }
 }

--- a/core/src/layers/dtrace.rs
+++ b/core/src/layers/dtrace.rs
@@ -1,0 +1,227 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use async_trait::async_trait;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+
+use crate::raw::*;
+use crate::*;
+use std::ffi:: CString;
+
+/// Support User Statically-Defined Tracing(aka USDT) on Linux
+/// 
+/// This layer is a experimental feature, it will be enabled by `features = ["layers-dtrace"]` in Cargo.toml.
+/// 
+/// Example:
+/// ```
+///
+/// use anyhow::Result;
+/// use opendal::services::Fs;
+/// use opendal::Operator;
+/// use opendal::layers::DTraceLayer;
+///
+/// #[tokio::main]
+/// async fn main() -> Result<()> {
+///     let mut builder = Fs::default();
+///
+///     builder.root("/tmp");
+///
+///     // `Accessor` provides the low level APIs, we will use `Operator` normally.
+///     let op: Operator = Operator::new(builder)?.layer(DTraceLayer{}).finish();
+///     
+///     let path="/tmp/test.txt";
+///     for _ in 1..100000{
+///         let bs = vec![0; 64 * 1024 * 1024];
+///         op.write(path, bs).await?;
+///         op.read(path).await?;
+///     }
+///     Ok(())
+/// }
+/// ```
+///
+/// Then you can use `readelf -n target/debug/examples/dtrace` to see the probes:
+///
+/// ```text
+/// Displaying notes found in: .note.stapsdt
+///   Owner                Data size        Description
+///   stapsdt              0x00000039       NT_STAPSDT (SystemTap probe descriptors)
+///     Provider: opendal
+///     Name: create_dir_start
+///     Location: 0x00000000000f8f05, Base: 0x0000000000000000, Semaphore: 0x00000000003649f8
+///     Arguments: -8@%rax
+///   stapsdt              0x00000037       NT_STAPSDT (SystemTap probe descriptors)
+///     Provider: opendal
+///     Name: create_dir_end
+///     Location: 0x00000000000f9284, Base: 0x0000000000000000, Semaphore: 0x00000000003649fa
+///     Arguments: -8@%rax
+///   stapsdt              0x0000003c       NT_STAPSDT (SystemTap probe descriptors)
+///     Provider: opendal
+///     Name: blocking_list_start
+///     Location: 0x00000000000f9487, Base: 0x0000000000000000, Semaphore: 0x0000000000364a28
+///     Arguments: -8@%rax
+///   stapsdt              0x0000003a       NT_STAPSDT (SystemTap probe descriptors)
+///     Provider: opendal
+///     Name: blocking_list_end
+///     Location: 0x00000000000f9546, Base: 0x0000000000000000, Semaphore: 0x0000000000364a2a
+///     Arguments: -8@%rax
+///   stapsdt              0x0000003c       NT_STAPSDT (SystemTap probe descriptors)
+/// ```
+#[derive(Default, Debug, Clone)]
+pub struct DTraceLayer {}
+
+impl<A: Accessor> Layer<A> for DTraceLayer {
+    type LayeredAccessor = DTraceAccessor<A>;
+    fn layer(&self, inner: A) -> Self::LayeredAccessor {
+        DTraceAccessor { inner }
+    }
+}
+
+#[derive(Clone)]
+pub struct DTraceAccessor<A: Accessor> {
+    inner: A,
+}
+
+impl<A: Accessor> Debug for DTraceAccessor<A> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DTraceAccessor")
+            .field("inner", &self.inner)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl<A: Accessor> LayeredAccessor for DTraceAccessor<A> {
+    type Inner = A;
+    type Reader = A::Reader;
+    type BlockingReader = A::BlockingReader;
+    type Writer = A::Writer;
+    type BlockingWriter = A::BlockingWriter;
+    type Lister = A::Lister;
+    type BlockingLister = A::BlockingLister;
+    fn inner(&self) -> &Self::Inner {
+        &self.inner
+    }
+
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
+        let c_path = CString::new(path).unwrap();
+        probe::probe_lazy!(opendal, create_dir_start, c_path.as_ptr());
+        let create_res = self.inner.create_dir(path, args).await;
+        probe::probe_lazy!(opendal, create_dir_end, c_path.as_ptr());
+        create_res
+    }
+
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        let c_path = CString::new(path).unwrap();
+        probe::probe_lazy!(opendal, read_start, c_path.as_ptr());
+        let read_res = self.inner.read(path, args).await;
+        probe::probe_lazy!(opendal, read_end, c_path.as_ptr());
+        read_res
+    }
+
+    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
+        let c_path = CString::new(path).unwrap();
+        probe::probe_lazy!(opendal, write_start, c_path.as_ptr());
+        let write_res = self.inner.write(path, args).await;
+        probe::probe_lazy!(opendal, write_end, c_path.as_ptr());
+        write_res
+    }
+
+    async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
+        let c_path = CString::new(path).unwrap();
+        probe::probe_lazy!(opendal, stat_start, c_path.as_ptr());
+        let stat_res = self.inner.stat(path, args).await;
+        probe::probe_lazy!(opendal, stat_end, c_path.as_ptr());
+        stat_res
+    }
+
+    async fn delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
+        let c_path = CString::new(path).unwrap();
+        probe::probe_lazy!(opendal, delete_start, c_path.as_ptr());
+        let delete_res = self.inner.delete(path, args).await;
+        probe::probe_lazy!(opendal, delete_end, c_path.as_ptr());
+        delete_res
+    }
+
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
+        let c_path = CString::new(path).unwrap();
+        probe::probe_lazy!(opendal, list_start, c_path.as_ptr());
+        let list_res = self.inner.list(path, args).await;
+        probe::probe_lazy!(opendal, list_end, c_path.as_ptr());
+        list_res
+    }
+
+    async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
+        self.inner.batch(args).await
+    }
+
+    async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
+        let c_path = CString::new(path).unwrap();
+        probe::probe_lazy!(opendal, presign_start, c_path.as_ptr());
+        let result = self.inner.presign(path, args).await;
+        probe::probe_lazy!(opendal, presign_end, c_path.as_ptr());
+        result
+    }
+
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
+        let c_path = CString::new(path).unwrap();
+        probe::probe_lazy!(opendal, blocking_create_dir_start, c_path.as_ptr());
+        let result = self.inner.blocking_create_dir(path, args);
+        probe::probe_lazy!(opendal, blocking_create_dir_end, c_path.as_ptr());
+        result
+    }
+
+    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
+        let c_path = CString::new(path).unwrap();
+        probe::probe_lazy!(opendal, blocking_read_start, c_path.as_ptr());
+        let result = self.inner.blocking_read(path, args);
+        probe::probe_lazy!(opendal, blocking_read_end, c_path.as_ptr());
+        result
+    }
+
+    fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
+        let c_path = CString::new(path).unwrap();
+        probe::probe_lazy!(opendal, blocking_write_start, c_path.as_ptr());
+        let result = self.inner.blocking_write(path, args);
+        probe::probe_lazy!(opendal, blocking_write_end, c_path.as_ptr());
+        result
+    }
+
+    fn blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
+        let c_path = CString::new(path).unwrap();
+        probe::probe_lazy!(opendal, blocking_stat_start, c_path.as_ptr());
+        let result = self.inner.blocking_stat(path, args);
+        probe::probe_lazy!(opendal, blocking_stat_end, c_path.as_ptr());
+        result
+    }
+
+    fn blocking_delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
+        let c_path = CString::new(path).unwrap();
+        probe::probe_lazy!(opendal, blocking_delete_start, c_path.as_ptr());
+        let result = self.inner.blocking_delete(path, args);
+        probe::probe_lazy!(opendal, blocking_delete_end, c_path.as_ptr());
+        result
+    }
+
+    fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingLister)> {
+        let c_path = CString::new(path).unwrap();
+        probe::probe_lazy!(opendal, blocking_list_start, c_path.as_ptr());
+        let result = self.inner.blocking_list(path, args);
+        probe::probe_lazy!(opendal, blocking_list_end, c_path.as_ptr());
+        result
+    }
+}

--- a/core/src/layers/dtrace.rs
+++ b/core/src/layers/dtrace.rs
@@ -32,6 +32,85 @@ use std::task::Poll;
 ///
 /// This layer is an experimental feature, it will be enabled by `features = ["layers-dtrace"]` in Cargo.toml.
 ///
+/// For now we have following probes:
+///
+/// ### For Accessor
+///
+/// 1. ${operation}_start, arguments: path
+///     1. create_dir
+///     2. read
+///     3. write
+///     4. stat
+///     5. delete
+///     6. list
+///     7. presign
+///     8. blocking_create_dir
+///     9. blocking_read
+///     10. blocking_write
+///     11. blocking_stat
+///     12. blocking_delete
+///     13. blocking_list
+/// 2. ${operation}_end, arguments: path
+///     1. create_dir
+///     2. read
+///     3. write
+///     4. stat
+///     5. delete
+///     6. list
+///     7. presign
+///     8. blocking_create_dir
+///     9. blocking_read
+///     10. blocking_write
+///     11. blocking_stat
+///     12. blocking_delete
+///     13. blocking_list
+///
+/// ### For Reader
+///
+/// 1. reader_read_start, arguments: path
+/// 2. reader_read_ok, arguments: path, length
+/// 3. reader_read_error, arguments: path
+/// 4. reader_seek_start, arguments: path
+/// 5. reader_seek_ok, arguments: path, offset
+/// 6. reader_seek_error, arguments: path
+/// 7. reader_next_start, arguments: path
+/// 8. reader_next_ok, arguments: path, length
+/// 9. reader_next_error, arguments: path
+/// 10. reader_next_end, arguments: path
+///
+/// ### For BlockingReader
+///
+/// 1. blocking_reader_read_start, arguments: path
+/// 2. blocking_reader_read_ok, arguments: path, length
+/// 3. blocking_reader_read_error, arguments: path
+/// 4. blocking_reader_seek_start, arguments: path
+/// 5. blocking_reader_seek_ok, arguments: path, offset
+/// 6. blocking_reader_seek_error, arguments: path
+/// 7. blocking_reader_next_start, arguments: path
+/// 8. blocking_reader_next_ok, arguments: path, length
+/// 9. blocking_reader_next_error, arguments: path
+///
+/// ### For Writer
+///
+/// 1. writer_write_start, arguments: path
+/// 2. writer_write_ok, arguments: path, length
+/// 3. writer_write_error, arguments: path
+/// 4. writer_poll_abort_start, arguments: path
+/// 5. writer_poll_abort_ok, arguments: path
+/// 6. writer_poll_abort_error, arguments: path
+/// 7. writer_close_start, arguments: path
+/// 8. writer_close_ok, arguments: path
+/// 9. writer_close_error, arguments: path
+///
+/// ### For BlockingWriter
+///
+/// 1. blocking_writer_write_start, arguments: path
+/// 2. blocking_writer_write_ok, arguments: path, length
+/// 3. blocking_writer_write_error, arguments: path
+/// 4. blocking_writer_close_start, arguments: path
+/// 5. blocking_writer_close_ok, arguments: path
+/// 6. blocking_writer_close_error, arguments: path
+///
 /// Example:
 /// ```
 ///

--- a/core/src/layers/dtrace.rs
+++ b/core/src/layers/dtrace.rs
@@ -25,7 +25,7 @@ use std::ffi:: CString;
 
 /// Support User Statically-Defined Tracing(aka USDT) on Linux
 /// 
-/// This layer is a experimental feature, it will be enabled by `features = ["layers-dtrace"]` in Cargo.toml.
+/// This layer is an experimental feature, it will be enabled by `features = ["layers-dtrace"]` in Cargo.toml.
 /// 
 /// Example:
 /// ```

--- a/core/src/layers/dtrace.rs
+++ b/core/src/layers/dtrace.rs
@@ -21,12 +21,12 @@ use std::fmt::Formatter;
 
 use crate::raw::*;
 use crate::*;
-use std::ffi:: CString;
+use std::ffi::CString;
 
 /// Support User Statically-Defined Tracing(aka USDT) on Linux
-/// 
+///
 /// This layer is an experimental feature, it will be enabled by `features = ["layers-dtrace"]` in Cargo.toml.
-/// 
+///
 /// Example:
 /// ```
 ///

--- a/core/src/layers/dtrace.rs
+++ b/core/src/layers/dtrace.rs
@@ -133,26 +133,26 @@ impl<A: Accessor> LayeredAccessor for DTraceAccessor<A> {
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let c_path = CString::new(path).unwrap();
-        probe_lazy!(opendal, reader_start, c_path.as_ptr());
+        probe_lazy!(opendal, read_start, c_path.as_ptr());
         let result = self
             .inner
             .read(path, args)
             .await
             .map(|(rp, r)| (rp, DtraceLayerWarpper::new(r, &path.to_string())));
-        probe_lazy!(opendal, reader_end, c_path.as_ptr());
+        probe_lazy!(opendal, read_end, c_path.as_ptr());
         result
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         let c_path = CString::new(path).unwrap();
-        probe_lazy!(opendal, writer_start, c_path.as_ptr());
+        probe_lazy!(opendal, write_start, c_path.as_ptr());
         let result = self
             .inner
             .write(path, args)
             .await
             .map(|(rp, r)| (rp, DtraceLayerWarpper::new(r, &path.to_string())));
 
-        probe_lazy!(opendal, writer_end, c_path.as_ptr());
+        probe_lazy!(opendal, write_end, c_path.as_ptr());
         result
     }
 
@@ -202,23 +202,23 @@ impl<A: Accessor> LayeredAccessor for DTraceAccessor<A> {
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
         let c_path = CString::new(path).unwrap();
-        probe_lazy!(opendal, blocking_reader_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_read_start, c_path.as_ptr());
         let result = self
             .inner
             .blocking_read(path, args)
             .map(|(rp, r)| (rp, DtraceLayerWarpper::new(r, &path.to_string())));
-        probe_lazy!(opendal, blocking_reader_end, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_read_end, c_path.as_ptr());
         result
     }
 
     fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
         let c_path = CString::new(path).unwrap();
-        probe_lazy!(opendal, blocking_writer_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_write_start, c_path.as_ptr());
         let result = self
             .inner
             .blocking_write(path, args)
             .map(|(rp, r)| (rp, DtraceLayerWarpper::new(r, &path.to_string())));
-        probe_lazy!(opendal, blocking_writer_end, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_write_end, c_path.as_ptr());
         result
     }
 
@@ -264,28 +264,28 @@ impl<R> DtraceLayerWarpper<R> {
 impl<R: oio::Read> oio::Read for DtraceLayerWarpper<R> {
     fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, read_start, c_path.as_ptr());
+        probe_lazy!(opendal, reader_read_start, c_path.as_ptr());
         self.inner.poll_read(cx, buf).map(|res| match res {
             Ok(n) => {
-                probe_lazy!(opendal, read_complete_ok, c_path.as_ptr(), n);
+                probe_lazy!(opendal, reader_read_ok, c_path.as_ptr(), n);
                 Ok(n)
             }
             Err(e) => {
-                probe_lazy!(opendal, read_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, reader_read_error, c_path.as_ptr());
                 Err(e)
             }
         })
     }
     fn poll_seek(&mut self, cx: &mut Context<'_>, pos: io::SeekFrom) -> Poll<Result<u64>> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, seek_start, c_path.as_ptr());
+        probe_lazy!(opendal, reader_seek_start, c_path.as_ptr());
         self.inner.poll_seek(cx, pos).map(|res| match res {
             Ok(n) => {
-                probe_lazy!(opendal, seek_complete_ok, c_path.as_ptr(), n);
+                probe_lazy!(opendal, reader_seek_ok, c_path.as_ptr(), n);
                 Ok(n)
             }
             Err(e) => {
-                probe_lazy!(opendal, seek_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, reader_seek_error, c_path.as_ptr());
                 Err(e)
             }
         })
@@ -293,18 +293,18 @@ impl<R: oio::Read> oio::Read for DtraceLayerWarpper<R> {
 
     fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, next_start, c_path.as_ptr());
+        probe_lazy!(opendal, reader_next_start, c_path.as_ptr());
         self.inner.poll_next(cx).map(|res| match res {
             Some(Ok(bytes)) => {
-                probe_lazy!(opendal, next_complete_ok, c_path.as_ptr(), bytes.len());
+                probe_lazy!(opendal, reader_next_ok, c_path.as_ptr(), bytes.len());
                 Some(Ok(bytes))
             }
             Some(Err(e)) => {
-                probe_lazy!(opendal, next_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, reader_next_error, c_path.as_ptr());
                 Some(Err(e))
             }
             None => {
-                probe_lazy!(opendal, next_complete, c_path.as_ptr());
+                probe_lazy!(opendal, reader_next_end, c_path.as_ptr());
                 None
             }
         })
@@ -314,49 +314,49 @@ impl<R: oio::Read> oio::Read for DtraceLayerWarpper<R> {
 impl<R: oio::BlockingRead> oio::BlockingRead for DtraceLayerWarpper<R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, blocking_read_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_reader_read_start, c_path.as_ptr());
         self.inner
             .read(buf)
             .map(|n| {
-                probe_lazy!(opendal, blocking_read_complete_ok, c_path.as_ptr(), n);
+                probe_lazy!(opendal, blocking_reader_read_ok, c_path.as_ptr(), n);
                 n
             })
             .map_err(|e| {
-                probe_lazy!(opendal, blocking_read_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, blocking_reader_read_error, c_path.as_ptr());
                 e
             })
     }
 
     fn seek(&mut self, pos: io::SeekFrom) -> Result<u64> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, blocking_seek_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_reader_seek_start, c_path.as_ptr());
         self.inner
             .seek(pos)
             .map(|res| {
-                probe_lazy!(opendal, blocking_seek_complete_ok, c_path.as_ptr(), res);
+                probe_lazy!(opendal, blocking_reader_seek_ok, c_path.as_ptr(), res);
                 res
             })
             .map_err(|e| {
-                probe_lazy!(opendal, blocking_seek_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, blocking_reader_seek_error, c_path.as_ptr());
                 e
             })
     }
 
     fn next(&mut self) -> Option<Result<Bytes>> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, blocking_next_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_reader_next_start, c_path.as_ptr());
         self.inner.next().map(|res| match res {
             Ok(bytes) => {
                 probe_lazy!(
                     opendal,
-                    blocking_next_complete_ok,
+                    blocking_reader_next_ok,
                     c_path.as_ptr(),
                     bytes.len()
                 );
                 Ok(bytes)
             }
             Err(e) => {
-                probe_lazy!(opendal, blocking_next_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, blocking_reader_next_error, c_path.as_ptr());
                 Err(e)
             }
         })
@@ -366,43 +366,43 @@ impl<R: oio::BlockingRead> oio::BlockingRead for DtraceLayerWarpper<R> {
 impl<R: oio::Write> oio::Write for DtraceLayerWarpper<R> {
     fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, write_start, c_path.as_ptr());
+        probe_lazy!(opendal, writer_write_start, c_path.as_ptr());
         self.inner
             .poll_write(cx, bs)
             .map_ok(|n| {
-                probe_lazy!(opendal, write_complete_ok, c_path.as_ptr(), n);
+                probe_lazy!(opendal, writer_write_ok, c_path.as_ptr(), n);
                 n
             })
             .map_err(|err| {
-                probe_lazy!(opendal, write_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, writer_write_error, c_path.as_ptr());
                 err
             })
     }
 
     fn poll_abort(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, poll_abort_start, c_path.as_ptr());
+        probe_lazy!(opendal, writer_poll_abort_start, c_path.as_ptr());
         self.inner
             .poll_abort(cx)
             .map_ok(|_| {
-                probe_lazy!(opendal, poll_abort_complete_ok, c_path.as_ptr());
+                probe_lazy!(opendal, writer_poll_abort_ok, c_path.as_ptr());
             })
             .map_err(|err| {
-                probe_lazy!(opendal, poll_abort_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, writer_poll_abort_error, c_path.as_ptr());
                 err
             })
     }
 
     fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, close_start, c_path.as_ptr());
+        probe_lazy!(opendal, writer_close_start, c_path.as_ptr());
         self.inner
             .poll_close(cx)
             .map_ok(|_| {
-                probe_lazy!(opendal, close_complete_ok, c_path.as_ptr());
+                probe_lazy!(opendal, writer_close_ok, c_path.as_ptr());
             })
             .map_err(|err| {
-                probe_lazy!(opendal, close_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, writer_close_error, c_path.as_ptr());
                 err
             })
     }
@@ -411,29 +411,29 @@ impl<R: oio::Write> oio::Write for DtraceLayerWarpper<R> {
 impl<R: oio::BlockingWrite> oio::BlockingWrite for DtraceLayerWarpper<R> {
     fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, blocking_write_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_writer_write_start, c_path.as_ptr());
         self.inner
             .write(bs)
             .map(|n| {
-                probe_lazy!(opendal, blocking_write_complete_ok, c_path.as_ptr(), n);
+                probe_lazy!(opendal, blocking_writer_write_ok, c_path.as_ptr(), n);
                 n
             })
             .map_err(|err| {
-                probe_lazy!(opendal, blocking_write_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, blocking_writer_write_error, c_path.as_ptr());
                 err
             })
     }
 
     fn close(&mut self) -> Result<()> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, blocking_close_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_writer_close_start, c_path.as_ptr());
         self.inner
             .close()
             .map(|_| {
-                probe_lazy!(opendal, blocking_close_complete_ok, c_path.as_ptr());
+                probe_lazy!(opendal, blocking_writer_close_ok, c_path.as_ptr());
             })
             .map_err(|err| {
-                probe_lazy!(opendal, blocking_close_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, blocking_writer_close_error, c_path.as_ptr());
                 err
             })
     }

--- a/core/src/layers/dtrace.rs
+++ b/core/src/layers/dtrace.rs
@@ -264,28 +264,28 @@ impl<R> DtraceLayerWarpper<R> {
 impl<R: oio::Read> oio::Read for DtraceLayerWarpper<R> {
     fn poll_read(&mut self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<usize>> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, poll_read_start, c_path.as_ptr());
+        probe_lazy!(opendal, read_start, c_path.as_ptr());
         self.inner.poll_read(cx, buf).map(|res| match res {
             Ok(n) => {
-                probe_lazy!(opendal, poll_read_complete_ok, c_path.as_ptr(), n);
+                probe_lazy!(opendal, read_complete_ok, c_path.as_ptr(), n);
                 Ok(n)
             }
             Err(e) => {
-                probe_lazy!(opendal, poll_read_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, read_complete_error, c_path.as_ptr());
                 Err(e)
             }
         })
     }
     fn poll_seek(&mut self, cx: &mut Context<'_>, pos: io::SeekFrom) -> Poll<Result<u64>> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, poll_seek_start, c_path.as_ptr());
+        probe_lazy!(opendal, seek_start, c_path.as_ptr());
         self.inner.poll_seek(cx, pos).map(|res| match res {
             Ok(n) => {
-                probe_lazy!(opendal, poll_seek_complete_ok, c_path.as_ptr(), n);
+                probe_lazy!(opendal, seek_complete_ok, c_path.as_ptr(), n);
                 Ok(n)
             }
             Err(e) => {
-                probe_lazy!(opendal, poll_seek_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, seek_complete_error, c_path.as_ptr());
                 Err(e)
             }
         })
@@ -293,18 +293,18 @@ impl<R: oio::Read> oio::Read for DtraceLayerWarpper<R> {
 
     fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Bytes>>> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, poll_next_start, c_path.as_ptr());
+        probe_lazy!(opendal, next_start, c_path.as_ptr());
         self.inner.poll_next(cx).map(|res| match res {
             Some(Ok(bytes)) => {
-                probe_lazy!(opendal, poll_next_complete_ok, c_path.as_ptr(), bytes.len());
+                probe_lazy!(opendal, next_complete_ok, c_path.as_ptr(), bytes.len());
                 Some(Ok(bytes))
             }
             Some(Err(e)) => {
-                probe_lazy!(opendal, poll_next_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, next_complete_error, c_path.as_ptr());
                 Some(Err(e))
             }
             None => {
-                probe_lazy!(opendal, poll_next_complete, c_path.as_ptr());
+                probe_lazy!(opendal, next_complete, c_path.as_ptr());
                 None
             }
         })
@@ -314,44 +314,44 @@ impl<R: oio::Read> oio::Read for DtraceLayerWarpper<R> {
 impl<R: oio::BlockingRead> oio::BlockingRead for DtraceLayerWarpper<R> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, read_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_read_start, c_path.as_ptr());
         self.inner
             .read(buf)
             .map(|n| {
-                probe_lazy!(opendal, read_complete_ok, c_path.as_ptr(), n);
+                probe_lazy!(opendal, blocking_read_complete_ok, c_path.as_ptr(), n);
                 n
             })
             .map_err(|e| {
-                probe_lazy!(opendal, read_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, blocking_read_complete_error, c_path.as_ptr());
                 e
             })
     }
 
     fn seek(&mut self, pos: io::SeekFrom) -> Result<u64> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, seek_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_seek_start, c_path.as_ptr());
         self.inner
             .seek(pos)
             .map(|res| {
-                probe_lazy!(opendal, seek_complete_ok, c_path.as_ptr(), res);
+                probe_lazy!(opendal, blocking_seek_complete_ok, c_path.as_ptr(), res);
                 res
             })
             .map_err(|e| {
-                probe_lazy!(opendal, seek_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, blocking_seek_complete_error, c_path.as_ptr());
                 e
             })
     }
 
     fn next(&mut self) -> Option<Result<Bytes>> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, next_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_next_start, c_path.as_ptr());
         self.inner.next().map(|res| match res {
             Ok(bytes) => {
-                probe_lazy!(opendal, next_complete_ok, c_path.as_ptr(), bytes.len());
+                probe_lazy!(opendal, blocking_next_complete_ok, c_path.as_ptr(), bytes.len());
                 Ok(bytes)
             }
             Err(e) => {
-                probe_lazy!(opendal, next_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, blocking_next_complete_error, c_path.as_ptr());
                 Err(e)
             }
         })
@@ -361,15 +361,15 @@ impl<R: oio::BlockingRead> oio::BlockingRead for DtraceLayerWarpper<R> {
 impl<R: oio::Write> oio::Write for DtraceLayerWarpper<R> {
     fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, poll_write_start, c_path.as_ptr());
+        probe_lazy!(opendal, write_start, c_path.as_ptr());
         self.inner
             .poll_write(cx, bs)
             .map_ok(|n| {
-                probe_lazy!(opendal, poll_write_complete_ok, c_path.as_ptr(), n);
+                probe_lazy!(opendal, write_complete_ok, c_path.as_ptr(), n);
                 n
             })
             .map_err(|err| {
-                probe_lazy!(opendal, poll_write_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, write_complete_error, c_path.as_ptr());
                 err
             })
     }
@@ -390,14 +390,14 @@ impl<R: oio::Write> oio::Write for DtraceLayerWarpper<R> {
 
     fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, poll_close_start, c_path.as_ptr());
+        probe_lazy!(opendal, close_start, c_path.as_ptr());
         self.inner
             .poll_close(cx)
             .map_ok(|_| {
-                probe_lazy!(opendal, poll_close_complete_ok, c_path.as_ptr());
+                probe_lazy!(opendal, close_complete_ok, c_path.as_ptr());
             })
             .map_err(|err| {
-                probe_lazy!(opendal, poll_close_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, close_complete_error, c_path.as_ptr());
                 err
             })
     }
@@ -406,29 +406,29 @@ impl<R: oio::Write> oio::Write for DtraceLayerWarpper<R> {
 impl<R: oio::BlockingWrite> oio::BlockingWrite for DtraceLayerWarpper<R> {
     fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, write_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_write_start, c_path.as_ptr());
         self.inner
             .write(bs)
             .map(|n| {
-                probe_lazy!(opendal, write_complete_ok, c_path.as_ptr(), n);
+                probe_lazy!(opendal, blocking_write_complete_ok, c_path.as_ptr(), n);
                 n
             })
             .map_err(|err| {
-                probe_lazy!(opendal, write_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, blocking_write_complete_error, c_path.as_ptr());
                 err
             })
     }
 
     fn close(&mut self) -> Result<()> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, close_start, c_path.as_ptr());
+        probe_lazy!(opendal, blocking_close_start, c_path.as_ptr());
         self.inner
             .close()
             .map(|_| {
-                probe_lazy!(opendal, close_complete_ok, c_path.as_ptr());
+                probe_lazy!(opendal, blocking_close_complete_ok, c_path.as_ptr());
             })
             .map_err(|err| {
-                probe_lazy!(opendal, close_complete_error, c_path.as_ptr());
+                probe_lazy!(opendal, blocking_close_complete_error, c_path.as_ptr());
                 err
             })
     }

--- a/core/src/layers/mod.rs
+++ b/core/src/layers/mod.rs
@@ -106,6 +106,5 @@ pub use self::async_backtrace::AsyncBacktraceLayer;
 
 #[cfg(all(target_os = "linux", feature = "layers-dtrace"))]
 mod dtrace;
-
 #[cfg(all(target_os = "linux", feature = "layers-dtrace"))]
-pub use self::dtrace::DTraceLayer;
+pub use self::dtrace::DtraceLayer;

--- a/core/src/layers/mod.rs
+++ b/core/src/layers/mod.rs
@@ -103,3 +103,9 @@ pub use self::await_tree::AwaitTreeLayer;
 mod async_backtrace;
 #[cfg(feature = "layers-async-backtrace")]
 pub use self::async_backtrace::AsyncBacktraceLayer;
+
+#[cfg(all(target_os = "linux", feature = "layers-dtrace"))]
+mod dtrace;
+
+#[cfg(all(target_os = "linux", feature = "layers-dtrace"))]
+pub use self::dtrace::DTraceLayer;


### PR DESCRIPTION
**This feature is an experimental feature**

TL;DR;

The PR will make the debug and tracing the opendal process easier in the Linux platform. The people can use so many modern tools like bpftrace to trace the internal state in the process


USDT is a way to allow people to pre-define some static hooks. Those hooks could be used to fetch some internal information when the process runs.

I will use this PR to describe the detailed behavior of the DTrace in the OpenDAL.

When people enabled `layers-dtrace` feature and added the layer to their code like the following code:

```rust
use anyhow::Result;
use opendal::services::Fs;
use opendal::Operator;
use opendal::layers::DTraceLayer;

#[tokio::main]
async fn main() -> Result<()> {
    let mut builder = Fs::default();

    builder.root("/tmp");

    // `Accessor` provides the low level APIs, we will use `Operator` normally.
    let op: Operator = Operator::new(builder)?.layer(DTraceLayer{}).finish();
    
    let path="/tmp/test.txt";
    for _ in 1..100000{
        let bs = vec![0; 64 * 1024 * 1024];
        op.write(path, bs).await?;
        op.read(path).await?;
    }
    Ok(())
}
```

Then we compile the code, and use `readelf -n ${target_binary}` to get the binary detail, we will find some information like following below

```text
Displaying notes found in: .note.stapsdt
  Owner                Data size        Description
  stapsdt              0x00000039       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: create_dir_start
    Location: 0x00000000000f8f05, Base: 0x0000000000000000, Semaphore: 0x00000000003649f8
    Arguments: -8@%rax
  stapsdt              0x00000037       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: create_dir_end
    Location: 0x00000000000f9284, Base: 0x0000000000000000, Semaphore: 0x00000000003649fa
    Arguments: -8@%rax
  stapsdt              0x0000003c       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: blocking_list_start
    Location: 0x00000000000f9487, Base: 0x0000000000000000, Semaphore: 0x0000000000364a28
    Arguments: -8@%rax
  stapsdt              0x0000003a       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: blocking_list_end
    Location: 0x00000000000f9546, Base: 0x0000000000000000, Semaphore: 0x0000000000364a2a
    Arguments: -8@%rax
  stapsdt              0x0000003c       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: blocking_read_start
    Location: 0x00000000000f9740, Base: 0x0000000000000000, Semaphore: 0x0000000000364a18
    Arguments: -8@%rax
  stapsdt              0x0000003a       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: blocking_read_end
    Location: 0x00000000000f97fd, Base: 0x0000000000000000, Semaphore: 0x0000000000364a1a
    Arguments: -8@%rax
  stapsdt              0x0000003c       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: blocking_stat_start
    Location: 0x00000000000f99f3, Base: 0x0000000000000000, Semaphore: 0x0000000000364a20
    Arguments: -8@%rax
  stapsdt              0x0000003a       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: blocking_stat_end
    Location: 0x00000000000f9ab9, Base: 0x0000000000000000, Semaphore: 0x0000000000364a22
    Arguments: -8@%rax
  stapsdt              0x0000003d       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: blocking_write_start
    Location: 0x00000000000f9cec, Base: 0x0000000000000000, Semaphore: 0x0000000000364a1c
    Arguments: -8@%rax
  stapsdt              0x0000003b       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: blocking_write_end
    Location: 0x00000000000f9df2, Base: 0x0000000000000000, Semaphore: 0x0000000000364a1e
    Arguments: -8@%rax
  stapsdt              0x0000003e       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: blocking_delete_start
    Location: 0x00000000000f9fdc, Base: 0x0000000000000000, Semaphore: 0x0000000000364a24
    Arguments: -8@%rax
  stapsdt              0x0000003c       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: blocking_delete_end
    Location: 0x00000000000fa0e6, Base: 0x0000000000000000, Semaphore: 0x0000000000364a26
    Arguments: -8@%rax
  stapsdt              0x00000042       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: blocking_create_dir_start
    Location: 0x00000000000fa250, Base: 0x0000000000000000, Semaphore: 0x0000000000364a14
    Arguments: -8@%rax
  stapsdt              0x00000040       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: blocking_create_dir_end
    Location: 0x00000000000fa30c, Base: 0x0000000000000000, Semaphore: 0x0000000000364a16
    Arguments: -8@%rax
  stapsdt              0x00000033       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: list_start
    Location: 0x00000000000fa869, Base: 0x0000000000000000, Semaphore: 0x0000000000364a0c
    Arguments: -8@%rax
  stapsdt              0x00000031       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: list_end
    Location: 0x00000000000faac7, Base: 0x0000000000000000, Semaphore: 0x0000000000364a0e
    Arguments: -8@%rax
  stapsdt              0x00000033       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: read_start
    Location: 0x00000000000fb0a4, Base: 0x0000000000000000, Semaphore: 0x00000000003649fc
    Arguments: -8@%rax
  stapsdt              0x00000031       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: read_end
    Location: 0x00000000000fb321, Base: 0x0000000000000000, Semaphore: 0x00000000003649fe
    Arguments: -8@%rax
  stapsdt              0x00000033       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: stat_start
    Location: 0x00000000000fb8eb, Base: 0x0000000000000000, Semaphore: 0x0000000000364a04
    Arguments: -8@%rax
  stapsdt              0x00000031       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: stat_end
    Location: 0x00000000000fbb66, Base: 0x0000000000000000, Semaphore: 0x0000000000364a06
    Arguments: -8@%rax
  stapsdt              0x00000034       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: write_start
    Location: 0x00000000000fc6e5, Base: 0x0000000000000000, Semaphore: 0x0000000000364a00
    Arguments: -8@%rax
  stapsdt              0x00000032       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: write_end
    Location: 0x00000000000fc954, Base: 0x0000000000000000, Semaphore: 0x0000000000364a02
    Arguments: -8@%rax
  stapsdt              0x00000035       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: delete_start
    Location: 0x00000000000fcf30, Base: 0x0000000000000000, Semaphore: 0x0000000000364a08
    Arguments: -8@%rax
  stapsdt              0x00000033       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: delete_end
    Location: 0x00000000000fd2aa, Base: 0x0000000000000000, Semaphore: 0x0000000000364a0a
    Arguments: -8@%rax
  stapsdt              0x00000036       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: presign_start
    Location: 0x00000000000fd87b, Base: 0x0000000000000000, Semaphore: 0x0000000000364a10
    Arguments: -8@%rax
  stapsdt              0x00000034       NT_STAPSDT (SystemTap probe descriptors)
    Provider: opendal
    Name: presign_end
    Location: 0x00000000000fdaf6, Base: 0x0000000000000000, Semaphore: 0x0000000000364a12
    Arguments: -8@%rax
```

We describe the offset, the argument of hook, and so many information else in each section of the text. For example, the `write_start` hook, we can find the offset is `0x00000000000fc6e5` and we can use gdb to verify it.

![image](https://github.com/apache/opendal/assets/7054676/ddb18f44-2fd4-47e4-aa8f-685383ffcfa0)

We will figure out the asm in 0x5555556506e5 is `NOP` (the process virtual address started at 0x555555554000 on my machine, and 0x555555554000+0x00000000000fc6e5=0x5555556506e5). The `NOP` instruction code will be replaced by the interrupt code when the hook is attached (In x86_64, the interrupt code is INT3)

We can also set a breakpoint at this address.

![image](https://github.com/apache/opendal/assets/7054676/f02307b9-d164-435a-b631-55ae28641ed4)

We will find the code paused on line 146 in dtrace.rs. This is exactly what we want

The USDT can help us debug it more easily and make it easier to trace it. 

```text
╭─   manjusaka@manjusaka-garuda   ~/Documents/projects/rust-demo                                                               02:14:06  
╰─ sudo bpftrace -e ' 
usdt:/home/manjusaka/Documents/projects/rust-demo/target/debug/demo:opendal:write_start { 
    @start[tid,str(arg0)]=nsecs;
}

usdt:/home/manjusaka/Documents/projects/rust-demo/target/debug/demo:opendal:write_end { 
    printf("Write %s use %d nsecs\n", str(arg0), nsecs - @start[tid,str(arg0)]);
    delete(@start[tid,str(arg0)]);
}' -p 385697      
Attaching 2 probes...
Write tmp/test.txt use 59609 nsecs
Write tmp/test.txt use 56546 nsecs
Write tmp/test.txt use 53352 nsecs
Write tmp/test.txt use 57003 nsecs
Write tmp/test.txt use 58479 nsecs
Write tmp/test.txt use 52876 nsecs
Write tmp/test.txt use 56553 nsecs
Write tmp/test.txt use 59414 nsecs
Write tmp/test.txt use 101736 nsecs
Write tmp/test.txt use 54204 nsecs
Write tmp/test.txt use 63272 nsecs
Write tmp/test.txt use 64367 nsecs
Write tmp/test.txt use 56620 nsecs
Write tmp/test.txt use 56536 nsecs
Write tmp/test.txt use 55383 nsecs
Write tmp/test.txt use 52547 nsecs
Write tmp/test.txt use 50337 nsecs
Write tmp/test.txt use 52908 nsecs
Write tmp/test.txt use 59654 nsecs
Write tmp/test.txt use 64653 nsecs
Write tmp/test.txt use 66440 nsecs
```

We can use many other tools to trace it.






