### PR TITLE
fix(bindings/python): Fix the semantic of `size` argument for python `File::read`

### DIFF
--- a/bindings/python/src/file.rs
+++ b/bindings/python/src/file.rs
@@ -57,7 +57,7 @@ impl File {
 
 #[pymethods]
 impl File {
-    /// Read and return size bytes, or if size is not given, until EOF.
+    /// Read and return at most size bytes, or if size is not given, until EOF.
     #[pyo3(signature = (size=None,))]
     pub fn read<'p>(&'p mut self, py: Python<'p>, size: Option<usize>) -> PyResult<&'p PyAny> {
         let reader = match &mut self.0 {
@@ -77,7 +77,7 @@ impl File {
         let buffer = match size {
             Some(size) => {
                 let bs = reader
-                    .read_exact(size)
+                    .read(size)
                     .map_err(|err| PyIOError::new_err(err.to_string()))?;
                 bs.to_vec()
             }
@@ -218,7 +218,7 @@ impl AsyncFile {
 
 #[pymethods]
 impl AsyncFile {
-    /// Read and return size bytes, or if size is not given, until EOF.
+    /// Read and return at most size bytes, or if size is not given, until EOF.
     pub fn read<'p>(&'p self, py: Python<'p>, size: Option<usize>) -> PyResult<&'p PyAny> {
         let state = self.0.clone();
 
@@ -241,7 +241,7 @@ impl AsyncFile {
             let buffer = match size {
                 Some(size) => {
                     let buffer = reader
-                        .read_exact(size)
+                        .read(size)
                         .await
                         .map_err(|err| PyIOError::new_err(err.to_string()))?;
                     buffer.to_vec()

--- a/bindings/python/tests/test_read.py
+++ b/bindings/python/tests/test_read.py
@@ -49,6 +49,11 @@ def test_sync_reader(service_name, operator, async_operator):
         assert read_content is not None
         assert read_content == content
 
+    with operator.open(filename, "rb") as reader:
+        read_content = reader.read(size + 1)
+        assert read_content is not None
+        assert read_content == content
+
     operator.delete(filename)
 
 
@@ -77,6 +82,11 @@ async def test_async_reader(service_name, operator, async_operator):
 
     async with await async_operator.open(filename, "rb") as reader:
         read_content = await reader.read()
+        assert read_content is not None
+        assert read_content == content
+
+    async with await async_operator.open(filename, "rb") as reader:
+        read_content = await reader.read(size + 1)
         assert read_content is not None
         assert read_content == content
 


### PR DESCRIPTION
This fixes #4357.