### PR TITLE
build(deps): upgrade crc32c version

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -763,7 +763,7 @@ dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
- "crc32c",
+ "crc32c 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc32fast",
  "hex",
  "http 0.2.12",
@@ -1891,6 +1891,14 @@ name = "crc32c"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
+dependencies = [
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.5"
+source = "git+https://github.com/zowens/crc32c?rev=04eabbc#04eabbc6ef33e0afe529da729e65916c48f9d032"
 dependencies = [
  "rustc_version 0.4.0",
 ]
@@ -4769,7 +4777,7 @@ dependencies = [
  "cacache",
  "chrono",
  "compio",
- "crc32c",
+ "crc32c 0.6.5 (git+https://github.com/zowens/crc32c?rev=04eabbc)",
  "criterion",
  "dashmap",
  "dotenvy",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -355,7 +355,7 @@ prometheus-client = { version = "0.22.2", optional = true }
 tracing = { version = "0.1", optional = true }
 # for layers-dtrace
 probe = { version = "0.5.1", optional = true }
-crc32c = "0.6.5"
+crc32c = { git = "https://github.com/zowens/crc32c", rev = "04eabbc" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }


### PR DESCRIPTION
Wait for https://github.com/zowens/crc32c/pull/60 released.