### PR TITLE
feat: add checksums to MultiPartComplete

### DIFF
--- a/core/src/raw/oio/write/multipart_write.rs
+++ b/core/src/raw/oio/write/multipart_write.rs
@@ -108,12 +108,15 @@ pub trait MultipartWrite: Send + Sync + Unpin + 'static {
 ///
 /// - `part_number` is the index of the part, starting from 0.
 /// - `etag` is the `ETag` of the part.
+/// - `checksum` is the optional checksum of the part.
 #[derive(Clone)]
 pub struct MultipartPart {
     /// The number of the part, starting from 0.
     pub part_number: usize,
     /// The etag of the part.
     pub etag: String,
+    /// The checksum of the part.
+    pub checksum: Option<String>
 }
 
 /// WritePartResult is the result returned by [`WritePartFuture`].
@@ -381,6 +384,7 @@ mod tests {
             Ok(MultipartPart {
                 part_number,
                 etag: "etag".to_string(),
+                checksum: None,
             })
         }
 

--- a/core/src/raw/oio/write/multipart_write.rs
+++ b/core/src/raw/oio/write/multipart_write.rs
@@ -116,7 +116,7 @@ pub struct MultipartPart {
     /// The etag of the part.
     pub etag: String,
     /// The checksum of the part.
-    pub checksum: Option<String>
+    pub checksum: Option<String>,
 }
 
 /// WritePartResult is the result returned by [`WritePartFuture`].

--- a/core/src/services/b2/writer.rs
+++ b/core/src/services/b2/writer.rs
@@ -106,6 +106,7 @@ impl oio::MultipartWrite for B2Writer {
                 Ok(oio::MultipartPart {
                     etag: result.content_sha1,
                     part_number,
+                    checksum: None,
                 })
             }
             _ => Err(parse_error(resp).await?),

--- a/core/src/services/cos/writer.rs
+++ b/core/src/services/cos/writer.rs
@@ -111,7 +111,11 @@ impl oio::MultipartWrite for CosWriter {
                     })?
                     .to_string();
 
-                Ok(oio::MultipartPart { part_number, etag })
+                Ok(oio::MultipartPart {
+                    part_number,
+                    etag,
+                    checksum: None,
+                })
             }
             _ => Err(parse_error(resp).await?),
         }

--- a/core/src/services/obs/writer.rs
+++ b/core/src/services/obs/writer.rs
@@ -112,7 +112,11 @@ impl oio::MultipartWrite for ObsWriter {
                     })?
                     .to_string();
 
-                Ok(MultipartPart { part_number, etag })
+                Ok(MultipartPart {
+                    part_number,
+                    etag,
+                    checksum: None,
+                })
             }
             _ => Err(parse_error(resp).await?),
         }

--- a/core/src/services/oss/writer.rs
+++ b/core/src/services/oss/writer.rs
@@ -117,7 +117,11 @@ impl oio::MultipartWrite for OssWriter {
                     })?
                     .to_string();
 
-                Ok(oio::MultipartPart { part_number, etag })
+                Ok(oio::MultipartPart {
+                    part_number,
+                    etag,
+                    checksum: None,
+                })
             }
             _ => Err(parse_error(resp).await?),
         }

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -800,7 +800,7 @@ pub struct CompleteMultipartUploadRequestPart {
     /// ref: <https://github.com/tafia/quick-xml/issues/362>
     #[serde(rename = "ETag")]
     pub etag: String,
-    #[serde(rename = "ChecksumCRC32C")]
+    #[serde(rename = "ChecksumCRC32C", skip_serializing_if = "Option::is_none")]
     pub checksum_crc32c: Option<String>,
 }
 

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -447,7 +447,7 @@ impl S3Core {
         if let Some(checksum) = self.calculate_checksum(&body) {
             // Set Checksum header.
             req = self.insert_checksum_header(req, &checksum);
-        }   
+        }
 
         // Set body
         let req = req.body(body).map_err(new_request_build_error)?;
@@ -631,7 +631,7 @@ impl S3Core {
         part_number: usize,
         size: u64,
         body: Buffer,
-        checksum: Option<String>
+        checksum: Option<String>,
     ) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
@@ -654,7 +654,7 @@ impl S3Core {
             // Set Checksum header.
             req = self.insert_checksum_header(req, &checksum);
         }
-        
+
         // Set body
         let req = req.body(body).map_err(new_request_build_error)?;
 
@@ -801,7 +801,7 @@ pub struct CompleteMultipartUploadRequestPart {
     #[serde(rename = "ETag")]
     pub etag: String,
     #[serde(rename = "ChecksumCRC32C")]
-    pub checksum_crc32c: Option<String>  
+    pub checksum_crc32c: Option<String>,
 }
 
 /// Request of DeleteObjects.

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -250,21 +250,23 @@ impl S3Core {
 
         req
     }
-
+    pub fn calculate_checksum(&self, body: &Buffer) -> Option<String> {
+        match self.checksum_algorithm {
+            None => None,
+            Some(ChecksumAlgorithm::Crc32c) => {
+                let mut crc = 0u32;
+                body.clone()
+                    .for_each(|b| crc = crc32c::crc32c_append(crc, &b));
+                Some(BASE64_STANDARD.encode(crc.to_be_bytes()))
+            }
+        }
+    }
     pub fn insert_checksum_header(
         &self,
         mut req: http::request::Builder,
-        body: &Buffer,
+        checksum: &str,
     ) -> http::request::Builder {
         if let Some(checksum_algorithm) = self.checksum_algorithm.as_ref() {
-            let checksum = match checksum_algorithm {
-                ChecksumAlgorithm::Crc32c => {
-                    let mut crc = 0u32;
-                    body.clone()
-                        .for_each(|b| crc = crc32c::crc32c_append(crc, &b));
-                    BASE64_STANDARD.encode(crc.to_be_bytes())
-                }
-            };
             req = req.header(checksum_algorithm.to_header_name(), checksum);
         }
         req
@@ -441,8 +443,11 @@ impl S3Core {
         // Set SSE headers.
         req = self.insert_sse_headers(req, true);
 
-        // Set Checksum header.
-        req = self.insert_checksum_header(req, &body);
+        // Calculate Checksum.
+        if let Some(checksum) = self.calculate_checksum(&body) {
+            // Set Checksum header.
+            req = self.insert_checksum_header(req, &checksum);
+        }   
 
         // Set body
         let req = req.body(body).map_err(new_request_build_error)?;
@@ -626,6 +631,7 @@ impl S3Core {
         part_number: usize,
         size: u64,
         body: Buffer,
+        checksum: Option<String>
     ) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
@@ -644,9 +650,11 @@ impl S3Core {
         // Set SSE headers.
         req = self.insert_sse_headers(req, true);
 
-        // Set Checksum header.
-        req = self.insert_checksum_header(req, &body);
-
+        if let Some(checksum) = checksum {
+            // Set Checksum header.
+            req = self.insert_checksum_header(req, &checksum);
+        }
+        
         // Set body
         let req = req.body(body).map_err(new_request_build_error)?;
 
@@ -792,6 +800,8 @@ pub struct CompleteMultipartUploadRequestPart {
     /// ref: <https://github.com/tafia/quick-xml/issues/362>
     #[serde(rename = "ETag")]
     pub etag: String,
+    #[serde(rename = "ChecksumCRC32C")]
+    pub checksum_crc32c: Option<String>  
 }
 
 /// Request of DeleteObjects.
@@ -921,14 +931,17 @@ mod tests {
                 CompleteMultipartUploadRequestPart {
                     part_number: 1,
                     etag: "\"a54357aff0632cce46d942af68356b38\"".to_string(),
+                    ..Default::default()
                 },
                 CompleteMultipartUploadRequestPart {
                     part_number: 2,
                     etag: "\"0c78aef83f66abc1fa1e8477f296d394\"".to_string(),
+                    ..Default::default()
                 },
                 CompleteMultipartUploadRequestPart {
                     part_number: 3,
                     etag: "\"acbd18db4cc2f85cedef654fccc4a4d8\"".to_string(),
+                    ..Default::default()
                 },
             ],
         };

--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -95,9 +95,14 @@ impl oio::MultipartWrite for S3Writer {
 
         let checksum = self.core.calculate_checksum(&body);
 
-        let mut req =
-            self.core
-                .s3_upload_part_request(&self.path, upload_id, part_number, size, body, checksum.clone())?;
+        let mut req = self.core.s3_upload_part_request(
+            &self.path,
+            upload_id,
+            part_number,
+            size,
+            body,
+            checksum.clone(),
+        )?;
 
         self.core.sign(&mut req).await?;
 
@@ -116,7 +121,11 @@ impl oio::MultipartWrite for S3Writer {
                     })?
                     .to_string();
 
-                Ok(oio::MultipartPart { part_number, etag, checksum})
+                Ok(oio::MultipartPart {
+                    part_number,
+                    etag,
+                    checksum,
+                })
             }
             _ => Err(parse_error(resp).await?),
         }

--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -145,7 +145,6 @@ impl oio::MultipartWrite for S3Writer {
                         part_number: p.part_number,
                         etag: p.etag.clone(),
                         checksum_crc32c: p.checksum.clone(),
-                        ..Default::default()
                     },
                 },
             })

--- a/core/src/services/upyun/writer.rs
+++ b/core/src/services/upyun/writer.rs
@@ -98,6 +98,7 @@ impl oio::MultipartWrite for UpyunWriter {
             StatusCode::NO_CONTENT | StatusCode::CREATED => Ok(oio::MultipartPart {
                 part_number,
                 etag: "".to_string(),
+                checksum: None,
             }),
             _ => Err(parse_error(resp).await?),
         }

--- a/core/src/services/vercel_blob/writer.rs
+++ b/core/src/services/vercel_blob/writer.rs
@@ -106,6 +106,7 @@ impl oio::MultipartWrite for VercelBlobWriter {
                 Ok(oio::MultipartPart {
                     part_number,
                     etag: resp.etag,
+                    checksum: None,
                 })
             }
             _ => Err(parse_error(resp).await?),


### PR DESCRIPTION
There was an issue with checksums missing in the `Part`s in [CompleteMultipartUpload](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html). 

The resulting error message was: 

> The upload was created using a crc32c checksum. The complete request must include the checksum for each part. It was missing for part 1 in the request.

I initially missed this because it does not appear to be a problem for very large files.

This PR should address that problem. 