### PR TITLE
fix(services/dropbox): fix dropbox batch test panic in ci

### DIFF
--- a/core/src/services/dropbox/core.rs
+++ b/core/src/services/dropbox/core.rs
@@ -343,7 +343,7 @@ impl DropboxCore {
                         .get(&error.tag)
                         .expect("error should be present")
                         .tag;
-                    // Ignore error about path lookup not found
+                    // Ignore errors about path lookup not found and report others.
                     if error.tag == "path_lookup" && error_cause == "not_found" {
                         ("".to_string(), Ok(RpDelete::default().into()))
                     } else {

--- a/core/src/services/dropbox/core.rs
+++ b/core/src/services/dropbox/core.rs
@@ -343,11 +343,16 @@ impl DropboxCore {
                         .get(&error.tag)
                         .expect("error should be present")
                         .tag;
-                    let err = Error::new(
-                        ErrorKind::Unexpected,
-                        &format!("delete failed with error {} {}", error.tag, error_cause),
-                    );
-                    ("".to_string(), Err(err))
+                    // Ignore error about path lookup not found
+                    if error.tag == "path_lookup" && error_cause == "not_found" {
+                        ("".to_string(), Ok(RpDelete::default().into()))
+                    } else {
+                        let err = Error::new(
+                            ErrorKind::Unexpected,
+                            &format!("delete failed with error {} {}", error.tag, error_cause),
+                        );
+                        ("".to_string(), Err(err))
+                    }
                 }
                 _ => (
                     "".to_string(),


### PR DESCRIPTION
fix: #4314 
related to: https://github.com/apache/opendal/pull/4317

When an error occurs during `batch` call, Dropbox returns an error like this (causing an expect error before):
```json
{
    ".tag": "failure",
    "failure": {
        ".tag": "path_lookup",
        "path_lookup": {
            ".tag": "not_found",
        }
    }
}
```
Added `DropboxDeleteBatchFailureResponse` to parse those special errors.
```rust
#[derive(Default, Debug, Deserialize)]
#[serde(default)]
pub struct DropboxDeleteBatchFailureResponse {
    #[serde(rename(deserialize = ".tag"))]
    pub tag: String,
    #[serde(flatten)]
    pub failure_cause_map: HashMap<String, DropboxDeleteBatchFailureResponseCause>,
}

#[derive(Default, Debug, Deserialize)]
#[serde(default)]
pub struct DropboxDeleteBatchFailureResponseCause {
    #[serde(rename(deserialize = ".tag"))]
    pub tag: String,
}
```