### PR TITLE
Bump to opendal version 0.45.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 * feat(services/azblob): support multi write for azblob by @wcy-fdu in https://github.com/apache/opendal/pull/4181
 * feat(release): Implement releasing OpenDAL components seperately by @Xuanwo in https://github.com/apache/opendal/pull/4196
 * feat: object store adapter based on v0.9 by @waynexia in https://github.com/apache/opendal/pull/4233
+* feat(bin/ofs): implement fuse for linux by @ho-229 in https://github.com/apache/opendal/pull/4179
 ### Changed
 * refactor(bindings/python): simplify async writer aexit by @suyanhanx in https://github.com/apache/opendal/pull/4128
 * refactor(service/d1): Add D1Config by @jihuayu in https://github.com/apache/opendal/pull/4129

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,78 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v0.45.1] - 2024-02-22
+
+### Added
+* feat(services/vercel_blob): support vercel blob by @hoslo in https://github.com/apache/opendal/pull/4103
+* feat(bindings/python): add ruff as linter by @asukaminato0721 in https://github.com/apache/opendal/pull/4135
+* feat(services/hdfs-native): Add capabilities for hdfs-native service by @jihuayu in https://github.com/apache/opendal/pull/4174
+* feat(services/sqlite): Add list capability supported for sqlite by @jihuayu in https://github.com/apache/opendal/pull/4180
+* feat(services/azblob): support multi write for azblob by @wcy-fdu in https://github.com/apache/opendal/pull/4181
+* feat(release): Implement releasing OpenDAL components seperately by @Xuanwo in https://github.com/apache/opendal/pull/4196
+* feat: object store adapter based on v0.9 by @waynexia in https://github.com/apache/opendal/pull/4233
+### Changed
+* refactor(bindings/python): simplify async writer aexit by @suyanhanx in https://github.com/apache/opendal/pull/4128
+* refactor(service/d1): Add D1Config by @jihuayu in https://github.com/apache/opendal/pull/4129
+### Fixed
+* fix: Azdls returns 403 while continuation contains `=` by @Xuanwo in https://github.com/apache/opendal/pull/4105
+* fix(bindings/python): missed to call close for the file internally by @zzl221000 in https://github.com/apache/opendal/pull/4122
+* fix(bindings/python): sync writer exit close raise error by @suyanhanx in https://github.com/apache/opendal/pull/4127
+* fix(services/chainsafe): fix 423 http status by @hoslo in https://github.com/apache/opendal/pull/4148
+* fix(services/webdav): Add possibility to answer without response if file isn't exist by @AJIOB in https://github.com/apache/opendal/pull/4170
+* fix(services/webdav): Recreate root directory if need by @AJIOB in https://github.com/apache/opendal/pull/4173
+* fix(services/webdav): remove base_dir component by @hoslo in https://github.com/apache/opendal/pull/4231
+* fix(core): Poll TimeoutLayer::sleep once to make sure timer registered by @Xuanwo in https://github.com/apache/opendal/pull/4230
+### Docs
+* docs: add request for add secrets of services by @suyanhanx in https://github.com/apache/opendal/pull/4104
+* docs(website): announce release v0.45.0 to news by @morristai in https://github.com/apache/opendal/pull/4152
+* docs(services/gdrive): Update Google Drive capabilities list docs by @jihuayu in https://github.com/apache/opendal/pull/4158
+* docs: Fix docs build by @Xuanwo in https://github.com/apache/opendal/pull/4162
+* docs: add docs for Ceph Rados Gateway S3 by @ZhengLin-Li in https://github.com/apache/opendal/pull/4190
+* docs: Fix typo in `core/src/services/http/docs.md` by @jbampton in https://github.com/apache/opendal/pull/4226
+* docs: Fix spelling in Rust files by @jbampton in https://github.com/apache/opendal/pull/4227
+* docs: fix typo in `website/README.md` by @jbampton in https://github.com/apache/opendal/pull/4228
+* docs: fix spelling by @jbampton in https://github.com/apache/opendal/pull/4229
+* docs: fix spelling; change `github` to `GitHub` by @jbampton in https://github.com/apache/opendal/pull/4232
+* docs: fix typo by @jbampton in https://github.com/apache/opendal/pull/4234
+* docs: fix typo in `bindings/c/CONTRIBUTING.md` by @jbampton in https://github.com/apache/opendal/pull/4235
+* docs: fix spelling in code comments by @jbampton in https://github.com/apache/opendal/pull/4236
+* docs: fix spelling in `CONTRIBUTING` by @jbampton in https://github.com/apache/opendal/pull/4237
+* docs: fix Markdown link in `bindings/README.md` by @jbampton in https://github.com/apache/opendal/pull/4238
+* docs: fix links and spelling in Markdown by @jbampton in https://github.com/apache/opendal/pull/4239
+* docs: fix grammar and spelling in Markdown in `examples/rust` by @jbampton in https://github.com/apache/opendal/pull/4241
+* docs: remove unneeded duplicate words from Rust files by @jbampton in https://github.com/apache/opendal/pull/4243
+### CI
+* ci: Use old version of seafile mc instead by @Xuanwo in https://github.com/apache/opendal/pull/4107
+* ci: Refactor workflows layout by @Xuanwo in https://github.com/apache/opendal/pull/4139
+* ci: Migrate hdfs default setup by @Xuanwo in https://github.com/apache/opendal/pull/4140
+* ci: Refactor check.sh into check.py to get ready for multi components release by @Xuanwo in https://github.com/apache/opendal/pull/4159
+* ci: Add test case for hdfs over gcs bucket by @ArmandoZ in https://github.com/apache/opendal/pull/4145
+* ci: Add hdfs test case for s3 by @ArmandoZ in https://github.com/apache/opendal/pull/4184
+* ci: Add hdfs test case for azurite by @ArmandoZ in https://github.com/apache/opendal/pull/4185
+* ci: Add support for releasing all rust packages by @Xuanwo in https://github.com/apache/opendal/pull/4200
+* ci: Fix dependabot not update by @Xuanwo in https://github.com/apache/opendal/pull/4202
+* ci: reduce the open pull request limits to 1 by @jbampton in https://github.com/apache/opendal/pull/4225
+### Chore
+* chore(deps): bump actions/cache from 3 to 4 by @dependabot in https://github.com/apache/opendal/pull/4118
+* chore(deps): bump toml from 0.8.8 to 0.8.9 by @dependabot in https://github.com/apache/opendal/pull/4109
+* chore(deps): bump dav-server from 0.5.7 to 0.5.8 by @dependabot in https://github.com/apache/opendal/pull/4111
+* chore(deps): bump assert_cmd from 2.0.12 to 2.0.13 by @dependabot in https://github.com/apache/opendal/pull/4112
+* chore(deps): bump actions/setup-dotnet from 3 to 4 by @dependabot in https://github.com/apache/opendal/pull/4115
+* chore(deps): bump mongodb from 2.7.1 to 2.8.0 by @dependabot in https://github.com/apache/opendal/pull/4110
+* chore(deps): bump quick-xml from 0.30.0 to 0.31.0 by @dependabot in https://github.com/apache/opendal/pull/4113
+* chore: Make every components seperate, remove workspace by @Xuanwo in https://github.com/apache/opendal/pull/4134
+* chore: Fix build of core by @Xuanwo in https://github.com/apache/opendal/pull/4137
+* chore: Fix workflow links for opendal by @Xuanwo in https://github.com/apache/opendal/pull/4147
+* chore(website): Bump download link for 0.45.0 release by @morristai in https://github.com/apache/opendal/pull/4149
+* chore: Fix name DtraceLayerWrapper by @jayvdb in https://github.com/apache/opendal/pull/4165
+* chore: Align core version by @Xuanwo in https://github.com/apache/opendal/pull/4197
+* chore: update benchmark doc by @wcy-fdu in https://github.com/apache/opendal/pull/4201
+* chore(deps): bump clap from 4.4.18 to 4.5.1 in /bin/oli by @dependabot in https://github.com/apache/opendal/pull/4221
+* chore(deps): bump serde from 1.0.196 to 1.0.197 in /bin/oay by @dependabot in https://github.com/apache/opendal/pull/4214
+* chore(deps): bump anyhow from 1.0.79 to 1.0.80 in /bin/ofs by @dependabot in https://github.com/apache/opendal/pull/4209
+* chore(deps): bump anyhow from 1.0.79 to 1.0.80 in /bin/oli by @dependabot in https://github.com/apache/opendal/pull/4216
+
 ## [v0.45.0] - 2024-01-29
 
 ### Added
@@ -3377,6 +3449,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 Hello, OpenDAL!
 
+[v0.45.1]: https://github.com/apache/opendal/compare/v0.45.0...v0.45.1
 [v0.45.0]: https://github.com/apache/opendal/compare/v0.44.2...v0.45.0
 [v0.44.2]: https://github.com/apache/opendal/compare/v0.44.1...v0.44.2
 [v0.44.1]: https://github.com/apache/opendal/compare/v0.44.0...v0.44.1

--- a/bin/oay/Cargo.lock
+++ b/bin/oay/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "dav-server-opendalfs"
-version = "0.0.0+core.0.45.0"
+version = "0.0.0+core.0.45.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "oay"
-version = "0.41.0+core.0.45.0"
+version = "0.41.1+core.0.45.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1167,7 +1167,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/oay/Cargo.toml
+++ b/bin/oay/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.67"
-version = "0.41.0+core.0.45.0"
+version = "0.41.1+core.0.45.1"
 
 [features]
 default = ["frontends-webdav", "frontends-s3"]
@@ -51,7 +51,7 @@ dav-server-opendalfs = { version = "0.0.0", path = "../../integrations/dav-serve
 dirs = "5.0.1"
 futures = "0.3"
 futures-util = { version = "0.3.29", optional = true }
-opendal = { version = "0.45.0", path = "../../core" }
+opendal = { version = "0.45.1", path = "../../core" }
 quick-xml = { version = "0.31", features = ["serialize", "overlapped-lists"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1.34", features = [

--- a/bin/oay/DEPENDENCIES.rust.tsv
+++ b/bin/oay/DEPENDENCIES.rust.tsv
@@ -1,51 +1,50 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
 addr2line@0.21.0		X							X					
 adler@1.0.2	X	X							X					
-ahash@0.8.6		X							X					
+ahash@0.8.7		X							X					
 aho-corasick@1.1.2									X				X	
 allocator-api2@0.2.16		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
 anstream@0.6.11		X							X					
-anstyle@1.0.4		X							X					
-anstyle-parse@0.2.2		X							X					
-anstyle-query@1.0.0		X							X					
-anstyle-wincon@3.0.1		X							X					
-anyhow@1.0.75		X							X					
-async-trait@0.1.75		X							X					
+anstyle@1.0.5		X							X					
+anstyle-parse@0.2.3		X							X					
+anstyle-query@1.0.2		X							X					
+anstyle-wincon@3.0.2		X							X					
+anyhow@1.0.80		X							X					
+async-trait@0.1.77		X							X					
 autocfg@1.1.0		X							X					
 axum@0.6.20									X					
 axum-core@0.3.4									X					
 backon@0.4.1		X												
 backtrace@0.3.69		X							X					
-base64@0.21.5		X							X					
+base64@0.21.7		X							X					
 base64ct@1.6.0		X							X					
 bitflags@1.3.2		X							X					
-bitflags@2.4.1		X							X					
+bitflags@2.4.2		X							X					
 block-buffer@0.10.4		X							X					
 bumpalo@3.14.0		X							X					
 byteorder@1.5.0									X				X	
 bytes@1.5.0									X					
 cc@1.0.83		X							X					
 cfg-if@1.0.0		X							X					
-chrono@0.4.31		X							X					
-clap@4.4.18		X							X					
-clap_builder@4.4.18		X							X					
-clap_derive@4.4.7		X							X					
-clap_lex@0.6.0		X							X					
+chrono@0.4.33		X							X					
+clap@4.5.1		X							X					
+clap_builder@4.5.1		X							X					
+clap_lex@0.7.0		X							X					
 colorchoice@1.0.0		X							X					
-const-oid@0.9.5		X							X					
+const-oid@0.9.6		X							X					
 const-random@0.1.17		X							X					
 const-random-macro@0.1.16		X							X					
-core-foundation@0.9.3		X							X					
-core-foundation-sys@0.8.4		X							X					
-cpufeatures@0.2.11		X							X					
+core-foundation@0.9.4		X							X					
+core-foundation-sys@0.8.6		X							X					
+cpufeatures@0.2.12		X							X					
 crunchy@0.2.2									X					
 crypto-common@0.1.6		X							X					
-dav-server@0.5.7		X												
-dav-server-opendalfs@0.45.0		X												
+dav-server@0.5.8		X												
+dav-server-opendalfs@0.0.0+core.0.45.1		X												
 der@0.7.8		X							X					
-deranged@0.3.9		X							X					
+deranged@0.3.11		X							X					
 digest@0.10.7		X							X					
 dirs@5.0.1		X							X					
 dirs-sys@0.4.1		X							X					
@@ -56,123 +55,122 @@ fastrand@1.9.0		X							X
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.29		X							X					
+futures@0.3.30		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
-futures-executor@0.3.29		X							X					
+futures-executor@0.3.30		X							X					
 futures-io@0.3.30		X							X					
 futures-macro@0.3.30		X							X					
 futures-sink@0.3.30		X							X					
 futures-task@0.3.30		X							X					
 futures-util@0.3.30		X							X					
 generic-array@0.14.7									X					
-getrandom@0.2.11		X							X					
-gimli@0.28.0		X							X					
-h2@0.3.22									X					
-hashbrown@0.14.2		X							X					
+getrandom@0.2.12		X							X					
+gimli@0.28.1		X							X					
+h2@0.3.24									X					
+hashbrown@0.14.3		X							X					
 headers@0.3.9									X					
 headers-core@0.2.0									X					
-heck@0.4.1		X							X					
-hermit-abi@0.3.3		X							X					
+hermit-abi@0.3.4		X							X					
 hex@0.4.3		X							X					
 hmac@0.12.1		X							X					
-home@0.5.5		X							X					
+home@0.5.9		X							X					
 htmlescape@0.3.1		X							X	X				
 http@0.2.11		X							X					
-http-body@0.4.5									X					
+http-body@0.4.6									X					
 http-range-header@0.3.1									X					
 httparse@1.8.0		X							X					
 httpdate@1.0.3		X							X					
-hyper@0.14.27									X					
+hyper@0.14.28									X					
 hyper-rustls@0.24.2		X						X	X					
-iana-time-zone@0.1.58		X							X					
+iana-time-zone@0.1.59		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
-indexmap@2.1.0		X							X					
+indexmap@2.2.2		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
-itoa@1.0.9		X							X					
-js-sys@0.3.66		X							X					
+itoa@1.0.10		X							X					
+js-sys@0.3.67		X							X					
 jsonwebtoken@9.2.0									X					
 lazy_static@1.4.0		X							X					
-libc@0.2.151		X							X					
+libc@0.2.153		X							X					
 libm@0.2.8		X							X					
 libredox@0.0.1									X					
 lock_api@0.4.11		X							X					
 log@0.4.20		X							X					
-lru@0.11.1									X					
+lru@0.12.2									X					
 matchers@0.1.0									X					
 matchit@0.7.3					X				X					
 md-5@0.10.6		X							X					
-memchr@2.6.4									X				X	
+memchr@2.7.1									X				X	
 mime@0.3.17		X							X					
 mime_guess@2.0.4									X					
 miniz_oxide@0.7.1		X							X					X
-mio@0.8.9									X					
+mio@0.8.10									X					
 nu-ansi-term@0.46.0									X					
 num-bigint@0.4.4		X							X					
 num-bigint-dig@0.8.4		X							X					
+num-conv@0.1.0		X							X					
 num-integer@0.1.45		X							X					
 num-iter@0.1.43		X							X					
 num-traits@0.2.17		X							X					
 num_cpus@1.16.0		X							X					
-oay@0.45.0		X												
-object@0.32.1		X							X					
+oay@0.41.1+core.0.45.1		X												
+object@0.32.2		X							X					
 once_cell@1.19.0		X							X					
-opendal@0.45.0		X												
+opendal@0.45.1		X												
 openssl-probe@0.1.5		X							X					
 option-ext@0.2.0										X				
-ordered-multimap@0.7.0									X					
+ordered-multimap@0.7.1									X					
 overload@0.1.1									X					
 parking_lot@0.12.1		X							X					
 parking_lot_core@0.9.9		X							X					
-pem@3.0.2									X					
+pem@3.0.3									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.3		X							X					
-pin-project-internal@1.1.3		X							X					
+pin-project@1.1.4		X							X					
+pin-project-internal@1.1.4		X							X					
 pin-project-lite@0.2.13		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.17		X							X					
-proc-macro2@1.0.69		X							X					
-quick-xml@0.30.0									X					
+proc-macro2@1.0.78		X							X					
 quick-xml@0.31.0									X					
-quote@1.0.33		X							X					
+quote@1.0.35		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 redox_syscall@0.4.1									X					
 redox_users@0.4.4									X					
-regex@1.10.2		X							X					
+regex@1.10.3		X							X					
 regex-automata@0.1.10									X				X	
-regex-automata@0.4.3		X							X					
+regex-automata@0.4.5		X							X					
 regex-syntax@0.6.29		X							X					
 regex-syntax@0.8.2		X							X					
-reqsign@0.14.6		X												
-reqwest@0.11.22		X							X					
-ring@0.17.5											X			
-rsa@0.9.4		X							X					
+reqsign@0.14.7		X												
+reqwest@0.11.24		X							X					
+ring@0.17.7											X			
+rsa@0.9.6		X							X					
 rust-ini@0.20.0									X					
 rustc-demangle@0.1.23		X							X					
-rustls@0.21.9		X						X	X					
+rustls@0.21.10		X						X	X					
 rustls-native-certs@0.6.3		X						X	X					
 rustls-pemfile@1.0.4		X						X	X					
 rustls-webpki@0.101.7								X						
 rustversion@1.0.14		X							X					
-ryu@1.0.15		X				X								
-schannel@0.1.22									X					
+ryu@1.0.16		X				X								
+schannel@0.1.23									X					
 scopeguard@1.2.0		X							X					
 sct@0.7.1		X						X	X					
 security-framework@2.9.2		X							X					
 security-framework-sys@2.9.1		X							X					
-serde@1.0.193		X							X					
-serde_derive@1.0.193		X							X					
-serde_json@1.0.108		X							X					
-serde_path_to_error@0.1.14		X							X					
-serde_spanned@0.6.4		X							X					
+serde@1.0.197		X							X					
+serde_derive@1.0.197		X							X					
+serde_json@1.0.113		X							X					
+serde_path_to_error@0.1.15		X							X					
+serde_spanned@0.6.5		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -180,34 +178,33 @@ sharded-slab@0.1.7									X
 signature@2.2.0		X							X					
 simple_asn1@0.6.2								X						
 slab@0.4.9									X					
-smallvec@1.11.2		X							X					
-socket2@0.4.10		X							X					
+smallvec@1.13.1		X							X					
 socket2@0.5.5		X							X					
 spin@0.5.2									X					
 spin@0.9.8									X					
-spki@0.7.2		X							X					
-strsim@0.10.0									X					
+spki@0.7.3		X							X					
+strsim@0.11.0									X					
 subtle@2.5.0					X									
-syn@2.0.39		X							X					
+syn@2.0.48		X							X					
 sync_wrapper@0.1.2		X												
 system-configuration@0.5.1		X							X					
 system-configuration-sys@0.5.0		X							X					
-thiserror@1.0.50		X							X					
-thiserror-impl@1.0.50		X							X					
+thiserror@1.0.56		X							X					
+thiserror-impl@1.0.56		X							X					
 thread_local@1.1.7		X							X					
-time@0.3.30		X							X					
+time@0.3.32		X							X					
 time-core@0.1.2		X							X					
-time-macros@0.2.15		X							X					
+time-macros@0.2.17		X							X					
 tiny-keccak@2.0.2							X							
 tinyvec@1.6.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.34.0									X					
+tokio@1.36.0									X					
 tokio-macros@2.2.0									X					
 tokio-rustls@0.24.1		X							X					
 tokio-util@0.7.10									X					
-toml@0.8.8		X							X					
+toml@0.8.10		X							X					
 toml_datetime@0.6.5		X							X					
-toml_edit@0.21.0		X							X					
+toml_edit@0.22.6		X							X					
 tower@0.4.13									X					
 tower-http@0.4.4									X					
 tower-layer@0.3.2									X					
@@ -217,44 +214,53 @@ tracing-attributes@0.1.27									X
 tracing-core@0.1.32									X					
 tracing-log@0.2.0									X					
 tracing-subscriber@0.3.18									X					
-try-lock@0.2.4									X					
+try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
 unicase@2.7.0		X							X					
-unicode-bidi@0.3.13		X							X					
+unicode-bidi@0.3.15		X							X					
 unicode-ident@1.0.12		X							X			X		
 unicode-normalization@0.1.22		X							X					
 untrusted@0.9.0								X						
 url@2.5.0		X							X					
 utf8parse@0.2.1		X							X					
-uuid@1.6.1		X							X					
+uuid@1.7.0		X							X					
 valuable@0.1.0									X					
 version_check@0.9.4		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.89		X							X					
-wasm-bindgen-backend@0.2.89		X							X					
-wasm-bindgen-futures@0.4.39		X							X					
-wasm-bindgen-macro@0.2.89		X							X					
-wasm-bindgen-macro-support@0.2.89		X							X					
-wasm-bindgen-shared@0.2.89		X							X					
-wasm-streams@0.3.0		X							X					
-web-sys@0.3.65		X							X					
+wasm-bindgen@0.2.90		X							X					
+wasm-bindgen-backend@0.2.90		X							X					
+wasm-bindgen-futures@0.4.40		X							X					
+wasm-bindgen-macro@0.2.90		X							X					
+wasm-bindgen-macro-support@0.2.90		X							X					
+wasm-bindgen-shared@0.2.90		X							X					
+wasm-streams@0.4.0		X							X					
+web-sys@0.3.67		X							X					
 winapi@0.3.9		X							X					
 winapi-i686-pc-windows-gnu@0.4.0		X							X					
 winapi-x86_64-pc-windows-gnu@0.4.0		X							X					
-windows-core@0.51.1		X							X					
+windows-core@0.52.0		X							X					
 windows-sys@0.48.0		X							X					
+windows-sys@0.52.0		X							X					
 windows-targets@0.48.5		X							X					
+windows-targets@0.52.0		X							X					
 windows_aarch64_gnullvm@0.48.5		X							X					
+windows_aarch64_gnullvm@0.52.0		X							X					
 windows_aarch64_msvc@0.48.5		X							X					
+windows_aarch64_msvc@0.52.0		X							X					
 windows_i686_gnu@0.48.5		X							X					
+windows_i686_gnu@0.52.0		X							X					
 windows_i686_msvc@0.48.5		X							X					
+windows_i686_msvc@0.52.0		X							X					
 windows_x86_64_gnu@0.48.5		X							X					
+windows_x86_64_gnu@0.52.0		X							X					
 windows_x86_64_gnullvm@0.48.5		X							X					
+windows_x86_64_gnullvm@0.52.0		X							X					
 windows_x86_64_msvc@0.48.5		X							X					
-winnow@0.5.19									X					
+windows_x86_64_msvc@0.52.0		X							X					
+winnow@0.6.2									X					
 winreg@0.50.0									X					
 xml-rs@0.8.19									X					
 xmltree@0.10.3									X					
-zerocopy@0.7.26		X		X					X					
+zerocopy@0.7.32		X		X					X					
 zeroize@1.7.0		X							X					

--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "ofs"
-version = "0.0.1+core.0.45.0"
+version = "0.0.2+core.0.45.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1047,7 +1047,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/ofs/Cargo.toml
+++ b/bin/ofs/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["filesystem"]
 description = "OpenDAL File System"
 keywords = ["storage", "data", "s3", "fs", "azblob"]
 name = "ofs"
-version = "0.0.1+core.0.45.0"
+version = "0.0.2+core.0.45.1"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -39,7 +39,7 @@ futures-util = "0.3.30"
 libc = "0.2.151"
 log = "0.4.20"
 nix = { version = "0.27.1", features = ["user"] }
-opendal = { version = "0.45.0", path = "../../core" }
+opendal = { version = "0.45.1", path = "../../core" }
 tokio = { version = "1.34", features = [
   "fs",
   "macros",

--- a/bin/ofs/DEPENDENCIES.rust.tsv
+++ b/bin/ofs/DEPENDENCIES.rust.tsv
@@ -5,182 +5,180 @@ aho-corasick@1.1.2								X			X
 android-tzdata@0.1.1		X						X				
 android_system_properties@0.1.5		X						X				
 anstream@0.6.11		X						X				
-anstyle@1.0.4		X						X				
-anstyle-parse@0.2.2		X						X				
-anstyle-query@1.0.0		X						X				
-anstyle-wincon@3.0.1		X						X				
-anyhow@1.0.75		X						X				
-async-trait@0.1.75		X						X				
+anstyle@1.0.5		X						X				
+anstyle-parse@0.2.3		X						X				
+anstyle-query@1.0.2		X						X				
+anstyle-wincon@3.0.2		X						X				
+anyhow@1.0.80		X						X				
+async-trait@0.1.77		X						X				
 autocfg@1.1.0		X						X				
 backon@0.4.1		X										
 backtrace@0.3.69		X						X				
-base64@0.21.5		X						X				
+base64@0.21.7		X						X				
 base64ct@1.6.0		X						X				
 bincode@1.3.3								X				
 bitflags@1.3.2		X						X				
-bitflags@2.4.1		X						X				
+bitflags@2.4.2		X						X				
 block-buffer@0.10.4		X						X				
 bumpalo@3.14.0		X						X				
 byteorder@1.5.0								X			X	
 bytes@1.5.0								X				
 cc@1.0.83		X						X				
 cfg-if@1.0.0		X						X				
-chrono@0.4.31		X						X				
-clap@4.4.18		X						X				
-clap_builder@4.4.18		X						X				
-clap_derive@4.4.7		X						X				
-clap_lex@0.6.0		X						X				
+chrono@0.4.33		X						X				
+clap@4.5.1		X						X				
+clap_builder@4.5.1		X						X				
+clap_derive@4.5.0		X						X				
+clap_lex@0.7.0		X						X				
 colorchoice@1.0.0		X						X				
-const-oid@0.9.5		X						X				
+const-oid@0.9.6		X						X				
 const-random@0.1.17		X						X				
 const-random-macro@0.1.16		X						X				
-core-foundation@0.9.3		X						X				
-core-foundation-sys@0.8.4		X						X				
-cpufeatures@0.2.11		X						X				
+core-foundation@0.9.4		X						X				
+core-foundation-sys@0.8.6		X						X				
+cpufeatures@0.2.12		X						X				
 crunchy@0.2.2								X				
 crypto-common@0.1.6		X						X				
 cstr@0.2.11								X				
 der@0.7.8		X						X				
-deranged@0.3.9		X						X				
+deranged@0.3.11		X						X				
 digest@0.10.7		X						X				
 dlv-list@0.5.2		X						X				
 either@1.9.0		X						X				
 encoding_rs@0.8.33		X		X				X				
-env_logger@0.10.1		X						X				
+env_filter@0.1.0		X						X				
+env_logger@0.11.1		X						X				
 equivalent@1.0.1		X						X				
 fastrand@1.9.0		X						X				
 flagset@0.4.4		X										
 fnv@1.0.7		X						X				
 form_urlencoded@1.2.1		X						X				
 fuse3@0.6.1								X				
-futures@0.3.29		X						X				
+futures@0.3.30		X						X				
 futures-channel@0.3.30		X						X				
 futures-core@0.3.30		X						X				
-futures-executor@0.3.29		X						X				
 futures-io@0.3.30		X						X				
 futures-macro@0.3.30		X						X				
 futures-sink@0.3.30		X						X				
 futures-task@0.3.30		X						X				
 futures-util@0.3.30		X						X				
 generic-array@0.14.7								X				
-getrandom@0.2.11		X						X				
-gimli@0.28.0		X						X				
-h2@0.3.22								X				
-hashbrown@0.14.2		X						X				
+getrandom@0.2.12		X						X				
+gimli@0.28.1		X						X				
+h2@0.3.24								X				
+hashbrown@0.14.3		X						X				
 heck@0.4.1		X						X				
-hermit-abi@0.3.3		X						X				
+hermit-abi@0.3.4		X						X				
 hex@0.4.3		X						X				
 hmac@0.12.1		X						X				
-home@0.5.5		X						X				
+home@0.5.9		X						X				
 http@0.2.11		X						X				
-http-body@0.4.5								X				
+http-body@0.4.6								X				
 httparse@1.8.0		X						X				
 httpdate@1.0.3		X						X				
 humantime@2.1.0		X						X				
-hyper@0.14.27								X				
+hyper@0.14.28								X				
 hyper-rustls@0.24.2		X					X	X				
-iana-time-zone@0.1.58		X						X				
+iana-time-zone@0.1.59		X						X				
 iana-time-zone-haiku@0.1.2		X						X				
 idna@0.5.0		X						X				
-indexmap@2.1.0		X						X				
+indexmap@2.2.2		X						X				
 instant@0.1.12				X								
 ipnet@2.9.0		X						X				
-is-terminal@0.4.9								X				
-itoa@1.0.9		X						X				
-js-sys@0.3.66		X						X				
+itoa@1.0.10		X						X				
+js-sys@0.3.67		X						X				
 jsonwebtoken@9.2.0								X				
 lazy_static@1.4.0		X						X				
-libc@0.2.151		X						X				
+libc@0.2.153		X						X				
 libm@0.2.8		X						X				
-linux-raw-sys@0.4.11		X	X					X				
+linux-raw-sys@0.4.13		X	X					X				
 log@0.4.20		X						X				
 md-5@0.10.6		X						X				
-memchr@2.6.4								X			X	
+memchr@2.7.1								X			X	
 memoffset@0.7.1								X				
 mime@0.3.17		X						X				
 miniz_oxide@0.7.1		X						X				X
-mio@0.8.9								X				
+mio@0.8.10								X				
 nix@0.26.4								X				
 nix@0.27.1								X				
 num-bigint@0.4.4		X						X				
 num-bigint-dig@0.8.4		X						X				
+num-conv@0.1.0		X						X				
 num-integer@0.1.45		X						X				
 num-iter@0.1.43		X						X				
 num-traits@0.2.17		X						X				
 num_cpus@1.16.0		X						X				
-object@0.32.1		X						X				
-ofs@0.0.1		X										
+object@0.32.2		X						X				
+ofs@0.0.2+core.0.45.1		X										
 once_cell@1.19.0		X						X				
-opendal@0.45.0		X										
+opendal@0.45.1		X										
 openssl-probe@0.1.5		X						X				
-ordered-multimap@0.7.0								X				
-pem@3.0.2								X				
+ordered-multimap@0.7.1								X				
+pem@3.0.3								X				
 pem-rfc7468@0.7.0		X						X				
 percent-encoding@2.3.1		X						X				
-pin-project@1.1.3		X						X				
-pin-project-internal@1.1.3		X						X				
+pin-project@1.1.4		X						X				
+pin-project-internal@1.1.4		X						X				
 pin-project-lite@0.2.13		X						X				
 pin-utils@0.1.0		X						X				
 pkcs1@0.7.5		X						X				
 pkcs8@0.10.2		X						X				
 powerfmt@0.2.0		X						X				
 ppv-lite86@0.2.17		X						X				
-proc-macro2@1.0.69		X						X				
-quick-xml@0.30.0								X				
+proc-macro2@1.0.78		X						X				
 quick-xml@0.31.0								X				
-quote@1.0.33		X						X				
+quote@1.0.35		X						X				
 rand@0.8.5		X						X				
 rand_chacha@0.3.1		X						X				
 rand_core@0.6.4		X						X				
-regex@1.10.2		X						X				
-regex-automata@0.4.3		X						X				
+regex@1.10.3		X						X				
+regex-automata@0.4.5		X						X				
 regex-syntax@0.8.2		X						X				
-reqsign@0.14.6		X										
-reqwest@0.11.22		X						X				
-ring@0.17.5									X			
-rsa@0.9.4		X						X				
+reqsign@0.14.7		X										
+reqwest@0.11.24		X						X				
+ring@0.17.7									X			
+rsa@0.9.6		X						X				
 rust-ini@0.20.0								X				
 rustc-demangle@0.1.23		X						X				
-rustix@0.38.25		X	X					X				
-rustls@0.21.9		X					X	X				
+rustix@0.38.31		X	X					X				
+rustls@0.21.10		X					X	X				
 rustls-native-certs@0.6.3		X					X	X				
 rustls-pemfile@1.0.4		X					X	X				
 rustls-webpki@0.101.7							X					
-ryu@1.0.15		X			X							
-schannel@0.1.22								X				
+ryu@1.0.16		X			X							
+schannel@0.1.23								X				
 sct@0.7.1		X					X	X				
 security-framework@2.9.2		X						X				
 security-framework-sys@2.9.1		X						X				
-serde@1.0.193		X						X				
-serde_derive@1.0.193		X						X				
-serde_json@1.0.108		X						X				
+serde@1.0.196		X						X				
+serde_derive@1.0.196		X						X				
+serde_json@1.0.113		X						X				
 serde_urlencoded@0.7.1		X						X				
 sha1@0.10.6		X						X				
 sha2@0.10.8		X						X				
 signature@2.2.0		X						X				
 simple_asn1@0.6.2							X					
 slab@0.4.9								X				
-smallvec@1.11.2		X						X				
-socket2@0.4.10		X						X				
+smallvec@1.13.1		X						X				
 socket2@0.5.5		X						X				
 spin@0.5.2								X				
 spin@0.9.8								X				
-spki@0.7.2		X						X				
-strsim@0.10.0								X				
+spki@0.7.3		X						X				
+strsim@0.11.0								X				
 subtle@2.5.0				X								
-syn@2.0.39		X						X				
+syn@2.0.48		X						X				
+sync_wrapper@0.1.2		X										
 system-configuration@0.5.1		X						X				
 system-configuration-sys@0.5.0		X						X				
-termcolor@1.4.0								X			X	
-thiserror@1.0.50		X						X				
-thiserror-impl@1.0.50		X						X				
-time@0.3.30		X						X				
+thiserror@1.0.56		X						X				
+thiserror-impl@1.0.56		X						X				
+time@0.3.32		X						X				
 time-core@0.1.2		X						X				
-time-macros@0.2.15		X						X				
+time-macros@0.2.17		X						X				
 tiny-keccak@2.0.2						X						
 tinyvec@1.6.0		X						X				X
 tinyvec_macros@0.1.1		X						X				X
-tokio@1.34.0								X				
+tokio@1.36.0								X				
 tokio-macros@2.2.0								X				
 tokio-rustls@0.24.1		X						X				
 tokio-util@0.7.10								X				
@@ -188,41 +186,45 @@ tower-service@0.3.2								X
 tracing@0.1.40								X				
 tracing-attributes@0.1.27								X				
 tracing-core@0.1.32								X				
-try-lock@0.2.4								X				
+try-lock@0.2.5								X				
 typenum@1.17.0		X						X				
-unicode-bidi@0.3.13		X						X				
+unicode-bidi@0.3.15		X						X				
 unicode-ident@1.0.12		X						X		X		
 unicode-normalization@0.1.22		X						X				
 untrusted@0.9.0							X					
 url@2.5.0		X						X				
 utf8parse@0.2.1		X						X				
-uuid@1.6.1		X						X				
-valuable@0.1.0								X				
+uuid@1.7.0		X						X				
 version_check@0.9.4		X						X				
 want@0.3.1								X				
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X				
-wasm-bindgen@0.2.89		X						X				
-wasm-bindgen-backend@0.2.89		X						X				
-wasm-bindgen-futures@0.4.39		X						X				
-wasm-bindgen-macro@0.2.89		X						X				
-wasm-bindgen-macro-support@0.2.89		X						X				
-wasm-bindgen-shared@0.2.89		X						X				
-wasm-streams@0.3.0		X						X				
-web-sys@0.3.65		X						X				
+wasm-bindgen@0.2.90		X						X				
+wasm-bindgen-backend@0.2.90		X						X				
+wasm-bindgen-futures@0.4.40		X						X				
+wasm-bindgen-macro@0.2.90		X						X				
+wasm-bindgen-macro-support@0.2.90		X						X				
+wasm-bindgen-shared@0.2.90		X						X				
+wasm-streams@0.4.0		X						X				
+web-sys@0.3.67		X						X				
 which@4.4.2								X				
-winapi@0.3.9		X						X				
-winapi-i686-pc-windows-gnu@0.4.0		X						X				
-winapi-util@0.1.6								X			X	
-winapi-x86_64-pc-windows-gnu@0.4.0		X						X				
-windows-core@0.51.1		X						X				
+windows-core@0.52.0		X						X				
 windows-sys@0.48.0		X						X				
+windows-sys@0.52.0		X						X				
 windows-targets@0.48.5		X						X				
+windows-targets@0.52.0		X						X				
 windows_aarch64_gnullvm@0.48.5		X						X				
+windows_aarch64_gnullvm@0.52.0		X						X				
 windows_aarch64_msvc@0.48.5		X						X				
+windows_aarch64_msvc@0.52.0		X						X				
 windows_i686_gnu@0.48.5		X						X				
+windows_i686_gnu@0.52.0		X						X				
 windows_i686_msvc@0.48.5		X						X				
+windows_i686_msvc@0.52.0		X						X				
 windows_x86_64_gnu@0.48.5		X						X				
+windows_x86_64_gnu@0.52.0		X						X				
 windows_x86_64_gnullvm@0.48.5		X						X				
+windows_x86_64_gnullvm@0.52.0		X						X				
 windows_x86_64_msvc@0.48.5		X						X				
+windows_x86_64_msvc@0.52.0		X						X				
 winreg@0.50.0								X				
 zeroize@1.7.0		X						X				

--- a/bin/oli/Cargo.lock
+++ b/bin/oli/Cargo.lock
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "oli"
-version = "0.41.0+core.0.45.0"
+version = "0.41.1+core.0.45.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1879,7 +1879,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "async-tls",

--- a/bin/oli/Cargo.toml
+++ b/bin/oli/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.67"
-version = "0.41.0+core.0.45.0"
+version = "0.41.1+core.0.45.1"
 
 [features]
 # Enable services dashmap support
@@ -60,7 +60,7 @@ dirs = "5.0.1"
 env_logger = "0.11"
 futures = "0.3"
 log = "0.4"
-opendal = { version = "0.45.0", path = "../../core" }
+opendal = { version = "0.45.1", path = "../../core" }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1.34", features = [
   "fs",

--- a/bin/oli/DEPENDENCIES.rust.tsv
+++ b/bin/oli/DEPENDENCIES.rust.tsv
@@ -5,226 +5,225 @@ aho-corasick@1.1.2								X				X
 android-tzdata@0.1.1		X						X					
 android_system_properties@0.1.5		X						X					
 anstream@0.6.11		X						X					
-anstyle@1.0.4		X						X					
-anstyle-parse@0.2.2		X						X					
-anstyle-query@1.0.0		X						X					
-anstyle-wincon@3.0.1		X						X					
-anyhow@1.0.75		X						X					
-async-trait@0.1.75		X						X					
+anstyle@1.0.5		X						X					
+anstyle-parse@0.2.3		X						X					
+anstyle-query@1.0.2		X						X					
+anstyle-wincon@3.0.2		X						X					
+anyhow@1.0.80		X						X					
+async-trait@0.1.77		X						X					
 autocfg@1.1.0		X						X					
 backon@0.4.1		X											
 backtrace@0.3.69		X						X					
-base64@0.21.5		X						X					
+base64@0.21.7		X						X					
 base64ct@1.6.0		X						X					
 bitflags@1.3.2		X						X					
-bitflags@2.4.1		X						X					
+bitflags@2.4.2		X						X					
 block-buffer@0.10.4		X						X					
 bumpalo@3.14.0		X						X					
 byteorder@1.5.0								X				X	
 bytes@1.5.0								X					
 cc@1.0.83		X						X					
 cfg-if@1.0.0		X						X					
-chrono@0.4.31		X						X					
-clap@4.4.18		X						X					
-clap_builder@4.4.18		X						X					
-clap_derive@4.4.7		X						X					
-clap_lex@0.6.0		X						X					
+chrono@0.4.33		X						X					
+clap@4.5.1		X						X					
+clap_builder@4.5.1		X						X					
+clap_lex@0.7.0		X						X					
 colorchoice@1.0.0		X						X					
-const-oid@0.9.5		X						X					
+const-oid@0.9.6		X						X					
 const-random@0.1.17		X						X					
 const-random-macro@0.1.16		X						X					
-core-foundation@0.9.3		X						X					
-core-foundation-sys@0.8.4		X						X					
-cpufeatures@0.2.11		X						X					
+core-foundation@0.9.4		X						X					
+core-foundation-sys@0.8.6		X						X					
+cpufeatures@0.2.12		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.8		X						X					
-deranged@0.3.9		X						X					
+deranged@0.3.11		X						X					
 digest@0.10.7		X						X					
 dirs@5.0.1		X						X					
 dirs-sys@0.4.1		X						X					
 dlv-list@0.5.2		X						X					
 encoding_rs@0.8.33		X		X				X					
-env_logger@0.10.1		X						X					
+env_filter@0.1.0		X						X					
+env_logger@0.11.1		X						X					
 equivalent@1.0.1		X						X					
 fastrand@1.9.0		X						X					
 flagset@0.4.4		X											
 fnv@1.0.7		X						X					
 form_urlencoded@1.2.1		X						X					
-futures@0.3.29		X						X					
+futures@0.3.30		X						X					
 futures-channel@0.3.30		X						X					
 futures-core@0.3.30		X						X					
-futures-executor@0.3.29		X						X					
+futures-executor@0.3.30		X						X					
 futures-io@0.3.30		X						X					
 futures-macro@0.3.30		X						X					
 futures-sink@0.3.30		X						X					
 futures-task@0.3.30		X						X					
 futures-util@0.3.30		X						X					
 generic-array@0.14.7								X					
-getrandom@0.2.11		X						X					
-gimli@0.28.0		X						X					
-h2@0.3.22								X					
-hashbrown@0.14.2		X						X					
-heck@0.4.1		X						X					
-hermit-abi@0.3.3		X						X					
+getrandom@0.2.12		X						X					
+gimli@0.28.1		X						X					
+h2@0.3.24								X					
+hashbrown@0.14.3		X						X					
+hermit-abi@0.3.4		X						X					
 hex@0.4.3		X						X					
 hmac@0.12.1		X						X					
-home@0.5.5		X						X					
+home@0.5.9		X						X					
 http@0.2.11		X						X					
-http-body@0.4.5								X					
+http-body@0.4.6								X					
 httparse@1.8.0		X						X					
 httpdate@1.0.3		X						X					
 humantime@2.1.0		X						X					
-hyper@0.14.27								X					
+hyper@0.14.28								X					
 hyper-rustls@0.24.2		X					X	X					
-iana-time-zone@0.1.58		X						X					
+iana-time-zone@0.1.59		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
-indexmap@2.1.0		X						X					
+indexmap@2.2.2		X						X					
 instant@0.1.12				X									
 ipnet@2.9.0		X						X					
-is-terminal@0.4.9								X					
-itoa@1.0.9		X						X					
-js-sys@0.3.66		X						X					
+itoa@1.0.10		X						X					
+js-sys@0.3.67		X						X					
 jsonwebtoken@9.2.0								X					
 lazy_static@1.4.0		X						X					
-libc@0.2.151		X						X					
+libc@0.2.153		X						X					
 libm@0.2.8		X						X					
 libredox@0.0.1								X					
-linux-raw-sys@0.4.11		X	X					X					
 log@0.4.20		X						X					
 md-5@0.10.6		X						X					
-memchr@2.6.4								X				X	
+memchr@2.7.1								X				X	
 mime@0.3.17		X						X					
 miniz_oxide@0.7.1		X						X					X
-mio@0.8.9								X					
+mio@0.8.10								X					
 num-bigint@0.4.4		X						X					
 num-bigint-dig@0.8.4		X						X					
+num-conv@0.1.0		X						X					
 num-integer@0.1.45		X						X					
 num-iter@0.1.43		X						X					
 num-traits@0.2.17		X						X					
 num_cpus@1.16.0		X						X					
-object@0.32.1		X						X					
-oli@0.45.0		X											
+object@0.32.2		X						X					
+oli@0.41.1+core.0.45.1		X											
 once_cell@1.19.0		X						X					
-opendal@0.45.0		X											
+opendal@0.45.1		X											
 openssl-probe@0.1.5		X						X					
 option-ext@0.2.0									X				
-ordered-multimap@0.7.0								X					
-pem@3.0.2								X					
+ordered-multimap@0.7.1								X					
+pem@3.0.3								X					
 pem-rfc7468@0.7.0		X						X					
 percent-encoding@2.3.1		X						X					
-pin-project@1.1.3		X						X					
-pin-project-internal@1.1.3		X						X					
+pin-project@1.1.4		X						X					
+pin-project-internal@1.1.4		X						X					
 pin-project-lite@0.2.13		X						X					
 pin-utils@0.1.0		X						X					
 pkcs1@0.7.5		X						X					
 pkcs8@0.10.2		X						X					
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.69		X						X					
-quick-xml@0.30.0								X					
+proc-macro2@1.0.78		X						X					
 quick-xml@0.31.0								X					
-quote@1.0.33		X						X					
+quote@1.0.35		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
 redox_syscall@0.4.1								X					
 redox_users@0.4.4								X					
-regex@1.10.2		X						X					
-regex-automata@0.4.3		X						X					
+regex@1.10.3		X						X					
+regex-automata@0.4.5		X						X					
 regex-syntax@0.8.2		X						X					
-reqsign@0.14.6		X											
-reqwest@0.11.22		X						X					
-ring@0.17.5										X			
-rsa@0.9.4		X						X					
+reqsign@0.14.7		X											
+reqwest@0.11.24		X						X					
+ring@0.17.7										X			
+rsa@0.9.6		X						X					
 rust-ini@0.20.0								X					
 rustc-demangle@0.1.23		X						X					
-rustix@0.38.25		X	X					X					
-rustls@0.21.9		X					X	X					
+rustls@0.21.10		X					X	X					
 rustls-native-certs@0.6.3		X					X	X					
 rustls-pemfile@1.0.4		X					X	X					
 rustls-webpki@0.101.7							X						
-ryu@1.0.15		X			X								
-schannel@0.1.22								X					
+ryu@1.0.16		X			X								
+schannel@0.1.23								X					
 sct@0.7.1		X					X	X					
 security-framework@2.9.2		X						X					
 security-framework-sys@2.9.1		X						X					
-serde@1.0.193		X						X					
-serde_derive@1.0.193		X						X					
-serde_json@1.0.108		X						X					
-serde_spanned@0.6.4		X						X					
+serde@1.0.197		X						X					
+serde_derive@1.0.197		X						X					
+serde_json@1.0.113		X						X					
+serde_spanned@0.6.5		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
 signature@2.2.0		X						X					
 simple_asn1@0.6.2							X						
 slab@0.4.9								X					
-smallvec@1.11.2		X						X					
-socket2@0.4.10		X						X					
+smallvec@1.13.1		X						X					
 socket2@0.5.5		X						X					
 spin@0.5.2								X					
 spin@0.9.8								X					
-spki@0.7.2		X						X					
-strsim@0.10.0								X					
+spki@0.7.3		X						X					
+strsim@0.11.0								X					
 subtle@2.5.0				X									
-syn@2.0.39		X						X					
+syn@2.0.48		X						X					
+sync_wrapper@0.1.2		X											
 system-configuration@0.5.1		X						X					
 system-configuration-sys@0.5.0		X						X					
-termcolor@1.4.0								X				X	
-thiserror@1.0.50		X						X					
-thiserror-impl@1.0.50		X						X					
-time@0.3.30		X						X					
+thiserror@1.0.56		X						X					
+thiserror-impl@1.0.56		X						X					
+time@0.3.32		X						X					
 time-core@0.1.2		X						X					
-time-macros@0.2.15		X						X					
+time-macros@0.2.17		X						X					
 tiny-keccak@2.0.2						X							
 tinyvec@1.6.0		X						X					X
 tinyvec_macros@0.1.1		X						X					X
-tokio@1.34.0								X					
+tokio@1.36.0								X					
 tokio-macros@2.2.0								X					
 tokio-rustls@0.24.1		X						X					
 tokio-util@0.7.10								X					
-toml@0.8.8		X						X					
+toml@0.8.10		X						X					
 toml_datetime@0.6.5		X						X					
-toml_edit@0.21.0		X						X					
+toml_edit@0.22.6		X						X					
 tower-service@0.3.2								X					
 tracing@0.1.40								X					
 tracing-core@0.1.32								X					
-try-lock@0.2.4								X					
+try-lock@0.2.5								X					
 typenum@1.17.0		X						X					
-unicode-bidi@0.3.13		X						X					
+unicode-bidi@0.3.15		X						X					
 unicode-ident@1.0.12		X						X			X		
 unicode-normalization@0.1.22		X						X					
 untrusted@0.9.0							X						
 url@2.5.0		X						X					
 utf8parse@0.2.1		X						X					
-uuid@1.6.1		X						X					
-valuable@0.1.0								X					
+uuid@1.7.0		X						X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
-wasm-bindgen@0.2.89		X						X					
-wasm-bindgen-backend@0.2.89		X						X					
-wasm-bindgen-futures@0.4.39		X						X					
-wasm-bindgen-macro@0.2.89		X						X					
-wasm-bindgen-macro-support@0.2.89		X						X					
-wasm-bindgen-shared@0.2.89		X						X					
-wasm-streams@0.3.0		X						X					
-web-sys@0.3.65		X						X					
-winapi@0.3.9		X						X					
-winapi-i686-pc-windows-gnu@0.4.0		X						X					
-winapi-util@0.1.6								X				X	
-winapi-x86_64-pc-windows-gnu@0.4.0		X						X					
-windows-core@0.51.1		X						X					
+wasm-bindgen@0.2.90		X						X					
+wasm-bindgen-backend@0.2.90		X						X					
+wasm-bindgen-futures@0.4.40		X						X					
+wasm-bindgen-macro@0.2.90		X						X					
+wasm-bindgen-macro-support@0.2.90		X						X					
+wasm-bindgen-shared@0.2.90		X						X					
+wasm-streams@0.4.0		X						X					
+web-sys@0.3.67		X						X					
+windows-core@0.52.0		X						X					
 windows-sys@0.48.0		X						X					
+windows-sys@0.52.0		X						X					
 windows-targets@0.48.5		X						X					
+windows-targets@0.52.0		X						X					
 windows_aarch64_gnullvm@0.48.5		X						X					
+windows_aarch64_gnullvm@0.52.0		X						X					
 windows_aarch64_msvc@0.48.5		X						X					
+windows_aarch64_msvc@0.52.0		X						X					
 windows_i686_gnu@0.48.5		X						X					
+windows_i686_gnu@0.52.0		X						X					
 windows_i686_msvc@0.48.5		X						X					
+windows_i686_msvc@0.52.0		X						X					
 windows_x86_64_gnu@0.48.5		X						X					
+windows_x86_64_gnu@0.52.0		X						X					
 windows_x86_64_gnullvm@0.48.5		X						X					
+windows_x86_64_gnullvm@0.52.0		X						X					
 windows_x86_64_msvc@0.48.5		X						X					
-winnow@0.5.19								X					
+windows_x86_64_msvc@0.52.0		X						X					
+winnow@0.6.2								X					
 winreg@0.50.0								X					
 zeroize@1.7.0		X						X					

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.67"
-version = "0.44.2+core.0.45.0"
+version = "0.44.3+core.0.45.1"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -20,7 +20,7 @@ bytes@1.5.0								X
 cbindgen@0.26.0									X				
 cc@1.0.83		X						X					
 cfg-if@1.0.0		X						X					
-chrono@0.4.32		X						X					
+chrono@0.4.33		X						X					
 clap@3.2.25		X						X					
 clap_lex@0.2.4		X						X					
 const-oid@0.9.6		X						X					
@@ -68,44 +68,45 @@ httparse@1.8.0		X						X
 httpdate@1.0.3		X						X					
 hyper@0.14.28								X					
 hyper-rustls@0.24.2		X					X	X					
-iana-time-zone@0.1.59		X						X					
+iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
 indexmap@1.9.3		X						X					
-indexmap@2.1.0		X						X					
+indexmap@2.2.2		X						X					
 instant@0.1.12				X									
 ipnet@2.9.0		X						X					
 itoa@1.0.10		X						X					
 js-sys@0.3.67		X						X					
 jsonwebtoken@9.2.0								X					
 lazy_static@1.4.0		X						X					
-libc@0.2.152		X						X					
+libc@0.2.153		X						X					
 libm@0.2.8		X						X					
 linux-raw-sys@0.4.13		X	X					X					
 log@0.4.20		X						X					
 md-5@0.10.6		X						X					
 memchr@2.7.1								X				X	
 mime@0.3.17		X						X					
-miniz_oxide@0.7.1		X						X					X
+miniz_oxide@0.7.2		X						X					X
 mio@0.8.10								X					
 num-bigint@0.4.4		X						X					
 num-bigint-dig@0.8.4		X						X					
+num-conv@0.1.0		X						X					
 num-integer@0.1.45		X						X					
 num-iter@0.1.43		X						X					
 num-traits@0.2.17		X						X					
 num_cpus@1.16.0		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.45.0		X											
-opendal-c@0.44.2		X											
+opendal@0.45.1		X											
+opendal-c@0.44.3+core.0.45.1		X											
 openssl-probe@0.1.5		X						X					
 ordered-multimap@0.7.1								X					
 os_str_bytes@6.6.1		X						X					
 pem@3.0.3								X					
 pem-rfc7468@0.7.0		X						X					
 percent-encoding@2.3.1		X						X					
-pin-project@1.1.3		X						X					
-pin-project-internal@1.1.3		X						X					
+pin-project@1.1.4		X						X					
+pin-project-internal@1.1.4		X						X					
 pin-project-lite@0.2.13		X						X					
 pin-utils@0.1.0		X						X					
 pkcs1@0.7.5		X						X					
@@ -113,20 +114,19 @@ pkcs8@0.10.2		X						X
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.17		X						X					
 proc-macro2@1.0.78		X						X					
-quick-xml@0.30.0								X					
 quick-xml@0.31.0								X					
 quote@1.0.35		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
 redox_syscall@0.4.1								X					
-reqsign@0.14.6		X											
-reqwest@0.11.23		X						X					
+reqsign@0.14.7		X											
+reqwest@0.11.24		X						X					
 ring@0.17.7										X			
 rsa@0.9.6		X						X					
 rust-ini@0.20.0								X					
 rustc-demangle@0.1.23		X						X					
-rustix@0.38.30		X	X					X					
+rustix@0.38.31		X	X					X					
 rustls@0.21.10		X					X	X					
 rustls-native-certs@0.6.3		X					X	X					
 rustls-pemfile@1.0.4		X					X	X					
@@ -136,9 +136,9 @@ schannel@0.1.23								X
 sct@0.7.1		X					X	X					
 security-framework@2.9.2		X						X					
 security-framework-sys@2.9.1		X						X					
-serde@1.0.195		X						X					
-serde_derive@1.0.195		X						X					
-serde_json@1.0.111		X						X					
+serde@1.0.196		X						X					
+serde_derive@1.0.196		X						X					
+serde_json@1.0.113		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -154,6 +154,7 @@ strsim@0.10.0								X
 subtle@2.5.0				X									
 syn@1.0.109		X						X					
 syn@2.0.48		X						X					
+sync_wrapper@0.1.2		X											
 system-configuration@0.5.1		X						X					
 system-configuration-sys@0.5.0		X						X					
 tempfile@3.9.0		X						X					
@@ -161,13 +162,13 @@ termcolor@1.4.1								X				X
 textwrap@0.16.0								X					
 thiserror@1.0.56		X						X					
 thiserror-impl@1.0.56		X						X					
-time@0.3.31		X						X					
+time@0.3.34		X						X					
 time-core@0.1.2		X						X					
-time-macros@0.2.16		X						X					
+time-macros@0.2.17		X						X					
 tiny-keccak@2.0.2						X							
 tinyvec@1.6.0		X						X					X
 tinyvec_macros@0.1.1		X						X					X
-tokio@1.35.1								X					
+tokio@1.36.0								X					
 tokio-macros@2.2.0								X					
 tokio-rustls@0.24.1		X						X					
 tokio-util@0.7.10								X					
@@ -192,7 +193,7 @@ wasm-bindgen-futures@0.4.40		X						X
 wasm-bindgen-macro@0.2.90		X						X					
 wasm-bindgen-macro-support@0.2.90		X						X					
 wasm-bindgen-shared@0.2.90		X						X					
-wasm-streams@0.3.0		X						X					
+wasm-streams@0.4.0		X						X					
 web-sys@0.3.67		X						X					
 winapi@0.3.9		X						X					
 winapi-i686-pc-windows-gnu@0.4.0		X						X					

--- a/bindings/cpp/Cargo.toml
+++ b/bindings/cpp/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.67"
-version = "0.44.2+core.0.45.0"
+version = "0.44.3+core.0.45.1"
 
 [lib]
 crate-type = ["staticlib"]
@@ -34,7 +34,7 @@ crate-type = ["staticlib"]
 anyhow = "1.0"
 chrono = "0.4"
 cxx = "1.0"
-opendal = { version = "0.45.0", path = "../../core" }
+opendal = { version = "0.45.1", path = "../../core" }
 
 [build-dependencies]
 cxx-build = "1.0"

--- a/bindings/cpp/DEPENDENCIES.rust.tsv
+++ b/bindings/cpp/DEPENDENCIES.rust.tsv
@@ -63,34 +63,35 @@ httparse@1.8.0		X						X
 httpdate@1.0.3		X						X				
 hyper@0.14.28								X				
 hyper-rustls@0.24.2		X					X	X				
-iana-time-zone@0.1.59		X						X				
+iana-time-zone@0.1.60		X						X				
 iana-time-zone-haiku@0.1.2		X						X				
 idna@0.5.0		X						X				
-indexmap@2.1.0		X						X				
+indexmap@2.2.2		X						X				
 instant@0.1.12				X								
 ipnet@2.9.0		X						X				
 itoa@1.0.10		X						X				
 js-sys@0.3.67		X						X				
 jsonwebtoken@9.2.0								X				
 lazy_static@1.4.0		X						X				
-libc@0.2.152		X						X				
+libc@0.2.153		X						X				
 libm@0.2.8		X						X				
 link-cplusplus@1.0.9		X						X				
 log@0.4.20		X						X				
 md-5@0.10.6		X						X				
 memchr@2.7.1								X			X	
 mime@0.3.17		X						X				
-miniz_oxide@0.7.1		X						X				X
+miniz_oxide@0.7.2		X						X				X
 mio@0.8.10								X				
 num-bigint@0.4.4		X						X				
 num-bigint-dig@0.8.4		X						X				
+num-conv@0.1.0		X						X				
 num-integer@0.1.45		X						X				
 num-iter@0.1.43		X						X				
 num-traits@0.2.17		X						X				
 object@0.32.2		X						X				
 once_cell@1.19.0		X						X				
-opendal@0.45.0		X										
-opendal-cpp@0.44.2		X										
+opendal@0.45.1		X										
+opendal-cpp@0.44.3+core.0.45.1		X										
 openssl-probe@0.1.5		X						X				
 ordered-multimap@0.7.1								X				
 pem@3.0.3								X				
@@ -105,14 +106,13 @@ pkcs8@0.10.2		X						X
 powerfmt@0.2.0		X						X				
 ppv-lite86@0.2.17		X						X				
 proc-macro2@1.0.78		X						X				
-quick-xml@0.30.0								X				
 quick-xml@0.31.0								X				
 quote@1.0.35		X						X				
 rand@0.8.5		X						X				
 rand_chacha@0.3.1		X						X				
 rand_core@0.6.4		X						X				
-reqsign@0.14.6		X										
-reqwest@0.11.23		X						X				
+reqsign@0.14.7		X										
+reqwest@0.11.24		X						X				
 ring@0.17.7									X			
 rsa@0.9.6		X						X				
 rust-ini@0.20.0								X				
@@ -129,7 +129,7 @@ security-framework@2.9.2		X						X
 security-framework-sys@2.9.1		X						X				
 serde@1.0.196		X						X				
 serde_derive@1.0.196		X						X				
-serde_json@1.0.112		X						X				
+serde_json@1.0.113		X						X				
 serde_urlencoded@0.7.1		X						X				
 sha1@0.10.6		X						X				
 sha2@0.10.8		X						X				
@@ -143,18 +143,19 @@ spin@0.9.8								X
 spki@0.7.3		X						X				
 subtle@2.5.0				X								
 syn@2.0.48		X						X				
+sync_wrapper@0.1.2		X										
 system-configuration@0.5.1		X						X				
 system-configuration-sys@0.5.0		X						X				
 termcolor@1.4.1								X			X	
 thiserror@1.0.56		X						X				
 thiserror-impl@1.0.56		X						X				
-time@0.3.31		X						X				
+time@0.3.34		X						X				
 time-core@0.1.2		X						X				
-time-macros@0.2.16		X						X				
+time-macros@0.2.17		X						X				
 tiny-keccak@2.0.2						X						
 tinyvec@1.6.0		X						X				X
 tinyvec_macros@0.1.1		X						X				X
-tokio@1.35.1								X				
+tokio@1.36.0								X				
 tokio-rustls@0.24.1		X						X				
 tokio-util@0.7.10								X				
 tower-service@0.3.2								X				
@@ -178,7 +179,7 @@ wasm-bindgen-futures@0.4.40		X						X
 wasm-bindgen-macro@0.2.90		X						X				
 wasm-bindgen-macro-support@0.2.90		X						X				
 wasm-bindgen-shared@0.2.90		X						X				
-wasm-streams@0.3.0		X						X				
+wasm-streams@0.4.0		X						X				
 web-sys@0.3.67		X						X				
 winapi@0.3.9		X						X				
 winapi-i686-pc-windows-gnu@0.4.0		X						X				

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-dotnet"
 publish = false
-version = "0.1.0+core.0.45.0"
+version = "0.1.1+core.0.45.1"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -32,4 +32,4 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
-opendal = { version = "0.45.0", path = "../../core" }
+opendal = { version = "0.45.1", path = "../../core" }

--- a/bindings/dotnet/DEPENDENCIES.rust.tsv
+++ b/bindings/dotnet/DEPENDENCIES.rust.tsv
@@ -58,33 +58,34 @@ httparse@1.8.0		X						X
 httpdate@1.0.3		X						X				
 hyper@0.14.28								X				
 hyper-rustls@0.24.2		X					X	X				
-iana-time-zone@0.1.59		X						X				
+iana-time-zone@0.1.60		X						X				
 iana-time-zone-haiku@0.1.2		X						X				
 idna@0.5.0		X						X				
-indexmap@2.1.0		X						X				
+indexmap@2.2.2		X						X				
 instant@0.1.12				X								
 ipnet@2.9.0		X						X				
 itoa@1.0.10		X						X				
 js-sys@0.3.67		X						X				
 jsonwebtoken@9.2.0								X				
 lazy_static@1.4.0		X						X				
-libc@0.2.152		X						X				
+libc@0.2.153		X						X				
 libm@0.2.8		X						X				
 log@0.4.20		X						X				
 md-5@0.10.6		X						X				
 memchr@2.7.1								X			X	
 mime@0.3.17		X						X				
-miniz_oxide@0.7.1		X						X				X
+miniz_oxide@0.7.2		X						X				X
 mio@0.8.10								X				
 num-bigint@0.4.4		X						X				
 num-bigint-dig@0.8.4		X						X				
+num-conv@0.1.0		X						X				
 num-integer@0.1.45		X						X				
 num-iter@0.1.43		X						X				
 num-traits@0.2.17		X						X				
 object@0.32.2		X						X				
 once_cell@1.19.0		X						X				
-opendal@0.45.0		X										
-opendal-dotnet@0.1.0		X										
+opendal@0.45.1		X										
+opendal-dotnet@0.1.1+core.0.45.1		X										
 openssl-probe@0.1.5		X						X				
 ordered-multimap@0.7.1								X				
 pem@3.0.3								X				
@@ -99,14 +100,13 @@ pkcs8@0.10.2		X						X
 powerfmt@0.2.0		X						X				
 ppv-lite86@0.2.17		X						X				
 proc-macro2@1.0.78		X						X				
-quick-xml@0.30.0								X				
 quick-xml@0.31.0								X				
 quote@1.0.35		X						X				
 rand@0.8.5		X						X				
 rand_chacha@0.3.1		X						X				
 rand_core@0.6.4		X						X				
-reqsign@0.14.6		X										
-reqwest@0.11.23		X						X				
+reqsign@0.14.7		X										
+reqwest@0.11.24		X						X				
 ring@0.17.7									X			
 rsa@0.9.6		X						X				
 rust-ini@0.20.0								X				
@@ -122,7 +122,7 @@ security-framework@2.9.2		X						X
 security-framework-sys@2.9.1		X						X				
 serde@1.0.196		X						X				
 serde_derive@1.0.196		X						X				
-serde_json@1.0.112		X						X				
+serde_json@1.0.113		X						X				
 serde_urlencoded@0.7.1		X						X				
 sha1@0.10.6		X						X				
 sha2@0.10.8		X						X				
@@ -136,17 +136,18 @@ spin@0.9.8								X
 spki@0.7.3		X						X				
 subtle@2.5.0				X								
 syn@2.0.48		X						X				
+sync_wrapper@0.1.2		X										
 system-configuration@0.5.1		X						X				
 system-configuration-sys@0.5.0		X						X				
 thiserror@1.0.56		X						X				
 thiserror-impl@1.0.56		X						X				
-time@0.3.31		X						X				
+time@0.3.34		X						X				
 time-core@0.1.2		X						X				
-time-macros@0.2.16		X						X				
+time-macros@0.2.17		X						X				
 tiny-keccak@2.0.2						X						
 tinyvec@1.6.0		X						X				X
 tinyvec_macros@0.1.1		X						X				X
-tokio@1.35.1								X				
+tokio@1.36.0								X				
 tokio-rustls@0.24.1		X						X				
 tokio-util@0.7.10								X				
 tower-service@0.3.2								X				
@@ -169,7 +170,7 @@ wasm-bindgen-futures@0.4.40		X						X
 wasm-bindgen-macro@0.2.90		X						X				
 wasm-bindgen-macro-support@0.2.90		X						X				
 wasm-bindgen-shared@0.2.90		X						X				
-wasm-streams@0.3.0		X						X				
+wasm-streams@0.4.0		X						X				
 web-sys@0.3.67		X						X				
 windows-core@0.52.0		X						X				
 windows-sys@0.48.0		X						X				

--- a/bindings/haskell/Cargo.toml
+++ b/bindings/haskell/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.67"
-version = "0.44.2+core.0.45.0"
+version = "0.44.3+core.0.45.1"
 
 [lib]
 crate-type = ["cdylib"]
@@ -34,4 +34,4 @@ doc = false
 [dependencies]
 chrono = "0.4"
 log = { version = "0.4", features = ["std"] }
-opendal = { version = "0.45.0", path = "../../core" }
+opendal = { version = "0.45.1", path = "../../core" }

--- a/bindings/haskell/DEPENDENCIES.rust.tsv
+++ b/bindings/haskell/DEPENDENCIES.rust.tsv
@@ -1,0 +1,195 @@
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
+addr2line@0.21.0		X						X				
+adler@1.0.2	X	X						X				
+android-tzdata@0.1.1		X						X				
+android_system_properties@0.1.5		X						X				
+anyhow@1.0.79		X						X				
+async-trait@0.1.77		X						X				
+autocfg@1.1.0		X						X				
+backon@0.4.1		X										
+backtrace@0.3.69		X						X				
+base64@0.21.7		X						X				
+base64ct@1.6.0		X						X				
+bitflags@1.3.2		X						X				
+block-buffer@0.10.4		X						X				
+bumpalo@3.14.0		X						X				
+byteorder@1.5.0								X			X	
+bytes@1.5.0								X				
+cc@1.0.83		X						X				
+cfg-if@1.0.0		X						X				
+chrono@0.4.33		X						X				
+const-oid@0.9.6		X						X				
+const-random@0.1.17		X						X				
+const-random-macro@0.1.16		X						X				
+core-foundation@0.9.4		X						X				
+core-foundation-sys@0.8.6		X						X				
+cpufeatures@0.2.12		X						X				
+crunchy@0.2.2								X				
+crypto-common@0.1.6		X						X				
+der@0.7.8		X						X				
+deranged@0.3.11		X						X				
+digest@0.10.7		X						X				
+dlv-list@0.5.2		X						X				
+encoding_rs@0.8.33		X		X				X				
+equivalent@1.0.1		X						X				
+fastrand@1.9.0		X						X				
+flagset@0.4.4		X										
+fnv@1.0.7		X						X				
+form_urlencoded@1.2.1		X						X				
+futures@0.3.30		X						X				
+futures-channel@0.3.30		X						X				
+futures-core@0.3.30		X						X				
+futures-io@0.3.30		X						X				
+futures-macro@0.3.30		X						X				
+futures-sink@0.3.30		X						X				
+futures-task@0.3.30		X						X				
+futures-util@0.3.30		X						X				
+generic-array@0.14.7								X				
+getrandom@0.2.12		X						X				
+gimli@0.28.1		X						X				
+h2@0.3.24								X				
+hashbrown@0.14.3		X						X				
+hex@0.4.3		X						X				
+hmac@0.12.1		X						X				
+home@0.5.9		X						X				
+http@0.2.11		X						X				
+http-body@0.4.6								X				
+httparse@1.8.0		X						X				
+httpdate@1.0.3		X						X				
+hyper@0.14.28								X				
+hyper-rustls@0.24.2		X					X	X				
+iana-time-zone@0.1.60		X						X				
+iana-time-zone-haiku@0.1.2		X						X				
+idna@0.5.0		X						X				
+indexmap@2.2.2		X						X				
+instant@0.1.12				X								
+ipnet@2.9.0		X						X				
+itoa@1.0.10		X						X				
+js-sys@0.3.67		X						X				
+jsonwebtoken@9.2.0								X				
+lazy_static@1.4.0		X						X				
+libc@0.2.153		X						X				
+libm@0.2.8		X						X				
+log@0.4.20		X						X				
+md-5@0.10.6		X						X				
+memchr@2.7.1								X			X	
+mime@0.3.17		X						X				
+miniz_oxide@0.7.2		X						X				X
+mio@0.8.10								X				
+num-bigint@0.4.4		X						X				
+num-bigint-dig@0.8.4		X						X				
+num-conv@0.1.0		X						X				
+num-integer@0.1.45		X						X				
+num-iter@0.1.43		X						X				
+num-traits@0.2.17		X						X				
+object@0.32.2		X						X				
+once_cell@1.19.0		X						X				
+opendal@0.45.1		X										
+opendal-hs@0.44.3+core.0.45.1		X										
+openssl-probe@0.1.5		X						X				
+ordered-multimap@0.7.1								X				
+pem@3.0.3								X				
+pem-rfc7468@0.7.0		X						X				
+percent-encoding@2.3.1		X						X				
+pin-project@1.1.4		X						X				
+pin-project-internal@1.1.4		X						X				
+pin-project-lite@0.2.13		X						X				
+pin-utils@0.1.0		X						X				
+pkcs1@0.7.5		X						X				
+pkcs8@0.10.2		X						X				
+powerfmt@0.2.0		X						X				
+ppv-lite86@0.2.17		X						X				
+proc-macro2@1.0.78		X						X				
+quick-xml@0.31.0								X				
+quote@1.0.35		X						X				
+rand@0.8.5		X						X				
+rand_chacha@0.3.1		X						X				
+rand_core@0.6.4		X						X				
+reqsign@0.14.7		X										
+reqwest@0.11.24		X						X				
+ring@0.17.7									X			
+rsa@0.9.6		X						X				
+rust-ini@0.20.0								X				
+rustc-demangle@0.1.23		X						X				
+rustls@0.21.10		X					X	X				
+rustls-native-certs@0.6.3		X					X	X				
+rustls-pemfile@1.0.4		X					X	X				
+rustls-webpki@0.101.7							X					
+ryu@1.0.16		X			X							
+schannel@0.1.23								X				
+sct@0.7.1		X					X	X				
+security-framework@2.9.2		X						X				
+security-framework-sys@2.9.1		X						X				
+serde@1.0.196		X						X				
+serde_derive@1.0.196		X						X				
+serde_json@1.0.113		X						X				
+serde_urlencoded@0.7.1		X						X				
+sha1@0.10.6		X						X				
+sha2@0.10.8		X						X				
+signature@2.2.0		X						X				
+simple_asn1@0.6.2							X					
+slab@0.4.9								X				
+smallvec@1.13.1		X						X				
+socket2@0.5.5		X						X				
+spin@0.5.2								X				
+spin@0.9.8								X				
+spki@0.7.3		X						X				
+subtle@2.5.0				X								
+syn@2.0.48		X						X				
+sync_wrapper@0.1.2		X										
+system-configuration@0.5.1		X						X				
+system-configuration-sys@0.5.0		X						X				
+thiserror@1.0.56		X						X				
+thiserror-impl@1.0.56		X						X				
+time@0.3.34		X						X				
+time-core@0.1.2		X						X				
+time-macros@0.2.17		X						X				
+tiny-keccak@2.0.2						X						
+tinyvec@1.6.0		X						X				X
+tinyvec_macros@0.1.1		X						X				X
+tokio@1.36.0								X				
+tokio-rustls@0.24.1		X						X				
+tokio-util@0.7.10								X				
+tower-service@0.3.2								X				
+tracing@0.1.40								X				
+tracing-core@0.1.32								X				
+try-lock@0.2.5								X				
+typenum@1.17.0		X						X				
+unicode-bidi@0.3.15		X						X				
+unicode-ident@1.0.12		X						X		X		
+unicode-normalization@0.1.22		X						X				
+untrusted@0.9.0							X					
+url@2.5.0		X						X				
+uuid@1.7.0		X						X				
+version_check@0.9.4		X						X				
+want@0.3.1								X				
+wasi@0.11.0+wasi-snapshot-preview1		X	X					X				
+wasm-bindgen@0.2.90		X						X				
+wasm-bindgen-backend@0.2.90		X						X				
+wasm-bindgen-futures@0.4.40		X						X				
+wasm-bindgen-macro@0.2.90		X						X				
+wasm-bindgen-macro-support@0.2.90		X						X				
+wasm-bindgen-shared@0.2.90		X						X				
+wasm-streams@0.4.0		X						X				
+web-sys@0.3.67		X						X				
+windows-core@0.52.0		X						X				
+windows-sys@0.48.0		X						X				
+windows-sys@0.52.0		X						X				
+windows-targets@0.48.5		X						X				
+windows-targets@0.52.0		X						X				
+windows_aarch64_gnullvm@0.48.5		X						X				
+windows_aarch64_gnullvm@0.52.0		X						X				
+windows_aarch64_msvc@0.48.5		X						X				
+windows_aarch64_msvc@0.52.0		X						X				
+windows_i686_gnu@0.48.5		X						X				
+windows_i686_gnu@0.52.0		X						X				
+windows_i686_msvc@0.48.5		X						X				
+windows_i686_msvc@0.52.0		X						X				
+windows_x86_64_gnu@0.48.5		X						X				
+windows_x86_64_gnu@0.52.0		X						X				
+windows_x86_64_gnullvm@0.48.5		X						X				
+windows_x86_64_gnullvm@0.52.0		X						X				
+windows_x86_64_msvc@0.48.5		X						X				
+windows_x86_64_msvc@0.52.0		X						X				
+winreg@0.50.0								X				
+zeroize@1.7.0		X						X				

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.67"
-version = "0.45.0+core.0.45.0"
+version = "0.45.1+core.0.45.1"
 
 [lib]
 crate-type = ["cdylib"]
@@ -51,7 +51,6 @@ default = [
 
 services-all = [
   "default",
-
   "services-cacache",
   "services-chainsafe",
   "services-dashmap",
@@ -156,7 +155,7 @@ anyhow = "1.0.71"
 jni = "0.21.1"
 num_cpus = "1.15.0"
 once_cell = "1.19.0"
-opendal = { version = "0.45.0", path = "../../core", features = [
+opendal = { version = "0.45.1", path = "../../core", features = [
   "layers-blocking",
 ] }
 tokio = { version = "1.28.1", features = ["full"] }

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -3,12 +3,12 @@ addr2line@0.21.0		X						X
 adler@1.0.2	X	X						X				
 android-tzdata@0.1.1		X						X				
 android_system_properties@0.1.5		X						X				
-anyhow@1.0.75		X						X				
-async-trait@0.1.75		X						X				
+anyhow@1.0.79		X						X				
+async-trait@0.1.77		X						X				
 autocfg@1.1.0		X						X				
 backon@0.4.1		X										
 backtrace@0.3.69		X						X				
-base64@0.21.5		X						X				
+base64@0.21.7		X						X				
 base64ct@1.6.0		X						X				
 bitflags@1.3.2		X						X				
 block-buffer@0.10.4		X						X				
@@ -18,18 +18,18 @@ bytes@1.5.0								X
 cc@1.0.83		X						X				
 cesu8@1.1.0		X						X				
 cfg-if@1.0.0		X						X				
-chrono@0.4.31		X						X				
+chrono@0.4.33		X						X				
 combine@4.6.6								X				
-const-oid@0.9.5		X						X				
+const-oid@0.9.6		X						X				
 const-random@0.1.17		X						X				
 const-random-macro@0.1.16		X						X				
-core-foundation@0.9.3		X						X				
-core-foundation-sys@0.8.4		X						X				
-cpufeatures@0.2.11		X						X				
+core-foundation@0.9.4		X						X				
+core-foundation-sys@0.8.6		X						X				
+cpufeatures@0.2.12		X						X				
 crunchy@0.2.2								X				
 crypto-common@0.1.6		X						X				
 der@0.7.8		X						X				
-deranged@0.3.9		X						X				
+deranged@0.3.11		X						X				
 digest@0.10.7		X						X				
 dlv-list@0.5.2		X						X				
 encoding_rs@0.8.33		X		X				X				
@@ -38,104 +38,103 @@ fastrand@1.9.0		X						X
 flagset@0.4.4		X										
 fnv@1.0.7		X						X				
 form_urlencoded@1.2.1		X						X				
-futures@0.3.29		X						X				
+futures@0.3.30		X						X				
 futures-channel@0.3.30		X						X				
 futures-core@0.3.30		X						X				
-futures-executor@0.3.29		X						X				
 futures-io@0.3.30		X						X				
 futures-macro@0.3.30		X						X				
 futures-sink@0.3.30		X						X				
 futures-task@0.3.30		X						X				
 futures-util@0.3.30		X						X				
 generic-array@0.14.7								X				
-getrandom@0.2.11		X						X				
-gimli@0.28.0		X						X				
-h2@0.3.22								X				
-hashbrown@0.14.2		X						X				
-hermit-abi@0.3.3		X						X				
+getrandom@0.2.12		X						X				
+gimli@0.28.1		X						X				
+h2@0.3.24								X				
+hashbrown@0.14.3		X						X				
+hermit-abi@0.3.4		X						X				
 hex@0.4.3		X						X				
 hmac@0.12.1		X						X				
-home@0.5.5		X						X				
+home@0.5.9		X						X				
 http@0.2.11		X						X				
-http-body@0.4.5								X				
+http-body@0.4.6								X				
 httparse@1.8.0		X						X				
 httpdate@1.0.3		X						X				
-hyper@0.14.27								X				
+hyper@0.14.28								X				
 hyper-rustls@0.24.2		X					X	X				
-iana-time-zone@0.1.58		X						X				
+iana-time-zone@0.1.59		X						X				
 iana-time-zone-haiku@0.1.2		X						X				
 idna@0.5.0		X						X				
-indexmap@2.1.0		X						X				
+indexmap@2.2.2		X						X				
 instant@0.1.12				X								
 ipnet@2.9.0		X						X				
-itoa@1.0.9		X						X				
+itoa@1.0.10		X						X				
 jni@0.21.1		X						X				
 jni-sys@0.3.0		X						X				
-js-sys@0.3.66		X						X				
+js-sys@0.3.67		X						X				
 jsonwebtoken@9.2.0								X				
 lazy_static@1.4.0		X						X				
-libc@0.2.151		X						X				
+libc@0.2.153		X						X				
 libm@0.2.8		X						X				
 lock_api@0.4.11		X						X				
 log@0.4.20		X						X				
 md-5@0.10.6		X						X				
-memchr@2.6.4								X			X	
+memchr@2.7.1								X			X	
 mime@0.3.17		X						X				
 miniz_oxide@0.7.1		X						X				X
-mio@0.8.9								X				
+mio@0.8.10								X				
 num-bigint@0.4.4		X						X				
 num-bigint-dig@0.8.4		X						X				
+num-conv@0.1.0		X						X				
 num-integer@0.1.45		X						X				
 num-iter@0.1.43		X						X				
 num-traits@0.2.17		X						X				
 num_cpus@1.16.0		X						X				
-object@0.32.1		X						X				
+object@0.32.2		X						X				
 once_cell@1.19.0		X						X				
-opendal@0.45.0		X										
-opendal-java@0.45.0		X										
+opendal@0.45.1		X										
+opendal-java@0.45.1+core.0.45.1		X										
 openssl-probe@0.1.5		X						X				
-ordered-multimap@0.7.0								X				
+ordered-multimap@0.7.1								X				
 parking_lot@0.12.1		X						X				
 parking_lot_core@0.9.9		X						X				
-pem@3.0.2								X				
+pem@3.0.3								X				
 pem-rfc7468@0.7.0		X						X				
 percent-encoding@2.3.1		X						X				
-pin-project@1.1.3		X						X				
-pin-project-internal@1.1.3		X						X				
+pin-project@1.1.4		X						X				
+pin-project-internal@1.1.4		X						X				
 pin-project-lite@0.2.13		X						X				
 pin-utils@0.1.0		X						X				
 pkcs1@0.7.5		X						X				
 pkcs8@0.10.2		X						X				
 powerfmt@0.2.0		X						X				
 ppv-lite86@0.2.17		X						X				
-proc-macro2@1.0.69		X						X				
-quick-xml@0.30.0								X				
+proc-macro2@1.0.78		X						X				
 quick-xml@0.31.0								X				
-quote@1.0.33		X						X				
+quote@1.0.35		X						X				
 rand@0.8.5		X						X				
 rand_chacha@0.3.1		X						X				
 rand_core@0.6.4		X						X				
 redox_syscall@0.4.1								X				
-reqsign@0.14.6		X										
-reqwest@0.11.22		X						X				
-ring@0.17.5									X			
-rsa@0.9.4		X						X				
+reqsign@0.14.7		X										
+reqwest@0.11.24		X						X				
+ring@0.17.7									X			
+rsa@0.9.6		X						X				
 rust-ini@0.20.0								X				
 rustc-demangle@0.1.23		X						X				
-rustls@0.21.9		X					X	X				
+rustls@0.21.10		X					X	X				
 rustls-native-certs@0.6.3		X					X	X				
 rustls-pemfile@1.0.4		X					X	X				
 rustls-webpki@0.101.7							X					
-ryu@1.0.15		X			X							
+ryu@1.0.16		X			X							
 same-file@1.0.6								X			X	
-schannel@0.1.22								X				
+schannel@0.1.23								X				
 scopeguard@1.2.0		X						X				
 sct@0.7.1		X					X	X				
 security-framework@2.9.2		X						X				
 security-framework-sys@2.9.1		X						X				
-serde@1.0.193		X						X				
-serde_derive@1.0.193		X						X				
-serde_json@1.0.108		X						X				
+serde@1.0.196		X						X				
+serde_derive@1.0.196		X						X				
+serde_json@1.0.113		X						X				
 serde_urlencoded@0.7.1		X						X				
 sha1@0.10.6		X						X				
 sha2@0.10.8		X						X				
@@ -143,74 +142,82 @@ signal-hook-registry@1.4.1		X						X
 signature@2.2.0		X						X				
 simple_asn1@0.6.2							X					
 slab@0.4.9								X				
-smallvec@1.11.2		X						X				
-socket2@0.4.10		X						X				
+smallvec@1.13.1		X						X				
 socket2@0.5.5		X						X				
 spin@0.5.2								X				
 spin@0.9.8								X				
-spki@0.7.2		X						X				
+spki@0.7.3		X						X				
 subtle@2.5.0				X								
-syn@2.0.39		X						X				
+syn@2.0.48		X						X				
+sync_wrapper@0.1.2		X										
 system-configuration@0.5.1		X						X				
 system-configuration-sys@0.5.0		X						X				
-thiserror@1.0.50		X						X				
-thiserror-impl@1.0.50		X						X				
-time@0.3.30		X						X				
+thiserror@1.0.56		X						X				
+thiserror-impl@1.0.56		X						X				
+time@0.3.32		X						X				
 time-core@0.1.2		X						X				
-time-macros@0.2.15		X						X				
+time-macros@0.2.17		X						X				
 tiny-keccak@2.0.2						X						
 tinyvec@1.6.0		X						X				X
 tinyvec_macros@0.1.1		X						X				X
-tokio@1.34.0								X				
+tokio@1.36.0								X				
 tokio-macros@2.2.0								X				
 tokio-rustls@0.24.1		X						X				
 tokio-util@0.7.10								X				
 tower-service@0.3.2								X				
 tracing@0.1.40								X				
 tracing-core@0.1.32								X				
-try-lock@0.2.4								X				
+try-lock@0.2.5								X				
 typenum@1.17.0		X						X				
-unicode-bidi@0.3.13		X						X				
+unicode-bidi@0.3.15		X						X				
 unicode-ident@1.0.12		X						X		X		
 unicode-normalization@0.1.22		X						X				
 untrusted@0.9.0							X					
 url@2.5.0		X						X				
-uuid@1.6.1		X						X				
-valuable@0.1.0								X				
+uuid@1.7.0		X						X				
 version_check@0.9.4		X						X				
 walkdir@2.4.0								X			X	
 want@0.3.1								X				
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X				
-wasm-bindgen@0.2.89		X						X				
-wasm-bindgen-backend@0.2.89		X						X				
-wasm-bindgen-futures@0.4.39		X						X				
-wasm-bindgen-macro@0.2.89		X						X				
-wasm-bindgen-macro-support@0.2.89		X						X				
-wasm-bindgen-shared@0.2.89		X						X				
-wasm-streams@0.3.0		X						X				
-web-sys@0.3.65		X						X				
+wasm-bindgen@0.2.90		X						X				
+wasm-bindgen-backend@0.2.90		X						X				
+wasm-bindgen-futures@0.4.40		X						X				
+wasm-bindgen-macro@0.2.90		X						X				
+wasm-bindgen-macro-support@0.2.90		X						X				
+wasm-bindgen-shared@0.2.90		X						X				
+wasm-streams@0.4.0		X						X				
+web-sys@0.3.67		X						X				
 winapi@0.3.9		X						X				
 winapi-i686-pc-windows-gnu@0.4.0		X						X				
 winapi-util@0.1.6								X			X	
 winapi-x86_64-pc-windows-gnu@0.4.0		X						X				
-windows-core@0.51.1		X						X				
+windows-core@0.52.0		X						X				
 windows-sys@0.45.0		X						X				
 windows-sys@0.48.0		X						X				
+windows-sys@0.52.0		X						X				
 windows-targets@0.42.2		X						X				
 windows-targets@0.48.5		X						X				
+windows-targets@0.52.0		X						X				
 windows_aarch64_gnullvm@0.42.2		X						X				
 windows_aarch64_gnullvm@0.48.5		X						X				
+windows_aarch64_gnullvm@0.52.0		X						X				
 windows_aarch64_msvc@0.42.2		X						X				
 windows_aarch64_msvc@0.48.5		X						X				
+windows_aarch64_msvc@0.52.0		X						X				
 windows_i686_gnu@0.42.2		X						X				
 windows_i686_gnu@0.48.5		X						X				
+windows_i686_gnu@0.52.0		X						X				
 windows_i686_msvc@0.42.2		X						X				
 windows_i686_msvc@0.48.5		X						X				
+windows_i686_msvc@0.52.0		X						X				
 windows_x86_64_gnu@0.42.2		X						X				
 windows_x86_64_gnu@0.48.5		X						X				
+windows_x86_64_gnu@0.52.0		X						X				
 windows_x86_64_gnullvm@0.42.2		X						X				
 windows_x86_64_gnullvm@0.48.5		X						X				
+windows_x86_64_gnullvm@0.52.0		X						X				
 windows_x86_64_msvc@0.42.2		X						X				
 windows_x86_64_msvc@0.48.5		X						X				
+windows_x86_64_msvc@0.52.0		X						X				
 winreg@0.50.0								X				
 zeroize@1.7.0		X						X				

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal-java</artifactId>
-    <version>0.45.0</version>
+    <version>0.45.1+core.0.45.1</version>
 
     <name>Apache OpenDAL™</name>
     <description>

--- a/bindings/lua/Cargo.toml
+++ b/bindings/lua/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-lua"
 publish = false
-version = "0.1.0+core.0.45.0"
+version = "0.1.1+core.0.45.1"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -39,4 +39,4 @@ mlua = { version = "0.9", features = [
   "module",
   "macros",
 ], default-features = false, optional = true }
-opendal = { version = "0.45.0", path = "../../core" }
+opendal = { version = "0.45.1", path = "../../core" }

--- a/bindings/lua/DEPENDENCIES.rust.tsv
+++ b/bindings/lua/DEPENDENCIES.rust.tsv
@@ -61,37 +61,38 @@ httparse@1.8.0		X						X
 httpdate@1.0.3		X						X				
 hyper@0.14.28								X				
 hyper-rustls@0.24.2		X					X	X				
-iana-time-zone@0.1.59		X						X				
+iana-time-zone@0.1.60		X						X				
 iana-time-zone-haiku@0.1.2		X						X				
 idna@0.5.0		X						X				
-indexmap@2.1.0		X						X				
+indexmap@2.2.2		X						X				
 instant@0.1.12				X								
 ipnet@2.9.0		X						X				
-itertools@0.12.0		X						X				
+itertools@0.12.1		X						X				
 itoa@1.0.10		X						X				
 js-sys@0.3.67		X						X				
 jsonwebtoken@9.2.0								X				
 lazy_static@1.4.0		X						X				
-libc@0.2.152		X						X				
+libc@0.2.153		X						X				
 libm@0.2.8		X						X				
 log@0.4.20		X						X				
 md-5@0.10.6		X						X				
 memchr@2.7.1								X			X	
 mime@0.3.17		X						X				
-miniz_oxide@0.7.1		X						X				X
+miniz_oxide@0.7.2		X						X				X
 mio@0.8.10								X				
 mlua@0.9.5								X				
 mlua-sys@0.5.1								X				
 mlua_derive@0.9.2								X				
 num-bigint@0.4.4		X						X				
 num-bigint-dig@0.8.4		X						X				
+num-conv@0.1.0		X						X				
 num-integer@0.1.45		X						X				
 num-iter@0.1.43		X						X				
 num-traits@0.2.17		X						X				
 object@0.32.2		X						X				
 once_cell@1.19.0		X						X				
-opendal@0.45.0		X										
-opendal-lua@0.1.0		X										
+opendal@0.45.1		X										
+opendal-lua@0.1.1+core.0.45.1		X										
 openssl-probe@0.1.5		X						X				
 ordered-multimap@0.7.1								X				
 pem@3.0.3								X				
@@ -109,7 +110,6 @@ ppv-lite86@0.2.17		X						X
 proc-macro-error@1.0.4		X						X				
 proc-macro-error-attr@1.0.4		X						X				
 proc-macro2@1.0.78		X						X				
-quick-xml@0.30.0								X				
 quick-xml@0.31.0								X				
 quote@1.0.35		X						X				
 rand@0.8.5		X						X				
@@ -118,8 +118,8 @@ rand_core@0.6.4		X						X
 regex@1.10.3		X						X				
 regex-automata@0.4.5		X						X				
 regex-syntax@0.8.2		X						X				
-reqsign@0.14.6		X										
-reqwest@0.11.23		X						X				
+reqsign@0.14.7		X										
+reqwest@0.11.24		X						X				
 ring@0.17.7									X			
 rsa@0.9.6		X						X				
 rust-ini@0.20.0								X				
@@ -136,7 +136,7 @@ security-framework@2.9.2		X						X
 security-framework-sys@2.9.1		X						X				
 serde@1.0.196		X						X				
 serde_derive@1.0.196		X						X				
-serde_json@1.0.112		X						X				
+serde_json@1.0.113		X						X				
 serde_urlencoded@0.7.1		X						X				
 sha1@0.10.6		X						X				
 sha2@0.10.8		X						X				
@@ -151,17 +151,18 @@ spki@0.7.3		X						X
 subtle@2.5.0				X								
 syn@1.0.109		X						X				
 syn@2.0.48		X						X				
+sync_wrapper@0.1.2		X										
 system-configuration@0.5.1		X						X				
 system-configuration-sys@0.5.0		X						X				
 thiserror@1.0.56		X						X				
 thiserror-impl@1.0.56		X						X				
-time@0.3.31		X						X				
+time@0.3.34		X						X				
 time-core@0.1.2		X						X				
-time-macros@0.2.16		X						X				
+time-macros@0.2.17		X						X				
 tiny-keccak@2.0.2						X						
 tinyvec@1.6.0		X						X				X
 tinyvec_macros@0.1.1		X						X				X
-tokio@1.35.1								X				
+tokio@1.36.0								X				
 tokio-rustls@0.24.1		X						X				
 tokio-util@0.7.10								X				
 tower-service@0.3.2								X				
@@ -184,7 +185,7 @@ wasm-bindgen-futures@0.4.40		X						X
 wasm-bindgen-macro@0.2.90		X						X				
 wasm-bindgen-macro-support@0.2.90		X						X				
 wasm-bindgen-shared@0.2.90		X						X				
-wasm-streams@0.3.0		X						X				
+wasm-streams@0.4.0		X						X				
 web-sys@0.3.67		X						X				
 windows-core@0.52.0		X						X				
 windows-sys@0.48.0		X						X				

--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.67"
-version = "0.45.0+core.0.45.0"
+version = "0.45.1+core.0.45.1"
 
 [features]
 default = [
@@ -47,7 +47,6 @@ default = [
 
 services-all = [
   "default",
-
   "services-alluxio",
   "services-azfile",
   "services-b2",
@@ -157,7 +156,7 @@ napi = { version = "2.11.3", default-features = false, features = [
   "async",
 ] }
 napi-derive = "2.14.6"
-opendal = { version = "0.45.0", path = "../../core", features = [
+opendal = { version = "0.45.1", path = "../../core", features = [
   "layers-blocking",
 ] }
 tokio = "1"

--- a/bindings/nodejs/DEPENDENCIES.rust.tsv
+++ b/bindings/nodejs/DEPENDENCIES.rust.tsv
@@ -4,34 +4,34 @@ adler@1.0.2	X	X						X
 aho-corasick@1.1.2								X			X	
 android-tzdata@0.1.1		X						X				
 android_system_properties@0.1.5		X						X				
-anyhow@1.0.75		X						X				
-async-trait@0.1.75		X						X				
+anyhow@1.0.79		X						X				
+async-trait@0.1.77		X						X				
 autocfg@1.1.0		X						X				
 backon@0.4.1		X										
 backtrace@0.3.69		X						X				
-base64@0.21.5		X						X				
+base64@0.21.7		X						X				
 base64ct@1.6.0		X						X				
 bitflags@1.3.2		X						X				
-bitflags@2.4.1		X						X				
+bitflags@2.4.2		X						X				
 block-buffer@0.10.4		X						X				
 bumpalo@3.14.0		X						X				
 byteorder@1.5.0								X			X	
 bytes@1.5.0								X				
 cc@1.0.83		X						X				
 cfg-if@1.0.0		X						X				
-chrono@0.4.31		X						X				
-const-oid@0.9.5		X						X				
+chrono@0.4.33		X						X				
+const-oid@0.9.6		X						X				
 const-random@0.1.17		X						X				
 const-random-macro@0.1.16		X						X				
 convert_case@0.6.0								X				
-core-foundation@0.9.3		X						X				
-core-foundation-sys@0.8.4		X						X				
-cpufeatures@0.2.11		X						X				
+core-foundation@0.9.4		X						X				
+core-foundation-sys@0.8.6		X						X				
+cpufeatures@0.2.12		X						X				
 crunchy@0.2.2								X				
 crypto-common@0.1.6		X						X				
-ctor@0.2.5		X						X				
+ctor@0.2.6		X						X				
 der@0.7.8		X						X				
-deranged@0.3.9		X						X				
+deranged@0.3.11		X						X				
 digest@0.10.7		X						X				
 dlv-list@0.5.2		X						X				
 encoding_rs@0.8.33		X		X				X				
@@ -40,170 +40,174 @@ fastrand@1.9.0		X						X
 flagset@0.4.4		X										
 fnv@1.0.7		X						X				
 form_urlencoded@1.2.1		X						X				
-futures@0.3.29		X						X				
+futures@0.3.30		X						X				
 futures-channel@0.3.30		X						X				
 futures-core@0.3.30		X						X				
-futures-executor@0.3.29		X						X				
+futures-executor@0.3.30		X						X				
 futures-io@0.3.30		X						X				
 futures-macro@0.3.30		X						X				
 futures-sink@0.3.30		X						X				
 futures-task@0.3.30		X						X				
 futures-util@0.3.30		X						X				
 generic-array@0.14.7								X				
-getrandom@0.2.11		X						X				
-gimli@0.28.0		X						X				
-h2@0.3.22								X				
-hashbrown@0.14.2		X						X				
-hermit-abi@0.3.3		X						X				
+getrandom@0.2.12		X						X				
+gimli@0.28.1		X						X				
+h2@0.3.24								X				
+hashbrown@0.14.3		X						X				
+hermit-abi@0.3.4		X						X				
 hex@0.4.3		X						X				
 hmac@0.12.1		X						X				
-home@0.5.5		X						X				
+home@0.5.9		X						X				
 http@0.2.11		X						X				
-http-body@0.4.5								X				
+http-body@0.4.6								X				
 httparse@1.8.0		X						X				
 httpdate@1.0.3		X						X				
-hyper@0.14.27								X				
+hyper@0.14.28								X				
 hyper-rustls@0.24.2		X					X	X				
-iana-time-zone@0.1.58		X						X				
+iana-time-zone@0.1.59		X						X				
 iana-time-zone-haiku@0.1.2		X						X				
 idna@0.5.0		X						X				
-indexmap@2.1.0		X						X				
+indexmap@2.2.2		X						X				
 instant@0.1.12				X								
 ipnet@2.9.0		X						X				
-itoa@1.0.9		X						X				
-js-sys@0.3.66		X						X				
+itoa@1.0.10		X						X				
+js-sys@0.3.67		X						X				
 jsonwebtoken@9.2.0								X				
 lazy_static@1.4.0		X						X				
-libc@0.2.151		X						X				
+libc@0.2.153		X						X				
 libloading@0.8.1							X					
 libm@0.2.8		X						X				
 log@0.4.20		X						X				
 md-5@0.10.6		X						X				
-memchr@2.6.4								X			X	
+memchr@2.7.1								X			X	
 mime@0.3.17		X						X				
 miniz_oxide@0.7.1		X						X				X
-mio@0.8.9								X				
-napi@2.14.1								X				
+mio@0.8.10								X				
+napi@2.15.1								X				
 napi-build@2.1.0								X				
-napi-derive@2.14.6								X				
-napi-derive-backend@1.0.58								X				
+napi-derive@2.15.0								X				
+napi-derive-backend@1.0.59								X				
 napi-sys@2.3.0								X				
 num-bigint@0.4.4		X						X				
 num-bigint-dig@0.8.4		X						X				
+num-conv@0.1.0		X						X				
 num-integer@0.1.45		X						X				
 num-iter@0.1.43		X						X				
 num-traits@0.2.17		X						X				
 num_cpus@1.16.0		X						X				
-object@0.32.1		X						X				
+object@0.32.2		X						X				
 once_cell@1.19.0		X						X				
-opendal@0.45.0		X										
-opendal-nodejs@0.45.0		X										
+opendal@0.45.1		X										
+opendal-nodejs@0.45.1+core.0.45.1		X										
 openssl-probe@0.1.5		X						X				
-ordered-multimap@0.7.0								X				
-pem@3.0.2								X				
+ordered-multimap@0.7.1								X				
+pem@3.0.3								X				
 pem-rfc7468@0.7.0		X						X				
 percent-encoding@2.3.1		X						X				
-pin-project@1.1.3		X						X				
-pin-project-internal@1.1.3		X						X				
+pin-project@1.1.4		X						X				
+pin-project-internal@1.1.4		X						X				
 pin-project-lite@0.2.13		X						X				
 pin-utils@0.1.0		X						X				
 pkcs1@0.7.5		X						X				
 pkcs8@0.10.2		X						X				
 powerfmt@0.2.0		X						X				
 ppv-lite86@0.2.17		X						X				
-proc-macro2@1.0.69		X						X				
-quick-xml@0.30.0								X				
+proc-macro2@1.0.78		X						X				
 quick-xml@0.31.0								X				
-quote@1.0.33		X						X				
+quote@1.0.35		X						X				
 rand@0.8.5		X						X				
 rand_chacha@0.3.1		X						X				
 rand_core@0.6.4		X						X				
-regex@1.10.2		X						X				
-regex-automata@0.4.3		X						X				
+regex@1.10.3		X						X				
+regex-automata@0.4.5		X						X				
 regex-syntax@0.8.2		X						X				
-reqsign@0.14.6		X										
-reqwest@0.11.22		X						X				
-ring@0.17.5									X			
-rsa@0.9.4		X						X				
+reqsign@0.14.7		X										
+reqwest@0.11.24		X						X				
+ring@0.17.7									X			
+rsa@0.9.6		X						X				
 rust-ini@0.20.0								X				
 rustc-demangle@0.1.23		X						X				
-rustls@0.21.9		X					X	X				
+rustls@0.21.10		X					X	X				
 rustls-native-certs@0.6.3		X					X	X				
 rustls-pemfile@1.0.4		X					X	X				
 rustls-webpki@0.101.7							X					
-ryu@1.0.15		X			X							
-schannel@0.1.22								X				
+ryu@1.0.16		X			X							
+schannel@0.1.23								X				
 sct@0.7.1		X					X	X				
 security-framework@2.9.2		X						X				
 security-framework-sys@2.9.1		X						X				
-semver@1.0.20		X						X				
-serde@1.0.193		X						X				
-serde_derive@1.0.193		X						X				
-serde_json@1.0.108		X						X				
+semver@1.0.21		X						X				
+serde@1.0.196		X						X				
+serde_derive@1.0.196		X						X				
+serde_json@1.0.113		X						X				
 serde_urlencoded@0.7.1		X						X				
 sha1@0.10.6		X						X				
 sha2@0.10.8		X						X				
 signature@2.2.0		X						X				
 simple_asn1@0.6.2							X					
 slab@0.4.9								X				
-smallvec@1.11.2		X						X				
-socket2@0.4.10		X						X				
+smallvec@1.13.1		X						X				
 socket2@0.5.5		X						X				
 spin@0.5.2								X				
 spin@0.9.8								X				
-spki@0.7.2		X						X				
+spki@0.7.3		X						X				
 subtle@2.5.0				X								
-syn@2.0.39		X						X				
+syn@2.0.48		X						X				
+sync_wrapper@0.1.2		X										
 system-configuration@0.5.1		X						X				
 system-configuration-sys@0.5.0		X						X				
-thiserror@1.0.50		X						X				
-thiserror-impl@1.0.50		X						X				
-time@0.3.30		X						X				
+thiserror@1.0.56		X						X				
+thiserror-impl@1.0.56		X						X				
+time@0.3.32		X						X				
 time-core@0.1.2		X						X				
-time-macros@0.2.15		X						X				
+time-macros@0.2.17		X						X				
 tiny-keccak@2.0.2						X						
 tinyvec@1.6.0		X						X				X
 tinyvec_macros@0.1.1		X						X				X
-tokio@1.34.0								X				
-tokio-macros@2.2.0								X				
+tokio@1.36.0								X				
 tokio-rustls@0.24.1		X						X				
 tokio-util@0.7.10								X				
 tower-service@0.3.2								X				
 tracing@0.1.40								X				
 tracing-core@0.1.32								X				
-try-lock@0.2.4								X				
+try-lock@0.2.5								X				
 typenum@1.17.0		X						X				
-unicode-bidi@0.3.13		X						X				
+unicode-bidi@0.3.15		X						X				
 unicode-ident@1.0.12		X						X		X		
 unicode-normalization@0.1.22		X						X				
 unicode-segmentation@1.10.1		X						X				
 untrusted@0.9.0							X					
 url@2.5.0		X						X				
-uuid@1.6.1		X						X				
-valuable@0.1.0								X				
+uuid@1.7.0		X						X				
 version_check@0.9.4		X						X				
 want@0.3.1								X				
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X				
-wasm-bindgen@0.2.89		X						X				
-wasm-bindgen-backend@0.2.89		X						X				
-wasm-bindgen-futures@0.4.39		X						X				
-wasm-bindgen-macro@0.2.89		X						X				
-wasm-bindgen-macro-support@0.2.89		X						X				
-wasm-bindgen-shared@0.2.89		X						X				
-wasm-streams@0.3.0		X						X				
-web-sys@0.3.65		X						X				
-winapi@0.3.9		X						X				
-winapi-i686-pc-windows-gnu@0.4.0		X						X				
-winapi-x86_64-pc-windows-gnu@0.4.0		X						X				
-windows-core@0.51.1		X						X				
+wasm-bindgen@0.2.90		X						X				
+wasm-bindgen-backend@0.2.90		X						X				
+wasm-bindgen-futures@0.4.40		X						X				
+wasm-bindgen-macro@0.2.90		X						X				
+wasm-bindgen-macro-support@0.2.90		X						X				
+wasm-bindgen-shared@0.2.90		X						X				
+wasm-streams@0.4.0		X						X				
+web-sys@0.3.67		X						X				
+windows-core@0.52.0		X						X				
 windows-sys@0.48.0		X						X				
+windows-sys@0.52.0		X						X				
 windows-targets@0.48.5		X						X				
+windows-targets@0.52.0		X						X				
 windows_aarch64_gnullvm@0.48.5		X						X				
+windows_aarch64_gnullvm@0.52.0		X						X				
 windows_aarch64_msvc@0.48.5		X						X				
+windows_aarch64_msvc@0.52.0		X						X				
 windows_i686_gnu@0.48.5		X						X				
+windows_i686_gnu@0.52.0		X						X				
 windows_i686_msvc@0.48.5		X						X				
+windows_i686_msvc@0.52.0		X						X				
 windows_x86_64_gnu@0.48.5		X						X				
+windows_x86_64_gnu@0.52.0		X						X				
 windows_x86_64_gnullvm@0.48.5		X						X				
+windows_x86_64_gnullvm@0.52.0		X						X				
 windows_x86_64_msvc@0.48.5		X						X				
+windows_x86_64_msvc@0.52.0		X						X				
 winreg@0.50.0								X				
 zeroize@1.7.0		X						X				

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-arm64",
   "repository": "git@github.com/apache/opendal.git",
-  "version": "0.45.0",
+  "version": "0.45.1+core.0.45.1",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-x64",
-  "version": "0.45.0",
+  "version": "0.45.1+core.0.45.1",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "darwin"

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-gnu",
-  "version": "0.45.0",
+  "version": "0.45.1+core.0.45.1",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-musl",
-  "version": "0.45.0",
+  "version": "0.45.1+core.0.45.1",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.45.0",
+  "version": "0.45.1+core.0.45.1",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-arm64-msvc",
-  "version": "0.45.0",
+  "version": "0.45.1+core.0.45.1",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.45.0",
+  "version": "0.45.1+core.0.45.1",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -94,14 +94,5 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
-  "packageManager": "pnpm@8.11.0",
-  "optionalDependencies": {
-    "@opendal/lib-win32-x64-msvc": "0.45.1+core.0.45.1",
-    "@opendal/lib-darwin-x64": "0.45.1+core.0.45.1",
-    "@opendal/lib-linux-x64-gnu": "0.45.1+core.0.45.1",
-    "@opendal/lib-darwin-arm64": "0.45.1+core.0.45.1",
-    "@opendal/lib-linux-arm64-gnu": "0.45.1+core.0.45.1",
-    "@opendal/lib-linux-arm64-musl": "0.45.1+core.0.45.1",
-    "@opendal/lib-win32-arm64-msvc": "0.45.1+core.0.45.1"
-  }
+  "packageManager": "pnpm@8.11.0"
 }

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "OpenDAL Contributors <dev@opendal.apache.org>",
-  "version": "0.45.0",
+  "version": "0.45.1+core.0.45.1",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",
@@ -94,5 +94,14 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
-  "packageManager": "pnpm@8.11.0"
+  "packageManager": "pnpm@8.11.0",
+  "optionalDependencies": {
+    "@opendal/lib-win32-x64-msvc": "0.45.1+core.0.45.1",
+    "@opendal/lib-darwin-x64": "0.45.1+core.0.45.1",
+    "@opendal/lib-linux-x64-gnu": "0.45.1+core.0.45.1",
+    "@opendal/lib-darwin-arm64": "0.45.1+core.0.45.1",
+    "@opendal/lib-linux-arm64-gnu": "0.45.1+core.0.45.1",
+    "@opendal/lib-linux-arm64-musl": "0.45.1+core.0.45.1",
+    "@opendal/lib-win32-arm64-msvc": "0.45.1+core.0.45.1"
+  }
 }

--- a/bindings/ocaml/Cargo.toml
+++ b/bindings/ocaml/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-ocaml"
 publish = false
-version = "0.0.0+core.0.45.0"
+version = "0.0.0+core.0.45.1"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -33,7 +33,7 @@ doc = false
 
 [dependencies]
 ocaml = { version = "^1.0.0-beta" }
-opendal = { version = "0.45.0", path = "../../core" }
+opendal = { version = "0.45.1", path = "../../core" }
 
 [build-dependencies]
 ocaml-build = { version = "^1.0.0-beta" }

--- a/bindings/ocaml/DEPENDENCIES.rust.tsv
+++ b/bindings/ocaml/DEPENDENCIES.rust.tsv
@@ -17,7 +17,7 @@ byteorder@1.5.0								X			X
 bytes@1.5.0								X				
 cc@1.0.83		X						X				
 cfg-if@1.0.0		X						X				
-chrono@0.4.32		X						X				
+chrono@0.4.33		X						X				
 const-oid@0.9.6		X						X				
 const-random@0.1.17		X						X				
 const-random-macro@0.1.16		X						X				
@@ -59,26 +59,27 @@ httparse@1.8.0		X						X
 httpdate@1.0.3		X						X				
 hyper@0.14.28								X				
 hyper-rustls@0.24.2		X					X	X				
-iana-time-zone@0.1.59		X						X				
+iana-time-zone@0.1.60		X						X				
 iana-time-zone-haiku@0.1.2		X						X				
 idna@0.5.0		X						X				
-indexmap@2.1.0		X						X				
+indexmap@2.2.2		X						X				
 instant@0.1.12				X								
 ipnet@2.9.0		X						X				
 itoa@1.0.10		X						X				
 js-sys@0.3.67		X						X				
 jsonwebtoken@9.2.0								X				
 lazy_static@1.4.0		X						X				
-libc@0.2.152		X						X				
+libc@0.2.153		X						X				
 libm@0.2.8		X						X				
 log@0.4.20		X						X				
 md-5@0.10.6		X						X				
 memchr@2.7.1								X			X	
 mime@0.3.17		X						X				
-miniz_oxide@0.7.1		X						X				X
+miniz_oxide@0.7.2		X						X				X
 mio@0.8.10								X				
 num-bigint@0.4.4		X						X				
 num-bigint-dig@0.8.4		X						X				
+num-conv@0.1.0		X						X				
 num-integer@0.1.45		X						X				
 num-iter@0.1.43		X						X				
 num-traits@0.2.17		X						X				
@@ -91,15 +92,15 @@ ocaml-interop@0.8.8								X
 ocaml-sys@0.22.3							X					
 ocaml-sys@0.23.0							X					
 once_cell@1.19.0		X						X				
-opendal@0.44.2		X										
-opendal-ocaml@0.0.0		X										
+opendal@0.45.1		X										
+opendal-ocaml@0.0.0+core.0.45.1		X										
 openssl-probe@0.1.5		X						X				
 ordered-multimap@0.7.1								X				
 pem@3.0.3								X				
 pem-rfc7468@0.7.0		X						X				
 percent-encoding@2.3.1		X						X				
-pin-project@1.1.3		X						X				
-pin-project-internal@1.1.3		X						X				
+pin-project@1.1.4		X						X				
+pin-project-internal@1.1.4		X						X				
 pin-project-lite@0.2.13		X						X				
 pin-utils@0.1.0		X						X				
 pkcs1@0.7.5		X						X				
@@ -107,14 +108,13 @@ pkcs8@0.10.2		X						X
 powerfmt@0.2.0		X						X				
 ppv-lite86@0.2.17		X						X				
 proc-macro2@1.0.78		X						X				
-quick-xml@0.30.0								X				
 quick-xml@0.31.0								X				
 quote@1.0.35		X						X				
 rand@0.8.5		X						X				
 rand_chacha@0.3.1		X						X				
 rand_core@0.6.4		X						X				
-reqsign@0.14.6		X										
-reqwest@0.11.23		X						X				
+reqsign@0.14.7		X										
+reqwest@0.11.24		X						X				
 ring@0.17.7									X			
 rsa@0.9.6		X						X				
 rust-ini@0.20.0								X				
@@ -128,9 +128,9 @@ schannel@0.1.23								X
 sct@0.7.1		X					X	X				
 security-framework@2.9.2		X						X				
 security-framework-sys@2.9.1		X						X				
-serde@1.0.195		X						X				
-serde_derive@1.0.195		X						X				
-serde_json@1.0.111		X						X				
+serde@1.0.196		X						X				
+serde_derive@1.0.196		X						X				
+serde_json@1.0.113		X						X				
 serde_urlencoded@0.7.1		X						X				
 sha1@0.10.6		X						X				
 sha2@0.10.8		X						X				
@@ -146,17 +146,18 @@ static_assertions@1.1.0		X						X
 subtle@2.5.0				X								
 syn@1.0.109		X						X				
 syn@2.0.48		X						X				
+sync_wrapper@0.1.2		X										
 system-configuration@0.5.1		X						X				
 system-configuration-sys@0.5.0		X						X				
 thiserror@1.0.56		X						X				
 thiserror-impl@1.0.56		X						X				
-time@0.3.31		X						X				
+time@0.3.34		X						X				
 time-core@0.1.2		X						X				
-time-macros@0.2.16		X						X				
+time-macros@0.2.17		X						X				
 tiny-keccak@2.0.2						X						
 tinyvec@1.6.0		X						X				X
 tinyvec_macros@0.1.1		X						X				X
-tokio@1.35.1								X				
+tokio@1.36.0								X				
 tokio-rustls@0.24.1		X						X				
 tokio-util@0.7.10								X				
 tower-service@0.3.2								X				
@@ -179,7 +180,7 @@ wasm-bindgen-futures@0.4.40		X						X
 wasm-bindgen-macro@0.2.90		X						X				
 wasm-bindgen-macro-support@0.2.90		X						X				
 wasm-bindgen-shared@0.2.90		X						X				
-wasm-streams@0.3.0		X						X				
+wasm-streams@0.4.0		X						X				
 web-sys@0.3.67		X						X				
 windows-core@0.52.0		X						X				
 windows-sys@0.48.0		X						X				

--- a/bindings/php/Cargo.toml
+++ b/bindings/php/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-php"
 publish = false
-version = "0.1.0+core.0.45.0"
+version = "0.1.1+core.0.45.1"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -32,4 +32,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ext-php-rs = "0.11.2"
-opendal = { version = "0.45.0", path = "../../core" }
+opendal = { version = "0.45.1", path = "../../core" }

--- a/bindings/php/DEPENDENCIES.rust.tsv
+++ b/bindings/php/DEPENDENCIES.rust.tsv
@@ -27,7 +27,7 @@ cargo_metadata@0.14.2								X
 cc@1.0.83		X						X				
 cexpr@0.6.0		X						X				
 cfg-if@1.0.0		X						X				
-chrono@0.4.32		X						X				
+chrono@0.4.33		X						X				
 cipher@0.4.4		X						X				
 clang-sys@1.7.0		X										
 const-oid@0.9.6		X						X				
@@ -85,11 +85,11 @@ httparse@1.8.0		X						X
 httpdate@1.0.3		X						X				
 hyper@0.14.28								X				
 hyper-rustls@0.24.2		X					X	X				
-iana-time-zone@0.1.59		X						X				
+iana-time-zone@0.1.60		X						X				
 iana-time-zone-haiku@0.1.2		X						X				
 ident_case@1.0.1		X						X				
 idna@0.5.0		X						X				
-indexmap@2.1.0		X						X				
+indexmap@2.2.2		X						X				
 inout@0.1.3		X						X				
 instant@0.1.12				X								
 ipnet@2.9.0		X						X				
@@ -99,7 +99,7 @@ js-sys@0.3.67		X						X
 jsonwebtoken@9.2.0								X				
 lazy_static@1.4.0		X						X				
 lazycell@1.3.0		X						X				
-libc@0.2.152		X						X				
+libc@0.2.153		X						X				
 libloading@0.8.1							X					
 libm@0.2.8		X						X				
 linux-raw-sys@0.4.13		X	X					X				
@@ -109,19 +109,20 @@ md-5@0.10.6		X						X
 memchr@2.7.1								X			X	
 mime@0.3.17		X						X				
 minimal-lexical@0.2.1		X						X				
-miniz_oxide@0.7.1		X						X				X
+miniz_oxide@0.7.2		X						X				X
 mio@0.8.10								X				
 native-tls@0.2.11		X						X				
 nom@7.1.3								X				
 num-bigint@0.4.4		X						X				
 num-bigint-dig@0.8.4		X						X				
+num-conv@0.1.0		X						X				
 num-integer@0.1.45		X						X				
 num-iter@0.1.43		X						X				
 num-traits@0.2.17		X						X				
 object@0.32.2		X						X				
 once_cell@1.19.0		X						X				
-opendal@0.45.0		X										
-opendal-php@0.1.0		X										
+opendal@0.45.1		X										
+opendal-php@0.1.1+core.0.45.1		X										
 openssl@0.10.63		X										
 openssl-macros@0.1.1		X						X				
 openssl-probe@0.1.5		X						X				
@@ -135,8 +136,8 @@ peeking_take_while@0.1.2		X						X
 pem@3.0.3								X				
 pem-rfc7468@0.7.0		X						X				
 percent-encoding@2.3.1		X						X				
-pin-project@1.1.3		X						X				
-pin-project-internal@1.1.3		X						X				
+pin-project@1.1.4		X						X				
+pin-project-internal@1.1.4		X						X				
 pin-project-lite@0.2.13		X						X				
 pin-utils@0.1.0		X						X				
 pkcs1@0.7.5		X						X				
@@ -146,8 +147,7 @@ powerfmt@0.2.0		X						X
 ppv-lite86@0.2.17		X						X				
 prettyplease@0.2.16		X						X				
 proc-macro2@1.0.78		X						X				
-pulldown-cmark@0.9.3								X				
-quick-xml@0.30.0								X				
+pulldown-cmark@0.9.6								X				
 quick-xml@0.31.0								X				
 quote@1.0.35		X						X				
 rand@0.8.5		X						X				
@@ -155,16 +155,16 @@ rand_chacha@0.3.1		X						X
 rand_core@0.6.4		X						X				
 redox_syscall@0.4.1								X				
 regex@1.10.3		X						X				
-regex-automata@0.4.4		X						X				
+regex-automata@0.4.5		X						X				
 regex-syntax@0.8.2		X						X				
-reqsign@0.14.6		X										
-reqwest@0.11.23		X						X				
+reqsign@0.14.7		X										
+reqwest@0.11.24		X						X				
 ring@0.17.7									X			
 rsa@0.9.6		X						X				
 rust-ini@0.20.0								X				
 rustc-demangle@0.1.23		X						X				
 rustc-hash@1.1.0		X						X				
-rustix@0.38.30		X	X					X				
+rustix@0.38.31		X	X					X				
 rustls@0.21.10		X					X	X				
 rustls-native-certs@0.6.3		X					X	X				
 rustls-pemfile@1.0.4		X					X	X				
@@ -177,9 +177,9 @@ sct@0.7.1		X					X	X
 security-framework@2.9.2		X						X				
 security-framework-sys@2.9.1		X						X				
 semver@1.0.21		X						X				
-serde@1.0.195		X						X				
-serde_derive@1.0.195		X						X				
-serde_json@1.0.111		X						X				
+serde@1.0.196		X						X				
+serde_derive@1.0.196		X						X				
+serde_json@1.0.113		X						X				
 serde_urlencoded@0.7.1		X						X				
 sha1@0.10.6		X						X				
 sha2@0.10.8		X						X				
@@ -197,18 +197,19 @@ strsim@0.10.0								X
 subtle@2.5.0				X								
 syn@1.0.109		X						X				
 syn@2.0.48		X						X				
+sync_wrapper@0.1.2		X										
 system-configuration@0.5.1		X						X				
 system-configuration-sys@0.5.0		X						X				
 tempfile@3.9.0		X						X				
 thiserror@1.0.56		X						X				
 thiserror-impl@1.0.56		X						X				
-time@0.3.31		X						X				
+time@0.3.34		X						X				
 time-core@0.1.2		X						X				
-time-macros@0.2.16		X						X				
+time-macros@0.2.17		X						X				
 tiny-keccak@2.0.2						X						
 tinyvec@1.6.0		X						X				X
 tinyvec_macros@0.1.1		X						X				X
-tokio@1.35.1								X				
+tokio@1.36.0								X				
 tokio-rustls@0.24.1		X						X				
 tokio-util@0.7.10								X				
 tower-service@0.3.2								X				
@@ -235,7 +236,7 @@ wasm-bindgen-futures@0.4.40		X						X
 wasm-bindgen-macro@0.2.90		X						X				
 wasm-bindgen-macro-support@0.2.90		X						X				
 wasm-bindgen-shared@0.2.90		X						X				
-wasm-streams@0.3.0		X						X				
+wasm-streams@0.4.0		X						X				
 web-sys@0.3.67		X						X				
 which@4.4.2								X				
 winapi@0.3.9		X						X				

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.67"
-version = "0.45.0+core.0.45.0"
+version = "0.45.1+core.0.45.1"
 
 [features]
 default = [
@@ -47,7 +47,6 @@ default = [
 
 services-all = [
   "default",
-
   "services-azfile",
   "services-cacache",
   "services-chainsafe",
@@ -154,7 +153,7 @@ doc = false
 
 [dependencies]
 futures = "0.3.28"
-opendal = { version = "0.45.0", path = "../../core", features = [
+opendal = { version = "0.45.1", path = "../../core", features = [
   "layers-blocking",
 ] }
 pyo3 = "0.20.1"
@@ -162,11 +161,10 @@ pyo3-asyncio = { version = "0.20", features = ["tokio-runtime"] }
 tokio = "1"
 
 [target.'cfg(unix)'.dependencies.opendal]
-version = "0.45.0"
+version = "0.45.1"
 path = "../../core"
 features = [
   "layers-blocking",
-
   # Depend on "openssh" which depends on "tokio-pipe" that is unavailable on Windows.
   "services-sftp",
 ]

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -3,12 +3,12 @@ addr2line@0.21.0		X						X
 adler@1.0.2	X	X						X				
 android-tzdata@0.1.1		X						X				
 android_system_properties@0.1.5		X						X				
-anyhow@1.0.75		X						X				
-async-trait@0.1.75		X						X				
+anyhow@1.0.79		X						X				
+async-trait@0.1.77		X						X				
 autocfg@1.1.0		X						X				
 backon@0.4.1		X										
 backtrace@0.3.69		X						X				
-base64@0.21.5		X						X				
+base64@0.21.7		X						X				
 base64ct@1.6.0		X						X				
 bitflags@1.3.2		X						X				
 block-buffer@0.10.4		X						X				
@@ -17,17 +17,17 @@ byteorder@1.5.0								X			X
 bytes@1.5.0								X				
 cc@1.0.83		X						X				
 cfg-if@1.0.0		X						X				
-chrono@0.4.31		X						X				
-const-oid@0.9.5		X						X				
+chrono@0.4.33		X						X				
+const-oid@0.9.6		X						X				
 const-random@0.1.17		X						X				
 const-random-macro@0.1.16		X						X				
-core-foundation@0.9.3		X						X				
-core-foundation-sys@0.8.4		X						X				
-cpufeatures@0.2.11		X						X				
+core-foundation@0.9.4		X						X				
+core-foundation-sys@0.8.6		X						X				
+cpufeatures@0.2.12		X						X				
 crunchy@0.2.2								X				
 crypto-common@0.1.6		X						X				
 der@0.7.8		X						X				
-deranged@0.3.9		X						X				
+deranged@0.3.11		X						X				
 digest@0.10.7		X						X				
 dlv-list@0.5.2		X						X				
 encoding_rs@0.8.33		X		X				X				
@@ -36,175 +36,179 @@ fastrand@1.9.0		X						X
 flagset@0.4.4		X										
 fnv@1.0.7		X						X				
 form_urlencoded@1.2.1		X						X				
-futures@0.3.29		X						X				
+futures@0.3.30		X						X				
 futures-channel@0.3.30		X						X				
 futures-core@0.3.30		X						X				
-futures-executor@0.3.29		X						X				
+futures-executor@0.3.30		X						X				
 futures-io@0.3.30		X						X				
 futures-macro@0.3.30		X						X				
 futures-sink@0.3.30		X						X				
 futures-task@0.3.30		X						X				
 futures-util@0.3.30		X						X				
 generic-array@0.14.7								X				
-getrandom@0.2.11		X						X				
-gimli@0.28.0		X						X				
-h2@0.3.22								X				
-hashbrown@0.14.2		X						X				
+getrandom@0.2.12		X						X				
+gimli@0.28.1		X						X				
+h2@0.3.24								X				
+hashbrown@0.14.3		X						X				
 heck@0.4.1		X						X				
-hermit-abi@0.3.3		X						X				
+hermit-abi@0.3.4		X						X				
 hex@0.4.3		X						X				
 hmac@0.12.1		X						X				
-home@0.5.5		X						X				
+home@0.5.9		X						X				
 http@0.2.11		X						X				
-http-body@0.4.5								X				
+http-body@0.4.6								X				
 httparse@1.8.0		X						X				
 httpdate@1.0.3		X						X				
-hyper@0.14.27								X				
+hyper@0.14.28								X				
 hyper-rustls@0.24.2		X					X	X				
-iana-time-zone@0.1.58		X						X				
+iana-time-zone@0.1.59		X						X				
 iana-time-zone-haiku@0.1.2		X						X				
 idna@0.5.0		X						X				
-indexmap@2.1.0		X						X				
+indexmap@2.2.2		X						X				
 indoc@2.0.4		X						X				
 instant@0.1.12				X								
 ipnet@2.9.0		X						X				
-itoa@1.0.9		X						X				
-js-sys@0.3.66		X						X				
+itoa@1.0.10		X						X				
+js-sys@0.3.67		X						X				
 jsonwebtoken@9.2.0								X				
 lazy_static@1.4.0		X						X				
-libc@0.2.151		X						X				
+libc@0.2.153		X						X				
 libm@0.2.8		X						X				
 lock_api@0.4.11		X						X				
 log@0.4.20		X						X				
 md-5@0.10.6		X						X				
-memchr@2.6.4								X			X	
+memchr@2.7.1								X			X	
 memoffset@0.9.0								X				
 mime@0.3.17		X						X				
 miniz_oxide@0.7.1		X						X				X
-mio@0.8.9								X				
+mio@0.8.10								X				
 num-bigint@0.4.4		X						X				
 num-bigint-dig@0.8.4		X						X				
+num-conv@0.1.0		X						X				
 num-integer@0.1.45		X						X				
 num-iter@0.1.43		X						X				
 num-traits@0.2.17		X						X				
 num_cpus@1.16.0		X						X				
-object@0.32.1		X						X				
+object@0.32.2		X						X				
 once_cell@1.19.0		X						X				
-opendal@0.45.0		X										
-opendal-python@0.45.0		X										
+opendal@0.45.1		X										
+opendal-python@0.45.1+core.0.45.1		X										
 openssl-probe@0.1.5		X						X				
-ordered-multimap@0.7.0								X				
+ordered-multimap@0.7.1								X				
 parking_lot@0.12.1		X						X				
 parking_lot_core@0.9.9		X						X				
-pem@3.0.2								X				
+pem@3.0.3								X				
 pem-rfc7468@0.7.0		X						X				
 percent-encoding@2.3.1		X						X				
-pin-project@1.1.3		X						X				
-pin-project-internal@1.1.3		X						X				
+pin-project@1.1.4		X						X				
+pin-project-internal@1.1.4		X						X				
 pin-project-lite@0.2.13		X						X				
 pin-utils@0.1.0		X						X				
 pkcs1@0.7.5		X						X				
 pkcs8@0.10.2		X						X				
 powerfmt@0.2.0		X						X				
 ppv-lite86@0.2.17		X						X				
-proc-macro2@1.0.69		X						X				
-pyo3@0.20.1		X						X				
+proc-macro2@1.0.78		X						X				
+pyo3@0.20.2		X						X				
 pyo3-asyncio@0.20.0		X										
-pyo3-build-config@0.20.1		X						X				
-pyo3-ffi@0.20.1		X						X				
-pyo3-macros@0.20.1		X						X				
-pyo3-macros-backend@0.20.1		X						X				
-quick-xml@0.30.0								X				
+pyo3-build-config@0.20.2		X						X				
+pyo3-ffi@0.20.2		X						X				
+pyo3-macros@0.20.2		X						X				
+pyo3-macros-backend@0.20.2		X						X				
 quick-xml@0.31.0								X				
-quote@1.0.33		X						X				
+quote@1.0.35		X						X				
 rand@0.8.5		X						X				
 rand_chacha@0.3.1		X						X				
 rand_core@0.6.4		X						X				
 redox_syscall@0.4.1								X				
-reqsign@0.14.6		X										
-reqwest@0.11.22		X						X				
-ring@0.17.5									X			
-rsa@0.9.4		X						X				
+reqsign@0.14.7		X										
+reqwest@0.11.24		X						X				
+ring@0.17.7									X			
+rsa@0.9.6		X						X				
 rust-ini@0.20.0								X				
 rustc-demangle@0.1.23		X						X				
-rustls@0.21.9		X					X	X				
+rustls@0.21.10		X					X	X				
 rustls-native-certs@0.6.3		X					X	X				
 rustls-pemfile@1.0.4		X					X	X				
 rustls-webpki@0.101.7							X					
-ryu@1.0.15		X			X							
-schannel@0.1.22								X				
+ryu@1.0.16		X			X							
+schannel@0.1.23								X				
 scopeguard@1.2.0		X						X				
 sct@0.7.1		X					X	X				
 security-framework@2.9.2		X						X				
 security-framework-sys@2.9.1		X						X				
-serde@1.0.193		X						X				
-serde_derive@1.0.193		X						X				
-serde_json@1.0.108		X						X				
+serde@1.0.196		X						X				
+serde_derive@1.0.196		X						X				
+serde_json@1.0.113		X						X				
 serde_urlencoded@0.7.1		X						X				
 sha1@0.10.6		X						X				
 sha2@0.10.8		X						X				
 signature@2.2.0		X						X				
 simple_asn1@0.6.2							X					
 slab@0.4.9								X				
-smallvec@1.11.2		X						X				
-socket2@0.4.10		X						X				
+smallvec@1.13.1		X						X				
 socket2@0.5.5		X						X				
 spin@0.5.2								X				
 spin@0.9.8								X				
-spki@0.7.2		X						X				
+spki@0.7.3		X						X				
 subtle@2.5.0				X								
-syn@2.0.39		X						X				
+syn@2.0.48		X						X				
+sync_wrapper@0.1.2		X										
 system-configuration@0.5.1		X						X				
 system-configuration-sys@0.5.0		X						X				
-target-lexicon@0.12.12			X									
-thiserror@1.0.50		X						X				
-thiserror-impl@1.0.50		X						X				
-time@0.3.30		X						X				
+target-lexicon@0.12.13			X									
+thiserror@1.0.56		X						X				
+thiserror-impl@1.0.56		X						X				
+time@0.3.32		X						X				
 time-core@0.1.2		X						X				
-time-macros@0.2.15		X						X				
+time-macros@0.2.17		X						X				
 tiny-keccak@2.0.2						X						
 tinyvec@1.6.0		X						X				X
 tinyvec_macros@0.1.1		X						X				X
-tokio@1.34.0								X				
-tokio-macros@2.2.0								X				
+tokio@1.36.0								X				
 tokio-rustls@0.24.1		X						X				
 tokio-util@0.7.10								X				
 tower-service@0.3.2								X				
 tracing@0.1.40								X				
 tracing-core@0.1.32								X				
-try-lock@0.2.4								X				
+try-lock@0.2.5								X				
 typenum@1.17.0		X						X				
-unicode-bidi@0.3.13		X						X				
+unicode-bidi@0.3.15		X						X				
 unicode-ident@1.0.12		X						X		X		
 unicode-normalization@0.1.22		X						X				
 unindent@0.2.3		X						X				
 untrusted@0.9.0							X					
 url@2.5.0		X						X				
-uuid@1.6.1		X						X				
-valuable@0.1.0								X				
+uuid@1.7.0		X						X				
 version_check@0.9.4		X						X				
 want@0.3.1								X				
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X				
-wasm-bindgen@0.2.89		X						X				
-wasm-bindgen-backend@0.2.89		X						X				
-wasm-bindgen-futures@0.4.39		X						X				
-wasm-bindgen-macro@0.2.89		X						X				
-wasm-bindgen-macro-support@0.2.89		X						X				
-wasm-bindgen-shared@0.2.89		X						X				
-wasm-streams@0.3.0		X						X				
-web-sys@0.3.65		X						X				
-winapi@0.3.9		X						X				
-winapi-i686-pc-windows-gnu@0.4.0		X						X				
-winapi-x86_64-pc-windows-gnu@0.4.0		X						X				
-windows-core@0.51.1		X						X				
+wasm-bindgen@0.2.90		X						X				
+wasm-bindgen-backend@0.2.90		X						X				
+wasm-bindgen-futures@0.4.40		X						X				
+wasm-bindgen-macro@0.2.90		X						X				
+wasm-bindgen-macro-support@0.2.90		X						X				
+wasm-bindgen-shared@0.2.90		X						X				
+wasm-streams@0.4.0		X						X				
+web-sys@0.3.67		X						X				
+windows-core@0.52.0		X						X				
 windows-sys@0.48.0		X						X				
+windows-sys@0.52.0		X						X				
 windows-targets@0.48.5		X						X				
+windows-targets@0.52.0		X						X				
 windows_aarch64_gnullvm@0.48.5		X						X				
+windows_aarch64_gnullvm@0.52.0		X						X				
 windows_aarch64_msvc@0.48.5		X						X				
+windows_aarch64_msvc@0.52.0		X						X				
 windows_i686_gnu@0.48.5		X						X				
+windows_i686_gnu@0.52.0		X						X				
 windows_i686_msvc@0.48.5		X						X				
+windows_i686_msvc@0.52.0		X						X				
 windows_x86_64_gnu@0.48.5		X						X				
+windows_x86_64_gnu@0.52.0		X						X				
 windows_x86_64_gnullvm@0.48.5		X						X				
+windows_x86_64_gnullvm@0.52.0		X						X				
 windows_x86_64_msvc@0.48.5		X						X				
+windows_x86_64_msvc@0.52.0		X						X				
 winreg@0.50.0								X				
 zeroize@1.7.0		X						X				

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-ruby"
 publish = false
-version = "0.1.0+core.0.45.0"
+version = "0.1.1+core.0.45.1"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -34,7 +34,7 @@ name = "opendal_ruby"
 
 [dependencies]
 magnus = { version = "0.5", features = ["bytes-crate"] }
-opendal = { version = "0.45.0", path = "../../core" }
+opendal = { version = "0.45.1", path = "../../core" }
 rb-sys = { version = "0.9.77", default-features = false }
 
 [build-dependencies]

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -5,7 +5,6 @@ aho-corasick@1.1.2								X			X
 android-tzdata@0.1.1		X						X				
 android_system_properties@0.1.5		X						X				
 anyhow@1.0.79		X						X				
-async-compat@0.2.3		X						X				
 async-trait@0.1.77		X						X				
 autocfg@1.1.0		X						X				
 backon@0.4.1		X										
@@ -22,7 +21,7 @@ bytes@1.5.0								X
 cc@1.0.83		X						X				
 cexpr@0.6.0		X						X				
 cfg-if@1.0.0		X						X				
-chrono@0.4.32		X						X				
+chrono@0.4.33		X						X				
 clang-sys@1.7.0		X										
 const-oid@0.9.6		X						X				
 const-random@0.1.17		X						X				
@@ -65,10 +64,10 @@ httparse@1.8.0		X						X
 httpdate@1.0.3		X						X				
 hyper@0.14.28								X				
 hyper-rustls@0.24.2		X					X	X				
-iana-time-zone@0.1.59		X						X				
+iana-time-zone@0.1.60		X						X				
 iana-time-zone-haiku@0.1.2		X						X				
 idna@0.5.0		X						X				
-indexmap@2.1.0		X						X				
+indexmap@2.2.2		X						X				
 instant@0.1.12				X								
 ipnet@2.9.0		X						X				
 itoa@1.0.10		X						X				
@@ -76,10 +75,9 @@ js-sys@0.3.67		X						X
 jsonwebtoken@9.2.0								X				
 lazy_static@1.4.0		X						X				
 lazycell@1.3.0		X						X				
-libc@0.2.152		X						X				
+libc@0.2.153		X						X				
 libloading@0.8.1							X					
 libm@0.2.8		X						X				
-lock_api@0.4.11		X						X				
 log@0.4.20		X						X				
 magnus@0.5.5								X				
 magnus-macros@0.4.1								X				
@@ -87,28 +85,27 @@ md-5@0.10.6		X						X
 memchr@2.7.1								X			X	
 mime@0.3.17		X						X				
 minimal-lexical@0.2.1		X						X				
-miniz_oxide@0.7.1		X						X				X
+miniz_oxide@0.7.2		X						X				X
 mio@0.8.10								X				
 nom@7.1.3								X				
 num-bigint@0.4.4		X						X				
 num-bigint-dig@0.8.4		X						X				
+num-conv@0.1.0		X						X				
 num-integer@0.1.45		X						X				
 num-iter@0.1.43		X						X				
 num-traits@0.2.17		X						X				
 object@0.32.2		X						X				
 once_cell@1.19.0		X						X				
-opendal@0.43.0		X										
-opendal-ruby@0.1.0		X										
+opendal@0.45.1		X										
+opendal-ruby@0.1.1+core.0.45.1		X										
 openssl-probe@0.1.5		X						X				
 ordered-multimap@0.7.1								X				
-parking_lot@0.12.1		X						X				
-parking_lot_core@0.9.9		X						X				
 peeking_take_while@0.1.2		X						X				
 pem@3.0.3								X				
 pem-rfc7468@0.7.0		X						X				
 percent-encoding@2.3.1		X						X				
-pin-project@1.1.3		X						X				
-pin-project-internal@1.1.3		X						X				
+pin-project@1.1.4		X						X				
+pin-project-internal@1.1.4		X						X				
 pin-project-lite@0.2.13		X						X				
 pin-utils@0.1.0		X						X				
 pkcs1@0.7.5		X						X				
@@ -116,7 +113,6 @@ pkcs8@0.10.2		X						X
 powerfmt@0.2.0		X						X				
 ppv-lite86@0.2.17		X						X				
 proc-macro2@1.0.78		X						X				
-quick-xml@0.30.0								X				
 quick-xml@0.31.0								X				
 quote@1.0.35		X						X				
 rand@0.8.5		X						X				
@@ -125,12 +121,11 @@ rand_core@0.6.4		X						X
 rb-sys@0.9.87		X						X				
 rb-sys-build@0.9.87		X						X				
 rb-sys-env@0.1.2		X						X				
-redox_syscall@0.4.1								X				
 regex@1.10.3		X						X				
-regex-automata@0.4.4		X						X				
+regex-automata@0.4.5		X						X				
 regex-syntax@0.8.2		X						X				
-reqsign@0.14.6		X										
-reqwest@0.11.23		X						X				
+reqsign@0.14.7		X										
+reqwest@0.11.24		X						X				
 ring@0.17.7									X			
 rsa@0.9.6		X						X				
 rust-ini@0.20.0								X				
@@ -142,13 +137,12 @@ rustls-pemfile@1.0.4		X					X	X
 rustls-webpki@0.101.7							X					
 ryu@1.0.16		X			X							
 schannel@0.1.23								X				
-scopeguard@1.2.0		X						X				
 sct@0.7.1		X					X	X				
 security-framework@2.9.2		X						X				
 security-framework-sys@2.9.1		X						X				
-serde@1.0.195		X						X				
-serde_derive@1.0.195		X						X				
-serde_json@1.0.111		X						X				
+serde@1.0.196		X						X				
+serde_derive@1.0.196		X						X				
+serde_json@1.0.113		X						X				
 serde_urlencoded@0.7.1		X						X				
 sha1@0.10.6		X						X				
 sha2@0.10.8		X						X				
@@ -165,17 +159,18 @@ spki@0.7.3		X						X
 subtle@2.5.0				X								
 syn@1.0.109		X						X				
 syn@2.0.48		X						X				
+sync_wrapper@0.1.2		X										
 system-configuration@0.5.1		X						X				
 system-configuration-sys@0.5.0		X						X				
 thiserror@1.0.56		X						X				
 thiserror-impl@1.0.56		X						X				
-time@0.3.31		X						X				
+time@0.3.34		X						X				
 time-core@0.1.2		X						X				
-time-macros@0.2.16		X						X				
+time-macros@0.2.17		X						X				
 tiny-keccak@2.0.2						X						
 tinyvec@1.6.0		X						X				X
 tinyvec_macros@0.1.1		X						X				X
-tokio@1.35.1								X				
+tokio@1.36.0								X				
 tokio-rustls@0.24.1		X						X				
 tokio-util@0.7.10								X				
 tower-service@0.3.2								X				
@@ -198,7 +193,7 @@ wasm-bindgen-futures@0.4.40		X						X
 wasm-bindgen-macro@0.2.90		X						X				
 wasm-bindgen-macro-support@0.2.90		X						X				
 wasm-bindgen-shared@0.2.90		X						X				
-wasm-streams@0.3.0		X						X				
+wasm-streams@0.4.0		X						X				
 web-sys@0.3.67		X						X				
 windows-core@0.52.0		X						X				
 windows-sys@0.48.0		X						X				

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -4010,7 +4010,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "anyhow",
  "async-backtrace",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.67"
-version = "0.45.0"
+version = "0.45.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -1,233 +1,200 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.21.0		X						X					
-adler@1.0.2	X	X						X					
-android-tzdata@0.1.1		X						X					
-android_system_properties@0.1.5		X						X					
-anyhow@1.0.75		X						X					
-arc-swap@1.6.0		X						X					
-async-trait@0.1.75		X						X					
-autocfg@1.1.0		X						X					
-awaitable@0.4.0								X					
-awaitable-error@0.1.0								X					
-backon@0.4.1		X											
-backtrace@0.3.69		X						X					
-base64@0.21.5		X						X					
-base64ct@1.6.0		X						X					
-bitflags@1.3.2		X						X					
-bitflags@2.4.1		X						X					
-block-buffer@0.10.4		X						X					
-bumpalo@3.14.0		X						X					
-byteorder@1.5.0								X				X	
-bytes@1.5.0								X					
-cc@1.0.83		X						X					
-cfg-if@1.0.0		X						X					
-chrono@0.4.31		X						X					
-concurrent_arena@0.1.8								X					
-const-oid@0.9.5		X						X					
-const-random@0.1.17		X						X					
-const-random-macro@0.1.16		X						X					
-core-foundation@0.9.3		X						X					
-core-foundation-sys@0.8.4		X						X					
-cpufeatures@0.2.11		X						X					
-crunchy@0.2.2								X					
-crypto-common@0.1.6		X						X					
-der@0.7.8		X						X					
-deranged@0.3.9		X						X					
-derive_destructure2@0.1.2		X						X					
-digest@0.10.7		X						X					
-dirs@5.0.1		X						X					
-dirs-sys@0.4.1		X						X					
-dlv-list@0.5.2		X						X					
-dotenvy@0.15.7								X					
-encoding_rs@0.8.33		X		X				X					
-equivalent@1.0.1		X						X					
-fastrand@1.9.0		X						X					
-fastrand@2.0.1		X						X					
-flagset@0.4.4		X											
-fnv@1.0.7		X						X					
-form_urlencoded@1.2.1		X						X					
-futures@0.3.29		X						X					
-futures-channel@0.3.30		X						X					
-futures-core@0.3.30		X						X					
-futures-executor@0.3.29		X						X					
-futures-io@0.3.30		X						X					
-futures-macro@0.3.30		X						X					
-futures-sink@0.3.30		X						X					
-futures-task@0.3.30		X						X					
-futures-util@0.3.30		X						X					
-generic-array@0.14.7								X					
-getrandom@0.2.11		X						X					
-gimli@0.28.0		X						X					
-h2@0.3.22								X					
-hashbrown@0.14.2		X						X					
-hermit-abi@0.3.3		X						X					
-hex@0.4.3		X						X					
-hmac@0.12.1		X						X					
-home@0.5.5		X						X					
-http@0.2.11		X						X					
-http-body@0.4.5								X					
-httparse@1.8.0		X						X					
-httpdate@1.0.3		X						X					
-hyper@0.14.27								X					
-hyper-rustls@0.24.2		X					X	X					
-iana-time-zone@0.1.58		X						X					
-iana-time-zone-haiku@0.1.2		X						X					
-idna@0.5.0		X						X					
-indexmap@2.1.0		X						X					
-instant@0.1.12				X									
-ipnet@2.9.0		X						X					
-itoa@1.0.9		X						X					
-js-sys@0.3.66		X						X					
-jsonwebtoken@9.2.0								X					
-lazy_static@1.4.0		X						X					
-libc@0.2.151		X						X					
-libm@0.2.8		X						X					
-libredox@0.0.1								X					
-linux-raw-sys@0.4.11		X	X					X					
-lock_api@0.4.11		X						X					
-log@0.4.20		X						X					
-md-5@0.10.6		X						X					
-memchr@2.6.4								X				X	
-mime@0.3.17		X						X					
-miniz_oxide@0.7.1		X						X					X
-mio@0.8.9								X					
-num-bigint@0.4.4		X						X					
-num-bigint-dig@0.8.4		X						X					
-num-derive@0.3.3		X						X					
-num-integer@0.1.45		X						X					
-num-iter@0.1.43		X						X					
-num-traits@0.2.17		X						X					
-num_cpus@1.16.0		X						X					
-object@0.32.1		X						X					
-once_cell@1.19.0		X						X					
-opendal@0.45.0		X											
-openssh@0.10.1		X						X					
-openssh-sftp-client@0.14.1								X					
-openssh-sftp-client-lowlevel@0.6.0								X					
-openssh-sftp-error@0.4.0								X					
-openssh-sftp-protocol@0.24.0								X					
-openssh-sftp-protocol-error@0.1.0								X					
-openssl-probe@0.1.5		X						X					
-option-ext@0.2.0									X				
-ordered-multimap@0.7.0								X					
-parking_lot@0.12.1		X						X					
-parking_lot_core@0.9.9		X						X					
-pem@3.0.2								X					
-pem-rfc7468@0.7.0		X						X					
-percent-encoding@2.3.1		X						X					
-pin-project@1.1.3		X						X					
-pin-project-internal@1.1.3		X						X					
-pin-project-lite@0.2.13		X						X					
-pin-utils@0.1.0		X						X					
-pkcs1@0.7.5		X						X					
-pkcs8@0.10.2		X						X					
-powerfmt@0.2.0		X						X					
-ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.69		X						X					
-quick-xml@0.30.0								X					
-quick-xml@0.31.0								X					
-quote@1.0.33		X						X					
-rand@0.8.5		X						X					
-rand_chacha@0.3.1		X						X					
-rand_core@0.6.4		X						X					
-redox_syscall@0.4.1								X					
-redox_users@0.4.4								X					
-reqsign@0.14.6		X											
-reqwest@0.11.22		X						X					
-ring@0.17.5										X			
-rsa@0.9.4		X						X					
-rust-ini@0.20.0								X					
-rustc-demangle@0.1.23		X						X					
-rustix@0.38.25		X	X					X					
-rustls@0.21.9		X					X	X					
-rustls-native-certs@0.6.3		X					X	X					
-rustls-pemfile@1.0.4		X					X	X					
-rustls-webpki@0.101.7							X						
-ryu@1.0.15		X			X								
-schannel@0.1.22								X					
-scopeguard@1.2.0		X						X					
-sct@0.7.1		X					X	X					
-security-framework@2.9.2		X						X					
-security-framework-sys@2.9.1		X						X					
-serde@1.0.193		X						X					
-serde_derive@1.0.193		X						X					
-serde_json@1.0.108		X						X					
-serde_urlencoded@0.7.1		X						X					
-sha1@0.10.6		X						X					
-sha2@0.10.8		X						X					
-shell-escape@0.1.5		X						X					
-signal-hook-registry@1.4.1		X						X					
-signature@2.2.0		X						X					
-simple_asn1@0.6.2							X						
-slab@0.4.9								X					
-smallvec@1.11.2		X						X					
-socket2@0.4.10		X						X					
-socket2@0.5.5		X						X					
-spin@0.5.2								X					
-spin@0.9.8								X					
-spki@0.7.2		X						X					
-ssh_format@0.14.1								X					
-ssh_format_error@0.1.0								X					
-stable_deref_trait@1.2.0		X						X					
-subtle@2.5.0				X									
-syn@1.0.109		X						X					
-syn@2.0.39		X						X					
-system-configuration@0.5.1		X						X					
-system-configuration-sys@0.5.0		X						X					
-tempfile@3.8.1		X						X					
-thin-vec@0.2.12		X						X					
-thiserror@1.0.50		X						X					
-thiserror-impl@1.0.50		X						X					
-time@0.3.30		X						X					
-time-core@0.1.2		X						X					
-time-macros@0.2.15		X						X					
-tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
-tinyvec_macros@0.1.1		X						X					X
-tokio@1.34.0								X					
-tokio-io-utility@0.7.6								X					
-tokio-macros@2.2.0								X					
-tokio-pipe@0.2.12		X						X					
-tokio-rustls@0.24.1		X						X					
-tokio-util@0.7.10								X					
-tower-service@0.3.2								X					
-tracing@0.1.40								X					
-tracing-attributes@0.1.27								X					
-tracing-core@0.1.32								X					
-triomphe@0.1.9		X						X					
-try-lock@0.2.4								X					
-typenum@1.17.0		X						X					
-unicode-bidi@0.3.13		X						X					
-unicode-ident@1.0.12		X						X			X		
-unicode-normalization@0.1.22		X						X					
-untrusted@0.9.0							X						
-url@2.5.0		X						X					
-uuid@1.6.1		X						X					
-valuable@0.1.0								X					
-vec-strings@0.4.8								X					
-version_check@0.9.4		X						X					
-want@0.3.1								X					
-wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
-wasm-bindgen@0.2.89		X						X					
-wasm-bindgen-backend@0.2.89		X						X					
-wasm-bindgen-futures@0.4.39		X						X					
-wasm-bindgen-macro@0.2.89		X						X					
-wasm-bindgen-macro-support@0.2.89		X						X					
-wasm-bindgen-shared@0.2.89		X						X					
-wasm-streams@0.3.0		X						X					
-web-sys@0.3.65		X						X					
-winapi@0.3.9		X						X					
-winapi-i686-pc-windows-gnu@0.4.0		X						X					
-winapi-x86_64-pc-windows-gnu@0.4.0		X						X					
-windows-core@0.51.1		X						X					
-windows-sys@0.48.0		X						X					
-windows-targets@0.48.5		X						X					
-windows_aarch64_gnullvm@0.48.5		X						X					
-windows_aarch64_msvc@0.48.5		X						X					
-windows_i686_gnu@0.48.5		X						X					
-windows_i686_msvc@0.48.5		X						X					
-windows_x86_64_gnu@0.48.5		X						X					
-windows_x86_64_gnullvm@0.48.5		X						X					
-windows_x86_64_msvc@0.48.5		X						X					
-winreg@0.50.0								X					
-zeroize@1.7.0		X						X					
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
+addr2line@0.21.0		X						X				
+adler@1.0.2	X	X						X				
+android-tzdata@0.1.1		X						X				
+android_system_properties@0.1.5		X						X				
+anyhow@1.0.79		X						X				
+async-trait@0.1.77		X						X				
+autocfg@1.1.0		X						X				
+backon@0.4.1		X										
+backtrace@0.3.69		X						X				
+base64@0.21.7		X						X				
+base64ct@1.6.0		X						X				
+bitflags@1.3.2		X						X				
+block-buffer@0.10.4		X						X				
+bumpalo@3.14.0		X						X				
+byteorder@1.5.0								X			X	
+bytes@1.5.0								X				
+cc@1.0.83		X						X				
+cfg-if@1.0.0		X						X				
+chrono@0.4.33		X						X				
+const-oid@0.9.6		X						X				
+const-random@0.1.17		X						X				
+const-random-macro@0.1.16		X						X				
+core-foundation@0.9.4		X						X				
+core-foundation-sys@0.8.6		X						X				
+cpufeatures@0.2.12		X						X				
+crunchy@0.2.2								X				
+crypto-common@0.1.6		X						X				
+der@0.7.8		X						X				
+deranged@0.3.11		X						X				
+digest@0.10.7		X						X				
+dlv-list@0.5.2		X						X				
+dotenvy@0.15.7								X				
+encoding_rs@0.8.33		X		X				X				
+equivalent@1.0.1		X						X				
+fastrand@1.9.0		X						X				
+flagset@0.4.4		X										
+fnv@1.0.7		X						X				
+form_urlencoded@1.2.1		X						X				
+futures@0.3.30		X						X				
+futures-channel@0.3.30		X						X				
+futures-core@0.3.30		X						X				
+futures-executor@0.3.30		X						X				
+futures-io@0.3.30		X						X				
+futures-macro@0.3.30		X						X				
+futures-sink@0.3.30		X						X				
+futures-task@0.3.30		X						X				
+futures-util@0.3.30		X						X				
+generic-array@0.14.7								X				
+getrandom@0.2.12		X						X				
+gimli@0.28.1		X						X				
+h2@0.3.24								X				
+hashbrown@0.14.3		X						X				
+hermit-abi@0.3.4		X						X				
+hex@0.4.3		X						X				
+hmac@0.12.1		X						X				
+home@0.5.5		X						X				
+http@0.2.11		X						X				
+http-body@0.4.6								X				
+httparse@1.8.0		X						X				
+httpdate@1.0.3		X						X				
+hyper@0.14.28								X				
+hyper-rustls@0.24.2		X					X	X				
+iana-time-zone@0.1.59		X						X				
+iana-time-zone-haiku@0.1.2		X						X				
+idna@0.5.0		X						X				
+indexmap@2.2.2		X						X				
+instant@0.1.12				X								
+ipnet@2.9.0		X						X				
+itoa@1.0.10		X						X				
+js-sys@0.3.67		X						X				
+jsonwebtoken@9.2.0								X				
+lazy_static@1.4.0		X						X				
+libc@0.2.153		X						X				
+libm@0.2.8		X						X				
+log@0.4.20		X						X				
+md-5@0.10.6		X						X				
+memchr@2.7.1								X			X	
+mime@0.3.17		X						X				
+miniz_oxide@0.7.1		X						X				X
+mio@0.8.10								X				
+num-bigint@0.4.4		X						X				
+num-bigint-dig@0.8.4		X						X				
+num-conv@0.1.0		X						X				
+num-integer@0.1.45		X						X				
+num-iter@0.1.43		X						X				
+num-traits@0.2.17		X						X				
+num_cpus@1.16.0		X						X				
+object@0.32.2		X						X				
+once_cell@1.19.0		X						X				
+opendal@0.45.1		X										
+openssl-probe@0.1.5		X						X				
+ordered-multimap@0.7.0								X				
+pem@3.0.3								X				
+pem-rfc7468@0.7.0		X						X				
+percent-encoding@2.3.1		X						X				
+pin-project@1.1.4		X						X				
+pin-project-internal@1.1.4		X						X				
+pin-project-lite@0.2.13		X						X				
+pin-utils@0.1.0		X						X				
+pkcs1@0.7.5		X						X				
+pkcs8@0.10.2		X						X				
+powerfmt@0.2.0		X						X				
+ppv-lite86@0.2.17		X						X				
+proc-macro2@1.0.78		X						X				
+quick-xml@0.31.0								X				
+quote@1.0.35		X						X				
+rand@0.8.5		X						X				
+rand_chacha@0.3.1		X						X				
+rand_core@0.6.4		X						X				
+reqsign@0.14.7		X										
+reqwest@0.11.24		X						X				
+ring@0.17.7									X			
+rsa@0.9.6		X						X				
+rust-ini@0.20.0								X				
+rustc-demangle@0.1.23		X						X				
+rustls@0.21.10		X					X	X				
+rustls-native-certs@0.6.3		X					X	X				
+rustls-pemfile@1.0.4		X					X	X				
+rustls-webpki@0.101.7							X					
+ryu@1.0.16		X			X							
+schannel@0.1.23								X				
+sct@0.7.1		X					X	X				
+security-framework@2.9.2		X						X				
+security-framework-sys@2.9.1		X						X				
+serde@1.0.196		X						X				
+serde_derive@1.0.196		X						X				
+serde_json@1.0.114		X						X				
+serde_urlencoded@0.7.1		X						X				
+sha1@0.10.6		X						X				
+sha2@0.10.8		X						X				
+signature@2.2.0		X						X				
+simple_asn1@0.6.2							X					
+slab@0.4.9								X				
+smallvec@1.13.1		X						X				
+socket2@0.5.5		X						X				
+spin@0.5.2								X				
+spin@0.9.8								X				
+spki@0.7.3		X						X				
+subtle@2.5.0				X								
+syn@2.0.48		X						X				
+sync_wrapper@0.1.2		X										
+system-configuration@0.5.1		X						X				
+system-configuration-sys@0.5.0		X						X				
+thiserror@1.0.56		X						X				
+thiserror-impl@1.0.56		X						X				
+time@0.3.32		X						X				
+time-core@0.1.2		X						X				
+time-macros@0.2.17		X						X				
+tiny-keccak@2.0.2						X						
+tinyvec@1.6.0		X						X				X
+tinyvec_macros@0.1.1		X						X				X
+tokio@1.36.0								X				
+tokio-macros@2.2.0								X				
+tokio-rustls@0.24.1		X						X				
+tokio-util@0.7.10								X				
+tower-service@0.3.2								X				
+tracing@0.1.40								X				
+tracing-core@0.1.32								X				
+try-lock@0.2.5								X				
+typenum@1.17.0		X						X				
+unicode-bidi@0.3.15		X						X				
+unicode-ident@1.0.12		X						X		X		
+unicode-normalization@0.1.22		X						X				
+untrusted@0.9.0							X					
+url@2.5.0		X						X				
+uuid@1.7.0		X						X				
+valuable@0.1.0								X				
+version_check@0.9.4		X						X				
+want@0.3.1								X				
+wasi@0.11.0+wasi-snapshot-preview1		X	X					X				
+wasm-bindgen@0.2.90		X						X				
+wasm-bindgen-backend@0.2.90		X						X				
+wasm-bindgen-futures@0.4.40		X						X				
+wasm-bindgen-macro@0.2.90		X						X				
+wasm-bindgen-macro-support@0.2.90		X						X				
+wasm-bindgen-shared@0.2.90		X						X				
+wasm-streams@0.4.0		X						X				
+web-sys@0.3.67		X						X				
+windows-core@0.52.0		X						X				
+windows-sys@0.48.0		X						X				
+windows-sys@0.52.0		X						X				
+windows-targets@0.48.5		X						X				
+windows-targets@0.52.0		X						X				
+windows_aarch64_gnullvm@0.48.5		X						X				
+windows_aarch64_gnullvm@0.52.0		X						X				
+windows_aarch64_msvc@0.48.5		X						X				
+windows_aarch64_msvc@0.52.0		X						X				
+windows_i686_gnu@0.48.5		X						X				
+windows_i686_gnu@0.52.0		X						X				
+windows_i686_msvc@0.48.5		X						X				
+windows_i686_msvc@0.52.0		X						X				
+windows_x86_64_gnu@0.48.5		X						X				
+windows_x86_64_gnu@0.52.0		X						X				
+windows_x86_64_gnullvm@0.48.5		X						X				
+windows_x86_64_gnullvm@0.52.0		X						X				
+windows_x86_64_msvc@0.48.5		X						X				
+windows_x86_64_msvc@0.52.0		X						X				
+winreg@0.50.0								X				
+zeroize@1.7.0		X						X				

--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 description = "Use OpenDAL as a backend to access data in various service with WebDAV protocol"
 name = "dav-server-opendalfs"
-version = "0.0.0+core.0.45.0"
+version = "0.0.0+core.0.45.1"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -35,7 +35,7 @@ dav-server = { version = "0.5.8" }
 dirs = "5.0.0"
 futures = "0.3"
 futures-util = { version = "0.3.16" }
-opendal = { version = "0.45.0", path = "../../core" }
+opendal = { version = "0.45.1", path = "../../core" }
 quick-xml = { version = "0.31", features = ["serialize", "overlapped-lists"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1.27", features = [

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -1,39 +1,39 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
 addr2line@0.21.0		X							X					
 adler@1.0.2	X	X							X					
-ahash@0.8.6		X							X					
+ahash@0.8.7		X							X					
 aho-corasick@1.1.2									X				X	
 allocator-api2@0.2.16		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.75		X							X					
-async-trait@0.1.75		X							X					
+anyhow@1.0.79		X							X					
+async-trait@0.1.77		X							X					
 autocfg@1.1.0		X							X					
 backon@0.4.1		X												
 backtrace@0.3.69		X							X					
-base64@0.21.5		X							X					
+base64@0.21.7		X							X					
 base64ct@1.6.0		X							X					
 bitflags@1.3.2		X							X					
-bitflags@2.4.1		X							X					
+bitflags@2.4.2		X							X					
 block-buffer@0.10.4		X							X					
 bumpalo@3.14.0		X							X					
 byteorder@1.5.0									X				X	
 bytes@1.5.0									X					
 cc@1.0.83		X							X					
 cfg-if@1.0.0		X							X					
-chrono@0.4.31		X							X					
-const-oid@0.9.5		X							X					
+chrono@0.4.33		X							X					
+const-oid@0.9.6		X							X					
 const-random@0.1.17		X							X					
 const-random-macro@0.1.16		X							X					
-core-foundation@0.9.3		X							X					
-core-foundation-sys@0.8.4		X							X					
-cpufeatures@0.2.11		X							X					
+core-foundation@0.9.4		X							X					
+core-foundation-sys@0.8.6		X							X					
+cpufeatures@0.2.12		X							X					
 crunchy@0.2.2									X					
 crypto-common@0.1.6		X							X					
-dav-server@0.5.7		X												
-dav-server-opendalfs@0.45.0		X												
+dav-server@0.5.8		X												
+dav-server-opendalfs@0.0.0+core.0.45.1		X												
 der@0.7.8		X							X					
-deranged@0.3.9		X							X					
+deranged@0.3.11		X							X					
 digest@0.10.7		X							X					
 dirs@5.0.1		X							X					
 dirs-sys@0.4.1		X							X					
@@ -44,178 +44,183 @@ fastrand@1.9.0		X							X
 flagset@0.4.4		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.29		X							X					
+futures@0.3.30		X							X					
 futures-channel@0.3.30		X							X					
 futures-core@0.3.30		X							X					
-futures-executor@0.3.29		X							X					
+futures-executor@0.3.30		X							X					
 futures-io@0.3.30		X							X					
 futures-macro@0.3.30		X							X					
 futures-sink@0.3.30		X							X					
 futures-task@0.3.30		X							X					
 futures-util@0.3.30		X							X					
 generic-array@0.14.7									X					
-getrandom@0.2.11		X							X					
-gimli@0.28.0		X							X					
-h2@0.3.22									X					
-hashbrown@0.14.2		X							X					
+getrandom@0.2.12		X							X					
+gimli@0.28.1		X							X					
+h2@0.3.24									X					
+hashbrown@0.14.3		X							X					
 headers@0.3.9									X					
 headers-core@0.2.0									X					
-hermit-abi@0.3.3		X							X					
+hermit-abi@0.3.4		X							X					
 hex@0.4.3		X							X					
 hmac@0.12.1		X							X					
-home@0.5.5		X							X					
+home@0.5.9		X							X					
 htmlescape@0.3.1		X							X	X				
 http@0.2.11		X							X					
-http-body@0.4.5									X					
+http-body@0.4.6									X					
 httparse@1.8.0		X							X					
 httpdate@1.0.3		X							X					
-hyper@0.14.27									X					
+hyper@0.14.28									X					
 hyper-rustls@0.24.2		X						X	X					
-iana-time-zone@0.1.58		X							X					
+iana-time-zone@0.1.59		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
-indexmap@2.1.0		X							X					
+indexmap@2.2.2		X							X					
 instant@0.1.12					X									
 ipnet@2.9.0		X							X					
-itoa@1.0.9		X							X					
-js-sys@0.3.66		X							X					
+itoa@1.0.10		X							X					
+js-sys@0.3.67		X							X					
 jsonwebtoken@9.2.0									X					
 lazy_static@1.4.0		X							X					
-libc@0.2.151		X							X					
+libc@0.2.153		X							X					
 libm@0.2.8		X							X					
 libredox@0.0.1									X					
 lock_api@0.4.11		X							X					
 log@0.4.20		X							X					
-lru@0.11.1									X					
+lru@0.12.2									X					
 md-5@0.10.6		X							X					
-memchr@2.6.4									X				X	
+memchr@2.7.1									X				X	
 mime@0.3.17		X							X					
 mime_guess@2.0.4									X					
 miniz_oxide@0.7.1		X							X					X
-mio@0.8.9									X					
+mio@0.8.10									X					
 num-bigint@0.4.4		X							X					
 num-bigint-dig@0.8.4		X							X					
+num-conv@0.1.0		X							X					
 num-integer@0.1.45		X							X					
 num-iter@0.1.43		X							X					
 num-traits@0.2.17		X							X					
 num_cpus@1.16.0		X							X					
-object@0.32.1		X							X					
+object@0.32.2		X							X					
 once_cell@1.19.0		X							X					
-opendal@0.45.0		X												
+opendal@0.45.1		X												
 openssl-probe@0.1.5		X							X					
 option-ext@0.2.0										X				
-ordered-multimap@0.7.0									X					
+ordered-multimap@0.7.1									X					
 parking_lot@0.12.1		X							X					
 parking_lot_core@0.9.9		X							X					
-pem@3.0.2									X					
+pem@3.0.3									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.3		X							X					
-pin-project-internal@1.1.3		X							X					
+pin-project@1.1.4		X							X					
+pin-project-internal@1.1.4		X							X					
 pin-project-lite@0.2.13		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.17		X							X					
-proc-macro2@1.0.69		X							X					
-quick-xml@0.30.0									X					
+proc-macro2@1.0.78		X							X					
 quick-xml@0.31.0									X					
-quote@1.0.33		X							X					
+quote@1.0.35		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 redox_syscall@0.4.1									X					
 redox_users@0.4.4									X					
-regex@1.10.2		X							X					
-regex-automata@0.4.3		X							X					
+regex@1.10.3		X							X					
+regex-automata@0.4.5		X							X					
 regex-syntax@0.8.2		X							X					
-reqsign@0.14.6		X												
-reqwest@0.11.22		X							X					
-ring@0.17.5											X			
-rsa@0.9.4		X							X					
+reqsign@0.14.7		X												
+reqwest@0.11.24		X							X					
+ring@0.17.7											X			
+rsa@0.9.6		X							X					
 rust-ini@0.20.0									X					
 rustc-demangle@0.1.23		X							X					
-rustls@0.21.9		X						X	X					
+rustls@0.21.10		X						X	X					
 rustls-native-certs@0.6.3		X						X	X					
 rustls-pemfile@1.0.4		X						X	X					
 rustls-webpki@0.101.7								X						
-ryu@1.0.15		X				X								
-schannel@0.1.22									X					
+ryu@1.0.16		X				X								
+schannel@0.1.23									X					
 scopeguard@1.2.0		X							X					
 sct@0.7.1		X						X	X					
 security-framework@2.9.2		X							X					
 security-framework-sys@2.9.1		X							X					
-serde@1.0.193		X							X					
-serde_derive@1.0.193		X							X					
-serde_json@1.0.108		X							X					
+serde@1.0.196		X							X					
+serde_derive@1.0.196		X							X					
+serde_json@1.0.113		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
 signature@2.2.0		X							X					
 simple_asn1@0.6.2								X						
 slab@0.4.9									X					
-smallvec@1.11.2		X							X					
-socket2@0.4.10		X							X					
+smallvec@1.13.1		X							X					
 socket2@0.5.5		X							X					
 spin@0.5.2									X					
 spin@0.9.8									X					
-spki@0.7.2		X							X					
+spki@0.7.3		X							X					
 subtle@2.5.0					X									
-syn@2.0.39		X							X					
+syn@2.0.48		X							X					
+sync_wrapper@0.1.2		X												
 system-configuration@0.5.1		X							X					
 system-configuration-sys@0.5.0		X							X					
-thiserror@1.0.50		X							X					
-thiserror-impl@1.0.50		X							X					
-time@0.3.30		X							X					
+thiserror@1.0.56		X							X					
+thiserror-impl@1.0.56		X							X					
+time@0.3.32		X							X					
 time-core@0.1.2		X							X					
-time-macros@0.2.15		X							X					
+time-macros@0.2.17		X							X					
 tiny-keccak@2.0.2							X							
 tinyvec@1.6.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.34.0									X					
+tokio@1.36.0									X					
 tokio-macros@2.2.0									X					
 tokio-rustls@0.24.1		X							X					
 tokio-util@0.7.10									X					
 tower-service@0.3.2									X					
 tracing@0.1.40									X					
 tracing-core@0.1.32									X					
-try-lock@0.2.4									X					
+try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
 unicase@2.7.0		X							X					
-unicode-bidi@0.3.13		X							X					
+unicode-bidi@0.3.15		X							X					
 unicode-ident@1.0.12		X							X			X		
 unicode-normalization@0.1.22		X							X					
 untrusted@0.9.0								X						
 url@2.5.0		X							X					
-uuid@1.6.1		X							X					
-valuable@0.1.0									X					
+uuid@1.7.0		X							X					
 version_check@0.9.4		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.89		X							X					
-wasm-bindgen-backend@0.2.89		X							X					
-wasm-bindgen-futures@0.4.39		X							X					
-wasm-bindgen-macro@0.2.89		X							X					
-wasm-bindgen-macro-support@0.2.89		X							X					
-wasm-bindgen-shared@0.2.89		X							X					
-wasm-streams@0.3.0		X							X					
-web-sys@0.3.65		X							X					
-winapi@0.3.9		X							X					
-winapi-i686-pc-windows-gnu@0.4.0		X							X					
-winapi-x86_64-pc-windows-gnu@0.4.0		X							X					
-windows-core@0.51.1		X							X					
+wasm-bindgen@0.2.90		X							X					
+wasm-bindgen-backend@0.2.90		X							X					
+wasm-bindgen-futures@0.4.40		X							X					
+wasm-bindgen-macro@0.2.90		X							X					
+wasm-bindgen-macro-support@0.2.90		X							X					
+wasm-bindgen-shared@0.2.90		X							X					
+wasm-streams@0.4.0		X							X					
+web-sys@0.3.67		X							X					
+windows-core@0.52.0		X							X					
 windows-sys@0.48.0		X							X					
+windows-sys@0.52.0		X							X					
 windows-targets@0.48.5		X							X					
+windows-targets@0.52.0		X							X					
 windows_aarch64_gnullvm@0.48.5		X							X					
+windows_aarch64_gnullvm@0.52.0		X							X					
 windows_aarch64_msvc@0.48.5		X							X					
+windows_aarch64_msvc@0.52.0		X							X					
 windows_i686_gnu@0.48.5		X							X					
+windows_i686_gnu@0.52.0		X							X					
 windows_i686_msvc@0.48.5		X							X					
+windows_i686_msvc@0.52.0		X							X					
 windows_x86_64_gnu@0.48.5		X							X					
+windows_x86_64_gnu@0.52.0		X							X					
 windows_x86_64_gnullvm@0.48.5		X							X					
+windows_x86_64_gnullvm@0.52.0		X							X					
 windows_x86_64_msvc@0.48.5		X							X					
+windows_x86_64_msvc@0.52.0		X							X					
 winreg@0.50.0									X					
 xml-rs@0.8.19									X					
 xmltree@0.10.3									X					
-zerocopy@0.7.26		X		X					X					
+zerocopy@0.7.32		X		X					X					
 zeroize@1.7.0		X							X					

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.67"
-version = "0.42.0+core.0.45.0"
+version = "0.43.0+core.0.45.1"
 
 [dependencies]
 async-trait = "0.1"
@@ -33,7 +33,7 @@ bytes = "1"
 futures = "0.3"
 futures-util = "0.3"
 object_store = "0.9"
-opendal = { version = "0.45.0", path = "../../core" }
+opendal = { version = "0.45.1", path = "../../core" }
 tokio = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -3,12 +3,12 @@ addr2line@0.21.0		X						X
 adler@1.0.2	X	X						X				
 android-tzdata@0.1.1		X						X				
 android_system_properties@0.1.5		X						X				
-anyhow@1.0.75		X						X				
-async-trait@0.1.75		X						X				
+anyhow@1.0.79		X						X				
+async-trait@0.1.77		X						X				
 autocfg@1.1.0		X						X				
 backon@0.4.1		X										
 backtrace@0.3.69		X						X				
-base64@0.21.5		X						X				
+base64@0.21.7		X						X				
 base64ct@1.6.0		X						X				
 bitflags@1.3.2		X						X				
 block-buffer@0.10.4		X						X				
@@ -17,17 +17,17 @@ byteorder@1.5.0								X			X
 bytes@1.5.0								X				
 cc@1.0.83		X						X				
 cfg-if@1.0.0		X						X				
-chrono@0.4.31		X						X				
-const-oid@0.9.5		X						X				
+chrono@0.4.33		X						X				
+const-oid@0.9.6		X						X				
 const-random@0.1.17		X						X				
 const-random-macro@0.1.16		X						X				
-core-foundation@0.9.3		X						X				
-core-foundation-sys@0.8.4		X						X				
-cpufeatures@0.2.11		X						X				
+core-foundation@0.9.4		X						X				
+core-foundation-sys@0.8.6		X						X				
+cpufeatures@0.2.12		X						X				
 crunchy@0.2.2								X				
 crypto-common@0.1.6		X						X				
 der@0.7.8		X						X				
-deranged@0.3.9		X						X				
+deranged@0.3.11		X						X				
 digest@0.10.7		X						X				
 dlv-list@0.5.2		X						X				
 doc-comment@0.3.3								X				
@@ -38,134 +38,134 @@ fastrand@1.9.0		X						X
 flagset@0.4.4		X										
 fnv@1.0.7		X						X				
 form_urlencoded@1.2.1		X						X				
-futures@0.3.29		X						X				
+futures@0.3.30		X						X				
 futures-channel@0.3.30		X						X				
 futures-core@0.3.30		X						X				
-futures-executor@0.3.29		X						X				
+futures-executor@0.3.30		X						X				
 futures-io@0.3.30		X						X				
 futures-macro@0.3.30		X						X				
 futures-sink@0.3.30		X						X				
 futures-task@0.3.30		X						X				
 futures-util@0.3.30		X						X				
 generic-array@0.14.7								X				
-getrandom@0.2.11		X						X				
-gimli@0.28.0		X						X				
-h2@0.3.22								X				
-hashbrown@0.14.2		X						X				
+getrandom@0.2.12		X						X				
+gimli@0.28.1		X						X				
+h2@0.3.24								X				
+hashbrown@0.14.3		X						X				
 heck@0.4.1		X						X				
-hermit-abi@0.3.3		X						X				
+hermit-abi@0.3.4		X						X				
 hex@0.4.3		X						X				
 hmac@0.12.1		X						X				
-home@0.5.5		X						X				
+home@0.5.9		X						X				
 http@0.2.11		X						X				
-http-body@0.4.5								X				
+http-body@0.4.6								X				
 httparse@1.8.0		X						X				
 httpdate@1.0.3		X						X				
 humantime@2.1.0		X						X				
-hyper@0.14.27								X				
+hyper@0.14.28								X				
 hyper-rustls@0.24.2		X					X	X				
-iana-time-zone@0.1.58		X						X				
+iana-time-zone@0.1.59		X						X				
 iana-time-zone-haiku@0.1.2		X						X				
 idna@0.5.0		X						X				
-indexmap@2.1.0		X						X				
+indexmap@2.2.2		X						X				
 instant@0.1.12				X								
 ipnet@2.9.0		X						X				
-itertools@0.11.0		X						X				
-itoa@1.0.9		X						X				
-js-sys@0.3.66		X						X				
+itertools@0.12.1		X						X				
+itoa@1.0.10		X						X				
+js-sys@0.3.67		X						X				
 jsonwebtoken@9.2.0								X				
 lazy_static@1.4.0		X						X				
-libc@0.2.151		X						X				
+libc@0.2.153		X						X				
 libm@0.2.8		X						X				
 lock_api@0.4.11		X						X				
 log@0.4.20		X						X				
 md-5@0.10.6		X						X				
-memchr@2.6.4								X			X	
+memchr@2.7.1								X			X	
 mime@0.3.17		X						X				
 miniz_oxide@0.7.1		X						X				X
-mio@0.8.9								X				
+mio@0.8.10								X				
 num-bigint@0.4.4		X						X				
 num-bigint-dig@0.8.4		X						X				
+num-conv@0.1.0		X						X				
 num-integer@0.1.45		X						X				
 num-iter@0.1.43		X						X				
 num-traits@0.2.17		X						X				
 num_cpus@1.16.0		X						X				
-object@0.32.1		X						X				
-object_store@0.7.1		X						X				
-object_store_opendal@0.45.0		X										
+object@0.32.2		X						X				
+object_store@0.9.0		X						X				
+object_store_opendal@0.43.0+core.0.45.1		X										
 once_cell@1.19.0		X						X				
-opendal@0.45.0		X										
+opendal@0.45.1		X										
 openssl-probe@0.1.5		X						X				
-ordered-multimap@0.7.0								X				
+ordered-multimap@0.7.1								X				
 parking_lot@0.12.1		X						X				
 parking_lot_core@0.9.9		X						X				
-pem@3.0.2								X				
+pem@3.0.3								X				
 pem-rfc7468@0.7.0		X						X				
 percent-encoding@2.3.1		X						X				
-pin-project@1.1.3		X						X				
-pin-project-internal@1.1.3		X						X				
+pin-project@1.1.4		X						X				
+pin-project-internal@1.1.4		X						X				
 pin-project-lite@0.2.13		X						X				
 pin-utils@0.1.0		X						X				
 pkcs1@0.7.5		X						X				
 pkcs8@0.10.2		X						X				
 powerfmt@0.2.0		X						X				
 ppv-lite86@0.2.17		X						X				
-proc-macro2@1.0.69		X						X				
-quick-xml@0.30.0								X				
+proc-macro2@1.0.78		X						X				
 quick-xml@0.31.0								X				
-quote@1.0.33		X						X				
+quote@1.0.35		X						X				
 rand@0.8.5		X						X				
 rand_chacha@0.3.1		X						X				
 rand_core@0.6.4		X						X				
 redox_syscall@0.4.1								X				
-reqsign@0.14.6		X										
-reqwest@0.11.22		X						X				
-ring@0.17.5									X			
-rsa@0.9.4		X						X				
+reqsign@0.14.7		X										
+reqwest@0.11.24		X						X				
+ring@0.17.7									X			
+rsa@0.9.6		X						X				
 rust-ini@0.20.0								X				
 rustc-demangle@0.1.23		X						X				
-rustls@0.21.9		X					X	X				
+rustls@0.21.10		X					X	X				
 rustls-native-certs@0.6.3		X					X	X				
 rustls-pemfile@1.0.4		X					X	X				
 rustls-webpki@0.101.7							X					
-ryu@1.0.15		X			X							
+ryu@1.0.16		X			X							
 same-file@1.0.6								X			X	
-schannel@0.1.22								X				
+schannel@0.1.23								X				
 scopeguard@1.2.0		X						X				
 sct@0.7.1		X					X	X				
 security-framework@2.9.2		X						X				
 security-framework-sys@2.9.1		X						X				
-serde@1.0.193		X						X				
-serde_derive@1.0.193		X						X				
-serde_json@1.0.108		X						X				
+serde@1.0.196		X						X				
+serde_derive@1.0.196		X						X				
+serde_json@1.0.113		X						X				
 serde_urlencoded@0.7.1		X						X				
 sha1@0.10.6		X						X				
 sha2@0.10.8		X						X				
 signature@2.2.0		X						X				
 simple_asn1@0.6.2							X					
 slab@0.4.9								X				
-smallvec@1.11.2		X						X				
+smallvec@1.13.1		X						X				
 snafu@0.7.5		X						X				
 snafu-derive@0.7.5		X						X				
-socket2@0.4.10		X						X				
 socket2@0.5.5		X						X				
 spin@0.5.2								X				
 spin@0.9.8								X				
-spki@0.7.2		X						X				
+spki@0.7.3		X						X				
 subtle@2.5.0				X								
 syn@1.0.109		X						X				
-syn@2.0.39		X						X				
+syn@2.0.48		X						X				
+sync_wrapper@0.1.2		X										
 system-configuration@0.5.1		X						X				
 system-configuration-sys@0.5.0		X						X				
-thiserror@1.0.50		X						X				
-thiserror-impl@1.0.50		X						X				
-time@0.3.30		X						X				
+thiserror@1.0.56		X						X				
+thiserror-impl@1.0.56		X						X				
+time@0.3.32		X						X				
 time-core@0.1.2		X						X				
-time-macros@0.2.15		X						X				
+time-macros@0.2.17		X						X				
 tiny-keccak@2.0.2						X						
 tinyvec@1.6.0		X						X				X
 tinyvec_macros@0.1.1		X						X				X
-tokio@1.34.0								X				
+tokio@1.36.0								X				
 tokio-macros@2.2.0								X				
 tokio-rustls@0.24.1		X						X				
 tokio-util@0.7.10								X				
@@ -173,40 +173,48 @@ tower-service@0.3.2								X
 tracing@0.1.40								X				
 tracing-attributes@0.1.27								X				
 tracing-core@0.1.32								X				
-try-lock@0.2.4								X				
+try-lock@0.2.5								X				
 typenum@1.17.0		X						X				
-unicode-bidi@0.3.13		X						X				
+unicode-bidi@0.3.15		X						X				
 unicode-ident@1.0.12		X						X		X		
 unicode-normalization@0.1.22		X						X				
 untrusted@0.9.0							X					
 url@2.5.0		X						X				
-uuid@1.6.1		X						X				
-valuable@0.1.0								X				
+uuid@1.7.0		X						X				
 version_check@0.9.4		X						X				
 walkdir@2.4.0								X			X	
 want@0.3.1								X				
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X				
-wasm-bindgen@0.2.89		X						X				
-wasm-bindgen-backend@0.2.89		X						X				
-wasm-bindgen-futures@0.4.39		X						X				
-wasm-bindgen-macro@0.2.89		X						X				
-wasm-bindgen-macro-support@0.2.89		X						X				
-wasm-bindgen-shared@0.2.89		X						X				
-wasm-streams@0.3.0		X						X				
-web-sys@0.3.65		X						X				
+wasm-bindgen@0.2.90		X						X				
+wasm-bindgen-backend@0.2.90		X						X				
+wasm-bindgen-futures@0.4.40		X						X				
+wasm-bindgen-macro@0.2.90		X						X				
+wasm-bindgen-macro-support@0.2.90		X						X				
+wasm-bindgen-shared@0.2.90		X						X				
+wasm-streams@0.4.0		X						X				
+web-sys@0.3.67		X						X				
 winapi@0.3.9		X						X				
 winapi-i686-pc-windows-gnu@0.4.0		X						X				
 winapi-util@0.1.6								X			X	
 winapi-x86_64-pc-windows-gnu@0.4.0		X						X				
-windows-core@0.51.1		X						X				
+windows-core@0.52.0		X						X				
 windows-sys@0.48.0		X						X				
+windows-sys@0.52.0		X						X				
 windows-targets@0.48.5		X						X				
+windows-targets@0.52.0		X						X				
 windows_aarch64_gnullvm@0.48.5		X						X				
+windows_aarch64_gnullvm@0.52.0		X						X				
 windows_aarch64_msvc@0.48.5		X						X				
+windows_aarch64_msvc@0.52.0		X						X				
 windows_i686_gnu@0.48.5		X						X				
+windows_i686_gnu@0.52.0		X						X				
 windows_i686_msvc@0.48.5		X						X				
+windows_i686_msvc@0.52.0		X						X				
 windows_x86_64_gnu@0.48.5		X						X				
+windows_x86_64_gnu@0.52.0		X						X				
 windows_x86_64_gnullvm@0.48.5		X						X				
+windows_x86_64_gnullvm@0.52.0		X						X				
 windows_x86_64_msvc@0.48.5		X						X				
+windows_x86_64_msvc@0.52.0		X						X				
 winreg@0.50.0								X				
 zeroize@1.7.0		X						X				


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Added
* feat(services/vercel_blob): support vercel blob by @hoslo in https://github.com/apache/opendal/pull/4103
* feat(bindings/python): add ruff as linter by @asukaminato0721 in https://github.com/apache/opendal/pull/4135
* feat(services/hdfs-native): Add capabilities for hdfs-native service by @jihuayu in https://github.com/apache/opendal/pull/4174
* feat(services/sqlite): Add list capability supported for sqlite by @jihuayu in https://github.com/apache/opendal/pull/4180
* feat(services/azblob): support multi write for azblob by @wcy-fdu in https://github.com/apache/opendal/pull/4181
* feat(release): Implement releasing OpenDAL components seperately by @Xuanwo in https://github.com/apache/opendal/pull/4196
* feat: object store adapter based on v0.9 by @waynexia in https://github.com/apache/opendal/pull/4233
### Changed
* refactor(bindings/python): simplify async writer aexit by @suyanhanx in https://github.com/apache/opendal/pull/4128
* refactor(service/d1): Add D1Config by @jihuayu in https://github.com/apache/opendal/pull/4129
### Fixed
* fix: Azdls returns 403 while continuation contains `=` by @Xuanwo in https://github.com/apache/opendal/pull/4105
* fix(bindings/python): missed to call close for the file internally by @zzl221000 in https://github.com/apache/opendal/pull/4122
* fix(bindings/python): sync writer exit close raise error by @suyanhanx in https://github.com/apache/opendal/pull/4127
* fix(services/chainsafe): fix 423 http status by @hoslo in https://github.com/apache/opendal/pull/4148
* fix(services/webdav): Add possibility to answer without response if file isn't exist by @AJIOB in https://github.com/apache/opendal/pull/4170
* fix(services/webdav): Recreate root directory if need by @AJIOB in https://github.com/apache/opendal/pull/4173
* fix(services/webdav): remove base_dir component by @hoslo in https://github.com/apache/opendal/pull/4231
* fix(core): Poll TimeoutLayer::sleep once to make sure timer registered by @Xuanwo in https://github.com/apache/opendal/pull/4230
### Docs
* docs: add request for add secrets of services by @suyanhanx in https://github.com/apache/opendal/pull/4104
* docs(website): announce release v0.45.0 to news by @morristai in https://github.com/apache/opendal/pull/4152
* docs(services/gdrive): Update Google Drive capabilities list docs by @jihuayu in https://github.com/apache/opendal/pull/4158
* docs: Fix docs build by @Xuanwo in https://github.com/apache/opendal/pull/4162
* docs: add docs for Ceph Rados Gateway S3 by @ZhengLin-Li in https://github.com/apache/opendal/pull/4190
* docs: Fix typo in `core/src/services/http/docs.md` by @jbampton in https://github.com/apache/opendal/pull/4226
* docs: Fix spelling in Rust files by @jbampton in https://github.com/apache/opendal/pull/4227
* docs: fix typo in `website/README.md` by @jbampton in https://github.com/apache/opendal/pull/4228
* docs: fix spelling by @jbampton in https://github.com/apache/opendal/pull/4229
* docs: fix spelling; change `github` to `GitHub` by @jbampton in https://github.com/apache/opendal/pull/4232
* docs: fix typo by @jbampton in https://github.com/apache/opendal/pull/4234
* docs: fix typo in `bindings/c/CONTRIBUTING.md` by @jbampton in https://github.com/apache/opendal/pull/4235
* docs: fix spelling in code comments by @jbampton in https://github.com/apache/opendal/pull/4236
* docs: fix spelling in `CONTRIBUTING` by @jbampton in https://github.com/apache/opendal/pull/4237
* docs: fix Markdown link in `bindings/README.md` by @jbampton in https://github.com/apache/opendal/pull/4238
* docs: fix links and spelling in Markdown by @jbampton in https://github.com/apache/opendal/pull/4239
* docs: fix grammar and spelling in Markdown in `examples/rust` by @jbampton in https://github.com/apache/opendal/pull/4241
* docs: remove unneeded duplicate words from Rust files by @jbampton in https://github.com/apache/opendal/pull/4243
### CI
* ci: Use old version of seafile mc instead by @Xuanwo in https://github.com/apache/opendal/pull/4107
* ci: Refactor workflows layout by @Xuanwo in https://github.com/apache/opendal/pull/4139
* ci: Migrate hdfs default setup by @Xuanwo in https://github.com/apache/opendal/pull/4140
* ci: Refactor check.sh into check.py to get ready for multi components release by @Xuanwo in https://github.com/apache/opendal/pull/4159
* ci: Add test case for hdfs over gcs bucket by @ArmandoZ in https://github.com/apache/opendal/pull/4145
* ci: Add hdfs test case for s3 by @ArmandoZ in https://github.com/apache/opendal/pull/4184
* ci: Add hdfs test case for azurite by @ArmandoZ in https://github.com/apache/opendal/pull/4185
* ci: Add support for releasing all rust packages by @Xuanwo in https://github.com/apache/opendal/pull/4200
* ci: Fix dependabot not update by @Xuanwo in https://github.com/apache/opendal/pull/4202
* ci: reduce the open pull request limits to 1 by @jbampton in https://github.com/apache/opendal/pull/4225
### Chore
* chore(deps): bump actions/cache from 3 to 4 by @dependabot in https://github.com/apache/opendal/pull/4118
* chore(deps): bump toml from 0.8.8 to 0.8.9 by @dependabot in https://github.com/apache/opendal/pull/4109
* chore(deps): bump dav-server from 0.5.7 to 0.5.8 by @dependabot in https://github.com/apache/opendal/pull/4111
* chore(deps): bump assert_cmd from 2.0.12 to 2.0.13 by @dependabot in https://github.com/apache/opendal/pull/4112
* chore(deps): bump actions/setup-dotnet from 3 to 4 by @dependabot in https://github.com/apache/opendal/pull/4115
* chore(deps): bump mongodb from 2.7.1 to 2.8.0 by @dependabot in https://github.com/apache/opendal/pull/4110
* chore(deps): bump quick-xml from 0.30.0 to 0.31.0 by @dependabot in https://github.com/apache/opendal/pull/4113
* chore: Make every components seperate, remove workspace by @Xuanwo in https://github.com/apache/opendal/pull/4134
* chore: Fix build of core by @Xuanwo in https://github.com/apache/opendal/pull/4137
* chore: Fix workflow links for opendal by @Xuanwo in https://github.com/apache/opendal/pull/4147
* chore(website): Bump download link for 0.45.0 release by @morristai in https://github.com/apache/opendal/pull/4149
* chore: Fix name DtraceLayerWrapper by @jayvdb in https://github.com/apache/opendal/pull/4165
* chore: Align core version by @Xuanwo in https://github.com/apache/opendal/pull/4197
* chore: update benchmark doc by @wcy-fdu in https://github.com/apache/opendal/pull/4201
* chore(deps): bump clap from 4.4.18 to 4.5.1 in /bin/oli by @dependabot in https://github.com/apache/opendal/pull/4221
* chore(deps): bump serde from 1.0.196 to 1.0.197 in /bin/oay by @dependabot in https://github.com/apache/opendal/pull/4214
* chore(deps): bump anyhow from 1.0.79 to 1.0.80 in /bin/ofs by @dependabot in https://github.com/apache/opendal/pull/4209
* chore(deps): bump anyhow from 1.0.79 to 1.0.80 in /bin/oli by @dependabot in https://github.com/apache/opendal/pull/4216

## New Contributors
* @zzl221000 made their first contribution in https://github.com/apache/opendal/pull/4122
* @jihuayu made their first contribution in https://github.com/apache/opendal/pull/4129
* @asukaminato0721 made their first contribution in https://github.com/apache/opendal/pull/4135
* @jayvdb made their first contribution in https://github.com/apache/opendal/pull/4165
* @AJIOB made their first contribution in https://github.com/apache/opendal/pull/4170
* @ZhengLin-Li made their first contribution in https://github.com/apache/opendal/pull/4190
* @waynexia made their first contribution in https://github.com/apache/opendal/pull/4233
