### PR TITLE
deps: allow building from source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,16 +1432,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,50 +1755,6 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e366bff8cd32dd8754b0991fb66b279dc48f598c3a18914852a6673deef583"
 dependencies = [
- "quote",
- "syn 2.0.39",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.110"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7129e341034ecb940c9072817cd9007974ea696844fc4dd582dc1653a7fbe2e8"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.110"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a24f3f5f8eed71936f21e570436f024f5c2e25628f7496aa7ccd03b90109d5"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.39",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.110"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fdd177fc61050d63f67f5bd6351fac6ab5526694ea8e359cd9cd3b75857f44"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.110"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587663dd5fb3d10932c8aecfe7c844db1bcf0aee93eeab08fac13dc1212c2e7f"
-dependencies = [
- "proc-macro2",
  "quote",
  "syn 2.0.39",
 ]
@@ -3696,15 +3642,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4049,46 +3986,6 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mlua"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c81f8ac20188feb5461a73eabb22a34dd09d6d58513535eb587e46bff6ba250"
-dependencies = [
- "bstr",
- "mlua-sys",
- "mlua_derive",
- "num-traits",
- "once_cell",
- "rustc-hash",
-]
-
-[[package]]
-name = "mlua-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc29228347d6bdc9e613dc95c69df2817f755434ee0f7f3b27b57755fe238b7f"
-dependencies = [
- "cc",
- "cfg-if",
- "pkg-config",
-]
-
-[[package]]
-name = "mlua_derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f359220f24e6452dd82a3f50d7242d4aab822b5594798048e953d7a9e0314c6"
-dependencies = [
- "itertools 0.11.0",
- "once_cell",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.39",
 ]
 
 [[package]]
@@ -4707,24 +4604,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opendal-cpp"
-version = "0.44.2"
-dependencies = [
- "anyhow",
- "chrono",
- "cxx",
- "cxx-build",
- "opendal",
-]
-
-[[package]]
-name = "opendal-dotnet"
-version = "0.1.0"
-dependencies = [
- "opendal",
-]
-
-[[package]]
 name = "opendal-fuzz"
 version = "0.0.0"
 dependencies = [
@@ -4741,15 +4620,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opendal-hs"
-version = "0.44.2"
-dependencies = [
- "chrono",
- "log",
- "opendal",
-]
-
-[[package]]
 name = "opendal-java"
 version = "0.44.2"
 dependencies = [
@@ -4759,14 +4629,6 @@ dependencies = [
  "once_cell",
  "opendal",
  "tokio",
-]
-
-[[package]]
-name = "opendal-lua"
-version = "0.1.0"
-dependencies = [
- "mlua",
- "opendal",
 ]
 
 [[package]]
@@ -6461,12 +6323,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scratch"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
 
 [[package]]
 name = "sct"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ exclude = [
   "bindings/ocaml",
   "bindings/php",
   "bindings/ruby",
+  "bindings/haskell",
+  "bindings/lua",
+  "bindings/dotnet",
+  "bindings/cpp",
 ]
 members = [
   "core",
@@ -34,10 +38,6 @@ members = [
   "bindings/nodejs",
   "bindings/python",
   "bindings/java",
-  "bindings/haskell",
-  "bindings/lua",
-  "bindings/dotnet",
-  "bindings/cpp",
 
   "bin/oli",
   "bin/oay",


### PR DESCRIPTION
the source released on github doesn't include
several bindings. This removes them from the
Cargo.toml to allow building from source

without this change, building from source results in errors like
```
 > error: failed to load manifest for workspace member `/private/tmp/nix-build-oli-0.44.2.drv-0/source/bindings/haskell`
       >
       > Caused by:
       >   failed to read `/private/tmp/nix-build-oli-0.44.2.drv-0/source/bindings/haskell/Cargo.toml`
       >
```

to give more context, I'm trying to package oli for nixpkgs, this seems like a very useful tool.

thank you for your work on opendal, this looks amazing!