### PR TITLE
website: replace community sync calendar with link

### DIFF
--- a/website/community/index.mdx
+++ b/website/community/index.mdx
@@ -89,7 +89,7 @@ These two meeting times alternate between each three-week cycle.
 
 The following is the calendar of the community events:
 
-<iframe src="https://calendar.google.com/calendar/embed?src=d32a8b1c08fc40d4230e3ce89145fd0e9a1ea4a374893a23ec7bd28ca646db45%40group.calendar.google.com&ctz=Asia%2FShanghai" style={{border: 0, width: "100%", maxWidth: "500px", height: "500px", aspectRatio: 1}} frameBorder="0"></iframe>
+Click here to view the calendar in a new tab: [Community Events Calendar](https://calendar.google.com/calendar/embed?src=d32a8b1c08fc40d4230e3ce89145fd0e9a1ea4a374893a23ec7bd28ca646db45%40group.calendar.google.com&ctz=Asia%2FShanghai).
 
 If you prefer to add these events to your personal calendar, please use this iCal link:
 [Add to your calendar](https://calendar.google.com/calendar/ical/d32a8b1c08fc40d4230e3ce89145fd0e9a1ea4a374893a23ec7bd28ca646db45%40group.calendar.google.com/public/basic.ics).


### PR DESCRIPTION
Replaced with the following link:
https://calendar.google.com/calendar/embed?src=d32a8b1c08fc40d4230e3ce89145fd0e9a1ea4a374893a23ec7bd28ca646db45%40group.calendar.google.com&ctz=Asia%2FShanghai