### PR TITLE
refactor(*): tiny refactor to the Error type

### DIFF
--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -135,7 +135,7 @@ impl<A: Access> CompleteAccessor<A> {
         let op = op.into();
         Error::new(
             ErrorKind::Unsupported,
-            &format!("service {scheme} doesn't support operation {op}"),
+            format!("service {scheme} doesn't support operation {op}"),
         )
         .with_operation(op)
     }
@@ -415,7 +415,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
         if args.append() && !capability.write_can_append {
             return Err(Error::new(
                 ErrorKind::Unsupported,
-                &format!(
+                format!(
                     "service {} doesn't support operation write with append",
                     self.info().scheme()
                 ),
@@ -540,7 +540,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
         if args.append() && !capability.write_can_append {
             return Err(Error::new(
                 ErrorKind::Unsupported,
-                &format!(
+                format!(
                     "service {} doesn't support operation write with append",
                     self.info().scheme()
                 ),

--- a/core/src/raw/http_util/body.rs
+++ b/core/src/raw/http_util/body.rs
@@ -86,12 +86,12 @@ impl HttpBody {
             Ordering::Equal => Ok(()),
             Ordering::Less => Err(Error::new(
                 ErrorKind::Unexpected,
-                &format!("http response got too little data, expect: {expect}, actual: {actual}"),
+                format!("http response got too little data, expect: {expect}, actual: {actual}"),
             )
             .set_temporary()),
             Ordering::Greater => Err(Error::new(
                 ErrorKind::Unexpected,
-                &format!("http response got too much data, expect: {expect}, actual: {actual}"),
+                format!("http response got too much data, expect: {expect}, actual: {actual}"),
             )
             .set_temporary()),
         }

--- a/core/src/raw/std_io_util.rs
+++ b/core/src/raw/std_io_util.rs
@@ -39,7 +39,7 @@ pub fn new_std_io_error(err: std::io::Error) -> Error {
         _ => (ErrorKind::Unexpected, true),
     };
 
-    let mut err = Error::new(kind, &err.kind().to_string()).set_source(err);
+    let mut err = Error::new(kind, err.kind().to_string()).set_source(err);
 
     if retryable {
         err = err.set_temporary();

--- a/core/src/services/aliyun_drive/error.rs
+++ b/core/src/services/aliyun_drive/error.rs
@@ -47,7 +47,7 @@ pub async fn parse_error(res: Response<Buffer>) -> Result<Error> {
         },
         _ => (ErrorKind::Unexpected, false),
     };
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
     if retryable {
         err = err.set_temporary();
     }

--- a/core/src/services/alluxio/error.rs
+++ b/core/src/services/alluxio/error.rs
@@ -52,7 +52,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         }
     }
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -729,7 +729,7 @@ impl Access for AzblobBackend {
             .map_err(|e| {
                 Error::new(
                     ErrorKind::Unexpected,
-                    &format!("get invalid CONTENT_TYPE header in response: {:?}", e),
+                    format!("get invalid CONTENT_TYPE header in response: {:?}", e),
                 )
             })?;
         let splits = content_type.split("boundary=").collect::<Vec<&str>>();

--- a/core/src/services/b2/error.rs
+++ b/core/src/services/b2/error.rs
@@ -55,7 +55,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         (kind, retryable) = parse_b2_error_code(b2_err.code.as_str()).unwrap_or((kind, retryable));
     };
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/chainsafe/error.rs
+++ b/core/src/services/chainsafe/error.rs
@@ -60,7 +60,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
             .map(|chainsafe_err| (format!("{chainsafe_err:?}"), Some(chainsafe_err)))
             .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/cloudflare_kv/backend.rs
+++ b/core/src/services/cloudflare_kv/backend.rs
@@ -286,7 +286,7 @@ impl kv::Adapter for Adapter {
                     serde_json::from_reader(body.reader()).map_err(|e| {
                         Error::new(
                             ErrorKind::Unexpected,
-                            &format!("failed to parse error response: {}", e),
+                            format!("failed to parse error response: {}", e),
                         )
                     })?;
                 Ok(response.result.into_iter().map(|r| r.name).collect())

--- a/core/src/services/cloudflare_kv/error.rs
+++ b/core/src/services/cloudflare_kv/error.rs
@@ -51,7 +51,7 @@ pub(crate) async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         (kind, retryable) = parse_cfkv_error_code(err.errors).unwrap_or((kind, retryable));
     }
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/cos/error.rs
+++ b/core/src/services/cos/error.rs
@@ -61,7 +61,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         Err(_) => String::from_utf8_lossy(&bs).into_owned(),
     };
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/d1/error.rs
+++ b/core/src/services/d1/error.rs
@@ -51,7 +51,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         (kind, retryable) = parse_d1_error_code(d1_err.errors).unwrap_or((kind, retryable));
     }
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/d1/model.rs
+++ b/core/src/services/d1/model.rs
@@ -39,14 +39,14 @@ impl D1Response {
         let response: D1Response = serde_json::from_slice(bs).map_err(|e| {
             Error::new(
                 crate::ErrorKind::Unexpected,
-                &format!("failed to parse error response: {}", e),
+                format!("failed to parse error response: {}", e),
             )
         })?;
 
         if !response.success {
             return Err(Error::new(
                 crate::ErrorKind::Unexpected,
-                &String::from_utf8_lossy(bs),
+                String::from_utf8_lossy(bs),
             ));
         }
         Ok(response)

--- a/core/src/services/dbfs/error.rs
+++ b/core/src/services/dbfs/error.rs
@@ -63,7 +63,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         Err(_) => String::from_utf8_lossy(&bs).into_owned(),
     };
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/dropbox/backend.rs
+++ b/core/src/services/dropbox/backend.rs
@@ -86,7 +86,7 @@ impl Access for DropboxBackend {
             if "file" == decoded_response.tag {
                 return Err(Error::new(
                     ErrorKind::NotADirectory,
-                    &format!("it's not a directory {}", path),
+                    format!("it's not a directory {}", path),
                 ));
             }
         }
@@ -132,7 +132,7 @@ impl Access for DropboxBackend {
                     } else {
                         return Err(Error::new(
                             ErrorKind::Unexpected,
-                            &format!("no size found for file {}", path),
+                            format!("no size found for file {}", path),
                         ));
                     }
                 }
@@ -272,7 +272,7 @@ impl Access for DropboxBackend {
             }
             _ => Err(Error::new(
                 ErrorKind::Unexpected,
-                &format!(
+                format!(
                     "delete batch failed with unexpected tag {}",
                     decoded_response.tag
                 ),

--- a/core/src/services/dropbox/core.rs
+++ b/core/src/services/dropbox/core.rs
@@ -261,7 +261,7 @@ impl DropboxCore {
             }
             _ => Err(Error::new(
                 ErrorKind::Unexpected,
-                &format!(
+                format!(
                     "delete batch check failed with unexpected tag {}",
                     decoded_response.tag
                 ),

--- a/core/src/services/dropbox/error.rs
+++ b/core/src/services/dropbox/error.rs
@@ -54,7 +54,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
             parse_dropbox_error_summary(&dropbox_err.error_summary).unwrap_or((kind, retryable));
     }
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/gcs/error.rs
+++ b/core/src/services/gcs/error.rs
@@ -71,7 +71,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         Err(_) => String::from_utf8_lossy(&bs).into_owned(),
     };
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/gdrive/core.rs
+++ b/core/src/services/gdrive/core.rs
@@ -60,7 +60,7 @@ impl GdriveCore {
         let path = build_abs_path(&self.root, path);
         let file_id = self.path_cache.get(&path).await?.ok_or(Error::new(
             ErrorKind::NotFound,
-            &format!("path not found: {}", path),
+            format!("path not found: {}", path),
         ))?;
 
         // The file metadata in the Google Drive API is very complex.
@@ -80,7 +80,7 @@ impl GdriveCore {
         let path = build_abs_path(&self.root, path);
         let path_id = self.path_cache.get(&path).await?.ok_or(Error::new(
             ErrorKind::NotFound,
-            &format!("path not found: {}", path),
+            format!("path not found: {}", path),
         ))?;
 
         let url: String = format!(
@@ -129,7 +129,7 @@ impl GdriveCore {
     ) -> Result<Response<Buffer>> {
         let source_file_id = self.path_cache.get(source).await?.ok_or(Error::new(
             ErrorKind::NotFound,
-            &format!("source path not found: {}", source),
+            format!("source path not found: {}", source),
         ))?;
         let source_parent = get_parent(source);
         let source_parent_id = self

--- a/core/src/services/gdrive/error.rs
+++ b/core/src/services/gdrive/error.rs
@@ -59,7 +59,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
             parse_gdrive_error_code(gdrive_err.error.message.as_str()).unwrap_or((kind, retryable));
     }
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -75,7 +75,7 @@ fn value_or_env(
             "{} not found, maybe not in github action environment?",
             env_var_name
         );
-        Error::new(ErrorKind::ConfigInvalid, &text)
+        Error::new(ErrorKind::ConfigInvalid, text)
             .with_operation(operation)
             .set_source(err)
     })

--- a/core/src/services/ghac/error.rs
+++ b/core/src/services/ghac/error.rs
@@ -41,7 +41,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
     let bs = body.copy_to_bytes(body.remaining());
     let message = String::from_utf8_lossy(&bs);
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/github/error.rs
+++ b/core/src/services/github/error.rs
@@ -60,7 +60,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
             .map(|github_content_err| (format!("{github_content_err:?}"), Some(github_content_err)))
             .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/hdfs_native/error.rs
+++ b/core/src/services/hdfs_native/error.rs
@@ -42,7 +42,7 @@ pub fn parse_hdfs_error(hdfs_error: HdfsError) -> Error {
         ),
     };
 
-    let mut err = Error::new(kind, &msg).set_source(hdfs_error);
+    let mut err = Error::new(kind, msg).set_source(hdfs_error);
 
     if retryable {
         err = err.set_temporary();

--- a/core/src/services/http/error.rs
+++ b/core/src/services/http/error.rs
@@ -42,7 +42,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
 
     let message = String::from_utf8_lossy(&bs);
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/huggingface/error.rs
+++ b/core/src/services/huggingface/error.rs
@@ -60,7 +60,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         Err(_) => String::from_utf8_lossy(&bs).into_owned(),
     };
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/icloud/core.rs
+++ b/core/src/services/icloud/core.rs
@@ -429,7 +429,7 @@ impl IcloudCore {
 
         let path_id = self.path_cache.get(base).await?.ok_or(Error::new(
             ErrorKind::NotFound,
-            &format!("read path not found: {}", base),
+            format!("read path not found: {}", base),
         ))?;
 
         if let Some(docwsid) = path_id.strip_prefix("FILE::com.apple.CloudDocs::") {
@@ -456,12 +456,12 @@ impl IcloudCore {
 
         let file_id = self.path_cache.get(base).await?.ok_or(Error::new(
             ErrorKind::NotFound,
-            &format!("stat path not found: {}", base),
+            format!("stat path not found: {}", base),
         ))?;
 
         let folder_id = self.path_cache.get(parent).await?.ok_or(Error::new(
             ErrorKind::NotFound,
-            &format!("stat path not found: {}", parent),
+            format!("stat path not found: {}", parent),
         ))?;
 
         let node = self.get_root(&folder_id).await?;
@@ -590,7 +590,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         }
     }
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/ipfs/error.rs
+++ b/core/src/services/ipfs/error.rs
@@ -41,7 +41,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
 
     let message = String::from_utf8_lossy(&bs);
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/ipmfs/error.rs
+++ b/core/src/services/ipmfs/error.rs
@@ -72,7 +72,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         None => String::from_utf8_lossy(&bs).into_owned(),
     };
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/koofr/error.rs
+++ b/core/src/services/koofr/error.rs
@@ -39,7 +39,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
 
     let message = String::from_utf8_lossy(&bs).into_owned();
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/obs/error.rs
+++ b/core/src/services/obs/error.rs
@@ -61,7 +61,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         Err(_) => String::from_utf8_lossy(&bs).into_owned(),
     };
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/onedrive/error.rs
+++ b/core/src/services/onedrive/error.rs
@@ -39,7 +39,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
 
     let message = String::from_utf8_lossy(&bs);
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/oss/error.rs
+++ b/core/src/services/oss/error.rs
@@ -57,7 +57,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         Err(_) => String::from_utf8_lossy(&bs).into_owned(),
     };
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/pcloud/backend.rs
+++ b/core/src/services/pcloud/backend.rs
@@ -277,10 +277,10 @@ impl Access for PcloudBackend {
                     serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
                 let result = resp.result;
                 if result == 2010 || result == 2055 || result == 2002 {
-                    return Err(Error::new(ErrorKind::NotFound, &format!("{resp:?}")));
+                    return Err(Error::new(ErrorKind::NotFound, format!("{resp:?}")));
                 }
                 if result != 0 {
-                    return Err(Error::new(ErrorKind::Unexpected, &format!("{resp:?}")));
+                    return Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")));
                 }
 
                 if let Some(md) = resp.metadata {
@@ -288,7 +288,7 @@ impl Access for PcloudBackend {
                     return md.map(RpStat::new);
                 }
 
-                Err(Error::new(ErrorKind::Unexpected, &format!("{resp:?}")))
+                Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")))
             }
             _ => Err(parse_error(resp).await?),
         }
@@ -339,7 +339,7 @@ impl Access for PcloudBackend {
 
                 // pCloud returns 2005 or 2009 if the file or folder is not found
                 if result != 0 && result != 2005 && result != 2009 {
-                    return Err(Error::new(ErrorKind::Unexpected, &format!("{resp:?}")));
+                    return Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")));
                 }
 
                 Ok(RpDelete::default())
@@ -371,10 +371,10 @@ impl Access for PcloudBackend {
                     serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
                 let result = resp.result;
                 if result == 2009 || result == 2010 || result == 2055 || result == 2002 {
-                    return Err(Error::new(ErrorKind::NotFound, &format!("{resp:?}")));
+                    return Err(Error::new(ErrorKind::NotFound, format!("{resp:?}")));
                 }
                 if result != 0 {
-                    return Err(Error::new(ErrorKind::Unexpected, &format!("{resp:?}")));
+                    return Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")));
                 }
 
                 Ok(RpCopy::default())
@@ -401,10 +401,10 @@ impl Access for PcloudBackend {
                     serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
                 let result = resp.result;
                 if result == 2009 || result == 2010 || result == 2055 || result == 2002 {
-                    return Err(Error::new(ErrorKind::NotFound, &format!("{resp:?}")));
+                    return Err(Error::new(ErrorKind::NotFound, format!("{resp:?}")));
                 }
                 if result != 0 {
-                    return Err(Error::new(ErrorKind::Unexpected, &format!("{resp:?}")));
+                    return Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")));
                 }
 
                 Ok(RpRename::default())

--- a/core/src/services/pcloud/core.rs
+++ b/core/src/services/pcloud/core.rs
@@ -88,10 +88,10 @@ impl PcloudCore {
                     serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
                 let result = resp.result;
                 if result == 2010 || result == 2055 || result == 2002 {
-                    return Err(Error::new(ErrorKind::NotFound, &format!("{resp:?}")));
+                    return Err(Error::new(ErrorKind::NotFound, format!("{resp:?}")));
                 }
                 if result != 0 {
-                    return Err(Error::new(ErrorKind::Unexpected, &format!("{resp:?}")));
+                    return Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")));
                 }
 
                 if let Some(hosts) = resp.hosts {
@@ -137,14 +137,14 @@ impl PcloudCore {
                         serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
                     let result = resp.result;
                     if result == 2010 || result == 2055 || result == 2002 {
-                        return Err(Error::new(ErrorKind::NotFound, &format!("{resp:?}")));
+                        return Err(Error::new(ErrorKind::NotFound, format!("{resp:?}")));
                     }
                     if result != 0 {
-                        return Err(Error::new(ErrorKind::Unexpected, &format!("{resp:?}")));
+                        return Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")));
                     }
 
                     if result != 0 {
-                        return Err(Error::new(ErrorKind::Unexpected, &format!("{resp:?}")));
+                        return Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")));
                     }
                 }
                 _ => return Err(parse_error(resp).await?),

--- a/core/src/services/pcloud/error.rs
+++ b/core/src/services/pcloud/error.rs
@@ -47,7 +47,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
     let bs = body.copy_to_bytes(body.remaining());
     let message = String::from_utf8_lossy(&bs).into_owned();
 
-    let mut err = Error::new(ErrorKind::Unexpected, &message);
+    let mut err = Error::new(ErrorKind::Unexpected, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/pcloud/lister.rs
+++ b/core/src/services/pcloud/lister.rs
@@ -61,7 +61,7 @@ impl oio::PageList for PcloudLister {
                 }
 
                 if result != 0 {
-                    return Err(Error::new(ErrorKind::Unexpected, &format!("{resp:?}")));
+                    return Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")));
                 }
 
                 if let Some(metadata) = resp.metadata {
@@ -86,7 +86,7 @@ impl oio::PageList for PcloudLister {
 
                 return Err(Error::new(
                     ErrorKind::Unexpected,
-                    &String::from_utf8_lossy(&bs.to_bytes()),
+                    String::from_utf8_lossy(&bs.to_bytes()),
                 ));
             }
             _ => Err(parse_error(resp).await?),

--- a/core/src/services/pcloud/writer.rs
+++ b/core/src/services/pcloud/writer.rs
@@ -55,7 +55,7 @@ impl oio::OneShotWrite for PcloudWriter {
                 let result = resp.result;
 
                 if result != 0 {
-                    return Err(Error::new(ErrorKind::Unexpected, &format!("{resp:?}")));
+                    return Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")));
                 }
 
                 Ok(())

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -1094,7 +1094,7 @@ impl Access for S3Backend {
 
         match status {
             StatusCode::OK => parse_into_metadata(path, resp.headers()).map(RpStat::new),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)?),
         }
     }
 
@@ -1109,7 +1109,7 @@ impl Access for S3Backend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf))?)
             }
         }
     }
@@ -1140,7 +1140,7 @@ impl Access for S3Backend {
             // This is not a standard behavior, only some s3 alike service like GCS XML API do this.
             // ref: <https://cloud.google.com/storage/docs/xml-api/delete-object>
             StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)?),
         }
     }
 
@@ -1162,7 +1162,7 @@ impl Access for S3Backend {
 
         match status {
             StatusCode::OK => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)?),
         }
     }
 
@@ -1237,7 +1237,7 @@ impl Access for S3Backend {
 
             Ok(RpBatch::new(batched_result))
         } else {
-            Err(parse_error(resp).await?)
+            Err(parse_error(resp)?)
         }
     }
 }

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -1094,7 +1094,7 @@ impl Access for S3Backend {
 
         match status {
             StatusCode::OK => parse_into_metadata(path, resp.headers()).map(RpStat::new),
-            _ => Err(parse_error(resp)?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -1109,7 +1109,7 @@ impl Access for S3Backend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf))?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -1140,7 +1140,7 @@ impl Access for S3Backend {
             // This is not a standard behavior, only some s3 alike service like GCS XML API do this.
             // ref: <https://cloud.google.com/storage/docs/xml-api/delete-object>
             StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp)?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -1162,7 +1162,7 @@ impl Access for S3Backend {
 
         match status {
             StatusCode::OK => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp)?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -1237,7 +1237,7 @@ impl Access for S3Backend {
 
             Ok(RpBatch::new(batched_result))
         } else {
-            Err(parse_error(resp)?)
+            Err(parse_error(resp))
         }
     }
 }

--- a/core/src/services/s3/error.rs
+++ b/core/src/services/s3/error.rs
@@ -35,7 +35,7 @@ pub(crate) struct S3Error {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub fn parse_error(resp: Response<Buffer>) -> Result<Error> {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 

--- a/core/src/services/s3/error.rs
+++ b/core/src/services/s3/error.rs
@@ -35,7 +35,7 @@ pub(crate) struct S3Error {
 }
 
 /// Parse error response into Error.
-pub fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -66,7 +66,7 @@ pub fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 /// Util function to build [`Error`] from a [`S3Error`] object.

--- a/core/src/services/s3/lister.rs
+++ b/core/src/services/s3/lister.rs
@@ -78,7 +78,7 @@ impl oio::PageList for S3Lister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp)?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();

--- a/core/src/services/s3/lister.rs
+++ b/core/src/services/s3/lister.rs
@@ -78,7 +78,7 @@ impl oio::PageList for S3Lister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp)?);
         }
 
         let bs = resp.into_body();

--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -58,7 +58,7 @@ impl oio::MultipartWrite for S3Writer {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)?),
         }
     }
 
@@ -79,7 +79,7 @@ impl oio::MultipartWrite for S3Writer {
 
                 Ok(result.upload_id)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)?),
         }
     }
 
@@ -127,7 +127,7 @@ impl oio::MultipartWrite for S3Writer {
                     checksum,
                 })
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)?),
         }
     }
 
@@ -170,7 +170,7 @@ impl oio::MultipartWrite for S3Writer {
 
                 Ok(())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)?),
         }
     }
 
@@ -182,7 +182,7 @@ impl oio::MultipartWrite for S3Writer {
         match resp.status() {
             // s3 returns code 204 if abort succeeds.
             StatusCode::NO_CONTENT => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)?),
         }
     }
 }

--- a/core/src/services/s3/writer.rs
+++ b/core/src/services/s3/writer.rs
@@ -58,7 +58,7 @@ impl oio::MultipartWrite for S3Writer {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp)?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -79,7 +79,7 @@ impl oio::MultipartWrite for S3Writer {
 
                 Ok(result.upload_id)
             }
-            _ => Err(parse_error(resp)?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -127,7 +127,7 @@ impl oio::MultipartWrite for S3Writer {
                     checksum,
                 })
             }
-            _ => Err(parse_error(resp)?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -170,7 +170,7 @@ impl oio::MultipartWrite for S3Writer {
 
                 Ok(())
             }
-            _ => Err(parse_error(resp)?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -182,7 +182,7 @@ impl oio::MultipartWrite for S3Writer {
         match resp.status() {
             // s3 returns code 204 if abort succeeds.
             StatusCode::NO_CONTENT => Ok(()),
-            _ => Err(parse_error(resp)?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/seafile/core.rs
+++ b/core/src/services/seafile/core.rs
@@ -143,7 +143,7 @@ impl SeafileCore {
                     if signer.auth_info.repo_id.is_empty() {
                         return Err(Error::new(
                             ErrorKind::NotFound,
-                            &format!("repo {} not found", self.repo_name),
+                            format!("repo {} not found", self.repo_name),
                         ));
                     }
                 }

--- a/core/src/services/seafile/error.rs
+++ b/core/src/services/seafile/error.rs
@@ -45,7 +45,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         .map(|seafile_err| (format!("{seafile_err:?}"), Some(seafile_err)))
         .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/supabase/error.rs
+++ b/core/src/services/supabase/error.rs
@@ -52,7 +52,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         })
         .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/swift/error.rs
+++ b/core/src/services/swift/error.rs
@@ -49,7 +49,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
 
     let message = parse_error_response(&bs);
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/upyun/error.rs
+++ b/core/src/services/upyun/error.rs
@@ -52,7 +52,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         .map(|upyun_err| (format!("{upyun_err:?}"), Some(upyun_err)))
         .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/upyun/writer.rs
+++ b/core/src/services/upyun/writer.rs
@@ -69,7 +69,7 @@ impl oio::MultipartWrite for UpyunWriter {
                 let id =
                     parse_header_to_str(resp.headers(), X_UPYUN_MULTI_UUID)?.ok_or(Error::new(
                         ErrorKind::Unexpected,
-                        &format!("{} header is missing", X_UPYUN_MULTI_UUID),
+                        format!("{} header is missing", X_UPYUN_MULTI_UUID),
                     ))?;
 
                 Ok(id.to_string())

--- a/core/src/services/vercel_artifacts/error.rs
+++ b/core/src/services/vercel_artifacts/error.rs
@@ -39,7 +39,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
 
     let message = String::from_utf8_lossy(&bs);
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/vercel_blob/error.rs
+++ b/core/src/services/vercel_blob/error.rs
@@ -53,7 +53,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         .map(|vercel_blob_err| (format!("{vercel_blob_err:?}"), Some(vercel_blob_err)))
         .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/webdav/core.rs
+++ b/core/src/services/webdav/core.rs
@@ -384,7 +384,7 @@ pub fn parse_propstat(propstat: &Propstat) -> Result<Metadata> {
         if code >= 400 {
             return Err(Error::new(
                 ErrorKind::Unexpected,
-                &format!("propfind response is unexpected: {} {}", code, text),
+                format!("propfind response is unexpected: {} {}", code, text),
             ));
         }
     }

--- a/core/src/services/webdav/error.rs
+++ b/core/src/services/webdav/error.rs
@@ -42,7 +42,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
 
     let message = String::from_utf8_lossy(&bs);
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/webhdfs/error.rs
+++ b/core/src/services/webhdfs/error.rs
@@ -66,7 +66,7 @@ pub(super) fn parse_error_msg(parts: Parts, body: &str) -> Result<Error> {
         Err(_) => body.to_owned(),
     };
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/services/yandex_disk/error.rs
+++ b/core/src/services/yandex_disk/error.rs
@@ -51,7 +51,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         .map(|yandex_disk_err| (format!("{yandex_disk_err:?}"), Some(yandex_disk_err)))
         .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
 
-    let mut err = Error::new(kind, &message);
+    let mut err = Error::new(kind, message);
 
     err = with_error_response_context(err, parts);
 

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -303,10 +303,10 @@ impl std::error::Error for Error {
 
 impl Error {
     /// Create a new Error with error kind and message.
-    pub fn new(kind: ErrorKind, message: &str) -> Self {
+    pub fn new(kind: ErrorKind, message: impl Into<String>) -> Self {
         Self {
             kind,
-            message: message.to_string(),
+            message: message.into(),
 
             status: ErrorStatus::Permanent,
             operation: "",


### PR DESCRIPTION
This patch
- removes unnecessary `async` and `Result` from `parse_error()`
- reduces potential `.clone()` on constructing new `Error`. As most of the error messages are newly formatted.