### PR TITLE
refactor(core/raw/oio): Use oio buffer in write

### DIFF
--- a/core/benches/oio/utils.rs
+++ b/core/benches/oio/utils.rs
@@ -24,7 +24,7 @@ use rand::RngCore;
 pub struct BlackHoleWriter;
 
 impl oio::Write for BlackHoleWriter {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> opendal::Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> opendal::Result<usize> {
         Ok(bs.len())
     }
 

--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -291,7 +291,7 @@ impl<I: oio::Read + 'static> oio::BlockingRead for BlockingWrapper<I> {
 }
 
 impl<I: oio::Write + 'static> oio::BlockingWrite for BlockingWrapper<I> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         self.handle.block_on(self.inner.write(bs))
     }
 

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -638,7 +638,7 @@ impl<W> oio::Write for CompleteWriter<W>
 where
     W: oio::Write,
 {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let w = self.inner.as_mut().ok_or_else(|| {
             Error::new(ErrorKind::Unexpected, "writer has been closed or aborted")
         })?;
@@ -673,7 +673,7 @@ impl<W> oio::BlockingWrite for CompleteWriter<W>
 where
     W: oio::BlockingWrite,
 {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let w = self.inner.as_mut().ok_or_else(|| {
             Error::new(ErrorKind::Unexpected, "writer has been closed or aborted")
         })?;

--- a/core/src/layers/concurrent_limit.rs
+++ b/core/src/layers/concurrent_limit.rs
@@ -266,7 +266,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for ConcurrentLimitWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for ConcurrentLimitWrapper<R> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         self.inner.write(bs).await
     }
 
@@ -280,7 +280,7 @@ impl<R: oio::Write> oio::Write for ConcurrentLimitWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for ConcurrentLimitWrapper<R> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         self.inner.write(bs)
     }
 

--- a/core/src/layers/dtrace.rs
+++ b/core/src/layers/dtrace.rs
@@ -381,7 +381,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for DtraceLayerWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for DtraceLayerWrapper<R> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let c_path = CString::new(self.path.clone()).unwrap();
         probe_lazy!(opendal, writer_write_start, c_path.as_ptr());
         self.inner
@@ -429,7 +429,7 @@ impl<R: oio::Write> oio::Write for DtraceLayerWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for DtraceLayerWrapper<R> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let c_path = CString::new(self.path.clone()).unwrap();
         probe_lazy!(opendal, blocking_writer_write_start, c_path.as_ptr());
         self.inner

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -366,7 +366,7 @@ impl<T: oio::BlockingRead> oio::BlockingRead for ErrorContextWrapper<T> {
 }
 
 impl<T: oio::Write> oio::Write for ErrorContextWrapper<T> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         self.inner.write(bs.clone()).await.map_err(|err| {
             err.with_operation(WriteOperation::Write)
                 .with_context("service", self.scheme)
@@ -393,7 +393,7 @@ impl<T: oio::Write> oio::Write for ErrorContextWrapper<T> {
 }
 
 impl<T: oio::BlockingWrite> oio::BlockingWrite for ErrorContextWrapper<T> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         self.inner.write(bs.clone()).map_err(|err| {
             err.with_operation(WriteOperation::BlockingWrite)
                 .with_context("service", self.scheme)

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -1075,7 +1075,7 @@ impl<W> LoggingWriter<W> {
 }
 
 impl<W: oio::Write> oio::Write for LoggingWriter<W> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         match self.inner.write(bs.clone()).await {
             Ok(n) => {
                 self.written += n as u64;
@@ -1173,7 +1173,7 @@ impl<W: oio::Write> oio::Write for LoggingWriter<W> {
 }
 
 impl<W: oio::BlockingWrite> oio::BlockingWrite for LoggingWriter<W> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         match self.inner.write(bs.clone()) {
             Ok(n) => {
                 self.written += n as u64;

--- a/core/src/layers/madsim.rs
+++ b/core/src/layers/madsim.rs
@@ -284,7 +284,7 @@ pub struct MadsimWriter {
 }
 
 impl oio::Write for MadsimWriter {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> crate::Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> crate::Result<usize> {
         #[cfg(madsim)]
         {
             let req = Request::Write(self.path.to_string(), bs);

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -788,7 +788,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for MetricWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for MetricWrapper<R> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let start = Instant::now();
 
         self.inner
@@ -822,7 +822,7 @@ impl<R: oio::Write> oio::Write for MetricWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for MetricWrapper<R> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         self.inner
             .write(bs)
             .map(|n| {

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -309,7 +309,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for MinitraceWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for MinitraceWrapper<R> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> impl Future<Output = Result<usize>> + Send {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> impl Future<Output = Result<usize>> + Send {
         let _g = self.span.set_local_parent();
         let _span = LocalSpan::enter_with_local_parent(WriteOperation::Write.into_static());
         self.inner.write(bs)
@@ -329,7 +329,7 @@ impl<R: oio::Write> oio::Write for MinitraceWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for MinitraceWrapper<R> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let _g = self.span.set_local_parent();
         let _span = LocalSpan::enter_with_local_parent(WriteOperation::BlockingWrite.into_static());
         self.inner.write(bs)

--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -287,7 +287,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for OtelTraceWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for OtelTraceWrapper<R> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> impl Future<Output = Result<usize>> + Send {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> impl Future<Output = Result<usize>> + Send {
         self.inner.write(bs)
     }
 
@@ -301,7 +301,7 @@ impl<R: oio::Write> oio::Write for OtelTraceWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for OtelTraceWrapper<R> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         self.inner.write(bs)
     }
 

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -729,7 +729,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for PrometheusMetricWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let labels = self.stats.generate_metric_label(
             self.scheme.into_static(),
             Operation::Write.into_static(),
@@ -767,7 +767,7 @@ impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for PrometheusMetricWrapper<R> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let labels = self.stats.generate_metric_label(
             self.scheme.into_static(),
             Operation::BlockingWrite.into_static(),

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -577,7 +577,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for PrometheusMetricWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let start = Instant::now();
 
         self.inner
@@ -614,7 +614,7 @@ impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for PrometheusMetricWrapper<R> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         self.inner
             .write(bs)
             .map(|n| {

--- a/core/src/layers/throttle.rs
+++ b/core/src/layers/throttle.rs
@@ -196,7 +196,7 @@ impl<R: oio::BlockingRead> oio::BlockingRead for ThrottleWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for ThrottleWrapper<R> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let buf_length = NonZeroU32::new(bs.len() as u32).unwrap();
 
         loop {
@@ -231,7 +231,7 @@ impl<R: oio::Write> oio::Write for ThrottleWrapper<R> {
 }
 
 impl<R: oio::BlockingWrite> oio::BlockingWrite for ThrottleWrapper<R> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let buf_length = NonZeroU32::new(bs.len() as u32).unwrap();
 
         loop {

--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -298,7 +298,7 @@ impl<R: oio::Read> oio::Read for TimeoutWrapper<R> {
 }
 
 impl<R: oio::Write> oio::Write for TimeoutWrapper<R> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let fut = self.inner.write(bs);
         Self::io_timeout(self.timeout, WriteOperation::Write.into_static(), fut).await
     }

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -289,7 +289,7 @@ impl<R: oio::Write> oio::Write for TracingWrapper<R> {
         parent = &self.span,
         level = "trace",
         skip_all)]
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> impl Future<Output = Result<usize>> + Send {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> impl Future<Output = Result<usize>> + Send {
         self.inner.write(bs)
     }
 
@@ -315,7 +315,7 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for TracingWrapper<R> {
         parent = &self.span,
         level = "trace",
         skip_all)]
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         self.inner.write(bs)
     }
 

--- a/core/src/raw/enum_utils.rs
+++ b/core/src/raw/enum_utils.rs
@@ -71,7 +71,7 @@ impl<ONE: oio::BlockingRead, TWO: oio::BlockingRead> oio::BlockingRead for TwoWa
 }
 
 impl<ONE: oio::Write, TWO: oio::Write> oio::Write for TwoWays<ONE, TWO> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         match self {
             Self::One(v) => v.write(bs).await,
             Self::Two(v) => v.write(bs).await,
@@ -130,7 +130,7 @@ impl<ONE: oio::BlockingRead, TWO: oio::BlockingRead, THREE: oio::BlockingRead> o
 impl<ONE: oio::Write, TWO: oio::Write, THREE: oio::Write> oio::Write
     for ThreeWays<ONE, TWO, THREE>
 {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         match self {
             Self::One(v) => v.write(bs).await,
             Self::Two(v) => v.write(bs).await,

--- a/core/src/raw/oio/buf/adaptive.rs
+++ b/core/src/raw/oio/buf/adaptive.rs
@@ -36,7 +36,7 @@ const DEFAULT_MAX_BUFFER_SIZE: usize = 4 * 1024 * 1024;
 pub struct AdaptiveBuf {
     /// The underlying buffer.
     buffer: BytesMut,
-
+    /// The next buffer size.
     next: usize,
     decrease_now: bool,
 }

--- a/core/src/raw/oio/buf/buffer.rs
+++ b/core/src/raw/oio/buf/buffer.rs
@@ -34,6 +34,7 @@ enum Inner {
     Contiguous(Bytes),
     NonContiguous {
         parts: Arc<[Bytes]>,
+        size: usize,
         idx: usize,
         offset: usize,
     },
@@ -54,6 +55,31 @@ impl Buffer {
         let mut bs = self.clone();
         bs.copy_to_bytes(bs.remaining())
     }
+
+    /// Get the length of the buffer.
+    #[inline]
+    pub fn len(&self) -> usize {
+        match &self.0 {
+            Inner::Contiguous(b) => b.remaining(),
+            Inner::NonContiguous { size, .. } => *size,
+        }
+    }
+
+    /// Shortens the buffer, keeping the first `len` bytes and dropping the rest.
+    ///
+    /// If `len` is greater than the buffer’s current length, this has no effect.
+    #[inline]
+    pub fn truncate(&mut self, len: usize) {
+        match &mut self.0 {
+            Inner::Contiguous(bs) => bs.truncate(len),
+            Inner::NonContiguous { size, .. } => {
+                if *size < len {
+                    return;
+                }
+                *size = len;
+            }
+        }
+    }
 }
 
 impl From<Vec<u8>> for Buffer {
@@ -71,8 +97,10 @@ impl From<Bytes> for Buffer {
 /// Transform `VecDeque<Bytes>` to `Arc<[Bytes]>`.
 impl From<VecDeque<Bytes>> for Buffer {
     fn from(bs: VecDeque<Bytes>) -> Self {
+        let size = bs.iter().map(|b| b.len()).sum();
         Self(Inner::NonContiguous {
             parts: Vec::from(bs).into(),
+            size,
             idx: 0,
             offset: 0,
         })
@@ -82,8 +110,26 @@ impl From<VecDeque<Bytes>> for Buffer {
 /// Transform `Vec<Bytes>` to `Arc<[Bytes]>`.
 impl From<Vec<Bytes>> for Buffer {
     fn from(bs: Vec<Bytes>) -> Self {
+        let size = bs.iter().map(|b| b.len()).sum();
         Self(Inner::NonContiguous {
             parts: bs.into(),
+            size,
+            idx: 0,
+            offset: 0,
+        })
+    }
+}
+
+impl From<Vec<Buffer>> for Buffer {
+    fn from(bs: Vec<Buffer>) -> Self {
+        let size = bs.iter().map(|b| b.len()).sum();
+        Self(Inner::NonContiguous {
+            parts: bs
+                .into_iter()
+                .map(|b| b.to_bytes())
+                .collect::<Vec<Bytes>>()
+                .into(),
+            size,
             idx: 0,
             offset: 0,
         })
@@ -93,28 +139,26 @@ impl From<Vec<Bytes>> for Buffer {
 impl Buf for Buffer {
     #[inline]
     fn remaining(&self) -> usize {
-        match &self.0 {
-            Inner::Contiguous(b) => b.remaining(),
-            Inner::NonContiguous { parts, idx, offset } => {
-                if *idx >= parts.len() {
-                    return 0;
-                }
-
-                parts[*idx..].iter().map(|p| p.len()).sum::<usize>() - offset
-            }
-        }
+        self.len()
     }
 
     #[inline]
     fn chunk(&self) -> &[u8] {
         match &self.0 {
             Inner::Contiguous(b) => b.chunk(),
-            Inner::NonContiguous { parts, idx, offset } => {
-                if *idx >= parts.len() {
+            Inner::NonContiguous {
+                parts,
+                size,
+                idx,
+                offset,
+            } => {
+                if *size == 0 {
                     return &[];
                 }
 
-                &parts[*idx][*offset..]
+                let chunk = &parts[*idx];
+                let n = (chunk.len() - *offset).min(*size);
+                &parts[*idx][*offset..*offset + n]
             }
         }
     }
@@ -123,7 +167,12 @@ impl Buf for Buffer {
     fn advance(&mut self, cnt: usize) {
         match &mut self.0 {
             Inner::Contiguous(b) => b.advance(cnt),
-            Inner::NonContiguous { parts, idx, offset } => {
+            Inner::NonContiguous {
+                parts,
+                size,
+                idx,
+                offset,
+            } => {
                 let mut new_cnt = cnt;
                 let mut new_idx = *idx;
                 let mut new_offset = *offset;
@@ -147,11 +196,131 @@ impl Buf for Buffer {
                 if new_cnt == 0 {
                     *idx = new_idx;
                     *offset = new_offset;
+                    *size -= cnt;
                 } else {
                     panic!("cannot advance past {cnt} bytes")
                 }
             }
         }
+    }
+}
+
+/// TODO: maybe we can optimize this by avoiding not needed operations?
+impl Iterator for Buffer {
+    type Item = Bytes;
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.len() == 0 {
+            return (0, Some(0));
+        }
+
+        match &self.0 {
+            Inner::Contiguous(_) => (1, Some(1)),
+            Inner::NonContiguous { parts, idx, .. } => (parts.len() - idx, Some(parts.len() - idx)),
+        }
+    }
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.len() == 0 {
+            return None;
+        }
+
+        match &mut self.0 {
+            Inner::Contiguous(bs) => {
+                let buf = bs.split_off(0);
+                Some(buf)
+            }
+            Inner::NonContiguous {
+                parts,
+                size,
+                idx,
+                offset,
+            } => {
+                let chunk = &parts[*idx];
+                let n = (chunk.len() - *offset).min(*size);
+                let buf = chunk.slice(*offset..*offset + n);
+                *size -= n;
+                *offset += n;
+                if *offset == chunk.len() {
+                    *idx += 1;
+                    *offset = 0;
+                }
+                Some(buf)
+            }
+        }
+    }
+}
+
+/// BufferQueue is a queue of [`Buffer`].
+///
+/// It's works like a `Vec<Buffer>` but with more efficient `advance` operation.
+pub struct BufferQueue(VecDeque<Buffer>);
+
+impl BufferQueue {
+    /// Create a new buffer queue.
+    #[inline]
+    pub fn new() -> Self {
+        Self(VecDeque::new())
+    }
+
+    /// Push new [`Buffer`] into the queue.
+    #[inline]
+    pub fn push(&mut self, buf: Buffer) {
+        self.0.push_back(buf);
+    }
+
+    /// Total bytes size inside the buffer queue.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.iter().map(|b| b.len()).sum()
+    }
+
+    /// Is the buffer queue empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Build a Buffer from the queue.
+    #[inline]
+    pub fn to_buffer(&self) -> Buffer {
+        if self.0.len() == 0 {
+            Buffer::new()
+        } else if self.0.len() == 1 {
+            self.0.clone().pop_front().unwrap()
+        } else {
+            let mut bytes = Vec::with_capacity(self.0.iter().map(|b| b.size_hint().0).sum());
+            for buf in self.0.clone() {
+                for bs in buf {
+                    bytes.push(bs);
+                }
+            }
+            Buffer::from(bytes)
+        }
+    }
+
+    /// Advance the buffer queue by `cnt` bytes.
+    #[inline]
+    pub fn advance(&mut self, cnt: usize) {
+        assert!(cnt <= self.len(), "cannot advance past {cnt} bytes");
+
+        let mut new_cnt = cnt;
+        while new_cnt > 0 {
+            let buf = self.0.front_mut().expect("buffer must be valid");
+            if new_cnt < buf.remaining() {
+                buf.advance(new_cnt);
+                break;
+            } else {
+                new_cnt -= buf.remaining();
+                self.0.pop_front();
+            }
+        }
+    }
+
+    /// Clear the buffer queue.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.0.clear()
     }
 }
 

--- a/core/src/raw/oio/buf/flex_buf.rs
+++ b/core/src/raw/oio/buf/flex_buf.rs
@@ -1,0 +1,98 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use bytes::BytesMut;
+use bytes::{Buf, BufMut, Bytes};
+
+/// FlexBuf is a buffer that support frozen bytes and reuse existing allocated memory.
+///
+/// It's useful when we want to freeze the buffer and reuse the memory for the next buffer.
+pub struct FlexBuf {
+    cap: usize,
+    buf: BytesMut,
+    frozen: Option<Bytes>,
+}
+
+impl FlexBuf {
+    /// Initializes a new `FlexBuf` with the given capacity.
+    pub fn new(cap: usize) -> Self {
+        FlexBuf {
+            cap,
+
+            buf: BytesMut::with_capacity(cap),
+            frozen: None,
+        }
+    }
+
+    /// Put slice into flex buf.
+    ///
+    /// Return 0 means the buffer is frozen.
+    pub fn put(&mut self, bs: &[u8]) -> usize {
+        if self.frozen.is_some() {
+            return 0;
+        }
+        let n = self.buf.remaining_mut().min(bs.len());
+        self.buf.put_slice(&bs[..n]);
+
+        if !self.buf.has_remaining_mut() {
+            let frozen = self.buf.split();
+            self.frozen = Some(frozen.freeze());
+        }
+
+        n
+    }
+
+    /// Freeze the buffer no matter it's full or not.
+    pub fn freeze(&mut self) {
+        let frozen = self.buf.split();
+        if frozen.is_empty() {
+            return;
+        }
+        self.frozen = Some(frozen.freeze());
+    }
+
+    /// Get the frozen buffer.
+    ///
+    /// Return `None` if the buffer is not frozen.
+    ///
+    /// # Notes
+    ///
+    /// This operation did nothing to the buffer. We use `&mut self` just for make
+    /// the API consistent with other APIs.
+    pub fn get(&mut self) -> Option<Bytes> {
+        self.frozen.clone()
+    }
+
+    // Advance the frozen buffer.
+    ///
+    /// # Panics
+    ///
+    /// Panic if the buffer is not frozen.
+    pub fn advance(&mut self, cnt: usize) {
+        let Some(bs) = self.frozen.as_mut() else {
+            unreachable!("It must be a bug to advance on not frozen buffer")
+        };
+        bs.advance(cnt);
+
+        if bs.is_empty() {
+            self.frozen = None;
+            // This reserve cloud be cheap since we can reuse already allocated memory.
+            // (if all references to the frozen buffer are dropped)
+            self.buf.reserve(self.cap);
+        }
+    }
+}

--- a/core/src/raw/oio/buf/mod.rs
+++ b/core/src/raw/oio/buf/mod.rs
@@ -20,9 +20,13 @@ pub use adaptive::AdaptiveBuf;
 
 mod buffer;
 pub use buffer::Buffer;
+pub use buffer::BufferQueue;
 
 mod readable_buf;
 pub use readable_buf::ReadableBuf;
 
 mod writable_buf;
 pub use writable_buf::WritableBuf;
+
+mod flex_buf;
+pub use flex_buf::FlexBuf;

--- a/core/src/raw/oio/write/append_write.rs
+++ b/core/src/raw/oio/write/append_write.rs
@@ -86,7 +86,7 @@ impl<W> oio::Write for AppendWriter<W>
 where
     W: AppendWrite,
 {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let offset = match self.offset {
             Some(offset) => offset,
             None => {

--- a/core/src/raw/oio/write/block_write.rs
+++ b/core/src/raw/oio/write/block_write.rs
@@ -183,7 +183,7 @@ impl<W> oio::Write for BlockWriter<W>
 where
     W: BlockWrite,
 {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         loop {
             if self.futures.has_remaining() {
                 // Fill cache with the first write.

--- a/core/src/raw/oio/write/exact_buf_write.rs
+++ b/core/src/raw/oio/write/exact_buf_write.rs
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use bytes::Buf;
-use bytes::BufMut;
-use bytes::BytesMut;
 
 use crate::raw::*;
 use crate::*;
@@ -34,7 +31,7 @@ pub struct ExactBufWriter<W: oio::Write> {
 
     /// The size for buffer, we will flush the underlying storage at the size of this buffer.
     buffer_size: usize,
-    buffer: BytesMut,
+    buffer: oio::BufferQueue,
 }
 
 impl<W: oio::Write> ExactBufWriter<W> {
@@ -43,41 +40,23 @@ impl<W: oio::Write> ExactBufWriter<W> {
         Self {
             inner,
             buffer_size,
-            buffer: BytesMut::with_capacity(buffer_size),
+            buffer: oio::BufferQueue::new(),
         }
     }
 }
 
 impl<W: oio::Write> oio::Write for ExactBufWriter<W> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
-        // Quick Path
-        //
-        // if buffer is empty and bs is larger than buffer_size, we can directly
-        // freeze the first buffer_size bytes.
-        if self.buffer.is_empty() && bs.len() >= self.buffer_size {
-            let written = self.inner.write(bs.take(self.buffer_size)).await?;
-            return Ok(written);
-        }
-
-        // Slow Path
-        //
-        // If buffer is full, flush the buffer first.
+    async unsafe fn write(&mut self, mut bs: oio::Buffer) -> Result<usize> {
         if self.buffer.len() >= self.buffer_size {
-            let written = self
-                .inner
-                .write(oio::ReadableBuf::from_slice(&self.buffer))
-                .await?;
+            let written = self.inner.write(self.buffer.to_buffer()).await?;
             self.buffer.advance(written);
         }
 
         let remaining = self.buffer_size - self.buffer.len();
-        if bs.len() >= remaining {
-            self.buffer.put_slice(&bs[0..remaining]);
-            Ok(remaining)
-        } else {
-            self.buffer.put_slice(&bs);
-            Ok(bs.len())
-        }
+        bs.truncate(remaining);
+        let n = bs.len();
+        self.buffer.push(bs);
+        Ok(n)
     }
 
     async fn close(&mut self) -> Result<()> {
@@ -86,11 +65,7 @@ impl<W: oio::Write> oio::Write for ExactBufWriter<W> {
                 break;
             }
 
-            let written = unsafe {
-                self.inner
-                    .write(oio::ReadableBuf::from_slice(&self.buffer))
-                    .await?
-            };
+            let written = unsafe { self.inner.write(self.buffer.to_buffer()).await? };
             self.buffer.advance(written);
         }
 
@@ -105,7 +80,7 @@ impl<W: oio::Write> oio::Write for ExactBufWriter<W> {
 
 #[cfg(test)]
 mod tests {
-    use bytes::Bytes;
+    use bytes::{Buf, Bytes};
     use log::debug;
     use pretty_assertions::assert_eq;
     use rand::thread_rng;
@@ -122,11 +97,12 @@ mod tests {
     }
 
     impl Write for MockWriter {
-        async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+        async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
             debug!("test_fuzz_exact_buf_writer: flush size: {}", &bs.len());
 
-            self.buf.extend_from_slice(&bs);
-            Ok(bs.remaining())
+            let chunk = bs.chunk();
+            self.buf.extend_from_slice(chunk);
+            Ok(chunk.len())
         }
 
         async fn close(&mut self) -> Result<()> {

--- a/core/src/raw/oio/write/exact_buf_write.rs
+++ b/core/src/raw/oio/write/exact_buf_write.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-
 use crate::raw::*;
 use crate::*;
 

--- a/core/src/raw/oio/write/multipart_write.rs
+++ b/core/src/raw/oio/write/multipart_write.rs
@@ -229,7 +229,7 @@ impl<W> oio::Write for MultipartWriter<W>
 where
     W: MultipartWrite,
 {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let upload_id = match self.upload_id.clone() {
             Some(v) => v,
             None => {

--- a/core/src/raw/oio/write/one_shot_write.rs
+++ b/core/src/raw/oio/write/one_shot_write.rs
@@ -55,7 +55,7 @@ impl<W: OneShotWrite> OneShotWriter<W> {
 }
 
 impl<W: OneShotWrite> oio::Write for OneShotWriter<W> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         match &self.buffer {
             Some(_) => Err(Error::new(
                 ErrorKind::Unsupported,

--- a/core/src/raw/oio/write/range_write.rs
+++ b/core/src/raw/oio/write/range_write.rs
@@ -163,7 +163,7 @@ impl<W: RangeWrite> RangeWriter<W> {
 }
 
 impl<W: RangeWrite> oio::Write for RangeWriter<W> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let location = match self.location.clone() {
             Some(location) => location,
             None => {

--- a/core/src/services/alluxio/writer.rs
+++ b/core/src/services/alluxio/writer.rs
@@ -43,7 +43,7 @@ impl AlluxioWriter {
 }
 
 impl oio::Write for AlluxioWriter {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let stream_id = match self.stream_id {
             Some(stream_id) => stream_id,
             None => {

--- a/core/src/services/ghac/writer.rs
+++ b/core/src/services/ghac/writer.rs
@@ -38,7 +38,7 @@ impl GhacWriter {
 }
 
 impl oio::Write for GhacWriter {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let size = bs.len();
         let offset = self.size;
 

--- a/core/src/services/hdfs/writer.rs
+++ b/core/src/services/hdfs/writer.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use bytes::Buf;
 use std::io::Write;
 use std::sync::Arc;
 
@@ -52,10 +53,10 @@ impl<F> HdfsWriter<F> {
 }
 
 impl oio::Write for HdfsWriter<hdrs::AsyncFile> {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let f = self.f.as_mut().expect("HdfsWriter must be initialized");
 
-        f.write(&bs).await.map_err(new_std_io_error)
+        f.write(bs.chunk()).await.map_err(new_std_io_error)
     }
 
     async fn close(&mut self) -> Result<()> {
@@ -81,9 +82,9 @@ impl oio::Write for HdfsWriter<hdrs::AsyncFile> {
 }
 
 impl oio::BlockingWrite for HdfsWriter<hdrs::File> {
-    unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
+    unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
         let f = self.f.as_mut().expect("HdfsWriter must be initialized");
-        f.write(&bs).map_err(new_std_io_error)
+        f.write(bs.chunk()).map_err(new_std_io_error)
     }
 
     fn close(&mut self) -> Result<()> {

--- a/core/src/services/hdfs_native/writer.rs
+++ b/core/src/services/hdfs_native/writer.rs
@@ -31,7 +31,7 @@ impl HdfsNativeWriter {
 }
 
 impl oio::Write for HdfsNativeWriter {
-    async unsafe fn write(&mut self, _bs: oio::ReadableBuf) -> Result<usize> {
+    async unsafe fn write(&mut self, _bs: oio::Buffer) -> Result<usize> {
         todo!()
     }
 

--- a/core/src/services/sftp/writer.rs
+++ b/core/src/services/sftp/writer.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use bytes::Buf;
 use std::pin::Pin;
 
 use openssh_sftp_client::file::File;
@@ -38,11 +39,8 @@ impl SftpWriter {
 }
 
 impl oio::Write for SftpWriter {
-    async unsafe fn write(&mut self, bs: oio::ReadableBuf) -> Result<usize> {
-        self.file
-            .write(bs.as_slice())
-            .await
-            .map_err(new_std_io_error)
+    async unsafe fn write(&mut self, bs: oio::Buffer) -> Result<usize> {
+        self.file.write(bs.chunk()).await.map_err(new_std_io_error)
     }
 
     async fn close(&mut self) -> Result<()> {


### PR DESCRIPTION
Use `oio::Buffer` in write instead of unsafe `ReadableBuf`.