### PR TITLE
feat(services/compfs): basic `Access` impl

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1653,10 +1653,10 @@ dependencies = [
 [[package]]
 name = "compio"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76871d1ab0619ccb72372cf8d87951ac2bf112e6e1ede1085f2f50ace4436ad3"
+source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
 dependencies = [
  "compio-buf",
+ "compio-dispatcher",
  "compio-driver",
  "compio-fs",
  "compio-io",
@@ -1668,8 +1668,7 @@ dependencies = [
 [[package]]
 name = "compio-buf"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d9ae28226834dc0f8cd9af2a129488528bcaa4426baaba16072e13cff8440b"
+source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1677,10 +1676,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compio-dispatcher"
+version = "0.2.0"
+source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
+dependencies = [
+ "compio-driver",
+ "compio-runtime",
+ "flume",
+ "futures-channel",
+]
+
+[[package]]
 name = "compio-driver"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b23ddd21203f5d4bee6e5a9f53e4f09f98229590a903ee1b5b4c88047a440d"
+source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
 dependencies = [
  "aligned-array",
  "cfg-if",
@@ -1688,13 +1697,13 @@ dependencies = [
  "compio-log",
  "crossbeam-channel",
  "crossbeam-queue",
+ "futures-util",
  "io-uring",
  "libc",
  "once_cell",
  "os_pipe",
  "paste",
  "polling 3.7.1",
- "slab",
  "socket2 0.5.7",
  "windows-sys 0.52.0",
 ]
@@ -1702,8 +1711,7 @@ dependencies = [
 [[package]]
 name = "compio-fs"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770d9c79a1174adc527b6ce880aa6a50d9f5fb630339024069785ebbd6848c2f"
+source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
 dependencies = [
  "cfg-if",
  "compio-buf",
@@ -1719,8 +1727,7 @@ dependencies = [
 [[package]]
 name = "compio-io"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6f47ce0edef794248555268b9e0cfbbbaaacaa3634fca4acc199818272a415"
+source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
 dependencies = [
  "compio-buf",
  "futures-util",
@@ -1730,8 +1737,7 @@ dependencies = [
 [[package]]
 name = "compio-log"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4e560213c1996b618da369b7c9109564b41af9033802ae534465c4ee4e132f"
+source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
 dependencies = [
  "tracing",
 ]
@@ -1739,8 +1745,7 @@ dependencies = [
 [[package]]
 name = "compio-net"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae469c47794087f9110a8858394b6c8112317b66c5d41d44d874ebf4218bc3ee"
+source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
 dependencies = [
  "cfg-if",
  "compio-buf",
@@ -1757,8 +1762,7 @@ dependencies = [
 [[package]]
 name = "compio-runtime"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c314b56ebb29d21e6f0dc3749ebbc83ddcb7d7a150f86b0c6d0e5b6ca228bae7"
+source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
 dependencies = [
  "async-task",
  "cfg-if",
@@ -1770,6 +1774,8 @@ dependencies = [
  "libc",
  "once_cell",
  "os_pipe",
+ "scoped-tls",
+ "slab",
  "smallvec",
  "socket2 0.5.7",
  "windows-sys 0.52.0",
@@ -4766,6 +4772,7 @@ dependencies = [
  "cacache",
  "chrono",
  "compio",
+ "compio-driver",
  "crc32c",
  "criterion",
  "dashmap",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1652,8 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "compio"
-version = "0.10.0"
-source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1704a939a6548e001b8502663fa4d90a87675569662ee4746d608c5ee62246ac"
 dependencies = [
  "compio-buf",
  "compio-dispatcher",
@@ -1667,8 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "compio-buf"
-version = "0.3.0"
-source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e280904a879019a48c3a9b0bbf6e158c097b9c21555be0608602c5b101755b"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1677,8 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "compio-dispatcher"
-version = "0.2.0"
-source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409f0680497022856f64e342ec9e0fd7384ed56bdaf82b3ef24ccab03eecd768"
 dependencies = [
  "compio-driver",
  "compio-runtime",
@@ -1688,8 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "compio-driver"
-version = "0.3.0"
-source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef034f0dafcead1e4738b1a18da070ff26abaf53ec9d9c4ba4b217b5f7a7c4a"
 dependencies = [
  "aligned-array",
  "cfg-if",
@@ -1710,8 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "compio-fs"
-version = "0.3.0"
-source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a51ed24575379a16f8aa23e04378b0fc291d7f608ba2b9928d0fffe24fb3100c"
 dependencies = [
  "cfg-if",
  "compio-buf",
@@ -1726,8 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "compio-io"
-version = "0.2.0"
-source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c6b524ae8226c007c41342a5803381f544f4f4066808d4c4ff146e75869ebb"
 dependencies = [
  "compio-buf",
  "futures-util",
@@ -1737,15 +1743,17 @@ dependencies = [
 [[package]]
 name = "compio-log"
 version = "0.1.0"
-source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4e560213c1996b618da369b7c9109564b41af9033802ae534465c4ee4e132f"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "compio-net"
-version = "0.3.0"
-source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6c4fcf2d8c86ac0f13b54c57d35ce351b81b2221a75f3cee286514634eef6e"
 dependencies = [
  "cfg-if",
  "compio-buf",
@@ -1761,8 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "compio-runtime"
-version = "0.3.0"
-source = "git+https://github.com/compio-rs/compio.git#9939253f42a171d701d94ff6e2ca9ed4dd5865d4"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8181cc373318910ccc4610dd54683d63d7933a96d21c6c69e61e750c01cd2016"
 dependencies = [
  "async-task",
  "cfg-if",
@@ -4772,7 +4781,6 @@ dependencies = [
  "cacache",
  "chrono",
  "compio",
- "compio-driver",
  "crc32c",
  "criterion",
  "dashmap",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -344,8 +344,7 @@ hdfs-native = { version = "0.9.4", optional = true }
 # for services-surrealdb
 surrealdb = { version = "1.3.0", optional = true, features = ["protocol-http"] }
 # for services-compfs
-compio = { git = "https://github.com/compio-rs/compio.git", version = "0.10.0", optional = true, features = ["runtime", "bytes", "polling", "dispatcher"] }
-compio-driver = { git = "https://github.com/compio-rs/compio.git", package = "compio-driver" }
+compio = { version = "0.11.0", optional = true, features = ["runtime", "bytes", "polling", "dispatcher"] }
 # for services-s3
 crc32c = { version = "0.6.6", optional = true }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -344,11 +344,8 @@ hdfs-native = { version = "0.9.4", optional = true }
 # for services-surrealdb
 surrealdb = { version = "1.3.0", optional = true, features = ["protocol-http"] }
 # for services-compfs
-compio = { version = "0.10.0", optional = true, features = [
-  "runtime",
-  "bytes",
-  "polling",
-] }
+compio = { git = "https://github.com/compio-rs/compio.git", version = "0.10.0", optional = true, features = ["runtime", "bytes", "polling", "dispatcher"] }
+compio-driver = { git = "https://github.com/compio-rs/compio.git", package = "compio-driver" }
 # for services-s3
 crc32c = { version = "0.6.6", optional = true }
 

--- a/core/src/services/compfs/backend.rs
+++ b/core/src/services/compfs/backend.rs
@@ -133,7 +133,7 @@ impl Access for CompfsBackend {
         let path = self.core.root.join(path.trim_end_matches('/'));
         let read_dir = match self
             .core
-            .exec_blocking(move || std::fs::read_dir(&path))
+            .exec_blocking(move || std::fs::read_dir(path))
             .await?
         {
             Ok(rd) => rd,

--- a/core/src/services/compfs/backend.rs
+++ b/core/src/services/compfs/backend.rs
@@ -15,12 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
-use std::path::PathBuf;
-
-use super::core::CompioThread;
+use super::{core::CompfsCore, lister::CompfsLister, reader::CompfsReader, writer::CompfsWriter};
 use crate::raw::*;
 use crate::*;
+
+use std::{collections::HashMap, io::Cursor, path::PathBuf, sync::Arc};
 
 /// [`compio`]-based file system support.
 #[derive(Debug, Clone, Default)]

--- a/core/src/services/compfs/backend.rs
+++ b/core/src/services/compfs/backend.rs
@@ -97,7 +97,7 @@ impl Access for CompfsBackend {
         am
     }
 
-    async fn read(&self, path: &str, _: OpRead) -> Result<(RpRead, Self::Reader)> {
+    async fn read(&self, path: &str, op: OpRead) -> Result<(RpRead, Self::Reader)> {
         let path = self.core.root.join(path.trim_end_matches('/'));
 
         let file = self
@@ -105,7 +105,7 @@ impl Access for CompfsBackend {
             .exec(|| async move { compio::fs::OpenOptions::new().read(true).open(&path).await })
             .await?;
 
-        let r = CompfsReader::new(self.core.clone(), file);
+        let r = CompfsReader::new(self.core.clone(), file, op.range());
         Ok((RpRead::new(), r))
     }
 

--- a/core/src/services/compfs/core.rs
+++ b/core/src/services/compfs/core.rs
@@ -15,103 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::future::Future;
-use std::thread::JoinHandle;
+use compio::{buf::IoBuf, dispatcher::Dispatcher};
+use std::{future::Future, path::PathBuf};
 
-use compio::buf::IoBuf;
-use compio::runtime::RuntimeBuilder;
-use futures::channel::mpsc;
-use futures::channel::mpsc::SendError;
-use futures::channel::oneshot;
-use futures::future::LocalBoxFuture;
-use futures::SinkExt;
-use futures::StreamExt;
-
-use crate::Buffer;
-
-/// This is arbitrary, but since all tasks are spawned instantly, we shouldn't need a too big buffer.
-const CHANNEL_SIZE: usize = 4;
-
-fn task<F, Fut, T>(func: F) -> (Task<T>, SpawnTask)
-where
-    F: (FnOnce() -> Fut) + Send + 'static,
-    Fut: Future<Output = T>,
-    T: Send + 'static,
-{
-    let (tx, recv) = oneshot::channel();
-
-    let boxed = Box::new(|| {
-        Box::pin(async move {
-            let res = func().await;
-            tx.send(res).ok();
-        }) as _
-    });
-
-    (Task(recv), SpawnTask(boxed))
-}
-
-/// A task handle that can be used to retrieve result spawned into [`CompioThread`].
-pub struct Task<T>(oneshot::Receiver<T>);
-
-/// Type erased task that can be spawned into a [`CompioThread`].
-struct SpawnTask(Box<dyn (FnOnce() -> LocalBoxFuture<'static, ()>) + Send>);
-
-impl SpawnTask {
-    fn call(self) -> LocalBoxFuture<'static, ()> {
-        (self.0)()
-    }
-}
-
-#[derive(Debug)]
-pub struct CompioThread {
-    thread: JoinHandle<()>,
-    handle: SpawnHandle,
-}
-
-impl CompioThread {
-    pub fn new(builder: RuntimeBuilder) -> Self {
-        let (send, mut recv) = mpsc::channel(CHANNEL_SIZE);
-        let handle = SpawnHandle(send);
-        let thread = std::thread::spawn(move || {
-            let rt = builder.build().expect("failed to create runtime");
-            rt.block_on(async {
-                while let Some(task) = recv.next().await {
-                    rt.spawn(task.call()).detach();
-                }
-            });
-        });
-        Self { thread, handle }
-    }
-
-    pub async fn spawn<F, Fut, T>(&self, func: F) -> Result<Task<T>, SendError>
-    where
-        F: (FnOnce() -> Fut) + Send + 'static,
-        Fut: Future<Output = T>,
-        T: Send + 'static,
-    {
-        self.handle.clone().spawn(func).await
-    }
-
-    pub fn handle(&self) -> SpawnHandle {
-        self.handle.clone()
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct SpawnHandle(mpsc::Sender<SpawnTask>);
-
-impl SpawnHandle {
-    pub async fn spawn<F, Fut, T>(&mut self, func: F) -> Result<Task<T>, SendError>
-    where
-        F: (FnOnce() -> Fut) + Send + 'static,
-        Fut: Future<Output = T>,
-        T: Send + 'static,
-    {
-        let (task, spawn) = task(func);
-        self.0.send(spawn).await?;
-        Ok(task)
-    }
-}
+use crate::raw::*;
+use crate::*;
 
 unsafe impl IoBuf for Buffer {
     fn as_buf_ptr(&self) -> *const u8 {
@@ -125,6 +33,41 @@ unsafe impl IoBuf for Buffer {
     fn buf_capacity(&self) -> usize {
         // `Bytes` doesn't expose uninitialized capacity, so treat it as the same as `len`
         self.current().len()
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct CompfsCore {
+    pub root: PathBuf,
+    pub dispatcher: Dispatcher,
+    pub buf_pool: oio::PooledBuf,
+}
+
+impl CompfsCore {
+    pub async fn exec<Fn, Fut, R>(&self, f: Fn) -> crate::Result<R>
+    where
+        Fn: FnOnce() -> Fut + Send + 'static,
+        Fut: Future<Output = std::io::Result<R>> + 'static,
+        R: Send + 'static,
+    {
+        self.dispatcher
+            .dispatch(f)
+            .map_err(|_| Error::new(ErrorKind::Unexpected, "compio spawn io task failed"))?
+            .await
+            .map_err(|_| Error::new(ErrorKind::Unexpected, "compio task cancelled"))?
+            .map_err(new_std_io_error)
+    }
+
+    pub async fn exec_blocking<Fn, R>(&self, f: Fn) -> Result<R>
+    where
+        Fn: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.dispatcher
+            .dispatch_blocking(f)
+            .map_err(|_| Error::new(ErrorKind::Unexpected, "compio spawn blocking task failed"))?
+            .await
+            .map_err(|_| Error::new(ErrorKind::Unexpected, "compio task cancelled"))
     }
 }
 

--- a/core/src/services/compfs/lister.rs
+++ b/core/src/services/compfs/lister.rs
@@ -43,7 +43,7 @@ fn next_entry(read_dir: &mut ReadDir, root: &Path) -> std::io::Result<Option<oio
     let path = entry.path();
     let rel_path = normalize_path(
         &path
-            .strip_prefix(&root)
+            .strip_prefix(root)
             .expect("cannot fail because the prefix is iterated")
             .to_string_lossy()
             .replace('\\', "/"),

--- a/core/src/services/compfs/lister.rs
+++ b/core/src/services/compfs/lister.rs
@@ -14,3 +14,68 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
+use std::{fs::ReadDir, path::Path, sync::Arc};
+
+use super::core::CompfsCore;
+use crate::raw::*;
+use crate::*;
+
+#[derive(Debug)]
+pub struct CompfsLister {
+    core: Arc<CompfsCore>,
+    read_dir: Option<ReadDir>,
+}
+
+impl CompfsLister {
+    pub fn new(core: Arc<CompfsCore>, read_dir: ReadDir) -> Self {
+        Self {
+            core,
+            read_dir: Some(read_dir),
+        }
+    }
+}
+
+fn next_entry(read_dir: &mut ReadDir, root: &Path) -> std::io::Result<Option<oio::Entry>> {
+    let Some(entry) = read_dir.next().transpose()? else {
+        return Ok(None);
+    };
+    let path = entry.path();
+    let rel_path = normalize_path(
+        &path
+            .strip_prefix(&root)
+            .expect("cannot fail because the prefix is iterated")
+            .to_string_lossy()
+            .replace('\\', "/"),
+    );
+
+    let file_type = entry.file_type()?;
+
+    let entry = if file_type.is_file() {
+        oio::Entry::new(&rel_path, Metadata::new(EntryMode::FILE))
+    } else if file_type.is_dir() {
+        oio::Entry::new(&format!("{rel_path}/"), Metadata::new(EntryMode::DIR))
+    } else {
+        oio::Entry::new(&rel_path, Metadata::new(EntryMode::Unknown))
+    };
+
+    Ok(Some(entry))
+}
+
+impl oio::List for CompfsLister {
+    async fn next(&mut self) -> Result<Option<oio::Entry>> {
+        let Some(mut read_dir) = self.read_dir.take() else {
+            return Ok(None);
+        };
+        let root = self.core.root.clone();
+        let (entry, read_dir) = self
+            .core
+            .exec_blocking(move || {
+                let entry = next_entry(&mut read_dir, &root).map_err(new_std_io_error);
+                (entry, read_dir)
+            })
+            .await?;
+        self.read_dir = Some(read_dir);
+        entry
+    }
+}

--- a/core/src/services/compfs/reader.rs
+++ b/core/src/services/compfs/reader.rs
@@ -14,3 +14,42 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
+use std::sync::Arc;
+
+use compio::{buf::buf_try, io::AsyncReadAt};
+
+use super::core::CompfsCore;
+use crate::raw::*;
+use crate::*;
+
+#[derive(Debug)]
+pub struct CompfsReader {
+    core: Arc<CompfsCore>,
+    f: compio::fs::File,
+}
+
+impl CompfsReader {
+    pub fn new(core: Arc<CompfsCore>, f: compio::fs::File) -> Self {
+        Self { core, f }
+    }
+}
+
+impl oio::Read for CompfsReader {
+    async fn read_at(&self, offset: u64, limit: usize) -> Result<Buffer> {
+        let mut bs = self.core.buf_pool.get();
+        bs.reserve(limit);
+        let f = self.f.clone();
+        let mut bs = self
+            .core
+            .exec(move || async move {
+                let (_, bs) = buf_try!(@try f.read_at(bs, offset).await);
+
+                Ok(bs)
+            })
+            .await?;
+        let frozen = bs.split().freeze();
+        self.core.buf_pool.put(bs);
+        Ok(Buffer::from(frozen))
+    }
+}

--- a/core/src/services/compfs/writer.rs
+++ b/core/src/services/compfs/writer.rs
@@ -14,3 +14,49 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
+use std::{io::Cursor, sync::Arc};
+
+use compio::{buf::buf_try, fs::File, io::AsyncWrite};
+
+use super::core::CompfsCore;
+use crate::raw::*;
+use crate::*;
+
+#[derive(Debug)]
+pub struct CompfsWriter {
+    core: Arc<CompfsCore>,
+    file: Cursor<File>,
+}
+
+impl CompfsWriter {
+    pub fn new(core: Arc<CompfsCore>, file: Cursor<File>) -> Self {
+        Self { core, file }
+    }
+}
+
+impl oio::Write for CompfsWriter {
+    async fn write(&mut self, bs: Buffer) -> Result<usize> {
+        let mut file = self.file.clone();
+
+        let n = self
+            .core
+            .exec(move || async move {
+                let (n, _) = buf_try!(@try file.write(bs).await);
+                Ok(n)
+            })
+            .await?;
+        Ok(n)
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        let f = self.file.clone();
+        self.core
+            .exec(move || async move { f.get_ref().sync_all().await })
+            .await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR implements basic function of `Access` for `Compfs`, include `CompfsReader`, `CompfsWriter` and `CompfsLister`. 

~~For now, this branch uses git dependency of `compio` to test the lastest updates. Before merging, compio should make a new release (by @George-Miao, me) and update the corresponding `Cargo.toml` entry.~~

New release has been made and updated. Ready to be merged.