### PR TITLE
fix: community sync calendar iframe load failed

### DIFF
--- a/website/community/index.mdx
+++ b/website/community/index.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 
 <head>
-  <meta httpEquiv="Content-Security-Policy" content="iframe-src https://calendar.google.com/"/>
+  <meta httpEquiv="Content-Security-Policy" content="frame-src https://calendar.google.com/"/>
 </head>
 
 Welcome to the Apache OpenDAL™ community!


### PR DESCRIPTION
I tried deploying on Vercel. It can be displayed normally.

(I wrote the wrong command in the last PR. 😅)