### PR TITLE
docs: Update links to o.a.o/discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apache OpenDAL™: *Access Data Freely*
 
 [![](https://img.shields.io/badge/maillist-dev%40opendal.apache.org-blue)](mailto:dev@opendal.apache.org)
-[![](https://img.shields.io/discord/1081052318650339399?logo=discord&label=discord)](https://discord.gg/XQy8yGR2dg)
+[![](https://img.shields.io/discord/1081052318650339399?logo=discord&label=discord)](https://opendal.apache.org/discord)
 
 OpenDAL offers a unified data access layer, empowering users to seamlessly and efficiently retrieve data from diverse storage services. Our goal is to deliver a comprehensive solution for any languages, methods, integrations, and services.
 
@@ -73,7 +73,7 @@ OpenDAL is an active open-source project. We are always open to people who want 
 - Submit [Issues](https://github.com/apache/opendal/issues/new) for bug report or feature requests.
 - Discuss at [dev mailing list](mailto:dev@opendal.apache.org) ([subscribe](mailto:dev-subscribe@opendal.apache.org?subject=(send%20this%20email%20to%20subscribe)) / [unsubscribe](mailto:dev-unsubscribe@opendal.apache.org?subject=(send%20this%20email%20to%20unsubscribe)) / [archives](https://lists.apache.org/list.html?dev@opendal.apache.org))
 - Asking questions in the [Discussions](https://github.com/apache/opendal/discussions/new?category=q-a).
-- Talk to community directly at [Discord](https://discord.gg/XQy8yGR2dg).
+- Talk to community directly at [Discord](https://opendal.apache.org/discord).
 
 ## Who is using OpenDAL?
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -48,7 +48,7 @@ main();
 - Start with [Contributing Guide](CONTRIBUTING.md).
 - Submit [Issues](https://github.com/apache/opendal/issues/new) for bug report or feature requests.
 - Asking questions in the [Discussions](https://github.com/apache/opendal/discussions/new?category=q-a).
-    - Talk to community at [Discord](https://opendal.apache.org/discord).
+  - Talk to community at [Discord](https://opendal.apache.org/discord).
 
 ## License and Trademarks
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -48,7 +48,7 @@ main();
 - Start with [Contributing Guide](CONTRIBUTING.md).
 - Submit [Issues](https://github.com/apache/opendal/issues/new) for bug report or feature requests.
 - Asking questions in the [Discussions](https://github.com/apache/opendal/discussions/new?category=q-a).
-- Talk to community at [Discord](https://discord.gg/XQy8yGR2dg).
+    - Talk to community at [Discord](https://opendal.apache.org/discord).
 
 ## License and Trademarks
 

--- a/core/README.md
+++ b/core/README.md
@@ -8,7 +8,7 @@
 [crates.io]: https://crates.io/crates/opendal
 [crate downloads]: https://img.shields.io/crates/d/opendal.svg
 [chat]: https://img.shields.io/discord/1081052318650339399
-[discord]: https://discord.gg/XQy8yGR2dg
+[discord]: https://opendal.apache.org/discord
 
 **OpenDAL** is a data access layer that allows users to easily and efficiently retrieve data from various storage services in a unified way.
 

--- a/core/src/docs/rfcs/README.md
+++ b/core/src/docs/rfcs/README.md
@@ -28,7 +28,7 @@ Preparing in advance before submitting an RFC hastily can increase its chances o
 
 It is great to seek feedback from other project developers first, as this can help validate the viability of the RFC. To ensure a sustained impact on the project, it is important to work together and reach a consensus.
 
-Common preparatory steps include presenting your idea on platforms such as GitHub [issues](https://github.com/apache/opendal/issues/) or [discussions](https://github.com/apache/opendal/discussions/categories/ideas), or engaging in discussions through our [email list](https://opendal.apache.org/community/#mailing-list) or [Discord server](https://discord.gg/XQy8yGR2dg). 
+Common preparatory steps include presenting your idea on platforms such as GitHub [issues](https://github.com/apache/opendal/issues/) or [discussions](https://github.com/apache/opendal/discussions/categories/ideas), or engaging in discussions through our [email list](https://opendal.apache.org/community/#mailing-list) or [Discord server](https://opendal.apache.org/discord). 
 
 ## The RFC process
 

--- a/website/blog/2023-03-16-opendal-entered-apache-incubator/index.md
+++ b/website/blog/2023-03-16-opendal-entered-apache-incubator/index.md
@@ -93,5 +93,5 @@ We welcome developers and users who are interested in participating in OpenDAL p
 
 - Visit OpenDAL official website: <https://opendal.apache.org>
 - Explore OpenDAL GitHub repository: <https://github.com/apache/opendal>
-- Join OpenDAL Discord channel: <https://discord.gg/XQy8yGR2dg>
+- Join OpenDAL Discord channel: <https://opendal.apache.org/discord>
 - Subscribe to OpenDAL mailing list: <dev@opendal.apache.org>

--- a/website/community/events/gsoc-proposal-guide.md
+++ b/website/community/events/gsoc-proposal-guide.md
@@ -15,7 +15,7 @@ We encourage you to think of your own interesting project ideas! There are plent
 
 ## Interacting with the OpenDAL community
 
-If you want to discuss our suggested project ideas or your own idea, you can do so on the [maillist](mailto:dev@opendal.apache.org) or [Discord](https://discord.gg/XQy8yGR2dg). Make sure to listen to the feedback of the mentors, and try to incorporate it in your project proposal.
+If you want to discuss our suggested project ideas or your own idea, you can do so on the [maillist](mailto:dev@opendal.apache.org) or [Discord](https://opendal.apache.org/discord). Make sure to listen to the feedback of the mentors, and try to incorporate it in your project proposal.
 
 When communicating on the OpenDAL mail list or discord (and when interacting with the OpenDAL community in general), please remember to be polite and uphold the [ASF Code of Conduct](https://www.apache.org/foundation/policies/conduct). Keep in mind that most OpenDAL contributors (and GSoC OpenDAL project mentors) are volunteers, and work on OpenDAL in their free time, so please treat them with respect and avoid spamming.
 


### PR DESCRIPTION
Replace discord links to o.a.o/discord