### PR TITLE
build(deps): upgrade crc32c to 0.6.6 for nightly toolchain

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1888,9 +1888,9 @@ checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32c"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
+checksum = "716b38bb6e49e9071060ab2c5e26195b70274f83fdf6cbc44542d63bb2f45c7d"
 dependencies = [
  "rustc_version 0.4.0",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -336,7 +336,7 @@ surrealdb = { version = "1.3.0", optional = true, features = ["protocol-http"] }
 # for services-compfs
 compio = { version = "0.10.0", optional = true, features = ["runtime", "bytes", "polling"] }
 # for services-s3
-crc32c = { version = "0.6.5", optional = true }
+crc32c = { version = "0.6.6", optional = true }
 
 # Layers
 # for layers-async-backtrace

--- a/core/src/types/buffer.rs
+++ b/core/src/types/buffer.rs
@@ -34,7 +34,7 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use futures::Stream;
 
-/// Buffer is a wrapper of contiguous `Bytes` and non contiguous `[Bytes]`.
+/// Buffer is a wrapper of contiguous `Bytes` and non-contiguous `[Bytes]`.
 ///
 /// We designed buffer to allow underlying storage to return non-contiguous bytes. For example,
 /// http based storage like s3 could generate non-contiguous bytes by stream.


### PR DESCRIPTION
See https://github.com/zowens/crc32c/pull/60.