### PR TITLE
refactor: centralize range expand logic

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -141,6 +141,24 @@ pub mod layers;
 pub mod raw;
 pub mod services;
 
+/// Expand [std::ops::RangeBounds] into (start, end) tuple.
+#[macro_export]
+macro_rules! expand_range {
+    ($range:ident) => {{
+        let start = match $range.start_bound() {
+            std::ops::Bound::Included(n) => Some(n.clone()),
+            std::ops::Bound::Excluded(n) => Some(n.checked_add(1).expect("out of range")),
+            std::ops::Bound::Unbounded => None,
+        };
+        let end = match $range.end_bound() {
+            std::ops::Bound::Included(n) => Some(n.checked_add(1).expect("out of range")),
+            std::ops::Bound::Excluded(n) => Some(n.clone()),
+            std::ops::Bound::Unbounded => None,
+        };
+        (start, end)
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use std::mem::size_of;

--- a/core/src/raw/http_util/bytes_range.rs
+++ b/core/src/raw/http_util/bytes_range.rs
@@ -183,17 +183,9 @@ where
     T: RangeBounds<u64>,
 {
     fn from(range: T) -> Self {
-        let offset = match range.start_bound().cloned() {
-            Bound::Included(n) => n,
-            Bound::Excluded(n) => n + 1,
-            Bound::Unbounded => 0,
-        };
-        let size = match range.end_bound().cloned() {
-            Bound::Included(n) => Some(n + 1 - offset),
-            Bound::Excluded(n) => Some(n - offset),
-            Bound::Unbounded => None,
-        };
-
+        let (offset, size) = expand_range!(range);
+        let offset = offset.unwrap_or(0);
+        let size = size.map(|size| size - offset);
         BytesRange(offset, size)
     }
 }

--- a/core/src/types/buffer.rs
+++ b/core/src/types/buffer.rs
@@ -21,7 +21,7 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::io::IoSlice;
 use std::mem;
-use std::ops::Bound;
+
 use std::ops::RangeBounds;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -244,16 +244,9 @@ impl Buffer {
     pub fn slice(&self, range: impl RangeBounds<usize>) -> Self {
         let len = self.len();
 
-        let begin = match range.start_bound() {
-            Bound::Included(&n) => n,
-            Bound::Excluded(&n) => n.checked_add(1).expect("out of range"),
-            Bound::Unbounded => 0,
-        };
-
-        let end = match range.end_bound() {
-            Bound::Included(&n) => n.checked_add(1).expect("out of range"),
-            Bound::Excluded(&n) => n,
-            Bound::Unbounded => len,
+        let (begin, end) = {
+            let (begin, end) = expand_range!(range);
+            (begin.unwrap_or(0), end.unwrap_or(len))
         };
 
         assert!(


### PR DESCRIPTION
Perhaps we can have a better name and better place to hold this logic. Just noticed that we repeat a few time to expand range bounds and they're subtly different.