### PR TITLE
chore: Specify opendal version for haskell binding

### DIFF
--- a/bindings/haskell/Cargo.toml
+++ b/bindings/haskell/Cargo.toml
@@ -34,4 +34,4 @@ doc = false
 [dependencies]
 chrono = "0.4"
 log = { version = "0.4", features = ["std"] }
-opendal = { path = "../../core" }
+opendal = { version = "0.44.2", path = "../../core" }


### PR DESCRIPTION
Fix build of haskell package.

Close https://github.com/apache/opendal/issues/4094