### PR TITLE
ci(binding/java): Don't create too many files in CI

### DIFF
--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncListTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncListTest.java
@@ -23,11 +23,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
 import org.apache.opendal.Capability;
 import org.apache.opendal.Entry;
 import org.apache.opendal.Metadata;
@@ -80,7 +82,7 @@ class AsyncListTest extends BehaviorTestBase {
         final String parent = "test_list_rich_dir";
         op().createDir(parent + "/").join();
         final List<String> expected = new ArrayList<>();
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 10; i++) {
             expected.add(String.format("%s/file-%d", parent, i));
         }
 
@@ -90,7 +92,7 @@ class AsyncListTest extends BehaviorTestBase {
 
         final List<Entry> entries = op().list(parent + "/").join();
         final List<String> actual =
-                entries.stream().map(Entry::getPath).sorted().collect(Collectors.toList());
+            entries.stream().map(Entry::getPath).sorted().collect(Collectors.toList());
 
         Collections.sort(expected);
         assertThat(actual).isEqualTo(expected);
@@ -185,7 +187,7 @@ class AsyncListTest extends BehaviorTestBase {
     @Test
     public void testRemoveAll() {
         final String parent = UUID.randomUUID().toString();
-        final String[] expected = new String[] {
+        final String[] expected = new String[]{
             "x/", "x/y", "x/x/", "x/x/y", "x/x/x/", "x/x/x/y", "x/x/x/x/",
         };
         for (String path : expected) {
@@ -203,8 +205,8 @@ class AsyncListTest extends BehaviorTestBase {
                 continue;
             }
             assertThatThrownBy(() ->
-                            op().stat(String.format("%s/%s", parent, path)).join())
-                    .is(OpenDALExceptionCondition.ofAsync(OpenDALException.Code.NotFound));
+                op().stat(String.format("%s/%s", parent, path)).join())
+                .is(OpenDALExceptionCondition.ofAsync(OpenDALException.Code.NotFound));
         }
 
         op().removeAll(parent + "/").join();


### PR DESCRIPTION
We should use `limit` instead to test the behacior of listing a large dir instead.