### PR TITLE
fix(devcontainer/post_create.sh): change pnpm@stable to pnpm@latest

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -33,7 +33,7 @@ sudo apt install -y python3-dev python3-pip python3-venv
 # Setup for nodejs binding
 curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && sudo apt-get install -y nodejs
 sudo corepack enable
-corepack prepare pnpm@stable --activate
+corepack prepare pnpm@latest --activate
 
 # Setup for java binding
 sudo apt install -y default-jdk


### PR DESCRIPTION
#4583 change `corepack prepare pnpm@stable --activate` to `corepack prepare pnpm@latest --activate`, while the former will get `Usage Error: Tag not found (stable)`.