### PR TITLE
ci: reduce the open pull request limits to 1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,50 +19,60 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    open-pull-requests-limit: 1
     schedule:
       interval: "monthly"
 
   - package-ecosystem: "cargo"
     directory: "/core"
+    open-pull-requests-limit: 1
     schedule:
       interval: "monthly"
 
   - package-ecosystem: "cargo"
     directory: "/bin/oay"
+    open-pull-requests-limit: 1
     schedule:
       interval: "monthly"
 
   - package-ecosystem: "cargo"
     directory: "/bin/ofs"
+    open-pull-requests-limit: 1
     schedule:
       interval: "monthly"
 
   - package-ecosystem: "cargo"
     directory: "/bin/oli"
+    open-pull-requests-limit: 1
     schedule:
       interval: "monthly"
 
   - package-ecosystem: "cargo"
     directory: "/integrations/dav-server"
+    open-pull-requests-limit: 1
     schedule:
       interval: "monthly"
 
   - package-ecosystem: "cargo"
     directory: "/integrations/object_store"
+    open-pull-requests-limit: 1
     schedule:
       interval: "monthly"
 
   - package-ecosystem: "cargo"
     directory: "/bindings/java"
+    open-pull-requests-limit: 1
     schedule:
       interval: "monthly"
 
   - package-ecosystem: "cargo"
     directory: "/bindings/nodejs"
+    open-pull-requests-limit: 1
     schedule:
       interval: "monthly"
 
   - package-ecosystem: "cargo"
     directory: "/bindings/python"
+    open-pull-requests-limit: 1
     schedule:
       interval: "monthly"


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit

Might help to reduce the flood of new prs being opened at once