### PR TITLE
fix(oay): support `WebdavFile` continuous reading and writing

### DIFF
--- a/integrations/dav-server/src/opendalfs.rs
+++ b/integrations/dav-server/src/opendalfs.rs
@@ -48,7 +48,10 @@ impl DavFileSystem for OpendalFs {
         _options: dav_server::fs::OpenOptions,
     ) -> dav_server::fs::FsFuture<Box<dyn dav_server::fs::DavFile>> {
         async move {
-            let file = WebdavFile::new(self.op.clone(), path.clone());
+            let path = path.as_url_string();
+            let reader = self.op.reader(&path).await.map_err(convert_error)?;
+            let writer = self.op.writer(&path).await.map_err(convert_error)?;
+            let file = WebdavFile::new(self.op.clone(), reader, writer, path.clone());
             Ok(Box::new(file) as Box<dyn DavFile>)
         }
         .boxed()

--- a/integrations/dav-server/tests/test.rs
+++ b/integrations/dav-server/tests/test.rs
@@ -36,7 +36,7 @@ async fn test_metadata() -> Result<()> {
         .metadata(&DavPath::new("/").unwrap())
         .await
         .unwrap();
-    assert_eq!(true, metadata.is_dir());
+    assert!(metadata.is_dir());
 
     Ok(())
 }


### PR DESCRIPTION
fix #3231

Added a `WebdavFileState` structure containing a `Reader` and a `Writer` to support continuous reading and writing of `WebdavFile`.