### PR TITLE
fix(bindings/python): Use abi3 and increase MSPV to 3.11

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -157,7 +157,7 @@ futures = "0.3.28"
 opendal = { version = "0.46.0", path = "../../core", features = [
   "layers-blocking",
 ] }
-pyo3 = "0.20.1"
+pyo3 = { version = "0.20.1", features = ["abi3", "abi3-py311"] }
 pyo3-asyncio = { version = "0.20", features = ["tokio-runtime"] }
 tokio = "1"
 

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -31,7 +31,7 @@ name = "opendal"
 readme = "README.md"
 # PyO3 doesn't support python 3.13 yet.
 # ref: https://github.com/apache/opendal/issues/4268
-requires-python = ">=3.7, < 3.13"
+requires-python = ">=3.11, < 3.13"
 
 [project.optional-dependencies]
 benchmark = [


### PR DESCRIPTION
This PR will use abi3 and increase MSPV to 3.11 to reduce our release size.