### PR TITLE
fix: Fetch the content length while end_bound is unknown

### DIFF
--- a/bin/oli/src/commands/cat.rs
+++ b/bin/oli/src/commands/cat.rs
@@ -39,7 +39,9 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
 
     let reader = op.reader(&path).await?;
     let meta = op.stat(&path).await?;
-    let mut buf_reader = reader.into_futures_async_read(0..meta.content_length());
+    let mut buf_reader = reader
+        .into_futures_async_read(0..meta.content_length())
+        .await?;
     let mut stdout = io::AllowStdIo::new(std::io::stdout());
     io::copy_buf(&mut buf_reader, &mut stdout).await?;
     Ok(())

--- a/bin/oli/src/commands/cp.rs
+++ b/bin/oli/src/commands/cp.rs
@@ -49,7 +49,9 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
         let mut dst_w = dst_op.writer(&dst_path).await?.into_futures_async_write();
         let src_meta = src_op.stat(&src_path).await?;
         let reader = src_op.reader_with(&src_path).chunk(8 * 1024 * 1024).await?;
-        let buf_reader = reader.into_futures_async_read(0..src_meta.content_length());
+        let buf_reader = reader
+            .into_futures_async_read(0..src_meta.content_length())
+            .await?;
         futures::io::copy_buf(buf_reader, &mut dst_w).await?;
         // flush data
         dst_w.close().await?;
@@ -71,7 +73,9 @@ pub async fn main(args: &ArgMatches) -> Result<()> {
             .strip_prefix(prefix)
             .expect("invalid path");
         let reader = src_op.reader_with(de.path()).chunk(8 * 1024 * 1024).await?;
-        let buf_reader = reader.into_futures_async_read(0..meta.content_length());
+        let buf_reader = reader
+            .into_futures_async_read(0..meta.content_length())
+            .await?;
 
         let mut writer = dst_op
             .writer(&dst_root.join(fp).to_string_lossy())

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -188,10 +188,12 @@ impl Operator {
     /// It could be used to read large file in a streaming way.
     #[napi]
     pub async fn reader(&self, path: String) -> Result<Reader> {
-        let meta = self.0.stat(&path).await.map_err(format_napi_error)?;
         let r = self.0.reader(&path).await.map_err(format_napi_error)?;
         Ok(Reader {
-            inner: r.into_futures_async_read(0..meta.content_length()),
+            inner: r
+                .into_futures_async_read(..)
+                .await
+                .map_err(format_napi_error)?,
         })
     }
 

--- a/bindings/python/src/file.rs
+++ b/bindings/python/src/file.rs
@@ -292,11 +292,9 @@ enum AsyncFileState {
 }
 
 impl AsyncFile {
-    pub fn new_reader(reader: ocore::Reader, size: u64, capability: Capability) -> Self {
+    pub fn new_reader(reader: ocore::FuturesAsyncReader, capability: Capability) -> Self {
         Self(
-            Arc::new(Mutex::new(AsyncFileState::Reader(
-                reader.into_futures_async_read(0..size),
-            ))),
+            Arc::new(Mutex::new(AsyncFileState::Reader(reader))),
             capability,
         )
     }

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -245,9 +245,14 @@ impl AsyncOperator {
 
         future_into_py(py, async move {
             if mode == "rb" {
-                let meta = this.stat(&path).await.map_err(format_pyerr)?;
-                let r = this.reader(&path).await.map_err(format_pyerr)?;
-                Ok(AsyncFile::new_reader(r, meta.content_length(), capability))
+                let r = this
+                    .reader(&path)
+                    .await
+                    .map_err(format_pyerr)?
+                    .into_futures_async_read(..)
+                    .await
+                    .map_err(format_pyerr)?;
+                Ok(AsyncFile::new_reader(r, capability))
             } else if mode == "wb" {
                 let w = this.writer(&path).await.map_err(format_pyerr)?;
                 Ok(AsyncFile::new_writer(w, capability))

--- a/core/benches/ops/read.rs
+++ b/core/benches/ops/read.rs
@@ -52,7 +52,10 @@ fn bench_read_full(c: &mut Criterion, name: &str, op: Operator) {
             b.to_async(&*TEST_RUNTIME).iter(|| async {
                 let r = op.reader_with(path).await.unwrap();
 
-                let r = r.into_futures_async_read(0..size.bytes() as u64);
+                let r = r
+                    .into_futures_async_read(0..size.bytes() as u64)
+                    .await
+                    .unwrap();
                 io::copy(r, &mut io::sink()).await.unwrap();
             })
         });

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -940,6 +940,7 @@ mod tests {
             let mut am = AccessorInfo::default();
             am.set_native_capability(Capability {
                 read: true,
+                stat: true,
                 list: true,
                 list_with_recursive: true,
                 batch: true,
@@ -947,6 +948,12 @@ mod tests {
             });
 
             am
+        }
+
+        async fn stat(&self, _: &str, _: OpStat) -> Result<RpStat> {
+            Ok(RpStat::new(
+                Metadata::new(EntryMode::FILE).with_content_length(13),
+            ))
         }
 
         async fn read(&self, _: &str, _: OpRead) -> Result<(RpRead, Self::Reader)> {

--- a/core/src/raw/atomic_util.rs
+++ b/core/src/raw/atomic_util.rs
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// AtomicContentLength is a wrapper of AtomicU64 that used to store content length.
+///
+/// It provides a way to store and load content length in atomic way, so caller don't need to
+/// use `Mutex` or `RwLock` to protect the content length.
+///
+/// We use value `u64::MAX` to represent unknown size, it's impossible for us to
+/// handle a file that has `u64::MAX` bytes.
+#[derive(Debug)]
+pub struct AtomicContentLength(AtomicU64);
+
+impl Default for AtomicContentLength {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AtomicContentLength {
+    /// Create a new AtomicContentLength.
+    pub const fn new() -> Self {
+        Self(AtomicU64::new(u64::MAX))
+    }
+
+    /// Load content length from AtomicU64.
+    #[inline]
+    pub fn load(&self) -> Option<u64> {
+        match self.0.load(Ordering::Relaxed) {
+            u64::MAX => None,
+            v => Some(v),
+        }
+    }
+
+    /// Store content length to AtomicU64.
+    #[inline]
+    pub fn store(&self, v: u64) {
+        self.0.store(v, Ordering::Relaxed)
+    }
+}

--- a/core/src/raw/mod.rs
+++ b/core/src/raw/mod.rs
@@ -78,6 +78,9 @@ pub use futures_util::MaybeSend;
 mod enum_utils;
 pub use enum_utils::*;
 
+mod atomic_util;
+pub use atomic_util::*;
+
 // Expose as a pub mod to avoid confusing.
 pub mod adapters;
 pub mod oio;

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
 
 use futures::stream;
@@ -547,8 +548,9 @@ impl Operator {
                     );
                 }
 
+                let path = Arc::new(path);
                 let range = options.range();
-                let r = Reader::create(inner, &path, args, options).await?;
+                let r = Reader::create(inner, path, args, options).await?;
                 let buf = r.read(range.to_range()).await?;
                 Ok(buf)
             },
@@ -656,7 +658,8 @@ impl Operator {
                     );
                 }
 
-                Reader::create(inner.clone(), &path, args, options).await
+                let path = Arc::new(path);
+                Reader::create(inner.clone(), path, args, options).await
             },
         )
     }

--- a/core/src/types/read/futures_bytes_stream.rs
+++ b/core/src/types/read/futures_bytes_stream.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use std::io;
-use std::ops::RangeBounds;
+use std::ops::Range;
 use std::pin::Pin;
 use std::task::ready;
 use std::task::Context;
@@ -46,7 +46,7 @@ unsafe impl Sync for FuturesBytesStream {}
 impl FuturesBytesStream {
     /// NOTE: don't allow users to create FuturesStream directly.
     #[inline]
-    pub(crate) fn new(r: oio::Reader, options: OpReader, range: impl RangeBounds<u64>) -> Self {
+    pub(crate) fn new(r: oio::Reader, options: OpReader, range: Range<u64>) -> Self {
         let stream = BufferStream::new(r, options, range);
 
         FuturesBytesStream {

--- a/core/src/types/read/reader.rs
+++ b/core/src/types/read/reader.rs
@@ -270,7 +270,10 @@ impl Reader {
     /// }
     /// ```
     #[inline]
-    pub async fn into_futures_async_read(self, range: Range<u64>) -> Result<FuturesAsyncReader> {
+    pub async fn into_futures_async_read(
+        self,
+        range: impl RangeBounds<u64>,
+    ) -> Result<FuturesAsyncReader> {
         let range = self.parse_range(range).await?;
         Ok(FuturesAsyncReader::new(self.inner, self.options, range))
     }

--- a/core/tests/behavior/async_read.rs
+++ b/core/tests/behavior/async_read.rs
@@ -159,6 +159,7 @@ pub async fn test_reader(op: Operator) -> anyhow::Result<()> {
         .reader(&path)
         .await?
         .into_bytes_stream(..)
+        .await?
         .try_fold(Vec::new(), |mut acc, chunk| {
             acc.extend_from_slice(&chunk);
             async { Ok(acc) }
@@ -175,7 +176,8 @@ pub async fn test_reader(op: Operator) -> anyhow::Result<()> {
     let mut futures_reader = op
         .reader(&path)
         .await?
-        .into_futures_async_read(0..size as u64);
+        .into_futures_async_read(0..size as u64)
+        .await?;
     let mut bs = Vec::new();
     futures_reader.read_to_end(&mut bs).await?;
     assert_eq!(size, bs.len(), "read size");

--- a/integrations/object_store/src/lib.rs
+++ b/integrations/object_store/src/lib.rs
@@ -139,6 +139,11 @@ impl ObjectStore for OpendalStore {
 
         let stream = r
             .into_bytes_stream(0..meta.size as u64)
+            .await
+            .map_err(|err| object_store::Error::Generic {
+                store: "IoError",
+                source: Box::new(err),
+            })?
             .into_send()
             .map_err(|err| object_store::Error::Generic {
                 store: "IoError",


### PR DESCRIPTION
We used to depends on the behavior that services can handle large range correctly, however, it doesn't. Many services can't handle range correctly like reported in https://github.com/apache/opendal/issues/4618.

Thus we should fetch the content length while end_bound is unknown.

I will start another PR to fix the `read_at`'s API docs.


- Fix https://github.com/apache/opendal/issues/4594
- Fix https://github.com/apache/opendal/issues/4618
