### PR TITLE
fix: Implement timeout layer correctly by using timeout

### DIFF
--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -83,7 +83,7 @@ use crate::*;
 /// a [`std::time::Instant`] and check the timeout by comparing the instant with current time.
 /// However, it doesn't works for all cases.
 ///
-/// For examples, users TCP connection could be in [Busy ESTAB](https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die) state. In this state, no IO event will be omit. The runtime
+/// For examples, users TCP connection could be in [Busy ESTAB](https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die) state. In this state, no IO event will be emit. The runtime
 /// will never poll our future again. From the application side, this future is hanging forever
 /// until this TCP connection is closed for reaching the linux [net.ipv4.tcp_retries2](https://man7.org/linux/man-pages/man7/tcp.7.html) times.
 #[derive(Clone)]

--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -79,7 +79,7 @@ use crate::*;
 /// timeout.
 ///
 /// This might introduce a bit overhead for IO operations, but it's the only way to implement
-/// timeout correctly. We used to implement tiemout layer in zero cost way that only stores
+/// timeout correctly. We used to implement timeout layer in zero cost way that only stores
 /// a [`std::time::Instant`] and check the timeout by comparing the instant with current time.
 /// However, it doesn't works for all cases.
 ///

--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -323,18 +323,18 @@ impl<R: oio::Write> oio::Write for TimeoutWrapper<R> {
         Poll::Ready(v)
     }
 
-    fn poll_abort(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        self.poll_timeout(cx, WriteOperation::Abort.into_static())?;
-
-        let v = ready!(self.inner.poll_abort(cx));
-        self.sleep = None;
-        Poll::Ready(v)
-    }
-
     fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
         self.poll_timeout(cx, WriteOperation::Close.into_static())?;
 
         let v = ready!(self.inner.poll_close(cx));
+        self.sleep = None;
+        Poll::Ready(v)
+    }
+
+    fn poll_abort(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.poll_timeout(cx, WriteOperation::Abort.into_static())?;
+
+        let v = ready!(self.inner.poll_abort(cx));
         self.sleep = None;
         Poll::Ready(v)
     }

--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -55,7 +55,7 @@ use crate::*;
 /// # Examples
 ///
 /// The following examples will create a timeout layer with 10 seconds timeout for all non-io
-/// operations, 3 seconds timeout for all io operations and 2 consecutive io timeouts are allowed.
+/// operations, 3 seconds timeout for all io operations.
 ///
 /// ```
 /// use anyhow::Result;
@@ -67,7 +67,9 @@ use crate::*;
 ///
 /// let _ = Operator::new(services::Memory::default())
 ///     .expect("must init")
-///     .layer(TimeoutLayer::default().with_timeout(Duration::from_secs(10)).with_io_timeout(3))
+///     .layer(TimeoutLayer::default()
+///         .with_timeout(Duration::from_secs(10))
+///         .with_io_timeout(Duration::from_secs(3)))
 ///     .finish();
 /// ```
 #[derive(Clone)]

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -35,7 +35,6 @@ use crate::ErrorKind;
 use crate::Result;
 
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
-const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(60);
 
 /// HttpClient that used across opendal.
 #[derive(Clone)]
@@ -65,8 +64,6 @@ impl HttpClient {
         builder = builder.no_brotli();
         // Make sure we don't enable auto deflate decompress.
         builder = builder.no_deflate();
-        // Make sure we keep tcp alive for 60s to avoid waiting dead connection.
-        builder = builder.tcp_keepalive(DEFAULT_TCP_KEEPALIVE);
         // Make sure we don't wait a connection establishment forever.
         builder = builder.connect_timeout(DEFAULT_CONNECT_TIMEOUT);
 

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -35,6 +35,7 @@ use crate::ErrorKind;
 use crate::Result;
 
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_TCP_KEEPALIVE: Duration = Duration::from_secs(60);
 
 /// HttpClient that used across opendal.
 #[derive(Clone)]
@@ -64,6 +65,8 @@ impl HttpClient {
         builder = builder.no_brotli();
         // Make sure we don't enable auto deflate decompress.
         builder = builder.no_deflate();
+        // Make sure we keep tcp alive for 60s to avoid waiting dead connection.
+        builder = builder.tcp_keepalive(DEFAULT_TCP_KEEPALIVE);
         // Make sure we don't wait a connection establishment forever.
         builder = builder.connect_timeout(DEFAULT_CONNECT_TIMEOUT);
 


### PR DESCRIPTION
TimeoutLayer is using `tokio::time::timeout` to implement timeout for operations. And IO Operations insides `reader`, `writer` will use `Pin<Box<tokio::time::Sleep>>` to track the timeout.

This might introduce a bit overhead for IO operations, but it's the only way to implement timeout correctly. We used to implement timeout layer in zero cost way that only stores a `std::time::Instant` and check the timeout by comparing the instant with current time. However, it doesn't works for all cases.

For examples, users TCP connection could be in [Busy ESTAB](https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die) state. In this state, no IO event will be emit. The runtime will never poll our future again. From the application side, this future is hanging forever until this TCP connection is closed for reaching the linux [net.ipv4.tcp_retries2](https://man7.org/linux/man-pages/man7/tcp.7.html) times.