### PR TITLE
feat(services/aliyun-drive): support AliyunDrive

### DIFF
--- a/.github/services/aliyun_drive/aliyun_drive/disabled_action.yml
+++ b/.github/services/aliyun_drive/aliyun_drive/disabled_action.yml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: aliyun_drive
+description: 'Behavior test for Aliyun Drive'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup
+      uses: 1password/load-secrets-action@v1
+      with:
+        export-env: true
+      env:
+        OPENDAL_ALIYUN_DRIVE_ROOT: op://services/aliyun_drive/root
+        OPENDAL_ALIYUN_DRIVE_REFRESH_TOKEN: op://services/aliyun_drive/refresh_token
+        OPENDAL_ALIYUN_DRIVE_CLIENT_ID: op://services/aliyun_drive/client_id
+        OPENDAL_ALIYUN_DRIVE_CLIENT_SECRET: op://services/aliyun_drive/client_secret

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -188,6 +188,7 @@ services-vercel-blob = []
 services-webdav = []
 services-webhdfs = []
 services-yandex-disk = []
+services-aliyun-drive = ["dep:sha1"]
 
 [lib]
 bench = false

--- a/core/src/services/aliyun_drive/backend.rs
+++ b/core/src/services/aliyun_drive/backend.rs
@@ -1,0 +1,471 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+use bytes::Buf;
+use chrono::Utc;
+use log::debug;
+use serde::Deserialize;
+use tokio::sync::Mutex;
+
+use super::core::*;
+use super::lister::AliyunDriveLister;
+use super::lister::AliyunDriveParent;
+use super::reader::AliyunDriveReader;
+use super::writer::{AliyunDriveWriter, AliyunDriveWriters};
+use crate::raw::*;
+use crate::*;
+
+/// Aliyun Drive services support.
+#[derive(Default, Deserialize)]
+#[serde(default)]
+#[non_exhaustive]
+pub struct AliyunDriveConfig {
+    /// root of this backend.
+    ///
+    /// All operations will happen under this root.
+    ///
+    /// default to `/` if not set.
+    pub root: Option<String>,
+    /// client_id of this backend.
+    ///
+    /// required.
+    pub client_id: String,
+    /// client_secret of this backend.
+    ///
+    /// required.
+    pub client_secret: String,
+    /// refresh_token of this backend.
+    ///
+    /// required.
+    pub refresh_token: String,
+    /// drive_type of this backend.
+    ///
+    /// All operations will happen under this type of drive.
+    ///
+    /// Available values are `default`, `backup` and `resource`.
+    ///
+    /// Fallback to default if not set or no other drives can be found.
+    pub drive_type: String,
+    /// rapid_upload of this backend.
+    ///
+    /// Skip uploading files that are already in the drive by hashing their content.
+    ///
+    /// Only works under the write_once operation.
+    pub rapid_upload: bool,
+}
+
+impl Debug for AliyunDriveConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("AliyunDriveConfig");
+
+        d.field("root", &self.root)
+            .field("drive_type", &self.drive_type);
+
+        d.finish_non_exhaustive()
+    }
+}
+
+#[doc = include_str!("docs.md")]
+#[derive(Default)]
+pub struct AliyunDriveBuilder {
+    config: AliyunDriveConfig,
+
+    http_client: Option<HttpClient>,
+}
+
+impl Debug for AliyunDriveBuilder {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("AliyunDriveBuilder");
+
+        d.field("config", &self.config);
+        d.finish_non_exhaustive()
+    }
+}
+
+impl AliyunDriveBuilder {
+    /// Set root of this backend.
+    ///
+    /// All operations will happen under this root.
+    pub fn root(&mut self, root: &str) -> &mut Self {
+        self.config.root = if root.is_empty() {
+            None
+        } else {
+            Some(root.to_string())
+        };
+
+        self
+    }
+
+    /// Set client_id of this backend.
+    pub fn client_id(&mut self, client_id: &str) -> &mut Self {
+        self.config.client_id = client_id.to_string();
+
+        self
+    }
+
+    /// Set client_secret of this backend.
+    pub fn client_secret(&mut self, client_secret: &str) -> &mut Self {
+        self.config.client_secret = client_secret.to_string();
+
+        self
+    }
+
+    /// Set refresh_token of this backend.
+    pub fn refresh_token(&mut self, refresh_token: &str) -> &mut Self {
+        self.config.refresh_token = refresh_token.to_string();
+
+        self
+    }
+
+    /// Set drive_type of this backend.
+    pub fn drive_type(&mut self, drive_type: &str) -> &mut Self {
+        self.config.drive_type = drive_type.to_string();
+
+        self
+    }
+
+    /// Set rapid_upload of this backend.
+    pub fn rapid_upload(&mut self, rapid_upload: bool) -> &mut Self {
+        self.config.rapid_upload = rapid_upload;
+
+        self
+    }
+
+    /// Specify the http client that used by this service.
+    ///
+    /// # Notes
+    ///
+    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
+    /// during minor updates.
+    pub fn http_client(&mut self, client: HttpClient) -> &mut Self {
+        self.http_client = Some(client);
+        self
+    }
+}
+
+impl Builder for AliyunDriveBuilder {
+    const SCHEME: Scheme = Scheme::AliyunDrive;
+
+    type Accessor = AliyunDriveBackend;
+
+    fn from_map(map: std::collections::HashMap<String, String>) -> Self {
+        let config = AliyunDriveConfig::deserialize(ConfigDeserializer::new(map))
+            .expect("config deserialize must succeed");
+        AliyunDriveBuilder {
+            config,
+
+            http_client: None,
+        }
+    }
+
+    fn build(&mut self) -> Result<Self::Accessor> {
+        debug!("backend build started: {:?}", &self);
+
+        let root = normalize_root(&self.config.root.clone().unwrap_or_default());
+        debug!("backend use root {}", &root);
+
+        let client = if let Some(client) = self.http_client.take() {
+            client
+        } else {
+            HttpClient::new().map_err(|err| {
+                err.with_operation("Builder::build")
+                    .with_context("service", Scheme::AliyunDrive)
+            })?
+        };
+
+        let client_id = self.config.client_id.clone();
+        if client_id.is_empty() {
+            return Err(
+                Error::new(ErrorKind::ConfigInvalid, "client_id is missing.")
+                    .with_operation("Builder::build")
+                    .with_context("service", Scheme::AliyunDrive),
+            );
+        }
+
+        let client_secret = self.config.client_secret.clone();
+        if client_secret.is_empty() {
+            return Err(
+                Error::new(ErrorKind::ConfigInvalid, "client_secret is missing.")
+                    .with_operation("Builder::build")
+                    .with_context("service", Scheme::AliyunDrive),
+            );
+        }
+
+        let refresh_token = self.config.refresh_token.clone();
+        if refresh_token.is_empty() {
+            return Err(
+                Error::new(ErrorKind::ConfigInvalid, "refresh_token is missing.")
+                    .with_operation("Builder::build")
+                    .with_context("service", Scheme::AliyunDrive),
+            );
+        }
+
+        let drive_type = match self.config.drive_type.as_str() {
+            "" | "default" => DriveType::Default,
+            "resource" => DriveType::Resource,
+            "backup" => DriveType::Backup,
+            _ => {
+                return Err(Error::new(
+                    ErrorKind::ConfigInvalid,
+                    "drive_type is invalid.",
+                ))
+            }
+        };
+        debug!("backend use drive_type {:?}", drive_type);
+
+        let rapid_upload = self.config.rapid_upload;
+        debug!("backend use rapid_upload {}", rapid_upload);
+
+        Ok(AliyunDriveBackend {
+            core: Arc::new(AliyunDriveCore {
+                endpoint: "https://openapi.alipan.com".to_string(),
+                root,
+                client_id,
+                client_secret,
+                drive_type,
+                rapid_upload,
+                signer: Arc::new(Mutex::new(AliyunDriveSigner {
+                    drive_id: None,
+                    access_token: None,
+                    refresh_token,
+                    expire_at: 0,
+                })),
+                client,
+            }),
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AliyunDriveBackend {
+    core: Arc<AliyunDriveCore>,
+}
+
+impl Access for AliyunDriveBackend {
+    type Reader = AliyunDriveReader;
+    type Writer = AliyunDriveWriters;
+    type Lister = oio::PageLister<AliyunDriveLister>;
+    type BlockingReader = ();
+    type BlockingWriter = ();
+    type BlockingLister = ();
+
+    fn info(&self) -> AccessorInfo {
+        let mut am = AccessorInfo::default();
+        am.set_scheme(Scheme::AliyunDrive)
+            .set_root(&self.core.root)
+            .set_native_capability(Capability {
+                stat: true,
+                create_dir: true,
+                read: true,
+                write: true,
+                write_can_multi: true,
+                // The min multipart size of AliyunDrive is 100 KiB.
+                write_multi_min_size: Some(100 * 1024),
+                // The max multipart size of AliyunDrive is 5 GiB.
+                write_multi_max_size: Some(5 * 1024 * 1024 * 1024),
+                delete: true,
+                copy: true,
+                rename: true,
+                list: true,
+                list_with_limit: true,
+
+                ..Default::default()
+            });
+        am
+    }
+
+    async fn create_dir(&self, path: &str, _args: OpCreateDir) -> Result<RpCreateDir> {
+        self.core.ensure_dir_exists(path).await?;
+
+        Ok(RpCreateDir::default())
+    }
+
+    async fn rename(&self, from: &str, to: &str, _args: OpRename) -> Result<RpRename> {
+        if from == to {
+            return Ok(RpRename::default());
+        }
+        let res = self.core.get_by_path(from).await?;
+        let file: AliyunDriveFile =
+            serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
+        // rename can overwrite.
+        match self.core.get_by_path(to).await {
+            Err(err) if err.kind() == ErrorKind::NotFound => {}
+            Err(err) => return Err(err),
+            Ok(res) => {
+                let file: AliyunDriveFile =
+                    serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
+                self.core.delete_path(&file.file_id).await?;
+            }
+        };
+
+        let parent_file_id = self.core.ensure_dir_exists(get_parent(to)).await?;
+        self.core.move_path(&file.file_id, &parent_file_id).await?;
+
+        let from_name = get_basename(from);
+        let to_name = get_basename(to);
+
+        if from_name != to_name {
+            self.core.update_path(&file.file_id, to_name).await?;
+        }
+
+        Ok(RpRename::default())
+    }
+
+    async fn copy(&self, from: &str, to: &str, _args: OpCopy) -> Result<RpCopy> {
+        if from == to {
+            return Ok(RpCopy::default());
+        }
+        let res = self.core.get_by_path(from).await?;
+        let file: AliyunDriveFile =
+            serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
+        // copy can overwrite.
+        match self.core.get_by_path(to).await {
+            Err(err) if err.kind() == ErrorKind::NotFound => {}
+            Err(err) => return Err(err),
+            Ok(res) => {
+                let file: AliyunDriveFile =
+                    serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
+                self.core.delete_path(&file.file_id).await?;
+            }
+        };
+        // there is no direct copy in AliyunDrive.
+        // so we need to copy the path first and then rename it.
+        let parent_path = get_parent(to);
+        let parent_file_id = self.core.ensure_dir_exists(parent_path).await?;
+
+        // if from and to are going to be placed in the same folder
+        // copy_path will fail as we cannot change name during this action.
+        // it has to be auto renamed.
+        let auto_rename = file.parent_file_id == parent_file_id;
+        let res = self
+            .core
+            .copy_path(&file.file_id, &parent_file_id, auto_rename)
+            .await?;
+        let file: CopyResponse =
+            serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
+        let file_id = file.file_id;
+
+        let from_name = get_basename(from);
+        let to_name = get_basename(to);
+
+        if from_name != to_name {
+            self.core.update_path(&file_id, to_name).await?;
+        }
+
+        Ok(RpCopy::default())
+    }
+
+    async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {
+        let res = self.core.get_by_path(path).await?;
+        let file: AliyunDriveFile =
+            serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
+
+        if file.path_type == "folder" {
+            let meta = Metadata::new(EntryMode::DIR).with_last_modified(
+                file.updated_at
+                    .parse::<chrono::DateTime<Utc>>()
+                    .map_err(|e| {
+                        Error::new(ErrorKind::Unexpected, "parse last modified time").set_source(e)
+                    })?,
+            );
+
+            return Ok(RpStat::new(meta));
+        }
+
+        let mut meta = Metadata::new(EntryMode::FILE).with_last_modified(
+            file.updated_at
+                .parse::<chrono::DateTime<Utc>>()
+                .map_err(|e| {
+                    Error::new(ErrorKind::Unexpected, "parse last modified time").set_source(e)
+                })?,
+        );
+        if let Some(v) = file.size {
+            meta = meta.with_content_length(v);
+        }
+        if let Some(v) = file.content_type {
+            meta = meta.with_content_type(v);
+        }
+
+        Ok(RpStat::new(meta))
+    }
+
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        let res = self.core.get_by_path(path).await?;
+        let file: AliyunDriveFile =
+            serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
+
+        let Some(size) = file.size else {
+            return Err(Error::new(ErrorKind::Unexpected, "cannot get file size"));
+        };
+
+        let download_url = self.core.get_download_url(&file.file_id).await?;
+
+        Ok((
+            RpRead::default(),
+            AliyunDriveReader::new(self.core.clone(), &download_url, size, args),
+        ))
+    }
+
+    async fn delete(&self, path: &str, _args: OpDelete) -> Result<RpDelete> {
+        let res = match self.core.get_by_path(path).await {
+            Ok(output) => Some(output),
+            Err(err) if err.kind() == ErrorKind::NotFound => None,
+            Err(err) => return Err(err),
+        };
+        if let Some(res) = res {
+            let file: AliyunDriveFile =
+                serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
+            self.core.delete_path(&file.file_id).await?;
+        }
+        Ok(RpDelete::default())
+    }
+
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
+        let parent = match self.core.get_by_path(path).await {
+            Err(err) if err.kind() == ErrorKind::NotFound => None,
+            Err(err) => return Err(err),
+            Ok(res) => {
+                let file: AliyunDriveFile =
+                    serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
+                Some(AliyunDriveParent {
+                    parent_path: path.to_string(),
+                    parent_file_id: file.file_id,
+                })
+            }
+        };
+
+        let l = AliyunDriveLister::new(self.core.clone(), parent, args.limit());
+
+        Ok((RpList::default(), oio::PageLister::new(l)))
+    }
+
+    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
+        let parent_path = get_parent(path);
+        let parent_file_id = self.core.ensure_dir_exists(parent_path).await?;
+
+        let writer =
+            AliyunDriveWriter::new(self.core.clone(), &parent_file_id, get_basename(path), args);
+
+        let w = oio::MultipartWriter::new(writer, 1);
+
+        Ok((RpWrite::default(), w))
+    }
+}

--- a/core/src/services/aliyun_drive/docs.md
+++ b/core/src/services/aliyun_drive/docs.md
@@ -1,0 +1,65 @@
+## Capabilities
+
+This service can be used to:
+
+- [x] stat
+- [x] read
+- [x] write
+- [x] create_dir
+- [x] delete
+- [x] copy
+- [x] rename
+- [x] list
+- [ ] presign
+- [ ] blocking
+
+## Configuration
+
+- `root`: Set the work dir for backend.
+- `client_id`: Set the client_id for backend.
+- `client_secret`: Set the client_secret for backend.
+- `refresh_token`: Set the refresh_token for backend.
+- `drive_type`: Set the drive_type for backend.
+- `rapid_upload`: Set the rapid_upload for backend.
+
+Refer to [`AliyunDriveBuilder`]`s  public API docs for more information.
+
+## Example
+
+### Basic Setup
+
+```rust,no_run
+use std::sync::Arc;
+
+use anyhow::Result;
+use opendal::services::AliyunDrive;
+use opendal::Operator;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Create aliyun-drive backend builder.
+    let mut builder = AliyunDrive::default();
+    // Set the root for aliyun-drive, all operations will happen under this root.
+    //
+    // NOTE: the root must be absolute path.
+    builder.root("/path/to/dir");
+    // Set the client_id. This is required.
+    builder.client_id("client_id");
+    // Set the client_secret. This is required.
+    builder.client_secret("client_secret");
+    // Set the refresh_token. This is required.
+    builder.refresh_token("refresh_token");
+    // Set the drive_type. This is required.
+    //
+    // Fallback to the default type if no other types found.
+    builder.drive_type("resource");
+    // Set the rapid_upload.
+    //
+    // Works only under the write_once operation for now.
+    builder.rapid_upload(true);
+
+    let op: Operator = Operator::new(builder)?.finish();
+
+    Ok(())
+}
+```

--- a/core/src/services/aliyun_drive/error.rs
+++ b/core/src/services/aliyun_drive/error.rs
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use bytes::Buf;
+use http::Response;
+use serde::Deserialize;
+
+use crate::*;
+
+#[derive(Default, Debug, Deserialize)]
+pub struct AliyunDriveError {
+    code: String,
+    message: String,
+}
+
+pub async fn parse_error(res: Response<Buffer>) -> Result<Error> {
+    let (parts, mut body) = res.into_parts();
+    let bs = body.copy_to_bytes(body.remaining());
+    let (code, message) = serde_json::from_reader::<_, AliyunDriveError>(bs.clone().reader())
+        .map(|err| (Some(err.code), err.message))
+        .unwrap_or((None, String::from_utf8_lossy(&bs).into_owned()));
+    let (kind, retryable) = match parts.status.as_u16() {
+        403 => (ErrorKind::PermissionDenied, false),
+        400 => match code {
+            Some(code) if code == "NotFound.File" => (ErrorKind::NotFound, false),
+            Some(code) if code == "AlreadyExist.File" => (ErrorKind::AlreadyExists, false),
+            Some(code) if code == "PreHashMatched" => (ErrorKind::IsSameFile, false),
+            _ => (ErrorKind::Unexpected, false),
+        },
+        429 => match code {
+            Some(code) if code == "TooManyRequests" => (ErrorKind::RateLimited, true),
+            _ => (ErrorKind::Unexpected, false),
+        },
+        _ => (ErrorKind::Unexpected, false),
+    };
+    let mut err = Error::new(kind, &message);
+    if retryable {
+        err = err.set_temporary();
+    }
+    Ok(err)
+}

--- a/core/src/services/aliyun_drive/lister.rs
+++ b/core/src/services/aliyun_drive/lister.rs
@@ -1,0 +1,152 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use bytes::Buf;
+use chrono::Utc;
+
+use crate::raw::*;
+use crate::EntryMode;
+use crate::Error;
+use crate::ErrorKind;
+use crate::Metadata;
+use crate::Result;
+
+use self::oio::Entry;
+
+use super::core::AliyunDriveCore;
+use super::core::AliyunDriveFile;
+use super::core::AliyunDriveFileList;
+
+pub struct AliyunDriveLister {
+    core: Arc<AliyunDriveCore>,
+
+    parent: Option<AliyunDriveParent>,
+    limit: Option<usize>,
+}
+
+pub struct AliyunDriveParent {
+    pub parent_path: String,
+    pub parent_file_id: String,
+}
+
+impl AliyunDriveLister {
+    pub fn new(
+        core: Arc<AliyunDriveCore>,
+        parent: Option<AliyunDriveParent>,
+        limit: Option<usize>,
+    ) -> Self {
+        AliyunDriveLister {
+            core,
+            parent,
+            limit,
+        }
+    }
+}
+
+impl oio::PageList for AliyunDriveLister {
+    async fn next_page(&self, ctx: &mut oio::PageContext) -> Result<()> {
+        let Some(parent) = &self.parent else {
+            ctx.done = true;
+            return Ok(());
+        };
+
+        let offset = if ctx.token.is_empty() {
+            None
+        } else {
+            Some(ctx.token.clone())
+        };
+
+        let res = self
+            .core
+            .list(&parent.parent_file_id, self.limit, offset)
+            .await;
+        let res = match res {
+            Err(err) if err.kind() == ErrorKind::NotFound => {
+                ctx.done = true;
+                None
+            }
+            Err(err) => return Err(err),
+            Ok(res) => Some(res),
+        };
+
+        let Some(res) = res else {
+            return Ok(());
+        };
+
+        let result: AliyunDriveFileList =
+            serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
+
+        let n = result.items.len();
+
+        for item in result.items {
+            let res = self.core.get(&item.file_id).await?;
+            let file: AliyunDriveFile =
+                serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
+
+            let path = if parent.parent_path.starts_with('/') {
+                build_abs_path(&parent.parent_path, &file.name)
+            } else {
+                build_abs_path(&format!("/{}", &parent.parent_path), &file.name)
+            };
+
+            let (path, md) = if file.path_type == "folder" {
+                let path = format!("{}/", path);
+                let meta = Metadata::new(EntryMode::DIR).with_last_modified(
+                    file.updated_at
+                        .parse::<chrono::DateTime<Utc>>()
+                        .map_err(|e| {
+                            Error::new(ErrorKind::Unexpected, "parse last modified time")
+                                .set_source(e)
+                        })?,
+                );
+                (path, meta)
+            } else {
+                let mut meta = Metadata::new(EntryMode::FILE).with_last_modified(
+                    file.updated_at
+                        .parse::<chrono::DateTime<Utc>>()
+                        .map_err(|e| {
+                            Error::new(ErrorKind::Unexpected, "parse last modified time")
+                                .set_source(e)
+                        })?,
+                );
+                if let Some(v) = file.size {
+                    meta = meta.with_content_length(v);
+                }
+                if let Some(v) = file.content_type {
+                    meta = meta.with_content_type(v);
+                }
+                (path, meta)
+            };
+
+            ctx.entries.push_back(Entry::new(&path, md));
+        }
+
+        if self.limit.is_some_and(|x| x < n) || result.next_marker.is_none() {
+            ctx.done = true;
+        }
+
+        if let Some(marker) = result.next_marker {
+            if marker.is_empty() {
+                ctx.done = true;
+            }
+            ctx.token = marker;
+        }
+        Ok(())
+    }
+}

--- a/core/src/services/aliyun_drive/mod.rs
+++ b/core/src/services/aliyun_drive/mod.rs
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+mod backend;
+mod error;
+mod lister;
+mod reader;
+mod writer;
+pub use backend::AliyunDriveBuilder as AliyunDrive;
+pub use backend::AliyunDriveConfig;
+
+mod core;

--- a/core/src/services/aliyun_drive/reader.rs
+++ b/core/src/services/aliyun_drive/reader.rs
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use http::{header, Request, StatusCode};
+
+use crate::raw::*;
+use crate::*;
+
+use super::core::AliyunDriveCore;
+use super::error::parse_error;
+
+pub struct AliyunDriveReader {
+    core: Arc<AliyunDriveCore>,
+
+    download_url: String,
+    size: u64,
+    _op: OpRead,
+}
+
+impl AliyunDriveReader {
+    pub fn new(core: Arc<AliyunDriveCore>, download_url: &str, size: u64, op: OpRead) -> Self {
+        AliyunDriveReader {
+            core,
+            download_url: download_url.to_string(),
+            size,
+            _op: op,
+        }
+    }
+}
+
+impl oio::Read for AliyunDriveReader {
+    async fn read_at(&self, offset: u64, limit: usize) -> Result<Buffer> {
+        // AliyunDrive responds with status OK even if the range is not statisfiable.
+        // and then the whole file will be read.
+        let limit = if offset >= self.size {
+            return Ok(Buffer::new());
+        } else if offset + (limit as u64) - 1 > self.size {
+            self.size - offset
+        } else {
+            limit as u64
+        };
+        let range = BytesRange::new(offset, Some(limit));
+        let req = Request::get(self.download_url.as_str())
+            .header(header::RANGE, range.to_header())
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+        let res = self.core.client.send(req).await?;
+        let status = res.status();
+        match status {
+            StatusCode::OK => Ok(Buffer::new()),
+            StatusCode::PARTIAL_CONTENT => Ok(res.into_body()),
+            _ => Err(parse_error(res).await?),
+        }
+    }
+}

--- a/core/src/services/aliyun_drive/writer.rs
+++ b/core/src/services/aliyun_drive/writer.rs
@@ -1,0 +1,272 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use base64::engine::general_purpose;
+use base64::Engine;
+use bytes::Buf;
+
+use md5::{Digest, Md5};
+use sha1::Sha1;
+use tokio::sync::RwLock;
+
+use crate::raw::*;
+use crate::services::aliyun_drive::core::{CheckNameMode, CreateResponse, CreateType};
+use crate::*;
+
+use super::core::{AliyunDriveCore, RapidUpload, UploadUrlResponse};
+
+pub type AliyunDriveWriters = oio::MultipartWriter<AliyunDriveWriter>;
+
+pub struct AliyunDriveWriter {
+    core: Arc<AliyunDriveCore>,
+
+    _op: OpWrite,
+    parent_file_id: String,
+    name: String,
+
+    file_id: Arc<RwLock<Option<String>>>,
+}
+
+impl AliyunDriveWriter {
+    pub fn new(core: Arc<AliyunDriveCore>, parent_file_id: &str, name: &str, op: OpWrite) -> Self {
+        AliyunDriveWriter {
+            core,
+            _op: op,
+            parent_file_id: parent_file_id.to_string(),
+            name: name.to_string(),
+            file_id: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    async fn write_file_id(&self, id: String) {
+        let mut file_id = self.file_id.write().await;
+
+        *file_id = Some(id);
+    }
+
+    async fn read_file_id(&self) -> Result<String> {
+        let file_id = self.file_id.read().await;
+        let Some(ref file_id) = *file_id else {
+            return Err(Error::new(ErrorKind::Unexpected, "cannot find file_id"));
+        };
+
+        Ok(file_id.clone())
+    }
+
+    async fn get_rapid_upload(
+        &self,
+        size: Option<u64>,
+        body: Option<crate::Buffer>,
+        pre_hash: bool,
+    ) -> Result<Option<RapidUpload>> {
+        let Some(size) = size else {
+            return Ok(None);
+        };
+        let Some(body) = body else {
+            return Ok(None);
+        };
+        if pre_hash && size > 1024 * 100 {
+            return Ok(Some(RapidUpload {
+                pre_hash: Some(format!(
+                    "{:x}",
+                    Sha1::new_with_prefix(body.slice(0..1024).to_vec()).finalize()
+                )),
+                content_hash: None,
+                proof_code: None,
+            }));
+        }
+        let (token, _) = self.core.get_token_and_drive().await?;
+        let Ok(index) = u64::from_str_radix(
+            &format!("{:x}", Md5::new_with_prefix(token.unwrap()).finalize())[0..16],
+            16,
+        ) else {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "cannot parse hexadecimal",
+            ));
+        };
+        let size = size as usize;
+        let index = index as usize % size;
+        let (range_start, range_end) = if index + 8 > size {
+            (index, size)
+        } else {
+            (index, index + 8)
+        };
+
+        Ok(Some(RapidUpload {
+            pre_hash: None,
+            content_hash: Some(format!(
+                "{:x}",
+                Sha1::new_with_prefix(body.to_vec()).finalize()
+            )),
+            proof_code: Some(
+                general_purpose::STANDARD.encode(body.to_bytes().slice(range_start..range_end)),
+            ),
+        }))
+    }
+
+    async fn write(
+        &self,
+        size: Option<u64>,
+        body: Option<crate::Buffer>,
+        pre_hash: bool,
+        upload_url: Option<&str>,
+    ) -> Result<(bool, Option<String>)> {
+        if let Some(upload_url) = upload_url {
+            let Some(body) = body else {
+                return Err(Error::new(
+                    ErrorKind::Unexpected,
+                    "cannot upload without body",
+                ));
+            };
+            self.core.upload(upload_url, body).await?;
+            return Ok((false, None));
+        }
+
+        let res = self
+            .core
+            .create_with_rapid_upload(
+                Some(&self.parent_file_id),
+                &self.name,
+                CreateType::File,
+                CheckNameMode::Refuse,
+                size,
+                self.get_rapid_upload(size, body.clone(), pre_hash).await?,
+            )
+            .await;
+
+        let res = match res {
+            Err(err) if err.kind() == ErrorKind::IsSameFile => {
+                return Ok((true, None));
+            }
+            Err(err) => {
+                return Err(err);
+            }
+            Ok(res) => res,
+        };
+
+        let output: CreateResponse =
+            serde_json::from_reader(res.reader()).map_err(new_json_deserialize_error)?;
+        self.write_file_id(output.file_id).await;
+
+        if output.upload_id.is_some() && output.rapid_upload.is_some_and(|x| !x) {
+            if let Some(body) = body {
+                let Some(part_info_list) = output.part_info_list else {
+                    return Err(Error::new(ErrorKind::Unexpected, "cannot find upload_url"));
+                };
+                if part_info_list.is_empty() {
+                    return Err(Error::new(ErrorKind::Unexpected, "cannot find upload_url"));
+                }
+                self.core
+                    .upload(&part_info_list[0].upload_url, body)
+                    .await?;
+            }
+        }
+
+        Ok((false, output.upload_id))
+    }
+}
+
+impl oio::MultipartWrite for AliyunDriveWriter {
+    async fn write_once(&self, size: u64, body: crate::Buffer) -> Result<()> {
+        let upload_id = if self.core.rapid_upload {
+            let (rapid, mut upload_id) = self
+                .write(Some(size), Some(body.clone()), true, None)
+                .await?;
+
+            let size = if rapid { Some(size) } else { None };
+            let (_, new_upload_id) = self.write(size, Some(body), false, None).await?;
+
+            if new_upload_id.is_some() {
+                upload_id = new_upload_id;
+            }
+
+            let Some(upload_id) = upload_id else {
+                return Err(Error::new(ErrorKind::Unexpected, "cannot find upload_id"));
+            };
+            upload_id
+        } else {
+            let upload_id = self.initiate_part().await?;
+            self.write_part(&upload_id, 0, size, body).await?;
+            upload_id
+        };
+        let file_id = self.read_file_id().await?;
+
+        self.core.complete(&file_id, &upload_id).await?;
+
+        Ok(())
+    }
+
+    async fn initiate_part(&self) -> Result<String> {
+        let (_, upload_id) = self.write(None, None, false, None).await?;
+
+        let Some(upload_id) = upload_id else {
+            return Err(Error::new(ErrorKind::Unsupported, "cannot find upload_id"));
+        };
+
+        Ok(upload_id)
+    }
+
+    async fn write_part(
+        &self,
+        upload_id: &str,
+        part_number: usize,
+        _size: u64,
+        body: crate::Buffer,
+    ) -> Result<oio::MultipartPart> {
+        let file_id = self.read_file_id().await?;
+        let res = self
+            .core
+            .get_upload_url(&file_id, upload_id, Some(part_number + 1))
+            .await?;
+        let output: UploadUrlResponse =
+            serde_json::from_reader(res.reader()).map_err(new_json_deserialize_error)?;
+
+        let Some(part_info_list) = output.part_info_list else {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "cannot find part_info_list",
+            ));
+        };
+        if part_info_list.is_empty() {
+            return Err(Error::new(ErrorKind::Unexpected, "cannot find upload_url"));
+        }
+        self.write(None, Some(body), false, Some(&part_info_list[0].upload_url))
+            .await?;
+
+        Ok(oio::MultipartPart {
+            part_number,
+            etag: part_info_list[0].etag.clone().unwrap_or("".to_string()),
+            checksum: None,
+        })
+    }
+
+    async fn complete_part(&self, upload_id: &str, _parts: &[oio::MultipartPart]) -> Result<()> {
+        let file_id = self.read_file_id().await?;
+        self.core.complete(&file_id, upload_id).await?;
+
+        Ok(())
+    }
+
+    async fn abort_part(&self, _upload_id: &str) -> Result<()> {
+        let file_id = self.read_file_id().await?;
+
+        self.core.delete_path(&file_id).await
+    }
+}

--- a/core/src/services/mod.rs
+++ b/core/src/services/mod.rs
@@ -19,6 +19,13 @@
 //!
 //! More ongoing services support is tracked at [opendal#5](https://github.com/apache/opendal/issues/5). Please feel free to submit issues if there are services not covered.
 
+#[cfg(feature = "services-aliyun-drive")]
+mod aliyun_drive;
+#[cfg(feature = "services-aliyun-drive")]
+pub use aliyun_drive::AliyunDrive;
+#[cfg(feature = "services-aliyun-drive")]
+pub use aliyun_drive::AliyunDriveConfig;
+
 #[cfg(feature = "services-azblob")]
 mod azblob;
 #[cfg(feature = "services-azblob")]

--- a/core/src/types/operator/builder.rs
+++ b/core/src/types/operator/builder.rs
@@ -150,6 +150,8 @@ impl Operator {
     #[allow(unused_variables, unreachable_code)]
     pub fn via_map(scheme: Scheme, map: HashMap<String, String>) -> Result<Operator> {
         let op = match scheme {
+            #[cfg(feature = "services-aliyun-drive")]
+            Scheme::AliyunDrive => Self::from_map::<services::AliyunDrive>(map)?.finish(),
             #[cfg(feature = "services-atomicserver")]
             Scheme::Atomicserver => Self::from_map::<services::Atomicserver>(map)?.finish(),
             #[cfg(feature = "services-alluxio")]

--- a/core/src/types/scheme.rs
+++ b/core/src/types/scheme.rs
@@ -32,6 +32,8 @@ use crate::Error;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum Scheme {
+    /// [aliyun_drive][crate::services::AliyunDrive]: Aliyun Drive services.
+    AliyunDrive,
     /// [atomicserver][crate::services::Atomicserver]: Atomicserver services.
     Atomicserver,
     /// [azblob][crate::services::Azblob]: Azure Storage Blob services.
@@ -191,6 +193,8 @@ impl Scheme {
     /// ```
     pub fn enabled() -> HashSet<Scheme> {
         HashSet::from([
+            #[cfg(feature = "services-aliyun-drive")]
+            Scheme::AliyunDrive,
             #[cfg(feature = "services-atomicserver")]
             Scheme::Atomicserver,
             #[cfg(feature = "services-alluxio")]
@@ -325,6 +329,7 @@ impl FromStr for Scheme {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.to_lowercase();
         match s.as_str() {
+            "aliyun_drive" => Ok(Scheme::AliyunDrive),
             "atomicserver" => Ok(Scheme::Atomicserver),
             "azblob" => Ok(Scheme::Azblob),
             "alluxio" => Ok(Scheme::Alluxio),
@@ -399,6 +404,7 @@ impl FromStr for Scheme {
 impl From<Scheme> for &'static str {
     fn from(v: Scheme) -> Self {
         match v {
+            Scheme::AliyunDrive => "aliyun_drive",
             Scheme::Atomicserver => "atomicserver",
             Scheme::Azblob => "azblob",
             Scheme::Azdls => "azdls",


### PR DESCRIPTION
Closing #3415. Ready for review.

API documentation reference: https://www.yuque.com/aliyundrive/zpfszx/gogo34oi2gy98w5d

Required Environment Variables:

```bash
export OPENDAL_ALIYUN_DRIVE_CLIENT_ID=
export OPENDAL_ALIYUN_DRIVE_CLIENT_SECRET=
export OPENDAL_ALIYUN_DRIVE_REFRESH_TOKEN=
export OPENDAL_ALIYUN_DRIVE_RAPID_UPLOAD=true
export OPENDAL_TEST=aliyun_drive
```

To run behavior tests, use the following command:

```bash
cd core && cargo test behavior --features tests,services-aliyun-drive -- --test-threads=1
```

Note that the test threads should be set to 1 as it may fail part of the test due to rate limit.

AliyunDrive has a feature called Rapid Upload, but it is difficult to implement completely because the `MultipartWriter` trait design isn't well compatible with this feature at present. Therefore, I have only implemented it on the `write_once` method.

Let's discuss proposing a new `RapiduploadWriter` for this kind of rapid-upload featured service together in the future if you would.