### PR TITLE
fix(core/services/gdrive): Fix gdrive create_dir request: trim trailing `/`

### DIFF
--- a/core/src/services/gdrive/core.rs
+++ b/core/src/services/gdrive/core.rs
@@ -397,7 +397,7 @@ impl PathQuery for GdrivePathQuery {
         let url = "https://www.googleapis.com/drive/v3/files";
 
         // trim "/" at the end of name
-        let name = name.trim_end_matches('/');
+        let name = name.trim_end_matches("/");
 
         let content = serde_json::to_vec(&json!({
             "name": name,

--- a/core/src/services/gdrive/core.rs
+++ b/core/src/services/gdrive/core.rs
@@ -396,6 +396,9 @@ impl PathQuery for GdrivePathQuery {
     async fn create_dir(&self, parent_id: &str, name: &str) -> Result<String> {
         let url = "https://www.googleapis.com/drive/v3/files";
 
+        // trim "/" at the end of name
+        let name = name.trim_end_matches('/');
+
         let content = serde_json::to_vec(&json!({
             "name": name,
             "mimeType": "application/vnd.google-apps.folder",


### PR DESCRIPTION
Per discussion https://github.com/apache/opendal/issues/4722

We have to remove `/` at the end of name