### PR TITLE
chore(core): Change std result to opendal result in core

### DIFF
--- a/core/src/raw/oio/write/block_write.rs
+++ b/core/src/raw/oio/write/block_write.rs
@@ -92,7 +92,7 @@ pub trait BlockWrite: Send + Sync + Unpin + 'static {
 /// WriteBlockResult is the result returned by [`WriteBlockFuture`].
 ///
 /// The error part will carries input `(block_id, bytes, err)` so caller can retry them.
-type WriteBlockResult = std::result::Result<Uuid, (Uuid, Buffer, Error)>;
+type WriteBlockResult = Result<Uuid, (Uuid, Buffer, Error)>;
 
 struct WriteBlockFuture(BoxedStaticFuture<WriteBlockResult>);
 

--- a/core/src/raw/serde_util.rs
+++ b/core/src/raw/serde_util.rs
@@ -59,14 +59,14 @@ impl ConfigDeserializer {
 impl<'de> Deserializer<'de> for ConfigDeserializer {
     type Error = de::value::Error;
 
-    fn deserialize_any<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
         self.deserialize_map(visitor)
     }
 
-    fn deserialize_map<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -106,14 +106,14 @@ impl<'de> IntoDeserializer<'de, de::value::Error> for Pair {
 impl<'de> Deserializer<'de> for Pair {
     type Error = de::value::Error;
 
-    fn deserialize_any<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
         self.1.into_deserializer().deserialize_any(visitor)
     }
 
-    fn deserialize_bool<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -127,7 +127,7 @@ impl<'de> Deserializer<'de> for Pair {
         }
     }
 
-    fn deserialize_i8<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -140,7 +140,7 @@ impl<'de> Deserializer<'de> for Pair {
         }
     }
 
-    fn deserialize_i16<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -153,7 +153,7 @@ impl<'de> Deserializer<'de> for Pair {
         }
     }
 
-    fn deserialize_i32<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -166,7 +166,7 @@ impl<'de> Deserializer<'de> for Pair {
         }
     }
 
-    fn deserialize_i64<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -179,7 +179,7 @@ impl<'de> Deserializer<'de> for Pair {
         }
     }
 
-    fn deserialize_u8<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -192,7 +192,7 @@ impl<'de> Deserializer<'de> for Pair {
         }
     }
 
-    fn deserialize_u16<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -205,7 +205,7 @@ impl<'de> Deserializer<'de> for Pair {
         }
     }
 
-    fn deserialize_u32<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -218,7 +218,7 @@ impl<'de> Deserializer<'de> for Pair {
         }
     }
 
-    fn deserialize_u64<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -231,7 +231,7 @@ impl<'de> Deserializer<'de> for Pair {
         }
     }
 
-    fn deserialize_f32<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -244,7 +244,7 @@ impl<'de> Deserializer<'de> for Pair {
         }
     }
 
-    fn deserialize_f64<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -257,7 +257,7 @@ impl<'de> Deserializer<'de> for Pair {
         }
     }
 
-    fn deserialize_option<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -268,7 +268,7 @@ impl<'de> Deserializer<'de> for Pair {
         }
     }
 
-    fn deserialize_seq<V>(self, visitor: V) -> std::result::Result<V::Value, Self::Error>
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {

--- a/core/src/services/cos/core.rs
+++ b/core/src/services/cos/core.rs
@@ -460,7 +460,7 @@ pub struct CompleteMultipartUploadRequestPart {
     ///     etag: String,
     /// }
     ///
-    /// fn partial_escape<S>(s: &str, ser: S) -> std::result::Result<S::Ok, S::Error>
+    /// fn partial_escape<S>(s: &str, ser: S) -> Result<S::Ok, S::Error>
     /// where
     ///     S: serde::Serializer,
     /// {

--- a/core/src/services/etcd/backend.rs
+++ b/core/src/services/etcd/backend.rs
@@ -272,7 +272,7 @@ impl bb8::ManageConnection for Manager {
     type Connection = Client;
     type Error = Error;
 
-    async fn connect(&self) -> std::result::Result<Self::Connection, Self::Error> {
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
         let conn = Client::connect(self.endpoints.clone(), Some(self.options.clone()))
             .await
             .map_err(format_etcd_error)?;
@@ -280,7 +280,7 @@ impl bb8::ManageConnection for Manager {
         Ok(conn)
     }
 
-    async fn is_valid(&self, conn: &mut Self::Connection) -> std::result::Result<(), Self::Error> {
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
         let _ = conn.status().await.map_err(format_etcd_error)?;
         Ok(())
     }

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -216,7 +216,7 @@ impl bb8::ManageConnection for Manager {
     type Connection = AsyncRustlsFtpStream;
     type Error = FtpError;
 
-    async fn connect(&self) -> std::result::Result<Self::Connection, Self::Error> {
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
         let stream = ImplAsyncFtpStream::connect(&self.endpoint).await?;
         // switch to secure mode if ssl/tls is on.
         let mut ftp_stream = if self.enable_secure {
@@ -253,7 +253,7 @@ impl bb8::ManageConnection for Manager {
         Ok(ftp_stream)
     }
 
-    async fn is_valid(&self, conn: &mut Self::Connection) -> std::result::Result<(), Self::Error> {
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
         conn.noop().await
     }
 

--- a/core/src/services/memcached/backend.rs
+++ b/core/src/services/memcached/backend.rs
@@ -281,7 +281,7 @@ impl bb8::ManageConnection for MemcacheConnectionManager {
     type Error = Error;
 
     /// TODO: Implement unix stream support.
-    async fn connect(&self) -> std::result::Result<Self::Connection, Self::Error> {
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
         let conn = TcpStream::connect(&self.address)
             .await
             .map_err(new_std_io_error)?;
@@ -293,7 +293,7 @@ impl bb8::ManageConnection for MemcacheConnectionManager {
         Ok(conn)
     }
 
-    async fn is_valid(&self, conn: &mut Self::Connection) -> std::result::Result<(), Self::Error> {
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
         conn.version().await.map(|_| ())
     }
 

--- a/core/src/services/memcached/binary.rs
+++ b/core/src/services/memcached/binary.rs
@@ -74,7 +74,7 @@ impl PacketHeader {
         Ok(())
     }
 
-    pub async fn read(reader: &mut TcpStream) -> std::result::Result<PacketHeader, io::Error> {
+    pub async fn read(reader: &mut TcpStream) -> Result<PacketHeader, io::Error> {
         let header = PacketHeader {
             magic: reader.read_u8().await?,
             opcode: reader.read_u8().await?,

--- a/core/src/services/obs/core.rs
+++ b/core/src/services/obs/core.rs
@@ -451,7 +451,7 @@ pub struct CompleteMultipartUploadRequestPart {
     ///     etag: String,
     /// }
     ///
-    /// fn partial_escape<S>(s: &str, ser: S) -> std::result::Result<S::Ok, S::Error>
+    /// fn partial_escape<S>(s: &str, ser: S) -> Result<S::Ok, S::Error>
     /// where
     ///     S: serde::Serializer,
     /// {

--- a/core/src/services/persy/backend.rs
+++ b/core/src/services/persy/backend.rs
@@ -114,7 +114,7 @@ impl Builder for PersyBuilder {
             persy: &persy::Persy,
             segment_name: &str,
             index_name: &str,
-        ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        ) -> Result<(), Box<dyn std::error::Error>> {
             let mut tx = persy.begin()?;
 
             if !tx.exists_segment(segment_name)? {

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -779,7 +779,7 @@ pub struct CompleteMultipartUploadRequestPart {
     ///     etag: String,
     /// }
     ///
-    /// fn partial_escape<S>(s: &str, ser: S) -> std::result::Result<S::Ok, S::Error>
+    /// fn partial_escape<S>(s: &str, ser: S) -> Result<S::Ok, S::Error>
     /// where
     ///     S: serde::Serializer,
     /// {

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -251,7 +251,7 @@ impl bb8::ManageConnection for Manager {
     type Connection = Sftp;
     type Error = Error;
 
-    async fn connect(&self) -> std::result::Result<Self::Connection, Self::Error> {
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
         let mut session = SessionBuilder::default();
 
         if let Some(user) = &self.user {
@@ -297,7 +297,7 @@ impl bb8::ManageConnection for Manager {
     }
 
     // Check if connect valid by checking the root path.
-    async fn is_valid(&self, conn: &mut Self::Connection) -> std::result::Result<(), Self::Error> {
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
         let _ = conn.fs().metadata("./").await.map_err(parse_sftp_error)?;
 
         Ok(())


### PR DESCRIPTION
This PR changes `std::result::Result` to `opendal::Result` in core/.

close #4536