### PR TITLE
feat(core): add access methods for `Buffer`

### DIFF
--- a/core/src/types/buffer.rs
+++ b/core/src/types/buffer.rs
@@ -176,6 +176,27 @@ impl Buffer {
         self.len() == 0
     }
 
+    /// Number of [`Bytes`] in [`Buffer`].
+    ///
+    /// For contiguous buffer, it's always 1. For non-contiguous buffer, it's number of bytes
+    /// available for use.
+    pub fn count(&self) -> usize {
+        match &self.0 {
+            Inner::Contiguous(_) => 1,
+            Inner::NonContiguous { parts, idx, .. } => parts.len() - idx,
+        }
+    }
+
+    /// Get current [`Bytes`].
+    pub fn current(&self) -> Bytes {
+        match &self.0 {
+            Inner::Contiguous(inner) => inner.clone(),
+            Inner::NonContiguous {
+                parts, idx, offset, ..
+            } => parts[*idx].slice(*offset..),
+        }
+    }
+
     /// Shortens the buffer, keeping the first `len` bytes and dropping the rest.
     ///
     /// If `len` is greater than the buffer’s current length, this has no effect.

--- a/core/src/types/buffer.rs
+++ b/core/src/types/buffer.rs
@@ -184,7 +184,10 @@ impl Buffer {
         match &self.0 {
             Inner::Contiguous(_) => 1,
             Inner::NonContiguous {
-                parts, idx, size, offset
+                parts,
+                idx,
+                size,
+                offset,
             } => {
                 parts
                     .iter()
@@ -206,12 +209,15 @@ impl Buffer {
         match &self.0 {
             Inner::Contiguous(inner) => inner.clone(),
             Inner::NonContiguous {
-                parts, idx, offset, size
+                parts,
+                idx,
+                offset,
+                size,
             } => {
                 let chunk = &parts[*idx];
                 let n = (chunk.len() - *offset).min(*size);
                 chunk.slice(*offset..*offset + n)
-            },
+            }
         }
     }
 


### PR DESCRIPTION
This PR adds two new public functions for `Buffer`:

- `count`, get the number of `bytes::Bytes` in `Buffer`
- `current`, get the current buffer, which doesn't alter any state or do any deep copy