### PR TITLE
docs(services/sftp): add more explanation for endpoint config

### DIFF
--- a/core/src/services/sftp/docs.md
+++ b/core/src/services/sftp/docs.md
@@ -17,7 +17,7 @@ This service can be used to:
 
 ## Configuration
 
-- `endpoint`: Set the endpoint for connection
+- `endpoint`: Set the endpoint for connection. The format is same as `openssh`, using either `[user@]hostname` or `ssh://[user@]hostname[:port]`. A username or port that is specified in the endpoint overrides the one set in the builder (but does not change the builder).
 - `root`: Set the work directory for backend. It uses the default directory set by the remote `sftp-server` as default
 - `user`: Set the login user
 - `key`: Set the public key for login


### PR DESCRIPTION
close #4043

Update:
- add more explanation for endpoint config
- Since users can set user config in endpoint, we can allow users to ignore the user config