### PR TITLE
fix(unftp-sbe): remove buffer for get

### DIFF
--- a/integrations/unftp-sbe/Cargo.lock
+++ b/integrations/unftp-sbe/Cargo.lock
@@ -1927,7 +1927,6 @@ name = "unftp-sbe-opendal"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "bytes",
  "libunftp",
  "opendal",
  "tokio",

--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -28,7 +28,6 @@ version = "0.0.0"
 
 [dependencies]
 async-trait = "0.1.80"
-bytes = "1.6.0"
 libunftp = "0.20.0"
 opendal = { version = "0.47.0", path = "../../core" }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util"] }

--- a/integrations/unftp-sbe/src/lib.rs
+++ b/integrations/unftp-sbe/src/lib.rs
@@ -17,14 +17,11 @@
 
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
-use std::task::Poll;
 
-use bytes::{Buf, BufMut};
 use libunftp::auth::UserDetail;
 use libunftp::storage::{self, StorageBackend};
-use opendal::{Buffer, Operator};
+use opendal::Operator;
 
-use tokio::io::AsyncRead;
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 
 #[derive(Debug, Clone)]
@@ -35,21 +32,6 @@ pub struct OpendalStorage {
 impl OpendalStorage {
     pub fn new(op: Operator) -> Self {
         Self { op }
-    }
-}
-
-/// A wrapper around [`Buffer`] to implement [`tokio::io::AsyncRead`].
-pub struct IoBuffer(Buffer);
-
-impl AsyncRead for IoBuffer {
-    fn poll_read(
-        mut self: std::pin::Pin<&mut Self>,
-        _: &mut std::task::Context<'_>,
-        buf: &mut tokio::io::ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        let len = std::io::copy(&mut self.as_mut().0.by_ref().reader(), &mut buf.writer())?;
-        self.0.advance(len as usize);
-        Poll::Ready(Ok(()))
     }
 }
 


### PR DESCRIPTION
This PR returnes a `tokio::io::AsyncRead` instance directly instead of read everything into buffer first and then return it.