### PR TITLE
ci(services/s3): Use minio/minio image instead

### DIFF
--- a/.github/scripts/behavior_test/plan.py
+++ b/.github/scripts/behavior_test/plan.py
@@ -94,9 +94,6 @@ def calculate_hint(changed_files: list[str]) -> Hint:
     # Remove all files that ends with `.md`
     changed_files = [f for f in changed_files if not f.endswith(".md")]
 
-    service_pattern = r"core/src/services/([^/]+)/"
-    test_pattern = r".github/services/([^/]+)/"
-
     for p in changed_files:
         # workflow behavior tests affected
         if p == ".github/workflows/behavior_test.yml":
@@ -134,7 +131,7 @@ def calculate_hint(changed_files: list[str]) -> Hint:
                 hint.all_service = True
 
         # core service affected
-        match = re.search(service_pattern, p)
+        match = re.search(r"core/src/services/([^/]+)/", p)
         if match:
             hint.core = True
             for language in LANGUAGE_BINDING:
@@ -142,7 +139,15 @@ def calculate_hint(changed_files: list[str]) -> Hint:
             hint.services.add(match.group(1))
 
         # core test affected
-        match = re.search(test_pattern, p)
+        match = re.search(r".github/services/([^/]+)/", p)
+        if match:
+            hint.core = True
+            for language in LANGUAGE_BINDING:
+                setattr(hint, f"binding_{language}", True)
+            hint.services.add(match.group(1))
+
+        # fixture affected
+        match = re.search(r"fixtures/([^/]+)/", p)
         if match:
             hint.core = True
             for language in LANGUAGE_BINDING:

--- a/fixtures/s3/docker-compose-minio.yml
+++ b/fixtures/s3/docker-compose-minio.yml
@@ -19,7 +19,7 @@ version: '3.8'
 
 services:
   minio:
-    image: wktk/minio-server
+    image: bitnami/minio:2024.1.18
     ports:
       - 9000:9000
     environment:

--- a/fixtures/s3/docker-compose-minio.yml
+++ b/fixtures/s3/docker-compose-minio.yml
@@ -22,13 +22,7 @@ services:
     image: quay.io/minio/minio:RELEASE.2024-01-18T22-51-28Z
     ports:
       - 9000:9000
-    command:
-      - server /data
+    command: server /data
     environment:
-      MINIO_ACCESS_KEY: "minioadmin"
-      MINIO_SECRET_KEY: "minioadmin"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
+      MINIO_ROOT_USER: "minioadmin"
+      MINIO_ROOT_PASSWORD: "minioadmin"

--- a/fixtures/s3/docker-compose-minio.yml
+++ b/fixtures/s3/docker-compose-minio.yml
@@ -19,9 +19,11 @@ version: '3.8'
 
 services:
   minio:
-    image: bitnami/minio:2024.1.18
+    image: quay.io/minio/minio:RELEASE.2024-01-18T22-51-28Z
     ports:
       - 9000:9000
+    command:
+      - server /data
     environment:
       MINIO_ACCESS_KEY: "minioadmin"
       MINIO_SECRET_KEY: "minioadmin"


### PR DESCRIPTION
Old minio has bug that make https://github.com/apache/opendal/pull/4067 CI failure.