### PR TITLE
refactor(core): Migrate `Accessor` to async fn in trait

### DIFF
--- a/core/src/layers/async_backtrace.rs
+++ b/core/src/layers/async_backtrace.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use async_trait::async_trait;
-
 use crate::raw::*;
 use crate::*;
 
@@ -58,8 +56,6 @@ pub struct AsyncBacktraceAccessor<A: Accessor> {
     inner: A,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for AsyncBacktraceAccessor<A> {
     type Inner = A;
     type Reader = A::Reader;

--- a/core/src/layers/await_tree.rs
+++ b/core/src/layers/await_tree.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use async_trait::async_trait;
 use await_tree::InstrumentAwait;
 
 use crate::raw::*;
@@ -66,8 +65,6 @@ pub struct AwaitTreeAccessor<A: Accessor> {
     inner: A,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for AwaitTreeAccessor<A> {
     type Inner = A;
     type Reader = A::Reader;

--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use async_trait::async_trait;
 use tokio::runtime::Handle;
 
 use crate::raw::*;
@@ -166,8 +165,6 @@ pub struct BlockingAccessor<A: Accessor> {
     handle: Handle,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for BlockingAccessor<A> {
     type Inner = A;
     type Reader = A::Reader;

--- a/core/src/layers/chaos.rs
+++ b/core/src/layers/chaos.rs
@@ -18,7 +18,6 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use async_trait::async_trait;
 use futures::FutureExt;
 use rand::prelude::*;
 use rand::rngs::StdRng;
@@ -97,8 +96,6 @@ pub struct ChaosAccessor<A> {
     error_ratio: f64,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for ChaosAccessor<A> {
     type Inner = A;
     type Reader = ChaosReader<A::Reader>;

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -19,8 +19,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
-
 use crate::raw::oio::FlatLister;
 use crate::raw::oio::PrefixLister;
 use crate::raw::TwoWays;
@@ -369,8 +367,6 @@ impl<A: Accessor> CompleteAccessor<A> {
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for CompleteAccessor<A> {
     type Inner = A;
     type Reader = CompleteReader<A::Reader>;
@@ -694,7 +690,6 @@ where
 mod tests {
     use std::time::Duration;
 
-    use async_trait::async_trait;
     use http::HeaderMap;
     use http::Method as HttpMethod;
 
@@ -705,8 +700,6 @@ mod tests {
         capability: Capability,
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl Accessor for MockService {
         type Reader = oio::Reader;
         type Writer = oio::Writer;

--- a/core/src/layers/concurrent_limit.rs
+++ b/core/src/layers/concurrent_limit.rs
@@ -18,7 +18,6 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
 
@@ -75,8 +74,6 @@ pub struct ConcurrentLimitAccessor<A: Accessor> {
     semaphore: Arc<Semaphore>,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for ConcurrentLimitAccessor<A> {
     type Inner = A;
     type Reader = ConcurrentLimitWrapper<A::Reader>;

--- a/core/src/layers/dtrace.rs
+++ b/core/src/layers/dtrace.rs
@@ -19,7 +19,6 @@ use std::ffi::CString;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use probe::probe_lazy;
 
@@ -189,7 +188,6 @@ impl<A: Accessor> Debug for DTraceAccessor<A> {
     }
 }
 
-#[async_trait]
 impl<A: Accessor> LayeredAccessor for DTraceAccessor<A> {
     type Inner = A;
     type Reader = DtraceLayerWrapper<A::Reader>;

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -18,7 +18,6 @@
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use async_trait::async_trait;
 use futures::TryFutureExt;
 
 use crate::raw::oio::ListOperation;
@@ -59,8 +58,6 @@ impl<A: Accessor> Debug for ErrorContextAccessor<A> {
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for ErrorContextAccessor<A> {
     type Inner = A;
     type Reader = ErrorContextWrapper<A::Reader>;

--- a/core/src/layers/immutable_index.rs
+++ b/core/src/layers/immutable_index.rs
@@ -19,8 +19,6 @@ use std::collections::HashSet;
 use std::fmt::Debug;
 use std::vec::IntoIter;
 
-use async_trait::async_trait;
-
 use crate::raw::*;
 use crate::*;
 
@@ -133,8 +131,6 @@ impl<A: Accessor> ImmutableIndexAccessor<A> {
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for ImmutableIndexAccessor<A> {
     type Inner = A;
     type Reader = A::Reader;

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -19,7 +19,6 @@ use std::fmt::Debug;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use futures::FutureExt;
 use futures::TryFutureExt;
@@ -209,8 +208,6 @@ pub struct LoggingAccessor<A: Accessor> {
 
 static LOGGING_TARGET: &str = "opendal::services";
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for LoggingAccessor<A> {
     type Inner = A;
     type Reader = LoggingReader<A::Reader>;

--- a/core/src/layers/madsim.rs
+++ b/core/src/layers/madsim.rs
@@ -34,7 +34,6 @@ use std::sync::Mutex;
 use std::task::Context;
 use std::task::Poll;
 
-use async_trait::async_trait;
 use bytes::Bytes;
 #[cfg(madsim)]
 use madsim::net::Endpoint;
@@ -142,8 +141,6 @@ pub struct MadsimAccessor {
     addr: SocketAddr,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl LayeredAccessor for MadsimAccessor {
     type Inner = ();
     type Reader = MadsimReader;

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -20,7 +20,6 @@ use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::Instant;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use futures::FutureExt;
 use futures::TryFutureExt;
@@ -402,8 +401,6 @@ impl<A: Accessor> Debug for MetricsAccessor<A> {
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for MetricsAccessor<A> {
     type Inner = A;
     type Reader = MetricWrapper<A::Reader>;

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -18,7 +18,6 @@
 use std::fmt::Debug;
 use std::future::Future;
 
-use async_trait::async_trait;
 use futures::FutureExt;
 use minitrace::prelude::*;
 
@@ -126,8 +125,6 @@ pub struct MinitraceAccessor<A> {
     inner: A,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for MinitraceAccessor<A> {
     type Inner = A;
     type Reader = MinitraceWrapper<A::Reader>;

--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -17,7 +17,6 @@
 
 use std::future::Future;
 
-use async_trait::async_trait;
 use futures::FutureExt;
 use opentelemetry::global;
 use opentelemetry::global::BoxedSpan;
@@ -63,8 +62,6 @@ pub struct OtelTraceAccessor<A> {
     inner: A,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for OtelTraceAccessor<A> {
     type Inner = A;
     type Reader = OtelTraceWrapper<A::Reader>;

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -19,7 +19,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use futures::FutureExt;
 use futures::TryFutureExt;
@@ -265,8 +264,6 @@ impl<A: Accessor> Debug for PrometheusAccessor<A> {
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     type Inner = A;
     type Reader = PrometheusMetricWrapper<A::Reader>;

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -21,7 +21,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use futures::FutureExt;
 use futures::TryFutureExt;
@@ -205,8 +204,6 @@ impl<A: Accessor> Debug for PrometheusAccessor<A> {
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for PrometheusAccessor<A> {
     type Inner = A;
     type Reader = PrometheusMetricWrapper<A::Reader>;

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -20,7 +20,6 @@ use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::Duration;
 
-use async_trait::async_trait;
 use backon::BlockingRetryable;
 use backon::ExponentialBuilder;
 use backon::Retryable;
@@ -269,8 +268,6 @@ impl<A: Accessor, I: RetryInterceptor> Debug for RetryAccessor<A, I> {
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor, I: RetryInterceptor> LayeredAccessor for RetryAccessor<A, I> {
     type Inner = A;
     type Reader = RetryWrapper<A::Reader, I>;
@@ -901,7 +898,6 @@ mod tests {
     use std::sync::Arc;
     use std::sync::Mutex;
 
-    use async_trait::async_trait;
     use bytes::Bytes;
     use futures::TryStreamExt;
 
@@ -932,8 +928,6 @@ mod tests {
         attempt: Arc<Mutex<usize>>,
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl Accessor for MockService {
         type Reader = MockReader;
         type Writer = ();

--- a/core/src/layers/throttle.rs
+++ b/core/src/layers/throttle.rs
@@ -19,7 +19,6 @@ use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::thread;
 
-use async_trait::async_trait;
 use governor::clock::Clock;
 use governor::clock::DefaultClock;
 use governor::middleware::NoOpMiddleware;
@@ -109,8 +108,6 @@ pub struct ThrottleAccessor<A: Accessor> {
     rate_limiter: SharedRateLimiter,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for ThrottleAccessor<A> {
     type Inner = A;
     type Reader = ThrottleWrapper<A::Reader>;

--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -18,8 +18,6 @@
 use std::future::Future;
 use std::time::Duration;
 
-use async_trait::async_trait;
-
 use crate::raw::oio::ListOperation;
 use crate::raw::oio::ReadOperation;
 use crate::raw::oio::WriteOperation;
@@ -184,8 +182,6 @@ impl<A: Accessor> TimeoutAccessor<A> {
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for TimeoutAccessor<A> {
     type Inner = A;
     type Reader = TimeoutWrapper<A::Reader>;
@@ -328,7 +324,6 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use async_trait::async_trait;
     use futures::StreamExt;
     use tokio::time::sleep;
     use tokio::time::timeout;
@@ -341,8 +336,6 @@ mod tests {
     #[derive(Debug, Clone, Default)]
     struct MockService;
 
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
     impl Accessor for MockService {
         type Reader = MockReader;
         type Writer = ();

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -18,7 +18,6 @@
 use std::fmt::Debug;
 use std::future::Future;
 
-use async_trait::async_trait;
 use futures::FutureExt;
 use tracing::Span;
 
@@ -127,8 +126,6 @@ pub struct TracingAccessor<A> {
     inner: A,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for TracingAccessor<A> {
     type Inner = A;
     type Reader = TracingWrapper<A::Reader>;

--- a/core/src/layers/type_eraser.rs
+++ b/core/src/layers/type_eraser.rs
@@ -19,8 +19,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
-
 use crate::raw::*;
 use crate::*;
 
@@ -53,8 +51,6 @@ impl<A: Accessor> Debug for TypeEraseAccessor<A> {
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<A: Accessor> LayeredAccessor for TypeEraseAccessor<A> {
     type Inner = A;
     type Reader = oio::Reader;

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -706,7 +706,7 @@ impl Accessor for () {
 
 /// All functions in `Accessor` only requires `&self`, so it's safe to implement
 /// `Accessor` for `Arc<impl Accessor>`.
-// If we use async fn directly, some weired higher rank trait bound error (`Send`/`Accessor` impl not general enough) will happen.
+// If we use async fn directly, some weird higher rank trait bound error (`Send`/`Accessor` impl not general enough) will happen.
 // Probably related to https://github.com/rust-lang/rust/issues/96865
 #[allow(clippy::manual_async_fn)]
 impl<T: Accessor + ?Sized> Accessor for Arc<T> {

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -485,99 +485,117 @@ where
     >,
 {
     fn info_dyn(&self) -> AccessorInfo {
-        <Self as Accessor>::info(self)
+        self.info()
     }
+
     fn create_dir_dyn<'a>(
         &'a self,
         path: &'a str,
         args: OpCreateDir,
     ) -> BoxedFuture<'a, Result<RpCreateDir>> {
-        <Self as Accessor>::create_dir(self, path, args).boxed()
+        self.create_dir(path, args).boxed()
     }
+
     fn stat_dyn<'a>(&'a self, path: &'a str, args: OpStat) -> BoxedFuture<'a, Result<RpStat>> {
-        <Self as Accessor>::stat(self, path, args).boxed()
+        self.stat(path, args).boxed()
     }
+
     fn read_dyn<'a>(
         &'a self,
         path: &'a str,
         args: OpRead,
     ) -> BoxedFuture<'a, Result<(RpRead, oio::Reader)>> {
-        <Self as Accessor>::read(self, path, args).boxed()
+        self.read(path, args).boxed()
     }
+
     fn write_dyn<'a>(
         &'a self,
         path: &'a str,
         args: OpWrite,
     ) -> BoxedFuture<'a, Result<(RpWrite, oio::Writer)>> {
-        <Self as Accessor>::write(self, path, args).boxed()
+        self.write(path, args).boxed()
     }
+
     fn delete_dyn<'a>(
         &'a self,
         path: &'a str,
         args: OpDelete,
     ) -> BoxedFuture<'a, Result<RpDelete>> {
-        <Self as Accessor>::delete(self, path, args).boxed()
+        self.delete(path, args).boxed()
     }
+
     fn list_dyn<'a>(
         &'a self,
         path: &'a str,
         args: OpList,
     ) -> BoxedFuture<'a, Result<(RpList, oio::Lister)>> {
-        <Self as Accessor>::list(self, path, args).boxed()
+        self.list(path, args).boxed()
     }
+
     fn copy_dyn<'a>(
         &'a self,
         from: &'a str,
         to: &'a str,
         args: OpCopy,
     ) -> BoxedFuture<'a, Result<RpCopy>> {
-        <Self as Accessor>::copy(self, from, to, args).boxed()
+        self.copy(from, to, args).boxed()
     }
+
     fn rename_dyn<'a>(
         &'a self,
         from: &'a str,
         to: &'a str,
         args: OpRename,
     ) -> BoxedFuture<'a, Result<RpRename>> {
-        <Self as Accessor>::rename(self, from, to, args).boxed()
+        self.rename(from, to, args).boxed()
     }
+
     fn presign_dyn<'a>(
         &'a self,
         path: &'a str,
         args: OpPresign,
     ) -> BoxedFuture<'a, Result<RpPresign>> {
-        <Self as Accessor>::presign(self, path, args).boxed()
+        self.presign(path, args).boxed()
     }
-    fn batch_dyn<'a>(&'a self, args: OpBatch) -> BoxedFuture<'a, Result<RpBatch>> {
-        <Self as Accessor>::batch(self, args).boxed()
+
+    fn batch_dyn(&self, args: OpBatch) -> BoxedFuture<'_, Result<RpBatch>> {
+        self.batch(args).boxed()
     }
+
     fn blocking_create_dir_dyn(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        <Self as Accessor>::blocking_create_dir(self, path, args)
+        self.blocking_create_dir(path, args)
     }
+
     fn blocking_stat_dyn(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        <Self as Accessor>::blocking_stat(self, path, args)
+        self.blocking_stat(path, args)
     }
+
     fn blocking_read_dyn(&self, path: &str, args: OpRead) -> Result<(RpRead, oio::BlockingReader)> {
-        <Self as Accessor>::blocking_read(self, path, args)
+        self.blocking_read(path, args)
     }
+
     fn blocking_write_dyn(
         &self,
         path: &str,
         args: OpWrite,
     ) -> Result<(RpWrite, oio::BlockingWriter)> {
-        <Self as Accessor>::blocking_write(self, path, args)
+        self.blocking_write(path, args)
     }
+
     fn blocking_delete_dyn(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
-        <Self as Accessor>::blocking_delete(self, path, args)
+        self.blocking_delete(path, args)
     }
+
     fn blocking_list_dyn(&self, path: &str, args: OpList) -> Result<(RpList, oio::BlockingLister)> {
-        <Self as Accessor>::blocking_list(self, path, args)
+        self.blocking_list(path, args)
     }
+
     fn blocking_copy_dyn(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
-        <Self as Accessor>::blocking_copy(self, from, to, args)
+        self.blocking_copy(from, to, args)
     }
+
     fn blocking_rename_dyn(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
-        <Self as Accessor>::blocking_rename(self, from, to, args)
+        self.blocking_rename(from, to, args)
     }
 }
 
@@ -593,74 +611,40 @@ impl Accessor for dyn AccessorDyn {
         self.info_dyn()
     }
 
-    fn create_dir(
-        &self,
-        path: &str,
-        args: OpCreateDir,
-    ) -> impl Future<Output = Result<RpCreateDir>> + MaybeSend {
-        async move { self.create_dir_dyn(path, args).await }
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
+        self.create_dir_dyn(path, args).await
     }
 
-    fn stat(&self, path: &str, args: OpStat) -> impl Future<Output = Result<RpStat>> + MaybeSend {
-        async move { self.stat_dyn(path, args).await }
+    async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
+        self.stat_dyn(path, args).await
     }
 
-    fn read(
-        &self,
-        path: &str,
-        args: OpRead,
-    ) -> impl Future<Output = Result<(RpRead, Self::Reader)>> + MaybeSend {
-        async move { self.read_dyn(path, args).await }
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        self.read_dyn(path, args).await
     }
 
-    fn write(
-        &self,
-        path: &str,
-        args: OpWrite,
-    ) -> impl Future<Output = Result<(RpWrite, Self::Writer)>> + MaybeSend {
-        async move { self.write_dyn(path, args).await }
+    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
+        self.write_dyn(path, args).await
     }
 
-    fn delete(
-        &self,
-        path: &str,
-        args: OpDelete,
-    ) -> impl Future<Output = Result<RpDelete>> + MaybeSend {
-        async move { self.delete_dyn(path, args).await }
+    async fn delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
+        self.delete_dyn(path, args).await
     }
 
-    fn list(
-        &self,
-        path: &str,
-        args: OpList,
-    ) -> impl Future<Output = Result<(RpList, Self::Lister)>> + MaybeSend {
-        async move { self.list_dyn(path, args).await }
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
+        self.list_dyn(path, args).await
     }
 
-    fn copy(
-        &self,
-        from: &str,
-        to: &str,
-        args: OpCopy,
-    ) -> impl Future<Output = Result<RpCopy>> + MaybeSend {
-        async move { self.copy_dyn(from, to, args).await }
+    async fn copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
+        self.copy_dyn(from, to, args).await
     }
 
-    fn rename(
-        &self,
-        from: &str,
-        to: &str,
-        args: OpRename,
-    ) -> impl Future<Output = Result<RpRename>> + MaybeSend {
-        async move { self.rename_dyn(from, to, args).await }
+    async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
+        self.rename_dyn(from, to, args).await
     }
 
-    fn presign(
-        &self,
-        path: &str,
-        args: OpPresign,
-    ) -> impl Future<Output = Result<RpPresign>> + MaybeSend {
-        async move { self.presign_dyn(path, args).await }
+    async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
+        self.presign_dyn(path, args).await
     }
 
     fn batch(&self, args: OpBatch) -> impl Future<Output = Result<RpBatch>> + MaybeSend {
@@ -722,6 +706,9 @@ impl Accessor for () {
 
 /// All functions in `Accessor` only requires `&self`, so it's safe to implement
 /// `Accessor` for `Arc<impl Accessor>`.
+// If we use async fn directly, some weired higher rank trait bound error (`Send`/`Accessor` impl not general enough) will happen.
+// Probably related to https://github.com/rust-lang/rust/issues/96865
+#[allow(clippy::manual_async_fn)]
 impl<T: Accessor + ?Sized> Accessor for Arc<T> {
     type Reader = T::Reader;
     type Writer = T::Writer;
@@ -734,49 +721,88 @@ impl<T: Accessor + ?Sized> Accessor for Arc<T> {
         self.as_ref().info()
     }
 
-    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        self.as_ref().create_dir(path, args).await
+    fn create_dir(
+        &self,
+        path: &str,
+        args: OpCreateDir,
+    ) -> impl Future<Output = Result<RpCreateDir>> + MaybeSend {
+        async move { self.as_ref().create_dir(path, args).await }
     }
 
-    async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        self.as_ref().stat(path, args).await
-    }
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        self.as_ref().read(path, args).await
+    fn stat(&self, path: &str, args: OpStat) -> impl Future<Output = Result<RpStat>> + MaybeSend {
+        async move { self.as_ref().stat(path, args).await }
     }
 
-    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        self.as_ref().write(path, args).await
+    fn read(
+        &self,
+        path: &str,
+        args: OpRead,
+    ) -> impl Future<Output = Result<(RpRead, Self::Reader)>> + MaybeSend {
+        async move { self.as_ref().read(path, args).await }
     }
 
-    async fn delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
-        self.as_ref().delete(path, args).await
+    fn write(
+        &self,
+        path: &str,
+        args: OpWrite,
+    ) -> impl Future<Output = Result<(RpWrite, Self::Writer)>> + MaybeSend {
+        async move { self.as_ref().write(path, args).await }
     }
 
-    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
-        self.as_ref().list(path, args).await
-    }
-    async fn copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
-        self.as_ref().copy(from, to, args).await
-    }
-    async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
-        self.as_ref().rename(from, to, args).await
+    fn delete(
+        &self,
+        path: &str,
+        args: OpDelete,
+    ) -> impl Future<Output = Result<RpDelete>> + MaybeSend {
+        async move { self.as_ref().delete(path, args).await }
     }
 
-    async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
-        self.as_ref().presign(path, args).await
+    fn list(
+        &self,
+        path: &str,
+        args: OpList,
+    ) -> impl Future<Output = Result<(RpList, Self::Lister)>> + MaybeSend {
+        async move { self.as_ref().list(path, args).await }
     }
 
-    async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
-        self.as_ref().batch(args).await
+    fn copy(
+        &self,
+        from: &str,
+        to: &str,
+        args: OpCopy,
+    ) -> impl Future<Output = Result<RpCopy>> + MaybeSend {
+        async move { self.as_ref().copy(from, to, args).await }
+    }
+
+    fn rename(
+        &self,
+        from: &str,
+        to: &str,
+        args: OpRename,
+    ) -> impl Future<Output = Result<RpRename>> + MaybeSend {
+        async move { self.as_ref().rename(from, to, args).await }
+    }
+
+    fn presign(
+        &self,
+        path: &str,
+        args: OpPresign,
+    ) -> impl Future<Output = Result<RpPresign>> + MaybeSend {
+        async move { self.as_ref().presign(path, args).await }
+    }
+
+    fn batch(&self, args: OpBatch) -> impl Future<Output = Result<RpBatch>> + MaybeSend {
+        async move { self.as_ref().batch(args).await }
     }
 
     fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
         self.as_ref().blocking_create_dir(path, args)
     }
+
     fn blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
         self.as_ref().blocking_stat(path, args)
     }
+
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
         self.as_ref().blocking_read(path, args)
     }
@@ -792,9 +818,11 @@ impl<T: Accessor + ?Sized> Accessor for Arc<T> {
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingLister)> {
         self.as_ref().blocking_list(path, args)
     }
+
     fn blocking_copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
         self.as_ref().blocking_copy(from, to, args)
     }
+
     fn blocking_rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
         self.as_ref().blocking_rename(from, to, args)
     }

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -19,7 +19,7 @@ use std::fmt::Debug;
 use std::future::ready;
 use std::sync::Arc;
 
-use futures::{Future, FutureExt};
+use futures::Future;
 
 use crate::raw::*;
 use crate::*;

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -493,11 +493,11 @@ where
         path: &'a str,
         args: OpCreateDir,
     ) -> BoxedFuture<'a, Result<RpCreateDir>> {
-        self.create_dir(path, args).boxed()
+        Box::pin(self.create_dir(path, args))
     }
 
     fn stat_dyn<'a>(&'a self, path: &'a str, args: OpStat) -> BoxedFuture<'a, Result<RpStat>> {
-        self.stat(path, args).boxed()
+        Box::pin(self.stat(path, args))
     }
 
     fn read_dyn<'a>(
@@ -505,7 +505,7 @@ where
         path: &'a str,
         args: OpRead,
     ) -> BoxedFuture<'a, Result<(RpRead, oio::Reader)>> {
-        self.read(path, args).boxed()
+        Box::pin(self.read(path, args))
     }
 
     fn write_dyn<'a>(
@@ -513,7 +513,7 @@ where
         path: &'a str,
         args: OpWrite,
     ) -> BoxedFuture<'a, Result<(RpWrite, oio::Writer)>> {
-        self.write(path, args).boxed()
+        Box::pin(self.write(path, args))
     }
 
     fn delete_dyn<'a>(
@@ -521,7 +521,7 @@ where
         path: &'a str,
         args: OpDelete,
     ) -> BoxedFuture<'a, Result<RpDelete>> {
-        self.delete(path, args).boxed()
+        Box::pin(self.delete(path, args))
     }
 
     fn list_dyn<'a>(
@@ -529,7 +529,7 @@ where
         path: &'a str,
         args: OpList,
     ) -> BoxedFuture<'a, Result<(RpList, oio::Lister)>> {
-        self.list(path, args).boxed()
+        Box::pin(self.list(path, args))
     }
 
     fn copy_dyn<'a>(
@@ -538,7 +538,7 @@ where
         to: &'a str,
         args: OpCopy,
     ) -> BoxedFuture<'a, Result<RpCopy>> {
-        self.copy(from, to, args).boxed()
+        Box::pin(self.copy(from, to, args))
     }
 
     fn rename_dyn<'a>(
@@ -547,7 +547,7 @@ where
         to: &'a str,
         args: OpRename,
     ) -> BoxedFuture<'a, Result<RpRename>> {
-        self.rename(from, to, args).boxed()
+        Box::pin(self.rename(from, to, args))
     }
 
     fn presign_dyn<'a>(
@@ -555,11 +555,11 @@ where
         path: &'a str,
         args: OpPresign,
     ) -> BoxedFuture<'a, Result<RpPresign>> {
-        self.presign(path, args).boxed()
+        Box::pin(self.presign(path, args))
     }
 
     fn batch_dyn(&self, args: OpBatch) -> BoxedFuture<'_, Result<RpBatch>> {
-        self.batch(args).boxed()
+        Box::pin(self.batch(args))
     }
 
     fn blocking_create_dir_dyn(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -16,9 +16,10 @@
 // under the License.
 
 use std::fmt::Debug;
+use std::future::ready;
 use std::sync::Arc;
 
-use async_trait::async_trait;
+use futures::{Future, FutureExt};
 
 use crate::raw::*;
 use crate::*;
@@ -53,8 +54,6 @@ use crate::*;
 /// - Operations with capability requirement like `presign` are optional operations.
 ///   - Services can implement them based on services capabilities.
 ///   - The default implementation should return [`ErrorKind::Unsupported`].
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     /// Reader is the associated reader returned in `read` operation.
     type Reader: oio::Read;
@@ -91,13 +90,17 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     ///
     /// - Input path MUST match with EntryMode, DON'T NEED to check mode.
     /// - Create on existing dir SHOULD succeed.
-    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
+    fn create_dir(
+        &self,
+        path: &str,
+        args: OpCreateDir,
+    ) -> impl Future<Output = Result<RpCreateDir>> + MaybeSend {
         let (_, _) = (path, args);
 
-        Err(Error::new(
+        ready(Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
-        ))
+        )))
     }
 
     /// Invoke the `stat` operation on the specified path.
@@ -109,13 +112,13 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     /// - `stat` empty path means stat backend's root path.
     /// - `stat` a path endswith "/" means stating a dir.
     /// - `mode` and `content_length` must be set.
-    async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
+    fn stat(&self, path: &str, args: OpStat) -> impl Future<Output = Result<RpStat>> + MaybeSend {
         let (_, _) = (path, args);
 
-        Err(Error::new(
+        ready(Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
-        ))
+        )))
     }
 
     /// Invoke the `read` operation on the specified path, returns a
@@ -127,13 +130,17 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     ///
     /// - Input path MUST be file path, DON'T NEED to check mode.
     /// - The returning content length may be smaller than the range specified.
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+    fn read(
+        &self,
+        path: &str,
+        args: OpRead,
+    ) -> impl Future<Output = Result<(RpRead, Self::Reader)>> + MaybeSend {
         let (_, _) = (path, args);
 
-        Err(Error::new(
+        ready(Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
-        ))
+        )))
     }
 
     /// Invoke the `write` operation on the specified path, returns a
@@ -144,13 +151,17 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     /// # Behavior
     ///
     /// - Input path MUST be file path, DON'T NEED to check mode.
-    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
+    fn write(
+        &self,
+        path: &str,
+        args: OpWrite,
+    ) -> impl Future<Output = Result<(RpWrite, Self::Writer)>> + MaybeSend {
         let (_, _) = (path, args);
 
-        Err(Error::new(
+        ready(Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
-        ))
+        )))
     }
 
     /// Invoke the `delete` operation on the specified path.
@@ -161,13 +172,17 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     ///
     /// - `delete` is an idempotent operation, it's safe to call `Delete` on the same path multiple times.
     /// - `delete` SHOULD return `Ok(())` if the path is deleted successfully or not exist.
-    async fn delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
+    fn delete(
+        &self,
+        path: &str,
+        args: OpDelete,
+    ) -> impl Future<Output = Result<RpDelete>> + MaybeSend {
         let (_, _) = (path, args);
 
-        Err(Error::new(
+        ready(Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
-        ))
+        )))
     }
 
     /// Invoke the `list` operation on the specified path.
@@ -178,13 +193,17 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     ///
     /// - Input path MUST be dir path, DON'T NEED to check mode.
     /// - List non-exist dir should return Empty.
-    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
+    fn list(
+        &self,
+        path: &str,
+        args: OpList,
+    ) -> impl Future<Output = Result<(RpList, Self::Lister)>> + MaybeSend {
         let (_, _) = (path, args);
 
-        Err(Error::new(
+        ready(Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
-        ))
+        )))
     }
 
     /// Invoke the `copy` operation on the specified `from` path and `to` path.
@@ -196,25 +215,35 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     /// - `from` and `to` MUST be file path, DON'T NEED to check mode.
     /// - Copy on existing file SHOULD succeed.
     /// - Copy on existing file SHOULD overwrite and truncate.
-    async fn copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
+    fn copy(
+        &self,
+        from: &str,
+        to: &str,
+        args: OpCopy,
+    ) -> impl Future<Output = Result<RpCopy>> + MaybeSend {
         let (_, _, _) = (from, to, args);
 
-        Err(Error::new(
+        ready(Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
-        ))
+        )))
     }
 
     /// Invoke the `rename` operation on the specified `from` path and `to` path.
     ///
     /// Require [Capability::rename]
-    async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
+    fn rename(
+        &self,
+        from: &str,
+        to: &str,
+        args: OpRename,
+    ) -> impl Future<Output = Result<RpRename>> + MaybeSend {
         let (_, _, _) = (from, to, args);
 
-        Err(Error::new(
+        ready(Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
-        ))
+        )))
     }
 
     /// Invoke the `presign` operation on the specified path.
@@ -224,25 +253,29 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     /// # Behavior
     ///
     /// - This API is optional, return [`std::io::ErrorKind::Unsupported`] if not supported.
-    async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
+    fn presign(
+        &self,
+        path: &str,
+        args: OpPresign,
+    ) -> impl Future<Output = Result<RpPresign>> + MaybeSend {
         let (_, _) = (path, args);
 
-        Err(Error::new(
+        ready(Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
-        ))
+        )))
     }
 
     /// Invoke the `batch` operations.
     ///
     /// Require [`Capability::batch`]
-    async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
+    fn batch(&self, args: OpBatch) -> impl Future<Output = Result<RpBatch>> + MaybeSend {
         let _ = args;
 
-        Err(Error::new(
+        ready(Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
-        ))
+        )))
     }
 
     /// Invoke the `blocking_create` operation on the specified path.
@@ -362,9 +395,312 @@ pub trait Accessor: Send + Sync + Debug + Unpin + 'static {
     }
 }
 
+/// `AccessorDyn` is the dyn version of [`Accessor`] make it possible to use as
+/// `Box<dyn AccessorDyn>`.
+pub trait AccessorDyn: Send + Sync + Debug + Unpin {
+    /// Dyn version of [`Accessor::info`]
+    fn info_dyn(&self) -> AccessorInfo;
+    /// Dyn version of [`Accessor::create_dir`]
+    fn create_dir_dyn<'a>(
+        &'a self,
+        path: &'a str,
+        args: OpCreateDir,
+    ) -> BoxedFuture<'a, Result<RpCreateDir>>;
+    /// Dyn version of [`Accessor::stat`]
+    fn stat_dyn<'a>(&'a self, path: &'a str, args: OpStat) -> BoxedFuture<'a, Result<RpStat>>;
+    /// Dyn version of [`Accessor::read`]
+    fn read_dyn<'a>(
+        &'a self,
+        path: &'a str,
+        args: OpRead,
+    ) -> BoxedFuture<'a, Result<(RpRead, oio::Reader)>>;
+    /// Dyn version of [`Accessor::write`]
+    fn write_dyn<'a>(
+        &'a self,
+        path: &'a str,
+        args: OpWrite,
+    ) -> BoxedFuture<'a, Result<(RpWrite, oio::Writer)>>;
+    /// Dyn version of [`Accessor::delete`]
+    fn delete_dyn<'a>(&'a self, path: &'a str, args: OpDelete)
+        -> BoxedFuture<'a, Result<RpDelete>>;
+    /// Dyn version of [`Accessor::list`]
+    fn list_dyn<'a>(
+        &'a self,
+        path: &'a str,
+        args: OpList,
+    ) -> BoxedFuture<'a, Result<(RpList, oio::Lister)>>;
+    /// Dyn version of [`Accessor::copy`]
+    fn copy_dyn<'a>(
+        &'a self,
+        from: &'a str,
+        to: &'a str,
+        args: OpCopy,
+    ) -> BoxedFuture<'a, Result<RpCopy>>;
+    /// Dyn version of [`Accessor::rename`]
+    fn rename_dyn<'a>(
+        &'a self,
+        from: &'a str,
+        to: &'a str,
+        args: OpRename,
+    ) -> BoxedFuture<'a, Result<RpRename>>;
+    /// Dyn version of [`Accessor::presign`]
+    fn presign_dyn<'a>(
+        &'a self,
+        path: &'a str,
+        args: OpPresign,
+    ) -> BoxedFuture<'a, Result<RpPresign>>;
+    /// Dyn version of [`Accessor::batch`]
+    fn batch_dyn(&self, args: OpBatch) -> BoxedFuture<'_, Result<RpBatch>>;
+    /// Dyn version of [`Accessor::blocking_create_dir`]
+    fn blocking_create_dir_dyn(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir>;
+    /// Dyn version of [`Accessor::blocking_stat`]
+    fn blocking_stat_dyn(&self, path: &str, args: OpStat) -> Result<RpStat>;
+    /// Dyn version of [`Accessor::blocking_read`]
+    fn blocking_read_dyn(&self, path: &str, args: OpRead) -> Result<(RpRead, oio::BlockingReader)>;
+    /// Dyn version of [`Accessor::blocking_write`]
+    fn blocking_write_dyn(
+        &self,
+        path: &str,
+        args: OpWrite,
+    ) -> Result<(RpWrite, oio::BlockingWriter)>;
+    /// Dyn version of [`Accessor::blocking_delete`]
+    fn blocking_delete_dyn(&self, path: &str, args: OpDelete) -> Result<RpDelete>;
+    /// Dyn version of [`Accessor::blocking_list`]
+    fn blocking_list_dyn(&self, path: &str, args: OpList) -> Result<(RpList, oio::BlockingLister)>;
+    /// Dyn version of [`Accessor::blocking_copy`]
+    fn blocking_copy_dyn(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy>;
+    /// Dyn version of [`Accessor::blocking_rename`]
+    fn blocking_rename_dyn(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename>;
+}
+
+impl<A: ?Sized> AccessorDyn for A
+where
+    A: Accessor<
+        Reader = oio::Reader,
+        BlockingReader = oio::BlockingReader,
+        Writer = oio::Writer,
+        BlockingWriter = oio::BlockingWriter,
+        Lister = oio::Lister,
+        BlockingLister = oio::BlockingLister,
+    >,
+{
+    fn info_dyn(&self) -> AccessorInfo {
+        <Self as Accessor>::info(self)
+    }
+    fn create_dir_dyn<'a>(
+        &'a self,
+        path: &'a str,
+        args: OpCreateDir,
+    ) -> BoxedFuture<'a, Result<RpCreateDir>> {
+        <Self as Accessor>::create_dir(self, path, args).boxed()
+    }
+    fn stat_dyn<'a>(&'a self, path: &'a str, args: OpStat) -> BoxedFuture<'a, Result<RpStat>> {
+        <Self as Accessor>::stat(self, path, args).boxed()
+    }
+    fn read_dyn<'a>(
+        &'a self,
+        path: &'a str,
+        args: OpRead,
+    ) -> BoxedFuture<'a, Result<(RpRead, oio::Reader)>> {
+        <Self as Accessor>::read(self, path, args).boxed()
+    }
+    fn write_dyn<'a>(
+        &'a self,
+        path: &'a str,
+        args: OpWrite,
+    ) -> BoxedFuture<'a, Result<(RpWrite, oio::Writer)>> {
+        <Self as Accessor>::write(self, path, args).boxed()
+    }
+    fn delete_dyn<'a>(
+        &'a self,
+        path: &'a str,
+        args: OpDelete,
+    ) -> BoxedFuture<'a, Result<RpDelete>> {
+        <Self as Accessor>::delete(self, path, args).boxed()
+    }
+    fn list_dyn<'a>(
+        &'a self,
+        path: &'a str,
+        args: OpList,
+    ) -> BoxedFuture<'a, Result<(RpList, oio::Lister)>> {
+        <Self as Accessor>::list(self, path, args).boxed()
+    }
+    fn copy_dyn<'a>(
+        &'a self,
+        from: &'a str,
+        to: &'a str,
+        args: OpCopy,
+    ) -> BoxedFuture<'a, Result<RpCopy>> {
+        <Self as Accessor>::copy(self, from, to, args).boxed()
+    }
+    fn rename_dyn<'a>(
+        &'a self,
+        from: &'a str,
+        to: &'a str,
+        args: OpRename,
+    ) -> BoxedFuture<'a, Result<RpRename>> {
+        <Self as Accessor>::rename(self, from, to, args).boxed()
+    }
+    fn presign_dyn<'a>(
+        &'a self,
+        path: &'a str,
+        args: OpPresign,
+    ) -> BoxedFuture<'a, Result<RpPresign>> {
+        <Self as Accessor>::presign(self, path, args).boxed()
+    }
+    fn batch_dyn<'a>(&'a self, args: OpBatch) -> BoxedFuture<'a, Result<RpBatch>> {
+        <Self as Accessor>::batch(self, args).boxed()
+    }
+    fn blocking_create_dir_dyn(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
+        <Self as Accessor>::blocking_create_dir(self, path, args)
+    }
+    fn blocking_stat_dyn(&self, path: &str, args: OpStat) -> Result<RpStat> {
+        <Self as Accessor>::blocking_stat(self, path, args)
+    }
+    fn blocking_read_dyn(&self, path: &str, args: OpRead) -> Result<(RpRead, oio::BlockingReader)> {
+        <Self as Accessor>::blocking_read(self, path, args)
+    }
+    fn blocking_write_dyn(
+        &self,
+        path: &str,
+        args: OpWrite,
+    ) -> Result<(RpWrite, oio::BlockingWriter)> {
+        <Self as Accessor>::blocking_write(self, path, args)
+    }
+    fn blocking_delete_dyn(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
+        <Self as Accessor>::blocking_delete(self, path, args)
+    }
+    fn blocking_list_dyn(&self, path: &str, args: OpList) -> Result<(RpList, oio::BlockingLister)> {
+        <Self as Accessor>::blocking_list(self, path, args)
+    }
+    fn blocking_copy_dyn(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
+        <Self as Accessor>::blocking_copy(self, from, to, args)
+    }
+    fn blocking_rename_dyn(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
+        <Self as Accessor>::blocking_rename(self, from, to, args)
+    }
+}
+
+impl Accessor for dyn AccessorDyn {
+    type Reader = oio::Reader;
+    type BlockingReader = oio::BlockingReader;
+    type Writer = oio::Writer;
+    type BlockingWriter = oio::BlockingWriter;
+    type Lister = oio::Lister;
+    type BlockingLister = oio::BlockingLister;
+
+    fn info(&self) -> AccessorInfo {
+        self.info_dyn()
+    }
+
+    fn create_dir(
+        &self,
+        path: &str,
+        args: OpCreateDir,
+    ) -> impl Future<Output = Result<RpCreateDir>> + MaybeSend {
+        async move { self.create_dir_dyn(path, args).await }
+    }
+
+    fn stat(&self, path: &str, args: OpStat) -> impl Future<Output = Result<RpStat>> + MaybeSend {
+        async move { self.stat_dyn(path, args).await }
+    }
+
+    fn read(
+        &self,
+        path: &str,
+        args: OpRead,
+    ) -> impl Future<Output = Result<(RpRead, Self::Reader)>> + MaybeSend {
+        async move { self.read_dyn(path, args).await }
+    }
+
+    fn write(
+        &self,
+        path: &str,
+        args: OpWrite,
+    ) -> impl Future<Output = Result<(RpWrite, Self::Writer)>> + MaybeSend {
+        async move { self.write_dyn(path, args).await }
+    }
+
+    fn delete(
+        &self,
+        path: &str,
+        args: OpDelete,
+    ) -> impl Future<Output = Result<RpDelete>> + MaybeSend {
+        async move { self.delete_dyn(path, args).await }
+    }
+
+    fn list(
+        &self,
+        path: &str,
+        args: OpList,
+    ) -> impl Future<Output = Result<(RpList, Self::Lister)>> + MaybeSend {
+        async move { self.list_dyn(path, args).await }
+    }
+
+    fn copy(
+        &self,
+        from: &str,
+        to: &str,
+        args: OpCopy,
+    ) -> impl Future<Output = Result<RpCopy>> + MaybeSend {
+        async move { self.copy_dyn(from, to, args).await }
+    }
+
+    fn rename(
+        &self,
+        from: &str,
+        to: &str,
+        args: OpRename,
+    ) -> impl Future<Output = Result<RpRename>> + MaybeSend {
+        async move { self.rename_dyn(from, to, args).await }
+    }
+
+    fn presign(
+        &self,
+        path: &str,
+        args: OpPresign,
+    ) -> impl Future<Output = Result<RpPresign>> + MaybeSend {
+        async move { self.presign_dyn(path, args).await }
+    }
+
+    fn batch(&self, args: OpBatch) -> impl Future<Output = Result<RpBatch>> + MaybeSend {
+        self.batch_dyn(args)
+    }
+
+    fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
+        self.blocking_create_dir_dyn(path, args)
+    }
+
+    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
+        self.blocking_read_dyn(path, args)
+    }
+
+    fn blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
+        self.blocking_stat_dyn(path, args)
+    }
+
+    fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
+        self.blocking_write_dyn(path, args)
+    }
+
+    fn blocking_delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
+        self.blocking_delete_dyn(path, args)
+    }
+
+    fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingLister)> {
+        self.blocking_list_dyn(path, args)
+    }
+
+    fn blocking_copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
+        self.blocking_copy_dyn(from, to, args)
+    }
+
+    fn blocking_rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
+        self.blocking_rename_dyn(from, to, args)
+    }
+}
+
 /// Dummy implementation of accessor.
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Accessor for () {
     type Reader = ();
     type Writer = ();
@@ -385,9 +721,7 @@ impl Accessor for () {
 }
 
 /// All functions in `Accessor` only requires `&self`, so it's safe to implement
-/// `Accessor` for `Arc<dyn Accessor>`.
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+/// `Accessor` for `Arc<impl Accessor>`.
 impl<T: Accessor + ?Sized> Accessor for Arc<T> {
     type Reader = T::Reader;
     type Writer = T::Writer;
@@ -467,16 +801,7 @@ impl<T: Accessor + ?Sized> Accessor for Arc<T> {
 }
 
 /// FusedAccessor is the type erased accessor with `Arc<dyn Accessor>`.
-pub type FusedAccessor = Arc<
-    dyn Accessor<
-        Reader = oio::Reader,
-        BlockingReader = oio::BlockingReader,
-        Writer = oio::Writer,
-        BlockingWriter = oio::BlockingWriter,
-        Lister = oio::Lister,
-        BlockingLister = oio::BlockingLister,
-    >,
->;
+pub type FusedAccessor = Arc<dyn AccessorDyn>;
 
 /// Metadata for accessor, users can use this metadata to get information of underlying backend.
 #[derive(Clone, Debug, Default)]

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -18,8 +18,6 @@
 use std::sync::Arc;
 use std::vec::IntoIter;
 
-use async_trait::async_trait;
-
 use super::Adapter;
 use crate::raw::oio::HierarchyLister;
 use crate::raw::oio::QueueBuf;
@@ -58,8 +56,6 @@ where
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<S: Adapter> Accessor for Backend<S> {
     type Reader = Buffer;
     type BlockingReader = Buffer;

--- a/core/src/raw/adapters/typed_kv/backend.rs
+++ b/core/src/raw/adapters/typed_kv/backend.rs
@@ -18,8 +18,6 @@
 use std::sync::Arc;
 use std::vec::IntoIter;
 
-use async_trait::async_trait;
-
 use super::Adapter;
 use super::Value;
 use crate::raw::oio::HierarchyLister;
@@ -53,8 +51,6 @@ where
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl<S: Adapter> Accessor for Backend<S> {
     type Reader = Buffer;
     type BlockingReader = Buffer;

--- a/core/src/raw/oio/list/flat_list.rs
+++ b/core/src/raw/oio/list/flat_list.rs
@@ -179,7 +179,6 @@ mod tests {
     use std::vec;
     use std::vec::IntoIter;
 
-    use async_trait::async_trait;
     use log::debug;
     use oio::BlockingList;
 
@@ -209,7 +208,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl Accessor for MockService {
         type Reader = ();
         type BlockingReader = ();

--- a/core/src/services/alluxio/backend.rs
+++ b/core/src/services/alluxio/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use log::debug;
 use serde::Deserialize;
 
@@ -180,7 +179,6 @@ pub struct AlluxioBackend {
     core: Arc<AlluxioCore>,
 }
 
-#[async_trait]
 impl Accessor for AlluxioBackend {
     type Reader = AlluxioReader;
     type Writer = AlluxioWriters;

--- a/core/src/services/atomicserver/backend.rs
+++ b/core/src/services/atomicserver/backend.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use async_trait::async_trait;
 use atomic_lib::agents::Agent;
 use atomic_lib::client::get_authentication_headers;
 use atomic_lib::commit::sign_message;
@@ -387,7 +386,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use bytes::Buf;
@@ -542,8 +541,6 @@ pub struct AzblobBackend {
     has_sas_token: bool,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Accessor for AzblobBackend {
     type Reader = AzblobReader;
     type Writer = AzblobWriters;

--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use http::StatusCode;
 use log::debug;
 use reqsign::AzureStorageConfig;
@@ -244,7 +243,6 @@ pub struct AzdlsBackend {
     core: Arc<AzdlsCore>,
 }
 
-#[async_trait]
 impl Accessor for AzdlsBackend {
     type Reader = AzdlsReader;
     type Writer = AzdlsWriters;

--- a/core/src/services/azfile/backend.rs
+++ b/core/src/services/azfile/backend.rs
@@ -354,7 +354,7 @@ impl Accessor for AzfileBackend {
         } else {
             AzfileWriters::One(oio::OneShotWriter::new(w))
         };
-        return Ok((RpWrite::default(), w));
+        Ok((RpWrite::default(), w))
     }
 
     async fn delete(&self, path: &str, _: OpDelete) -> Result<RpDelete> {

--- a/core/src/services/azfile/backend.rs
+++ b/core/src/services/azfile/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use http::StatusCode;
 use log::debug;
 use reqsign::AzureStorageConfig;
@@ -265,7 +264,6 @@ pub struct AzfileBackend {
     core: Arc<AzfileCore>,
 }
 
-#[async_trait]
 impl Accessor for AzfileBackend {
     type Reader = AzfileReader;
     type Writer = AzfileWriters;

--- a/core/src/services/b2/backend.rs
+++ b/core/src/services/b2/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::Request;
 use http::StatusCode;
@@ -267,7 +266,6 @@ pub struct B2Backend {
     core: Arc<B2Core>,
 }
 
-#[async_trait]
 impl Accessor for B2Backend {
     type Reader = B2Reader;
     type Writer = B2Writers;

--- a/core/src/services/cacache/backend.rs
+++ b/core/src/services/cacache/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::str;
 
-use async_trait::async_trait;
 use cacache;
 use serde::Deserialize;
 
@@ -93,7 +92,6 @@ impl Debug for Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/chainsafe/backend.rs
+++ b/core/src/services/chainsafe/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::StatusCode;
 use log::debug;
@@ -203,7 +202,6 @@ pub struct ChainsafeBackend {
     core: Arc<ChainsafeCore>,
 }
 
-#[async_trait]
 impl Accessor for ChainsafeBackend {
     type Reader = ChainsafeReader;
     type Writer = ChainsafeWriters;

--- a/core/src/services/cloudflare_kv/backend.rs
+++ b/core/src/services/cloudflare_kv/backend.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::header;
 use http::Request;
@@ -209,7 +208,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/compfs/backend.rs
+++ b/core/src/services/compfs/backend.rs
@@ -18,7 +18,7 @@
 use super::core::CompioThread;
 use crate::raw::*;
 use crate::*;
-use async_trait::async_trait;
+
 use std::collections::HashMap;
 use std::path::PathBuf;
 
@@ -63,7 +63,6 @@ pub struct CompfsBackend {
     rt: CompioThread,
 }
 
-#[async_trait]
 impl Accessor for CompfsBackend {
     type Reader = ();
     type Writer = ();

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use http::StatusCode;
 use http::Uri;
 use log::debug;
@@ -253,7 +252,6 @@ pub struct CosBackend {
     core: Arc<CosCore>,
 }
 
-#[async_trait]
 impl Accessor for CosBackend {
     type Reader = CosReader;
     type Writer = CosWriters;

--- a/core/src/services/d1/backend.rs
+++ b/core/src/services/d1/backend.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::header;
 use http::Request;
@@ -286,7 +285,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/dashmap/backend.rs
+++ b/core/src/services/dashmap/backend.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use async_trait::async_trait;
 use dashmap::DashMap;
 use serde::Deserialize;
 
@@ -83,7 +82,6 @@ impl Debug for Adapter {
     }
 }
 
-#[async_trait]
 impl typed_kv::Adapter for Adapter {
     fn info(&self) -> typed_kv::Info {
         typed_kv::Info::new(

--- a/core/src/services/dbfs/backend.rs
+++ b/core/src/services/dbfs/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::StatusCode;
 use log::debug;
@@ -166,7 +165,6 @@ pub struct DbfsBackend {
     core: Arc<DbfsCore>,
 }
 
-#[async_trait]
 impl Accessor for DbfsBackend {
     type Reader = DbfsReader;
     type Writer = oio::OneShotWriter<DbfsWriter>;

--- a/core/src/services/dropbox/backend.rs
+++ b/core/src/services/dropbox/backend.rs
@@ -18,7 +18,6 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use backon::Retryable;
 use bytes::Buf;
 use http::StatusCode;
@@ -36,7 +35,6 @@ pub struct DropboxBackend {
     pub core: Arc<DropboxCore>,
 }
 
-#[async_trait]
 impl Accessor for DropboxBackend {
     type Reader = DropboxReader;
     type Writer = oio::OneShotWriter<DropboxWriter>;

--- a/core/src/services/etcd/backend.rs
+++ b/core/src/services/etcd/backend.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use async_trait::async_trait;
 use bb8::PooledConnection;
 use bb8::RunError;
 use etcd_client::Certificate;
@@ -267,7 +266,7 @@ pub struct Manager {
     options: ConnectOptions,
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl bb8::ManageConnection for Manager {
     type Connection = Client;
     type Error = Error;
@@ -333,7 +332,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/foundationdb/backend.rs
+++ b/core/src/services/foundationdb/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use foundationdb::api::NetworkAutoStop;
 use foundationdb::Database;
 use serde::Deserialize;
@@ -134,7 +133,6 @@ impl Debug for Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -20,7 +20,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use chrono::DateTime;
 use log::debug;
 
@@ -167,7 +166,6 @@ pub struct FsBackend {
     core: Arc<FsCore>,
 }
 
-#[async_trait]
 impl Accessor for FsBackend {
     type Reader = FsReader;
     type Writer = FsWriter<tokio::fs::File>;

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -22,7 +22,7 @@ use std::str;
 use std::str::FromStr;
 
 use async_tls::TlsConnector;
-use async_trait::async_trait;
+
 use bb8::PooledConnection;
 use bb8::RunError;
 use http::Uri;
@@ -211,7 +211,7 @@ pub struct Manager {
     enable_secure: bool,
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl bb8::ManageConnection for Manager {
     type Connection = AsyncRustlsFtpStream;
     type Error = FtpError;
@@ -282,7 +282,6 @@ impl Debug for FtpBackend {
     }
 }
 
-#[async_trait]
 impl Accessor for FtpBackend {
     type Reader = FtpReader;
     type Writer = FtpWriter;

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -336,7 +336,7 @@ impl Accessor for FtpBackend {
             }
         }
 
-        return Ok(RpCreateDir::default());
+        Ok(RpCreateDir::default())
     }
 
     async fn stat(&self, path: &str, _: OpStat) -> Result<RpStat> {

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::StatusCode;
 use log::debug;
@@ -331,8 +330,6 @@ pub struct GcsBackend {
     core: Arc<GcsCore>,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Accessor for GcsBackend {
     type Reader = GcsReader;
     type Writer = GcsWriters;

--- a/core/src/services/gdrive/backend.rs
+++ b/core/src/services/gdrive/backend.rs
@@ -18,7 +18,6 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use bytes::Bytes;
 use chrono::Utc;
@@ -40,8 +39,6 @@ pub struct GdriveBackend {
     pub core: Arc<GdriveCore>,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Accessor for GdriveBackend {
     type Reader = GdriveReader;
     type Writer = oio::OneShotWriter<GdriveWriter>;

--- a/core/src/services/gdrive/backend.rs
+++ b/core/src/services/gdrive/backend.rs
@@ -143,7 +143,7 @@ impl Accessor for GdriveBackend {
 
         self.core.path_cache.remove(&path).await;
 
-        return Ok(RpDelete::default());
+        Ok(RpDelete::default())
     }
 
     async fn list(&self, path: &str, _args: OpList) -> Result<(RpList, Self::Lister)> {

--- a/core/src/services/gdrive/core.rs
+++ b/core/src/services/gdrive/core.rs
@@ -19,7 +19,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes;
 use bytes::Buf;
 use bytes::Bytes;
@@ -345,8 +344,6 @@ impl GdrivePathQuery {
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl PathQuery for GdrivePathQuery {
     async fn root(&self) -> Result<String> {
         Ok("root".to_string())

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -18,7 +18,6 @@
 use std::collections::HashMap;
 use std::env;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use bytes::Bytes;
 use http::header;
@@ -227,7 +226,6 @@ pub struct GhacBackend {
     pub client: HttpClient,
 }
 
-#[async_trait]
 impl Accessor for GhacBackend {
     type Reader = GhacReader;
     type Writer = GhacWriter;

--- a/core/src/services/github/backend.rs
+++ b/core/src/services/github/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::StatusCode;
 use log::debug;
@@ -217,7 +216,6 @@ pub struct GithubBackend {
     core: Arc<GithubCore>,
 }
 
-#[async_trait]
 impl Accessor for GithubBackend {
     type Reader = GithubReader;
 

--- a/core/src/services/gridfs/backend.rs
+++ b/core/src/services/gridfs/backend.rs
@@ -18,7 +18,6 @@
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use async_trait::async_trait;
 use futures::AsyncWriteExt;
 use futures::StreamExt;
 use mongodb::bson::doc;
@@ -215,7 +214,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -22,7 +22,6 @@ use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use futures::AsyncWriteExt;
 use log::debug;
 use serde::Deserialize;
@@ -244,7 +243,6 @@ pub struct HdfsBackend {
 unsafe impl Send for HdfsBackend {}
 unsafe impl Sync for HdfsBackend {}
 
-#[async_trait]
 impl Accessor for HdfsBackend {
     type Reader = HdfsReader;
     type Writer = HdfsWriter<hdrs::AsyncFile>;

--- a/core/src/services/hdfs_native/backend.rs
+++ b/core/src/services/hdfs_native/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use hdfs_native::WriteOptions;
 use log::debug;
 use serde::Deserialize;
@@ -171,7 +170,6 @@ pub struct HdfsNativeBackend {
 unsafe impl Send for HdfsNativeBackend {}
 unsafe impl Sync for HdfsNativeBackend {}
 
-#[async_trait]
 impl Accessor for HdfsNativeBackend {
     type Reader = HdfsNativeReader;
     type BlockingReader = ();

--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use async_trait::async_trait;
 use http::header;
 use http::header::IF_MATCH;
 use http::header::IF_NONE_MATCH;
@@ -222,8 +221,6 @@ impl Debug for HttpBackend {
     }
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Accessor for HttpBackend {
     type Reader = HttpReader;
     type Writer = ();

--- a/core/src/services/huggingface/backend.rs
+++ b/core/src/services/huggingface/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::StatusCode;
 use log::debug;
@@ -243,7 +242,6 @@ pub struct HuggingfaceBackend {
     core: Arc<HuggingfaceCore>,
 }
 
-#[async_trait]
 impl Accessor for HuggingfaceBackend {
     type Reader = HuggingfaceReader;
     type Writer = ();

--- a/core/src/services/icloud/backend.rs
+++ b/core/src/services/icloud/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use serde::Deserialize;
 use tokio::sync::Mutex;
 
@@ -265,7 +264,6 @@ pub struct IcloudBackend {
     core: Arc<IcloudCore>,
 }
 
-#[async_trait]
 impl Accessor for IcloudBackend {
     type Reader = IcloudReader;
     type BlockingReader = ();

--- a/core/src/services/icloud/core.rs
+++ b/core/src/services/icloud/core.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use bytes::Bytes;
 use http::header;
@@ -487,7 +486,6 @@ impl IcloudPathQuery {
     }
 }
 
-#[async_trait]
 impl PathQuery for IcloudPathQuery {
     async fn root(&self) -> Result<String> {
         Ok("FOLDER::com.apple.CloudDocs::root".to_string())

--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use http::Request;
 use http::Response;
 use http::StatusCode;
@@ -160,7 +159,6 @@ impl Debug for IpfsBackend {
     }
 }
 
-#[async_trait]
 impl Accessor for IpfsBackend {
     type Reader = IpfsReader;
     type Writer = ();

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Write;
 use std::str;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::Request;
 use http::Response;
@@ -62,7 +61,6 @@ impl IpmfsBackend {
     }
 }
 
-#[async_trait]
 impl Accessor for IpmfsBackend {
     type Reader = IpmfsReader;
     type Writer = oio::OneShotWriter<IpmfsWriter>;

--- a/core/src/services/koofr/backend.rs
+++ b/core/src/services/koofr/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::StatusCode;
 use log::debug;
@@ -235,7 +234,6 @@ pub struct KoofrBackend {
     core: Arc<KoofrCore>,
 }
 
-#[async_trait]
 impl Accessor for KoofrBackend {
     type Reader = KoofrReader;
     type Writer = KoofrWriters;

--- a/core/src/services/libsql/backend.rs
+++ b/core/src/services/libsql/backend.rs
@@ -362,7 +362,7 @@ impl kv::Adapter for Adapter {
                     }),
             }) => {
                 if rows.is_empty() || rows[0].is_empty() {
-                    return Ok(None);
+                    Ok(None)
                 } else {
                     let val = &rows[0][0];
                     match val {

--- a/core/src/services/libsql/backend.rs
+++ b/core/src/services/libsql/backend.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::str;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use bytes::Bytes;
 use hrana_client_proto::pipeline::ClientMsg;
@@ -334,7 +333,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/memcached/backend.rs
+++ b/core/src/services/memcached/backend.rs
@@ -18,7 +18,6 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use async_trait::async_trait;
 use bb8::RunError;
 use serde::Deserialize;
 use tokio::net::TcpStream;
@@ -215,7 +214,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(
@@ -275,7 +273,7 @@ impl MemcacheConnectionManager {
     }
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl bb8::ManageConnection for MemcacheConnectionManager {
     type Connection = binary::Connection;
     type Error = Error;

--- a/core/src/services/memory/backend.rs
+++ b/core/src/services/memory/backend.rs
@@ -21,7 +21,6 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use async_trait::async_trait;
 use serde::Deserialize;
 
 use self::raw::ConfigDeserializer;
@@ -86,7 +85,6 @@ impl Debug for Adapter {
     }
 }
 
-#[async_trait]
 impl typed_kv::Adapter for Adapter {
     fn info(&self) -> typed_kv::Info {
         typed_kv::Info::new(

--- a/core/src/services/mini_moka/backend.rs
+++ b/core/src/services/mini_moka/backend.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::time::Duration;
 
-use async_trait::async_trait;
 use log::debug;
 use mini_moka::sync::Cache;
 use mini_moka::sync::CacheBuilder;
@@ -137,7 +136,6 @@ impl Debug for Adapter {
     }
 }
 
-#[async_trait]
 impl typed_kv::Adapter for Adapter {
     fn info(&self) -> typed_kv::Info {
         typed_kv::Info::new(

--- a/core/src/services/moka/backend.rs
+++ b/core/src/services/moka/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::time::Duration;
 
-use async_trait::async_trait;
 use log::debug;
 use moka::sync::CacheBuilder;
 use moka::sync::SegmentedCache;
@@ -178,7 +177,6 @@ impl Debug for Adapter {
     }
 }
 
-#[async_trait]
 impl typed_kv::Adapter for Adapter {
     fn info(&self) -> typed_kv::Info {
         typed_kv::Info::new(

--- a/core/src/services/mongodb/backend.rs
+++ b/core/src/services/mongodb/backend.rs
@@ -18,7 +18,6 @@
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use async_trait::async_trait;
 use mongodb::bson::doc;
 use mongodb::bson::Binary;
 use mongodb::bson::Document;
@@ -249,7 +248,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/mysql/backend.rs
+++ b/core/src/services/mysql/backend.rs
@@ -18,7 +18,6 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 
-use async_trait::async_trait;
 use mysql_async::prelude::*;
 use mysql_async::Opts;
 use mysql_async::Pool;
@@ -220,7 +219,6 @@ impl Debug for Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use http::StatusCode;
 use http::Uri;
 use log::debug;
@@ -247,7 +246,6 @@ pub struct ObsBackend {
     core: Arc<ObsCore>,
 }
 
-#[async_trait]
 impl Accessor for ObsBackend {
     type Reader = ObsReader;
     type Writer = ObsWriters;

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -17,7 +17,6 @@
 
 use std::fmt::Debug;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use bytes::Bytes;
 use http::header;
@@ -62,7 +61,6 @@ impl Debug for OnedriveBackend {
     }
 }
 
-#[async_trait]
 impl Accessor for OnedriveBackend {
     type Reader = OnedriveReader;
     type Writer = oio::OneShotWriter<OneDriveWriter>;

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -21,7 +21,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::StatusCode;
 use http::Uri;
@@ -375,7 +374,6 @@ pub struct OssBackend {
     core: Arc<OssCore>,
 }
 
-#[async_trait]
 impl Accessor for OssBackend {
     type Reader = OssReader;
     type Writer = OssWriters;

--- a/core/src/services/pcloud/backend.rs
+++ b/core/src/services/pcloud/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::StatusCode;
 use log::debug;
@@ -228,7 +227,6 @@ pub struct PcloudBackend {
     core: Arc<PcloudCore>,
 }
 
-#[async_trait]
 impl Accessor for PcloudBackend {
     type Reader = PcloudReader;
     type Writer = PcloudWriters;

--- a/core/src/services/persy/backend.rs
+++ b/core/src/services/persy/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::str;
 
-use async_trait::async_trait;
 use persy;
 use tokio::task;
 
@@ -160,7 +159,6 @@ impl Debug for Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/postgresql/backend.rs
+++ b/core/src/services/postgresql/backend.rs
@@ -21,7 +21,6 @@ use std::fmt::Formatter;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bb8::Pool;
 use bb8_postgres::PostgresConnectionManager;
 use serde::Deserialize;
@@ -262,7 +261,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/redb/backend.rs
+++ b/core/src/services/redb/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use redb::ReadableTable;
 use tokio::task;
 
@@ -118,7 +117,6 @@ impl Debug for Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/redis/backend.rs
+++ b/core/src/services/redis/backend.rs
@@ -21,7 +21,6 @@ use std::fmt::Formatter;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use async_trait::async_trait;
 use http::Uri;
 use redis::aio::ConnectionManager;
 use redis::cluster::ClusterClient;
@@ -374,7 +373,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/rocksdb/backend.rs
+++ b/core/src/services/rocksdb/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use rocksdb::DB;
 use serde::Deserialize;
 use tokio::task;
@@ -110,7 +109,6 @@ impl Debug for Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -23,7 +23,6 @@ use std::str::FromStr;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use bytes::Buf;
@@ -1019,8 +1018,6 @@ pub struct S3Backend {
     core: Arc<S3Core>,
 }
 
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 impl Accessor for S3Backend {
     type Reader = S3Reader;
     type Writer = S3Writers;

--- a/core/src/services/seafile/backend.rs
+++ b/core/src/services/seafile/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use log::debug;
 use serde::Deserialize;
 use tokio::sync::RwLock;
@@ -253,7 +252,6 @@ pub struct SeafileBackend {
     core: Arc<SeafileCore>,
 }
 
-#[async_trait]
 impl Accessor for SeafileBackend {
     type Reader = SeafileReader;
     type Writer = SeafileWriters;

--- a/core/src/services/seafile/backend.rs
+++ b/core/src/services/seafile/backend.rs
@@ -314,7 +314,7 @@ impl Accessor for SeafileBackend {
     }
 
     async fn delete(&self, path: &str, _args: OpDelete) -> Result<RpDelete> {
-        let _ = self.core.delete(path).await?;
+        self.core.delete(path).await?;
 
         Ok(RpDelete::default())
     }

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -396,7 +396,7 @@ impl Accessor for SftpBackend {
             fs.set_cwd(&current);
         }
 
-        return Ok(RpCreateDir::default());
+        Ok(RpCreateDir::default())
     }
 
     async fn stat(&self, path: &str, _: OpStat) -> Result<RpStat> {

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -21,7 +21,6 @@ use std::fmt::Formatter;
 use std::path::Path;
 use std::path::PathBuf;
 
-use async_trait::async_trait;
 use bb8::PooledConnection;
 use bb8::RunError;
 use log::debug;
@@ -246,7 +245,7 @@ pub struct Manager {
     known_hosts_strategy: KnownHosts,
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl bb8::ManageConnection for Manager {
     type Connection = Sftp;
     type Error = Error;
@@ -342,7 +341,6 @@ impl SftpBackend {
     }
 }
 
-#[async_trait]
 impl Accessor for SftpBackend {
     type Reader = SftpReader;
     type Writer = SftpWriter;

--- a/core/src/services/sled/backend.rs
+++ b/core/src/services/sled/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::str;
 
-use async_trait::async_trait;
 use serde::Deserialize;
 use tokio::task;
 
@@ -155,7 +154,6 @@ impl Debug for Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/sqlite/backend.rs
+++ b/core/src/services/sqlite/backend.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use async_trait::async_trait;
 use rusqlite::params;
 use rusqlite::Connection;
 use serde::Deserialize;
@@ -252,7 +251,6 @@ impl Debug for Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/supabase/backend.rs
+++ b/core/src/services/supabase/backend.rs
@@ -18,7 +18,6 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use http::StatusCode;
 use log::debug;
 
@@ -155,7 +154,6 @@ pub struct SupabaseBackend {
     core: Arc<SupabaseCore>,
 }
 
-#[async_trait]
 impl Accessor for SupabaseBackend {
     type Reader = SupabaseReader;
     type Writer = oio::OneShotWriter<SupabaseWriter>;

--- a/core/src/services/surrealdb/backend.rs
+++ b/core/src/services/surrealdb/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use serde::Deserialize;
 use surrealdb::engine::any::Any;
 use surrealdb::opt::auth::Database;
@@ -317,7 +316,7 @@ impl Adapter {
             .map(|v| v.as_ref())
     }
 }
-#[async_trait]
+
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/swift/backend.rs
+++ b/core/src/services/swift/backend.rs
@@ -243,7 +243,7 @@ impl Accessor for SwiftBackend {
 
         let w = oio::OneShotWriter::new(writer);
 
-        return Ok((RpWrite::default(), w));
+        Ok((RpWrite::default(), w))
     }
 
     async fn delete(&self, path: &str, _args: OpDelete) -> Result<RpDelete> {

--- a/core/src/services/swift/backend.rs
+++ b/core/src/services/swift/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use http::StatusCode;
 use log::debug;
 
@@ -189,7 +188,6 @@ pub struct SwiftBackend {
     core: Arc<SwiftCore>,
 }
 
-#[async_trait]
 impl Accessor for SwiftBackend {
     type Reader = SwiftReader;
     type Writer = oio::OneShotWriter<SwiftWriter>;

--- a/core/src/services/tikv/backend.rs
+++ b/core/src/services/tikv/backend.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 
-use async_trait::async_trait;
 use serde::Deserialize;
 use tikv_client::Config;
 use tikv_client::RawClient;
@@ -216,7 +215,6 @@ impl Adapter {
     }
 }
 
-#[async_trait]
 impl kv::Adapter for Adapter {
     fn metadata(&self) -> kv::Metadata {
         kv::Metadata::new(

--- a/core/src/services/upyun/backend.rs
+++ b/core/src/services/upyun/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use http::StatusCode;
 use log::debug;
 use serde::Deserialize;
@@ -232,7 +231,6 @@ pub struct UpyunBackend {
     core: Arc<UpyunCore>,
 }
 
-#[async_trait]
 impl Accessor for UpyunBackend {
     type Reader = UpyunReader;
     type Writer = UpyunWriters;

--- a/core/src/services/vercel_artifacts/backend.rs
+++ b/core/src/services/vercel_artifacts/backend.rs
@@ -17,7 +17,6 @@
 
 use std::fmt::Debug;
 
-use async_trait::async_trait;
 use http::header;
 use http::Request;
 use http::Response;
@@ -44,7 +43,6 @@ impl Debug for VercelArtifactsBackend {
     }
 }
 
-#[async_trait]
 impl Accessor for VercelArtifactsBackend {
     type Reader = VercelArtifactsReader;
     type Writer = oio::OneShotWriter<VercelArtifactsWriter>;

--- a/core/src/services/vercel_blob/backend.rs
+++ b/core/src/services/vercel_blob/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::StatusCode;
 use log::debug;
@@ -178,7 +177,6 @@ pub struct VercelBlobBackend {
     core: Arc<VercelBlobCore>,
 }
 
-#[async_trait]
 impl Accessor for VercelBlobBackend {
     type Reader = VercelBlobReader;
     type Writer = VercelBlobWriters;

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -21,7 +21,6 @@ use std::fmt::Formatter;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use http::StatusCode;
 use log::debug;
 use serde::Deserialize;
@@ -236,7 +235,6 @@ impl Debug for WebdavBackend {
     }
 }
 
-#[async_trait]
 impl Accessor for WebdavBackend {
     type Reader = WebdavReader;
     type Writer = oio::OneShotWriter<WebdavWriter>;

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -18,7 +18,6 @@
 use core::fmt::Debug;
 use std::collections::HashMap;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
@@ -530,7 +529,6 @@ impl WebhdfsBackend {
     }
 }
 
-#[async_trait]
 impl Accessor for WebhdfsBackend {
     type Reader = WebhdfsReader;
     type Writer = WebhdfsWriters;

--- a/core/src/services/yandex_disk/backend.rs
+++ b/core/src/services/yandex_disk/backend.rs
@@ -20,7 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use bytes::Buf;
 use http::StatusCode;
 use log::debug;
@@ -178,7 +177,6 @@ pub struct YandexDiskBackend {
     core: Arc<YandexDiskCore>,
 }
 
-#[async_trait]
 impl Accessor for YandexDiskBackend {
     type Reader = YandexDiskReader;
     type Writer = YandexDiskWriters;

--- a/core/src/types/list.rs
+++ b/core/src/types/list.rs
@@ -178,7 +178,7 @@ impl Stream for Lister {
                             } else {
                                 let acc = self.acc.clone();
                                 let fut = async move {
-                                    let res = acc.stat_dyn(&path, OpStat::default()).await;
+                                    let res = acc.stat(&path, OpStat::default()).await;
                                     (path, res.map(|rp| rp.into_metadata()))
                                 };
                                 self.tasks.push_back(StatTask::Stating(Box::pin(fut)));

--- a/core/src/types/list.rs
+++ b/core/src/types/list.rs
@@ -178,7 +178,7 @@ impl Stream for Lister {
                             } else {
                                 let acc = self.acc.clone();
                                 let fut = async move {
-                                    let res = acc.stat(&path, OpStat::default()).await;
+                                    let res = acc.stat_dyn(&path, OpStat::default()).await;
                                     (path, res.map(|rp| rp.into_metadata()))
                                 };
                                 self.tasks.push_back(StatTask::Stating(Box::pin(fut)));


### PR DESCRIPTION
This PR removes `async_trait` for `Accessor` and two kv adapters (`raw::adapters::{kv::Adapter, typed_kv::Adapter}`), and add `AccessorDyn` so that `FusedAccessor` now becomes `Arc<dyn AccessorDyn>`.