### PR TITLE
feat(services/gdrive): Support shared drives in Google Drive API integration

### DIFF
--- a/core/src/services/gdrive/builder.rs
+++ b/core/src/services/gdrive/builder.rs
@@ -52,6 +52,8 @@ pub struct GdriveConfig {
     pub client_id: Option<String>,
     /// Client secret for gdrive.
     pub client_secret: Option<String>,
+    /// ID of shared drive to search.
+    pub drive_id: Option<String>,
 }
 
 impl Debug for GdriveConfig {
@@ -124,6 +126,12 @@ impl GdriveBuilder {
     /// This is required for OAuth 2.0 Flow with refresh the access token.
     pub fn client_secret(&mut self, client_secret: &str) -> &mut Self {
         self.config.client_secret = Some(client_secret.to_string());
+        self
+    }
+
+    /// Set the drive id for GoogleDrive
+    pub fn drive_id(&mut self, drive_id: &str) -> &mut Self {
+        self.config.drive_id = Some(drive_id.to_string());
         self
     }
 
@@ -219,6 +227,7 @@ impl Builder for GdriveBuilder {
         Ok(GdriveBackend {
             core: Arc::new(GdriveCore {
                 root,
+                drive_id: self.config.drive_id.clone(),
                 signer: signer.clone(),
                 client: client.clone(),
                 path_cache: PathCacher::new(GdrivePathQuery::new(client, signer)).with_lock(),

--- a/core/src/services/gdrive/core.rs
+++ b/core/src/services/gdrive/core.rs
@@ -39,6 +39,8 @@ use crate::*;
 pub struct GdriveCore {
     pub root: String,
 
+    pub drive_id: Option<String>,
+
     pub client: HttpClient,
 
     pub signer: Arc<Mutex<GdriveSigner>>,
@@ -112,6 +114,10 @@ impl GdriveCore {
         if !next_page_token.is_empty() {
             url += &format!("&pageToken={next_page_token}");
         };
+
+        if let Some(drive_id) = self.drive_id.as_ref() {
+            url += &format!("&drive_id={}&supportsAllDrives=true", drive_id);
+        }
 
         let mut req = Request::get(&url)
             .body(Buffer::new())


### PR DESCRIPTION
close #4576 
This PR introduces the capability to work with shared drives in our Google Drive API integration by handling the driveId parameter. This change enables users to specify a shared drive ID that will be used in API requests, allowing operations to be performed on shared drives.

Changes:
Added drive_id field to GdriveConfig to store the ID of the shared drive.
Implemented drive_id setter method in GdriveBuilder to allow the passing of the drive ID during configuration.
Modified GdriveCore to append the drive_id to the URL query parameters if present, also enabling support for all drives with supportsAllDrives=true.
Documentation Reference:
For more information on enabling shared drives, see the official Google documentation: [Enabling Shared Drives](https://developers.google.com/drive/api/guides/enable-shareddrives)

Impact:
This enhancement allows our application to interact not just with user-specific drives but also with shared drives, broadening our application's scope in collaborative environments.