### PR TITLE
feat(ofs): add freebsd OS support

### DIFF
--- a/bin/ofs/Cargo.toml
+++ b/bin/ofs/Cargo.toml
@@ -47,8 +47,6 @@ url = "2.5.0"
 chrono = "0.4.34"
 sharded-slab = "0.1.7"
 bytes = "1.5.0"
-
-[target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.151"
 fuse3 = { "version" = "0.7.1", "features" = ["tokio-runtime", "unprivileged"] }
 nix = { version = "0.27.1", features = ["user"] }

--- a/bin/ofs/README.md
+++ b/bin/ofs/README.md
@@ -15,6 +15,12 @@ sudo pacman -S fuse3 --noconfirm # archlinux
 sudo apt-get -y install fuse     # debian/ubuntu
 ```
 
+### Load `FUSE` kernel module on FreeBSD
+
+```shell
+kldload fuse
+```
+
 ### Install `ofs`
 
 `ofs` could be installed by `cargo`:

--- a/bin/ofs/src/config.rs
+++ b/bin/ofs/src/config.rs
@@ -22,7 +22,6 @@ use url::Url;
 #[command(version, about)]
 pub struct Config {
     /// fuse mount path
-    #[cfg(target_os = "linux")]
     #[arg(env = "OFS_MOUNT_PATH", index = 1)]
     pub mount_path: String,
 

--- a/bin/ofs/src/lib.rs
+++ b/bin/ofs/src/lib.rs
@@ -48,7 +48,6 @@ pub async fn execute(cfg: Config) -> Result<()> {
     let backend = Operator::via_map(scheme, op_args)?;
 
     let args = Args {
-        #[cfg(target_os = "linux")]
         mount_path: cfg.mount_path,
         backend,
     };

--- a/bin/ofs/src/lib.rs
+++ b/bin/ofs/src/lib.rs
@@ -59,7 +59,13 @@ struct Args {
     mount_path: String,
     backend: Operator,
 }
+#[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
+async fn execute_inner(args: Args) -> Result<()> {
+    _ = args.backend;
+    Err(anyhow::anyhow!("platform not supported"))
+}
 
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 async fn execute_inner(args: Args) -> Result<()> {
     use fuse3::path::Session;
     use fuse3::MountOptions;

--- a/bin/ofs/src/lib.rs
+++ b/bin/ofs/src/lib.rs
@@ -27,7 +27,6 @@ use tokio::signal;
 pub mod config;
 pub use config::Config;
 
-#[cfg(target_os = "linux")]
 mod fuse;
 
 pub async fn execute(cfg: Config) -> Result<()> {
@@ -58,18 +57,10 @@ pub async fn execute(cfg: Config) -> Result<()> {
 
 #[derive(Debug)]
 struct Args {
-    #[cfg(target_os = "linux")]
     mount_path: String,
     backend: Operator,
 }
 
-#[cfg(not(target_os = "linux"))]
-async fn execute_inner(args: Args) -> Result<()> {
-    _ = args.backend;
-    Err(anyhow::anyhow!("platform not supported"))
-}
-
-#[cfg(target_os = "linux")]
 async fn execute_inner(args: Args) -> Result<()> {
     use fuse3::path::Session;
     use fuse3::MountOptions;


### PR DESCRIPTION

1. FreeBSD 13

```
root@freebsd:~/opendal/bin/ofs # echo "Hello OpenDAL ofs From Freebsd 13" > exampless/data.txt
root@freebsd:~/opendal/bin/ofs # cat exampless/data.txt 
Hello OpenDAL ofs From Freebsd 13
root@freebsd:~/opendal/bin/ofs # uname -a
FreeBSD freebsd 13.3-RELEASE FreeBSD 13.3-RELEASE releng/13.3-n257428-80d2b634ddf0 GENERIC amd64
```

```
[root@freebsd ~/opendal/bin/ofs]#  RUST_LOG=info ./target/debug/ofs ./exampless "fs://?root=/tmp" 
[2024-03-27T17:20:46Z INFO  fuse3::raw::session] handle_init; request=Request { unique: 1, uid: 0, gid: 0, pid: 2126 } fuse_connection=FuseConnection { unmount_notify: Notify { count: false, event: Event { listeners_notified: 18446744073709551615, listeners_total: 0 } }, mode: NonBlock(NonBlockFuseConnection { fd: AsyncFd { inner: Some(OwnedFd { fd: 9 }) }, read: Mutex { is_locked: false, has_waiters: false }, write: Mutex { is_locked: false, has_waiters: false } }) }
[2024-03-27T17:20:54Z INFO  fuse3::raw::session] handle_access; request=Request { unique: 2, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 48, opcode: 34, unique: 2, nodeid: 1, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:54Z INFO  fuse3::raw::session] handle_lookup; request=Request { unique: 3, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 49, opcode: 1, unique: 3, nodeid: 1, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:54Z INFO  fuse3::raw::session] handle_access; request=Request { unique: 4, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 48, opcode: 34, unique: 4, nodeid: 2, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:54Z INFO  fuse3::raw::session] handle_open; request=Request { unique: 5, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 48, opcode: 14, unique: 5, nodeid: 2, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:54Z INFO  fuse3::raw::session] handle_setattr; request=Request { unique: 6, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 128, opcode: 4, unique: 6, nodeid: 2, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:54Z INFO  fuse3::raw::session] handle_write; request=Request { unique: 7, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 114, opcode: 16, unique: 7, nodeid: 2, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:54Z INFO  fuse3::raw::session] handle_flush; request=Request { unique: 8, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 64, opcode: 25, unique: 8, nodeid: 2, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:54Z INFO  fuse3::raw::session] handle_release; request=Request { unique: 9, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 64, opcode: 18, unique: 9, nodeid: 2, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:56Z INFO  fuse3::raw::session] handle_getattr; request=Request { unique: 10, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 56, opcode: 3, unique: 10, nodeid: 1, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:58Z INFO  fuse3::raw::session] handle_access; request=Request { unique: 11, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 48, opcode: 34, unique: 11, nodeid: 1, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:58Z INFO  fuse3::raw::session] handle_opendir; request=Request { unique: 12, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 48, opcode: 27, unique: 12, nodeid: 1, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:58Z INFO  fuse3::raw::session] handle_readdir; request=Request { unique: 13, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 80, opcode: 28, unique: 13, nodeid: 1, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:58Z INFO  fuse3::raw::session] handle_readdir; request=Request { unique: 14, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 80, opcode: 28, unique: 14, nodeid: 1, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:58Z INFO  fuse3::raw::session] handle_access; request=Request { unique: 15, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 48, opcode: 34, unique: 15, nodeid: 1, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:58Z INFO  fuse3::raw::session] handle_lookup; request=Request { unique: 16, uid: 0, gid: 0, pid: 1624 } in_header=fuse_in_header { len: 49, opcode: 1, unique: 16, nodeid: 1, uid: 0, gid: 0, pid: 1624, padding: 0 }
[2024-03-27T17:20:59Z INFO  fuse3::raw::session] handle_access; request=Request { unique: 17, uid: 0, gid: 0, pid: 2127 } in_header=fuse_in_header { len: 48, opcode: 34, unique: 17, nodeid: 1, uid: 0, gid: 0, pid: 2127, padding: 0 }
[2024-03-27T17:20:59Z INFO  fuse3::raw::session] handle_access; request=Request { unique: 18, uid: 0, gid: 0, pid: 2127 } in_header=fuse_in_header { len: 48, opcode: 34, unique: 18, nodeid: 2, uid: 0, gid: 0, pid: 2127, padding: 0 }
[2024-03-27T17:20:59Z INFO  fuse3::raw::session] handle_open; request=Request { unique: 19, uid: 0, gid: 0, pid: 2127 } in_header=fuse_in_header { len: 48, opcode: 14, unique: 19, nodeid: 2, uid: 0, gid: 0, pid: 2127, padding: 0 }
[2024-03-27T17:20:59Z INFO  fuse3::raw::session] handle_read; request=Request { unique: 20, uid: 0, gid: 0, pid: 2127 } in_header=fuse_in_header { len: 80, opcode: 15, unique: 20, nodeid: 2, uid: 0, gid: 0, pid: 2127, padding: 0 }
[2024-03-27T17:20:59Z INFO  fuse3::raw::session] handle_setattr; request=Request { unique: 21, uid: 0, gid: 0, pid: 2127 } in_header=fuse_in_header { len: 128, opcode: 4, unique: 21, nodeid: 2, uid: 0, gid: 0, pid: 2127, padding: 0 }
[2024-03-27T17:20:59Z INFO  fuse3::raw::session] handle_release; request=Request { unique: 22, uid: 0, gid: 0, pid: 2127 } in_header=fuse_in_header { len: 64, opcode: 18, unique: 22, nodeid: 2, uid: 0, gid: 0, pid: 2127, padding: 0 }

```