### PR TITLE
fix(services/hdfs-native): remove unsupported capabilities

### DIFF
--- a/core/src/services/hdfs_native/backend.rs
+++ b/core/src/services/hdfs_native/backend.rs
@@ -186,7 +186,7 @@ impl Accessor for HdfsNativeBackend {
             .set_root(&self.root)
             .set_native_capability(Capability {
                 stat: true,
-                
+
                 delete: true,
                 rename: true,
                 blocking: true,

--- a/core/src/services/hdfs_native/backend.rs
+++ b/core/src/services/hdfs_native/backend.rs
@@ -186,18 +186,8 @@ impl Accessor for HdfsNativeBackend {
             .set_root(&self.root)
             .set_native_capability(Capability {
                 stat: true,
-
-                read: true,
-                read_can_seek: true,
-
-                write: true,
-                write_can_append: self._enable_append,
-
-                create_dir: true,
+                
                 delete: true,
-
-                list: true,
-
                 rename: true,
                 blocking: true,
 

--- a/core/src/services/hdfs_native/docs.md
+++ b/core/src/services/hdfs_native/docs.md
@@ -6,14 +6,14 @@ Using [Native Rust HDFS client](https://github.com/Kimahriman/hdfs-native).
 This service can be used to:
 
 - [x] stat
-- [x] read
-- [x] write
-- [x] create_dir
+- [ ] read
+- [ ] write
+- [ ] create_dir
 - [x] delete
 - [x] rename
-- [x] list
+- [ ] list
 - [x] blocking
-- [x] append
+- [ ] append
 
 ## Differences with webhdfs
 


### PR DESCRIPTION
I remove unsupported capabilities from the code and documentation of HDFS-native.

I spent a lot of time, but I couldn't use HDFS native to write files on the HSDF cluster I built. I have tried several methods to set up the cluster, but the problem still exists. :sob::sob::sob:

If no one solves this problem, I will come back to look at it again after a while.