### PR TITLE
feat(core): change Result to default error

### DIFF
--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -43,7 +43,7 @@ use std::fmt::Formatter;
 use std::io;
 
 /// Result that is a wrapper of `Result<T, opendal::Error>`
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// ErrorKind is all kinds of Error of opendal.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
This PR changes `Result<T> = std::result::Result<T, Error>` to `Result<T, E = Error> = std::result::Result<T, E>`, makes it easier for user to use even when they have non-opendal errors. 

## Example

```rust
use opendal::Result;

// This still works
let a: Result<T>;

// And this works too
let b: Result<T, MyError>;
```
