### PR TITLE
feat(services/compfs): implement auxiliary functions

### DIFF
--- a/core/src/services/compfs/core.rs
+++ b/core/src/services/compfs/core.rs
@@ -44,6 +44,10 @@ pub(super) struct CompfsCore {
 }
 
 impl CompfsCore {
+    pub fn prepare_path(&self, path: &str) -> PathBuf {
+        self.root.join(path.trim_end_matches('/'))
+    }
+
     pub async fn exec<Fn, Fut, R>(&self, f: Fn) -> crate::Result<R>
     where
         Fn: FnOnce() -> Fut + Send + 'static,

--- a/core/src/services/compfs/lister.rs
+++ b/core/src/services/compfs/lister.rs
@@ -28,7 +28,7 @@ pub struct CompfsLister {
 }
 
 impl CompfsLister {
-    pub fn new(core: Arc<CompfsCore>, read_dir: ReadDir) -> Self {
+    pub(super) fn new(core: Arc<CompfsCore>, read_dir: ReadDir) -> Self {
         Self {
             core,
             read_dir: Some(read_dir),

--- a/core/src/services/compfs/reader.rs
+++ b/core/src/services/compfs/reader.rs
@@ -31,7 +31,7 @@ pub struct CompfsReader {
 }
 
 impl CompfsReader {
-    pub fn new(core: Arc<CompfsCore>, file: compio::fs::File, range: BytesRange) -> Self {
+    pub(super) fn new(core: Arc<CompfsCore>, file: compio::fs::File, range: BytesRange) -> Self {
         Self { core, file, range }
     }
 }

--- a/core/src/services/compfs/reader.rs
+++ b/core/src/services/compfs/reader.rs
@@ -40,13 +40,14 @@ impl oio::Read for CompfsReader {
     async fn read(&mut self) -> Result<Buffer> {
         let mut bs = self.core.buf_pool.get();
 
+        let pos = self.range.offset();
         let len = self.range.size().expect("range size is always Some");
         bs.reserve(len as _);
         let f = self.file.clone();
         let mut bs = self
             .core
             .exec(move || async move {
-                let (_, bs) = buf_try!(@try f.read_at(bs, len).await);
+                let (_, bs) = buf_try!(@try f.read_at(bs, pos).await);
                 Ok(bs)
             })
             .await?;

--- a/core/src/services/compfs/writer.rs
+++ b/core/src/services/compfs/writer.rs
@@ -30,7 +30,7 @@ pub struct CompfsWriter {
 }
 
 impl CompfsWriter {
-    pub fn new(core: Arc<CompfsCore>, file: Cursor<File>) -> Self {
+    pub(super) fn new(core: Arc<CompfsCore>, file: Cursor<File>) -> Self {
         Self { core, file }
     }
 }


### PR DESCRIPTION
This PR impelements auxiliary Access functions for Compfs, include `create_dir`, `stat`, `delete`, `copy` and `rename`, and finished builder logic.
