### PR TITLE
docs(bindings/python): ipynb examples for polars and pandas

### DIFF
--- a/bindings/python/examples/pandas.ipynb
+++ b/bindings/python/examples/pandas.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install the opendal and pandas\n",
+    "!pip install opendal, pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import opendal\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Init an operator.\n",
+    "op = opendal.Operator(\"fs\", root=\"/tmp\")\n",
+    "\n",
+    "# Create and write a csv file\n",
+    "op.write(\"test.csv\", b\"name,age\\nAlice,25\\nBob,30\\nCharlie,35\")\n",
+    "\n",
+    "# Open and read the DataFrame from the file.\n",
+    "with op.open(\"test123.csv\", mode=\"rb\") as file:\n",
+    "    read_df = pd.read_csv(file)\n",
+    "    print(f\"read_df: {read_df}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/bindings/python/examples/polars.ipynb
+++ b/bindings/python/examples/polars.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install the opendal and polars\n",
+    "!pip install opendal, polars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import opendal\n",
+    "import polars as pl\n",
+    "\n",
+    "# Init an operator.\n",
+    "op = opendal.Operator(\"fs\", root=\"/tmp\")\n",
+    "\n",
+    "# Create a DataFrame.\n",
+    "df = pl.DataFrame({\"name\": [\"Alice\", \"Bob\"], \"age\": [20, 30]})\n",
+    "print(f\"df: {df}\")\n",
+    "\n",
+    "# Open and write the DataFrame to the file.\n",
+    "with op.open(\"test.csv\", mode=\"wb\") as file:\n",
+    "    df.write_csv(file)\n",
+    "\n",
+    "# Open and read the DataFrame from the file.\n",
+    "with op.open(\"test.csv\", mode=\"rb\") as file:\n",
+    "    read_df = pl.read_csv(file)\n",
+    "    print(f\"read_df: {read_df}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I have compiled opendal include the change of #4367 locally, and ran the new introduced two `ipynb` examples:

This is the result(output):

for pandas:
```python
read_df:     name  age
0  Alice   20
1    Bob   30
```


for polars:

```python
df: shape: (2, 2)
┌───────┬─────┐
│ name  ┆ age │
│ ---   ┆ --- │
│ str   ┆ i64 │
╞═══════╪═════╡
│ Alice ┆ 20  │
│ Bob   ┆ 30  │
└───────┴─────┘
read_df: shape: (2, 2)
┌───────┬─────┐
│ name  ┆ age │
│ ---   ┆ --- │
│ str   ┆ i64 │
╞═══════╪═════╡
│ Alice ┆ 20  │
│ Bob   ┆ 30  │
└───────┴─────┘
```

This closes #4270.