### PR TITLE
refactor(core): core doesn't expose invalid input error anymore

### DIFF
--- a/bindings/java/src/error.rs
+++ b/bindings/java/src/error.rs
@@ -59,7 +59,6 @@ impl Error {
             ErrorKind::ConditionNotMatch => "ConditionNotMatch",
             ErrorKind::ContentTruncated => "ContentTruncated",
             ErrorKind::ContentIncomplete => "ContentIncomplete",
-            ErrorKind::InvalidInput => "InvalidInput",
             _ => "Unexpected",
         })?;
         let message = env.new_string(format!("{:?}", self.inner))?;

--- a/bindings/java/src/main/java/org/apache/opendal/OpenDALException.java
+++ b/bindings/java/src/main/java/org/apache/opendal/OpenDALException.java
@@ -73,6 +73,5 @@ public class OpenDALException extends RuntimeException {
         ConditionNotMatch,
         ContentTruncated,
         ContentIncomplete,
-        InvalidInput,
     }
 }

--- a/bindings/python/python/opendal/exceptions.pyi
+++ b/bindings/python/python/opendal/exceptions.pyi
@@ -80,7 +80,3 @@ class ContentIncomplete(Error):
 
     pass
 
-class InvalidInput(Error):
-    """Invalid input"""
-
-    pass

--- a/bindings/python/src/errors.rs
+++ b/bindings/python/src/errors.rs
@@ -38,7 +38,6 @@ create_exception!(
 );
 create_exception!(opendal, ContentTruncatedError, Error, "Content truncated");
 create_exception!(opendal, ContentIncompleteError, Error, "Content incomplete");
-create_exception!(opendal, InvalidInputError, Error, "Invalid input");
 
 pub fn format_pyerr(err: ocore::Error) -> PyErr {
     use ocore::ErrorKind::*;
@@ -55,7 +54,6 @@ pub fn format_pyerr(err: ocore::Error) -> PyErr {
         ConditionNotMatch => ConditionNotMatchError::new_err(err.to_string()),
         ContentTruncated => ContentTruncatedError::new_err(err.to_string()),
         ContentIncomplete => ContentIncompleteError::new_err(err.to_string()),
-        InvalidInput => InvalidInputError::new_err(err.to_string()),
         _ => UnexpectedError::new_err(err.to_string()),
     }
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -105,7 +105,6 @@ fn _opendal(py: Python, m: &PyModule) -> PyResult<()> {
     exception_module.add("ConditionNotMatch", py.get_type::<ConditionNotMatchError>())?;
     exception_module.add("ContentTruncated", py.get_type::<ContentTruncatedError>())?;
     exception_module.add("ContentIncomplete", py.get_type::<ContentIncompleteError>())?;
-    exception_module.add("InvalidInput", py.get_type::<InvalidInputError>())?;
     m.add_submodule(exception_module)?;
     py.import("sys")?
         .getattr("modules")?

--- a/core/src/raw/std_io_util.rs
+++ b/core/src/raw/std_io_util.rs
@@ -33,7 +33,6 @@ pub fn new_std_io_error(err: std::io::Error) -> Error {
         NotFound => (ErrorKind::NotFound, false),
         PermissionDenied => (ErrorKind::PermissionDenied, false),
         AlreadyExists => (ErrorKind::AlreadyExists, false),
-        InvalidInput => (ErrorKind::InvalidInput, false),
         Unsupported => (ErrorKind::Unsupported, false),
 
         Interrupted | UnexpectedEof | TimedOut | WouldBlock => (ErrorKind::Unexpected, true),
@@ -59,7 +58,6 @@ pub(crate) fn format_std_io_error(err: Error) -> io::Error {
     let kind = match err.kind() {
         ErrorKind::NotFound => io::ErrorKind::NotFound,
         ErrorKind::PermissionDenied => io::ErrorKind::PermissionDenied,
-        ErrorKind::InvalidInput => io::ErrorKind::InvalidInput,
         _ => io::ErrorKind::Interrupted,
     };
 

--- a/core/src/services/alluxio/error.rs
+++ b/core/src/services/alluxio/error.rs
@@ -48,7 +48,6 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         kind = match alluxio_err.status_code.as_str() {
             "ALREADY_EXISTS" => ErrorKind::AlreadyExists,
             "NOT_FOUND" => ErrorKind::NotFound,
-            "INVALID_ARGUMENT" => ErrorKind::InvalidInput,
             _ => ErrorKind::Unexpected,
         }
     }
@@ -77,10 +76,6 @@ mod tests {
             (
                 r#"{"statusCode":"NOT_FOUND","message":"The resource you requested does not exist"}"#,
                 ErrorKind::NotFound,
-            ),
-            (
-                r#"{"statusCode":"INVALID_ARGUMENT","message":"The argument you provided is invalid"}"#,
-                ErrorKind::InvalidInput,
             ),
             (
                 r#"{"statusCode":"INTERNAL_SERVER_ERROR","message":"Internal server error"}"#,

--- a/core/src/services/gridfs/backend.rs
+++ b/core/src/services/gridfs/backend.rs
@@ -143,7 +143,7 @@ impl Builder for GridFsBuilder {
             Some(v) => v.clone(),
             None => {
                 return Err(
-                    Error::new(ErrorKind::InvalidInput, "connection_string is required")
+                    Error::new(ErrorKind::ConfigInvalid, "connection_string is required")
                         .with_context("service", Scheme::Gridfs),
                 )
             }
@@ -151,7 +151,7 @@ impl Builder for GridFsBuilder {
         let database = match &self.database.clone() {
             Some(v) => v.clone(),
             None => {
-                return Err(Error::new(ErrorKind::InvalidInput, "database is required")
+                return Err(Error::new(ErrorKind::ConfigInvalid, "database is required")
                     .with_context("service", Scheme::Gridfs))
             }
         };

--- a/core/src/services/hdfs_native/error.rs
+++ b/core/src/services/hdfs_native/error.rs
@@ -29,8 +29,6 @@ pub fn parse_hdfs_error(hdfs_error: HdfsError) -> Error {
             false,
             "checksums didn't match".to_string(),
         ),
-        HdfsError::InvalidPath(msg) => (ErrorKind::InvalidInput, false, msg.clone()),
-        HdfsError::InvalidArgument(msg) => (ErrorKind::InvalidInput, false, msg.clone()),
         HdfsError::UrlParseError(err) => (ErrorKind::Unexpected, false, err.to_string()),
         HdfsError::AlreadyExists(msg) => (ErrorKind::AlreadyExists, false, msg.clone()),
         HdfsError::OperationFailed(msg) => (ErrorKind::Unexpected, false, msg.clone()),

--- a/core/src/services/mongodb/backend.rs
+++ b/core/src/services/mongodb/backend.rs
@@ -166,7 +166,7 @@ impl Builder for MongodbBuilder {
             Some(v) => v.clone(),
             None => {
                 return Err(
-                    Error::new(ErrorKind::InvalidInput, "connection_string is required")
+                    Error::new(ErrorKind::ConfigInvalid, "connection_string is required")
                         .with_context("service", Scheme::Mongodb),
                 )
             }
@@ -174,7 +174,7 @@ impl Builder for MongodbBuilder {
         let database = match &self.config.database.clone() {
             Some(v) => v.clone(),
             None => {
-                return Err(Error::new(ErrorKind::InvalidInput, "database is required")
+                return Err(Error::new(ErrorKind::ConfigInvalid, "database is required")
                     .with_context("service", Scheme::Mongodb))
             }
         };
@@ -182,7 +182,7 @@ impl Builder for MongodbBuilder {
             Some(v) => v.clone(),
             None => {
                 return Err(
-                    Error::new(ErrorKind::InvalidInput, "collection is required")
+                    Error::new(ErrorKind::ConfigInvalid, "collection is required")
                         .with_context("service", Scheme::Mongodb),
                 )
             }

--- a/core/src/services/seafile/error.rs
+++ b/core/src/services/seafile/error.rs
@@ -35,7 +35,6 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
     let bs = body.copy_to_bytes(body.remaining());
 
     let (kind, _retryable) = match parts.status.as_u16() {
-        400 => (ErrorKind::InvalidInput, false),
         403 => (ErrorKind::PermissionDenied, false),
         404 => (ErrorKind::NotFound, false),
         520 => (ErrorKind::Unexpected, false),

--- a/core/src/services/yandex_disk/error.rs
+++ b/core/src/services/yandex_disk/error.rs
@@ -38,7 +38,6 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
     let bs = body.copy_to_bytes(body.remaining());
 
     let (kind, retryable) = match parts.status.as_u16() {
-        400 => (ErrorKind::InvalidInput, false),
         410 | 403 => (ErrorKind::PermissionDenied, false),
         404 => (ErrorKind::NotFound, false),
         // We should retry it when we get 423 error.

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -100,10 +100,6 @@ pub enum ErrorKind {
     /// - Users expected to read 1024 bytes, but service returned less bytes.
     /// - Service expected to write 1024 bytes, but users write less bytes.
     ContentIncomplete,
-    /// The input is invalid.
-    ///
-    /// For example, user try to seek to a negative position
-    InvalidInput,
 }
 
 impl ErrorKind {
@@ -135,7 +131,6 @@ impl From<ErrorKind> for &'static str {
             ErrorKind::ConditionNotMatch => "ConditionNotMatch",
             ErrorKind::ContentTruncated => "ContentTruncated",
             ErrorKind::ContentIncomplete => "ContentIncomplete",
-            ErrorKind::InvalidInput => "InvalidInput",
         }
     }
 }
@@ -427,7 +422,6 @@ impl From<Error> for io::Error {
         let kind = match err.kind() {
             ErrorKind::NotFound => io::ErrorKind::NotFound,
             ErrorKind::PermissionDenied => io::ErrorKind::PermissionDenied,
-            ErrorKind::InvalidInput => io::ErrorKind::InvalidInput,
             _ => io::ErrorKind::Other,
         };
 


### PR DESCRIPTION
`InvalidInput` is designed for `oio::Read::seek` only, but we don't provide seek API anymore. And I found some places use this error kind in wrong. This PR fixed them at the same time.