### PR TITLE
chore(editorconfig): add `rdf` file type as `indent_size = 2`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,3 +55,6 @@ indent_size = 2
 
 [*.html]
 indent_size = 2
+
+[*.rdf]
+indent_size = 2


### PR DESCRIPTION
We have the `doap.rdf` file in the repo root which uses 2 spaces for indent