### PR TITLE
fix(bin/ofs): ofs behavior tests

### DIFF
--- a/.github/actions/test_behavior_bin_ofs/action.yaml
+++ b/.github/actions/test_behavior_bin_ofs/action.yaml
@@ -42,7 +42,6 @@ runs:
             shell: bash
             working-directory: bin/ofs
             run: cargo test --features ${{ inputs.feature }} --no-default-features -- --nocapture
-            timeout-minutes: 1
             env:
               OPENDAL_TEST: ${{ inputs.service }}
         EOF

--- a/.github/actions/test_behavior_bin_ofs/action.yaml
+++ b/.github/actions/test_behavior_bin_ofs/action.yaml
@@ -41,7 +41,8 @@ runs:
           - name: Run Test Ofs
             shell: bash
             working-directory: bin/ofs
-            run: cargo test --features ${{ inputs.feature }} --no-default-features
+            timeout-minutes: 1
+            run: cargo test --features ${{ inputs.feature }} --no-default-features -- --nocapture
             env:
               OPENDAL_TEST: ${{ inputs.service }}
         EOF

--- a/.github/actions/test_behavior_bin_ofs/action.yaml
+++ b/.github/actions/test_behavior_bin_ofs/action.yaml
@@ -41,8 +41,8 @@ runs:
           - name: Run Test Ofs
             shell: bash
             working-directory: bin/ofs
-            timeout-minutes: 1
             run: cargo test --features ${{ inputs.feature }} --no-default-features -- --nocapture
+            timeout-minutes: 1
             env:
               OPENDAL_TEST: ${{ inputs.service }}
         EOF

--- a/.github/workflows/test_behavior_bin_ofs.yml
+++ b/.github/workflows/test_behavior_bin_ofs.yml
@@ -31,6 +31,8 @@ jobs:
   test:
     name: ${{ matrix.cases.service }} / ${{ matrix.cases.setup }}
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 10
+
     strategy:
       matrix:
         cases: ${{ fromJson(inputs.cases) }}

--- a/bin/ofs/tests/common/mod.rs
+++ b/bin/ofs/tests/common/mod.rs
@@ -15,27 +15,49 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{collections::HashMap, env, process::Command};
+use std::{collections::HashMap, env, process::Command, sync::OnceLock, thread, time::Duration};
 
 use tempfile::TempDir;
-use test_context::AsyncTestContext;
-use tokio::task::JoinHandle;
+use test_context::TestContext;
+use tokio::{
+    runtime::{self, Runtime},
+    task::JoinHandle,
+};
+
+static INIT_LOGGER: OnceLock<()> = OnceLock::new();
+static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
 pub(crate) struct OfsTestContext {
     pub mount_point: TempDir,
-    ofs_task: JoinHandle<anyhow::Result<()>>,
+    ofs_task: JoinHandle<()>,
 }
 
-impl AsyncTestContext for OfsTestContext {
-    async fn setup() -> Self {
+impl TestContext for OfsTestContext {
+    fn setup() -> Self {
         let backend = backend_scheme().unwrap();
 
-        let mount_point = tempfile::tempdir().unwrap();
+        INIT_LOGGER.get_or_init(|| env_logger::init());
 
-        let ofs_task = tokio::spawn(ofs::execute(ofs::Config {
-            mount_path: mount_point.path().to_string_lossy().to_string(),
-            backend: backend.parse().unwrap(),
-        }));
+        let mount_point = tempfile::tempdir().unwrap();
+        let mount_point_str = mount_point.path().to_string_lossy().to_string();
+        let ofs_task = RUNTIME
+            .get_or_init(|| {
+                runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build runtime")
+            })
+            .spawn(async move {
+                ofs::execute(ofs::Config {
+                    mount_path: mount_point_str,
+                    backend: backend.parse().unwrap(),
+                })
+                .await
+                .unwrap();
+            });
+
+        // wait for ofs to start
+        thread::sleep(Duration::from_secs(1));
 
         OfsTestContext {
             mount_point,
@@ -43,7 +65,7 @@ impl AsyncTestContext for OfsTestContext {
         }
     }
 
-    async fn teardown(self) {
+    fn teardown(self) {
         // FIXME: ofs could not unmount
         Command::new("fusermount3")
             .args(["-u", self.mount_point.path().to_str().unwrap()])

--- a/bin/ofs/tests/common/mod.rs
+++ b/bin/ofs/tests/common/mod.rs
@@ -36,7 +36,7 @@ impl TestContext for OfsTestContext {
     fn setup() -> Self {
         let backend = backend_scheme().unwrap();
 
-        INIT_LOGGER.get_or_init(|| env_logger::init());
+        INIT_LOGGER.get_or_init(env_logger::init);
 
         let mount_point = tempfile::tempdir().unwrap();
         let mount_point_str = mount_point.path().to_string_lossy().to_string();

--- a/bin/ofs/tests/file.rs
+++ b/bin/ofs/tests/file.rs
@@ -55,11 +55,7 @@ fn test_file_append(ctx: &mut OfsTestContext) {
     file.write_all(TEST_TEXT.as_bytes()).unwrap();
     drop(file);
 
-    let mut file = File::options()
-        .write(true)
-        .append(true)
-        .open(&path)
-        .unwrap();
+    let mut file = File::options().append(true).open(&path).unwrap();
     file.write_all(b"test").unwrap();
     drop(file);
 

--- a/bin/ofs/tests/file.rs
+++ b/bin/ofs/tests/file.rs
@@ -17,75 +17,77 @@
 
 mod common;
 
-use std::io::SeekFrom;
+use std::{
+    fs::{self, File},
+    io::{Read, Seek, SeekFrom, Write},
+};
 
 use common::OfsTestContext;
 
 use test_context::test_context;
-use tokio::{
-    fs::{self, File},
-    io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
-};
 
 static TEST_TEXT: &str = include_str!("../Cargo.toml");
 
 #[test_context(OfsTestContext)]
-#[tokio::test]
-async fn test_file(ctx: &mut OfsTestContext) {
+#[test]
+fn test_file(ctx: &mut OfsTestContext) {
     let path = ctx.mount_point.path().join("test_file.txt");
-    let mut file = File::create(&path).await.unwrap();
+    let mut file = File::create(&path).unwrap();
 
-    file.write_all(TEST_TEXT.as_bytes()).await.unwrap();
+    file.write_all(TEST_TEXT.as_bytes()).unwrap();
     drop(file);
 
-    let mut file = File::open(&path).await.unwrap();
+    let mut file = File::open(&path).unwrap();
     let mut buf = String::new();
-    file.read_to_string(&mut buf).await.unwrap();
+    file.read_to_string(&mut buf).unwrap();
     assert_eq!(buf, TEST_TEXT);
     drop(file);
 
-    fs::remove_file(path).await.unwrap();
+    fs::remove_file(path).unwrap();
 }
 
 #[test_context(OfsTestContext)]
-#[tokio::test]
-async fn test_file_append(ctx: &mut OfsTestContext) {
+#[test]
+fn test_file_append(ctx: &mut OfsTestContext) {
     let path = ctx.mount_point.path().join("test_file_append.txt");
-    let mut file = File::create(&path).await.unwrap();
+    let mut file = File::create(&path).unwrap();
 
-    file.write_all(TEST_TEXT.as_bytes()).await.unwrap();
+    file.write_all(TEST_TEXT.as_bytes()).unwrap();
     drop(file);
 
-    let mut file = File::options().append(true).open(&path).await.unwrap();
-    file.write_all(b"test").await.unwrap();
+    let mut file = File::options()
+        .write(true)
+        .append(true)
+        .open(&path)
+        .unwrap();
+    file.write_all(b"test").unwrap();
     drop(file);
 
-    let mut file = File::open(&path).await.unwrap();
+    let mut file = File::open(&path).unwrap();
     let mut buf = String::new();
-    file.read_to_string(&mut buf).await.unwrap();
+    file.read_to_string(&mut buf).unwrap();
     assert_eq!(buf, TEST_TEXT.to_owned() + "test");
     drop(file);
 
-    fs::remove_file(path).await.unwrap();
+    fs::remove_file(path).unwrap();
 }
 
 #[test_context(OfsTestContext)]
-#[tokio::test]
-async fn test_file_seek(ctx: &mut OfsTestContext) {
+#[test]
+fn test_file_seek(ctx: &mut OfsTestContext) {
     let path = ctx.mount_point.path().join("test_file_seek.txt");
-    let mut file = File::create(&path).await.unwrap();
+    let mut file = File::create(&path).unwrap();
 
-    file.write_all(TEST_TEXT.as_bytes()).await.unwrap();
+    file.write_all(TEST_TEXT.as_bytes()).unwrap();
     drop(file);
 
-    let mut file = File::open(&path).await.unwrap();
+    let mut file = File::open(&path).unwrap();
     file.seek(SeekFrom::Start(TEST_TEXT.len() as u64 / 2))
-        .await
         .unwrap();
     let mut buf = String::new();
-    file.read_to_string(&mut buf).await.unwrap();
+    file.read_to_string(&mut buf).unwrap();
     assert_eq!(buf, TEST_TEXT[TEST_TEXT.len() / 2..]);
     drop(file);
 
-    fs::remove_file(path).await.unwrap();
+    fs::remove_file(path).unwrap();
 }

--- a/bin/ofs/tests/path.rs
+++ b/bin/ofs/tests/path.rs
@@ -17,15 +17,16 @@
 
 mod common;
 
+use std::fs;
+
 use common::OfsTestContext;
 
 use test_context::test_context;
-use tokio::fs;
 use walkdir::WalkDir;
 
 #[test_context(OfsTestContext)]
-#[tokio::test]
-async fn test_path(ctx: &mut OfsTestContext) {
+#[test]
+fn test_path(ctx: &mut OfsTestContext) {
     let actual_entries = [
         ("dir1", false),
         ("dir2", false),
@@ -44,8 +45,8 @@ async fn test_path(ctx: &mut OfsTestContext) {
     for (path, is_file) in actual_entries.iter() {
         let path = ctx.mount_point.path().join(path);
         match is_file {
-            true => fs::write(path, "hello").await.unwrap(),
-            false => fs::create_dir(path).await.unwrap(),
+            true => fs::write(path, "hello").unwrap(),
+            false => fs::create_dir(path).unwrap(),
         }
     }
 


### PR DESCRIPTION
- Fix test cases run before Ofs mount
- Use `std::fs` to test instead of `tokio::fs`
- Add timeout for Ofs tests