### PR TITLE
ci: Split python CI into release and checks

### DIFF
--- a/.github/workflows/ci_bindings_python.yml
+++ b/.github/workflows/ci_bindings_python.yml
@@ -21,24 +21,20 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*'
   pull_request:
     branches:
       - main
     paths:
       - ".github/workflows/ci_bindings_python.yml"
+      - "bindings/python/**"
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
-  sdist:
+  check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,100 +43,3 @@ jobs:
         run: |
           pip install ruff
           ruff check .
-      - uses: PyO3/maturin-action@v1
-        with:
-          working-directory: "bindings/python"
-          command: sdist
-          args: -o dist
-      - name: Upload sdist
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: bindings/python/dist
-
-  linux:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        target: [ x86_64, aarch64, armv7l ]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup
-      - uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.target }}
-          manylinux: auto
-          working-directory: "bindings/python"
-          command: build
-          args: --release -o dist --find-interpreter --features=pyo3/extension-module,services-all
-        env:
-          # Workaround ring 0.17 build issue
-          CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
-      - name: Upload wheels
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: bindings/python/dist
-
-  windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup
-      - uses: PyO3/maturin-action@v1
-        with:
-          working-directory: "bindings/python"
-          command: build
-          args: --release -o dist --find-interpreter --features=pyo3/extension-module,services-all
-      - name: Upload wheels
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: bindings/python/dist
-
-  macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup
-      - uses: PyO3/maturin-action@v1
-        with:
-          working-directory: "bindings/python"
-          command: build
-          target: universal2-apple-darwin
-          args: --release -o dist --find-interpreter --features=pyo3/extension-module,services-all
-      - name: Upload wheels
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: bindings/python/dist
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
-    permissions:
-      contents: read
-      id-token: write
-    needs: [ macos, linux, windows ]
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: wheels
-          path: bindings/python/dist
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        if: "contains(github.ref, '-')"
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-          packages-dir: bindings/python/dist
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        if: "!contains(github.ref, '-')"
-        with:
-          skip-existing: true
-          packages-dir: bindings/python/dist

--- a/.github/workflows/release_java.yml
+++ b/.github/workflows/release_java.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Bindings Java Release
+name: Release Java Binding
 
 on:
   push:
@@ -108,7 +108,7 @@ jobs:
 
   deploy-staged-snapshots:
     runs-on: ubuntu-latest
-    needs: [stage-snapshot]
+    needs: [ stage-snapshot ]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -1,0 +1,139 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Release Python
+
+on:
+  push:
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/release_python.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: PyO3/maturin-action@v1
+        with:
+          working-directory: "bindings/python"
+          command: sdist
+          args: -o dist
+      - name: Upload sdist
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: bindings/python/dist
+
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [ x86_64, aarch64, armv7l ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup
+      - uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          manylinux: auto
+          working-directory: "bindings/python"
+          command: build
+          args: --release -o dist --find-interpreter --features=pyo3/extension-module,services-all
+        env:
+          # Workaround ring 0.17 build issue
+          CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: bindings/python/dist
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup
+      - uses: PyO3/maturin-action@v1
+        with:
+          working-directory: "bindings/python"
+          command: build
+          args: --release -o dist --find-interpreter --features=pyo3/extension-module,services-all
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: bindings/python/dist
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup
+      - uses: PyO3/maturin-action@v1
+        with:
+          working-directory: "bindings/python"
+          command: build
+          target: universal2-apple-darwin
+          args: --release -o dist --find-interpreter --features=pyo3/extension-module,services-all
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: bindings/python/dist
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    permissions:
+      contents: read
+      id-token: write
+    needs: [ macos, linux, windows ]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: bindings/python/dist
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: "contains(github.ref, '-')"
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          packages-dir: bindings/python/dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: "!contains(github.ref, '-')"
+        with:
+          skip-existing: true
+          packages-dir: bindings/python/dist


### PR DESCRIPTION
Extract release CI from binding python CI.