### PR TITLE
refactor(core): Return unexpected error while content incomplete happen

### DIFF
--- a/bin/ofs/src/fuse.rs
+++ b/bin/ofs/src/fuse.rs
@@ -832,8 +832,6 @@ fn opendal_error2errno(err: opendal::Error) -> fuse3::Errno {
         ErrorKind::PermissionDenied => Errno::from(libc::EACCES),
         ErrorKind::AlreadyExists => Errno::from(libc::EEXIST),
         ErrorKind::NotADirectory => Errno::from(libc::ENOTDIR),
-        ErrorKind::ContentTruncated => Errno::from(libc::EAGAIN),
-        ErrorKind::ContentIncomplete => Errno::from(libc::EIO),
         _ => Errno::from(libc::ENOENT),
     }
 }

--- a/bindings/java/src/error.rs
+++ b/bindings/java/src/error.rs
@@ -57,8 +57,6 @@ impl Error {
             ErrorKind::RateLimited => "RateLimited",
             ErrorKind::IsSameFile => "IsSameFile",
             ErrorKind::ConditionNotMatch => "ConditionNotMatch",
-            ErrorKind::ContentTruncated => "ContentTruncated",
-            ErrorKind::ContentIncomplete => "ContentIncomplete",
             _ => "Unexpected",
         })?;
         let message = env.new_string(format!("{:?}", self.inner))?;

--- a/bindings/python/python/opendal/exceptions.pyi
+++ b/bindings/python/python/opendal/exceptions.pyi
@@ -70,13 +70,3 @@ class ConditionNotMatch(Error):
 
     pass
 
-class ContentTruncated(Error):
-    """Content truncated"""
-
-    pass
-
-class ContentIncomplete(Error):
-    """Content incomplete"""
-
-    pass
-

--- a/bindings/python/src/errors.rs
+++ b/bindings/python/src/errors.rs
@@ -36,8 +36,6 @@ create_exception!(
     Error,
     "Condition not match"
 );
-create_exception!(opendal, ContentTruncatedError, Error, "Content truncated");
-create_exception!(opendal, ContentIncompleteError, Error, "Content incomplete");
 
 pub fn format_pyerr(err: ocore::Error) -> PyErr {
     use ocore::ErrorKind::*;
@@ -52,8 +50,6 @@ pub fn format_pyerr(err: ocore::Error) -> PyErr {
         AlreadyExists => AlreadyExistsError::new_err(err.to_string()),
         IsSameFile => IsSameFileError::new_err(err.to_string()),
         ConditionNotMatch => ConditionNotMatchError::new_err(err.to_string()),
-        ContentTruncated => ContentTruncatedError::new_err(err.to_string()),
-        ContentIncomplete => ContentIncompleteError::new_err(err.to_string()),
         _ => UnexpectedError::new_err(err.to_string()),
     }
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -103,8 +103,6 @@ fn _opendal(py: Python, m: &PyModule) -> PyResult<()> {
     exception_module.add("AlreadyExists", py.get_type::<AlreadyExistsError>())?;
     exception_module.add("IsSameFile", py.get_type::<IsSameFileError>())?;
     exception_module.add("ConditionNotMatch", py.get_type::<ConditionNotMatchError>())?;
-    exception_module.add("ContentTruncated", py.get_type::<ContentTruncatedError>())?;
-    exception_module.add("ContentIncomplete", py.get_type::<ContentIncompleteError>())?;
     m.add_submodule(exception_module)?;
     py.import("sys")?
         .getattr("modules")?

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -168,13 +168,13 @@ fn check(expect: u64, actual: u64) -> Result<()> {
     match actual.cmp(&expect) {
         Ordering::Equal => Ok(()),
         Ordering::Less => Err(Error::new(
-            ErrorKind::ContentIncomplete,
-            &format!("reader got too little data, expect: {expect}, actual: {actual}"),
+            ErrorKind::Unexpected,
+            &format!("http response got too little data, expect: {expect}, actual: {actual}"),
         )
         .set_temporary()),
         Ordering::Greater => Err(Error::new(
-            ErrorKind::ContentTruncated,
-            &format!("reader got too much data, expect: {expect}, actual: {actual}"),
+            ErrorKind::Unexpected,
+            &format!("http response got too much data, expect: {expect}, actual: {actual}"),
         )
         .set_temporary()),
     }

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -82,24 +82,6 @@ pub enum ErrorKind {
     /// As OpenDAL cannot handle the `condition not match` error, it will always return this error to users.
     /// So users could to handle this error by themselves.
     ConditionNotMatch,
-    /// The content is truncated.
-    ///
-    /// This error kind means there are more content to come but been truncated.
-    ///
-    /// For examples:
-    ///
-    /// - Users expected to read 1024 bytes, but service returned more bytes.
-    /// - Service expected to write 1024 bytes, but users write more bytes.
-    ContentTruncated,
-    /// The content is incomplete.
-    ///
-    /// This error kind means expect content length is not reached.
-    ///
-    /// For examples:
-    ///
-    /// - Users expected to read 1024 bytes, but service returned less bytes.
-    /// - Service expected to write 1024 bytes, but users write less bytes.
-    ContentIncomplete,
 }
 
 impl ErrorKind {
@@ -129,8 +111,6 @@ impl From<ErrorKind> for &'static str {
             ErrorKind::RateLimited => "RateLimited",
             ErrorKind::IsSameFile => "IsSameFile",
             ErrorKind::ConditionNotMatch => "ConditionNotMatch",
-            ErrorKind::ContentTruncated => "ContentTruncated",
-            ErrorKind::ContentIncomplete => "ContentIncomplete",
         }
     }
 }


### PR DESCRIPTION
We used to return two different errors, `ContentIncomplete` and `ContentTruncated`, when the HTTP response had too much or too little data. However, these error codes were not helpful to users as they provided no actionable steps.

This PR addresses this issue by returning a generic unexpected error instead.