### PR TITLE
feat: Implement and refactor concurrent tasks for multipart write

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -232,7 +232,7 @@ chrono = { version = "0.4.28", default-features = false, features = [
     "std",
 ] }
 flagset = "0.4"
-futures = { version = "0.3", default-features = false, features = ["std"] }
+futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 http = "1.1"
 log = "0.4"
 md-5 = "0.10"

--- a/core/benches/types/concurrent_tasks.rs
+++ b/core/benches/types/concurrent_tasks.rs
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use criterion::{black_box, BatchSize, Criterion};
+use once_cell::sync::Lazy;
+use opendal::raw::ConcurrentTasks;
+use opendal::Executor;
+
+pub static TOKIO: Lazy<tokio::runtime::Runtime> =
+    Lazy::new(|| tokio::runtime::Runtime::new().expect("build tokio runtime"));
+
+pub fn bench_concurrent_tasks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bench_concurrent_tasks");
+
+    for concurrent in [1, 2, 4, 8, 16] {
+        group.bench_with_input(concurrent.to_string(), &concurrent, |b, concurrent| {
+            b.to_async(&*TOKIO).iter_batched(
+                || {
+                    ConcurrentTasks::new(Some(Executor::new()), *concurrent, |()| {
+                        Box::pin(async {
+                            black_box(());
+                            ((), Ok(()))
+                        })
+                    })
+                },
+                |mut tasks| async move {
+                    let _ = tasks.execute(()).await;
+                },
+                BatchSize::NumIterations(1000),
+            )
+        });
+    }
+
+    group.finish()
+}

--- a/core/benches/types/main.rs
+++ b/core/benches/types/main.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 mod buffer;
+mod concurrent_tasks;
 mod utils;
 
 use criterion::criterion_group;
@@ -25,5 +26,6 @@ criterion_group!(
     benches,
     buffer::bench_non_contiguous_buffer,
     buffer::bench_non_contiguous_buffer_with_extreme,
+    concurrent_tasks::bench_concurrent_tasks,
 );
 criterion_main!(benches);

--- a/core/src/raw/mod.rs
+++ b/core/src/raw/mod.rs
@@ -73,6 +73,7 @@ mod futures_util;
 pub use futures_util::BoxedFuture;
 pub use futures_util::BoxedStaticFuture;
 pub use futures_util::ConcurrentFutures;
+pub use futures_util::ConcurrentTasks;
 pub use futures_util::MaybeSend;
 
 mod enum_utils;

--- a/core/src/services/aliyun_drive/backend.rs
+++ b/core/src/services/aliyun_drive/backend.rs
@@ -461,10 +461,12 @@ impl Access for AliyunDriveBackend {
         let parent_path = get_parent(path);
         let parent_file_id = self.core.ensure_dir_exists(parent_path).await?;
 
+        let executor = args.executor().cloned();
+
         let writer =
             AliyunDriveWriter::new(self.core.clone(), &parent_file_id, get_basename(path), args);
 
-        let w = oio::MultipartWriter::new(writer, 1);
+        let w = oio::MultipartWriter::new(writer, executor, 1);
 
         Ok((RpWrite::default(), w))
     }

--- a/core/src/services/b2/backend.rs
+++ b/core/src/services/b2/backend.rs
@@ -360,9 +360,10 @@ impl Access for B2Backend {
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         let concurrent = args.concurrent();
+        let executor = args.executor().cloned();
         let writer = B2Writer::new(self.core.clone(), path, args);
 
-        let w = oio::MultipartWriter::new(writer, concurrent);
+        let w = oio::MultipartWriter::new(writer, executor, concurrent);
 
         Ok((RpWrite::default(), w))
     }

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -336,7 +336,11 @@ impl Access for CosBackend {
         let w = if args.append() {
             CosWriters::Two(oio::AppendWriter::new(writer))
         } else {
-            CosWriters::One(oio::MultipartWriter::new(writer, args.concurrent()))
+            CosWriters::One(oio::MultipartWriter::new(
+                writer,
+                args.executor().cloned(),
+                args.concurrent(),
+            ))
         };
 
         Ok((RpWrite::default(), w))

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -333,7 +333,11 @@ impl Access for ObsBackend {
         let w = if args.append() {
             ObsWriters::Two(oio::AppendWriter::new(writer))
         } else {
-            ObsWriters::One(oio::MultipartWriter::new(writer, args.concurrent()))
+            ObsWriters::One(oio::MultipartWriter::new(
+                writer,
+                args.executor().cloned(),
+                args.concurrent(),
+            ))
         };
 
         Ok((RpWrite::default(), w))

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -466,7 +466,11 @@ impl Access for OssBackend {
         let w = if args.append() {
             OssWriters::Two(oio::AppendWriter::new(writer))
         } else {
-            OssWriters::One(oio::MultipartWriter::new(writer, args.concurrent()))
+            OssWriters::One(oio::MultipartWriter::new(
+                writer,
+                args.executor().cloned(),
+                args.concurrent(),
+            ))
         };
 
         Ok((RpWrite::default(), w))

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -1107,9 +1107,10 @@ impl Access for S3Backend {
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         let concurrent = args.concurrent();
+        let executor = args.executor().cloned();
         let writer = S3Writer::new(self.core.clone(), path, args);
 
-        let w = oio::MultipartWriter::new(writer, concurrent);
+        let w = oio::MultipartWriter::new(writer, executor, concurrent);
 
         Ok((RpWrite::default(), w))
     }

--- a/core/src/services/upyun/backend.rs
+++ b/core/src/services/upyun/backend.rs
@@ -304,9 +304,10 @@ impl Access for UpyunBackend {
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         let concurrent = args.concurrent();
+        let executor = args.executor().cloned();
         let writer = UpyunWriter::new(self.core.clone(), args, path.to_string());
 
-        let w = oio::MultipartWriter::new(writer, concurrent);
+        let w = oio::MultipartWriter::new(writer, executor, concurrent);
 
         Ok((RpWrite::default(), w))
     }

--- a/core/src/services/vercel_blob/backend.rs
+++ b/core/src/services/vercel_blob/backend.rs
@@ -238,9 +238,10 @@ impl Access for VercelBlobBackend {
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         let concurrent = args.concurrent();
+        let executor = args.executor().cloned();
         let writer = VercelBlobWriter::new(self.core.clone(), args, path.to_string());
 
-        let w = oio::MultipartWriter::new(writer, concurrent);
+        let w = oio::MultipartWriter::new(writer, executor, concurrent);
 
         Ok((RpWrite::default(), w))
     }

--- a/core/src/types/execute/api.rs
+++ b/core/src/types/execute/api.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use crate::raw::BoxedStaticFuture;
-use crate::*;
 use futures::future::RemoteHandle;
 use futures::FutureExt;
 use std::future::Future;
@@ -30,16 +29,12 @@ pub trait Execute: Send + Sync + 'static {
     /// # Behavior
     ///
     /// - Implementor must manage the executing futures and keep making progress.
-    /// - Implementor must return `Error::Unexpected` if failed to execute new task.
-    fn execute(&self, f: BoxedStaticFuture<()>) -> Result<()>;
+    fn execute(&self, f: BoxedStaticFuture<()>);
 }
 
 impl Execute for () {
-    fn execute(&self, _: BoxedStaticFuture<()>) -> Result<()> {
-        Err(Error::new(
-            ErrorKind::Unexpected,
-            "no executor has been set",
-        ))
+    fn execute(&self, _: BoxedStaticFuture<()>) {
+        panic!("concurrent tasks executed with no executor has been enabled")
     }
 }
 
@@ -59,7 +54,6 @@ pub struct Task<T> {
 impl<T: 'static> Task<T> {
     /// Create a new task.
     #[inline]
-    #[allow(unused)]
     pub fn new(handle: RemoteHandle<T>) -> Self {
         Self { handle }
     }

--- a/core/src/types/execute/executor.rs
+++ b/core/src/types/execute/executor.rs
@@ -17,7 +17,6 @@
 
 use super::*;
 use crate::raw::MaybeSend;
-use crate::*;
 use futures::FutureExt;
 use std::fmt::{Debug, Formatter};
 use std::future::Future;
@@ -72,13 +71,13 @@ impl Executor {
 
     /// Run given future in background immediately.
     #[allow(unused)]
-    pub(crate) fn execute<F>(&self, f: F) -> Result<Task<F::Output>>
+    pub(crate) fn execute<F>(&self, f: F) -> Task<F::Output>
     where
         F: Future + MaybeSend + 'static,
         F::Output: MaybeSend + 'static,
     {
         let (fut, handle) = f.remote_handle();
-        self.executor.execute(Box::pin(fut))?;
-        Ok(Task::new(handle))
+        self.executor.execute(Box::pin(fut));
+        Task::new(handle)
     }
 }

--- a/core/src/types/execute/executors/tokio_executor.rs
+++ b/core/src/types/execute/executors/tokio_executor.rs
@@ -24,9 +24,8 @@ pub struct TokioExecutor {}
 
 impl Execute for TokioExecutor {
     /// Tokio's JoinHandle has it's own `abort` support, so dropping handle won't cancel the task.
-    fn execute(&self, f: BoxedStaticFuture<()>) -> Result<()> {
+    fn execute(&self, f: BoxedStaticFuture<()>) {
         let _handle = tokio::task::spawn(f);
-        Ok(())
     }
 }
 
@@ -46,12 +45,10 @@ mod tests {
         let finished = Arc::new(AtomicBool::new(false));
 
         let finished_clone = finished.clone();
-        let _task = executor
-            .execute(async move {
-                sleep(Duration::from_secs(1)).await;
-                finished_clone.store(true, Ordering::Relaxed);
-            })
-            .unwrap();
+        let _task = executor.execute(async move {
+            sleep(Duration::from_secs(1)).await;
+            finished_clone.store(true, Ordering::Relaxed);
+        });
 
         sleep(Duration::from_secs(2)).await;
         // Task must has been finished even without await task.


### PR DESCRIPTION
Part of https://github.com/apache/opendal/issues/4639

This PR implements `ConcurrentTasks` based on existing `Executor` and replace the `ConcurrentFutures` used by multipart write.