### PR TITLE
chore(core): Align Reader and Writer's API design

### DIFF
--- a/bin/oli/src/commands/cat.rs
+++ b/bin/oli/src/commands/cat.rs
@@ -39,7 +39,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
 
     let reader = op.reader(&path).await?;
     let meta = op.stat(&path).await?;
-    let mut buf_reader = reader.into_futures_io_async_read(0..meta.content_length());
+    let mut buf_reader = reader.into_futures_async_read(0..meta.content_length());
     let mut stdout = io::AllowStdIo::new(std::io::stdout());
     io::copy_buf(&mut buf_reader, &mut stdout).await?;
     Ok(())

--- a/bin/oli/src/commands/cp.rs
+++ b/bin/oli/src/commands/cp.rs
@@ -52,7 +52,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
             .into_futures_io_async_write();
         let src_meta = src_op.stat(&src_path).await?;
         let reader = src_op.reader_with(&src_path).chunk(8 * 1024 * 1024).await?;
-        let buf_reader = reader.into_futures_io_async_read(0..src_meta.content_length());
+        let buf_reader = reader.into_futures_async_read(0..src_meta.content_length());
         futures::io::copy_buf(buf_reader, &mut dst_w).await?;
         // flush data
         dst_w.close().await?;
@@ -74,7 +74,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
             .strip_prefix(prefix)
             .expect("invalid path");
         let reader = src_op.reader_with(de.path()).chunk(8 * 1024 * 1024).await?;
-        let buf_reader = reader.into_futures_io_async_read(0..meta.content_length());
+        let buf_reader = reader.into_futures_async_read(0..meta.content_length());
 
         let mut writer = dst_op
             .writer(&dst_root.join(fp).to_string_lossy())

--- a/bin/oli/src/commands/cp.rs
+++ b/bin/oli/src/commands/cp.rs
@@ -46,10 +46,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
     let (dst_op, dst_path) = cfg.parse_location(dst)?;
 
     if !recursive {
-        let mut dst_w = dst_op
-            .writer(&dst_path)
-            .await?
-            .into_futures_io_async_write();
+        let mut dst_w = dst_op.writer(&dst_path).await?.into_futures_async_write();
         let src_meta = src_op.stat(&src_path).await?;
         let reader = src_op.reader_with(&src_path).chunk(8 * 1024 * 1024).await?;
         let buf_reader = reader.into_futures_async_read(0..src_meta.content_length());
@@ -79,7 +76,7 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
         let mut writer = dst_op
             .writer(&dst_root.join(fp).to_string_lossy())
             .await?
-            .into_futures_io_async_write();
+            .into_futures_async_write();
 
         println!("Copying {}", de.path());
         futures::io::copy_buf(buf_reader, &mut writer).await?;

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -212,7 +212,7 @@ typedef struct OperatorInfo OperatorInfo;
  *
  * StdReader also implements [`Send`] and [`Sync`].
  */
-typedef struct StdIoReader StdIoReader;
+typedef struct StdReader StdReader;
 
 /**
  * \brief opendal_bytes carries raw-bytes with its length
@@ -408,7 +408,7 @@ typedef struct opendal_result_read {
  * a opendal::BlockingReader, which is inside the Rust core code.
  */
 typedef struct opendal_reader {
-  struct StdIoReader *inner;
+  struct StdReader *inner;
 } opendal_reader;
 
 /**

--- a/bindings/c/src/reader.rs
+++ b/bindings/c/src/reader.rs
@@ -26,13 +26,13 @@ use super::*;
 /// a opendal::BlockingReader, which is inside the Rust core code.
 #[repr(C)]
 pub struct opendal_reader {
-    inner: *mut core::StdIoReader,
+    inner: *mut core::StdReader,
 }
 
 impl opendal_reader {
     pub(crate) fn new(reader: core::BlockingReader, size: u64) -> Self {
         Self {
-            inner: Box::into_raw(Box::new(reader.into_std_io_read(0..size))),
+            inner: Box::into_raw(Box::new(reader.into_std_read(0..size))),
         }
     }
 

--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -156,9 +156,7 @@ impl Operator {
     fn reader(&self, path: &str) -> Result<Box<Reader>> {
         let meta = self.0.stat(path)?;
         Ok(Box::new(Reader(
-            self.0
-                .reader(path)?
-                .into_std_io_read(0..meta.content_length()),
+            self.0.reader(path)?.into_std_read(0..meta.content_length()),
         )))
     }
 

--- a/bindings/cpp/src/reader.rs
+++ b/bindings/cpp/src/reader.rs
@@ -21,7 +21,7 @@ use std::io::{Read, Seek};
 
 use super::ffi;
 
-pub struct Reader(pub od::StdIoReader);
+pub struct Reader(pub od::StdReader);
 
 impl Reader {
     pub fn read(&mut self, buf: &mut [u8]) -> Result<usize> {

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -220,7 +220,7 @@ impl Operator {
         let meta = self.0.blocking().stat(&path).map_err(format_napi_error)?;
         let r = self.0.blocking().reader(&path).map_err(format_napi_error)?;
         Ok(BlockingReader {
-            inner: r.into_std_io_read(0..meta.content_length()),
+            inner: r.into_std_read(0..meta.content_length()),
         })
     }
 
@@ -660,7 +660,7 @@ pub struct ListOptions {
 /// manner.
 #[napi]
 pub struct BlockingReader {
-    inner: opendal::StdIoReader,
+    inner: opendal::StdReader,
 }
 
 #[napi]
@@ -677,7 +677,7 @@ impl BlockingReader {
 /// manner.
 #[napi]
 pub struct Reader {
-    inner: opendal::FuturesIoAsyncReader,
+    inner: opendal::FuturesAsyncReader,
 }
 
 #[napi]

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -191,7 +191,7 @@ impl Operator {
         let meta = self.0.stat(&path).await.map_err(format_napi_error)?;
         let r = self.0.reader(&path).await.map_err(format_napi_error)?;
         Ok(Reader {
-            inner: r.into_futures_io_async_read(0..meta.content_length()),
+            inner: r.into_futures_async_read(0..meta.content_length()),
         })
     }
 

--- a/bindings/python/src/file.rs
+++ b/bindings/python/src/file.rs
@@ -40,17 +40,14 @@ use crate::*;
 pub struct File(FileState, Capability);
 
 enum FileState {
-    Reader(ocore::StdIoReader),
+    Reader(ocore::StdReader),
     Writer(ocore::BlockingWriter),
     Closed,
 }
 
 impl File {
     pub fn new_reader(reader: ocore::BlockingReader, size: u64, capability: Capability) -> Self {
-        Self(
-            FileState::Reader(reader.into_std_io_read(0..size)),
-            capability,
-        )
+        Self(FileState::Reader(reader.into_std_read(0..size)), capability)
     }
 
     pub fn new_writer(writer: ocore::BlockingWriter, capability: Capability) -> Self {
@@ -289,7 +286,7 @@ impl File {
 pub struct AsyncFile(Arc<Mutex<AsyncFileState>>, Capability);
 
 enum AsyncFileState {
-    Reader(ocore::FuturesIoAsyncReader),
+    Reader(ocore::FuturesAsyncReader),
     Writer(ocore::Writer),
     Closed,
 }
@@ -298,7 +295,7 @@ impl AsyncFile {
     pub fn new_reader(reader: ocore::Reader, size: u64, capability: Capability) -> Self {
         Self(
             Arc::new(Mutex::new(AsyncFileState::Reader(
-                reader.into_futures_io_async_read(0..size),
+                reader.into_futures_async_read(0..size),
             ))),
             capability,
         )

--- a/core/benches/ops/read.rs
+++ b/core/benches/ops/read.rs
@@ -52,7 +52,7 @@ fn bench_read_full(c: &mut Criterion, name: &str, op: Operator) {
             b.to_async(&*TEST_RUNTIME).iter(|| async {
                 let r = op.reader_with(path).await.unwrap();
 
-                let r = r.into_futures_io_async_read(0..size.bytes() as u64);
+                let r = r.into_futures_async_read(0..size.bytes() as u64);
                 io::copy(r, &mut io::sink()).await.unwrap();
             })
         });

--- a/core/src/types/mod.rs
+++ b/core/src/types/mod.rs
@@ -29,7 +29,7 @@ pub use metadata::Metadata;
 pub use metadata::Metakey;
 
 mod reader;
-pub use reader::into_futures_async_read::FuturesIoAsyncReader;
+pub use reader::into_futures_async_read::FuturesAsyncReader;
 pub use reader::into_futures_stream::FuturesBytesStream;
 pub use reader::Reader;
 

--- a/core/src/types/mod.rs
+++ b/core/src/types/mod.rs
@@ -35,11 +35,11 @@ pub use reader::Reader;
 
 mod blocking_reader;
 pub use blocking_reader::into_std_iterator::StdBytesIterator;
-pub use blocking_reader::into_std_read::StdIoReader;
+pub use blocking_reader::into_std_read::StdReader;
 pub use blocking_reader::BlockingReader;
 
 mod writer;
-pub use writer::into_futures_async_write::FuturesIoAsyncWriter;
+pub use writer::into_futures_async_write::FuturesAsyncWriter;
 pub use writer::BlockingWriter;
 pub use writer::Writer;
 

--- a/core/src/types/reader.rs
+++ b/core/src/types/reader.rs
@@ -178,8 +178,7 @@ impl Reader {
         FuturesAsyncReader::new(self.inner, self.options.chunk(), range)
     }
 
-    /// Convert reader into [`FuturesBytesStream`] which implements [`futures::Stream`],
-    /// [`futures::AsyncSeek`] and [`futures::AsyncBufRead`].
+    /// Convert reader into [`FuturesBytesStream`] which implements [`futures::Stream`].
     #[inline]
     pub fn into_bytes_stream(self, range: Range<u64>) -> FuturesBytesStream {
         FuturesBytesStream::new(self.inner, self.options.chunk(), range)

--- a/core/src/types/writer.rs
+++ b/core/src/types/writer.rs
@@ -176,9 +176,9 @@ impl Writer {
         self.inner.close().await
     }
 
-    /// Convert writer into [`FuturesIoAsyncWriter`] which implements [`futures::AsyncWrite`],
-    pub fn into_futures_io_async_write(self) -> FuturesIoAsyncWriter {
-        FuturesIoAsyncWriter::new(self.inner)
+    /// Convert writer into [`FuturesAsyncWriter`] which implements [`futures::AsyncWrite`],
+    pub fn into_futures_async_write(self) -> FuturesAsyncWriter {
+        FuturesAsyncWriter::new(self.inner)
     }
 }
 
@@ -204,7 +204,7 @@ pub mod into_futures_async_write {
     /// # TODO
     ///
     /// We should insert checks if the input slice changed after future created.
-    pub struct FuturesIoAsyncWriter {
+    pub struct FuturesAsyncWriter {
         state: State,
         buf: oio::FlexBuf,
     }
@@ -220,18 +220,18 @@ pub mod into_futures_async_write {
     /// FuturesReader only exposes `&mut self` to the outside world, so it's safe to be `Sync`.
     unsafe impl Sync for State {}
 
-    impl FuturesIoAsyncWriter {
+    impl FuturesAsyncWriter {
         /// NOTE: don't allow users to create FuturesIoAsyncWriter directly.
         #[inline]
         pub fn new(r: oio::Writer) -> Self {
-            FuturesIoAsyncWriter {
+            FuturesAsyncWriter {
                 state: State::Idle(Some(r)),
                 buf: oio::FlexBuf::new(256 * 1024),
             }
         }
     }
 
-    impl AsyncWrite for FuturesIoAsyncWriter {
+    impl AsyncWrite for FuturesAsyncWriter {
         fn poll_write(
             self: Pin<&mut Self>,
             cx: &mut Context<'_>,

--- a/core/tests/behavior/async_write.rs
+++ b/core/tests/behavior/async_write.rs
@@ -416,7 +416,7 @@ pub async fn test_writer_futures_copy(op: Operator) -> Result<()> {
         .writer_with(&path)
         .buffer(8 * 1024 * 1024)
         .await?
-        .into_futures_io_async_write();
+        .into_futures_async_write();
 
     // Wrap a buf reader here to make sure content is read in 1MiB chunks.
     let mut cursor = BufReader::with_capacity(1024 * 1024, Cursor::new(content.clone()));
@@ -452,7 +452,7 @@ pub async fn test_writer_futures_copy_with_concurrent(op: Operator) -> Result<()
         .buffer(8 * 1024 * 1024)
         .concurrent(4)
         .await?
-        .into_futures_io_async_write();
+        .into_futures_async_write();
 
     // Wrap a buf reader here to make sure content is read in 1MiB chunks.
     let mut cursor = BufReader::with_capacity(1024 * 1024, Cursor::new(content.clone()));
@@ -515,7 +515,7 @@ pub async fn test_writer_with_append(op: Operator) -> Result<()> {
         .writer_with(&path)
         .append(true)
         .await?
-        .into_futures_io_async_write();
+        .into_futures_async_write();
 
     // Wrap a buf reader here to make sure content is read in 1MiB chunks.
     let mut cursor = BufReader::with_capacity(1024 * 1024, Cursor::new(content.clone()));

--- a/integrations/object_store/src/lib.rs
+++ b/integrations/object_store/src/lib.rs
@@ -134,12 +134,12 @@ impl ObjectStore for OpendalStore {
             .await
             .map_err(|err| format_object_store_error(err, location.as_ref()))?;
 
-        let stream = r
-            .into_futures_bytes_stream(0..meta.size as u64)
-            .map_err(|err| object_store::Error::Generic {
-                store: "IoError",
-                source: Box::new(err),
-            });
+        let stream =
+            r.into_bytes_stream(0..meta.size as u64)
+                .map_err(|err| object_store::Error::Generic {
+                    store: "IoError",
+                    source: Box::new(err),
+                });
 
         Ok(GetResult {
             payload: GetResultPayload::Stream(Box::pin(stream)),


### PR DESCRIPTION
Align the Reader and Writer's API design as mentioned in  https://github.com/apache/opendal/issues/4465

- From `into_futures_io_async_read` to `into_futures_async_read`.
- From `into_futures_io_async_write` to `into_futures_async_write`.
- From `into_std_io_read` to `into_std_read`.

The context is clear that we don't need to re-mention `io` in our API.

- From `into_futures_bytes_stream` to `into_bytes_stream`
- From `into_std_bytes_iterator` to `into_bytes_iterator`

There is only one widely used stream API so far. Remove `futures` to make API more clear.