### PR TITLE
fix(bindings/python): `File::write` should return the written bytes

### DIFF
--- a/bindings/python/src/file.rs
+++ b/bindings/python/src/file.rs
@@ -94,7 +94,7 @@ impl File {
     }
 
     /// Write bytes into the file.
-    pub fn write(&mut self, bs: &[u8]) -> PyResult<()> {
+    pub fn write(&mut self, bs: &[u8]) -> PyResult<usize> {
         let writer = match &mut self.0 {
             FileState::Reader(_) => {
                 return Err(PyIOError::new_err(
@@ -111,6 +111,7 @@ impl File {
 
         writer
             .write_all(bs)
+            .map(|_| bs.len())
             .map_err(|err| PyIOError::new_err(err.to_string()))
     }
 
@@ -286,6 +287,7 @@ impl AsyncFile {
             writer
                 .write_all(&bs)
                 .await
+                .map(|_| bs.len())
                 .map_err(|err| PyIOError::new_err(err.to_string()))
         })
     }

--- a/bindings/python/tests/test_write.py
+++ b/bindings/python/tests/test_write.py
@@ -108,7 +108,8 @@ async def test_async_writer(service_name, operator, async_operator):
     filename = f"test_file_{str(uuid4())}.txt"
     content = os.urandom(size)
     f = await async_operator.open(filename, "wb")
-    await f.write(content)
+    written_bytes = await f.write(content)
+    assert written_bytes == size
     await f.close()
     await async_operator.delete(filename)
     with pytest.raises(NotFound):
@@ -120,7 +121,8 @@ def test_sync_writer(service_name, operator, async_operator):
     filename = f"test_file_{str(uuid4())}.txt"
     content = os.urandom(size)
     f = operator.open(filename, "wb")
-    f.write(content)
+    written_bytes = f.write(content)
+    assert written_bytes == size
     f.close()
     operator.delete(filename)
     with pytest.raises(NotFound):


### PR DESCRIPTION
This fixes #4366.