### PR TITLE
fix(core/oio): Make ConcurrentTasks cancel safe by only pop after ready

### DIFF
--- a/core/src/raw/oio/write/multipart_write.rs
+++ b/core/src/raw/oio/write/multipart_write.rs
@@ -276,9 +276,14 @@ where
             self.parts.push(result)
         }
 
-        #[cfg(debug_assertions)]
-        {
-            assert_eq!(self.parts.len(), self.next_part_number);
+        if self.parts.len() != self.next_part_number {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "multipart part numbers mismatch, please report bug to opendal",
+            )
+            .with_context("expected", self.next_part_number)
+            .with_context("actual", self.parts.len())
+            .with_context("upload_id", upload_id));
         }
         self.w.complete_part(&upload_id, &self.parts).await
     }

--- a/core/src/types/execute/api.rs
+++ b/core/src/types/execute/api.rs
@@ -91,6 +91,14 @@ impl<T: 'static> Task<T> {
     pub fn new(handle: RemoteHandle<T>) -> Self {
         Self { handle }
     }
+
+    /// Replace the task with a new task.
+    ///
+    /// The old task will be dropped directly.
+    #[inline]
+    pub fn replace(&mut self, new_task: Self) {
+        self.handle = new_task.handle;
+    }
 }
 
 impl<T: 'static> Future for Task<T> {


### PR DESCRIPTION
`ConcurrentTasks` is not cancel safe since it will change states when poll returns Pending. This PR fixed this by only pop task after it returns ready.