### PR TITLE
ci: use official typos github action

### DIFF
--- a/.github/workflows/ci_check.yml
+++ b/.github/workflows/ci_check.yml
@@ -38,16 +38,10 @@ jobs:
     timeout-minutes: 10
     env:
       FORCE_COLOR: 1
-      TYPOS_VERSION: v1.21.0
     steps:
-      - name: download typos
-        run: curl -LsSf https://github.com/crate-ci/typos/releases/download/$TYPOS_VERSION/typos-$TYPOS_VERSION-x86_64-unknown-linux-musl.tar.gz | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: do typos check with typos-cli
-        run: typos
+      - uses: actions/checkout@v4
+      - name: Check typos
+        uses: crate-ci/typos@v1.21.0
 
   licenses:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`create-ci/typos` is whitelisted in https://issues.apache.org/jira/browse/INFRA-25798. I propose to switch