### PR TITLE
fix(core/types): remove_all not work under object-store backend

### DIFF
--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -1398,22 +1398,32 @@ impl Operator {
     /// # }
     /// ```
     pub async fn remove_all(&self, path: &str) -> Result<()> {
-        let meta = match self.stat(path).await {
+        match self.stat(path).await {
             // If object exists.
-            Ok(metadata) => metadata,
+            Ok(metadata) => {
+                // If the object is a file, we can delete it.
+                if metadata.mode() != EntryMode::DIR {
+                    self.delete(path).await?;
+                    // There may still be objects prefixed with the path in some backend, so we can't return here.
+                }
+            }
 
-            // If object not found, return success.
-            Err(e) if e.kind() == ErrorKind::NotFound => return Ok(()),
+            // If dir not found, it may be a prefix in object store like S3,
+            // and we still need to delete objects under the prefix.
+            Err(e) if e.kind() == ErrorKind::NotFound => {}
 
             // Pass on any other error.
             Err(e) => return Err(e),
         };
 
-        if meta.mode() != EntryMode::DIR {
-            return self.delete(path).await;
-        }
-
-        let obs = self.lister_with(path).recursive(true).await?;
+        let obs = match self.lister_with(path).recursive(true).await {
+            Ok(obs) => obs,
+            Err(e) if e.kind() == ErrorKind::NotFound => {
+                // If lister still returns NotFound, we can confirm there are no objects under the prefix in any backend.
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        };
 
         if self.info().full_capability().batch {
             let mut obs = obs.try_chunks(self.limit());


### PR DESCRIPTION
Fix #4654 

The root cause is described in https://github.com/apache/opendal/issues/4654#issuecomment-2140685110

The fix covered several cases in object-store like backend:

1. Both prefix and objects exist, when remove_all("a"), we should not only delete the object "a", e.g.:
   * a
   * a/b
   * a/c
2. Normal case, when remove_all("a"), we should remove all objects under the prefix.
   * a/b
   * a/c
