### PR TITLE
ci(scripts): Add a script to generate version list

### DIFF
--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -61,7 +61,7 @@ def get_rust_package_version(path):
 #
 # For examples:
 # core: `0.45.0`
-# packages depends on core: `0.1.0+core.0.45.0`
+# packages depends on core: `0.1.0`
 def get_package_version(package):
     if package == "core":
         return get_rust_package_version("core")
@@ -78,10 +78,3 @@ def get_package_version(package):
     #
     # However, those packages are not mature enough, it's much easier for us to always return `0.0.0` instead.
     return f"0.0.0"
-
-
-if __name__ == "__main__":
-    for v in PACKAGES:
-        print(
-            f"{v}: version={get_package_version(v)}"
-        )

--- a/scripts/dependencies.py
+++ b/scripts/dependencies.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import subprocess
 from constants import PACKAGES
 
+
 def check_deps():
     cargo_dirs = PACKAGES
     for root in cargo_dirs:
@@ -50,18 +51,16 @@ if __name__ == "__main__":
     subparsers = parser.add_subparsers()
 
     parser_check = subparsers.add_parser(
-        'check',
-        description="Check dependencies",
-        help="Check dependencies")
+        "check", description="Check dependencies", help="Check dependencies"
+    )
     parser_check.set_defaults(func=check_deps)
 
     parser_generate = subparsers.add_parser(
-        'generate',
-        description="Generate dependencies",
-        help="Generate dependencies")
+        "generate", description="Generate dependencies", help="Generate dependencies"
+    )
     parser_generate.set_defaults(func=generate_deps)
 
     args = parser.parse_args()
     arg_dict = dict(vars(args))
-    del arg_dict['func']
+    del arg_dict["func"]
     args.func(**arg_dict)

--- a/scripts/merge_local_staging.py
+++ b/scripts/merge_local_staging.py
@@ -53,7 +53,7 @@ def print_directory_contents(directory, prefix=""):
 
 
 def print_index_contents(directory):
-    for sub_dir in directory.rglob('.index'):
+    for sub_dir in directory.rglob(".index"):
         with sub_dir.open("r") as file:
             print(file.read())
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -84,7 +84,13 @@ def generate_checksum():
     for i in Path(ROOT_DIR / "dist").glob("*.tar.gz"):
         print(f"Check checksum for {i}")
         subprocess.run(
-            ["shasum", "-a", "512", "-c", f"{str(i.relative_to(ROOT_DIR / 'dist'))}.sha512"],
+            [
+                "shasum",
+                "-a",
+                "512",
+                "-c",
+                f"{str(i.relative_to(ROOT_DIR / 'dist'))}.sha512",
+            ],
             cwd=ROOT_DIR / "dist",
             check=True,
         )

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -146,7 +146,9 @@ if __name__ == "__main__":
                 print(
                     "Cargo is not found, please check if rust development has been setup correctly"
                 )
-                print("Visit https://www.rust-lang.org/tools/install for more information")
+                print(
+                    "Visit https://www.rust-lang.org/tools/install for more information"
+                )
                 sys.exit(1)
 
         if "java" in dir.name:

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from constants import PACKAGES, get_package_version
+
+
+def increment_patch_version(version):
+    parts = version.split(".")
+    parts[-1] = str(int(parts[-1]) + 1)
+    return ".".join(parts)
+
+
+if __name__ == "__main__":
+    print(f"| {'Name':<25} | {'Version':<7} | {'Next':<7} |")
+    print(f"| {'-':<25} | {'-':<7} | {'-':<7} |")
+    for v in PACKAGES:
+        cur = get_package_version(v)
+        next = increment_patch_version(cur)
+
+        print(f"| {str(v):<25} | {cur:<7} | {next:<7} |")

--- a/website/community/release/release.md
+++ b/website/community/release/release.md
@@ -86,9 +86,13 @@ This issue is used to track tasks of the opendal ${opendal_version} release.
 
 ### Blockers
 
-> Blockers are the tasks that must be completed before the release.
+<!-- Blockers are the tasks that must be completed before the release. -->
 
 ### Build Release
+
+#### Relelase List
+
+<!-- Generate release list by `./scripts/version.py`, please adapt with the actual needs. -->
 
 #### GitHub Side
 
@@ -121,6 +125,17 @@ This issue is used to track tasks of the opendal ${opendal_version} release.
 
 For details of each step, please refer to: https://opendal.apache.org/community/release/
 ```
+
+## Release List
+
+Use `./script/version.py` to generate a release version list for review.
+
+This list bumps `patch` version by default, please adapt with the actual needs.
+
+For example:
+
+- If breaking change happened, we need to bump `minor` version instead of `patch`.
+- If this package is not ready for release, we can skip it.
 
 ## GitHub Side
 


### PR DESCRIPTION
This PR will add a script to generate version list in markdown.

For example:

```
:) ./scripts/version.py
| Name                      | Version | Next    |
| -                         | -       | -       |
| core                      | 0.47.1  | 0.47.2  |
| bin/oay                   | 0.41.4  | 0.41.5  |
| bin/oli                   | 0.41.4  | 0.41.5  |
| bin/ofs                   | 0.0.5   | 0.0.6   |
| bindings/python           | 0.45.4  | 0.45.5  |
| bindings/nodejs           | 0.46.2  | 0.46.3  |
| bindings/c                | 0.44.6  | 0.44.7  |
| bindings/zig              | 0.0.0   | 0.0.1   |
| bindings/dotnet           | 0.1.2   | 0.1.3   |
| bindings/haskell          | 0.44.4  | 0.44.5  |
| bindings/java             | 0.46.1  | 0.46.2  |
| bindings/lua              | 0.1.2   | 0.1.3   |
| bindings/ruby             | 0.1.2   | 0.1.3   |
| bindings/swift            | 0.0.0   | 0.0.1   |
| bindings/ocaml            | 0.0.0   | 0.0.1   |
| bindings/php              | 0.1.2   | 0.1.3   |
| bindings/cpp              | 0.45.4  | 0.45.5  |
| bindings/go               | 0.0.0   | 0.0.1   |
| integrations/object_store | 0.44.1  | 0.44.2  |
| integrations/dav-server   | 0.0.3   | 0.0.4   |
| integrations/fuse3        | 0.0.0   | 0.0.1   |
| integrations/virtiofs     | 0.0.0   | 0.0.1   |
| integrations/unftp-sbe    | 0.0.0   | 0.0.1   |
| integrations/cloudfilter  | 0.0.0   | 0.0.1   |

```