### PR TITLE
refactor(core/raw): Migrate oio::Write from WriteBuf to Bytes

### DIFF
--- a/core/benches/oio/utils.rs
+++ b/core/benches/oio/utils.rs
@@ -27,12 +27,8 @@ use rand::RngCore;
 pub struct BlackHoleWriter;
 
 impl oio::Write for BlackHoleWriter {
-    fn poll_write(
-        &mut self,
-        _: &mut Context<'_>,
-        bs: &dyn oio::WriteBuf,
-    ) -> Poll<opendal::Result<usize>> {
-        Poll::Ready(Ok(bs.remaining()))
+    fn poll_write(&mut self, _: &mut Context<'_>, bs: Bytes) -> Poll<opendal::Result<usize>> {
+        Poll::Ready(Ok(bs.len()))
     }
 
     fn poll_abort(&mut self, _: &mut Context<'_>) -> Poll<opendal::Result<()>> {

--- a/core/benches/oio/write.rs
+++ b/core/benches/oio/write.rs
@@ -48,7 +48,7 @@ pub fn bench_exact_buf_write(c: &mut Criterion) {
 
                 let mut bs = content.clone();
                 while !bs.is_empty() {
-                    let n = w.write(&bs).await.unwrap();
+                    let n = w.write(bs.clone()).await.unwrap();
                     bs.advance(n);
                 }
                 w.close().await.unwrap();

--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -298,9 +298,9 @@ impl<I: oio::Read + 'static> oio::BlockingRead for BlockingWrapper<I> {
 }
 
 impl<I: oio::Write + 'static> oio::BlockingWrite for BlockingWrapper<I> {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
         self.handle
-            .block_on(poll_fn(|cx| self.inner.poll_write(cx, bs)))
+            .block_on(poll_fn(|cx| self.inner.poll_write(cx, bs.clone())))
     }
 
     fn close(&mut self) -> Result<()> {

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -24,6 +24,7 @@ use std::task::Context;
 use std::task::Poll;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 
 use crate::raw::oio::BufferReader;
 use crate::raw::oio::FileReader;
@@ -711,7 +712,7 @@ impl<W> oio::Write for CompleteWriter<W>
 where
     W: oio::Write,
 {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         let w = self.inner.as_mut().ok_or_else(|| {
             Error::new(ErrorKind::Unexpected, "writer has been closed or aborted")
         })?;
@@ -747,7 +748,7 @@ impl<W> oio::BlockingWrite for CompleteWriter<W>
 where
     W: oio::BlockingWrite,
 {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
         let w = self.inner.as_mut().ok_or_else(|| {
             Error::new(ErrorKind::Unexpected, "writer has been closed or aborted")
         })?;

--- a/core/src/layers/concurrent_limit.rs
+++ b/core/src/layers/concurrent_limit.rs
@@ -278,7 +278,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for ConcurrentLimitWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for ConcurrentLimitWrapper<R> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         self.inner.poll_write(cx, bs)
     }
 
@@ -292,7 +292,7 @@ impl<R: oio::Write> oio::Write for ConcurrentLimitWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for ConcurrentLimitWrapper<R> {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
         self.inner.write(bs)
     }
 

--- a/core/src/layers/dtrace.rs
+++ b/core/src/layers/dtrace.rs
@@ -408,7 +408,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for DtraceLayerWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for DtraceLayerWrapper<R> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         let c_path = CString::new(self.path.clone()).unwrap();
         probe_lazy!(opendal, writer_write_start, c_path.as_ptr());
         self.inner
@@ -453,7 +453,7 @@ impl<R: oio::Write> oio::Write for DtraceLayerWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for DtraceLayerWrapper<R> {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
         let c_path = CString::new(self.path.clone()).unwrap();
         probe_lazy!(opendal, blocking_writer_write_start, c_path.as_ptr());
         self.inner

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -389,12 +389,12 @@ impl<T: oio::BlockingRead> oio::BlockingRead for ErrorContextWrapper<T> {
 
 #[async_trait::async_trait]
 impl<T: oio::Write> oio::Write for ErrorContextWrapper<T> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
-        self.inner.poll_write(cx, bs).map_err(|err| {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
+        self.inner.poll_write(cx, bs.clone()).map_err(|err| {
             err.with_operation(WriteOperation::Write)
                 .with_context("service", self.scheme)
                 .with_context("path", &self.path)
-                .with_context("write_buf", bs.remaining().to_string())
+                .with_context("write_buf", bs.len().to_string())
         })
     }
 
@@ -416,12 +416,12 @@ impl<T: oio::Write> oio::Write for ErrorContextWrapper<T> {
 }
 
 impl<T: oio::BlockingWrite> oio::BlockingWrite for ErrorContextWrapper<T> {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
-        self.inner.write(bs).map_err(|err| {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
+        self.inner.write(bs.clone()).map_err(|err| {
             err.with_operation(WriteOperation::BlockingWrite)
                 .with_context("service", self.scheme)
                 .with_context("path", &self.path)
-                .with_context("write_buf", bs.remaining().to_string())
+                .with_context("write_buf", bs.len().to_string())
         })
     }
 

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -1147,8 +1147,8 @@ impl<W> LoggingWriter<W> {
 }
 
 impl<W: oio::Write> oio::Write for LoggingWriter<W> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
-        match ready!(self.inner.poll_write(cx, bs)) {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
+        match ready!(self.inner.poll_write(cx, bs.clone())) {
             Ok(n) => {
                 self.written += n as u64;
                 trace!(
@@ -1158,7 +1158,7 @@ impl<W: oio::Write> oio::Write for LoggingWriter<W> {
                     WriteOperation::Write,
                     self.path,
                     self.written,
-                    bs.remaining(),
+                    bs.len(),
                     n,
                 );
                 Poll::Ready(Ok(n))
@@ -1245,8 +1245,8 @@ impl<W: oio::Write> oio::Write for LoggingWriter<W> {
 }
 
 impl<W: oio::BlockingWrite> oio::BlockingWrite for LoggingWriter<W> {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
-        match self.inner.write(bs) {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
+        match self.inner.write(bs.clone()) {
             Ok(n) => {
                 self.written += n as u64;
                 trace!(
@@ -1256,7 +1256,7 @@ impl<W: oio::BlockingWrite> oio::BlockingWrite for LoggingWriter<W> {
                     WriteOperation::BlockingWrite,
                     self.path,
                     self.written,
-                    bs.remaining(),
+                    bs.len(),
                     n
                 );
                 Ok(n)

--- a/core/src/layers/madsim.rs
+++ b/core/src/layers/madsim.rs
@@ -291,11 +291,7 @@ pub struct MadsimWriter {
 }
 
 impl oio::Write for MadsimWriter {
-    fn poll_write(
-        &mut self,
-        cx: &mut Context<'_>,
-        bs: &dyn oio::WriteBuf,
-    ) -> Poll<crate::Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<crate::Result<usize>> {
         #[cfg(madsim)]
         {
             let req = Request::Write(self.path.to_string(), bs);

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -820,7 +820,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for MetricWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for MetricWrapper<R> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         self.inner
             .poll_write(cx, bs)
             .map_ok(|n| {
@@ -849,7 +849,7 @@ impl<R: oio::Write> oio::Write for MetricWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for MetricWrapper<R> {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
         self.inner
             .write(bs)
             .map(|n| {

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -324,7 +324,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for MinitraceWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for MinitraceWrapper<R> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         let _g = self.span.set_local_parent();
         let _span = LocalSpan::enter_with_local_parent(WriteOperation::Write.into_static());
         self.inner.poll_write(cx, bs)
@@ -344,7 +344,7 @@ impl<R: oio::Write> oio::Write for MinitraceWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for MinitraceWrapper<R> {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
         let _g = self.span.set_local_parent();
         let _span = LocalSpan::enter_with_local_parent(WriteOperation::BlockingWrite.into_static());
         self.inner.write(bs)

--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -298,7 +298,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for OtelTraceWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for OtelTraceWrapper<R> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         self.inner.poll_write(cx, bs)
     }
 
@@ -312,7 +312,7 @@ impl<R: oio::Write> oio::Write for OtelTraceWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for OtelTraceWrapper<R> {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
         self.inner.write(bs)
     }
 

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -749,7 +749,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for PrometheusMetricWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         let labels = self.stats.generate_metric_label(
             self.scheme.into_static(),
             Operation::Write.into_static(),
@@ -786,7 +786,7 @@ impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for PrometheusMetricWrapper<R> {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
         let labels = self.stats.generate_metric_label(
             self.scheme.into_static(),
             Operation::BlockingWrite.into_static(),

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -590,7 +590,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for PrometheusMetricWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         self.inner
             .poll_write(cx, bs)
             .map_ok(|n| {
@@ -622,7 +622,7 @@ impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for PrometheusMetricWrapper<R> {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
         self.inner
             .write(bs)
             .map(|n| {

--- a/core/src/layers/throttle.rs
+++ b/core/src/layers/throttle.rs
@@ -207,8 +207,8 @@ impl<R: oio::BlockingRead> oio::BlockingRead for ThrottleWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for ThrottleWrapper<R> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
-        let buf_length = NonZeroU32::new(bs.remaining() as u32).unwrap();
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
+        let buf_length = NonZeroU32::new(bs.len() as u32).unwrap();
 
         loop {
             match self.limiter.check_n(buf_length) {
@@ -242,8 +242,8 @@ impl<R: oio::Write> oio::Write for ThrottleWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for ThrottleWrapper<R> {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
-        let buf_length = NonZeroU32::new(bs.remaining() as u32).unwrap();
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
+        let buf_length = NonZeroU32::new(bs.len() as u32).unwrap();
 
         loop {
             match self.limiter.check_n(buf_length) {

--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -334,7 +334,7 @@ impl<R: oio::Read> oio::Read for TimeoutWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for TimeoutWrapper<R> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         self.poll_timeout(cx, WriteOperation::Write.into_static())?;
 
         let v = ready!(self.inner.poll_write(cx, bs));

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -309,7 +309,7 @@ impl<R: oio::Write> oio::Write for TracingWrapper<R> {
         parent = &self.span,
         level = "trace",
         skip_all)]
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         self.inner.poll_write(cx, bs)
     }
 
@@ -335,7 +335,7 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for TracingWrapper<R> {
         parent = &self.span,
         level = "trace",
         skip_all)]
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
         self.inner.write(bs)
     }
 

--- a/core/src/raw/enum_utils.rs
+++ b/core/src/raw/enum_utils.rs
@@ -90,7 +90,7 @@ impl<ONE: oio::BlockingRead, TWO: oio::BlockingRead> oio::BlockingRead for TwoWa
 }
 
 impl<ONE: oio::Write, TWO: oio::Write> oio::Write for TwoWays<ONE, TWO> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         match self {
             Self::One(v) => v.poll_write(cx, bs),
             Self::Two(v) => v.poll_write(cx, bs),
@@ -165,7 +165,7 @@ impl<ONE: oio::BlockingRead, TWO: oio::BlockingRead, THREE: oio::BlockingRead> o
 impl<ONE: oio::Write, TWO: oio::Write, THREE: oio::Write> oio::Write
     for ThreeWays<ONE, TWO, THREE>
 {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         match self {
             Self::One(v) => v.poll_write(cx, bs),
             Self::Two(v) => v.poll_write(cx, bs),

--- a/core/src/raw/oio/write/api.rs
+++ b/core/src/raw/oio/write/api.rs
@@ -136,7 +136,7 @@ impl<T: Write> WriteExt for T {}
 /// Extension of [`Read`] to make it easier for use.
 pub trait WriteExt: Write {
     /// Build a future for `poll_write`.
-    fn write<'a>(&'a mut self, buf: Bytes) -> WriteFuture<'a, Self> {
+    fn write(&mut self, buf: Bytes) -> WriteFuture<'_, Self> {
         WriteFuture { writer: self, buf }
     }
 

--- a/core/src/raw/oio/write/api.rs
+++ b/core/src/raw/oio/write/api.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use bytes::Bytes;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::future::Future;
@@ -84,7 +85,7 @@ pub trait Write: Unpin + Send + Sync {
     ///
     /// It's possible that `n < bs.len()`, caller should pass the remaining bytes
     /// repeatedly until all bytes has been written.
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>>;
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>>;
 
     /// Close the writer and make sure all data has been flushed.
     fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>>;
@@ -94,7 +95,7 @@ pub trait Write: Unpin + Send + Sync {
 }
 
 impl Write for () {
-    fn poll_write(&mut self, _: &mut Context<'_>, _: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, _: &mut Context<'_>, _: Bytes) -> Poll<Result<usize>> {
         unimplemented!("write is required to be implemented for oio::Write")
     }
 
@@ -117,7 +118,7 @@ impl Write for () {
 ///
 /// To make Writer work as expected, we must add this impl.
 impl<T: Write + ?Sized> Write for Box<T> {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         (**self).poll_write(cx, bs)
     }
 
@@ -136,7 +137,7 @@ impl<T: Write> WriteExt for T {}
 /// Extension of [`Read`] to make it easier for use.
 pub trait WriteExt: Write {
     /// Build a future for `poll_write`.
-    fn write<'a>(&'a mut self, buf: &'a dyn oio::WriteBuf) -> WriteFuture<'a, Self> {
+    fn write<'a>(&'a mut self, buf: Bytes) -> WriteFuture<'a, Self> {
         WriteFuture { writer: self, buf }
     }
 
@@ -153,7 +154,7 @@ pub trait WriteExt: Write {
 
 pub struct WriteFuture<'a, W: Write + Unpin + ?Sized> {
     writer: &'a mut W,
-    buf: &'a dyn oio::WriteBuf,
+    buf: Bytes,
 }
 
 impl<W> Future for WriteFuture<'_, W>
@@ -164,7 +165,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<usize>> {
         let this = self.get_mut();
-        this.writer.poll_write(cx, this.buf)
+        this.writer.poll_write(cx, this.buf.clone())
     }
 }
 
@@ -204,14 +205,14 @@ pub type BlockingWriter = Box<dyn BlockingWrite>;
 /// BlockingWrite is the trait that OpenDAL returns to callers.
 pub trait BlockingWrite: Send + Sync + 'static {
     /// Write whole content at once.
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize>;
+    fn write(&mut self, bs: Bytes) -> Result<usize>;
 
     /// Close the writer and make sure all data has been flushed.
     fn close(&mut self) -> Result<()>;
 }
 
 impl BlockingWrite for () {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
         let _ = bs;
 
         unimplemented!("write is required to be implemented for oio::BlockingWrite")
@@ -229,7 +230,7 @@ impl BlockingWrite for () {
 ///
 /// To make BlockingWriter work as expected, we must add this impl.
 impl<T: BlockingWrite + ?Sized> BlockingWrite for Box<T> {
-    fn write(&mut self, bs: &dyn oio::WriteBuf) -> Result<usize> {
+    fn write(&mut self, bs: Bytes) -> Result<usize> {
         (**self).write(bs)
     }
 

--- a/core/src/raw/oio/write/api.rs
+++ b/core/src/raw/oio/write/api.rs
@@ -23,7 +23,6 @@ use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
 
-use crate::raw::*;
 use crate::*;
 
 /// WriteOperation is the name for APIs of Writer.

--- a/core/src/raw/oio/write/exact_buf_write.rs
+++ b/core/src/raw/oio/write/exact_buf_write.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use bytes::{Bytes};
+use bytes::Bytes;
 use std::task::ready;
 use std::task::Context;
 use std::task::Poll;

--- a/core/src/raw/oio/write/exact_buf_write.rs
+++ b/core/src/raw/oio/write/exact_buf_write.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use bytes::{Bytes, BytesMut};
+use bytes::{Bytes};
 use std::task::ready;
 use std::task::Context;
 use std::task::Poll;

--- a/core/src/raw/oio/write/range_write.rs
+++ b/core/src/raw/oio/write/range_write.rs
@@ -27,7 +27,6 @@ use futures::Future;
 use futures::FutureExt;
 use futures::StreamExt;
 
-
 use crate::raw::*;
 use crate::*;
 

--- a/core/src/raw/oio/write/range_write.rs
+++ b/core/src/raw/oio/write/range_write.rs
@@ -27,7 +27,7 @@ use futures::Future;
 use futures::FutureExt;
 use futures::StreamExt;
 
-use crate::raw::oio::WriteBuf;
+
 use crate::raw::*;
 use crate::*;
 

--- a/core/src/services/alluxio/writer.rs
+++ b/core/src/services/alluxio/writer.rs
@@ -25,7 +25,7 @@ use bytes::Bytes;
 use futures::future::BoxFuture;
 
 use super::core::AlluxioCore;
-use crate::raw::oio::WriteBuf;
+
 use crate::raw::*;
 use crate::*;
 

--- a/core/src/services/alluxio/writer.rs
+++ b/core/src/services/alluxio/writer.rs
@@ -21,6 +21,7 @@ use std::task::Context;
 use std::task::Poll;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use futures::future::BoxFuture;
 
 use super::core::AlluxioCore;
@@ -63,13 +64,12 @@ unsafe impl Sync for State {}
 
 #[async_trait]
 impl oio::Write for AlluxioWriter {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         loop {
             match &mut self.state {
                 State::Idle(w) => match self.stream_id.as_ref() {
                     Some(stream_id) => {
-                        let size = bs.remaining();
-                        let cb = oio::ChunkedBytes::from_vec(bs.vectored_bytes(size)).clone();
+                        let cb = oio::ChunkedBytes::from_vec(vec![bs.clone()]);
 
                         let stream_id = *stream_id;
 

--- a/core/src/services/azdls/writer.rs
+++ b/core/src/services/azdls/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::AzdlsCore;
@@ -43,7 +44,7 @@ impl AzdlsWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for AzdlsWriter {
-    async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let mut req =
             self.core
                 .azdls_create_request(&self.path, "file", &self.op, AsyncBody::Empty)?;
@@ -64,12 +65,11 @@ impl oio::OneShotWrite for AzdlsWriter {
             }
         }
 
-        let bs = oio::ChunkedBytes::from_vec(bs.vectored_bytes(bs.remaining()));
         let mut req = self.core.azdls_update_request(
             &self.path,
             Some(bs.len() as u64),
             0,
-            AsyncBody::ChunkedBytes(bs),
+            AsyncBody::Bytes(bs),
         )?;
 
         self.core.sign(&mut req).await?;

--- a/core/src/services/azdls/writer.rs
+++ b/core/src/services/azdls/writer.rs
@@ -23,7 +23,7 @@ use http::StatusCode;
 
 use super::core::AzdlsCore;
 use super::error::parse_error;
-use crate::raw::oio::WriteBuf;
+
 use crate::raw::*;
 use crate::*;
 

--- a/core/src/services/azfile/writer.rs
+++ b/core/src/services/azfile/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::AzfileCore;
@@ -41,9 +42,7 @@ impl AzfileWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for AzfileWriter {
-    async fn write_once(&self, bs: &dyn oio::WriteBuf) -> Result<()> {
-        let bs = oio::ChunkedBytes::from_vec(bs.vectored_bytes(bs.remaining()));
-
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let resp = self
             .core
             .azfile_create_file(&self.path, bs.len(), &self.op)
@@ -63,7 +62,7 @@ impl oio::OneShotWrite for AzfileWriter {
 
         let resp = self
             .core
-            .azfile_update(&self.path, bs.len() as u64, 0, AsyncBody::ChunkedBytes(bs))
+            .azfile_update(&self.path, bs.len() as u64, 0, AsyncBody::Bytes(bs))
             .await?;
         let status = resp.status();
         return match status {

--- a/core/src/services/chainsafe/writer.rs
+++ b/core/src/services/chainsafe/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::ChainsafeCore;
@@ -45,9 +46,7 @@ impl ChainsafeWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for ChainsafeWriter {
-    async fn write_once(&self, bs: &dyn oio::WriteBuf) -> Result<()> {
-        let bs = bs.bytes(bs.remaining());
-
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let resp = self.core.upload_object(&self.path, bs).await?;
 
         let status = resp.status();

--- a/core/src/services/dbfs/writer.rs
+++ b/core/src/services/dbfs/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::error::parse_error;
@@ -41,8 +42,7 @@ impl DbfsWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for DbfsWriter {
-    async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
-        let bs = bs.bytes(bs.remaining());
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let size = bs.len();
 
         // MAX_BLOCK_SIZE_EXCEEDED will be thrown if this limit(1MB) is exceeded.

--- a/core/src/services/dbfs/writer.rs
+++ b/core/src/services/dbfs/writer.rs
@@ -22,7 +22,7 @@ use bytes::Bytes;
 use http::StatusCode;
 
 use super::error::parse_error;
-use crate::raw::oio::WriteBuf;
+
 use crate::raw::*;
 use crate::services::dbfs::core::DbfsCore;
 use crate::*;

--- a/core/src/services/dropbox/writer.rs
+++ b/core/src/services/dropbox/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::DropboxCore;
@@ -39,17 +40,10 @@ impl DropboxWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for DropboxWriter {
-    async fn write_once(&self, bs: &dyn oio::WriteBuf) -> Result<()> {
-        let bs = oio::ChunkedBytes::from_vec(bs.vectored_bytes(bs.remaining()));
-
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let resp = self
             .core
-            .dropbox_update(
-                &self.path,
-                Some(bs.len()),
-                &self.op,
-                AsyncBody::ChunkedBytes(bs),
-            )
+            .dropbox_update(&self.path, Some(bs.len()), &self.op, AsyncBody::Bytes(bs))
             .await?;
         let status = resp.status();
         match status {

--- a/core/src/services/ftp/writer.rs
+++ b/core/src/services/ftp/writer.rs
@@ -20,7 +20,7 @@ use bytes::Bytes;
 use futures::AsyncWriteExt;
 
 use super::backend::FtpBackend;
-use crate::raw::oio::WriteBuf;
+
 use crate::raw::*;
 use crate::services::ftp::err::parse_error;
 use crate::*;

--- a/core/src/services/ftp/writer.rs
+++ b/core/src/services/ftp/writer.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use futures::AsyncWriteExt;
 
 use super::backend::FtpBackend;
@@ -49,10 +50,7 @@ unsafe impl Sync for FtpWriter {}
 
 #[async_trait]
 impl oio::OneShotWrite for FtpWriter {
-    async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
-        let size = bs.remaining();
-        let bs = bs.bytes(size);
-
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let mut ftp_stream = self.backend.ftp_connect(Operation::Write).await?;
         let mut data_stream = ftp_stream
             .append_with_stream(&self.path)

--- a/core/src/services/gdrive/writer.rs
+++ b/core/src/services/gdrive/writer.rs
@@ -18,12 +18,12 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::GdriveCore;
 use super::core::GdriveFile;
 use super::error::parse_error;
-use crate::raw::oio::WriteBuf;
 use crate::raw::*;
 use crate::*;
 
@@ -49,8 +49,7 @@ impl GdriveWriter {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl oio::OneShotWrite for GdriveWriter {
-    async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
-        let bs = bs.bytes(bs.remaining());
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let size = bs.len();
 
         let resp = if let Some(file_id) = &self.file_id {

--- a/core/src/services/ghac/writer.rs
+++ b/core/src/services/ghac/writer.rs
@@ -20,6 +20,7 @@ use std::task::Context;
 use std::task::Poll;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use futures::future::BoxFuture;
 
 use super::backend::GhacBackend;
@@ -57,7 +58,7 @@ unsafe impl Sync for State {}
 
 #[async_trait]
 impl oio::Write for GhacWriter {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         loop {
             match &mut self.state {
                 State::Idle(backend) => {
@@ -65,8 +66,8 @@ impl oio::Write for GhacWriter {
 
                     let cache_id = self.cache_id;
                     let offset = self.size;
-                    let size = bs.remaining();
-                    let bs = bs.bytes(size);
+                    let size = bs.len();
+                    let bs = bs.clone();
 
                     let fut = async move {
                         let res = async {

--- a/core/src/services/github/writer.rs
+++ b/core/src/services/github/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::GithubCore;
@@ -40,9 +41,7 @@ impl GithubWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for GithubWriter {
-    async fn write_once(&self, bs: &dyn oio::WriteBuf) -> Result<()> {
-        let bs = bs.bytes(bs.remaining());
-
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let resp = self.core.upload(&self.path, bs).await?;
 
         let status = resp.status();

--- a/core/src/services/hdfs_native/writer.rs
+++ b/core/src/services/hdfs_native/writer.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use bytes::Bytes;
 use std::task::Context;
 use std::task::Poll;
 
@@ -35,7 +36,7 @@ impl HdfsNativeWriter {
 }
 
 impl oio::Write for HdfsNativeWriter {
-    fn poll_write(&mut self, _cx: &mut Context<'_>, _bs: &dyn WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, _: &mut Context<'_>, _: Bytes) -> Poll<Result<usize>> {
         todo!()
     }
 

--- a/core/src/services/hdfs_native/writer.rs
+++ b/core/src/services/hdfs_native/writer.rs
@@ -22,7 +22,7 @@ use std::task::Poll;
 use hdfs_native::file::FileWriter;
 
 use crate::raw::oio;
-use crate::raw::oio::WriteBuf;
+
 use crate::*;
 
 pub struct HdfsNativeWriter {

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -21,6 +21,7 @@ use std::str;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::Request;
 use http::Response;
 use http::StatusCode;
@@ -276,7 +277,7 @@ impl IpmfsBackend {
     pub async fn ipmfs_write(
         &self,
         path: &str,
-        body: oio::ChunkedBytes,
+        body: Bytes,
     ) -> Result<Response<IncomingAsyncBody>> {
         let p = build_rooted_abs_path(&self.root, path);
 
@@ -286,8 +287,7 @@ impl IpmfsBackend {
             percent_encode_path(&p)
         );
 
-        let multipart = Multipart::new()
-            .part(FormDataPart::new("data").stream(body.len() as u64, Box::new(body)));
+        let multipart = Multipart::new().part(FormDataPart::new("data").content(body));
 
         let req: http::request::Builder = Request::post(url);
         let req = multipart.apply(req)?;

--- a/core/src/services/ipmfs/writer.rs
+++ b/core/src/services/ipmfs/writer.rs
@@ -21,7 +21,7 @@ use http::StatusCode;
 
 use super::backend::IpmfsBackend;
 use super::error::parse_error;
-use crate::raw::oio::WriteBuf;
+
 use crate::raw::*;
 use crate::*;
 

--- a/core/src/services/ipmfs/writer.rs
+++ b/core/src/services/ipmfs/writer.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::backend::IpmfsBackend;
@@ -38,8 +39,7 @@ impl IpmfsWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for IpmfsWriter {
-    async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
-        let bs = oio::ChunkedBytes::from_vec(bs.vectored_bytes(bs.remaining()));
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let resp = self.backend.ipmfs_write(&self.path, bs).await?;
 
         let status = resp.status();

--- a/core/src/services/koofr/writer.rs
+++ b/core/src/services/koofr/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::KoofrCore;
@@ -40,10 +41,8 @@ impl KoofrWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for KoofrWriter {
-    async fn write_once(&self, bs: &dyn oio::WriteBuf) -> Result<()> {
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         self.core.ensure_dir_exists(&self.path).await?;
-
-        let bs = bs.bytes(bs.remaining());
 
         let resp = self.core.put(&self.path, bs).await?;
 

--- a/core/src/services/onedrive/writer.rs
+++ b/core/src/services/onedrive/writer.rs
@@ -23,7 +23,6 @@ use super::backend::OnedriveBackend;
 use super::error::parse_error;
 use super::graph_model::OneDriveUploadSessionCreationRequestBody;
 use super::graph_model::OneDriveUploadSessionCreationResponseBody;
-use crate::raw::oio::WriteBuf;
 use crate::raw::*;
 use crate::*;
 

--- a/core/src/services/onedrive/writer.rs
+++ b/core/src/services/onedrive/writer.rs
@@ -46,8 +46,7 @@ impl OneDriveWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for OneDriveWriter {
-    async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
-        let bs = bs.bytes(bs.remaining());
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let size = bs.len();
 
         if size <= Self::MAX_SIMPLE_SIZE {

--- a/core/src/services/pcloud/writer.rs
+++ b/core/src/services/pcloud/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::PcloudCore;
@@ -41,9 +42,7 @@ impl PcloudWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for PcloudWriter {
-    async fn write_once(&self, bs: &dyn oio::WriteBuf) -> Result<()> {
-        let bs = bs.bytes(bs.remaining());
-
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         self.core.ensure_dir_exists(&self.path).await?;
 
         let resp = self.core.upload_file(&self.path, bs).await?;

--- a/core/src/services/seafile/writer.rs
+++ b/core/src/services/seafile/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::header;
 use http::Request;
 use http::StatusCode;
@@ -47,9 +48,7 @@ impl SeafileWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for SeafileWriter {
-    async fn write_once(&self, bs: &dyn oio::WriteBuf) -> Result<()> {
-        let bs = oio::ChunkedBytes::from_vec(bs.vectored_bytes(bs.remaining()));
-
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let upload_url = self.core.get_upload_url().await?;
 
         let req = Request::post(upload_url);
@@ -68,7 +67,7 @@ impl oio::OneShotWrite for SeafileWriter {
                     .parse()
                     .unwrap(),
             )
-            .stream(bs.len() as u64, Box::new(bs));
+            .content(bs);
 
         let multipart = Multipart::new()
             .part(FormDataPart::new("parent_dir").content("/"))

--- a/core/src/services/sftp/writer.rs
+++ b/core/src/services/sftp/writer.rs
@@ -20,6 +20,7 @@ use std::task::Context;
 use std::task::Poll;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use openssh_sftp_client::file::File;
 use openssh_sftp_client::file::TokioCompatFile;
 use tokio::io::AsyncWrite;
@@ -41,10 +42,10 @@ impl SftpWriter {
 
 #[async_trait]
 impl oio::Write for SftpWriter {
-    fn poll_write(&mut self, cx: &mut Context<'_>, bs: &dyn oio::WriteBuf) -> Poll<Result<usize>> {
+    fn poll_write(&mut self, cx: &mut Context<'_>, bs: Bytes) -> Poll<Result<usize>> {
         self.file
             .as_mut()
-            .poll_write(cx, bs.chunk())
+            .poll_write(cx, &bs)
             .map_err(new_std_io_error)
     }
 

--- a/core/src/services/supabase/writer.rs
+++ b/core/src/services/supabase/writer.rs
@@ -23,7 +23,7 @@ use http::StatusCode;
 
 use super::core::*;
 use super::error::parse_error;
-use crate::raw::oio::WriteBuf;
+
 use crate::raw::*;
 use crate::*;
 

--- a/core/src/services/supabase/writer.rs
+++ b/core/src/services/supabase/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::*;
@@ -45,14 +46,12 @@ impl SupabaseWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for SupabaseWriter {
-    async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
-        let bs = oio::ChunkedBytes::from_vec(bs.vectored_bytes(bs.remaining()));
-
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let mut req = self.core.supabase_upload_object_request(
             &self.path,
             Some(bs.len()),
             self.op.content_type(),
-            AsyncBody::ChunkedBytes(bs),
+            AsyncBody::Bytes(bs),
         )?;
 
         self.core.sign(&mut req)?;

--- a/core/src/services/swift/writer.rs
+++ b/core/src/services/swift/writer.rs
@@ -23,7 +23,7 @@ use http::StatusCode;
 
 use super::core::SwiftCore;
 use super::error::parse_error;
-use crate::raw::oio::WriteBuf;
+
 use crate::raw::*;
 use crate::*;
 

--- a/core/src/services/swift/writer.rs
+++ b/core/src/services/swift/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::SwiftCore;
@@ -39,9 +40,7 @@ impl SwiftWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for SwiftWriter {
-    async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
-        let bs = bs.bytes(bs.remaining());
-
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let resp = self
             .core
             .swift_create_object(&self.path, bs.len() as u64, AsyncBody::Bytes(bs))

--- a/core/src/services/vercel_artifacts/writer.rs
+++ b/core/src/services/vercel_artifacts/writer.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::backend::VercelArtifactsBackend;
@@ -42,16 +43,10 @@ impl VercelArtifactsWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for VercelArtifactsWriter {
-    async fn write_once(&self, bs: &dyn oio::WriteBuf) -> Result<()> {
-        let bs = oio::ChunkedBytes::from_vec(bs.vectored_bytes(bs.remaining()));
-
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let resp = self
             .backend
-            .vercel_artifacts_put(
-                self.path.as_str(),
-                bs.len() as u64,
-                AsyncBody::ChunkedBytes(bs),
-            )
+            .vercel_artifacts_put(self.path.as_str(), bs.len() as u64, AsyncBody::Bytes(bs))
             .await?;
 
         let status = resp.status();

--- a/core/src/services/webdav/writer.rs
+++ b/core/src/services/webdav/writer.rs
@@ -23,7 +23,7 @@ use http::StatusCode;
 
 use super::core::*;
 use super::error::parse_error;
-use crate::raw::oio::WriteBuf;
+
 use crate::raw::*;
 use crate::*;
 

--- a/core/src/services/webdav/writer.rs
+++ b/core/src/services/webdav/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 
 use super::core::*;
@@ -41,16 +42,14 @@ impl WebdavWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for WebdavWriter {
-    async fn write_once(&self, bs: &dyn WriteBuf) -> Result<()> {
-        let bs = oio::ChunkedBytes::from_vec(bs.vectored_bytes(bs.remaining()));
-
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         let resp = self
             .core
             .webdav_put(
                 &self.path,
                 Some(bs.len() as u64),
                 &self.op,
-                AsyncBody::ChunkedBytes(bs),
+                AsyncBody::Bytes(bs),
             )
             .await?;
 

--- a/core/src/services/yandex_disk/writer.rs
+++ b/core/src/services/yandex_disk/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::Request;
 use http::StatusCode;
 
@@ -41,12 +42,10 @@ impl YandexDiskWriter {
 
 #[async_trait]
 impl oio::OneShotWrite for YandexDiskWriter {
-    async fn write_once(&self, bs: &dyn oio::WriteBuf) -> Result<()> {
+    async fn write_once(&self, bs: Bytes) -> Result<()> {
         self.core.ensure_dir_exists(&self.path).await?;
 
         let upload_url = self.core.get_upload_url(&self.path).await?;
-
-        let bs = bs.bytes(bs.remaining());
 
         let req = Request::put(upload_url)
             .body(AsyncBody::Bytes(bs))

--- a/core/src/types/operator/blocking_operator.rs
+++ b/core/src/types/operator/blocking_operator.rs
@@ -653,8 +653,8 @@ impl BlockingOperator {
                 }
 
                 let (_, mut w) = inner.blocking_write(&path, args)?;
-                while bs.remaining() > 0 {
-                    let n = w.write(&bs)?;
+                while bs.len() > 0 {
+                    let n = w.write(bs.clone())?;
                     bs.advance(n);
                 }
                 w.close()?;

--- a/core/src/types/operator/blocking_operator.rs
+++ b/core/src/types/operator/blocking_operator.rs
@@ -653,7 +653,7 @@ impl BlockingOperator {
                 }
 
                 let (_, mut w) = inner.blocking_write(&path, args)?;
-                while bs.len() > 0 {
+                while !bs.is_empty() {
                     let n = w.write(bs.clone())?;
                     bs.advance(n);
                 }

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -1269,7 +1269,7 @@ impl Operator {
                 }
 
                 let (_, mut w) = inner.write(&path, args).await?;
-                while bs.len() > 0 {
+                while !bs.is_empty() {
                     let n = w.write(bs.clone()).await?;
                     bs.advance(n);
                 }

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -1269,8 +1269,8 @@ impl Operator {
                 }
 
                 let (_, mut w) = inner.write(&path, args).await?;
-                while bs.remaining() > 0 {
-                    let n = w.write(&bs).await?;
+                while bs.len() > 0 {
+                    let n = w.write(bs.clone()).await?;
                     bs.advance(n);
                 }
 

--- a/core/src/types/writer.rs
+++ b/core/src/types/writer.rs
@@ -92,7 +92,7 @@ impl Writer {
     /// Write into inner writer.
     pub async fn write(&mut self, bs: impl Into<Bytes>) -> Result<()> {
         let mut bs = bs.into();
-        while bs.len() > 0 {
+        while !bs.is_empty() {
             let n = self.inner.write(bs.clone()).await?;
             bs.advance(n);
         }
@@ -138,7 +138,7 @@ impl Writer {
         let mut written = 0;
         while let Some(bs) = sink_from.try_next().await? {
             let mut bs = bs.into();
-            while bs.len() > 0 {
+            while !bs.is_empty() {
                 let n = self.inner.write(bs.clone()).await?;
                 bs.advance(n);
                 written += n as u64;
@@ -277,7 +277,7 @@ impl BlockingWriter {
     /// Write into inner writer.
     pub fn write(&mut self, bs: impl Into<Bytes>) -> Result<()> {
         let mut bs = bs.into();
-        while bs.len() > 0 {
+        while !bs.is_empty() {
             let n = self.inner.write(bs.clone())?;
             bs.advance(n);
         }


### PR DESCRIPTION
This PR is part of the oio::Write's async in trait refactor. We will transform into take an ownership of input to make lives easier instead of using `&dyn WriteBuf`. We might build something `enum WriteBuf` in the future but it's not a blocker of this migration.

This PR has some todos related to `ChunkedBytes`. I will clean them up in following PRs.