### PR TITLE
chore: bump version to 0.47.0

### DIFF
--- a/bin/oay/Cargo.lock
+++ b/bin/oay/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "oay"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1034,7 +1034,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/oay/Cargo.toml
+++ b/bin/oay/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.41.2"
+version = "0.41.3"
 
 [features]
 default = ["frontends-webdav", "frontends-s3"]
@@ -51,7 +51,7 @@ dav-server-opendalfs = { version = "0.0.2", path = "../../integrations/dav-serve
 dirs = "5.0.1"
 futures = "0.3"
 futures-util = { version = "0.3.29", optional = true }
-opendal = { version = "0.46.0", path = "../../core" }
+opendal = { version = "0.47.0", path = "../../core" }
 quick-xml = { version = "0.31", features = ["serialize", "overlapped-lists"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1.34", features = [

--- a/bin/oay/DEPENDENCIES.rust.tsv
+++ b/bin/oay/DEPENDENCIES.rust.tsv
@@ -16,7 +16,7 @@ async-trait@0.1.77		X						X
 autocfg@1.1.0		X						X					
 axum@0.6.20								X					
 axum-core@0.3.4								X					
-backon@0.4.3		X											
+backon@0.4.4		X											
 backtrace@0.3.69		X						X					
 base64@0.21.7		X						X					
 base64@0.22.0		X						X					
@@ -34,7 +34,6 @@ clap_lex@0.7.0		X						X
 colorchoice@1.0.0		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
 crypto-common@0.1.6		X						X					
 dav-server@0.5.8		X											
 dav-server-opendalfs@0.0.2		X											
@@ -101,10 +100,10 @@ nu-ansi-term@0.46.0								X
 num-conv@0.1.0		X						X					
 num-traits@0.2.17		X						X					
 num_cpus@1.16.0		X						X					
-oay@0.41.2		X											
+oay@0.41.3		X											
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
+opendal@0.47.0		X											
 option-ext@0.2.0									X				
 overload@0.1.1								X					
 parking_lot@0.12.1		X						X					
@@ -132,7 +131,6 @@ regex-syntax@0.8.2		X						X
 reqwest@0.12.2		X						X					
 ring@0.17.7										X			
 rustc-demangle@0.1.23		X						X					
-rustc_version@0.4.0		X						X					
 rustls@0.22.3		X					X	X					
 rustls-pemfile@1.0.4		X					X	X					
 rustls-pki-types@1.4.0		X						X					
@@ -140,7 +138,6 @@ rustls-webpki@0.102.2							X
 rustversion@1.0.14		X						X					
 ryu@1.0.16		X				X							
 scopeguard@1.2.0		X						X					
-semver@1.0.22		X						X					
 serde@1.0.197		X						X					
 serde_derive@1.0.197		X						X					
 serde_json@1.0.113		X						X					

--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "ofs"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -961,7 +961,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/ofs/Cargo.toml
+++ b/bin/ofs/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["filesystem"]
 description = "OpenDAL File System"
 keywords = ["storage", "data", "s3", "fs", "azblob"]
 name = "ofs"
-version = "0.0.3"
+version = "0.0.4"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -40,7 +40,7 @@ futures-util = "0.3.30"
 libc = "0.2.154"
 log = "0.4.21"
 nix = { version = "0.28.0", features = ["user"] }
-opendal = { version = "0.46.0", path = "../../core" }
+opendal = { version = "0.47.0", path = "../../core" }
 sharded-slab = "0.1.7"
 tokio = { version = "1.37.0", features = [
   "fs",
@@ -62,4 +62,4 @@ test-context = "0.3.0"
 urlencoding = "2.1.3"
 uuid = "1.7.0"
 walkdir = "2.5.0"
-opendal = { version = "0.46.0", path = "../../core", features = ["tests"] }
+opendal = { version = "0.47.0", path = "../../core", features = ["tests"] }

--- a/bin/ofs/DEPENDENCIES.rust.tsv
+++ b/bin/ofs/DEPENDENCIES.rust.tsv
@@ -1,199 +1,211 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.21.0		X					X					
-adler@1.0.2	X	X					X					
-aho-corasick@1.1.2							X				X	
-android-tzdata@0.1.1		X					X					
-android_system_properties@0.1.5		X					X					
-anstream@0.6.11		X					X					
-anstyle@1.0.6		X					X					
-anstyle-parse@0.2.3		X					X					
-anstyle-query@1.0.2		X					X					
-anstyle-wincon@3.0.2		X					X					
-anyhow@1.0.80		X					X					
-async-notify@0.3.0							X					
-async-trait@0.1.79		X					X					
-autocfg@1.1.0		X					X					
-backon@0.4.3		X										
-backtrace@0.3.69		X					X					
-base64@0.21.7		X					X					
-base64@0.22.0		X					X					
-bincode@1.3.3							X					
-bitflags@2.4.2		X					X					
-block-buffer@0.10.4		X					X					
-bumpalo@3.14.0		X					X					
-bytes@1.6.0							X					
-cc@1.0.83		X					X					
-cfg-if@1.0.0		X					X					
-cfg_aliases@0.1.1							X					
-chrono@0.4.35		X					X					
-clap@4.5.1		X					X					
-clap_builder@4.5.1		X					X					
-clap_derive@4.5.0		X					X					
-clap_lex@0.7.0		X					X					
-colorchoice@1.0.0		X					X					
-concurrent-queue@2.4.0		X					X					
-const-oid@0.9.6		X					X					
-core-foundation-sys@0.8.6		X					X					
-cpufeatures@0.2.12		X					X					
-crc32c@0.6.5		X					X					
-crossbeam-utils@0.8.19		X					X					
-crypto-common@0.1.6		X					X					
-cstr@0.2.11							X					
-digest@0.10.7		X					X					
-either@1.9.0		X					X					
-env_filter@0.1.0		X					X					
-env_logger@0.11.2		X					X					
-errno@0.3.8		X					X					
-event-listener@4.0.3		X					X					
-fastrand@2.0.1		X					X					
-flagset@0.4.4		X										
-fnv@1.0.7		X					X					
-form_urlencoded@1.2.1		X					X					
-fuse3@0.7.1							X					
-futures@0.3.30		X					X					
-futures-channel@0.3.30		X					X					
-futures-core@0.3.30		X					X					
-futures-executor@0.3.30		X					X					
-futures-io@0.3.30		X					X					
-futures-macro@0.3.30		X					X					
-futures-sink@0.3.30		X					X					
-futures-task@0.3.30		X					X					
-futures-util@0.3.30		X					X					
-generic-array@0.14.7							X					
-getrandom@0.2.12		X					X					
-gimli@0.28.1		X					X					
-heck@0.4.1		X					X					
-hex@0.4.3		X					X					
-hmac@0.12.1		X					X					
-home@0.5.9		X					X					
-http@1.1.0		X					X					
-http-body@1.0.0							X					
-http-body-util@0.1.1							X					
-httparse@1.8.0		X					X					
-humantime@2.1.0		X					X					
-hyper@1.2.0							X					
-hyper-rustls@0.26.0		X				X	X					
-hyper-util@0.1.3							X					
-iana-time-zone@0.1.59		X					X					
-iana-time-zone-haiku@0.1.2		X					X					
-idna@0.5.0		X					X					
-ipnet@2.9.0		X					X					
-itoa@1.0.10		X					X					
-js-sys@0.3.67		X					X					
-lazy_static@1.4.0		X					X					
-libc@0.2.154		X					X					
-linux-raw-sys@0.4.13		X	X				X					
-log@0.4.21		X					X					
-md-5@0.10.6		X					X					
-memchr@2.7.1							X				X	
-memoffset@0.9.0							X					
-mime@0.3.17		X					X					
-miniz_oxide@0.7.1		X					X					X
-mio@0.8.10							X					
-nix@0.28.0							X					
-num-traits@0.2.17		X					X					
-object@0.32.2		X					X					
-ofs@0.0.3		X										
-once_cell@1.19.0		X					X					
-opendal@0.46.0		X										
-parking@2.2.0		X					X					
-percent-encoding@2.3.1		X					X					
-pin-project@1.1.4		X					X					
-pin-project-internal@1.1.4		X					X					
-pin-project-lite@0.2.13		X					X					
-pin-utils@0.1.0		X					X					
-ppv-lite86@0.2.17		X					X					
-proc-macro2@1.0.78		X					X					
-quick-xml@0.31.0							X					
-quote@1.0.35		X					X					
-rand@0.8.5		X					X					
-rand_chacha@0.3.1		X					X					
-rand_core@0.6.4		X					X					
-regex@1.10.3		X					X					
-regex-automata@0.4.5		X					X					
-regex-syntax@0.8.2		X					X					
-reqsign@0.15.0		X										
-reqwest@0.12.2		X					X					
-ring@0.17.7									X			
-rustc-demangle@0.1.23		X					X					
-rustc_version@0.4.0		X					X					
-rustix@0.38.31		X	X				X					
-rustls@0.22.3		X				X	X					
-rustls-pemfile@1.0.4		X				X	X					
-rustls-pki-types@1.4.0		X					X					
-rustls-webpki@0.102.2						X						
-ryu@1.0.16		X			X							
-semver@1.0.22		X					X					
-serde@1.0.196		X					X					
-serde_derive@1.0.196		X					X					
-serde_json@1.0.113		X					X					
-serde_urlencoded@0.7.1		X					X					
-sha1@0.10.6		X					X					
-sha2@0.10.8		X					X					
-sharded-slab@0.1.7							X					
-signal-hook-registry@1.4.1		X					X					
-slab@0.4.9							X					
-smallvec@1.13.2		X					X					
-socket2@0.5.5		X					X					
-spin@0.9.8							X					
-strsim@0.11.0							X					
-subtle@2.5.0				X								
-syn@2.0.48		X					X					
-sync_wrapper@0.1.2		X										
-tinyvec@1.6.0		X					X					X
-tinyvec_macros@0.1.1		X					X					X
-tokio@1.37.0							X					
-tokio-macros@2.2.0							X					
-tokio-rustls@0.25.0		X					X					
-tokio-util@0.7.10							X					
-tower@0.4.13							X					
-tower-layer@0.3.2							X					
-tower-service@0.3.2							X					
-tracing@0.1.40							X					
-tracing-attributes@0.1.27							X					
-tracing-core@0.1.32							X					
-trait-make@0.1.0		X					X					
-try-lock@0.2.5							X					
-typenum@1.17.0		X					X					
-unicode-bidi@0.3.15		X					X					
-unicode-ident@1.0.12		X					X			X		
-unicode-normalization@0.1.22		X					X					
-untrusted@0.9.0						X						
-url@2.5.0		X					X					
-utf8parse@0.2.1		X					X					
-uuid@1.7.0		X					X					
-version_check@0.9.4		X					X					
-want@0.3.1							X					
-wasi@0.11.0+wasi-snapshot-preview1		X	X				X					
-wasm-bindgen@0.2.90		X					X					
-wasm-bindgen-backend@0.2.90		X					X					
-wasm-bindgen-futures@0.4.40		X					X					
-wasm-bindgen-macro@0.2.90		X					X					
-wasm-bindgen-macro-support@0.2.90		X					X					
-wasm-bindgen-shared@0.2.90		X					X					
-wasm-streams@0.4.0		X					X					
-web-sys@0.3.67		X					X					
-webpki-roots@0.26.1								X				
-which@6.0.1							X					
-windows-core@0.52.0		X					X					
-windows-sys@0.48.0		X					X					
-windows-sys@0.52.0		X					X					
-windows-targets@0.48.5		X					X					
-windows-targets@0.52.0		X					X					
-windows_aarch64_gnullvm@0.48.5		X					X					
-windows_aarch64_gnullvm@0.52.0		X					X					
-windows_aarch64_msvc@0.48.5		X					X					
-windows_aarch64_msvc@0.52.0		X					X					
-windows_i686_gnu@0.48.5		X					X					
-windows_i686_gnu@0.52.0		X					X					
-windows_i686_msvc@0.48.5		X					X					
-windows_i686_msvc@0.52.0		X					X					
-windows_x86_64_gnu@0.48.5		X					X					
-windows_x86_64_gnu@0.52.0		X					X					
-windows_x86_64_gnullvm@0.48.5		X					X					
-windows_x86_64_gnullvm@0.52.0		X					X					
-windows_x86_64_msvc@0.48.5		X					X					
-windows_x86_64_msvc@0.52.0		X					X					
-winreg@0.50.0							X					
-winsafe@0.0.19							X					
-zeroize@1.7.0		X					X					
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
+addr2line@0.21.0		X						X					
+adler@1.0.2	X	X						X					
+aho-corasick@1.1.2								X				X	
+android-tzdata@0.1.1		X						X					
+android_system_properties@0.1.5		X						X					
+anstream@0.6.11		X						X					
+anstyle@1.0.6		X						X					
+anstyle-parse@0.2.3		X						X					
+anstyle-query@1.0.2		X						X					
+anstyle-wincon@3.0.2		X						X					
+anyhow@1.0.80		X						X					
+async-notify@0.3.0								X					
+async-trait@0.1.79		X						X					
+autocfg@1.1.0		X						X					
+backon@0.4.4		X											
+backtrace@0.3.69		X						X					
+base64@0.21.7		X						X					
+base64@0.22.0		X						X					
+bincode@1.3.3								X					
+bitflags@2.4.2		X						X					
+block-buffer@0.10.4		X						X					
+bumpalo@3.14.0		X						X					
+bytes@1.6.0								X					
+cc@1.0.83		X						X					
+cfg-if@1.0.0		X						X					
+cfg_aliases@0.1.1								X					
+chrono@0.4.35		X						X					
+clap@4.5.1		X						X					
+clap_builder@4.5.1		X						X					
+clap_derive@4.5.0		X						X					
+clap_lex@0.7.0		X						X					
+colorchoice@1.0.0		X						X					
+concurrent-queue@2.4.0		X						X					
+const-oid@0.9.6		X						X					
+const-random@0.1.18		X						X					
+const-random-macro@0.1.16		X						X					
+core-foundation-sys@0.8.6		X						X					
+cpufeatures@0.2.12		X						X					
+crc32c@0.6.7		X						X					
+crossbeam-utils@0.8.19		X						X					
+crunchy@0.2.2								X					
+crypto-common@0.1.6		X						X					
+cstr@0.2.11								X					
+digest@0.10.7		X						X					
+dlv-list@0.5.2		X						X					
+dotenvy@0.15.7								X					
+either@1.9.0		X						X					
+env_filter@0.1.0		X						X					
+env_logger@0.11.2		X						X					
+errno@0.3.8		X						X					
+event-listener@4.0.3		X						X					
+fastrand@2.0.1		X						X					
+flagset@0.4.4		X											
+fnv@1.0.7		X						X					
+form_urlencoded@1.2.1		X						X					
+fuse3@0.7.2								X					
+futures@0.3.30		X						X					
+futures-channel@0.3.30		X						X					
+futures-core@0.3.30		X						X					
+futures-executor@0.3.30		X						X					
+futures-io@0.3.30		X						X					
+futures-macro@0.3.30		X						X					
+futures-sink@0.3.30		X						X					
+futures-task@0.3.30		X						X					
+futures-util@0.3.30		X						X					
+generic-array@0.14.7								X					
+getrandom@0.2.12		X						X					
+gimli@0.28.1		X						X					
+hashbrown@0.14.3		X						X					
+heck@0.4.1		X						X					
+hermit-abi@0.3.9		X						X					
+hex@0.4.3		X						X					
+hmac@0.12.1		X						X					
+home@0.5.9		X						X					
+http@1.1.0		X						X					
+http-body@1.0.0								X					
+http-body-util@0.1.1								X					
+httparse@1.8.0		X						X					
+humantime@2.1.0		X						X					
+hyper@1.2.0								X					
+hyper-rustls@0.26.0		X					X	X					
+hyper-util@0.1.3								X					
+iana-time-zone@0.1.59		X						X					
+iana-time-zone-haiku@0.1.2		X						X					
+idna@0.5.0		X						X					
+ipnet@2.9.0		X						X					
+itoa@1.0.10		X						X					
+js-sys@0.3.67		X						X					
+lazy_static@1.4.0		X						X					
+libc@0.2.154		X						X					
+linux-raw-sys@0.4.13		X	X					X					
+log@0.4.21		X						X					
+md-5@0.10.6		X						X					
+memchr@2.7.1								X				X	
+memoffset@0.9.0								X					
+mime@0.3.17		X						X					
+miniz_oxide@0.7.1		X						X					X
+mio@0.8.10								X					
+nix@0.28.0								X					
+num-traits@0.2.17		X						X					
+num_cpus@1.16.0		X						X					
+object@0.32.2		X						X					
+ofs@0.0.4		X											
+once_cell@1.19.0		X						X					
+opendal@0.47.0		X											
+ordered-multimap@0.7.1								X					
+parking@2.2.0		X						X					
+percent-encoding@2.3.1		X						X					
+pin-project@1.1.4		X						X					
+pin-project-internal@1.1.4		X						X					
+pin-project-lite@0.2.13		X						X					
+pin-utils@0.1.0		X						X					
+ppv-lite86@0.2.17		X						X					
+proc-macro2@1.0.78		X						X					
+quick-xml@0.31.0								X					
+quote@1.0.35		X						X					
+rand@0.8.5		X						X					
+rand_chacha@0.3.1		X						X					
+rand_core@0.6.4		X						X					
+regex@1.10.3		X						X					
+regex-automata@0.4.5		X						X					
+regex-syntax@0.8.2		X						X					
+reqsign@0.15.0		X											
+reqwest@0.12.2		X						X					
+ring@0.17.7										X			
+rust-ini@0.21.0								X					
+rustc-demangle@0.1.23		X						X					
+rustc_version@0.4.0		X						X					
+rustix@0.38.31		X	X					X					
+rustls@0.22.3		X					X	X					
+rustls-pemfile@1.0.4		X					X	X					
+rustls-pki-types@1.4.0		X						X					
+rustls-webpki@0.102.2							X						
+ryu@1.0.16		X			X								
+semver@1.0.22		X						X					
+serde@1.0.196		X						X					
+serde_derive@1.0.196		X						X					
+serde_json@1.0.113		X						X					
+serde_urlencoded@0.7.1		X						X					
+sha1@0.10.6		X						X					
+sha2@0.10.8		X						X					
+sharded-slab@0.1.7								X					
+signal-hook-registry@1.4.1		X						X					
+slab@0.4.9								X					
+smallvec@1.13.2		X						X					
+socket2@0.5.5		X						X					
+spin@0.9.8								X					
+strsim@0.11.0								X					
+subtle@2.5.0				X									
+syn@2.0.48		X						X					
+sync_wrapper@0.1.2		X											
+tiny-keccak@2.0.2						X							
+tinyvec@1.6.0		X						X					X
+tinyvec_macros@0.1.1		X						X					X
+tokio@1.37.0								X					
+tokio-macros@2.2.0								X					
+tokio-rustls@0.25.0		X						X					
+tokio-util@0.7.10								X					
+tower@0.4.13								X					
+tower-layer@0.3.2								X					
+tower-service@0.3.2								X					
+tracing@0.1.40								X					
+tracing-attributes@0.1.27								X					
+tracing-core@0.1.32								X					
+trait-make@0.1.0		X						X					
+trim-in-place@0.1.7								X					
+try-lock@0.2.5								X					
+typenum@1.17.0		X						X					
+unicode-bidi@0.3.15		X						X					
+unicode-ident@1.0.12		X						X			X		
+unicode-normalization@0.1.22		X						X					
+untrusted@0.9.0							X						
+url@2.5.0		X						X					
+utf8parse@0.2.1		X						X					
+uuid@1.7.0		X						X					
+version_check@0.9.4		X						X					
+want@0.3.1								X					
+wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
+wasm-bindgen@0.2.90		X						X					
+wasm-bindgen-backend@0.2.90		X						X					
+wasm-bindgen-futures@0.4.40		X						X					
+wasm-bindgen-macro@0.2.90		X						X					
+wasm-bindgen-macro-support@0.2.90		X						X					
+wasm-bindgen-shared@0.2.90		X						X					
+wasm-streams@0.4.0		X						X					
+web-sys@0.3.67		X						X					
+webpki-roots@0.26.1									X				
+which@6.0.1								X					
+windows-core@0.52.0		X						X					
+windows-sys@0.48.0		X						X					
+windows-sys@0.52.0		X						X					
+windows-targets@0.48.5		X						X					
+windows-targets@0.52.0		X						X					
+windows_aarch64_gnullvm@0.48.5		X						X					
+windows_aarch64_gnullvm@0.52.0		X						X					
+windows_aarch64_msvc@0.48.5		X						X					
+windows_aarch64_msvc@0.52.0		X						X					
+windows_i686_gnu@0.48.5		X						X					
+windows_i686_gnu@0.52.0		X						X					
+windows_i686_msvc@0.48.5		X						X					
+windows_i686_msvc@0.52.0		X						X					
+windows_x86_64_gnu@0.48.5		X						X					
+windows_x86_64_gnu@0.52.0		X						X					
+windows_x86_64_gnullvm@0.48.5		X						X					
+windows_x86_64_gnullvm@0.52.0		X						X					
+windows_x86_64_msvc@0.48.5		X						X					
+windows_x86_64_msvc@0.52.0		X						X					
+winreg@0.50.0								X					
+winsafe@0.0.19								X					
+zeroize@1.7.0		X						X					

--- a/bin/oli/Cargo.lock
+++ b/bin/oli/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "oli"
-version = "0.41.2"
+version = "0.41.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2010,7 +2010,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "async-tls",

--- a/bin/oli/Cargo.toml
+++ b/bin/oli/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.41.2"
+version = "0.41.3"
 
 [features]
 # Enable services dashmap support
@@ -60,7 +60,7 @@ dirs = "5.0.1"
 env_logger = "0.11"
 futures = "0.3"
 log = "0.4"
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
   # These are default features before v0.46. TODO: change to optional features
   "services-azblob",
   "services-azdls",

--- a/bin/oli/DEPENDENCIES.rust.tsv
+++ b/bin/oli/DEPENDENCIES.rust.tsv
@@ -13,7 +13,7 @@ anstyle-wincon@3.0.2		X						X
 anyhow@1.0.82		X						X					
 async-trait@0.1.77		X						X					
 autocfg@1.1.0		X						X					
-backon@0.4.3		X											
+backon@0.4.4		X											
 backtrace@0.3.69		X						X					
 base64@0.21.7		X						X					
 base64@0.22.0		X						X					
@@ -39,7 +39,7 @@ const-random@0.1.17		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
+crc32c@0.6.7		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.8		X						X					
@@ -107,9 +107,9 @@ num-iter@0.1.43		X						X
 num-traits@0.2.17		X						X					
 num_cpus@1.16.0		X						X					
 object@0.32.2		X						X					
-oli@0.41.2		X											
+oli@0.41.3		X											
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
+opendal@0.47.0		X											
 option-ext@0.2.0									X				
 ordered-multimap@0.7.1								X					
 pbkdf2@0.12.2		X						X					

--- a/bin/ovfs/DEPENDENCIES.rust.tsv
+++ b/bin/ovfs/DEPENDENCIES.rust.tsv
@@ -1,0 +1,26 @@
+crate	Apache-2.0	BSD-3-Clause	MIT	Unicode-DFS-2016	Unlicensed
+anyhow@1.0.86	X		X	
+arc-swap@1.7.1	X		X	
+bitflags@1.3.2	X		X	
+bitflags@2.5.0	X		X	
+heck@0.5.0	X		X	
+libc@0.2.155	X		X	
+log@0.4.21	X		X	
+ovfs@0.1.0					X
+proc-macro2@1.0.84	X		X	
+quote@1.0.36	X		X	
+snafu@0.8.3	X		X	
+snafu-derive@0.8.3	X		X	
+syn@2.0.66	X		X	
+thiserror@1.0.61	X		X	
+thiserror-impl@1.0.61	X		X	
+unicode-ident@1.0.12	X		X	X
+vhost@0.11.0	X	X		
+vhost-user-backend@0.14.0	X			
+virtio-bindings@0.2.2	X	X		
+virtio-queue@0.11.0	X	X		
+vm-memory@0.14.1	X	X		
+vmm-sys-util@0.12.1		X		
+winapi@0.3.9	X		X	
+winapi-i686-pc-windows-gnu@0.4.0	X		X	
+winapi-x86_64-pc-windows-gnu@0.4.0	X		X	

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.44.4"
+version = "0.44.5"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]
@@ -37,7 +37,7 @@ cbindgen = "0.26.0"
 [dependencies]
 bytes = "1.4.0"
 once_cell = "1.17.1"
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
   "layers-blocking",
   # These are default features before v0.46. TODO: change to optional features #4313
   "services-azblob",

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -33,7 +33,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
+crc32c@0.6.7		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
@@ -99,8 +99,8 @@ num-traits@0.2.18		X						X
 num_cpus@1.16.0		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
-opendal-c@0.44.4		X											
+opendal@0.47.0		X											
+opendal-c@0.44.5		X											
 ordered-multimap@0.7.3								X					
 os_str_bytes@6.6.1		X						X					
 pbkdf2@0.12.2		X						X					

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 cmake_minimum_required(VERSION 3.10)
-project(opendal-cpp VERSION 0.45.2 LANGUAGES CXX)
+project(opendal-cpp VERSION 0.45.3 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/bindings/cpp/Cargo.toml
+++ b/bindings/cpp/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.44.3"
+version = "0.45.3"
 
 [lib]
 crate-type = ["staticlib"]
@@ -34,7 +34,7 @@ crate-type = ["staticlib"]
 anyhow = "1.0"
 chrono = "0.4"
 cxx = "1.0"
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
   # These are default features before v0.46. TODO: change to optional features
   "services-azblob",
   "services-azdls",

--- a/bindings/cpp/DEPENDENCIES.rust.tsv
+++ b/bindings/cpp/DEPENDENCIES.rust.tsv
@@ -28,7 +28,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
+crc32c@0.6.7		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 cxx@1.0.121		X						X					
@@ -91,8 +91,8 @@ num-iter@0.1.44		X						X
 num-traits@0.2.18		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
-opendal-cpp@0.44.3		X											
+opendal@0.47.0		X											
+opendal-cpp@0.45.3		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
 pem@3.0.4								X					

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -32,7 +32,7 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
   # These are default features before v0.46. TODO: change to optional features
   "services-azblob",
   "services-azdls",

--- a/bindings/dotnet/DEPENDENCIES.rust.tsv
+++ b/bindings/dotnet/DEPENDENCIES.rust.tsv
@@ -27,7 +27,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
+crc32c@0.6.7		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
@@ -85,7 +85,7 @@ num-iter@0.1.44		X						X
 num-traits@0.2.18		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
+opendal@0.47.0		X											
 opendal-dotnet@0.1.1		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					

--- a/bindings/haskell/Cargo.toml
+++ b/bindings/haskell/Cargo.toml
@@ -34,7 +34,7 @@ doc = false
 [dependencies]
 chrono = "0.4"
 log = { version = "0.4", features = ["std"] }
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
   # These are default features before v0.46. TODO: change to optional features
   "services-azblob",
   "services-azdls",

--- a/bindings/haskell/DEPENDENCIES.rust.tsv
+++ b/bindings/haskell/DEPENDENCIES.rust.tsv
@@ -27,7 +27,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
+crc32c@0.6.7		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
@@ -85,7 +85,7 @@ num-iter@0.1.44		X						X
 num-traits@0.2.18		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
+opendal@0.47.0		X											
 opendal-hs@0.44.3		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					

--- a/bindings/haskell/opendal.cabal
+++ b/bindings/haskell/opendal.cabal
@@ -41,7 +41,7 @@ source-repository head
 source-repository this
     type:     git
     location: https://github.com/apache/opendal
-    tag:      v0.45.2
+    tag:      v0.45.3
     subdir:   bindings/haskell
 
 common base
@@ -77,7 +77,7 @@ test-suite opendal-test
     main-is:          Spec.hs
     other-modules:    BasicTest
     hs-source-dirs:   test
-    build-depends:    
+    build-depends:
         opendal,
         tasty >= 1.5 && < 1.6,
         tasty-hunit >= 0.10.1 && < 0.11,

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.1"
+version = "0.46.0"
 
 [lib]
 crate-type = ["cdylib"]
@@ -155,7 +155,7 @@ anyhow = "1.0.71"
 jni = "0.21.1"
 num_cpus = "1.15.0"
 once_cell = "1.19.0"
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
   "layers-blocking",
 ] }
 tokio = { version = "1.28.1", features = ["full"] }

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -35,7 +35,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
+crc32c@0.6.6		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
@@ -102,8 +102,8 @@ num-traits@0.2.18		X						X
 num_cpus@1.16.0		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
-opendal-java@0.45.1		X											
+opendal@0.47.0		X											
+opendal-java@0.46.0		X											
 openssh@0.10.4		X						X					
 openssh-sftp-client@0.14.3								X					
 openssh-sftp-client-lowlevel@0.6.0								X					

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal-java</artifactId>
-    <version>0.45.2</version>
+    <version>0.46.0</version>
 
     <name>Apache OpenDAL™</name>
     <description>

--- a/bindings/lua/Cargo.toml
+++ b/bindings/lua/Cargo.toml
@@ -39,7 +39,7 @@ mlua = { version = "0.9", features = [
   "module",
   "macros",
 ], default-features = false, optional = true }
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
   # These are default features before v0.46. TODO: change to optional features
   "services-azblob",
   "services-azdls",

--- a/bindings/lua/DEPENDENCIES.rust.tsv
+++ b/bindings/lua/DEPENDENCIES.rust.tsv
@@ -29,7 +29,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
+crc32c@0.6.7		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
@@ -92,7 +92,7 @@ num-iter@0.1.44		X						X
 num-traits@0.2.18		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
+opendal@0.47.0		X											
 opendal-lua@0.1.1		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					

--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.46.0"
+version = "0.46.1"
 
 [features]
 default = [
@@ -156,7 +156,7 @@ napi = { version = "2.11.3", default-features = false, features = [
   "async",
 ] }
 napi-derive = "2.14.6"
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
   "layers-blocking",
 ] }
 tokio = "1"

--- a/bindings/nodejs/DEPENDENCIES.rust.tsv
+++ b/bindings/nodejs/DEPENDENCIES.rust.tsv
@@ -30,7 +30,7 @@ const-random-macro@0.1.16		X						X
 convert_case@0.6.0								X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
+crc32c@0.6.7		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 ctor@0.2.8		X						X					
@@ -98,8 +98,8 @@ num-traits@0.2.18		X						X
 num_cpus@1.16.0		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
-opendal-nodejs@0.46.0		X											
+opendal@0.47.0		X											
+opendal-nodejs@0.46.1		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
 pem@3.0.4								X					

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-arm64",
   "repository": "git@github.com/apache/opendal.git",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-x64",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "darwin"

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-gnu",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-musl",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-arm64-msvc",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "Apache OpenDAL <dev@opendal.apache.org>",
-  "version": "0.45.2",
+  "version": "0.46.1",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",

--- a/bindings/ocaml/Cargo.toml
+++ b/bindings/ocaml/Cargo.toml
@@ -33,7 +33,7 @@ doc = false
 
 [dependencies]
 ocaml = { version = "^1.0.0-beta" }
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
   # These are default features before v0.46. TODO: change to optional features
   "services-azblob",
   "services-azdls",

--- a/bindings/ocaml/DEPENDENCIES.rust.tsv
+++ b/bindings/ocaml/DEPENDENCIES.rust.tsv
@@ -27,7 +27,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
+crc32c@0.6.7		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 cty@0.2.2		X						X					
@@ -93,7 +93,7 @@ ocaml-interop@0.8.8								X
 ocaml-sys@0.22.3							X						
 ocaml-sys@0.23.0							X						
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
+opendal@0.47.0		X											
 opendal-ocaml@0.0.0		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					

--- a/bindings/php/Cargo.toml
+++ b/bindings/php/Cargo.toml
@@ -32,7 +32,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ext-php-rs = "0.11.2"
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
   # These are default features before v0.46. TODO: change to optional features
   "services-azblob",
   "services-azdls",

--- a/bindings/php/DEPENDENCIES.rust.tsv
+++ b/bindings/php/DEPENDENCIES.rust.tsv
@@ -40,7 +40,7 @@ constant_time_eq@0.1.5						X
 core-foundation@0.9.4		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
+crc32c@0.6.7		X						X					
 crc32fast@1.4.0		X						X					
 crossbeam-utils@0.8.19		X						X					
 crunchy@0.2.2								X					
@@ -121,7 +121,7 @@ num-iter@0.1.44		X						X
 num-traits@0.2.18		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
+opendal@0.47.0		X											
 opendal-php@0.1.1		X											
 openssl@0.10.64		X											
 openssl-macros@0.1.1		X						X					

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.2"
+version = "0.45.3"
 
 [features]
 default = [
@@ -154,7 +154,7 @@ doc = false
 [dependencies]
 bytes = "1.5.0"
 futures = "0.3.28"
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
   "layers-blocking",
 ] }
 pyo3 = { version = "0.20.1", features = ["abi3", "abi3-py311"] }
@@ -168,4 +168,4 @@ features = [
   "services-sftp",
 ]
 path = "../../core"
-version = "0.46.0"
+version = "0.47.0"

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -33,7 +33,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
+crc32c@0.6.7		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
@@ -102,8 +102,8 @@ num-traits@0.2.18		X						X
 num_cpus@1.16.0		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
-opendal-python@0.45.2		X											
+opendal@0.47.0		X											
+opendal-python@0.45.3		X											
 openssh@0.10.4		X						X					
 openssh-sftp-client@0.14.3								X					
 openssh-sftp-client-lowlevel@0.6.0								X					

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -34,7 +34,7 @@ name = "opendal_ruby"
 
 [dependencies]
 magnus = { version = "0.5", features = ["bytes-crate"] }
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
   # These are default features before v0.46. TODO: change to optional features
   "services-azblob",
   "services-azdls",

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -32,7 +32,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
+crc32c@0.6.7		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
@@ -99,7 +99,7 @@ num-iter@0.1.44		X						X
 num-traits@0.2.18		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
+opendal@0.47.0		X											
 opendal-ruby@0.1.1		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -4753,7 +4753,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "async-backtrace",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.46.0"
+version = "0.47.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -20,7 +20,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
+crc32c@0.6.6		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 digest@0.10.7		X						X					
@@ -71,7 +71,7 @@ num-traits@0.2.18		X						X
 num_cpus@1.16.0		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
+opendal@0.47.0		X											
 ordered-multimap@0.7.3								X					
 percent-encoding@2.3.1		X						X					
 pin-project@1.1.5		X						X					

--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -35,7 +35,7 @@ dav-server = { version = "0.5.8" }
 dirs = "5.0.0"
 futures = "0.3"
 futures-util = { version = "0.3.16" }
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
   "services-fs",
 ] }
 quick-xml = { version = "0.31", features = ["serialize", "overlapped-lists"] }

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -22,7 +22,6 @@ cfg-if@1.0.0		X						X
 chrono@0.4.38		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.5		X						X					
 crypto-common@0.1.6		X						X					
 dav-server@0.5.8		X											
 dav-server-opendalfs@0.0.2		X											
@@ -84,7 +83,7 @@ num-traits@0.2.18		X						X
 num_cpus@1.16.0		X						X					
 object@0.32.2		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.46.0		X											
+opendal@0.47.0		X											
 option-ext@0.2.0									X				
 parking_lot@0.12.2		X						X					
 parking_lot_core@0.9.10		X						X					
@@ -105,14 +104,12 @@ regex-syntax@0.8.3		X						X
 reqwest@0.12.4		X						X					
 ring@0.17.8										X			
 rustc-demangle@0.1.23		X						X					
-rustc_version@0.4.0		X						X					
 rustls@0.22.4		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.5.0		X						X					
 rustls-webpki@0.102.3							X						
 ryu@1.0.17		X				X							
 scopeguard@1.2.0		X						X					
-semver@1.0.22		X						X					
 serde@1.0.200		X						X					
 serde_derive@1.0.200		X						X					
 serde_json@1.0.116		X						X					

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.43.1"
+version = "0.43.2"
 
 [features]
 send_wrapper = ["dep:send_wrapper"]
@@ -36,13 +36,13 @@ bytes = "1"
 futures = "0.3"
 futures-util = "0.3"
 object_store = "0.10.0"
-opendal = { version = "0.46.0", path = "../../core" }
+opendal = { version = "0.47.0", path = "../../core" }
 pin-project = "1.1"
 send_wrapper = { version = "0.6", features = ["futures"], optional = true }
 tokio = { version = "1", default-features = false }
 
 [dev-dependencies]
-opendal = { version = "0.46.0", path = "../../core", features = [
+opendal = { version = "0.47.0", path = "../../core", features = [
     "services-memory",
 ] }
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread"] }

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -35,7 +35,7 @@ async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
 futures-util = "0.3"
-object_store = "0.10.0"
+object_store = "0.10"
 opendal = { version = "0.47.0", path = "../../core" }
 pin-project = "1.1"
 send_wrapper = { version = "0.6", features = ["futures"], optional = true }
@@ -43,6 +43,7 @@ tokio = { version = "1", default-features = false }
 
 [dev-dependencies]
 opendal = { version = "0.47.0", path = "../../core", features = [
-    "services-memory",
+  "services-memory",
+  "services-s3",
 ] }
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread"] }

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.43.2"
+version = "0.44.0"
 
 [features]
 send_wrapper = ["dep:send_wrapper"]

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -17,7 +17,6 @@ cc@1.0.96		X					X
 cfg-if@1.0.0		X					X					
 chrono@0.4.38		X					X					
 core-foundation-sys@0.8.6		X					X					
-crc32c@0.6.5		X					X					
 crypto-common@0.1.6		X					X					
 digest@0.10.7		X					X					
 doc-comment@0.3.3							X					
@@ -66,10 +65,10 @@ mio@0.8.11							X
 num-traits@0.2.18		X					X					
 num_cpus@1.16.0		X					X					
 object@0.32.2		X					X					
-object_store@0.9.1		X					X					
-object_store_opendal@0.43.1		X										
+object_store@0.10.1		X					X					
+object_store_opendal@0.43.2		X										
 once_cell@1.19.0		X					X					
-opendal@0.46.0		X										
+opendal@0.47.0		X										
 parking_lot@0.12.2		X					X					
 parking_lot_core@0.9.10		X					X					
 percent-encoding@2.3.1		X					X					
@@ -84,7 +83,6 @@ redox_syscall@0.5.1							X
 reqwest@0.12.4		X					X					
 ring@0.17.8									X			
 rustc-demangle@0.1.23		X					X					
-rustc_version@0.4.0		X					X					
 rustls@0.22.4		X				X	X					
 rustls-pemfile@2.1.2		X				X	X					
 rustls-pki-types@1.5.0		X					X					
@@ -92,7 +90,6 @@ rustls-webpki@0.102.3						X
 ryu@1.0.17		X			X							
 same-file@1.0.6							X				X	
 scopeguard@1.2.0		X					X					
-semver@1.0.22		X					X					
 serde@1.0.200		X					X					
 serde_derive@1.0.200		X					X					
 serde_json@1.0.116		X					X					

--- a/integrations/object_store/README.md
+++ b/integrations/object_store/README.md
@@ -12,7 +12,7 @@ first you need to add the following dependencies to your `Cargo.toml`:
 [dependencies]
 object_store = "0.9.0"
 object_store_opendal = "0.43.1"
-opendal = { version = "0.46.0", features = ["services-s3"] }
+opendal = { version = "0.47.0", features = ["services-s3"] }
 ```
 
 > the current version we support is object store 0.9

--- a/integrations/object_store/README.md
+++ b/integrations/object_store/README.md
@@ -6,68 +6,32 @@ The `OpendalStore` uses the `opendal` crate to interact with the underlying obje
 
 ## Examples
 
-first you need to add the following dependencies to your `Cargo.toml`:
+Firstly, you need to add the following dependencies to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-object_store = "0.9.0"
-object_store_opendal = "0.43.1"
+object_store = "0.10.0"
+object_store_opendal = "0.44.0"
 opendal = { version = "0.47.0", features = ["services-s3"] }
 ```
 
-> the current version we support is object store 0.9
+> [!NOTE]
+> 
+> The current version we support is object store 0.10.
 
-Then you can use the `OpendalStore` as follows:
-
-```rust
-use std::sync::Arc;
-
-use bytes::Bytes;
-use object_store::path::Path;
-use object_store::ObjectStore;
-use object_store_opendal::OpendalStore;
-use opendal::{services::S3, Builder, Operator};
-
-async fn operate_object_store() {
-    let builder = S3::from_map(
-        vec![
-            ("access_key".to_string(), "my_access_key".to_string()),
-            ("secret_key".to_string(), "my_secret_key".to_string()),
-            ("endpoint".to_string(), "my_endpoint".to_string()),
-            ("region".to_string(), "my_region".to_string()),
-        ]
-        .into_iter()
-        .collect(),
-    );
-
-    // Create a new operator
-    let operator = Operator::new(builder).unwrap().finish();
-
-    // Create a new object store
-    let object_store = Arc::new(OpendalStore::new(operator));
-
-    let path = Path::from("data/nested/test.txt");
-    let bytes = Bytes::from_static(b"hello, world! I am nested.");
-
-    object_store.put(&path, bytes.clone().into()).await.unwrap();
-
-    let content = object_store.get(&path).await.unwrap().bytes().await.unwrap();
-
-    assert_eq!(content, bytes);
-}
-```
+Then you can use the `OpendalStore` as in the [example](examples/basic.rs).
 
 ## API
 
 The `OpendalStore` implements the `ObjectStore` trait, which provides the following methods:
 
-| Method | Description | link |
-| --- | --- | --- |
-| `put` | Put an object into the store. | [put](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.put) |
-| `get` | Get an object from the store. | [get](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.get) |
-| `get_range` | Get a range of bytes from an object in the store. | [get_range](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.get_range) |
-| `head` | Get the metadata of an object in the store. | [head](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.head) |
-| `delete` | Delete an object from the store. | [delete](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.delete) |
-| `list` | List objects in the store. | [list](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.list) |
-| `list_with_offset` | List objects in the store with an offset. | [list_with_offset](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.list_with_offset) |
-| `list_with_delimiter` | List objects in the store with a delimiter. | [list_with_delimiter](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.list_with_delimiter) |
+| Method                | Description                                       | link                                                                                                                       |
+|-----------------------|---------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `put`                 | Put an object into the store.                     | [put](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.put)                                 |
+| `get`                 | Get an object from the store.                     | [get](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.get)                                 |
+| `get_range`           | Get a range of bytes from an object in the store. | [get_range](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.get_range)                     |
+| `head`                | Get the metadata of an object in the store.       | [head](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.head)                               |
+| `delete`              | Delete an object from the store.                  | [delete](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.delete)                           |
+| `list`                | List objects in the store.                        | [list](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.list)                               |
+| `list_with_offset`    | List objects in the store with an offset.         | [list_with_offset](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.list_with_offset)       |
+| `list_with_delimiter` | List objects in the store with a delimiter.       | [list_with_delimiter](https://docs.rs/object_store/0.9.0/object_store/trait.ObjectStore.html#tymethod.list_with_delimiter) |

--- a/integrations/object_store/examples/basic.rs
+++ b/integrations/object_store/examples/basic.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use object_store::path::Path;
+use object_store::ObjectStore;
+use object_store_opendal::OpendalStore;
+use opendal::{Builder, Operator};
+use opendal::services::S3;
+
+#[tokio::main]
+async fn main() {
+    let builder = S3::from_map(
+        vec![
+            ("access_key".to_string(), "my_access_key".to_string()),
+            ("secret_key".to_string(), "my_secret_key".to_string()),
+            ("endpoint".to_string(), "my_endpoint".to_string()),
+            ("region".to_string(), "my_region".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    // Create a new operator
+    let operator = Operator::new(builder).unwrap().finish();
+
+    // Create a new object store
+    let object_store = Arc::new(OpendalStore::new(operator));
+
+    let path = Path::from("data/nested/test.txt");
+    let bytes = Bytes::from_static(b"hello, world! I am nested.");
+
+    object_store.put(&path, bytes.clone().into()).await.unwrap();
+
+    let content = object_store
+        .get(&path)
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+
+    assert_eq!(content, bytes);
+}

--- a/integrations/object_store/examples/basic.rs
+++ b/integrations/object_store/examples/basic.rs
@@ -4,8 +4,8 @@ use bytes::Bytes;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use object_store_opendal::OpendalStore;
-use opendal::{Builder, Operator};
 use opendal::services::S3;
+use opendal::{Builder, Operator};
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
This closes https://github.com/apache/opendal/issues/4703 in https://github.com/apache/opendal/commit/48c6fa92e2dc07dcbd07e460949fdc118a616966