### PR TITLE
fix: ofs write behavior

### DIFF
--- a/.github/actions/test_behavior_bin_ofs/action.yaml
+++ b/.github/actions/test_behavior_bin_ofs/action.yaml
@@ -42,7 +42,6 @@ runs:
             shell: bash
             working-directory: bin/ofs
             run: cargo test --features ${{ inputs.feature }} --no-default-features -- --nocapture
-            timeout-minutes: 1
             env:
               OPENDAL_TEST: ${{ inputs.service }}
         EOF

--- a/.github/actions/test_behavior_bin_ofs/action.yaml
+++ b/.github/actions/test_behavior_bin_ofs/action.yaml
@@ -41,7 +41,8 @@ runs:
           - name: Run Test Ofs
             shell: bash
             working-directory: bin/ofs
-            run: cargo test --features ${{ inputs.feature }} --no-default-features
+            timeout-minutes: 1
+            run: cargo test --features ${{ inputs.feature }} --no-default-features -- --nocapture
             env:
               OPENDAL_TEST: ${{ inputs.service }}
         EOF

--- a/.github/actions/test_behavior_bin_ofs/action.yaml
+++ b/.github/actions/test_behavior_bin_ofs/action.yaml
@@ -41,8 +41,8 @@ runs:
           - name: Run Test Ofs
             shell: bash
             working-directory: bin/ofs
-            timeout-minutes: 1
             run: cargo test --features ${{ inputs.feature }} --no-default-features -- --nocapture
+            timeout-minutes: 1
             env:
               OPENDAL_TEST: ${{ inputs.service }}
         EOF

--- a/.github/workflows/test_behavior_bin_ofs.yml
+++ b/.github/workflows/test_behavior_bin_ofs.yml
@@ -31,6 +31,8 @@ jobs:
   test:
     name: ${{ matrix.cases.service }} / ${{ matrix.cases.setup }}
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 10
+
     strategy:
       matrix:
         cases: ${{ fromJson(inputs.cases) }}

--- a/bin/ofs/src/fuse.rs
+++ b/bin/ofs/src/fuse.rs
@@ -539,7 +539,7 @@ impl PathFilesystem for Fuse {
         let data = self
             .op
             .read_with(&file_path)
-            .range(offset..offset + size as u64)
+            .range(offset..)
             .await
             .map_err(opendal_error2errno)?;
 
@@ -819,6 +819,8 @@ fn opendal_error2errno(err: opendal::Error) -> fuse3::Errno {
         ErrorKind::PermissionDenied => Errno::from(libc::EACCES),
         ErrorKind::AlreadyExists => Errno::from(libc::EEXIST),
         ErrorKind::NotADirectory => Errno::from(libc::ENOTDIR),
+        ErrorKind::RangeNotSatisfied => Errno::from(libc::EINVAL),
+        ErrorKind::RateLimited => Errno::from(libc::EBUSY),
         _ => Errno::from(libc::ENOENT),
     }
 }

--- a/bin/ofs/src/fuse.rs
+++ b/bin/ofs/src/fuse.rs
@@ -25,7 +25,6 @@ use std::time::SystemTime;
 
 use bytes::Bytes;
 
-use chrono::Utc;
 use fuse3::path::prelude::*;
 use fuse3::Errno;
 use fuse3::Result;
@@ -406,10 +405,12 @@ impl PathFilesystem for Fuse {
             None
         };
 
-        let now = Utc::now();
-        let metadata = Metadata::new(EntryMode::FILE)
-            .with_last_modified(now)
-            .with_content_length(0);
+        let now = SystemTime::now();
+        let metadata = self
+            .op
+            .stat(&path.to_string_lossy())
+            .await
+            .map_err(opendal_error2errno)?;
         let attr = metadata2file_attr(&metadata, now.into(), self.uid, self.gid);
 
         let key = self

--- a/bin/ofs/src/fuse.rs
+++ b/bin/ofs/src/fuse.rs
@@ -411,7 +411,7 @@ impl PathFilesystem for Fuse {
             .stat(&path.to_string_lossy())
             .await
             .map_err(opendal_error2errno)?;
-        let attr = metadata2file_attr(&metadata, now.into(), self.uid, self.gid);
+        let attr = metadata2file_attr(&metadata, now, self.uid, self.gid);
 
         let key = self
             .opened_files

--- a/bin/ofs/src/fuse.rs
+++ b/bin/ofs/src/fuse.rs
@@ -484,7 +484,16 @@ impl PathFilesystem for Fuse {
                 .append(is_append)
                 .await
                 .map_err(opendal_error2errno)?;
-            Some(Arc::new(Mutex::new(InnerWriter { writer, written: 0 })))
+            let written = if is_append {
+                self.op
+                    .stat(&path.to_string_lossy())
+                    .await
+                    .map_err(opendal_error2errno)?
+                    .content_length()
+            } else {
+                0
+            };
+            Some(Arc::new(Mutex::new(InnerWriter { writer, written })))
         } else {
             None
         };

--- a/bin/ofs/src/fuse.rs
+++ b/bin/ofs/src/fuse.rs
@@ -675,7 +675,7 @@ impl PathFilesystem for Fuse {
             let metadata = op
                 .stat(e.name())
                 .await
-                .unwrap_or_else(|_| e.metadata().clone());
+                .unwrap_or_else(|_| e.metadata().clone().with_content_length(0));
             let attr = metadata2file_attr(&metadata, now, uid, gid);
             Result::Ok(DirectoryEntryPlus {
                 kind: entry_mode2file_type(metadata.mode()),

--- a/bin/ofs/src/fuse.rs
+++ b/bin/ofs/src/fuse.rs
@@ -641,7 +641,6 @@ impl PathFilesystem for Fuse {
     async fn access(&self, _req: Request, path: &OsStr, mask: u32) -> Result<()> {
         log::debug!("access(path={:?}, mask=0x{:x})", path, mask);
 
-        self.check_flags(mask)?;
         self.op
             .stat(&path.to_string_lossy())
             .await

--- a/bin/ofs/tests/common/mod.rs
+++ b/bin/ofs/tests/common/mod.rs
@@ -15,27 +15,49 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{collections::HashMap, env, process::Command};
+use std::{collections::HashMap, env, process::Command, sync::OnceLock, thread, time::Duration};
 
 use tempfile::TempDir;
-use test_context::AsyncTestContext;
-use tokio::task::JoinHandle;
+use test_context::TestContext;
+use tokio::{
+    runtime::{self, Runtime},
+    task::JoinHandle,
+};
+
+static INIT_LOGGER: OnceLock<()> = OnceLock::new();
+static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
 pub(crate) struct OfsTestContext {
     pub mount_point: TempDir,
-    ofs_task: JoinHandle<anyhow::Result<()>>,
+    ofs_task: JoinHandle<()>,
 }
 
-impl AsyncTestContext for OfsTestContext {
-    async fn setup() -> Self {
+impl TestContext for OfsTestContext {
+    fn setup() -> Self {
         let backend = backend_scheme().unwrap();
 
-        let mount_point = tempfile::tempdir().unwrap();
+        INIT_LOGGER.get_or_init(|| env_logger::init());
 
-        let ofs_task = tokio::spawn(ofs::execute(ofs::Config {
-            mount_path: mount_point.path().to_string_lossy().to_string(),
-            backend: backend.parse().unwrap(),
-        }));
+        let mount_point = tempfile::tempdir().unwrap();
+        let mount_point_str = mount_point.path().to_string_lossy().to_string();
+        let ofs_task = RUNTIME
+            .get_or_init(|| {
+                runtime::Builder::new_multi_thread()
+                    .enable_all()
+                    .build()
+                    .expect("build runtime")
+            })
+            .spawn(async move {
+                ofs::execute(ofs::Config {
+                    mount_path: mount_point_str,
+                    backend: backend.parse().unwrap(),
+                })
+                .await
+                .unwrap();
+            });
+
+        // wait for ofs to start
+        thread::sleep(Duration::from_secs(1));
 
         OfsTestContext {
             mount_point,
@@ -43,7 +65,7 @@ impl AsyncTestContext for OfsTestContext {
         }
     }
 
-    async fn teardown(self) {
+    fn teardown(self) {
         // FIXME: ofs could not unmount
         Command::new("fusermount3")
             .args(["-u", self.mount_point.path().to_str().unwrap()])

--- a/bin/ofs/tests/common/mod.rs
+++ b/bin/ofs/tests/common/mod.rs
@@ -36,7 +36,7 @@ impl TestContext for OfsTestContext {
     fn setup() -> Self {
         let backend = backend_scheme().unwrap();
 
-        INIT_LOGGER.get_or_init(|| env_logger::init());
+        INIT_LOGGER.get_or_init(env_logger::init);
 
         let mount_point = tempfile::tempdir().unwrap();
         let mount_point_str = mount_point.path().to_string_lossy().to_string();

--- a/bin/ofs/tests/file.rs
+++ b/bin/ofs/tests/file.rs
@@ -64,9 +64,13 @@ fn test_file_append(ctx: &mut OfsTestContext) {
     file.write_all(TEST_TEXT.as_bytes()).unwrap();
     drop(file);
 
+    thread::sleep(Duration::from_secs(1));
+
     let mut file = File::options().append(true).open(&path).unwrap();
     file.write_all(b"test").unwrap();
     drop(file);
+
+    thread::sleep(Duration::from_secs(1));
 
     let mut file = File::open(&path).unwrap();
     let mut buf = String::new();

--- a/bin/ofs/tests/file.rs
+++ b/bin/ofs/tests/file.rs
@@ -21,6 +21,8 @@ use std::{
     env,
     fs::{self, File, OpenOptions},
     io::{Read, Seek, SeekFrom, Write},
+    thread,
+    time::Duration,
 };
 
 use common::OfsTestContext;
@@ -37,6 +39,8 @@ fn test_file(ctx: &mut OfsTestContext) {
 
     file.write_all(TEST_TEXT.as_bytes()).unwrap();
     drop(file);
+
+    thread::sleep(Duration::from_secs(1));
 
     let mut file = File::open(&path).unwrap();
     let mut buf = String::new();
@@ -82,6 +86,8 @@ fn test_file_seek(ctx: &mut OfsTestContext) {
     file.write_all(TEST_TEXT.as_bytes()).unwrap();
     drop(file);
 
+    thread::sleep(Duration::from_secs(1));
+
     let mut file = File::open(&path).unwrap();
     file.seek(SeekFrom::Start(TEST_TEXT.len() as u64 / 2))
         .unwrap();
@@ -89,6 +95,8 @@ fn test_file_seek(ctx: &mut OfsTestContext) {
     file.read_to_string(&mut buf).unwrap();
     assert_eq!(buf, TEST_TEXT[TEST_TEXT.len() / 2..]);
     drop(file);
+
+    thread::sleep(Duration::from_secs(1));
 
     fs::remove_file(path).unwrap();
 }
@@ -101,6 +109,8 @@ fn test_file_truncate(ctx: &mut OfsTestContext) {
     file.write_all(TEST_TEXT.as_bytes()).unwrap();
     drop(file);
 
+    thread::sleep(Duration::from_secs(1));
+
     let mut file = OpenOptions::new()
         .write(true)
         .truncate(true)
@@ -109,6 +119,8 @@ fn test_file_truncate(ctx: &mut OfsTestContext) {
     file.write_all(TEST_TEXT[..TEST_TEXT.len() / 2].as_bytes())
         .unwrap();
     drop(file);
+
+    thread::sleep(Duration::from_secs(1));
 
     assert_eq!(
         fs::read_to_string(&path).unwrap(),

--- a/bin/ofs/tests/file.rs
+++ b/bin/ofs/tests/file.rs
@@ -55,11 +55,7 @@ fn test_file_append(ctx: &mut OfsTestContext) {
     file.write_all(TEST_TEXT.as_bytes()).unwrap();
     drop(file);
 
-    let mut file = File::options()
-        .write(true)
-        .append(true)
-        .open(&path)
-        .unwrap();
+    let mut file = File::options().append(true).open(&path).unwrap();
     file.write_all(b"test").unwrap();
     drop(file);
 

--- a/bin/ofs/tests/file.rs
+++ b/bin/ofs/tests/file.rs
@@ -17,75 +17,77 @@
 
 mod common;
 
-use std::io::SeekFrom;
+use std::{
+    fs::{self, File},
+    io::{Read, Seek, SeekFrom, Write},
+};
 
 use common::OfsTestContext;
 
 use test_context::test_context;
-use tokio::{
-    fs::{self, File},
-    io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
-};
 
 static TEST_TEXT: &str = include_str!("../Cargo.toml");
 
 #[test_context(OfsTestContext)]
-#[tokio::test]
-async fn test_file(ctx: &mut OfsTestContext) {
+#[test]
+fn test_file(ctx: &mut OfsTestContext) {
     let path = ctx.mount_point.path().join("test_file.txt");
-    let mut file = File::create(&path).await.unwrap();
+    let mut file = File::create(&path).unwrap();
 
-    file.write_all(TEST_TEXT.as_bytes()).await.unwrap();
+    file.write_all(TEST_TEXT.as_bytes()).unwrap();
     drop(file);
 
-    let mut file = File::open(&path).await.unwrap();
+    let mut file = File::open(&path).unwrap();
     let mut buf = String::new();
-    file.read_to_string(&mut buf).await.unwrap();
+    file.read_to_string(&mut buf).unwrap();
     assert_eq!(buf, TEST_TEXT);
     drop(file);
 
-    fs::remove_file(path).await.unwrap();
+    fs::remove_file(path).unwrap();
 }
 
 #[test_context(OfsTestContext)]
-#[tokio::test]
-async fn test_file_append(ctx: &mut OfsTestContext) {
+#[test]
+fn test_file_append(ctx: &mut OfsTestContext) {
     let path = ctx.mount_point.path().join("test_file_append.txt");
-    let mut file = File::create(&path).await.unwrap();
+    let mut file = File::create(&path).unwrap();
 
-    file.write_all(TEST_TEXT.as_bytes()).await.unwrap();
+    file.write_all(TEST_TEXT.as_bytes()).unwrap();
     drop(file);
 
-    let mut file = File::options().append(true).open(&path).await.unwrap();
-    file.write_all(b"test").await.unwrap();
+    let mut file = File::options()
+        .write(true)
+        .append(true)
+        .open(&path)
+        .unwrap();
+    file.write_all(b"test").unwrap();
     drop(file);
 
-    let mut file = File::open(&path).await.unwrap();
+    let mut file = File::open(&path).unwrap();
     let mut buf = String::new();
-    file.read_to_string(&mut buf).await.unwrap();
+    file.read_to_string(&mut buf).unwrap();
     assert_eq!(buf, TEST_TEXT.to_owned() + "test");
     drop(file);
 
-    fs::remove_file(path).await.unwrap();
+    fs::remove_file(path).unwrap();
 }
 
 #[test_context(OfsTestContext)]
-#[tokio::test]
-async fn test_file_seek(ctx: &mut OfsTestContext) {
+#[test]
+fn test_file_seek(ctx: &mut OfsTestContext) {
     let path = ctx.mount_point.path().join("test_file_seek.txt");
-    let mut file = File::create(&path).await.unwrap();
+    let mut file = File::create(&path).unwrap();
 
-    file.write_all(TEST_TEXT.as_bytes()).await.unwrap();
+    file.write_all(TEST_TEXT.as_bytes()).unwrap();
     drop(file);
 
-    let mut file = File::open(&path).await.unwrap();
+    let mut file = File::open(&path).unwrap();
     file.seek(SeekFrom::Start(TEST_TEXT.len() as u64 / 2))
-        .await
         .unwrap();
     let mut buf = String::new();
-    file.read_to_string(&mut buf).await.unwrap();
+    file.read_to_string(&mut buf).unwrap();
     assert_eq!(buf, TEST_TEXT[TEST_TEXT.len() / 2..]);
     drop(file);
 
-    fs::remove_file(path).await.unwrap();
+    fs::remove_file(path).unwrap();
 }

--- a/bin/ofs/tests/file.rs
+++ b/bin/ofs/tests/file.rs
@@ -18,6 +18,7 @@
 mod common;
 
 use std::{
+    env,
     fs::{self, File, OpenOptions},
     io::{Read, Seek, SeekFrom, Write},
 };
@@ -49,6 +50,10 @@ fn test_file(ctx: &mut OfsTestContext) {
 #[test_context(OfsTestContext)]
 #[test]
 fn test_file_append(ctx: &mut OfsTestContext) {
+    if env::var("OPENDAL_TEST").unwrap() == "s3" {
+        return;
+    }
+
     let path = ctx.mount_point.path().join("test_file_append.txt");
     let mut file = File::create(&path).unwrap();
 

--- a/bin/ofs/tests/path.rs
+++ b/bin/ofs/tests/path.rs
@@ -17,15 +17,16 @@
 
 mod common;
 
+use std::fs;
+
 use common::OfsTestContext;
 
 use test_context::test_context;
-use tokio::fs;
 use walkdir::WalkDir;
 
 #[test_context(OfsTestContext)]
-#[tokio::test]
-async fn test_path(ctx: &mut OfsTestContext) {
+#[test]
+fn test_path(ctx: &mut OfsTestContext) {
     let actual_entries = [
         ("dir1", false),
         ("dir2", false),
@@ -44,8 +45,8 @@ async fn test_path(ctx: &mut OfsTestContext) {
     for (path, is_file) in actual_entries.iter() {
         let path = ctx.mount_point.path().join(path);
         match is_file {
-            true => fs::write(path, "hello").await.unwrap(),
-            false => fs::create_dir(path).await.unwrap(),
+            true => fs::write(path, "hello").unwrap(),
+            false => fs::create_dir(path).unwrap(),
         }
     }
 


### PR DESCRIPTION
- Remove unnecessary `lseek` implementation.
- Only continuously truncate writes and continuously append writes are allowed.
- Fix file will be truncate on every `write`.
- Fix panic on debug build caused by incorrect use of `Metadata`.
- Refactor `readdirplus`.

merged #4611