### PR TITLE
feat(services/sqlite): Add list capability supported for sqlite

### DIFF
--- a/core/src/services/sqlite/backend.rs
+++ b/core/src/services/sqlite/backend.rs
@@ -354,7 +354,7 @@ impl kv::Adapter for Adapter {
         );
         let mut statement = conn.prepare(&query).map_err(parse_rusqlite_error)?;
         let like_param = format!("{}%", path);
-        let result = statement.query(params![like_param,path]);
+        let result = statement.query(params![like_param, path]);
 
         match result {
             Ok(mut rows) => {

--- a/core/src/services/sqlite/backend.rs
+++ b/core/src/services/sqlite/backend.rs
@@ -263,6 +263,7 @@ impl kv::Adapter for Adapter {
                 write: true,
                 delete: true,
                 blocking: true,
+                list: true,
                 ..Default::default()
             },
         )
@@ -334,6 +335,44 @@ impl kv::Adapter for Adapter {
         let mut statement = conn.prepare(&query).map_err(parse_rusqlite_error)?;
         statement.execute([path]).map_err(parse_rusqlite_error)?;
         Ok(())
+    }
+
+    /// Scan a key prefix to get all keys that start with this key.
+    async fn scan(&self, path: &str) -> Result<Vec<String>> {
+        let this = self.clone();
+        let path = path.to_string();
+
+        task::spawn_blocking(move || this.blocking_scan(&path))
+            .await
+            .map_err(new_task_join_error)?
+    }
+
+    /// Scan a key prefix to get all keys that start with this key
+    /// in blocking way.
+    fn blocking_scan(&self, path: &str) -> Result<Vec<String>> {
+        let conn = self.pool.get().map_err(parse_r2d2_error)?;
+
+        let query = format!(
+            "SELECT {} FROM {} WHERE `{}` like $1",
+            self.key_field, self.table, self.key_field
+        );
+        let mut statement = conn.prepare(&query).map_err(parse_rusqlite_error)?;
+        let param = format!("{}%", path);
+
+        let result = statement.query([param]);
+
+        match result {
+            Ok(mut rows) => {
+                let mut keys: Vec<String> = Vec::new();
+                while let Some(row) = rows.next().map_err(parse_rusqlite_error)? {
+                    let item = row.get(0).map_err(parse_rusqlite_error)?;
+                    keys.push(item);
+                }
+                Ok(keys)
+            }
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(vec![]),
+            Err(err) => Err(parse_rusqlite_error(err)),
+        }
     }
 }
 

--- a/core/src/services/sqlite/backend.rs
+++ b/core/src/services/sqlite/backend.rs
@@ -337,7 +337,6 @@ impl kv::Adapter for Adapter {
         Ok(())
     }
 
-    /// Scan a key prefix to get all keys that start with this key.
     async fn scan(&self, path: &str) -> Result<Vec<String>> {
         let this = self.clone();
         let path = path.to_string();
@@ -347,8 +346,6 @@ impl kv::Adapter for Adapter {
             .map_err(new_task_join_error)?
     }
 
-    /// Scan a key prefix to get all keys that start with this key
-    /// in blocking way.
     fn blocking_scan(&self, path: &str) -> Result<Vec<String>> {
         let conn = self.pool.get().map_err(parse_r2d2_error)?;
 

--- a/core/src/services/sqlite/docs.md
+++ b/core/src/services/sqlite/docs.md
@@ -9,9 +9,7 @@ This service can be used to:
 - [x] delete
 - [ ] copy
 - [ ] rename
-- [ ] ~~list~~
-- [ ] scan
-- [ ] ~~presign~~
+- [x] list
 - [ ] blocking
 
 ## Configuration


### PR DESCRIPTION
I implemented kv adapter scan function for sqlite service, so the sqlite backend supports list capability now.

I have a question about the scan function, don't we need to add a cursor to scan? Like the [redis' scan](https://redis.io/commands/scan/)
