### PR TITLE
feat: Allow selecting webpki for reqwest

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -5331,6 +5331,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -71,6 +71,7 @@ trust-dns = ["reqwest/trust-dns"]
 
 # Enable rustls for TLS support
 rustls = ["reqwest/rustls-tls-native-roots"]
+rustls-webpki = ["reqwest/rustls-tls-webpki-roots"]
 # Enable native-tls for TLS support
 native-tls = ["reqwest/native-tls"]
 # Enable vendored native-tls for TLS support


### PR DESCRIPTION
This is handy for environments such as docker scratch where you may not have a cert chain locally.