### PR TITLE
chore(ci): disable aliyun_drive for bindings test

### DIFF
--- a/.github/scripts/test_behavior/plan.py
+++ b/.github/scripts/test_behavior/plan.py
@@ -86,7 +86,7 @@ class Hint:
     # Is bin ofs affected?
     bin_ofs: bool = field(default=False, init=False)
 
-    # Should we run all services test?
+    # Should we run all services tests?
     all_service: bool = field(default=False, init=False)
     # affected services set.
     services: set = field(default_factory=set, init=False)
@@ -95,7 +95,7 @@ class Hint:
 def calculate_hint(changed_files: list[str]) -> Hint:
     hint = Hint()
 
-    # Remove all files that ends with `.md`
+    # Remove all files that end with `.md`
     changed_files = [f for f in changed_files if not f.endswith(".md")]
 
     for p in changed_files:
@@ -179,9 +179,9 @@ def calculate_hint(changed_files: list[str]) -> Hint:
     return hint
 
 
-# unique_cases is used to only one setup for each service.
+# `unique_cases` is used to only one setup for each service.
 #
-# We need this because we have multiple setup for each service and they have already been
+# We need this because we have multiple setups for each service, and they have already been
 # tested by `core` workflow. So we can only test unique setup for each service for bindings.
 #
 # We make sure that we return the first setup for each service in alphabet order.
@@ -221,7 +221,10 @@ def generate_language_binding_cases(
 ) -> list[dict[str, str]]:
     cases = unique_cases(cases)
 
-    # Remove hdfs cases for java.
+    # Disable aliyun_drive case for every language.
+    cases = [v for v in cases if v["service"] != "aliyun_drive"]
+
+    # Remove hdfs cases for jav:a.
     if language == "java":
         cases = [v for v in cases if v["service"] != "hdfs"]
 
@@ -246,7 +249,7 @@ def generate_bin_cases(
     # Return empty if this bin is False
     if not getattr(hint, f"bin_{bin}"):
         return []
-    
+
     cases = unique_cases(cases)
 
     if bin == "ofs":

--- a/.github/scripts/test_behavior/plan.py
+++ b/.github/scripts/test_behavior/plan.py
@@ -222,6 +222,9 @@ def generate_language_binding_cases(
     cases = unique_cases(cases)
 
     # Disable aliyun_drive case for every language.
+    #
+    # This is because aliyun_drive has a speed limit and tests may not be stable enough.
+    # Bindings may be treated as parallel requests, so we need to disable it for all languages.
     cases = [v for v in cases if v["service"] != "aliyun_drive"]
 
     # Remove hdfs cases for jav:a.

--- a/core/src/services/aliyun_drive/backend.rs
+++ b/core/src/services/aliyun_drive/backend.rs
@@ -43,31 +43,31 @@ use crate::*;
 #[serde(default)]
 #[non_exhaustive]
 pub struct AliyunDriveConfig {
-    /// root of this backend.
+    /// The Root of this backend.
     ///
     /// All operations will happen under this root.
     ///
-    /// default to `/` if not set.
+    /// Default to `/` if not set.
     pub root: Option<String>,
-    /// access_token of this backend.
+    /// The access_token of this backend.
     ///
     /// Solution for client-only purpose. #4733
     ///
-    /// required if no client_id, client_secret and refresh_token are provided.
+    /// Required if no client_id, client_secret and refresh_token are provided.
     pub access_token: Option<String>,
-    /// client_id of this backend.
+    /// The client_id of this backend.
     ///
-    /// required if no access_token is provided.
+    /// Required if no access_token is provided.
     pub client_id: Option<String>,
-    /// client_secret of this backend.
+    /// The client_secret of this backend.
     ///
-    /// required if no access_token is provided.
+    /// Required if no access_token is provided.
     pub client_secret: Option<String>,
-    /// refresh_token of this backend.
+    /// The refresh_token of this backend.
     ///
-    /// required if no access_token is provided.
+    /// Required if no access_token is provided.
     pub refresh_token: Option<String>,
-    /// drive_type of this backend.
+    /// The drive_type of this backend.
     ///
     /// All operations will happen under this type of drive.
     ///
@@ -106,7 +106,7 @@ impl Debug for AliyunDriveBuilder {
 }
 
 impl AliyunDriveBuilder {
-    /// Set root of this backend.
+    /// Set the root of this backend.
     ///
     /// All operations will happen under this root.
     pub fn root(&mut self, root: &str) -> &mut Self {
@@ -342,8 +342,8 @@ impl Access for AliyunDriveBackend {
         let parent_path = get_parent(to);
         let parent_file_id = self.core.ensure_dir_exists(parent_path).await?;
 
-        // if from and to are going to be placed in the same folder
-        // copy_path will fail as we cannot change name during this action.
+        // if from and to are going to be placed in the same folder,
+        // copy_path will fail as we cannot change the name during this action.
         // it has to be auto renamed.
         let auto_rename = file.parent_file_id == parent_file_id;
         let res = self

--- a/core/src/services/aliyun_drive/core.rs
+++ b/core/src/services/aliyun_drive/core.rs
@@ -40,11 +40,11 @@ pub enum DriveType {
     Default,
     /// Use the backup type of Aliyun Drive.
     ///
-    /// fallback to the default type if no backup drive found.
+    /// Fallback to the default type if no backup drive is found.
     Backup,
     /// Use the resource type of Aliyun Drive.
     ///
-    /// fallback to the default type if no resource drive found.
+    /// Fallback to the default type if no resource drive is found.
     Resource,
 }
 


### PR DESCRIPTION
The current aliyun_drive test may not be stable enough. 
There is a concurrent write limit, so disable it for our bindings.