### PR TITLE
fix(s3): parse MultipartUploadResponse to check error in body

### DIFF
--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -765,16 +765,6 @@ pub struct CompleteMultipartUploadRequest {
     pub part: Vec<CompleteMultipartUploadRequestPart>,
 }
 
-/// Result of MultipartUploadRequest.
-///
-/// Result part on success are ignored.
-#[derive(Default, Debug, Deserialize, Eq, PartialEq)]
-#[serde(default, rename = "Error", rename_all = "PascalCase")]
-pub struct CompleteMultipartUploadResult {
-    pub code: String,
-    pub message: String,
-}
-
 #[derive(Clone, Default, Debug, Serialize)]
 #[serde(default, rename_all = "PascalCase")]
 pub struct CompleteMultipartUploadRequestPart {
@@ -979,44 +969,6 @@ mod tests {
                 // Escape `"` by hand to address <https://github.com/tafia/quick-xml/issues/362>
                 .replace('"', "&quot;")
         )
-    }
-
-    /// This example is from https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html#API_CompleteMultipartUpload_Example_4
-    #[test]
-    fn test_deserialize_complete_multipart_upload_response() {
-        let bs = Bytes::from(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-            <Error>
-                <Code>InternalError</Code>
-                <Message>We encountered an internal error. Please try again.</Message>
-                <RequestId>656c76696e6727732072657175657374</RequestId>
-                <HostId>Uuag1LuByRx9e6j5Onimru9pO4ZVKnJ2Qz7/C1NPcfTWAtRPfTaOFg==</HostId>
-            </Error>"#,
-        );
-
-        let expected = CompleteMultipartUploadResult {
-            code: "InternalError".to_string(),
-            message: "We encountered an internal error. Please try again.".to_string(),
-        };
-
-        let actual: CompleteMultipartUploadResult =
-            quick_xml::de::from_reader(bs.reader()).expect("must success");
-        assert_eq!(actual, expected);
-
-        // suceess case are ignored
-        let bs = Bytes::from(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
-            <CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-              <Location>http://Example-Bucket.s3.amazonaws.com/Example-Object</Location>
-              <Bucket>example-bucket</Bucket>
-              <Key>example-object</Key>
-              <ETag>"3858f62230ac3c915f300c664312c11f-9"</ETag>
-            </CompleteMultipartUploadResult>"#,
-        );
-        let expected = CompleteMultipartUploadResult::default();
-        let actual: CompleteMultipartUploadResult =
-            quick_xml::de::from_reader(bs.reader()).expect("must success");
-        assert_eq!(actual, expected);
     }
 
     /// This example is from https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html#API_DeleteObjects_Examples

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -769,14 +769,8 @@ pub struct CompleteMultipartUploadRequest {
 ///
 /// Result part on success are ignored.
 #[derive(Default, Debug, Deserialize, Eq, PartialEq)]
-#[serde(default, rename_all = "PascalCase")]
+#[serde(default, rename = "Error", rename_all = "PascalCase")]
 pub struct CompleteMultipartUploadResult {
-    pub error: Vec<CompleteMultipartUploadResultError>,
-}
-
-#[derive(Default, Debug, Deserialize, PartialEq, Eq)]
-#[serde(default, rename_all = "PascalCase")]
-pub struct CompleteMultipartUploadResultError {
     pub code: String,
     pub message: String,
 }
@@ -1001,10 +995,8 @@ mod tests {
         );
 
         let expected = CompleteMultipartUploadResult {
-            error: vec![CompleteMultipartUploadResultError {
-                code: "InternalError".to_string(),
-                message: "We encountered an internal error. Please try again.".to_string(),
-            }],
+            code: "InternalError".to_string(),
+            message: "We encountered an internal error. Please try again.".to_string(),
         };
 
         let actual: CompleteMultipartUploadResult =

--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -159,10 +159,9 @@ impl oio::MultipartWrite for S3Writer {
 
         match status {
             StatusCode::OK => {
-                let (_, mut body) = resp.into_parts();
-                let bs = body.copy_to_bytes(body.remaining());
                 let result: CompleteMultipartUploadResult =
-                    quick_xml::de::from_reader(bs.reader()).map_err(new_xml_deserialize_error)?;
+                    quick_xml::de::from_reader(resp.into_body().reader())
+                        .map_err(new_xml_deserialize_error)?;
                 if !result.code.is_empty() {
                     return Err(Error::new(ErrorKind::Unexpected, &result.message));
                 }

--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -163,8 +163,8 @@ impl oio::MultipartWrite for S3Writer {
                 let bs = body.copy_to_bytes(body.remaining());
                 let result: CompleteMultipartUploadResult =
                     quick_xml::de::from_reader(bs.reader()).map_err(new_xml_deserialize_error)?;
-                if !result.error.is_empty() {
-                    return Err(Error::new(ErrorKind::Unexpected, &result.error[0].message));
+                if !result.code.is_empty() {
+                    return Err(Error::new(ErrorKind::Unexpected, &result.message));
                 }
                 Ok(())
             }


### PR DESCRIPTION
S3 may return an error when the HTTP code is 200. Like this https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html#API_CompleteMultipartUpload_Example_4

This patch defines a `MultipartUploadResult` result which only contains error's definition. It will be deserialized on complete multipart upload's 200 result, to check if the body contains any error.

For more background reference to https://github.com/awslabs/aws-sdk-rust/issues/1163