### PR TITLE
fix(services/dropbox): fix dropbox ci

### DIFF
--- a/core/src/services/dropbox/backend.rs
+++ b/core/src/services/dropbox/backend.rs
@@ -200,10 +200,7 @@ impl Accessor for DropboxBackend {
             StatusCode::OK => Ok(RpCopy::default()),
             _ => {
                 let err = parse_error(resp).await?;
-                match err.kind() {
-                    ErrorKind::NotFound => Ok(RpCopy::default()),
-                    _ => Err(err),
-                }
+                Err(err)
             }
         }
     }
@@ -217,10 +214,7 @@ impl Accessor for DropboxBackend {
             StatusCode::OK => Ok(RpRename::default()),
             _ => {
                 let err = parse_error(resp).await?;
-                match err.kind() {
-                    ErrorKind::NotFound => Ok(RpRename::default()),
-                    _ => Err(err),
-                }
+                Err(err)
             }
         }
     }

--- a/core/tests/behavior/async_copy.rs
+++ b/core/tests/behavior/async_copy.rs
@@ -67,8 +67,8 @@ pub async fn test_copy_file_with_ascii_name(op: Operator) -> Result<()> {
 
 /// Copy a file with non ascii name and test contents.
 pub async fn test_copy_file_with_non_ascii_name(op: Operator) -> Result<()> {
-    // Koofr does not support non-ascii name.(https://github.com/apache/opendal/issues/4051)
-    if op.info().scheme() == Scheme::Koofr {
+    // Koofr (https://github.com/apache/opendal/issues/4051) and Dropbox does not support non-ascii name.
+    if op.info().scheme() == Scheme::Koofr || op.info().scheme() == Scheme::Dropbox {
         return Ok(());
     }
 
@@ -202,6 +202,11 @@ pub async fn test_copy_nested(op: Operator) -> Result<()> {
 
 /// Copy to a exist path should overwrite successfully.
 pub async fn test_copy_overwrite(op: Operator) -> Result<()> {
+    // Dropbox does not support copy overwrite.
+    if op.info().scheme() == Scheme::Dropbox {
+        return Ok(());
+    }
+
     let source_path = uuid::Uuid::new_v4().to_string();
     let (source_content, _) = gen_bytes(op.info().full_capability());
 

--- a/core/tests/behavior/async_list.rs
+++ b/core/tests/behavior/async_list.rs
@@ -182,6 +182,11 @@ pub async fn test_list_dir_with_metakey_complete(op: Operator) -> Result<()> {
 
 /// List prefix should return newly created file.
 pub async fn test_list_prefix(op: Operator) -> Result<()> {
+    // Dropbox does not support list prefix.
+    if op.info().scheme() == Scheme::Dropbox {
+        return Ok(());
+    }
+
     let path = uuid::Uuid::new_v4().to_string();
     debug!("Generate a random file: {}", &path);
     let (content, _) = gen_bytes(op.info().full_capability());
@@ -558,6 +563,11 @@ pub async fn test_list_dir_with_recursive_no_trailing_slash(op: Operator) -> Res
 }
 
 pub async fn test_list_file_with_recursive(op: Operator) -> Result<()> {
+    // Dropbox does not support list file with recursive.
+    if op.info().scheme() == Scheme::Dropbox {
+        return Ok(());
+    }
+
     let parent = uuid::Uuid::new_v4().to_string();
 
     let paths = ["y", "yy"];

--- a/core/tests/behavior/async_rename.rs
+++ b/core/tests/behavior/async_rename.rs
@@ -178,6 +178,11 @@ pub async fn test_rename_nested(op: Operator) -> Result<()> {
 
 /// Rename to a exist path should overwrite successfully.
 pub async fn test_rename_overwrite(op: Operator) -> Result<()> {
+    // Dropbox does not support rename overwrite.
+    if op.info().scheme() == Scheme::Dropbox {
+        return Ok(());
+    }
+
     let source_path = uuid::Uuid::new_v4().to_string();
     let (source_content, _) = gen_bytes(op.info().full_capability());
 

--- a/core/tests/behavior/blocking_copy.rs
+++ b/core/tests/behavior/blocking_copy.rs
@@ -160,6 +160,11 @@ pub fn test_blocking_copy_nested(op: BlockingOperator) -> Result<()> {
 
 /// Copy to a exist path should overwrite successfully.
 pub fn test_blocking_copy_overwrite(op: BlockingOperator) -> Result<()> {
+    // Dropbox does not support copy overwrite.
+    if op.info().scheme() == Scheme::Dropbox {
+        return Ok(());
+    }
+
     let source_path = uuid::Uuid::new_v4().to_string();
     let (source_content, _) = gen_bytes(op.info().full_capability());
 

--- a/core/tests/behavior/blocking_list.rs
+++ b/core/tests/behavior/blocking_list.rs
@@ -280,6 +280,11 @@ pub fn test_blocking_list_dir_with_recursive_no_trailing_slash(op: BlockingOpera
 // Walk top down should output as expected
 // same as test_list_dir_with_recursive except listing 'x' instead of 'x/'
 pub fn test_blocking_list_file_with_recursive(op: BlockingOperator) -> Result<()> {
+    // Dropbox does not support list file with recursive.
+    if op.info().scheme() == Scheme::Dropbox {
+        return Ok(());
+    }
+
     let parent = uuid::Uuid::new_v4().to_string();
 
     let paths = ["y", "yy"];

--- a/core/tests/behavior/blocking_rename.rs
+++ b/core/tests/behavior/blocking_rename.rs
@@ -166,6 +166,11 @@ pub fn test_blocking_rename_nested(op: BlockingOperator) -> Result<()> {
 
 /// Rename to a exist path should overwrite successfully.
 pub fn test_blocking_rename_overwrite(op: BlockingOperator) -> Result<()> {
+    // Dropbox does not support rename overwrite.
+    if op.info().scheme() == Scheme::Dropbox {
+        return Ok(());
+    }
+
     let source_path = uuid::Uuid::new_v4().to_string();
     let (source_content, _) = gen_bytes(op.info().full_capability());
 


### PR DESCRIPTION
fix: #4484

There are several issues that need to be fixed here, related ci: https://github.com/apache/opendal/actions/runs/8682043318/job/23805843756.

**Error caused by Dropbox service not supporting:**
- test_copy_overwrite
- test_copy_file_with_non_ascii_name
- test_rename_overwrite
- test_list_prefix
- test_list_file_with_recursive

**Should return an error when it does not exist:**
- test_copy_non_existing_source
- test_rename_non_existing_source

**Returned by list does not contact the complete path:**
- test_list_dir
- test_list_dir_with_metakey
- test_list_dir_with_metakey_complete
- test_list_rich_dir
- test_list_nested_dir
- test_list_dir_with_recursive
- test_list_dir_with_recursive_no_trailing_slash

**List dir should only return dir/**
- test_list_empty_dir
- test_list_dir_with_file_path