### PR TITLE
fix(services/s3): omit default ports

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -632,7 +632,8 @@ impl S3Builder {
 
         // Omit default ports if specified.
         if let Ok(url) = Url::from_str(&endpoint) {
-            endpoint = url.to_string();
+            // Remove the trailing `/` of root path.
+            endpoint = url.to_string().trim_end_matches('/').to_string();
         }
 
         // Update with endpoint templates.

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Write;
+use std::str::FromStr;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -37,6 +38,7 @@ use reqsign::AwsConfig;
 use reqsign::AwsCredentialLoad;
 use reqsign::AwsDefaultLoader;
 use reqsign::AwsV4Signer;
+use reqwest::Url;
 use serde::Deserialize;
 
 use super::core::*;
@@ -627,6 +629,11 @@ impl S3Builder {
 
         // If endpoint contains bucket name, we should trim them.
         endpoint = endpoint.replace(&format!("//{bucket}."), "//");
+
+        // Omit default ports if specified.
+        if let Ok(url) = Url::from_str(&endpoint) {
+            endpoint = url.to_string();
+        }
 
         // Update with endpoint templates.
         endpoint = if let Some(template) = ENDPOINT_TEMPLATES.get(endpoint.as_str()) {


### PR DESCRIPTION
try fix https://github.com/apache/opendal/issues/4249

The default port is omitted by Url::from(xx) when sending request: https://github.com/apache/opendal/blob/4c1752b5a60c9051a686c2e2f9a6af871105d4fe/core/src/raw/http_util/client.rs#L89-L95

They are not ignored when calculating signatures:
https://github.com/apache/opendal/blob/4c1752b5a60c9051a686c2e2f9a6af871105d4fe/core/src/services/s3/core.rs#L382-L384