### PR TITLE
fix(raw): Allow retrying request while decoding response failed

### DIFF
--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -106,17 +106,11 @@ impl HttpClient {
         }
 
         let mut resp = req_builder.send().await.map_err(|err| {
-            let is_temporary = is_temporary_error(&err);
-
-            let mut oerr = Error::new(ErrorKind::Unexpected, "send http request")
+            Error::new(ErrorKind::Unexpected, "send http request")
                 .with_operation("http_util::Client::send")
                 .with_context("url", uri.to_string())
-                .set_source(err);
-            if is_temporary {
-                oerr = oerr.set_temporary();
-            }
-
-            oerr
+                .with_temporary(is_temporary_error(&err))
+                .set_source(err)
         })?;
 
         // Get content length from header so that we can check it.
@@ -150,17 +144,11 @@ impl HttpClient {
             .try_collect()
             .await
             .map_err(|err| {
-                let is_temporary = is_temporary_error(&err);
-
-                let mut oerr = Error::new(ErrorKind::Unexpected, "read data from http response")
+                Error::new(ErrorKind::Unexpected, "read data from http response")
                     .with_operation("http_util::Client::send")
                     .with_context("url", uri.to_string())
-                    .set_source(err);
-                if is_temporary {
-                    oerr = oerr.set_temporary();
-                }
-
-                oerr
+                    .with_temporary(is_temporary_error(&err))
+                    .set_source(err)
             })?;
 
         let buffer = Buffer::from(bs);

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -393,6 +393,16 @@ impl Error {
         self
     }
 
+    /// Set temporary status for error by given temporary.
+    ///
+    /// By set temporary, we indicate this error is retryable.
+    pub(crate) fn with_temporary(mut self, temporary: bool) -> Self {
+        if temporary {
+            self.status = ErrorStatus::Temporary;
+        }
+        self
+    }
+
     /// Set persistent status for error.
     ///
     /// By setting persistent, we indicate the retry should be stopped.


### PR DESCRIPTION
We will treat decoding response errors as hard errors, but they are usually safe to retry, similar to connection resets.