### PR TITLE
docs: fix spelling

### DIFF
--- a/core/src/docs/rfcs/0044_error_handle.md
+++ b/core/src/docs/rfcs/0044_error_handle.md
@@ -73,7 +73,7 @@ if let Err(e) = meta {
 }
 ```
 
-For a backend implementor, we can provide as much information as possible. For example, we can return `bucket is empty` to let the user know:
+For a backend implementer, we can provide as much information as possible. For example, we can return `bucket is empty` to let the user know:
 
 ```rust
 return Err(Error::Backend {
@@ -162,7 +162,7 @@ pub fn kind(&self) -> Kind {
 }
 ```
 
-The implementor should do their best to carry as much context as possible. Such as, they should return `Error::Object` to carry the `op` and `path`, instead of just returns `Error::Unexpected(anyhow::Error::from(err))`.
+The implementer should do their best to carry as much context as possible. Such as, they should return `Error::Object` to carry the `op` and `path`, instead of just returns `Error::Unexpected(anyhow::Error::from(err))`.
 
 ```rust
 Error::Object {

--- a/core/src/docs/rfcs/0069_object_stream.md
+++ b/core/src/docs/rfcs/0069_object_stream.md
@@ -111,7 +111,7 @@ pub async fn metadata_cached(&mut self) -> Result<&Metadata> {
 }
 ```
 
-The backend implementor must make sure `complete` is correctly set.
+The backend implementer must make sure `complete` is correctly set.
 
 `Metadata` will be immutable outsides, so all `set_xxx` APIs will be set to crate public only:
 

--- a/core/src/docs/rfcs/0191_async_streaming_io.md
+++ b/core/src/docs/rfcs/0191_async_streaming_io.md
@@ -11,7 +11,7 @@ Use `Stream`/`Sink` instead of `AsyncRead` in `Accessor`.
 
 # Motivation
 
-`Accessor` intends to be the `underlying trait of all backends for implementors`. However, it's not so underlying enough.
+`Accessor` intends to be the `underlying trait of all backends for implementers`. However, it's not so underlying enough.
 
 ## Over-wrapped
 

--- a/core/src/docs/rfcs/1420_object_writer.md
+++ b/core/src/docs/rfcs/1420_object_writer.md
@@ -104,7 +104,7 @@ pub trait Accessor {
 
 # Drawbacks
 
-More heavy work for service implementors.
+More heavy work for service implementers.
 
 # Rationale and alternatives
 

--- a/core/src/docs/rfcs/README.md
+++ b/core/src/docs/rfcs/README.md
@@ -58,5 +58,5 @@ feel free to inquire by leaving a comment on the associated issue.
 
 ## Some useful tips
 
-- The author of an RFC may not be the same one as the implementor. Therefore, when submitting an RFC, it is advisable to include sufficient information.
+- The author of an RFC may not be the same one as the implementer. Therefore, when submitting an RFC, it is advisable to include sufficient information.
 - If modifications are needed for an accepted RFC, please submit a new pull request or create a new RFC to propose changes.

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 use crate::raw::*;
 use crate::*;
 
-/// Underlying trait of all backends for implementors.
+/// Underlying trait of all backends for implementers.
 ///
 /// The actual data access of storage service happens in Accessor layer.
 /// Every storage supported by OpenDAL must implement [`Accessor`] but not all

--- a/core/src/raw/layer.rs
+++ b/core/src/raw/layer.rs
@@ -27,7 +27,7 @@ use crate::*;
 /// Struct that implement this trait must accept input `Arc<dyn Accessor>` as inner,
 /// and returns a new `Arc<dyn Accessor>` as output.
 ///
-/// All functions in `Accessor` requires `&self`, so it's implementor's responsibility
+/// All functions in `Accessor` requires `&self`, so it's implementer's responsibility
 /// to maintain the internal mutability. Please also keep in mind that `Accessor`
 /// requires `Send` and `Sync`.
 ///

--- a/core/src/raw/oio/buf/write_buf.rs
+++ b/core/src/raw/oio/buf/write_buf.rs
@@ -78,7 +78,7 @@ pub trait WriteBuf: Send + Sync {
     ///
     /// # Notes
     ///
-    /// This function is used to avoid copy when possible. Implementors should return `true`
+    /// This function is used to avoid copy when possible. Implementers should return `true`
     /// the given `self.bytes(size)` could be done without cost. For example, the underlying
     /// buffer is `Bytes`.
     ///
@@ -98,7 +98,7 @@ pub trait WriteBuf: Send + Sync {
     /// This functions is used to return a vectored bytes from underlying chunks.
     /// Use `bytes` if you just want to get a continuous bytes.
     ///
-    /// # Notes for implementors
+    /// # Notes for implementers
     ///
     /// It's better to align the vectored bytes with underlying chunks to avoid copy.
     ///

--- a/core/src/raw/oio/list/page_list.rs
+++ b/core/src/raw/oio/list/page_list.rs
@@ -44,7 +44,7 @@ pub trait PageList: Send + Sync + Unpin + 'static {
 
 /// PageContext is the context passing between `PageList`.
 ///
-/// [`PageLister`] will init the PageContext, and implementor of [`PageList`] should fill the `PageContext`
+/// [`PageLister`] will init the PageContext, and implementer of [`PageList`] should fill the `PageContext`
 /// based on their needs.
 ///
 /// - Set `done` to `true` if all page have been fetched.
@@ -60,7 +60,7 @@ pub struct PageContext {
     /// entries is used to store entries fetched from underlying storage.
     ///
     /// Please always reuse the same `VecDeque` to avoid unnecessary memory allocation.
-    /// PageLister makes sure that entries is reset before calling `next_page`. Implementor
+    /// PageLister makes sure that entries is reset before calling `next_page`. Implementer
     /// can calling `push_back` on `entries` directly.
     pub entries: VecDeque<oio::Entry>,
 }


### PR DESCRIPTION
From Oxford Reference:

"Although the variant spelling implementor predominated for much of the late 20th century, today implementer is considered standard.Current ratio: 4:1"

https://www.oxfordreference.com/display/10.1093/acref/9780190491482.001.0001/acref-9780190491482-e-4046