### PR TITLE
feat: add ofs ctrl-c exit unmount hook

### DIFF
--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -96,10 +96,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
-name = "async-trait"
-version = "0.1.77"
+name = "async-notify"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "db96c36382f56ea91e5d012c4c7170046c7731449daa46655cbcabc594c8bee6"
+dependencies = [
+ "event-listener",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -263,6 +274,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +332,12 @@ checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crunchy"
@@ -415,6 +441,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,22 +480,23 @@ dependencies = [
 
 [[package]]
 name = "fuse3"
-version = "0.6.1"
+version = "0.7.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aaac75c1369ee81ed34a8e26216258126a3c555bfc85e49eb33b5e239fd182e"
+checksum = "5f2c31ac1f50145d6df478922d47ac1f4dca17dedeb7ac82640c84737170dd1c"
 dependencies = [
- "async-trait",
+ "async-notify",
  "bincode",
  "bytes",
  "cstr",
  "futures-channel",
  "futures-util",
  "libc",
- "nix 0.26.4",
+ "nix",
  "serde",
  "slab",
  "tokio",
  "tracing",
+ "trait-make",
  "which",
 ]
 
@@ -813,9 +851,9 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -848,18 +886,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
@@ -867,6 +893,7 @@ dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -910,7 +937,7 @@ dependencies = [
  "futures-util",
  "libc",
  "log",
- "nix 0.27.1",
+ "nix",
  "opendal",
  "sharded-slab",
  "tokio",
@@ -959,6 +986,12 @@ dependencies = [
  "dlv-list",
  "hashbrown",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "percent-encoding"
@@ -1327,6 +1360,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +1479,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -1512,6 +1555,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "trait-make"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96cbd06a7b648f1603e60d75d9ed295d096b340d30e9f9324f4b512b5d40cd92"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1698,14 +1752,14 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "which"
-version = "4.4.2"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
 dependencies = [
  "either",
  "home",
- "once_cell",
  "rustix",
+ "winsafe",
 ]
 
 [[package]]
@@ -1858,3 +1912,9 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"

--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -214,6 +214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chrono"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "fuse3"
-version = "0.7.0-alpha.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c31ac1f50145d6df478922d47ac1f4dca17dedeb7ac82640c84737170dd1c"
+checksum = "2a1df9aa50861c978c49522864d986093bb773558d431ea54c9e258ad3d6ce28"
 dependencies = [
  "async-notify",
  "bincode",
@@ -491,7 +497,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "libc",
- "nix",
+ "nix 0.28.0",
  "serde",
  "slab",
  "tokio",
@@ -893,6 +899,18 @@ dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
  "memoffset",
 ]
 
@@ -937,7 +955,7 @@ dependencies = [
  "futures-util",
  "libc",
  "log",
- "nix",
+ "nix 0.27.1",
  "opendal",
  "sharded-slab",
  "tokio",

--- a/bin/ofs/Cargo.toml
+++ b/bin/ofs/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "1.34", features = [
   "macros",
   "rt-multi-thread",
   "io-std",
+  "signal",
 ] }
 url = "2.5.0"
 chrono = "0.4.34"
@@ -49,7 +50,7 @@ bytes = "1.5.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.151"
-fuse3 = { "version" = "0.6.1", "features" = ["tokio-runtime", "unprivileged"] }
+fuse3 = { "version" = "0.7.0-alpha.2", "features" = ["tokio-runtime", "unprivileged"] }
 nix = { version = "0.27.1", features = ["user"] }
 
 [features]

--- a/bin/ofs/Cargo.toml
+++ b/bin/ofs/Cargo.toml
@@ -50,7 +50,7 @@ bytes = "1.5.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.151"
-fuse3 = { "version" = "0.7.0-alpha.2", "features" = ["tokio-runtime", "unprivileged"] }
+fuse3 = { "version" = "0.7.1", "features" = ["tokio-runtime", "unprivileged"] }
 nix = { version = "0.27.1", features = ["user"] }
 
 [features]

--- a/bin/ofs/src/fuse.rs
+++ b/bin/ofs/src/fuse.rs
@@ -17,8 +17,8 @@
 
 use std::ffi::OsStr;
 use std::ffi::OsString;
-use std::ops::Deref;
 use std::num::NonZeroU32;
+use std::ops::Deref;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::time::SystemTime;

--- a/bin/ofs/src/fuse.rs
+++ b/bin/ofs/src/fuse.rs
@@ -23,7 +23,6 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 use bytes::Bytes;
-use fuse3::async_trait;
 use fuse3::path::prelude::*;
 use fuse3::Errno;
 use fuse3::Result;
@@ -127,7 +126,6 @@ impl Fuse {
     }
 }
 
-#[async_trait]
 impl PathFilesystem for Fuse {
     type DirEntryStream = BoxStream<'static, Result<DirectoryEntry>>;
     type DirEntryPlusStream = BoxStream<'static, Result<DirectoryEntryPlus>>;
@@ -474,6 +472,7 @@ impl PathFilesystem for Fuse {
         fh: u64,
         offset: u64,
         data: &[u8],
+        _write_flags: u32,
         flags: u32,
     ) -> Result<ReplyWrite> {
         log::debug!(

--- a/bin/ofs/src/lib.rs
+++ b/bin/ofs/src/lib.rs
@@ -91,9 +91,9 @@ async fn execute_inner(args: Args) -> Result<()> {
     let handle = &mut mount_handle;
 
     tokio::select! {
-        res = handle => res.unwrap(),
+        res = handle => res?,
         _ = signal::ctrl_c() => {
-            mount_handle.unmount().await.unwrap()
+            mount_handle.unmount().await?
         }
     }
 


### PR DESCRIPTION
currently, if we stop `ofs` running, it does not unmount fuse3 dir,
```
╭─ouyang@owl-home ~/code/opendal/bin/ofs ‹main› 
╰─$ RUST_LOG=debug ./target/debug/ofs ./exampless "fs://?root=/home/ouyang/tmp" 
[2024-03-25T14:27:05Z DEBUG opendal::services::fs::backend] backend build started: FsBuilder { root: Some("/home/ouyang/tmp"), atomic_write_dir: None }
[2024-03-25T14:27:05Z DEBUG opendal::services::fs::backend] backend use root /home/ouyang/tmp
[2024-03-25T14:27:05Z DEBUG opendal::services::fs::backend] backend build finished: FsBuilder { root: None, atomic_write_dir: None }
^C
╭─ouyang@owl-home ~/code/opendal/bin/ofs ‹main› 
╰─$ ls -al ./exampless                                                                                                                                                   130 ↵
ls: cannot access './exampless': Transport endpoint is not connected
╭─ouyang@owl-home ~/code/opendal/bin/ofs ‹main› 
╰─$ sudo fusermount3 -u ./exampless           
```

`fuse3` has been implement `unmount` feature https://github.com/Sherlock-Holo/fuse3/pull/78, but it just include by  alpha release. I am not sure if we can accept the alpha release crates library (due to `ofs` being early stage)?
```
╭─ouyang@owl-home ~/code/opendal/bin/ofs ‹feat/ofs-unmount-ctrl-c› 
╰─$ RUST_LOG=debug ./target/debug/ofs ./exampless "fs://?root=/home/ouyang/tmp"                                                                                          130 ↵
[2024-03-25T14:31:45Z DEBUG opendal::services::fs::backend] backend build started: FsBuilder { root: Some("/home/ouyang/tmp"), atomic_write_dir: None }
[2024-03-25T14:31:45Z DEBUG opendal::services::fs::backend] backend use root /home/ouyang/tmp
[2024-03-25T14:31:45Z DEBUG opendal::services::fs::backend] backend build finished: FsBuilder { root: None, atomic_write_dir: None }
^C%                                                                                                                                                                            ╭─ouyang@owl-home ~/code/opendal/bin/ofs ‹feat/ofs-unmount-ctrl-c› 
╰─$ ls -al ./exampless
total 0
drwxr-xr-x 1 ouyang ouyang   0 Mar 25 16:59 .
drwxr-xr-x 1 ouyang ouyang 166 Mar 25 22:31 ..

```