### PR TITLE
feat: ?Send async trait for HttpBackend when the target is wasm32

### DIFF
--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -222,7 +222,8 @@ impl Debug for HttpBackend {
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Accessor for HttpBackend {
     type Reader = HttpReader;
     type Writer = ();


### PR DESCRIPTION
Related to https://github.com/apache/opendal/issues/3803

Applies the same pattern to `HttpBackend` as other `Accessor` implementors.