### PR TITLE
chore: Bump version to 0.47.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- Release notes generated using configuration in .github/release.yml at main -->
 
+## [v0.47.2] - 2024-06-30
+
+### Added
+* feat(services/compfs): basic `Access` impl by @George-Miao in https://github.com/apache/opendal/pull/4693
+* feat(unftp-sbe): impl `OpendalStorage` by @George-Miao in https://github.com/apache/opendal/pull/4765
+* feat(services/compfs): implement auxiliary functions by @George-Miao in https://github.com/apache/opendal/pull/4778
+* feat: make AwaitTreeLayer covers oio::Read and oio::Write by @PsiACE in https://github.com/apache/opendal/pull/4787
+* feat: Nodejs add devbox by @bxb100 in https://github.com/apache/opendal/pull/4791
+* feat: make AsyncBacktraceLayer covers oio::Read and oio::Write by @PsiACE in https://github.com/apache/opendal/pull/4789
+* feat(nodejs): add `WriteOptions` for write methods by @bxb100 in https://github.com/apache/opendal/pull/4785
+* feat: setup cloud filter integration by @ho-229 in https://github.com/apache/opendal/pull/4779
+* feat: add position write by @hoslo in https://github.com/apache/opendal/pull/4795
+* fix(core): write concurrent doesn't set correctly by @hoslo in https://github.com/apache/opendal/pull/4816
+* feat(ovfs): add filesystem to handle message by @zjregee in https://github.com/apache/opendal/pull/4720
+* feat(unftp-sbe): add derives for `OpendalMetadata` by @George-Miao in https://github.com/apache/opendal/pull/4819
+* feat(core/gcs): Add concurrent write for gcs back by @Xuanwo in https://github.com/apache/opendal/pull/4820
+### Changed
+* refactor(nodejs)!: Remove append api by @bxb100 in https://github.com/apache/opendal/pull/4796
+* refactor(core): Remove unused layer `MadsimLayer` by @zzzk1 in https://github.com/apache/opendal/pull/4788
+### Fixed
+* fix(services/aliyun-drive): list dir without trailing slash by @yuchanns in https://github.com/apache/opendal/pull/4766
+* fix(unftp-sbe): remove buffer for get by @George-Miao in https://github.com/apache/opendal/pull/4775
+* fix(services/aliyun-drive): write op cannot overwrite existing files by @yuchanns in https://github.com/apache/opendal/pull/4781
+* fix(core/services/onedrive): remove @odata.count for onedrive list op by @imWildCat in https://github.com/apache/opendal/pull/4803
+* fix(core): Gcs's RangeWrite doesn't support concurrent write by @Xuanwo in https://github.com/apache/opendal/pull/4806
+* fix(tests/behavior): skip test of write_with_overwrite for ghac by @yuchanns in https://github.com/apache/opendal/pull/4823
+* fix(docs): some typos in website and nodejs binding docs by @suyanhanx in https://github.com/apache/opendal/pull/4814
+### Docs
+* doc(unftp-sbe): adds example and readme by @George-Miao in https://github.com/apache/opendal/pull/4777
+* doc(nodejs): update upgrade.md by @bxb100 in https://github.com/apache/opendal/pull/4799
+* docs: Add README and rustdoc for fuse3_opendal by @Xuanwo in https://github.com/apache/opendal/pull/4813
+* docs: use version variable in gradle, same to maven by @shoothzj in https://github.com/apache/opendal/pull/4824
+### CI
+* ci: set behavior test ci for aliyun drive by @suyanhanx in https://github.com/apache/opendal/pull/4657
+* ci: Fix lib-darwin-x64 no released by @Xuanwo in https://github.com/apache/opendal/pull/4798
+* ci(unftp-sbe): init by @George-Miao in https://github.com/apache/opendal/pull/4809
+* ci: Build docs for all integrations by @Xuanwo in https://github.com/apache/opendal/pull/4811
+* ci(scripts): Add a script to generate version list by @Xuanwo in https://github.com/apache/opendal/pull/4827
+### Chore
+* chore(ci): disable aliyun_drive for bindings test by @suyanhanx in https://github.com/apache/opendal/pull/4770
+* chore(unftp-sbe): remove Cargo.lock by @George-Miao in https://github.com/apache/opendal/pull/4805
+
 ## [v0.47.1] - 2024-06-18
 
 ### Added
@@ -3760,6 +3802,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 Hello, OpenDAL!
 
+[v0.47.2]: https://github.com/apache/opendal/compare/v0.47.1...v0.47.2
 [v0.47.1]: https://github.com/apache/opendal/compare/v0.47.0...v0.47.1
 [v0.47.0]: https://github.com/apache/opendal/compare/v0.46.0...v0.47.0
 [v0.46.0]: https://github.com/apache/opendal/compare/v0.45.1...v0.46.0

--- a/bin/oay/Cargo.lock
+++ b/bin/oay/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -227,9 +227,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -254,9 +254,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "2755ff20a1d93490d26ba33a6f092a38a508398a5320df5d4b3014fcccce9410"
 
 [[package]]
 name = "cfg-if"
@@ -280,18 +280,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.6"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9689a29b593160de5bc4aacab7b5d54fb52231de70122626c178e6a368994c7"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.6"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5387378c84f6faa26890ebf9f0a92989f8873d4d380467bcd0d8d8620424df"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
  "anstream",
  "anstyle",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "dav-server-opendalfs"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -417,17 +417,6 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -650,12 +639,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "pin-project-lite",
@@ -663,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -695,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http",
@@ -708,6 +697,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -754,133 +744,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "idna"
-version = "1.0.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4716a3a0933a1d01c2f72450e89596eb51dd34ef3c211ccd875acdf1f8fe47ed"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "icu_normalizer",
- "icu_properties",
- "smallvec",
- "utf8_iter",
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -922,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -943,12 +813,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "litemap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
@@ -1000,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -1012,9 +876,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
@@ -1022,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -1077,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "oay"
-version = "0.41.4"
+version = "0.41.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -1104,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -1119,7 +983,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1230,9 +1094,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1255,6 +1119,53 @@ checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1298,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
  "bitflags",
 ]
@@ -1318,14 +1229,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1339,13 +1250,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1356,15 +1267,15 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1383,13 +1294,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -1425,12 +1337,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
-name = "rustls"
-version = "0.22.4"
+name = "rustc-hash"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustls"
+version = "0.23.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -1505,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
 dependencies = [
  "itoa",
  "ryu",
@@ -1597,12 +1515,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,15 +1522,15 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1636,17 +1548,6 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
-
-[[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "thiserror"
@@ -1710,14 +1611,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.7.6"
+name = "tinyvec"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
 dependencies = [
- "displaydoc",
- "zerovec",
+ "tinyvec_macros",
 ]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1749,9 +1655,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
@@ -1934,10 +1840,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "untrusted"
@@ -1947,9 +1868,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c25da092f0a868cdf09e8674cd3b7ef3a7d92a24253e663a2fb85e2496de56"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1957,28 +1878,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
  "rand",
@@ -2103,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2300,18 +2209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
 name = "xml-rs"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2324,30 +2221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
 dependencies = [
  "xml-rs",
-]
-
-[[package]]
-name = "yoke"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -2371,50 +2244,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-
-[[package]]
-name = "zerovec"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]

--- a/bin/oay/Cargo.toml
+++ b/bin/oay/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.41.4"
+version = "0.41.5"
 
 [features]
 default = ["frontends-webdav", "frontends-s3"]
@@ -47,7 +47,7 @@ bytes = { version = "1.5.0", optional = true }
 chrono = "0.4.31"
 clap = { version = "4", features = ["cargo", "string"] }
 dav-server = { version = "0.6", optional = true }
-dav-server-opendalfs = { version = "0.0.3", path = "../../integrations/dav-server", optional = true }
+dav-server-opendalfs = { version = "0.0.4", path = "../../integrations/dav-server", optional = true }
 dirs = "5.0.1"
 futures = "0.3"
 futures-util = { version = "0.3.29", optional = true }

--- a/bin/oay/DEPENDENCIES.rust.tsv
+++ b/bin/oay/DEPENDENCIES.rust.tsv
@@ -1,251 +1,230 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-3.0	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.22.0		X						X						
-adler@1.0.2	X	X						X						
-ahash@0.8.11		X						X						
-aho-corasick@1.1.3								X					X	
-allocator-api2@0.2.18		X						X						
-android-tzdata@0.1.1		X						X						
-android_system_properties@0.1.5		X						X						
-anstream@0.6.14		X						X						
-anstyle@1.0.7		X						X						
-anstyle-parse@0.2.4		X						X						
-anstyle-query@1.1.0		X						X						
-anstyle-wincon@3.0.3		X						X						
-anyhow@1.0.86		X						X						
-async-trait@0.1.80		X						X						
-autocfg@1.3.0		X						X						
-axum@0.7.5								X						
-axum-core@0.4.3								X						
-backon@0.4.4		X												
-backtrace@0.3.72		X						X						
-base64@0.21.7		X						X						
-base64@0.22.1		X						X						
-bitflags@2.5.0		X						X						
-block-buffer@0.10.4		X						X						
-bumpalo@3.16.0		X						X						
-bytes@1.6.0								X						
-cc@1.0.98		X						X						
-cfg-if@1.0.0		X						X						
-chrono@0.4.38		X						X						
-clap@4.5.6		X						X						
-clap_builder@4.5.6		X						X						
-clap_lex@0.7.1		X						X						
-colorchoice@1.0.1		X						X						
-core-foundation-sys@0.8.6		X						X						
-cpufeatures@0.2.12		X						X						
-crypto-common@0.1.6		X						X						
-dav-server@0.6.0		X												
-dav-server-opendalfs@0.0.3		X												
-deranged@0.3.11		X						X						
-digest@0.10.7		X						X						
-dirs@5.0.1		X						X						
-dirs-sys@0.4.1		X						X						
-displaydoc@0.2.4		X						X						
-equivalent@1.0.1		X						X						
-fastrand@2.1.0		X						X						
-flagset@0.4.5		X												
-fnv@1.0.7		X						X						
-form_urlencoded@1.2.1		X						X						
-futures@0.3.30		X						X						
-futures-channel@0.3.30		X						X						
-futures-core@0.3.30		X						X						
-futures-executor@0.3.30		X						X						
-futures-io@0.3.30		X						X						
-futures-macro@0.3.30		X						X						
-futures-sink@0.3.30		X						X						
-futures-task@0.3.30		X						X						
-futures-util@0.3.30		X						X						
-generic-array@0.14.7								X						
-getrandom@0.2.15		X						X						
-gimli@0.29.0		X						X						
-hashbrown@0.14.5		X						X						
-headers@0.4.0								X						
-headers-core@0.3.0								X						
-hermit-abi@0.3.9		X						X						
-htmlescape@0.3.1		X						X	X					
-http@1.1.0		X						X						
-http-body@1.0.0								X						
-http-body-util@0.1.1								X						
-httparse@1.8.0		X						X						
-httpdate@1.0.3		X						X						
-hyper@1.3.1								X						
-hyper-rustls@0.26.0		X					X	X						
-hyper-util@0.1.5								X						
-iana-time-zone@0.1.60		X						X						
-iana-time-zone-haiku@0.1.2		X						X						
-icu_collections@1.5.0											X			
-icu_locid@1.5.0											X			
-icu_locid_transform@1.5.0											X			
-icu_locid_transform_data@1.5.0											X			
-icu_normalizer@1.5.0											X			
-icu_normalizer_data@1.5.0											X			
-icu_properties@1.5.0											X			
-icu_properties_data@1.5.0											X			
-icu_provider@1.5.0											X			
-icu_provider_macros@1.5.0											X			
-idna@1.0.0		X						X						
-indexmap@2.2.6		X						X						
-ipnet@2.9.0		X						X						
-is_terminal_polyfill@1.70.0		X						X						
-itoa@1.0.11		X						X						
-js-sys@0.3.69		X						X						
-lazy_static@1.4.0		X						X						
-libc@0.2.155		X						X						
-libredox@0.1.3								X						
-litemap@0.7.3											X			
-lock_api@0.4.12		X						X						
-log@0.4.21		X						X						
-lru@0.12.3								X						
-matchers@0.1.0								X						
-matchit@0.7.3					X			X						
-md-5@0.10.6		X						X						
-memchr@2.7.2								X					X	
-mime@0.3.17		X						X						
-mime_guess@2.0.4								X						
-miniz_oxide@0.7.3		X						X						X
-mio@0.8.11								X						
-nu-ansi-term@0.46.0								X						
-num-conv@0.1.0		X						X						
-num-traits@0.2.19		X						X						
-num_cpus@1.16.0		X						X						
-oay@0.41.4		X												
-object@0.35.0		X						X						
-once_cell@1.19.0		X						X						
-opendal@0.47.1		X												
-option-ext@0.2.0									X					
-overload@0.1.1								X						
-parking_lot@0.12.3		X						X						
-parking_lot_core@0.9.10		X						X						
-percent-encoding@2.3.1		X						X						
-pin-project@1.1.5		X						X						
-pin-project-internal@1.1.5		X						X						
-pin-project-lite@0.2.14		X						X						
-pin-utils@0.1.0		X						X						
-powerfmt@0.2.0		X						X						
-ppv-lite86@0.2.17		X						X						
-proc-macro2@1.0.85		X						X						
-quick-xml@0.31.0								X						
-quick-xml@0.32.0								X						
-quote@1.0.36		X						X						
-rand@0.8.5		X						X						
-rand_chacha@0.3.1		X						X						
-rand_core@0.6.4		X						X						
-redox_syscall@0.5.1								X						
-redox_users@0.4.5								X						
-regex@1.10.4		X						X						
-regex-automata@0.1.10								X					X	
-regex-automata@0.4.6		X						X						
-regex-syntax@0.6.29		X						X						
-regex-syntax@0.8.3		X						X						
-reqwest@0.12.4		X						X						
-ring@0.17.8										X				
-rustc-demangle@0.1.24		X						X						
-rustls@0.22.4		X					X	X						
-rustls-pemfile@2.1.2		X					X	X						
-rustls-pki-types@1.7.0		X						X						
-rustls-webpki@0.102.4							X							
-rustversion@1.0.17		X						X						
-ryu@1.0.18		X				X								
-scopeguard@1.2.0		X						X						
-serde@1.0.203		X						X						
-serde_derive@1.0.203		X						X						
-serde_json@1.0.117		X						X						
-serde_path_to_error@0.1.16		X						X						
-serde_spanned@0.6.6		X						X						
-serde_urlencoded@0.7.1		X						X						
-sha1@0.10.6		X						X						
-sharded-slab@0.1.7								X						
-slab@0.4.9								X						
-smallvec@1.13.2		X						X						
-socket2@0.5.7		X						X						
-spin@0.9.8								X						
-stable_deref_trait@1.2.0		X						X						
-strsim@0.11.1								X						
-subtle@2.5.0					X									
-syn@2.0.66		X						X						
-sync_wrapper@0.1.2		X												
-sync_wrapper@1.0.1		X												
-synstructure@0.13.1								X						
-thiserror@1.0.61		X						X						
-thiserror-impl@1.0.61		X						X						
-thread_local@1.1.8		X						X						
-time@0.3.36		X						X						
-time-core@0.1.2		X						X						
-time-macros@0.2.18		X						X						
-tinystr@0.7.6											X			
-tokio@1.38.0								X						
-tokio-macros@2.3.0								X						
-tokio-rustls@0.25.0		X						X						
-tokio-util@0.7.11								X						
-toml@0.8.14		X						X						
-toml_datetime@0.6.6		X						X						
-toml_edit@0.22.14		X						X						
-tower@0.4.13								X						
-tower-http@0.5.2								X						
-tower-layer@0.3.2								X						
-tower-service@0.3.2								X						
-tracing@0.1.40								X						
-tracing-attributes@0.1.27								X						
-tracing-core@0.1.32								X						
-tracing-log@0.2.0								X						
-tracing-subscriber@0.3.18								X						
-try-lock@0.2.5								X						
-typenum@1.17.0		X						X						
-unicase@2.7.0		X						X						
-unicode-ident@1.0.12		X						X				X		
-untrusted@0.9.0							X							
-url@2.5.1		X						X						
-utf16_iter@1.0.5		X						X						
-utf8_iter@1.0.4		X						X						
-utf8parse@0.2.1		X						X						
-uuid@1.8.0		X						X						
-valuable@0.1.0								X						
-version_check@0.9.4		X						X						
-want@0.3.1								X						
-wasi@0.11.0+wasi-snapshot-preview1		X	X					X						
-wasm-bindgen@0.2.92		X						X						
-wasm-bindgen-backend@0.2.92		X						X						
-wasm-bindgen-futures@0.4.42		X						X						
-wasm-bindgen-macro@0.2.92		X						X						
-wasm-bindgen-macro-support@0.2.92		X						X						
-wasm-bindgen-shared@0.2.92		X						X						
-wasm-streams@0.4.0		X						X						
-web-sys@0.3.69		X						X						
-webpki-roots@0.26.2									X					
-winapi@0.3.9		X						X						
-winapi-i686-pc-windows-gnu@0.4.0		X						X						
-winapi-x86_64-pc-windows-gnu@0.4.0		X						X						
-windows-core@0.52.0		X						X						
-windows-sys@0.48.0		X						X						
-windows-sys@0.52.0		X						X						
-windows-targets@0.48.5		X						X						
-windows-targets@0.52.5		X						X						
-windows_aarch64_gnullvm@0.48.5		X						X						
-windows_aarch64_gnullvm@0.52.5		X						X						
-windows_aarch64_msvc@0.48.5		X						X						
-windows_aarch64_msvc@0.52.5		X						X						
-windows_i686_gnu@0.48.5		X						X						
-windows_i686_gnu@0.52.5		X						X						
-windows_i686_gnullvm@0.52.5		X						X						
-windows_i686_msvc@0.48.5		X						X						
-windows_i686_msvc@0.52.5		X						X						
-windows_x86_64_gnu@0.48.5		X						X						
-windows_x86_64_gnu@0.52.5		X						X						
-windows_x86_64_gnullvm@0.48.5		X						X						
-windows_x86_64_gnullvm@0.52.5		X						X						
-windows_x86_64_msvc@0.48.5		X						X						
-windows_x86_64_msvc@0.52.5		X						X						
-winnow@0.6.13								X						
-winreg@0.52.0								X						
-write16@1.0.0		X						X						
-writeable@0.5.5											X			
-xml-rs@0.8.20								X						
-xmltree@0.10.3								X						
-yoke@0.7.4											X			
-yoke-derive@0.7.4											X			
-zerocopy@0.7.34		X		X				X						
-zerofrom@0.1.4											X			
-zerofrom-derive@0.1.4											X			
-zeroize@1.8.1		X						X						
-zerovec@0.10.2											X			
-zerovec-derive@0.10.2											X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
+addr2line@0.22.0		X						X					
+adler@1.0.2	X	X						X					
+ahash@0.8.11		X						X					
+aho-corasick@1.1.3								X				X	
+allocator-api2@0.2.18		X						X					
+android-tzdata@0.1.1		X						X					
+android_system_properties@0.1.5		X						X					
+anstream@0.6.14		X						X					
+anstyle@1.0.7		X						X					
+anstyle-parse@0.2.4		X						X					
+anstyle-query@1.1.0		X						X					
+anstyle-wincon@3.0.3		X						X					
+anyhow@1.0.86		X						X					
+async-trait@0.1.80		X						X					
+autocfg@1.3.0		X						X					
+axum@0.7.5								X					
+axum-core@0.4.3								X					
+backon@0.4.4		X											
+backtrace@0.3.73		X						X					
+base64@0.21.7		X						X					
+base64@0.22.1		X						X					
+bitflags@2.6.0		X						X					
+block-buffer@0.10.4		X						X					
+bumpalo@3.16.0		X						X					
+bytes@1.6.0								X					
+cc@1.0.103		X						X					
+cfg-if@1.0.0		X						X					
+chrono@0.4.38		X						X					
+clap@4.5.8		X						X					
+clap_builder@4.5.8		X						X					
+clap_lex@0.7.1		X						X					
+colorchoice@1.0.1		X						X					
+core-foundation-sys@0.8.6		X						X					
+cpufeatures@0.2.12		X						X					
+crypto-common@0.1.6		X						X					
+dav-server@0.6.0		X											
+dav-server-opendalfs@0.0.4		X											
+deranged@0.3.11		X						X					
+digest@0.10.7		X						X					
+dirs@5.0.1		X						X					
+dirs-sys@0.4.1		X						X					
+equivalent@1.0.1		X						X					
+fastrand@2.1.0		X						X					
+flagset@0.4.5		X											
+fnv@1.0.7		X						X					
+form_urlencoded@1.2.1		X						X					
+futures@0.3.30		X						X					
+futures-channel@0.3.30		X						X					
+futures-core@0.3.30		X						X					
+futures-executor@0.3.30		X						X					
+futures-io@0.3.30		X						X					
+futures-macro@0.3.30		X						X					
+futures-sink@0.3.30		X						X					
+futures-task@0.3.30		X						X					
+futures-util@0.3.30		X						X					
+generic-array@0.14.7								X					
+getrandom@0.2.15		X						X					
+gimli@0.29.0		X						X					
+hashbrown@0.14.5		X						X					
+headers@0.4.0								X					
+headers-core@0.3.0								X					
+hermit-abi@0.3.9		X						X					
+htmlescape@0.3.1		X						X	X				
+http@1.1.0		X						X					
+http-body@1.0.0								X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
+httpdate@1.0.3		X						X					
+hyper@1.3.1								X					
+hyper-rustls@0.27.2		X					X	X					
+hyper-util@0.1.5								X					
+iana-time-zone@0.1.60		X						X					
+iana-time-zone-haiku@0.1.2		X						X					
+idna@0.5.0		X						X					
+indexmap@2.2.6		X						X					
+ipnet@2.9.0		X						X					
+is_terminal_polyfill@1.70.0		X						X					
+itoa@1.0.11		X						X					
+js-sys@0.3.69		X						X					
+lazy_static@1.5.0		X						X					
+libc@0.2.155		X						X					
+libredox@0.1.3								X					
+lock_api@0.4.12		X						X					
+log@0.4.22		X						X					
+lru@0.12.3								X					
+matchers@0.1.0								X					
+matchit@0.7.3					X			X					
+md-5@0.10.6		X						X					
+memchr@2.7.4								X				X	
+mime@0.3.17		X						X					
+mime_guess@2.0.5								X					
+miniz_oxide@0.7.4		X						X					X
+mio@0.8.11								X					
+nu-ansi-term@0.46.0								X					
+num-conv@0.1.0		X						X					
+num-traits@0.2.19		X						X					
+num_cpus@1.16.0		X						X					
+oay@0.41.5		X											
+object@0.36.1		X						X					
+once_cell@1.19.0		X						X					
+opendal@0.47.2		X											
+option-ext@0.2.0									X				
+overload@0.1.1								X					
+parking_lot@0.12.3		X						X					
+parking_lot_core@0.9.10		X						X					
+percent-encoding@2.3.1		X						X					
+pin-project@1.1.5		X						X					
+pin-project-internal@1.1.5		X						X					
+pin-project-lite@0.2.14		X						X					
+pin-utils@0.1.0		X						X					
+powerfmt@0.2.0		X						X					
+ppv-lite86@0.2.17		X						X					
+proc-macro2@1.0.86		X						X					
+quick-xml@0.31.0								X					
+quick-xml@0.32.0								X					
+quote@1.0.36		X						X					
+rand@0.8.5		X						X					
+rand_chacha@0.3.1		X						X					
+rand_core@0.6.4		X						X					
+redox_syscall@0.5.2								X					
+redox_users@0.4.5								X					
+regex@1.10.5		X						X					
+regex-automata@0.1.10								X				X	
+regex-automata@0.4.7		X						X					
+regex-syntax@0.6.29		X						X					
+regex-syntax@0.8.4		X						X					
+reqwest@0.12.5		X						X					
+ring@0.17.8										X			
+rustc-demangle@0.1.24		X						X					
+rustls@0.23.10		X					X	X					
+rustls-pemfile@2.1.2		X					X	X					
+rustls-pki-types@1.7.0		X						X					
+rustls-webpki@0.102.4							X						
+rustversion@1.0.17		X						X					
+ryu@1.0.18		X				X							
+scopeguard@1.2.0		X						X					
+serde@1.0.203		X						X					
+serde_derive@1.0.203		X						X					
+serde_json@1.0.118		X						X					
+serde_path_to_error@0.1.16		X						X					
+serde_spanned@0.6.6		X						X					
+serde_urlencoded@0.7.1		X						X					
+sha1@0.10.6		X						X					
+sharded-slab@0.1.7								X					
+slab@0.4.9								X					
+smallvec@1.13.2		X						X					
+socket2@0.5.7		X						X					
+spin@0.9.8								X					
+strsim@0.11.1								X					
+subtle@2.6.1					X								
+syn@2.0.68		X						X					
+sync_wrapper@0.1.2		X											
+sync_wrapper@1.0.1		X											
+thiserror@1.0.61		X						X					
+thiserror-impl@1.0.61		X						X					
+thread_local@1.1.8		X						X					
+time@0.3.36		X						X					
+time-core@0.1.2		X						X					
+time-macros@0.2.18		X						X					
+tinyvec@1.6.1		X						X					X
+tinyvec_macros@0.1.1		X						X					X
+tokio@1.38.0								X					
+tokio-macros@2.3.0								X					
+tokio-rustls@0.26.0		X						X					
+tokio-util@0.7.11								X					
+toml@0.8.14		X						X					
+toml_datetime@0.6.6		X						X					
+toml_edit@0.22.14		X						X					
+tower@0.4.13								X					
+tower-http@0.5.2								X					
+tower-layer@0.3.2								X					
+tower-service@0.3.2								X					
+tracing@0.1.40								X					
+tracing-attributes@0.1.27								X					
+tracing-core@0.1.32								X					
+tracing-log@0.2.0								X					
+tracing-subscriber@0.3.18								X					
+try-lock@0.2.5								X					
+typenum@1.17.0		X						X					
+unicase@2.7.0		X						X					
+unicode-bidi@0.3.15		X						X					
+unicode-ident@1.0.12		X						X			X		
+unicode-normalization@0.1.23		X						X					
+untrusted@0.9.0							X						
+url@2.5.2		X						X					
+utf8parse@0.2.2		X						X					
+uuid@1.9.1		X						X					
+valuable@0.1.0								X					
+version_check@0.9.4		X						X					
+want@0.3.1								X					
+wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
+wasm-bindgen@0.2.92		X						X					
+wasm-bindgen-backend@0.2.92		X						X					
+wasm-bindgen-futures@0.4.42		X						X					
+wasm-bindgen-macro@0.2.92		X						X					
+wasm-bindgen-macro-support@0.2.92		X						X					
+wasm-bindgen-shared@0.2.92		X						X					
+wasm-streams@0.4.0		X						X					
+web-sys@0.3.69		X						X					
+webpki-roots@0.26.3									X				
+winapi@0.3.9		X						X					
+winapi-i686-pc-windows-gnu@0.4.0		X						X					
+winapi-x86_64-pc-windows-gnu@0.4.0		X						X					
+windows-core@0.52.0		X						X					
+windows-sys@0.48.0		X						X					
+windows-sys@0.52.0		X						X					
+windows-targets@0.48.5		X						X					
+windows-targets@0.52.5		X						X					
+windows_aarch64_gnullvm@0.48.5		X						X					
+windows_aarch64_gnullvm@0.52.5		X						X					
+windows_aarch64_msvc@0.48.5		X						X					
+windows_aarch64_msvc@0.52.5		X						X					
+windows_i686_gnu@0.48.5		X						X					
+windows_i686_gnu@0.52.5		X						X					
+windows_i686_gnullvm@0.52.5		X						X					
+windows_i686_msvc@0.48.5		X						X					
+windows_i686_msvc@0.52.5		X						X					
+windows_x86_64_gnu@0.48.5		X						X					
+windows_x86_64_gnu@0.52.5		X						X					
+windows_x86_64_gnullvm@0.48.5		X						X					
+windows_x86_64_gnullvm@0.52.5		X						X					
+windows_x86_64_msvc@0.48.5		X						X					
+windows_x86_64_msvc@0.52.5		X						X					
+winnow@0.6.13								X					
+winreg@0.52.0								X					
+xml-rs@0.8.20								X					
+xmltree@0.10.3								X					
+zerocopy@0.7.34		X		X				X					
+zeroize@1.8.1		X						X					

--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -195,9 +195,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "2755ff20a1d93490d26ba33a6f092a38a508398a5320df5d4b3014fcccce9410"
 
 [[package]]
 name = "cfg-if"
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
  "anstream",
  "anstyle",
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.5"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "crc32c"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0227b9f93e535d49bc7ce914c066243424ce85ed90864cebd0874b184e9b6947"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
  "rustc_version",
 ]
@@ -391,9 +391,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "env_filter"
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "fuse3_opendal"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "bytes",
  "fuse3",
@@ -685,12 +685,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "pin-project-lite",
@@ -698,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "humantime"
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http",
@@ -742,6 +742,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -826,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -844,9 +845,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "md-5"
@@ -860,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -881,9 +882,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -933,16 +934,16 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "ofs"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -974,7 +975,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1065,9 +1066,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -1080,6 +1081,53 @@ checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1123,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1135,9 +1183,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1146,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqsign"
@@ -1180,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64",
  "bytes",
@@ -1201,6 +1249,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -1254,6 +1303,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,11 +1332,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -1359,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
 dependencies = [
  "itoa",
  "ryu",
@@ -1459,15 +1514,15 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1476,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "tempfile"
@@ -1514,6 +1569,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1568,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
@@ -1706,9 +1781,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1723,15 +1798,15 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
  "serde",
@@ -1859,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/bin/ofs/Cargo.toml
+++ b/bin/ofs/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["filesystem"]
 description = "OpenDAL File System"
 keywords = ["storage", "data", "s3", "fs", "azblob"]
 name = "ofs"
-version = "0.0.5"
+version = "0.0.6"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -36,7 +36,7 @@ chrono = "0.4.34"
 clap = { version = "4.5.7", features = ["derive", "env"] }
 env_logger = "0.11.2"
 fuse3 = { "version" = "0.7.2", "features" = ["tokio-runtime", "unprivileged"] }
-fuse3_opendal = { version = "0.0.0", path = "../../integrations/fuse3" }
+fuse3_opendal = { version = "0.0.1", path = "../../integrations/fuse3" }
 futures-util = "0.3.30"
 libc = "0.2.154"
 log = "0.4.21"

--- a/bin/ofs/DEPENDENCIES.rust.tsv
+++ b/bin/ofs/DEPENDENCIES.rust.tsv
@@ -14,20 +14,20 @@ async-notify@0.3.0								X
 async-trait@0.1.80		X						X					
 autocfg@1.3.0		X						X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.22.1		X						X					
 bincode@1.3.3								X					
-bitflags@2.5.0		X						X					
+bitflags@2.6.0		X						X					
 block-buffer@0.10.4		X						X					
 bumpalo@3.16.0		X						X					
 bytes@1.6.0								X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cfg-if@1.0.0		X						X					
 cfg_aliases@0.1.1								X					
 chrono@0.4.38		X						X					
-clap@4.5.7		X						X					
-clap_builder@4.5.7		X						X					
-clap_derive@4.5.5		X						X					
+clap@4.5.8		X						X					
+clap_builder@4.5.8		X						X					
+clap_derive@4.5.8		X						X					
 clap_lex@0.7.1		X						X					
 colorchoice@1.0.1		X						X					
 concurrent-queue@2.5.0		X						X					
@@ -36,7 +36,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crossbeam-utils@0.8.20		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
@@ -44,7 +44,7 @@ cstr@0.2.12								X
 digest@0.10.7		X						X					
 dlv-list@0.5.2		X						X					
 dotenvy@0.15.7								X					
-either@1.12.0		X						X					
+either@1.13.0		X						X					
 env_filter@0.1.0		X						X					
 env_logger@0.11.3		X						X					
 errno@0.3.9		X						X					
@@ -54,7 +54,7 @@ flagset@0.4.5		X
 fnv@1.0.7		X						X					
 form_urlencoded@1.2.1		X						X					
 fuse3@0.7.2								X					
-fuse3_opendal@0.0.0		X											
+fuse3_opendal@0.0.1		X											
 futures@0.3.30		X						X					
 futures-channel@0.3.30		X						X					
 futures-core@0.3.30		X						X					
@@ -75,11 +75,11 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 humantime@2.1.0		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -88,23 +88,23 @@ ipnet@2.9.0		X						X
 is_terminal_polyfill@1.70.0		X						X					
 itoa@1.0.11		X						X					
 js-sys@0.3.69		X						X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 libc@0.2.155		X						X					
 linux-raw-sys@0.4.14		X	X					X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 memoffset@0.9.1								X					
 mime@0.3.17		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
 nix@0.28.0								X					
 num-traits@0.2.19		X						X					
 num_cpus@1.16.0		X						X					
-object@0.35.0		X						X					
-ofs@0.0.5		X											
+object@0.36.1		X						X					
+ofs@0.0.6		X											
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
+opendal@0.47.2		X											
 ordered-multimap@0.7.3								X					
 parking@2.2.0		X						X					
 percent-encoding@2.3.1		X						X					
@@ -113,23 +113,23 @@ pin-project-internal@1.1.5		X						X
 pin-project-lite@0.2.14		X						X					
 pin-utils@0.1.0		X						X					
 ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
-regex@1.10.4		X						X					
-regex-automata@0.4.6		X						X					
-regex-syntax@0.8.3		X						X					
+regex@1.10.5		X						X					
+regex-automata@0.4.7		X						X					
+regex-syntax@0.8.4		X						X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rust-ini@0.21.0								X					
 rustc-demangle@0.1.24		X						X					
 rustc_version@0.4.0		X						X					
 rustix@0.38.34		X	X					X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -137,7 +137,7 @@ ryu@1.0.18		X			X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -148,15 +148,15 @@ smallvec@1.13.2		X						X
 socket2@0.5.7		X						X					
 spin@0.9.8								X					
 strsim@0.11.1								X					
-subtle@2.5.0				X									
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+subtle@2.6.1				X									
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
 tokio-macros@2.3.0								X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 tower@0.4.13								X					
 tower-layer@0.3.2								X					
@@ -172,9 +172,9 @@ unicode-bidi@0.3.15		X						X
 unicode-ident@1.0.12		X						X			X		
 unicode-normalization@0.1.23		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-utf8parse@0.2.1		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+utf8parse@0.2.2		X						X					
+uuid@1.9.1		X						X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
@@ -186,7 +186,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 which@6.0.1								X					
 windows-core@0.52.0		X						X					
 windows-sys@0.48.0		X						X					

--- a/bin/oli/Cargo.lock
+++ b/bin/oli/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
  "futures-io",
  "futures-lite 2.3.0",
  "parking",
- "polling 3.7.1",
+ "polling 3.7.2",
  "rustix 0.38.34",
  "slab",
  "tracing",
@@ -283,7 +283,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -313,7 +313,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -350,7 +350,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
@@ -387,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -420,12 +420,11 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bb8"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7c2093d15d6a1d33b1f972e1c5ea3177748742b97a5f392aa83a65262c6780"
+checksum = "b10cf871f3ff2ce56432fddc2615ac7acc3aa22ca321f8fea800846fbb32f188"
 dependencies = [
  "async-trait",
- "futures-channel",
  "futures-util",
  "parking_lot 0.12.3",
  "tokio",
@@ -449,7 +448,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -460,9 +459,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "block-buffer"
@@ -583,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "2755ff20a1d93490d26ba33a6f092a38a508398a5320df5d4b3014fcccce9410"
 dependencies = [
  "jobserver",
  "libc",
@@ -644,18 +643,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
  "anstream",
  "anstyle",
@@ -757,9 +756,9 @@ checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32c"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0227b9f93e535d49bc7ce914c066243424ce85ed90864cebd0874b184e9b6947"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
  "rustc_version",
 ]
@@ -902,9 +901,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "env_filter"
@@ -1142,7 +1141,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1299,6 +1298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,12 +1372,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -1380,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -1441,19 +1446,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
  "hyper 1.3.1",
  "hyper-util",
- "rustls 0.22.4",
+ "rustls 0.23.10",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tower-service",
+ "webpki-roots 0.26.3",
 ]
 
 [[package]]
@@ -1566,7 +1572,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1679,16 +1685,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
@@ -1705,9 +1711,9 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.5",
@@ -1725,7 +1731,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -1778,9 +1784,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "value-bag",
 ]
@@ -1803,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -1836,9 +1842,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -1902,9 +1908,9 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1969,22 +1975,22 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "oli"
-version = "0.41.4"
+version = "0.41.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2010,7 +2016,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "anyhow",
  "async-tls",
@@ -2120,7 +2126,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.1",
+ "redox_syscall 0.5.2",
  "smallvec",
  "windows-targets 0.52.5",
 ]
@@ -2193,7 +2199,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2281,13 +2287,13 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6a007746f34ed64099e88783b0ae369eaa3da6392868ba262e2af9b8fbaea1"
+checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "pin-project-lite",
  "rustix 0.38.34",
  "tracing",
@@ -2343,14 +2349,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -2392,7 +2398,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types",
  "regex",
- "syn 2.0.66",
+ "syn 2.0.68",
  "tempfile",
 ]
 
@@ -2419,7 +2425,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2437,7 +2443,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "memchr",
  "unicase",
 ]
@@ -2465,6 +2471,53 @@ checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2 0.5.7",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2512,7 +2565,7 @@ version = "11.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2556,11 +2609,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2576,9 +2629,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2588,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2599,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqsign"
@@ -2636,9 +2689,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2657,15 +2710,16 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.4",
+ "quinn",
+ "rustls 0.23.10",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -2673,7 +2727,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.2",
+ "webpki-roots 0.26.3",
  "winreg",
 ]
 
@@ -2687,7 +2741,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
+ "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -2775,7 +2829,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -2796,11 +2850,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
- "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.4",
@@ -2938,7 +2992,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2981,14 +3035,14 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
 dependencies = [
  "itoa",
  "ryu",
@@ -3140,12 +3194,6 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
@@ -3168,9 +3216,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suppaftp"
@@ -3203,9 +3251,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3217,6 +3265,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "tagptr"
@@ -3259,7 +3313,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3304,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3353,7 +3407,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3379,11 +3433,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.22.4",
+ "rustls 0.23.10",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3486,7 +3540,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3540,7 +3594,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3560,9 +3614,9 @@ checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
 
 [[package]]
 name = "triomphe"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2cb4fbb9995eeb36ac86fadf24031ccd58f99d6b4b2d7b911db70bddb80d90"
+checksum = "e6631e42e10b40c0690bf92f404ebcfe6e1fdb480391d15f17cc8e96eeed5369"
 
 [[package]]
 name = "try-lock"
@@ -3614,9 +3668,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3625,15 +3679,15 @@ dependencies = [
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom",
  "serde",
@@ -3718,7 +3772,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "wasm-bindgen-shared",
 ]
 
@@ -3752,7 +3806,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3807,9 +3861,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/bin/oli/Cargo.toml
+++ b/bin/oli/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.41.4"
+version = "0.41.5"
 
 [features]
 # Enable services dashmap support

--- a/bin/oli/DEPENDENCIES.rust.tsv
+++ b/bin/oli/DEPENDENCIES.rust.tsv
@@ -14,23 +14,23 @@ anyhow@1.0.86		X						X
 async-trait@0.1.80		X						X					
 autocfg@1.3.0		X						X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.21.7		X						X					
 base64@0.22.1		X						X					
 base64ct@1.6.0		X						X					
-bitflags@2.5.0		X						X					
+bitflags@2.6.0		X						X					
 block-buffer@0.10.4		X						X					
 block-padding@0.3.3		X						X					
 bumpalo@3.16.0		X						X					
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
-clap@4.5.7		X						X					
-clap_builder@4.5.7		X						X					
+clap@4.5.8		X						X					
+clap_builder@4.5.8		X						X					
 clap_lex@0.7.1		X						X					
 colorchoice@1.0.1		X						X					
 const-oid@0.9.6		X						X					
@@ -38,7 +38,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
@@ -73,11 +73,11 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 humantime@2.1.0		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -89,27 +89,27 @@ is_terminal_polyfill@1.70.0		X						X
 itoa@1.0.11		X						X					
 js-sys@0.3.69		X						X					
 jsonwebtoken@9.3.0								X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 libc@0.2.155		X						X					
 libm@0.2.8		X						X					
 libredox@0.1.3								X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 mime@0.3.17		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
-num-bigint@0.4.5		X						X					
+num-bigint@0.4.6		X						X					
 num-bigint-dig@0.8.4		X						X					
 num-conv@0.1.0		X						X					
 num-integer@0.1.46		X						X					
 num-iter@0.1.45		X						X					
 num-traits@0.2.19		X						X					
 num_cpus@1.16.0		X						X					
-object@0.35.0		X						X					
-oli@0.41.4		X											
+object@0.36.1		X						X					
+oli@0.41.5		X											
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
+opendal@0.47.2		X											
 option-ext@0.2.0									X				
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
@@ -125,24 +125,24 @@ pkcs5@0.7.1		X						X
 pkcs8@0.10.2		X						X					
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
 redox_users@0.4.5								X					
-regex@1.10.4		X						X					
-regex-automata@0.4.6		X						X					
-regex-syntax@0.8.3		X						X					
+regex@1.10.5		X						X					
+regex-automata@0.4.7		X						X					
+regex-syntax@0.8.4		X						X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rsa@0.9.6		X						X					
 rust-ini@0.21.0								X					
 rustc-demangle@0.1.24		X						X					
 rustc_version@0.4.0		X						X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -152,7 +152,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_spanned@0.6.6		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
@@ -162,24 +162,23 @@ simple_asn1@0.6.2							X
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
-spin@0.5.2								X					
 spin@0.9.8								X					
 spki@0.7.3		X						X					
 strsim@0.11.1								X					
-subtle@2.5.0				X									
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+subtle@2.6.1				X									
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 thiserror@1.0.61		X						X					
 thiserror-impl@1.0.61		X						X					
 time@0.3.36		X						X					
 time-core@0.1.2		X						X					
 time-macros@0.2.18		X						X					
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
 tokio-macros@2.3.0								X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 toml@0.8.14		X						X					
 toml_datetime@0.6.6		X						X					
@@ -196,9 +195,9 @@ unicode-bidi@0.3.15		X						X
 unicode-ident@1.0.12		X						X			X		
 unicode-normalization@0.1.23		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-utf8parse@0.2.1		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+utf8parse@0.2.2		X						X					
+uuid@1.9.1		X						X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
@@ -210,7 +209,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 windows-core@0.52.0		X						X					
 windows-sys@0.48.0		X						X					
 windows-sys@0.52.0		X						X					

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.44.6"
+version = "0.44.7"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -9,12 +9,12 @@ async-trait@0.1.80		X						X
 atty@0.2.14								X					
 autocfg@1.3.0		X						X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.21.7		X						X					
 base64@0.22.1		X						X					
 base64ct@1.6.0		X						X					
 bitflags@1.3.2		X						X					
-bitflags@2.5.0		X						X					
+bitflags@2.6.0		X						X					
 block-buffer@0.10.4		X						X					
 block-padding@0.3.3		X						X					
 bumpalo@3.16.0		X						X					
@@ -22,7 +22,7 @@ byteorder@1.5.0								X				X
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
 cbindgen@0.26.0									X				
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -33,7 +33,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
@@ -66,10 +66,10 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -80,27 +80,27 @@ ipnet@2.9.0		X						X
 itoa@1.0.11		X						X					
 js-sys@0.3.69		X						X					
 jsonwebtoken@9.3.0								X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 libc@0.2.155		X						X					
 libm@0.2.8		X						X					
 linux-raw-sys@0.4.14		X	X					X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 mime@0.3.17		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
-num-bigint@0.4.5		X						X					
+num-bigint@0.4.6		X						X					
 num-bigint-dig@0.8.4		X						X					
 num-conv@0.1.0		X						X					
 num-integer@0.1.46		X						X					
 num-iter@0.1.45		X						X					
 num-traits@0.2.19		X						X					
 num_cpus@1.16.0		X						X					
-object@0.35.0		X						X					
+object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
-opendal-c@0.44.6		X											
+opendal@0.47.2		X											
+opendal-c@0.44.7		X											
 ordered-multimap@0.7.3								X					
 os_str_bytes@6.6.1		X						X					
 pbkdf2@0.12.2		X						X					
@@ -116,21 +116,21 @@ pkcs5@0.7.1		X						X
 pkcs8@0.10.2		X						X					
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rsa@0.9.6		X						X					
 rust-ini@0.21.0								X					
 rustc-demangle@0.1.24		X						X					
 rustc_version@0.4.0		X						X					
 rustix@0.38.34		X	X					X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -140,7 +140,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -149,14 +149,13 @@ simple_asn1@0.6.2							X
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
-spin@0.5.2								X					
 spin@0.9.8								X					
 spki@0.7.3		X						X					
 strsim@0.10.0								X					
-subtle@2.5.0				X									
+subtle@2.6.1				X									
 syn@1.0.109		X						X					
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 tempfile@3.10.1		X						X					
 termcolor@1.4.1								X				X	
 textwrap@0.16.1								X					
@@ -166,11 +165,11 @@ time@0.3.36		X						X
 time-core@0.1.2		X						X					
 time-macros@0.2.18		X						X					
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
 tokio-macros@2.3.0								X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 toml@0.5.11		X						X					
 tower@0.4.13								X					
@@ -185,8 +184,8 @@ unicode-bidi@0.3.15		X						X
 unicode-ident@1.0.12		X						X			X		
 unicode-normalization@0.1.23		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+uuid@1.9.1		X						X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
@@ -198,7 +197,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 winapi@0.3.9		X						X					
 winapi-i686-pc-windows-gnu@0.4.0		X						X					
 winapi-util@0.1.8								X				X	

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 cmake_minimum_required(VERSION 3.10)
-project(opendal-cpp VERSION 0.45.4 LANGUAGES CXX)
+project(opendal-cpp VERSION 0.45.5 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/bindings/cpp/Cargo.toml
+++ b/bindings/cpp/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.4"
+version = "0.45.5"
 
 [lib]
 crate-type = ["staticlib"]

--- a/bindings/cpp/DEPENDENCIES.rust.tsv
+++ b/bindings/cpp/DEPENDENCIES.rust.tsv
@@ -8,7 +8,7 @@ anyhow@1.0.86		X						X
 async-trait@0.1.80		X						X					
 autocfg@1.3.0		X						X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.21.7		X						X					
 base64@0.22.1		X						X					
 base64ct@1.6.0		X						X					
@@ -18,7 +18,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -28,13 +28,13 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
-cxx@1.0.123		X						X					
-cxx-build@1.0.123		X						X					
-cxxbridge-flags@1.0.123		X						X					
-cxxbridge-macro@1.0.123		X						X					
+cxx@1.0.124		X						X					
+cxx-build@1.0.124		X						X					
+cxxbridge-flags@1.0.124		X						X					
+cxxbridge-macro@1.0.124		X						X					
 der@0.7.9		X						X					
 deranged@0.3.11		X						X					
 digest@0.10.7		X						X					
@@ -60,10 +60,10 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -73,26 +73,26 @@ ipnet@2.9.0		X						X
 itoa@1.0.11		X						X					
 js-sys@0.3.69		X						X					
 jsonwebtoken@9.3.0								X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 libc@0.2.155		X						X					
 libm@0.2.8		X						X					
 link-cplusplus@1.0.9		X						X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 mime@0.3.17		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
-num-bigint@0.4.5		X						X					
+num-bigint@0.4.6		X						X					
 num-bigint-dig@0.8.4		X						X					
 num-conv@0.1.0		X						X					
 num-integer@0.1.46		X						X					
 num-iter@0.1.45		X						X					
 num-traits@0.2.19		X						X					
-object@0.35.0		X						X					
+object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
-opendal-cpp@0.45.4		X											
+opendal@0.47.2		X											
+opendal-cpp@0.45.5		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
 pem@3.0.4								X					
@@ -107,20 +107,20 @@ pkcs5@0.7.1		X						X
 pkcs8@0.10.2		X						X					
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rsa@0.9.6		X						X					
 rust-ini@0.21.0								X					
 rustc-demangle@0.1.24		X						X					
 rustc_version@0.4.0		X						X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -131,7 +131,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -140,12 +140,11 @@ simple_asn1@0.6.2							X
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
-spin@0.5.2								X					
 spin@0.9.8								X					
 spki@0.7.3		X						X					
-subtle@2.5.0				X									
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+subtle@2.6.1				X									
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 termcolor@1.4.1								X				X	
 thiserror@1.0.61		X						X					
 thiserror-impl@1.0.61		X						X					
@@ -153,10 +152,10 @@ time@0.3.36		X						X
 time-core@0.1.2		X						X					
 time-macros@0.2.18		X						X					
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 tower@0.4.13								X					
 tower-layer@0.3.2								X					
@@ -171,8 +170,8 @@ unicode-ident@1.0.12		X						X			X
 unicode-normalization@0.1.23		X						X					
 unicode-width@0.1.13		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+uuid@1.9.1		X						X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
@@ -184,7 +183,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 winapi-util@0.1.8								X				X	
 windows-core@0.52.0		X						X					
 windows-sys@0.48.0		X						X					

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-dotnet"
 publish = false
-version = "0.1.2"
+version = "0.1.3"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/dotnet/DEPENDENCIES.rust.tsv
+++ b/bindings/dotnet/DEPENDENCIES.rust.tsv
@@ -8,7 +8,7 @@ anyhow@1.0.86		X						X
 async-trait@0.1.80		X						X					
 autocfg@1.3.0		X						X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.21.7		X						X					
 base64@0.22.1		X						X					
 base64ct@1.6.0		X						X					
@@ -18,7 +18,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -27,7 +27,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
@@ -55,10 +55,10 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -68,25 +68,25 @@ ipnet@2.9.0		X						X
 itoa@1.0.11		X						X					
 js-sys@0.3.69		X						X					
 jsonwebtoken@9.3.0								X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 libc@0.2.155		X						X					
 libm@0.2.8		X						X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 mime@0.3.17		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
-num-bigint@0.4.5		X						X					
+num-bigint@0.4.6		X						X					
 num-bigint-dig@0.8.4		X						X					
 num-conv@0.1.0		X						X					
 num-integer@0.1.46		X						X					
 num-iter@0.1.45		X						X					
 num-traits@0.2.19		X						X					
-object@0.35.0		X						X					
+object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
-opendal-dotnet@0.1.2		X											
+opendal@0.47.2		X											
+opendal-dotnet@0.1.3		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
 pem@3.0.4								X					
@@ -101,20 +101,20 @@ pkcs5@0.7.1		X						X
 pkcs8@0.10.2		X						X					
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rsa@0.9.6		X						X					
 rust-ini@0.21.0								X					
 rustc-demangle@0.1.24		X						X					
 rustc_version@0.4.0		X						X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -124,7 +124,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -133,22 +133,21 @@ simple_asn1@0.6.2							X
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
-spin@0.5.2								X					
 spin@0.9.8								X					
 spki@0.7.3		X						X					
-subtle@2.5.0				X									
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+subtle@2.6.1				X									
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 thiserror@1.0.61		X						X					
 thiserror-impl@1.0.61		X						X					
 time@0.3.36		X						X					
 time-core@0.1.2		X						X					
 time-macros@0.2.18		X						X					
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 tower@0.4.13								X					
 tower-layer@0.3.2								X					
@@ -162,8 +161,8 @@ unicode-bidi@0.3.15		X						X
 unicode-ident@1.0.12		X						X			X		
 unicode-normalization@0.1.23		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+uuid@1.9.1		X						X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
@@ -175,7 +174,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 windows-core@0.52.0		X						X					
 windows-sys@0.48.0		X						X					
 windows-sys@0.52.0		X						X					

--- a/bindings/haskell/Cargo.toml
+++ b/bindings/haskell/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.44.4"
+version = "0.44.5"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/haskell/DEPENDENCIES.rust.tsv
+++ b/bindings/haskell/DEPENDENCIES.rust.tsv
@@ -8,7 +8,7 @@ anyhow@1.0.86		X						X
 async-trait@0.1.80		X						X					
 autocfg@1.3.0		X						X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.21.7		X						X					
 base64@0.22.1		X						X					
 base64ct@1.6.0		X						X					
@@ -18,7 +18,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -27,7 +27,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
@@ -55,10 +55,10 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -68,25 +68,25 @@ ipnet@2.9.0		X						X
 itoa@1.0.11		X						X					
 js-sys@0.3.69		X						X					
 jsonwebtoken@9.3.0								X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 libc@0.2.155		X						X					
 libm@0.2.8		X						X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 mime@0.3.17		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
-num-bigint@0.4.5		X						X					
+num-bigint@0.4.6		X						X					
 num-bigint-dig@0.8.4		X						X					
 num-conv@0.1.0		X						X					
 num-integer@0.1.46		X						X					
 num-iter@0.1.45		X						X					
 num-traits@0.2.19		X						X					
-object@0.35.0		X						X					
+object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
-opendal-hs@0.44.4		X											
+opendal@0.47.2		X											
+opendal-hs@0.44.5		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
 pem@3.0.4								X					
@@ -101,20 +101,20 @@ pkcs5@0.7.1		X						X
 pkcs8@0.10.2		X						X					
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rsa@0.9.6		X						X					
 rust-ini@0.21.0								X					
 rustc-demangle@0.1.24		X						X					
 rustc_version@0.4.0		X						X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -124,7 +124,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -133,22 +133,21 @@ simple_asn1@0.6.2							X
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
-spin@0.5.2								X					
 spin@0.9.8								X					
 spki@0.7.3		X						X					
-subtle@2.5.0				X									
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+subtle@2.6.1				X									
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 thiserror@1.0.61		X						X					
 thiserror-impl@1.0.61		X						X					
 time@0.3.36		X						X					
 time-core@0.1.2		X						X					
 time-macros@0.2.18		X						X					
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 tower@0.4.13								X					
 tower-layer@0.3.2								X					
@@ -162,8 +161,8 @@ unicode-bidi@0.3.15		X						X
 unicode-ident@1.0.12		X						X			X		
 unicode-normalization@0.1.23		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+uuid@1.9.1		X						X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
@@ -175,7 +174,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 windows-core@0.52.0		X						X					
 windows-sys@0.48.0		X						X					
 windows-sys@0.52.0		X						X					

--- a/bindings/haskell/opendal.cabal
+++ b/bindings/haskell/opendal.cabal
@@ -17,7 +17,7 @@ cabal-version:      3.0
 -- under the License.
 
 name:               opendal
-version:            0.44.4.0
+version:            0.44.5.0
 license:            Apache-2.0
 synopsis:           Apache OpenDAL™ Haskell Binding
 description:

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.46.1"
+version = "0.46.2"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -11,19 +11,19 @@ autocfg@1.3.0		X						X
 awaitable@0.4.0								X					
 awaitable-error@0.1.0								X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.21.7		X						X					
 base64@0.22.1		X						X					
 base64ct@1.6.0		X						X					
-bb8@0.8.3								X					
-bitflags@2.5.0		X						X					
+bb8@0.8.5								X					
+bitflags@2.6.0		X						X					
 block-buffer@0.10.4		X						X					
 block-padding@0.3.3		X						X					
 bumpalo@3.16.0		X						X					
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cesu8@1.1.0		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
@@ -35,7 +35,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
@@ -66,10 +66,10 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -81,18 +81,18 @@ jni@0.21.1		X						X
 jni-sys@0.3.0		X						X					
 js-sys@0.3.69		X						X					
 jsonwebtoken@9.3.0								X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 libc@0.2.155		X						X					
 libm@0.2.8		X						X					
 linux-raw-sys@0.4.14		X	X					X					
 lock_api@0.4.12		X						X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 mime@0.3.17		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
-num-bigint@0.4.5		X						X					
+num-bigint@0.4.6		X						X					
 num-bigint-dig@0.8.4		X						X					
 num-conv@0.1.0		X						X					
 num-derive@0.3.3		X						X					
@@ -100,12 +100,12 @@ num-integer@0.1.46		X						X
 num-iter@0.1.45		X						X					
 num-traits@0.2.19		X						X					
 num_cpus@1.16.0		X						X					
-object@0.35.0		X						X					
+object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
-opendal-java@0.46.1		X											
+opendal@0.47.2		X											
+opendal-java@0.46.2		X											
 openssh@0.10.4		X						X					
-openssh-sftp-client@0.14.3								X					
+openssh-sftp-client@0.14.4								X					
 openssh-sftp-client-lowlevel@0.6.0								X					
 openssh-sftp-error@0.4.0								X					
 openssh-sftp-protocol@0.24.0								X					
@@ -126,22 +126,22 @@ pkcs5@0.7.1		X						X
 pkcs8@0.10.2		X						X					
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
-redox_syscall@0.5.1								X					
+redox_syscall@0.5.2								X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rsa@0.9.6		X						X					
 rust-ini@0.21.0								X					
 rustc-demangle@0.1.24		X						X					
 rustc_version@0.4.0		X						X					
 rustix@0.38.34		X	X					X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -153,7 +153,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -164,16 +164,15 @@ simple_asn1@0.6.2							X
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
-spin@0.5.2								X					
 spin@0.9.8								X					
 spki@0.7.3		X						X					
 ssh_format@0.14.1								X					
 ssh_format_error@0.1.0								X					
 stable_deref_trait@1.2.0		X						X					
-subtle@2.5.0				X									
+subtle@2.6.1				X									
 syn@1.0.109		X						X					
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 tempfile@3.10.1		X						X					
 thin-vec@0.2.13		X						X					
 thiserror@1.0.61		X						X					
@@ -182,13 +181,13 @@ time@0.3.36		X						X
 time-core@0.1.2		X						X					
 time-macros@0.2.18		X						X					
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
 tokio-io-utility@0.7.6								X					
 tokio-macros@2.3.0								X					
 tokio-pipe@0.2.12		X						X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 tower@0.4.13								X					
 tower-layer@0.3.2								X					
@@ -197,15 +196,15 @@ tracing@0.1.40								X
 tracing-attributes@0.1.27								X					
 tracing-core@0.1.32								X					
 trim-in-place@0.1.7								X					
-triomphe@0.1.12		X						X					
+triomphe@0.1.13		X						X					
 try-lock@0.2.5								X					
 typenum@1.17.0		X						X					
 unicode-bidi@0.3.15		X						X					
 unicode-ident@1.0.12		X						X			X		
 unicode-normalization@0.1.23		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+uuid@1.9.1		X						X					
 vec-strings@0.4.8								X					
 version_check@0.9.4		X						X					
 walkdir@2.5.0								X				X	
@@ -219,7 +218,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 winapi-util@0.1.8								X				X	
 windows-core@0.52.0		X						X					
 windows-sys@0.45.0		X						X					

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal-java</artifactId>
-    <version>0.46.1</version>
+    <version>0.46.2</version>
 
     <name>Apache OpenDAL™</name>
     <description>

--- a/bindings/lua/Cargo.toml
+++ b/bindings/lua/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-lua"
 publish = false
-version = "0.1.2"
+version = "0.1.3"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/lua/DEPENDENCIES.rust.tsv
+++ b/bindings/lua/DEPENDENCIES.rust.tsv
@@ -9,7 +9,7 @@ anyhow@1.0.86		X						X
 async-trait@0.1.80		X						X					
 autocfg@1.3.0		X						X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.21.7		X						X					
 base64@0.22.1		X						X					
 base64ct@1.6.0		X						X					
@@ -20,7 +20,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -29,14 +29,14 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
 deranged@0.3.11		X						X					
 digest@0.10.7		X						X					
 dlv-list@0.5.2		X						X					
-either@1.12.0		X						X					
+either@1.13.0		X						X					
 fastrand@2.1.0		X						X					
 flagset@0.4.5		X											
 fnv@1.0.7		X						X					
@@ -58,10 +58,10 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -72,28 +72,28 @@ itertools@0.12.1		X						X
 itoa@1.0.11		X						X					
 js-sys@0.3.69		X						X					
 jsonwebtoken@9.3.0								X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 libc@0.2.155		X						X					
 libm@0.2.8		X						X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 mime@0.3.17		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
-mlua@0.9.8								X					
-mlua-sys@0.6.0								X					
+mlua@0.9.9								X					
+mlua-sys@0.6.1								X					
 mlua_derive@0.9.3								X					
-num-bigint@0.4.5		X						X					
+num-bigint@0.4.6		X						X					
 num-bigint-dig@0.8.4		X						X					
 num-conv@0.1.0		X						X					
 num-integer@0.1.46		X						X					
 num-iter@0.1.45		X						X					
 num-traits@0.2.19		X						X					
-object@0.35.0		X						X					
+object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
-opendal-lua@0.1.2		X											
+opendal@0.47.2		X											
+opendal-lua@0.1.3		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
 pem@3.0.4								X					
@@ -111,24 +111,24 @@ powerfmt@0.2.0		X						X
 ppv-lite86@0.2.17		X						X					
 proc-macro-error@1.0.4		X						X					
 proc-macro-error-attr@1.0.4		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
-regex@1.10.4		X						X					
-regex-automata@0.4.6		X						X					
-regex-syntax@0.8.3		X						X					
+regex@1.10.5		X						X					
+regex-automata@0.4.7		X						X					
+regex-syntax@0.8.4		X						X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rsa@0.9.6		X						X					
 rust-ini@0.21.0								X					
 rustc-demangle@0.1.24		X						X					
-rustc-hash@1.1.0		X						X					
+rustc-hash@2.0.0		X						X					
 rustc_version@0.4.0		X						X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -138,7 +138,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -147,23 +147,22 @@ simple_asn1@0.6.2							X
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
-spin@0.5.2								X					
 spin@0.9.8								X					
 spki@0.7.3		X						X					
-subtle@2.5.0				X									
+subtle@2.6.1				X									
 syn@1.0.109		X						X					
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 thiserror@1.0.61		X						X					
 thiserror-impl@1.0.61		X						X					
 time@0.3.36		X						X					
 time-core@0.1.2		X						X					
 time-macros@0.2.18		X						X					
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 tower@0.4.13								X					
 tower-layer@0.3.2								X					
@@ -177,8 +176,8 @@ unicode-bidi@0.3.15		X						X
 unicode-ident@1.0.12		X						X			X		
 unicode-normalization@0.1.23		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+uuid@1.9.1		X						X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
@@ -190,7 +189,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 windows-core@0.52.0		X						X					
 windows-sys@0.48.0		X						X					
 windows-sys@0.52.0		X						X					

--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.46.2"
+version = "0.47.0"
 
 [features]
 default = [

--- a/bindings/nodejs/DEPENDENCIES.rust.tsv
+++ b/bindings/nodejs/DEPENDENCIES.rust.tsv
@@ -9,18 +9,18 @@ anyhow@1.0.86		X						X
 async-trait@0.1.80		X						X					
 autocfg@1.3.0		X						X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.21.7		X						X					
 base64@0.22.1		X						X					
 base64ct@1.6.0		X						X					
-bitflags@2.5.0		X						X					
+bitflags@2.6.0		X						X					
 block-buffer@0.10.4		X						X					
 block-padding@0.3.3		X						X					
 bumpalo@3.16.0		X						X					
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -30,7 +30,7 @@ const-random-macro@0.1.16		X						X
 convert_case@0.6.0								X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 ctor@0.2.8		X						X					
@@ -61,10 +61,10 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -74,32 +74,32 @@ ipnet@2.9.0		X						X
 itoa@1.0.11		X						X					
 js-sys@0.3.69		X						X					
 jsonwebtoken@9.3.0								X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 libc@0.2.155		X						X					
-libloading@0.8.3							X						
+libloading@0.8.4							X						
 libm@0.2.8		X						X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 mime@0.3.17		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
-napi@2.16.6								X					
+napi@2.16.8								X					
 napi-build@2.1.3								X					
-napi-derive@2.16.5								X					
-napi-derive-backend@1.0.67								X					
+napi-derive@2.16.6								X					
+napi-derive-backend@1.0.68								X					
 napi-sys@2.4.0								X					
-num-bigint@0.4.5		X						X					
+num-bigint@0.4.6		X						X					
 num-bigint-dig@0.8.4		X						X					
 num-conv@0.1.0		X						X					
 num-integer@0.1.46		X						X					
 num-iter@0.1.45		X						X					
 num-traits@0.2.19		X						X					
 num_cpus@1.16.0		X						X					
-object@0.35.0		X						X					
+object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
-opendal-nodejs@0.46.2		X											
+opendal@0.47.2		X											
+opendal-nodejs@0.47.0		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
 pem@3.0.4								X					
@@ -114,23 +114,23 @@ pkcs5@0.7.1		X						X
 pkcs8@0.10.2		X						X					
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
-regex@1.10.4		X						X					
-regex-automata@0.4.6		X						X					
-regex-syntax@0.8.3		X						X					
+regex@1.10.5		X						X					
+regex-automata@0.4.7		X						X					
+regex-syntax@0.8.4		X						X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rsa@0.9.6		X						X					
 rust-ini@0.21.0								X					
 rustc-demangle@0.1.24		X						X					
 rustc_version@0.4.0		X						X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -140,7 +140,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -149,22 +149,21 @@ simple_asn1@0.6.2							X
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
-spin@0.5.2								X					
 spin@0.9.8								X					
 spki@0.7.3		X						X					
-subtle@2.5.0				X									
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+subtle@2.6.1				X									
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 thiserror@1.0.61		X						X					
 thiserror-impl@1.0.61		X						X					
 time@0.3.36		X						X					
 time-core@0.1.2		X						X					
 time-macros@0.2.18		X						X					
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 tower@0.4.13								X					
 tower-layer@0.3.2								X					
@@ -179,8 +178,8 @@ unicode-ident@1.0.12		X						X			X
 unicode-normalization@0.1.23		X						X					
 unicode-segmentation@1.11.0		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+uuid@1.9.1		X						X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
@@ -192,7 +191,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 windows-core@0.52.0		X						X					
 windows-sys@0.48.0		X						X					
 windows-sys@0.52.0		X						X					

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-arm64",
   "repository": "git@github.com/apache/opendal.git",
-  "version": "0.46.2",
+  "version": "0.47.0",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-x64",
-  "version": "0.46.2",
+  "version": "0.47.0",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "darwin"

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-gnu",
-  "version": "0.46.2",
+  "version": "0.47.0",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-musl",
-  "version": "0.46.2",
+  "version": "0.47.0",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.46.2",
+  "version": "0.47.0",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-arm64-msvc",
-  "version": "0.46.2",
+  "version": "0.47.0",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.46.2",
+  "version": "0.47.0",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/upgrade.md
+++ b/bindings/nodejs/upgrade.md
@@ -1,4 +1,4 @@
-# Unreleased
+# Upgrade to v0.47
 
 ## Breaking change
 

--- a/bindings/ocaml/DEPENDENCIES.rust.tsv
+++ b/bindings/ocaml/DEPENDENCIES.rust.tsv
@@ -8,7 +8,7 @@ anyhow@1.0.86		X						X
 async-trait@0.1.80		X						X					
 autocfg@1.3.0		X						X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.21.7		X						X					
 base64@0.22.1		X						X					
 base64ct@1.6.0		X						X					
@@ -18,7 +18,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -27,7 +27,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 cty@0.2.2		X						X					
@@ -56,10 +56,10 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -69,22 +69,22 @@ ipnet@2.9.0		X						X
 itoa@1.0.11		X						X					
 js-sys@0.3.69		X						X					
 jsonwebtoken@9.3.0								X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 libc@0.2.155		X						X					
 libm@0.2.8		X						X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 mime@0.3.17		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
-num-bigint@0.4.5		X						X					
+num-bigint@0.4.6		X						X					
 num-bigint-dig@0.8.4		X						X					
 num-conv@0.1.0		X						X					
 num-integer@0.1.46		X						X					
 num-iter@0.1.45		X						X					
 num-traits@0.2.19		X						X					
-object@0.35.0		X						X					
+object@0.36.1		X						X					
 ocaml@1.0.0-beta.5							X						
 ocaml-boxroot-sys@0.2.0								X					
 ocaml-build@1.0.0-beta.4							X						
@@ -93,7 +93,7 @@ ocaml-interop@0.8.8								X
 ocaml-sys@0.22.3							X						
 ocaml-sys@0.23.0							X						
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
+opendal@0.47.2		X											
 opendal-ocaml@0.0.0		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
@@ -109,20 +109,20 @@ pkcs5@0.7.1		X						X
 pkcs8@0.10.2		X						X					
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rsa@0.9.6		X						X					
 rust-ini@0.21.0								X					
 rustc-demangle@0.1.24		X						X					
 rustc_version@0.4.0		X						X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -132,7 +132,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -141,24 +141,23 @@ simple_asn1@0.6.2							X
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
-spin@0.5.2								X					
 spin@0.9.8								X					
 spki@0.7.3		X						X					
 static_assertions@1.1.0		X						X					
-subtle@2.5.0				X									
+subtle@2.6.1				X									
 syn@1.0.109		X						X					
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 thiserror@1.0.61		X						X					
 thiserror-impl@1.0.61		X						X					
 time@0.3.36		X						X					
 time-core@0.1.2		X						X					
 time-macros@0.2.18		X						X					
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 tower@0.4.13								X					
 tower-layer@0.3.2								X					
@@ -172,8 +171,8 @@ unicode-bidi@0.3.15		X						X
 unicode-ident@1.0.12		X						X			X		
 unicode-normalization@0.1.23		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+uuid@1.9.1		X						X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
@@ -185,7 +184,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 windows-core@0.52.0		X						X					
 windows-sys@0.48.0		X						X					
 windows-sys@0.52.0		X						X					

--- a/bindings/php/Cargo.toml
+++ b/bindings/php/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-php"
 publish = false
-version = "0.1.2"
+version = "0.1.3"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/php/DEPENDENCIES.rust.tsv
+++ b/bindings/php/DEPENDENCIES.rust.tsv
@@ -8,12 +8,12 @@ anyhow@1.0.86		X						X
 async-trait@0.1.80		X						X					
 autocfg@1.3.0		X						X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.21.7		X						X					
 base64@0.22.1		X						X					
 base64ct@1.6.0		X						X					
 bindgen@0.68.1				X									
-bitflags@2.5.0		X						X					
+bitflags@2.6.0		X						X					
 block-buffer@0.10.4		X						X					
 block-padding@0.3.3		X						X					
 bumpalo@3.16.0		X						X					
@@ -26,7 +26,7 @@ camino@1.1.7		X						X
 cargo-platform@0.1.8		X						X					
 cargo_metadata@0.14.2								X					
 cbc@0.1.2		X						X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cexpr@0.6.0		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
@@ -39,7 +39,7 @@ constant_time_eq@0.1.5						X
 core-foundation@0.9.4		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crc32fast@1.4.2		X						X					
 crossbeam-utils@0.8.20		X						X					
 crunchy@0.2.2								X					
@@ -51,7 +51,7 @@ der@0.7.9		X						X
 deranged@0.3.11		X						X					
 digest@0.10.7		X						X					
 dlv-list@0.5.2		X						X					
-either@1.12.0		X						X					
+either@1.13.0		X						X					
 errno@0.3.9		X						X					
 error-chain@0.12.4		X						X					
 ext-php-rs@0.11.2		X						X					
@@ -81,10 +81,10 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -96,32 +96,32 @@ itoa@1.0.11		X						X
 jobserver@0.1.31		X						X					
 js-sys@0.3.69		X						X					
 jsonwebtoken@9.3.0								X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 lazycell@1.3.0		X						X					
 libc@0.2.155		X						X					
-libloading@0.8.3							X						
+libloading@0.8.4							X						
 libm@0.2.8		X						X					
 linux-raw-sys@0.4.14		X	X					X					
 lock_api@0.4.12		X						X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 mime@0.3.17		X						X					
 minimal-lexical@0.2.1		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
 native-tls@0.2.12		X						X					
 nom@7.1.3								X					
-num-bigint@0.4.5		X						X					
+num-bigint@0.4.6		X						X					
 num-bigint-dig@0.8.4		X						X					
 num-conv@0.1.0		X						X					
 num-integer@0.1.46		X						X					
 num-iter@0.1.45		X						X					
 num-traits@0.2.19		X						X					
-object@0.35.0		X						X					
+object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
-opendal-php@0.1.2		X											
+opendal@0.47.2		X											
+opendal-php@0.1.3		X											
 openssl@0.10.64		X											
 openssl-macros@0.1.1		X						X					
 openssl-probe@0.1.5		X						X					
@@ -147,19 +147,19 @@ pkg-config@0.3.30		X						X
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.17		X						X					
 prettyplease@0.2.20		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 pulldown-cmark@0.9.6								X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
-redox_syscall@0.5.1								X					
-regex@1.10.4		X						X					
-regex-automata@0.4.6		X						X					
-regex-syntax@0.8.3		X						X					
+redox_syscall@0.5.2								X					
+regex@1.10.5		X						X					
+regex-automata@0.4.7		X						X					
+regex-syntax@0.8.4		X						X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rsa@0.9.6		X						X					
 rust-ini@0.21.0								X					
@@ -167,7 +167,7 @@ rustc-demangle@0.1.24		X						X
 rustc-hash@1.1.0		X						X					
 rustc_version@0.4.0		X						X					
 rustix@0.38.34		X	X					X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -182,7 +182,7 @@ security-framework-sys@2.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -193,14 +193,13 @@ skeptic@0.13.7		X						X
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
-spin@0.5.2								X					
 spin@0.9.8								X					
 spki@0.7.3		X						X					
 strsim@0.10.0								X					
-subtle@2.5.0				X									
+subtle@2.6.1				X									
 syn@1.0.109		X						X					
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 tempfile@3.10.1		X						X					
 thiserror@1.0.61		X						X					
 thiserror-impl@1.0.61		X						X					
@@ -208,10 +207,10 @@ time@0.3.36		X						X
 time-core@0.1.2		X						X					
 time-macros@0.2.18		X						X					
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 tower@0.4.13								X					
 tower-layer@0.3.2								X					
@@ -227,8 +226,8 @@ unicode-ident@1.0.12		X						X			X
 unicode-normalization@0.1.23		X						X					
 untrusted@0.9.0							X						
 ureq@2.9.7		X						X					
-url@2.5.0		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+uuid@1.9.1		X						X					
 vcpkg@0.2.15		X						X					
 version_check@0.9.4		X						X					
 walkdir@2.5.0								X				X	
@@ -242,7 +241,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 which@4.4.2								X					
 winapi-util@0.1.8								X				X	
 windows-core@0.52.0		X						X					
@@ -270,4 +269,4 @@ zeroize@1.8.1		X						X
 zip@0.6.6								X					
 zstd@0.11.2+zstd.1.5.2								X					
 zstd-safe@5.0.2+zstd.1.5.2		X						X					
-zstd-sys@2.0.10+zstd.1.5.6		X						X					
+zstd-sys@2.0.11+zstd.1.5.6		X						X					

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.4"
+version = "0.45.5"
 
 [features]
 default = [

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -11,19 +11,19 @@ autocfg@1.3.0		X						X
 awaitable@0.4.0								X					
 awaitable-error@0.1.0								X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.21.7		X						X					
 base64@0.22.1		X						X					
 base64ct@1.6.0		X						X					
-bb8@0.8.3								X					
-bitflags@2.5.0		X						X					
+bb8@0.8.5								X					
+bitflags@2.6.0		X						X					
 block-buffer@0.10.4		X						X					
 block-padding@0.3.3		X						X					
 bumpalo@3.16.0		X						X					
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -33,7 +33,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
@@ -66,10 +66,10 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -80,19 +80,19 @@ ipnet@2.9.0		X						X
 itoa@1.0.11		X						X					
 js-sys@0.3.69		X						X					
 jsonwebtoken@9.3.0								X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 libc@0.2.155		X						X					
 libm@0.2.8		X						X					
 linux-raw-sys@0.4.14		X	X					X					
 lock_api@0.4.12		X						X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 memoffset@0.9.1								X					
 mime@0.3.17		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
-num-bigint@0.4.5		X						X					
+num-bigint@0.4.6		X						X					
 num-bigint-dig@0.8.4		X						X					
 num-conv@0.1.0		X						X					
 num-derive@0.3.3		X						X					
@@ -100,12 +100,12 @@ num-integer@0.1.46		X						X
 num-iter@0.1.45		X						X					
 num-traits@0.2.19		X						X					
 num_cpus@1.16.0		X						X					
-object@0.35.0		X						X					
+object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
-opendal-python@0.45.4		X											
+opendal@0.47.2		X											
+opendal-python@0.45.5		X											
 openssh@0.10.4		X						X					
-openssh-sftp-client@0.14.3								X					
+openssh-sftp-client@0.14.4								X					
 openssh-sftp-client-lowlevel@0.6.0								X					
 openssh-sftp-error@0.4.0								X					
 openssh-sftp-protocol@0.24.0								X					
@@ -127,7 +127,7 @@ pkcs8@0.10.2		X						X
 portable-atomic@1.6.0		X						X					
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 pyo3@0.21.2		X						X					
 pyo3-asyncio-0-21@0.21.0		X											
 pyo3-build-config@0.21.2		X						X					
@@ -139,16 +139,16 @@ quote@1.0.36		X						X
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
-redox_syscall@0.5.1								X					
+redox_syscall@0.5.2								X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rsa@0.9.6		X						X					
 rust-ini@0.21.0								X					
 rustc-demangle@0.1.24		X						X					
 rustc_version@0.4.0		X						X					
 rustix@0.38.34		X	X					X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -159,7 +159,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -170,16 +170,15 @@ simple_asn1@0.6.2							X
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
-spin@0.5.2								X					
 spin@0.9.8								X					
 spki@0.7.3		X						X					
 ssh_format@0.14.1								X					
 ssh_format_error@0.1.0								X					
 stable_deref_trait@1.2.0		X						X					
-subtle@2.5.0				X									
+subtle@2.6.1				X									
 syn@1.0.109		X						X					
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 target-lexicon@0.12.14			X										
 tempfile@3.10.1		X						X					
 thin-vec@0.2.13		X						X					
@@ -189,13 +188,13 @@ time@0.3.36		X						X
 time-core@0.1.2		X						X					
 time-macros@0.2.18		X						X					
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
 tokio-io-utility@0.7.6								X					
 tokio-macros@2.3.0								X					
 tokio-pipe@0.2.12		X						X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 tower@0.4.13								X					
 tower-layer@0.3.2								X					
@@ -204,7 +203,7 @@ tracing@0.1.40								X
 tracing-attributes@0.1.27								X					
 tracing-core@0.1.32								X					
 trim-in-place@0.1.7								X					
-triomphe@0.1.12		X						X					
+triomphe@0.1.13		X						X					
 try-lock@0.2.5								X					
 typenum@1.17.0		X						X					
 unicode-bidi@0.3.15		X						X					
@@ -212,8 +211,8 @@ unicode-ident@1.0.12		X						X			X
 unicode-normalization@0.1.23		X						X					
 unindent@0.2.3		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+uuid@1.9.1		X						X					
 vec-strings@0.4.8								X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
@@ -226,7 +225,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 windows-core@0.52.0		X						X					
 windows-sys@0.48.0		X						X					
 windows-sys@0.52.0		X						X					

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-ruby"
 publish = false
-version = "0.1.2"
+version = "0.1.3"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -9,19 +9,19 @@ anyhow@1.0.86		X						X
 async-trait@0.1.80		X						X					
 autocfg@1.3.0		X						X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.21.7		X						X					
 base64@0.22.1		X						X					
 base64ct@1.6.0		X						X					
 bindgen@0.69.4				X									
-bitflags@2.5.0		X						X					
+bitflags@2.6.0		X						X					
 block-buffer@0.10.4		X						X					
 block-padding@0.3.3		X						X					
 bumpalo@3.16.0		X						X					
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cexpr@0.6.0		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
@@ -32,14 +32,14 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 der@0.7.9		X						X					
 deranged@0.3.11		X						X					
 digest@0.10.7		X						X					
 dlv-list@0.5.2		X						X					
-either@1.12.0		X						X					
+either@1.13.0		X						X					
 fastrand@2.1.0		X						X					
 flagset@0.4.5		X											
 fnv@1.0.7		X						X					
@@ -62,10 +62,10 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -76,31 +76,31 @@ itertools@0.12.1		X						X
 itoa@1.0.11		X						X					
 js-sys@0.3.69		X						X					
 jsonwebtoken@9.3.0								X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 lazycell@1.3.0		X						X					
 libc@0.2.155		X						X					
-libloading@0.8.3							X						
+libloading@0.8.4							X						
 libm@0.2.8		X						X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 magnus@0.5.5								X					
 magnus-macros@0.4.1								X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 mime@0.3.17		X						X					
 minimal-lexical@0.2.1		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
 nom@7.1.3								X					
-num-bigint@0.4.5		X						X					
+num-bigint@0.4.6		X						X					
 num-bigint-dig@0.8.4		X						X					
 num-conv@0.1.0		X						X					
 num-integer@0.1.46		X						X					
 num-iter@0.1.45		X						X					
 num-traits@0.2.19		X						X					
-object@0.35.0		X						X					
+object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
-opendal-ruby@0.1.2		X											
+opendal@0.47.2		X											
+opendal-ruby@0.1.3		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
 pem@3.0.4								X					
@@ -115,7 +115,7 @@ pkcs5@0.7.1		X						X
 pkcs8@0.10.2		X						X					
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
@@ -124,18 +124,18 @@ rand_core@0.6.4		X						X
 rb-sys@0.9.97		X						X					
 rb-sys-build@0.9.97		X						X					
 rb-sys-env@0.1.2		X						X					
-regex@1.10.4		X						X					
-regex-automata@0.4.6		X						X					
-regex-syntax@0.8.3		X						X					
+regex@1.10.5		X						X					
+regex-automata@0.4.7		X						X					
+regex-syntax@0.8.4		X						X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rsa@0.9.6		X						X					
 rust-ini@0.21.0								X					
 rustc-demangle@0.1.24		X						X					
 rustc-hash@1.1.0		X						X					
 rustc_version@0.4.0		X						X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -145,7 +145,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -156,23 +156,22 @@ simple_asn1@0.6.2							X
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
-spin@0.5.2								X					
 spin@0.9.8								X					
 spki@0.7.3		X						X					
-subtle@2.5.0				X									
+subtle@2.6.1				X									
 syn@1.0.109		X						X					
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 thiserror@1.0.61		X						X					
 thiserror-impl@1.0.61		X						X					
 time@0.3.36		X						X					
 time-core@0.1.2		X						X					
 time-macros@0.2.18		X						X					
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 tower@0.4.13								X					
 tower-layer@0.3.2								X					
@@ -186,8 +185,8 @@ unicode-bidi@0.3.15		X						X
 unicode-ident@1.0.12		X						X			X		
 unicode-normalization@0.1.23		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+uuid@1.9.1		X						X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
@@ -199,7 +198,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 windows-core@0.52.0		X						X					
 windows-sys@0.48.0		X						X					
 windows-sys@0.52.0		X						X					

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -242,7 +242,7 @@ checksum = "affbba0d438add06462a0371997575927bc05052f7ec486e7a4ca405c956c3d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -328,7 +328,7 @@ dependencies = [
  "futures-io",
  "futures-lite 2.3.0",
  "parking",
- "polling 3.7.1",
+ "polling 3.7.2",
  "rustix 0.38.34",
  "slab",
  "tracing",
@@ -374,7 +374,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -422,7 +422,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -452,7 +452,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -465,12 +465,6 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.0",
 ]
-
-[[package]]
-name = "atomic"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "atomic-polyfill"
@@ -590,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75588e7ee5e8496eed939adac2035a6dbab9f7eb2acdd9ab2d31856dab6f3955"
+checksum = "9a4a5e448145999d7de17bf44a886900ecb834953408dae8aaf90465ce91c1dd"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -614,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.31.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67520cfee50a8a075a86e7960a6ff30a0a93f6b83ef36f7dff42a9fad9ec1818"
+checksum = "724119d8fd2d2638b9979673f3b5c2979fa388c9ca27815e3cb5ad6234fac3f5"
 dependencies = [
  "ahash 0.8.11",
  "aws-credential-types",
@@ -716,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b56f1cbe6fd4d0c2573df72868f20ab1c125ca9c9dbce17927a463433a2e57"
+checksum = "31eed8d45759b2c5fe7fd304dd70739060e9e0de509209036eabea14d0720cce"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -756,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.60.8"
+version = "0.60.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509e33efbd853e1e670c47e49af2f4df3d2ae0de8b845b068ddbf04636a6700d"
+checksum = "c5b30ea96823b8b25fb6471643a516e1bd475fd5575304e6240aea179f213216"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -854,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4179bd8a1c943e1aceb46c5b9fc014a561bd6c35a2153e816ba29076ee49d245"
+checksum = "1b570ea39eb95bd32543f6e4032bce172cb6209b9bc8c83c770d08169e875afc"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -871,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.1.10"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6764ba7e1c5ede1c9f9e4046645534f06c2581402461c559b481a420330a83"
+checksum = "cfe321a6b21f5d8eabd0ade9c55d3d0335f3c3157fc2b3e87f05f34b539e4df5"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -906,15 +900,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f734808d43702a67e57d478a12e227d4d038d0b90c9005a78c87890d3805922"
+checksum = "2009a9733865d0ebf428a314440bbe357cc10d0c16d86a8e15d32e9b47c1e80e"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 0.2.12",
  "rustc_version 0.4.0",
  "tracing",
 ]
@@ -941,7 +934,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
@@ -978,9 +971,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -1033,12 +1026,11 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bb8"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7c2093d15d6a1d33b1f972e1c5ea3177748742b97a5f392aa83a65262c6780"
+checksum = "b10cf871f3ff2ce56432fddc2615ac7acc3aa22ca321f8fea800846fbb32f188"
 dependencies = [
  "async-trait",
- "futures-channel",
  "futures-util",
  "parking_lot 0.12.3",
  "tokio",
@@ -1108,7 +1100,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.66",
+ "syn 2.0.68",
  "which",
 ]
 
@@ -1118,7 +1110,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -1129,7 +1121,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1155,9 +1147,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitvec"
@@ -1241,7 +1233,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "syn_derive",
 ]
 
@@ -1302,9 +1294,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 
 [[package]]
 name = "byteorder"
@@ -1420,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "2755ff20a1d93490d26ba33a6f092a38a508398a5320df5d4b3014fcccce9410"
 dependencies = [
  "jobserver",
  "libc",
@@ -1572,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.6"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9689a29b593160de5bc4aacab7b5d54fb52231de70122626c178e6a368994c7"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1582,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.6"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5387378c84f6faa26890ebf9f0a92989f8873d4d380467bcd0d8d8620424df"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1594,14 +1586,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.5"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1707,7 +1699,7 @@ dependencies = [
  "once_cell",
  "os_pipe",
  "paste",
- "polling 3.7.1",
+ "polling 3.7.2",
  "socket2 0.5.7",
  "windows-sys 0.52.0",
 ]
@@ -1900,9 +1892,9 @@ checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32c"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0227b9f93e535d49bc7ce914c066243424ce85ed90864cebd0874b184e9b6947"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
 dependencies = [
  "rustc_version 0.4.0",
 ]
@@ -2142,7 +2134,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2175,7 +2167,7 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core 0.20.9",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2258,7 +2250,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2300,20 +2292,20 @@ checksum = "64b697ac90ff296f0fc031ee5a61c7ac31fb9fff50e3fb32873b09223613fc0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 1.0.109",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2430,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_aws_s3_assume_role_with_web_identity"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "opendal",
  "tokio",
@@ -2439,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_file_write_on_full_disk"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "futures",
  "opendal",
@@ -2449,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_s3_read_on_wasm"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "opendal",
  "wasm-bindgen",
@@ -2459,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -2758,7 +2750,7 @@ checksum = "83c8d52fe8b46ab822b4decdcc0d6d85aeedfc98f0d52ba2bd4aec4a97807516"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "try_map",
 ]
 
@@ -2796,7 +2788,7 @@ checksum = "b0fa992f1656e1707946bbba340ad244f0814009ef8c0118eb7b658395f19a2e"
 dependencies = [
  "frunk_proc_macro_helpers",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2808,7 +2800,7 @@ dependencies = [
  "frunk_core",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2820,7 +2812,7 @@ dependencies = [
  "frunk_core",
  "frunk_proc_macro_helpers",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2861,6 +2853,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-buffered"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02dcae03ee5afa5ea17b1aebc793806b8ddfc6dc500e0b8e8e1eb30b9dad22c0"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2872,11 +2875,12 @@ dependencies = [
 
 [[package]]
 name = "futures-concurrency"
-version = "7.6.0"
+version = "7.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ee14e256b9143bfafbf2fddeede6f396650bacf95d06fc1b3f2b503df129a0"
+checksum = "4b14ac911e85d57c5ea6eef76d7b4d4a3177ecd15f4bea2e61927e9e3823e19f"
 dependencies = [
  "bitvec",
+ "futures-buffered",
  "futures-core",
  "futures-lite 1.13.0",
  "pin-project",
@@ -2943,7 +2947,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -3355,6 +3359,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3446,12 +3456,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -3459,9 +3469,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -3536,19 +3546,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
  "hyper 1.3.1",
  "hyper-util",
- "rustls 0.22.4",
+ "rustls 0.23.10",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tower-service",
+ "webpki-roots 0.26.3",
 ]
 
 [[package]]
@@ -3686,7 +3697,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -3725,7 +3736,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3835,7 +3846,7 @@ dependencies = [
  "petgraph",
  "pico-args",
  "regex",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -3849,7 +3860,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata 0.4.6",
+ "regex-automata 0.4.7",
 ]
 
 [[package]]
@@ -3872,16 +3883,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3991,9 +4002,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
  "windows-targets 0.52.5",
@@ -4011,7 +4022,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -4092,9 +4103,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "value-bag",
 ]
@@ -4178,9 +4189,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
@@ -4233,7 +4244,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4244,9 +4255,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.4"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
@@ -4275,9 +4286,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minitrace"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d9bd7c509d9caa22fbe52612af7fcf77e3988a646a7bcc0738767b8615d33b"
+checksum = "197d538cd69839d49a593c8c72df44291b0ea3296ecc0c85529002c53c8fbc6f"
 dependencies = [
  "minitrace-macro",
  "minstant",
@@ -4290,9 +4301,9 @@ dependencies = [
 
 [[package]]
 name = "minitrace-macro"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22157883acc4c810151c39d1e0a8fe49d58a81f6c2dbd2065a8e9a5d362f4d23"
+checksum = "14efd4b574325fcb981bce1ac700b9ccf071ec2eb94f7a6a6b583a84f228ba47"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -4302,9 +4313,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -4421,7 +4432,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "termcolor",
  "thiserror",
 ]
@@ -4471,7 +4482,7 @@ dependencies = [
  "base64 0.21.7",
  "bigdecimal",
  "bindgen 0.69.4",
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "bitvec",
  "byteorder",
  "bytes",
@@ -4584,9 +4595,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -4662,15 +4673,15 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -4710,7 +4721,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "anyhow",
  "async-backtrace",
@@ -4767,7 +4778,7 @@ dependencies = [
  "redb",
  "redis",
  "reqsign",
- "reqwest 0.12.4",
+ "reqwest 0.12.5",
  "rocksdb",
  "rusqlite",
  "serde",
@@ -4815,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-basic"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "futures",
  "opendal",
@@ -4824,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-concurrent-upload"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "futures",
  "opendal",
@@ -4833,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-multipart-upload"
-version = "0.47.1"
+version = "0.47.2"
 dependencies = [
  "futures",
  "opendal",
@@ -4873,9 +4884,9 @@ dependencies = [
 
 [[package]]
 name = "openssh-sftp-client"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a48110b19eb705dcdf58105f8cc48548517c89f874b2ea0dfcdecf71b405bc1"
+checksum = "005e582b370ce61b5edaf1ebd4c40b2019dbf0f3db923a00cc084eec6ba06638"
 dependencies = [
  "bytes",
  "derive_destructure2",
@@ -4929,7 +4940,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf38532d784978966f95d241226223823f351d5bb2a4bebcf6b20b9cb1e393e0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "num-derive",
  "num-traits",
  "openssh-sftp-protocol-error",
@@ -4955,7 +4966,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4972,7 +4983,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5101,7 +5112,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.1",
+ "redox_syscall 0.5.2",
  "smallvec",
  "windows-targets 0.52.5",
 ]
@@ -5277,7 +5288,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5403,13 +5414,13 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6a007746f34ed64099e88783b0ae369eaa3da6392868ba262e2af9b8fbaea1"
+checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "pin-project-lite",
  "rustix 0.38.34",
  "tracing",
@@ -5495,7 +5506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5559,9 +5570,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -5572,7 +5583,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "hex",
  "lazy_static",
  "procfs-core",
@@ -5585,7 +5596,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "hex",
 ]
 
@@ -5626,7 +5637,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5666,7 +5677,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types",
  "regex",
- "syn 2.0.66",
+ "syn 2.0.68",
  "tempfile",
 ]
 
@@ -5693,7 +5704,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5752,7 +5763,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "memchr",
  "unicase",
 ]
@@ -5798,6 +5809,53 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
  "parking_lot 0.12.3",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring 0.17.8",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2 0.5.7",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5914,7 +5972,7 @@ version = "11.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -5998,11 +6056,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -6033,30 +6091,30 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3138c30c59ed9b8572f82bed97ea591ecd7e45012566046cc39e72679cff22"
+checksum = "6d731e7e3ebfcf422d96b8473e507d5b64790900dd5464772d38d1da9da24d3a"
 dependencies = [
  "cfg-if",
  "rustix 0.38.34",
- "windows 0.56.0",
+ "windows 0.57.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -6070,20 +6128,20 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
 name = "regex-lite"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b661b2f27137bdbc16f00eda72866a92bb28af1753ffbd56744fb6e2e9cd8e"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
@@ -6093,9 +6151,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rend"
@@ -6128,7 +6186,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.8.5",
- "reqwest 0.12.4",
+ "reqwest 0.12.5",
  "rsa",
  "rust-ini",
  "serde",
@@ -6166,7 +6224,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -6183,9 +6241,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6195,7 +6253,7 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.3.1",
- "hyper-rustls 0.26.0",
+ "hyper-rustls 0.27.2",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -6204,15 +6262,16 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.4",
+ "quinn",
+ "rustls 0.23.10",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -6220,7 +6279,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.2",
+ "webpki-roots 0.26.3",
  "winreg 0.52.0",
 ]
 
@@ -6236,9 +6295,9 @@ dependencies = [
 
 [[package]]
 name = "revision"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588784c1d9453cfd2ce1b7aff06c903513677cf0e63779a0a3085ee8a44f5b17"
+checksum = "4df61cfb2522f24fd6aa90ce3489c2c8660a181075e7bac3ae7bdf22287d238f"
 dependencies = [
  "bincode",
  "chrono",
@@ -6262,7 +6321,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6337,9 +6396,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26f4c25a604fcb3a1bcd96dd6ba37c93840de95de8198d94c0d571a74a804d1"
+checksum = "7699249cc2c7d71939f30868f47e9d7add0bdc030d90ee10bfd16887ff8bb1c8"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -6418,7 +6477,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
@@ -6532,7 +6591,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -6558,6 +6617,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+dependencies = [
+ "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
  "rustls-webpki 0.102.4",
@@ -6747,7 +6820,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -6805,9 +6878,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
@@ -6820,14 +6893,14 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -6896,7 +6969,7 @@ dependencies = [
  "darling 0.20.9",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7123,9 +7196,9 @@ dependencies = [
 
 [[package]]
 name = "spade"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b20a809169ae442497e41a997fc5f14e2eea04e6ac590816a910d5d8068c8c0"
+checksum = "9f4ec45f91925e2c9ab3b6a857ee9ed36916990df76a1c475d783a328e247cc8"
 dependencies = [
  "hashbrown 0.14.5",
  "num-traits",
@@ -7299,9 +7372,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suppaftp"
@@ -7323,9 +7396,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ccf39357a204b7db24f7e6951607fad95bc9e41384543d0ca914936af48c2a"
+checksum = "31819be880ed2c134afc1350dc29c22b1f1d9b93715d25eac07ba65677235eed"
 dependencies = [
  "async-channel 1.9.0",
  "bincode",
@@ -7471,9 +7544,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7489,7 +7562,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7497,6 +7570,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "system-configuration"
@@ -7592,7 +7671,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7693,9 +7772,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "c55115c6fbe2d2bef26eb09ad74bde02d8255476fc0c7b515ef09fbb35742d82"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7753,7 +7832,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7825,11 +7904,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.22.4",
+ "rustls 0.23.10",
  "rustls-pki-types",
  "tokio",
 ]
@@ -7942,7 +8021,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7996,7 +8075,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -8057,9 +8136,9 @@ checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
 
 [[package]]
 name = "triomphe"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2cb4fbb9995eeb36ac86fadf24031ccd58f99d6b4b2d7b911db70bddb80d90"
+checksum = "e6631e42e10b40c0690bf92f404ebcfe6e1fdb480391d15f17cc8e96eeed5369"
 dependencies = [
  "arc-swap",
  "serde",
@@ -8279,14 +8358,14 @@ dependencies = [
  "rustls-pki-types",
  "rustls-webpki 0.102.4",
  "url",
- "webpki-roots 0.26.2",
+ "webpki-roots 0.26.3",
 ]
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna 0.5.0",
@@ -8316,17 +8395,16 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
- "atomic",
  "getrandom 0.2.15",
  "serde",
  "wasm-bindgen",
@@ -8445,7 +8523,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "wasm-bindgen-shared",
 ]
 
@@ -8479,7 +8557,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8512,7 +8590,7 @@ checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -8603,9 +8681,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8681,11 +8759,11 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
- "windows-core 0.56.0",
+ "windows-core 0.57.0",
  "windows-targets 0.52.5",
 ]
 
@@ -8700,9 +8778,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -8712,31 +8790,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.56.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.5",
 ]
@@ -8978,7 +9056,7 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.47.1"
+version = "0.47.2"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -42,7 +42,7 @@ members = [".", "examples/*", "fuzz", "edge/*", "benches/vs_*"]
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.75"
-version = "0.47.1"
+version = "0.47.2"
 
 [features]
 default = ["reqwest/rustls-tls", "executors-tokio", "services-memory"]

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -7,12 +7,12 @@ anyhow@1.0.86		X						X
 async-trait@0.1.80		X						X					
 autocfg@1.3.0		X						X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.22.1		X						X					
 block-buffer@0.10.4		X						X					
 bumpalo@3.16.0		X						X					
 bytes@1.6.0								X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 const-oid@0.9.6		X						X					
@@ -20,7 +20,7 @@ const-random@0.1.18		X						X
 const-random-macro@0.1.16		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
-crc32c@0.6.7		X						X					
+crc32c@0.6.8		X						X					
 crunchy@0.2.2								X					
 crypto-common@0.1.6		X						X					
 digest@0.10.7		X						X					
@@ -48,10 +48,10 @@ hmac@0.12.1		X						X
 home@0.5.9		X						X					
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -60,17 +60,17 @@ ipnet@2.9.0		X						X
 itoa@1.0.11		X						X					
 js-sys@0.3.69		X						X					
 libc@0.2.155		X						X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 mime@0.3.17		X						X					
-miniz_oxide@0.7.3		X						X					X
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
 num-traits@0.2.19		X						X					
 num_cpus@1.16.0		X						X					
-object@0.35.0		X						X					
+object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
+opendal@0.47.2		X											
 ordered-multimap@0.7.3								X					
 percent-encoding@2.3.1		X						X					
 pin-project@1.1.5		X						X					
@@ -78,19 +78,19 @@ pin-project-internal@1.1.5		X						X
 pin-project-lite@0.2.14		X						X					
 pin-utils@0.1.0		X						X					
 ppv-lite86@0.2.17		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
 reqsign@0.15.2		X											
-reqwest@0.12.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rust-ini@0.21.0								X					
 rustc-demangle@0.1.24		X						X					
 rustc_version@0.4.0		X						X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -98,7 +98,7 @@ ryu@1.0.18		X			X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
@@ -106,15 +106,15 @@ slab@0.4.9								X
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
 spin@0.9.8								X					
-subtle@2.5.0				X									
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+subtle@2.6.1				X									
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 tiny-keccak@2.0.2						X							
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
 tokio-macros@2.3.0								X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 tower@0.4.13								X					
 tower-layer@0.3.2								X					
@@ -128,8 +128,8 @@ unicode-bidi@0.3.15		X						X
 unicode-ident@1.0.12		X						X			X		
 unicode-normalization@0.1.23		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+uuid@1.9.1		X						X					
 valuable@0.1.0								X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
@@ -142,7 +142,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 windows-core@0.52.0		X						X					
 windows-sys@0.48.0		X						X					
 windows-sys@0.52.0		X						X					

--- a/integrations/cloudfilter/DEPENDENCIES.rust.tsv
+++ b/integrations/cloudfilter/DEPENDENCIES.rust.tsv
@@ -12,7 +12,7 @@ base64@0.22.1		X					X
 block-buffer@0.10.4		X					X					
 bumpalo@3.16.0		X					X					
 bytes@1.6.0							X					
-cc@1.0.99		X					X					
+cc@1.0.103		X					X					
 cfg-if@1.0.0		X					X					
 chrono@0.4.38		X					X					
 cloudfilter_opendal@0.0.0		X										
@@ -48,22 +48,22 @@ ipnet@2.9.0		X					X
 itoa@1.0.11		X					X					
 js-sys@0.3.69		X					X					
 libc@0.2.155		X					X					
-log@0.4.21		X					X					
+log@0.4.22		X					X					
 md-5@0.10.6		X					X					
 memchr@2.7.4							X				X	
 mime@0.3.17		X					X					
 miniz_oxide@0.7.4		X					X					X
 mio@0.8.11							X					
 num-traits@0.2.19		X					X					
-object@0.36.0		X					X					
+object@0.36.1		X					X					
 once_cell@1.19.0		X					X					
-opendal@0.47.1		X										
+opendal@0.47.2		X										
 percent-encoding@2.3.1		X					X					
 pin-project@1.1.5		X					X					
 pin-project-internal@1.1.5		X					X					
 pin-project-lite@0.2.14		X					X					
 pin-utils@0.1.0		X					X					
-proc-macro2@1.0.85		X					X					
+proc-macro2@1.0.86		X					X					
 quick-xml@0.31.0							X					
 quote@1.0.36		X					X					
 reqwest@0.12.5		X					X					
@@ -76,16 +76,16 @@ rustls-webpki@0.102.4						X
 ryu@1.0.18		X			X							
 serde@1.0.203		X					X					
 serde_derive@1.0.203		X					X					
-serde_json@1.0.117		X					X					
+serde_json@1.0.118		X					X					
 serde_urlencoded@0.7.1		X					X					
 slab@0.4.9							X					
 smallvec@1.13.2		X					X					
 socket2@0.5.7		X					X					
 spin@0.9.8							X					
-subtle@2.6.0				X								
-syn@2.0.66		X					X					
+subtle@2.6.1				X								
+syn@2.0.68		X					X					
 sync_wrapper@1.0.1		X										
-tinyvec@1.6.0		X					X					X
+tinyvec@1.6.1		X					X					X
 tinyvec_macros@0.1.1		X					X					X
 tokio@1.38.0							X					
 tokio-rustls@0.26.0		X					X					
@@ -102,7 +102,7 @@ unicode-ident@1.0.12		X					X			X
 unicode-normalization@0.1.23		X					X					
 untrusted@0.9.0						X						
 url@2.5.2		X					X					
-uuid@1.8.0		X					X					
+uuid@1.9.1		X					X					
 version_check@0.9.4		X					X					
 want@0.3.1							X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X				X					

--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 description = "Use OpenDAL as a backend to access data in various service with WebDAV protocol"
 name = "dav-server-opendalfs"
-version = "0.0.3"
+version = "0.0.4"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -10,21 +10,21 @@ anyhow@1.0.86		X						X
 async-trait@0.1.80		X						X					
 autocfg@1.3.0		X						X					
 backon@0.4.4		X											
-backtrace@0.3.72		X						X					
+backtrace@0.3.73		X						X					
 base64@0.21.7		X						X					
 base64@0.22.1		X						X					
-bitflags@2.5.0		X						X					
+bitflags@2.6.0		X						X					
 block-buffer@0.10.4		X						X					
 bumpalo@3.16.0		X						X					
 bytes@1.6.0								X					
-cc@1.0.98		X						X					
+cc@1.0.103		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
 crypto-common@0.1.6		X						X					
 dav-server@0.6.0		X											
-dav-server-opendalfs@0.0.3		X											
+dav-server-opendalfs@0.0.4		X											
 deranged@0.3.11		X						X					
 digest@0.10.7		X						X					
 fastrand@2.1.0		X						X					
@@ -50,11 +50,11 @@ hermit-abi@0.3.9		X						X
 htmlescape@0.3.1		X						X	X				
 http@1.1.0		X						X					
 http-body@1.0.0								X					
-http-body-util@0.1.1								X					
-httparse@1.8.0		X						X					
+http-body-util@0.1.2								X					
+httparse@1.9.4		X						X					
 httpdate@1.0.3		X						X					
 hyper@1.3.1								X					
-hyper-rustls@0.26.0		X					X	X					
+hyper-rustls@0.27.2		X					X	X					
 hyper-util@0.1.5								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
@@ -62,23 +62,23 @@ idna@0.5.0		X						X
 ipnet@2.9.0		X						X					
 itoa@1.0.11		X						X					
 js-sys@0.3.69		X						X					
-lazy_static@1.4.0		X						X					
+lazy_static@1.5.0		X						X					
 libc@0.2.155		X						X					
 lock_api@0.4.12		X						X					
-log@0.4.21		X						X					
+log@0.4.22		X						X					
 lru@0.12.3								X					
 md-5@0.10.6		X						X					
-memchr@2.7.2								X				X	
+memchr@2.7.4								X				X	
 mime@0.3.17		X						X					
-mime_guess@2.0.4								X					
-miniz_oxide@0.7.3		X						X					X
+mime_guess@2.0.5								X					
+miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
 num-conv@0.1.0		X						X					
 num-traits@0.2.19		X						X					
 num_cpus@1.16.0		X						X					
-object@0.35.0		X						X					
+object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.1		X											
+opendal@0.47.2		X											
 parking_lot@0.12.3		X						X					
 parking_lot_core@0.9.10		X						X					
 percent-encoding@2.3.1		X						X					
@@ -87,17 +87,17 @@ pin-project-internal@1.1.5		X						X
 pin-project-lite@0.2.14		X						X					
 pin-utils@0.1.0		X						X					
 powerfmt@0.2.0		X						X					
-proc-macro2@1.0.85		X						X					
+proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
 quote@1.0.36		X						X					
-redox_syscall@0.5.1								X					
-regex@1.10.4		X						X					
-regex-automata@0.4.6		X						X					
-regex-syntax@0.8.3		X						X					
-reqwest@0.12.4		X						X					
+redox_syscall@0.5.2								X					
+regex@1.10.5		X						X					
+regex-automata@0.4.7		X						X					
+regex-syntax@0.8.4		X						X					
+reqwest@0.12.5		X						X					
 ring@0.17.8										X			
 rustc-demangle@0.1.24		X						X					
-rustls@0.22.4		X					X	X					
+rustls@0.23.10		X					X	X					
 rustls-pemfile@2.1.2		X					X	X					
 rustls-pki-types@1.7.0		X						X					
 rustls-webpki@0.102.4							X						
@@ -105,24 +105,24 @@ ryu@1.0.18		X				X
 scopeguard@1.2.0		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.117		X						X					
+serde_json@1.0.118		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
 socket2@0.5.7		X						X					
 spin@0.9.8								X					
-subtle@2.5.0					X								
-syn@2.0.66		X						X					
-sync_wrapper@0.1.2		X											
+subtle@2.6.1					X								
+syn@2.0.68		X						X					
+sync_wrapper@1.0.1		X											
 time@0.3.36		X						X					
 time-core@0.1.2		X						X					
 time-macros@0.2.18		X						X					
-tinyvec@1.6.0		X						X					X
+tinyvec@1.6.1		X						X					X
 tinyvec_macros@0.1.1		X						X					X
 tokio@1.38.0								X					
 tokio-macros@2.3.0								X					
-tokio-rustls@0.25.0		X						X					
+tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.11								X					
 tower@0.4.13								X					
 tower-layer@0.3.2								X					
@@ -136,8 +136,8 @@ unicode-bidi@0.3.15		X						X
 unicode-ident@1.0.12		X						X			X		
 unicode-normalization@0.1.23		X						X					
 untrusted@0.9.0							X						
-url@2.5.0		X						X					
-uuid@1.8.0		X						X					
+url@2.5.2		X						X					
+uuid@1.9.1		X						X					
 version_check@0.9.4		X						X					
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
@@ -149,7 +149,7 @@ wasm-bindgen-macro-support@0.2.92		X						X
 wasm-bindgen-shared@0.2.92		X						X					
 wasm-streams@0.4.0		X						X					
 web-sys@0.3.69		X						X					
-webpki-roots@0.26.2									X				
+webpki-roots@0.26.3									X				
 windows-core@0.52.0		X						X					
 windows-sys@0.48.0		X						X					
 windows-sys@0.52.0		X						X					

--- a/integrations/fuse3/Cargo.toml
+++ b/integrations/fuse3/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.0.0"
+version = "0.0.1"
 
 [dependencies]
 bytes = "1.6.0"

--- a/integrations/fuse3/DEPENDENCIES.rust.tsv
+++ b/integrations/fuse3/DEPENDENCIES.rust.tsv
@@ -1,185 +1,164 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-3.0	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.22.0		X					X						
-adler@1.0.2	X	X					X						
-android-tzdata@0.1.1		X					X						
-android_system_properties@0.1.5		X					X						
-anyhow@1.0.86		X					X						
-async-notify@0.3.0							X						
-async-trait@0.1.80		X					X						
-autocfg@1.3.0		X					X						
-backon@0.4.4		X											
-backtrace@0.3.73		X					X						
-base64@0.22.1		X					X						
-bincode@1.3.3							X						
-bitflags@2.5.0		X					X						
-block-buffer@0.10.4		X					X						
-bumpalo@3.16.0		X					X						
-bytes@1.6.0							X						
-cc@1.0.99		X					X						
-cfg-if@1.0.0		X					X						
-cfg_aliases@0.1.1							X						
-chrono@0.4.38		X					X						
-concurrent-queue@2.5.0		X					X						
-core-foundation-sys@0.8.6		X					X						
-crossbeam-utils@0.8.20		X					X						
-crypto-common@0.1.6		X					X						
-cstr@0.2.12							X						
-digest@0.10.7		X					X						
-displaydoc@0.2.4		X					X						
-either@1.12.0		X					X						
-errno@0.3.9		X					X						
-event-listener@4.0.3		X					X						
-fastrand@2.1.0		X					X						
-flagset@0.4.5		X											
-fnv@1.0.7		X					X						
-form_urlencoded@1.2.1		X					X						
-fuse3@0.7.2							X						
-fuse3_opendal@0.0.0		X											
-futures@0.3.30		X					X						
-futures-channel@0.3.30		X					X						
-futures-core@0.3.30		X					X						
-futures-io@0.3.30		X					X						
-futures-macro@0.3.30		X					X						
-futures-sink@0.3.30		X					X						
-futures-task@0.3.30		X					X						
-futures-util@0.3.30		X					X						
-generic-array@0.14.7							X						
-getrandom@0.2.15		X					X						
-gimli@0.29.0		X					X						
-home@0.5.9		X					X						
-http@1.1.0		X					X						
-http-body@1.0.0							X						
-http-body-util@0.1.2							X						
-httparse@1.9.3		X					X						
-hyper@1.3.1							X						
-hyper-rustls@0.26.0		X				X	X						
-hyper-util@0.1.5							X						
-iana-time-zone@0.1.60		X					X						
-iana-time-zone-haiku@0.1.2		X					X						
-icu_collections@1.5.0										X			
-icu_locid@1.5.0										X			
-icu_locid_transform@1.5.0										X			
-icu_locid_transform_data@1.5.0										X			
-icu_normalizer@1.5.0										X			
-icu_normalizer_data@1.5.0										X			
-icu_properties@1.5.0										X			
-icu_properties_data@1.5.0										X			
-icu_provider@1.5.0										X			
-icu_provider_macros@1.5.0										X			
-idna@1.0.0		X					X						
-ipnet@2.9.0		X					X						
-itoa@1.0.11		X					X						
-js-sys@0.3.69		X					X						
-lazy_static@1.4.0		X					X						
-libc@0.2.155		X					X						
-linux-raw-sys@0.4.14		X	X				X						
-litemap@0.7.3										X			
-log@0.4.21		X					X						
-md-5@0.10.6		X					X						
-memchr@2.7.2							X					X	
-memoffset@0.9.1							X						
-mime@0.3.17		X					X						
-miniz_oxide@0.7.3		X					X						X
-mio@0.8.11							X						
-nix@0.28.0							X						
-num-traits@0.2.19		X					X						
-object@0.36.0		X					X						
-once_cell@1.19.0		X					X						
-opendal@0.47.1		X											
-parking@2.2.0		X					X						
-percent-encoding@2.3.1		X					X						
-pin-project@1.1.5		X					X						
-pin-project-internal@1.1.5		X					X						
-pin-project-lite@0.2.14		X					X						
-pin-utils@0.1.0		X					X						
-proc-macro2@1.0.85		X					X						
-quick-xml@0.31.0							X						
-quote@1.0.36		X					X						
-reqwest@0.12.4		X					X						
-ring@0.17.8									X				
-rustc-demangle@0.1.24		X					X						
-rustix@0.38.34		X	X				X						
-rustls@0.22.4		X				X	X						
-rustls-pemfile@2.1.2		X				X	X						
-rustls-pki-types@1.7.0		X					X						
-rustls-webpki@0.102.4						X							
-ryu@1.0.18		X			X								
-serde@1.0.203		X					X						
-serde_derive@1.0.203		X					X						
-serde_json@1.0.117		X					X						
-serde_urlencoded@0.7.1		X					X						
-sharded-slab@0.1.7							X						
-signal-hook-registry@1.4.2		X					X						
-slab@0.4.9							X						
-smallvec@1.13.2		X					X						
-socket2@0.5.7		X					X						
-spin@0.9.8							X						
-stable_deref_trait@1.2.0		X					X						
-subtle@2.5.0				X									
-syn@2.0.66		X					X						
-sync_wrapper@0.1.2		X											
-synstructure@0.13.1							X						
-tinystr@0.7.6										X			
-tokio@1.38.0							X						
-tokio-macros@2.3.0							X						
-tokio-rustls@0.25.0		X					X						
-tokio-util@0.7.11							X						
-tower@0.4.13							X						
-tower-layer@0.3.2							X						
-tower-service@0.3.2							X						
-tracing@0.1.40							X						
-tracing-attributes@0.1.27							X						
-tracing-core@0.1.32							X						
-trait-make@0.1.0		X					X						
-try-lock@0.2.5							X						
-typenum@1.17.0		X					X						
-unicode-ident@1.0.12		X					X				X		
-untrusted@0.9.0						X							
-url@2.5.1		X					X						
-utf16_iter@1.0.5		X					X						
-utf8_iter@1.0.4		X					X						
-uuid@1.8.0		X					X						
-version_check@0.9.4		X					X						
-want@0.3.1							X						
-wasi@0.11.0+wasi-snapshot-preview1		X	X				X						
-wasm-bindgen@0.2.92		X					X						
-wasm-bindgen-backend@0.2.92		X					X						
-wasm-bindgen-futures@0.4.42		X					X						
-wasm-bindgen-macro@0.2.92		X					X						
-wasm-bindgen-macro-support@0.2.92		X					X						
-wasm-bindgen-shared@0.2.92		X					X						
-wasm-streams@0.4.0		X					X						
-web-sys@0.3.69		X					X						
-webpki-roots@0.26.2								X					
-which@6.0.1							X						
-windows-core@0.52.0		X					X						
-windows-sys@0.48.0		X					X						
-windows-sys@0.52.0		X					X						
-windows-targets@0.48.5		X					X						
-windows-targets@0.52.5		X					X						
-windows_aarch64_gnullvm@0.48.5		X					X						
-windows_aarch64_gnullvm@0.52.5		X					X						
-windows_aarch64_msvc@0.48.5		X					X						
-windows_aarch64_msvc@0.52.5		X					X						
-windows_i686_gnu@0.48.5		X					X						
-windows_i686_gnu@0.52.5		X					X						
-windows_i686_gnullvm@0.52.5		X					X						
-windows_i686_msvc@0.48.5		X					X						
-windows_i686_msvc@0.52.5		X					X						
-windows_x86_64_gnu@0.48.5		X					X						
-windows_x86_64_gnu@0.52.5		X					X						
-windows_x86_64_gnullvm@0.48.5		X					X						
-windows_x86_64_gnullvm@0.52.5		X					X						
-windows_x86_64_msvc@0.48.5		X					X						
-windows_x86_64_msvc@0.52.5		X					X						
-winreg@0.52.0							X						
-winsafe@0.0.19							X						
-write16@1.0.0		X					X						
-writeable@0.5.5										X			
-yoke@0.7.4										X			
-yoke-derive@0.7.4										X			
-zerofrom@0.1.4										X			
-zerofrom-derive@0.1.4										X			
-zeroize@1.8.1		X					X						
-zerovec@0.10.2										X			
-zerovec-derive@0.10.2										X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
+addr2line@0.22.0		X					X					
+adler@1.0.2	X	X					X					
+android-tzdata@0.1.1		X					X					
+android_system_properties@0.1.5		X					X					
+anyhow@1.0.86		X					X					
+async-notify@0.3.0							X					
+async-trait@0.1.80		X					X					
+autocfg@1.3.0		X					X					
+backon@0.4.4		X										
+backtrace@0.3.73		X					X					
+base64@0.22.1		X					X					
+bincode@1.3.3							X					
+bitflags@2.6.0		X					X					
+block-buffer@0.10.4		X					X					
+bumpalo@3.16.0		X					X					
+bytes@1.6.0							X					
+cc@1.0.103		X					X					
+cfg-if@1.0.0		X					X					
+cfg_aliases@0.1.1							X					
+chrono@0.4.38		X					X					
+concurrent-queue@2.5.0		X					X					
+core-foundation-sys@0.8.6		X					X					
+crossbeam-utils@0.8.20		X					X					
+crypto-common@0.1.6		X					X					
+cstr@0.2.12							X					
+digest@0.10.7		X					X					
+either@1.13.0		X					X					
+errno@0.3.9		X					X					
+event-listener@4.0.3		X					X					
+fastrand@2.1.0		X					X					
+flagset@0.4.5		X										
+fnv@1.0.7		X					X					
+form_urlencoded@1.2.1		X					X					
+fuse3@0.7.2							X					
+fuse3_opendal@0.0.1		X										
+futures@0.3.30		X					X					
+futures-channel@0.3.30		X					X					
+futures-core@0.3.30		X					X					
+futures-io@0.3.30		X					X					
+futures-macro@0.3.30		X					X					
+futures-sink@0.3.30		X					X					
+futures-task@0.3.30		X					X					
+futures-util@0.3.30		X					X					
+generic-array@0.14.7							X					
+getrandom@0.2.15		X					X					
+gimli@0.29.0		X					X					
+home@0.5.9		X					X					
+http@1.1.0		X					X					
+http-body@1.0.0							X					
+http-body-util@0.1.2							X					
+httparse@1.9.4		X					X					
+hyper@1.3.1							X					
+hyper-rustls@0.27.2		X				X	X					
+hyper-util@0.1.5							X					
+iana-time-zone@0.1.60		X					X					
+iana-time-zone-haiku@0.1.2		X					X					
+idna@0.5.0		X					X					
+ipnet@2.9.0		X					X					
+itoa@1.0.11		X					X					
+js-sys@0.3.69		X					X					
+lazy_static@1.5.0		X					X					
+libc@0.2.155		X					X					
+linux-raw-sys@0.4.14		X	X				X					
+log@0.4.22		X					X					
+md-5@0.10.6		X					X					
+memchr@2.7.4							X				X	
+memoffset@0.9.1							X					
+mime@0.3.17		X					X					
+miniz_oxide@0.7.4		X					X					X
+mio@0.8.11							X					
+nix@0.28.0							X					
+num-traits@0.2.19		X					X					
+object@0.36.1		X					X					
+once_cell@1.19.0		X					X					
+opendal@0.47.2		X										
+parking@2.2.0		X					X					
+percent-encoding@2.3.1		X					X					
+pin-project@1.1.5		X					X					
+pin-project-internal@1.1.5		X					X					
+pin-project-lite@0.2.14		X					X					
+pin-utils@0.1.0		X					X					
+proc-macro2@1.0.86		X					X					
+quick-xml@0.31.0							X					
+quote@1.0.36		X					X					
+reqwest@0.12.5		X					X					
+ring@0.17.8									X			
+rustc-demangle@0.1.24		X					X					
+rustix@0.38.34		X	X				X					
+rustls@0.23.10		X				X	X					
+rustls-pemfile@2.1.2		X				X	X					
+rustls-pki-types@1.7.0		X					X					
+rustls-webpki@0.102.4						X						
+ryu@1.0.18		X			X							
+serde@1.0.203		X					X					
+serde_derive@1.0.203		X					X					
+serde_json@1.0.118		X					X					
+serde_urlencoded@0.7.1		X					X					
+sharded-slab@0.1.7							X					
+signal-hook-registry@1.4.2		X					X					
+slab@0.4.9							X					
+smallvec@1.13.2		X					X					
+socket2@0.5.7		X					X					
+spin@0.9.8							X					
+subtle@2.6.1				X								
+syn@2.0.68		X					X					
+sync_wrapper@1.0.1		X										
+tinyvec@1.6.1		X					X					X
+tinyvec_macros@0.1.1		X					X					X
+tokio@1.38.0							X					
+tokio-macros@2.3.0							X					
+tokio-rustls@0.26.0		X					X					
+tokio-util@0.7.11							X					
+tower@0.4.13							X					
+tower-layer@0.3.2							X					
+tower-service@0.3.2							X					
+tracing@0.1.40							X					
+tracing-attributes@0.1.27							X					
+tracing-core@0.1.32							X					
+trait-make@0.1.0		X					X					
+try-lock@0.2.5							X					
+typenum@1.17.0		X					X					
+unicode-bidi@0.3.15		X					X					
+unicode-ident@1.0.12		X					X			X		
+unicode-normalization@0.1.23		X					X					
+untrusted@0.9.0						X						
+url@2.5.2		X					X					
+uuid@1.9.1		X					X					
+version_check@0.9.4		X					X					
+want@0.3.1							X					
+wasi@0.11.0+wasi-snapshot-preview1		X	X				X					
+wasm-bindgen@0.2.92		X					X					
+wasm-bindgen-backend@0.2.92		X					X					
+wasm-bindgen-futures@0.4.42		X					X					
+wasm-bindgen-macro@0.2.92		X					X					
+wasm-bindgen-macro-support@0.2.92		X					X					
+wasm-bindgen-shared@0.2.92		X					X					
+wasm-streams@0.4.0		X					X					
+web-sys@0.3.69		X					X					
+webpki-roots@0.26.3								X				
+which@6.0.1							X					
+windows-core@0.52.0		X					X					
+windows-sys@0.48.0		X					X					
+windows-sys@0.52.0		X					X					
+windows-targets@0.48.5		X					X					
+windows-targets@0.52.5		X					X					
+windows_aarch64_gnullvm@0.48.5		X					X					
+windows_aarch64_gnullvm@0.52.5		X					X					
+windows_aarch64_msvc@0.48.5		X					X					
+windows_aarch64_msvc@0.52.5		X					X					
+windows_i686_gnu@0.48.5		X					X					
+windows_i686_gnu@0.52.5		X					X					
+windows_i686_gnullvm@0.52.5		X					X					
+windows_i686_msvc@0.48.5		X					X					
+windows_i686_msvc@0.52.5		X					X					
+windows_x86_64_gnu@0.48.5		X					X					
+windows_x86_64_gnu@0.52.5		X					X					
+windows_x86_64_gnullvm@0.48.5		X					X					
+windows_x86_64_gnullvm@0.52.5		X					X					
+windows_x86_64_msvc@0.48.5		X					X					
+windows_x86_64_msvc@0.52.5		X					X					
+winreg@0.52.0							X					
+winsafe@0.0.19							X					
+zeroize@1.8.1		X					X					

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.44.1"
+version = "0.44.2"
 
 [features]
 send_wrapper = ["dep:send_wrapper"]

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -7,23 +7,23 @@ anyhow@1.0.86		X					X
 async-trait@0.1.80		X					X					
 autocfg@1.3.0		X					X					
 backon@0.4.4		X										
-backtrace@0.3.72		X					X					
+backtrace@0.3.73		X					X					
 base64@0.22.1		X					X					
-bitflags@2.5.0		X					X					
+bitflags@2.6.0		X					X					
 block-buffer@0.10.4		X					X					
 bumpalo@3.16.0		X					X					
 bytes@1.6.0							X					
-cc@1.0.98		X					X					
+cc@1.0.103		X					X					
 cfg-if@1.0.0		X					X					
 chrono@0.4.38		X					X					
 const-oid@0.9.6		X					X					
 core-foundation-sys@0.8.6		X					X					
 cpufeatures@0.2.12		X					X					
-crc32c@0.6.7		X					X					
+crc32c@0.6.8		X					X					
 crypto-common@0.1.6		X					X					
 digest@0.10.7		X					X					
 doc-comment@0.3.3							X					
-either@1.12.0		X					X					
+either@1.13.0		X					X					
 fastrand@2.1.0		X					X					
 flagset@0.4.5		X										
 fnv@1.0.7		X					X					
@@ -47,11 +47,11 @@ hmac@0.12.1		X					X
 home@0.5.9		X					X					
 http@1.1.0		X					X					
 http-body@1.0.0							X					
-http-body-util@0.1.1							X					
-httparse@1.8.0		X					X					
+http-body-util@0.1.2							X					
+httparse@1.9.4		X					X					
 humantime@2.1.0		X					X					
 hyper@1.3.1							X					
-hyper-rustls@0.26.0		X				X	X					
+hyper-rustls@0.27.2		X				X	X					
 hyper-util@0.1.5							X					
 iana-time-zone@0.1.60		X					X					
 iana-time-zone-haiku@0.1.2		X					X					
@@ -62,19 +62,19 @@ itoa@1.0.11		X					X
 js-sys@0.3.69		X					X					
 libc@0.2.155		X					X					
 lock_api@0.4.12		X					X					
-log@0.4.21		X					X					
+log@0.4.22		X					X					
 md-5@0.10.6		X					X					
-memchr@2.7.2							X				X	
+memchr@2.7.4							X				X	
 mime@0.3.17		X					X					
-miniz_oxide@0.7.3		X					X					X
+miniz_oxide@0.7.4		X					X					X
 mio@0.8.11							X					
 num-traits@0.2.19		X					X					
 num_cpus@1.16.0		X					X					
-object@0.35.0		X					X					
+object@0.36.1		X					X					
 object_store@0.10.1		X					X					
-object_store_opendal@0.44.1		X										
+object_store_opendal@0.44.2		X										
 once_cell@1.19.0		X					X					
-opendal@0.47.1		X										
+opendal@0.47.2		X										
 parking_lot@0.12.3		X					X					
 parking_lot_core@0.9.10		X					X					
 percent-encoding@2.3.1		X					X					
@@ -83,19 +83,19 @@ pin-project-internal@1.1.5		X					X
 pin-project-lite@0.2.14		X					X					
 pin-utils@0.1.0		X					X					
 ppv-lite86@0.2.17		X					X					
-proc-macro2@1.0.85		X					X					
+proc-macro2@1.0.86		X					X					
 quick-xml@0.31.0							X					
 quote@1.0.36		X					X					
 rand@0.8.5		X					X					
 rand_chacha@0.3.1		X					X					
 rand_core@0.6.4		X					X					
-redox_syscall@0.5.1							X					
+redox_syscall@0.5.2							X					
 reqsign@0.15.2		X										
-reqwest@0.12.4		X					X					
+reqwest@0.12.5		X					X					
 ring@0.17.8									X			
 rustc-demangle@0.1.24		X					X					
 rustc_version@0.4.0		X					X					
-rustls@0.22.4		X				X	X					
+rustls@0.23.10		X				X	X					
 rustls-pemfile@2.1.2		X				X	X					
 rustls-pki-types@1.7.0		X					X					
 rustls-webpki@0.102.4						X						
@@ -105,7 +105,7 @@ scopeguard@1.2.0		X					X
 semver@1.0.23		X					X					
 serde@1.0.203		X					X					
 serde_derive@1.0.203		X					X					
-serde_json@1.0.117		X					X					
+serde_json@1.0.118		X					X					
 serde_urlencoded@0.7.1		X					X					
 sha1@0.10.6		X					X					
 sha2@0.10.8		X					X					
@@ -115,15 +115,15 @@ snafu@0.7.5		X					X
 snafu-derive@0.7.5		X					X					
 socket2@0.5.7		X					X					
 spin@0.9.8							X					
-subtle@2.5.0				X								
+subtle@2.6.1				X								
 syn@1.0.109		X					X					
-syn@2.0.66		X					X					
-sync_wrapper@0.1.2		X										
-tinyvec@1.6.0		X					X					X
+syn@2.0.68		X					X					
+sync_wrapper@1.0.1		X										
+tinyvec@1.6.1		X					X					X
 tinyvec_macros@0.1.1		X					X					X
 tokio@1.38.0							X					
 tokio-macros@2.3.0							X					
-tokio-rustls@0.25.0		X					X					
+tokio-rustls@0.26.0		X					X					
 tokio-util@0.7.11							X					
 tower@0.4.13							X					
 tower-layer@0.3.2							X					
@@ -137,8 +137,8 @@ unicode-bidi@0.3.15		X					X
 unicode-ident@1.0.12		X					X			X		
 unicode-normalization@0.1.23		X					X					
 untrusted@0.9.0						X						
-url@2.5.0		X					X					
-uuid@1.8.0		X					X					
+url@2.5.2		X					X					
+uuid@1.9.1		X					X					
 version_check@0.9.4		X					X					
 walkdir@2.5.0							X				X	
 want@0.3.1							X					
@@ -151,7 +151,7 @@ wasm-bindgen-macro-support@0.2.92		X					X
 wasm-bindgen-shared@0.2.92		X					X					
 wasm-streams@0.4.0		X					X					
 web-sys@0.3.69		X					X					
-webpki-roots@0.26.2								X				
+webpki-roots@0.26.3								X				
 winapi-util@0.1.8							X				X	
 windows-core@0.52.0		X					X					
 windows-sys@0.48.0		X					X					

--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 name = "unftp-sbe-opendal"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.0.0"
+version = "0.0.1"
 
 [dependencies]
 async-trait = "0.1.80"

--- a/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
+++ b/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
@@ -1,238 +1,224 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-3.0	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.22.0		X					X						
-adler@1.0.2	X	X					X						
-android-tzdata@0.1.1		X					X						
-android_system_properties@0.1.5		X					X						
-anyhow@1.0.86		X					X						
-arc-swap@1.7.1		X					X						
-asn1-rs@0.6.1		X					X						
-asn1-rs-derive@0.5.0		X					X						
-asn1-rs-impl@0.2.0		X					X						
-async-trait@0.1.80		X					X						
-autocfg@1.3.0		X					X						
-backon@0.4.4		X											
-backtrace@0.3.73		X					X						
-base64@0.21.7		X					X						
-base64@0.22.1		X					X						
-bitflags@2.5.0		X					X						
-block-buffer@0.10.4		X					X						
-bumpalo@3.16.0		X					X						
-bytecount@0.6.8		X					X						
-bytes@1.6.0							X						
-camino@1.1.7		X					X						
-cargo-platform@0.1.8		X					X						
-cargo_metadata@0.14.2							X						
-cc@1.0.99		X					X						
-cfg-if@1.0.0		X					X						
-cfg_aliases@0.1.1							X						
-chrono@0.4.38		X					X						
-convert_case@0.4.0							X						
-core-foundation-sys@0.8.6		X					X						
-crossbeam-channel@0.5.13		X					X						
-crossbeam-epoch@0.9.18		X					X						
-crossbeam-utils@0.8.20		X					X						
-crypto-common@0.1.6		X					X						
-dashmap@5.5.3							X						
-data-encoding@2.6.0							X						
-der-parser@9.0.0		X					X						
-deranged@0.3.11		X					X						
-derive_more@0.99.18							X						
-digest@0.10.7		X					X						
-displaydoc@0.2.4		X					X						
-doc-comment@0.3.3							X						
-errno@0.3.9		X					X						
-error-chain@0.12.4		X					X						
-fastrand@2.1.0		X					X						
-flagset@0.4.5		X											
-fnv@1.0.7		X					X						
-form_urlencoded@1.2.1		X					X						
-futures@0.3.30		X					X						
-futures-channel@0.3.30		X					X						
-futures-core@0.3.30		X					X						
-futures-io@0.3.30		X					X						
-futures-macro@0.3.30		X					X						
-futures-sink@0.3.30		X					X						
-futures-task@0.3.30		X					X						
-futures-util@0.3.30		X					X						
-generic-array@0.14.7							X						
-getrandom@0.2.15		X					X						
-gimli@0.29.0		X					X						
-glob@0.3.1		X					X						
-hashbrown@0.14.5		X					X						
-http@1.1.0		X					X						
-http-body@1.0.0							X						
-http-body-util@0.1.2							X						
-httparse@1.9.4		X					X						
-hyper@1.3.1							X						
-hyper-rustls@0.27.2		X				X	X						
-hyper-util@0.1.5							X						
-iana-time-zone@0.1.60		X					X						
-iana-time-zone-haiku@0.1.2		X					X						
-icu_collections@1.5.0										X			
-icu_locid@1.5.0										X			
-icu_locid_transform@1.5.0										X			
-icu_locid_transform_data@1.5.0										X			
-icu_normalizer@1.5.0										X			
-icu_normalizer_data@1.5.0										X			
-icu_properties@1.5.0										X			
-icu_properties_data@1.5.0										X			
-icu_provider@1.5.0										X			
-icu_provider_macros@1.5.0										X			
-idna@1.0.0		X					X						
-ipnet@2.9.0		X					X						
-itoa@1.0.11		X					X						
-js-sys@0.3.69		X					X						
-lazy_static@1.4.0		X					X						
-libc@0.2.155		X					X						
-libunftp@0.20.0		X											
-linux-raw-sys@0.4.14		X	X				X						
-litemap@0.7.3										X			
-lock_api@0.4.12		X					X						
-log@0.4.21		X					X						
-md-5@0.10.6		X					X						
-memchr@2.7.4							X					X	
-mime@0.3.17		X					X						
-minimal-lexical@0.2.1		X					X						
-miniz_oxide@0.7.4		X					X						X
-mio@0.8.11							X						
-moka@0.11.3		X					X						
-nix@0.28.0							X						
-nom@7.1.3							X						
-num-bigint@0.4.5		X					X						
-num-conv@0.1.0		X					X						
-num-integer@0.1.46		X					X						
-num-traits@0.2.19		X					X						
-object@0.36.0		X					X						
-oid-registry@0.7.0		X					X						
-once_cell@1.19.0		X					X						
-opendal@0.47.1		X											
-parking_lot@0.12.3		X					X						
-parking_lot_core@0.9.10		X					X						
-percent-encoding@2.3.1		X					X						
-pin-project@1.1.5		X					X						
-pin-project-internal@1.1.5		X					X						
-pin-project-lite@0.2.14		X					X						
-pin-utils@0.1.0		X					X						
-powerfmt@0.2.0		X					X						
-proc-macro2@1.0.85		X					X						
-prometheus@0.13.4		X											
-proxy-protocol@0.5.0		X					X						
-pulldown-cmark@0.9.6							X						
-quick-xml@0.31.0							X						
-quote@1.0.36		X					X						
-redox_syscall@0.5.2							X						
-reqwest@0.12.5		X					X						
-ring@0.17.8									X				
-rustc-demangle@0.1.24		X					X						
-rustc_version@0.4.0		X					X						
-rusticata-macros@4.1.0		X					X						
-rustix@0.38.34		X	X				X						
-rustls@0.21.12		X				X	X						
-rustls@0.23.10		X				X	X						
-rustls-pemfile@1.0.4		X				X	X						
-rustls-pemfile@2.1.2		X				X	X						
-rustls-pki-types@1.7.0		X					X						
-rustls-webpki@0.101.7						X							
-rustls-webpki@0.102.4						X							
-ryu@1.0.18		X			X								
-same-file@1.0.6							X					X	
-scheduled-thread-pool@0.2.7		X					X						
-scopeguard@1.2.0		X					X						
-sct@0.7.1		X				X	X						
-semver@1.0.23		X					X						
-serde@1.0.203		X					X						
-serde_derive@1.0.203		X					X						
-serde_json@1.0.117		X					X						
-serde_urlencoded@0.7.1		X					X						
-signal-hook-registry@1.4.2		X					X						
-skeptic@0.13.7		X					X						
-slab@0.4.9							X						
-slog@2.7.0		X					X	X					
-slog-scope@4.4.0		X					X	X					
-slog-stdlog@4.1.1		X					X	X					
-smallvec@1.13.2		X					X						
-snafu@0.6.10		X					X						
-snafu-derive@0.6.10		X					X						
-socket2@0.5.7		X					X						
-spin@0.9.8							X						
-stable_deref_trait@1.2.0		X					X						
-subtle@2.5.0				X									
-syn@1.0.109		X					X						
-syn@2.0.66		X					X						
-sync_wrapper@1.0.1		X											
-synstructure@0.13.1							X						
-tagptr@0.2.0		X					X						
-tempfile@3.10.1		X					X						
-thiserror@1.0.61		X					X						
-thiserror-impl@1.0.61		X					X						
-time@0.3.36		X					X						
-time-core@0.1.2		X					X						
-time-macros@0.2.18		X					X						
-tinystr@0.7.6										X			
-tokio@1.38.0							X						
-tokio-macros@2.3.0							X						
-tokio-rustls@0.24.1		X					X						
-tokio-rustls@0.26.0		X					X						
-tokio-util@0.7.11							X						
-tower@0.4.13							X						
-tower-layer@0.3.2							X						
-tower-service@0.3.2							X						
-tracing@0.1.40							X						
-tracing-attributes@0.1.27							X						
-tracing-core@0.1.32							X						
-triomphe@0.1.13		X					X						
-try-lock@0.2.5							X						
-typenum@1.17.0		X					X						
-unftp-sbe-opendal@0.0.0		X											
-unicase@2.7.0		X					X						
-unicode-ident@1.0.12		X					X				X		
-untrusted@0.9.0						X							
-url@2.5.1		X					X						
-utf16_iter@1.0.5		X					X						
-utf8_iter@1.0.4		X					X						
-uuid@1.8.0		X					X						
-version_check@0.9.4		X					X						
-walkdir@2.5.0							X					X	
-want@0.3.1							X						
-wasi@0.11.0+wasi-snapshot-preview1		X	X				X						
-wasm-bindgen@0.2.92		X					X						
-wasm-bindgen-backend@0.2.92		X					X						
-wasm-bindgen-futures@0.4.42		X					X						
-wasm-bindgen-macro@0.2.92		X					X						
-wasm-bindgen-macro-support@0.2.92		X					X						
-wasm-bindgen-shared@0.2.92		X					X						
-wasm-streams@0.4.0		X					X						
-web-sys@0.3.69		X					X						
-webpki-roots@0.26.3								X					
-winapi-util@0.1.8							X					X	
-windows-core@0.52.0		X					X						
-windows-sys@0.48.0		X					X						
-windows-sys@0.52.0		X					X						
-windows-targets@0.48.5		X					X						
-windows-targets@0.52.5		X					X						
-windows_aarch64_gnullvm@0.48.5		X					X						
-windows_aarch64_gnullvm@0.52.5		X					X						
-windows_aarch64_msvc@0.48.5		X					X						
-windows_aarch64_msvc@0.52.5		X					X						
-windows_i686_gnu@0.48.5		X					X						
-windows_i686_gnu@0.52.5		X					X						
-windows_i686_gnullvm@0.52.5		X					X						
-windows_i686_msvc@0.48.5		X					X						
-windows_i686_msvc@0.52.5		X					X						
-windows_x86_64_gnu@0.48.5		X					X						
-windows_x86_64_gnu@0.52.5		X					X						
-windows_x86_64_gnullvm@0.48.5		X					X						
-windows_x86_64_gnullvm@0.52.5		X					X						
-windows_x86_64_msvc@0.48.5		X					X						
-windows_x86_64_msvc@0.52.5		X					X						
-winreg@0.52.0							X						
-write16@1.0.0		X					X						
-writeable@0.5.5										X			
-x509-parser@0.16.0		X					X						
-yoke@0.7.4										X			
-yoke-derive@0.7.4										X			
-zerofrom@0.1.4										X			
-zerofrom-derive@0.1.4										X			
-zeroize@1.8.1		X					X						
-zerovec@0.10.2										X			
-zerovec-derive@0.10.2										X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MIT-0	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
+addr2line@0.22.0		X						X						
+adler@1.0.2	X	X						X						
+android-tzdata@0.1.1		X						X						
+android_system_properties@0.1.5		X						X						
+anyhow@1.0.86		X						X						
+arc-swap@1.7.1		X						X						
+asn1-rs@0.6.1		X						X						
+asn1-rs-derive@0.5.0		X						X						
+asn1-rs-impl@0.2.0		X						X						
+async-trait@0.1.80		X						X						
+autocfg@1.3.0		X						X						
+aws-lc-rs@1.8.0		X					X							
+aws-lc-sys@0.19.0		X					X				X			
+backon@0.4.4		X												
+backtrace@0.3.73		X						X						
+base64@0.22.1		X						X						
+bindgen@0.69.4				X										
+bitflags@2.6.0		X						X						
+block-buffer@0.10.4		X						X						
+bumpalo@3.16.0		X						X						
+bytes@1.6.0								X						
+cc@1.0.103		X						X						
+cexpr@0.6.0		X						X						
+cfg-if@1.0.0		X						X						
+cfg_aliases@0.2.1								X						
+chrono@0.4.38		X						X						
+clang-sys@1.8.1		X												
+cmake@0.1.50		X						X						
+convert_case@0.4.0								X						
+core-foundation-sys@0.8.6		X						X						
+crossbeam-channel@0.5.13		X						X						
+crossbeam-epoch@0.9.18		X						X						
+crossbeam-utils@0.8.20		X						X						
+crypto-common@0.1.6		X						X						
+dashmap@5.5.3								X						
+data-encoding@2.6.0								X						
+der-parser@9.0.0		X						X						
+deranged@0.3.11		X						X						
+derive_more@0.99.18								X						
+digest@0.10.7		X						X						
+displaydoc@0.2.5		X						X						
+doc-comment@0.3.3								X						
+dunce@1.0.4		X				X			X					
+either@1.13.0		X						X						
+errno@0.3.9		X						X						
+fastrand@2.1.0		X						X						
+flagset@0.4.5		X												
+fnv@1.0.7		X						X						
+form_urlencoded@1.2.1		X						X						
+fs_extra@1.3.0								X						
+futures@0.3.30		X						X						
+futures-channel@0.3.30		X						X						
+futures-core@0.3.30		X						X						
+futures-io@0.3.30		X						X						
+futures-macro@0.3.30		X						X						
+futures-sink@0.3.30		X						X						
+futures-task@0.3.30		X						X						
+futures-util@0.3.30		X						X						
+generic-array@0.14.7								X						
+getrandom@0.2.15		X						X						
+gimli@0.29.0		X						X						
+glob@0.3.1		X						X						
+hashbrown@0.14.5		X						X						
+home@0.5.9		X						X						
+http@1.1.0		X						X						
+http-body@1.0.0								X						
+http-body-util@0.1.2								X						
+httparse@1.9.4		X						X						
+hyper@1.3.1								X						
+hyper-rustls@0.27.2		X					X	X						
+hyper-util@0.1.5								X						
+iana-time-zone@0.1.60		X						X						
+iana-time-zone-haiku@0.1.2		X						X						
+idna@0.5.0		X						X						
+ipnet@2.9.0		X						X						
+itertools@0.12.1		X						X						
+itoa@1.0.11		X						X						
+jobserver@0.1.31		X						X						
+js-sys@0.3.69		X						X						
+lazy_static@1.5.0		X						X						
+lazycell@1.3.0		X						X						
+libc@0.2.155		X						X						
+libloading@0.8.4							X							
+libunftp@0.20.1		X												
+linux-raw-sys@0.4.14		X	X					X						
+lock_api@0.4.12		X						X						
+log@0.4.22		X						X						
+md-5@0.10.6		X						X						
+memchr@2.7.4								X					X	
+mime@0.3.17		X						X						
+minimal-lexical@0.2.1		X						X						
+miniz_oxide@0.7.4		X						X						X
+mio@0.8.11								X						
+mirai-annotations@1.12.0								X						
+moka@0.12.7		X						X						
+nix@0.29.0								X						
+nom@7.1.3								X						
+num-bigint@0.4.6		X						X						
+num-conv@0.1.0		X						X						
+num-integer@0.1.46		X						X						
+num-traits@0.2.19		X						X						
+object@0.36.1		X						X						
+oid-registry@0.7.0		X						X						
+once_cell@1.19.0		X						X						
+opendal@0.47.2		X												
+parking_lot@0.12.3		X						X						
+parking_lot_core@0.9.10		X						X						
+paste@1.0.15		X						X						
+percent-encoding@2.3.1		X						X						
+pin-project@1.1.5		X						X						
+pin-project-internal@1.1.5		X						X						
+pin-project-lite@0.2.14		X						X						
+pin-utils@0.1.0		X						X						
+powerfmt@0.2.0		X						X						
+prettyplease@0.2.20		X						X						
+proc-macro2@1.0.86		X						X						
+prometheus@0.13.4		X												
+proxy-protocol@0.5.0		X						X						
+quick-xml@0.31.0								X						
+quote@1.0.36		X						X						
+redox_syscall@0.5.2								X						
+regex@1.10.5		X						X						
+regex-automata@0.4.7		X						X						
+regex-syntax@0.8.4		X						X						
+reqwest@0.12.5		X						X						
+ring@0.17.8											X			
+rustc-demangle@0.1.24		X						X						
+rustc-hash@1.1.0		X						X						
+rustc_version@0.4.0		X						X						
+rusticata-macros@4.1.0		X						X						
+rustix@0.38.34		X	X					X						
+rustls@0.23.10		X					X	X						
+rustls-pemfile@2.1.2		X					X	X						
+rustls-pki-types@1.7.0		X						X						
+rustls-webpki@0.102.4							X							
+ryu@1.0.18		X			X									
+scopeguard@1.2.0		X						X						
+semver@1.0.23		X						X						
+serde@1.0.203		X						X						
+serde_derive@1.0.203		X						X						
+serde_json@1.0.118		X						X						
+serde_urlencoded@0.7.1		X						X						
+shlex@1.3.0		X						X						
+signal-hook-registry@1.4.2		X						X						
+slab@0.4.9								X						
+slog@2.7.0		X						X		X				
+slog-scope@4.4.0		X						X		X				
+slog-stdlog@4.1.1		X						X		X				
+smallvec@1.13.2		X						X						
+snafu@0.6.10		X						X						
+snafu-derive@0.6.10		X						X						
+socket2@0.5.7		X						X						
+spin@0.9.8								X						
+subtle@2.6.1				X										
+syn@1.0.109		X						X						
+syn@2.0.68		X						X						
+sync_wrapper@1.0.1		X												
+synstructure@0.13.1								X						
+tagptr@0.2.0		X						X						
+thiserror@1.0.61		X						X						
+thiserror-impl@1.0.61		X						X						
+time@0.3.36		X						X						
+time-core@0.1.2		X						X						
+time-macros@0.2.18		X						X						
+tinyvec@1.6.1		X						X						X
+tinyvec_macros@0.1.1		X						X						X
+tokio@1.38.0								X						
+tokio-macros@2.3.0								X						
+tokio-rustls@0.26.0		X						X						
+tokio-util@0.7.11								X						
+tower@0.4.13								X						
+tower-layer@0.3.2								X						
+tower-service@0.3.2								X						
+tracing@0.1.40								X						
+tracing-attributes@0.1.27								X						
+tracing-core@0.1.32								X						
+triomphe@0.1.13		X						X						
+try-lock@0.2.5								X						
+typenum@1.17.0		X						X						
+unftp-sbe-opendal@0.0.1		X												
+unicode-bidi@0.3.15		X						X						
+unicode-ident@1.0.12		X						X				X		
+unicode-normalization@0.1.23		X						X						
+untrusted@0.9.0							X							
+url@2.5.2		X						X						
+uuid@1.9.1		X						X						
+version_check@0.9.4		X						X						
+want@0.3.1								X						
+wasi@0.11.0+wasi-snapshot-preview1		X	X					X						
+wasm-bindgen@0.2.92		X						X						
+wasm-bindgen-backend@0.2.92		X						X						
+wasm-bindgen-futures@0.4.42		X						X						
+wasm-bindgen-macro@0.2.92		X						X						
+wasm-bindgen-macro-support@0.2.92		X						X						
+wasm-bindgen-shared@0.2.92		X						X						
+wasm-streams@0.4.0		X						X						
+web-sys@0.3.69		X						X						
+webpki-roots@0.26.3										X				
+which@4.4.2								X						
+windows-core@0.52.0		X						X						
+windows-sys@0.48.0		X						X						
+windows-sys@0.52.0		X						X						
+windows-targets@0.48.5		X						X						
+windows-targets@0.52.5		X						X						
+windows_aarch64_gnullvm@0.48.5		X						X						
+windows_aarch64_gnullvm@0.52.5		X						X						
+windows_aarch64_msvc@0.48.5		X						X						
+windows_aarch64_msvc@0.52.5		X						X						
+windows_i686_gnu@0.48.5		X						X						
+windows_i686_gnu@0.52.5		X						X						
+windows_i686_gnullvm@0.52.5		X						X						
+windows_i686_msvc@0.48.5		X						X						
+windows_i686_msvc@0.52.5		X						X						
+windows_x86_64_gnu@0.48.5		X						X						
+windows_x86_64_gnu@0.52.5		X						X						
+windows_x86_64_gnullvm@0.48.5		X						X						
+windows_x86_64_gnullvm@0.52.5		X						X						
+windows_x86_64_msvc@0.48.5		X						X						
+windows_x86_64_msvc@0.52.5		X						X						
+winreg@0.52.0								X						
+x509-parser@0.16.0		X						X						
+zeroize@1.8.1		X						X						
+zeroize_derive@1.4.2		X						X						

--- a/integrations/virtiofs/DEPENDENCIES.rust.tsv
+++ b/integrations/virtiofs/DEPENDENCIES.rust.tsv
@@ -2,15 +2,15 @@ crate	Apache-2.0	BSD-3-Clause	MIT	Unicode-DFS-2016
 anyhow@1.0.86	X		X	
 arc-swap@1.7.1	X		X	
 bitflags@1.3.2	X		X	
-bitflags@2.5.0	X		X	
+bitflags@2.6.0	X		X	
 heck@0.5.0	X		X	
 libc@0.2.155	X		X	
-log@0.4.21	X		X	
-proc-macro2@1.0.85	X		X	
+log@0.4.22	X		X	
+proc-macro2@1.0.86	X		X	
 quote@1.0.36	X		X	
 snafu@0.8.3	X		X	
 snafu-derive@0.8.3	X		X	
-syn@2.0.66	X		X	
+syn@2.0.68	X		X	
 thiserror@1.0.61	X		X	
 thiserror-impl@1.0.61	X		X	
 unicode-ident@1.0.12	X		X	X

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -25,10 +25,13 @@ ROOT_DIR = Path(__file__).parent.parent
 def list_packages():
     packages = ["core"]
 
-    for dir in ["bin", "bindings", "integrations"]:
+    for dir in ["integrations", "bin", "bindings"]:
+        cur = []
         for path in (ROOT_DIR / dir).iterdir():
             if path.is_dir():
-                packages.append(path.relative_to(ROOT_DIR))
+                cur.append(path.relative_to(ROOT_DIR))
+        cur.sort()
+        packages.extend(cur)
     return packages
 
 


### PR DESCRIPTION
Part of https://github.com/apache/opendal/issues/4828

This PR contains the following release change:

| Name                      | Version | Next    |
| -                         | -       | -       |
| core                      | 0.47.1  | 0.47.2  |
| integrations/cloudfilter  | 0.0.0   | 0.0.0   |
| integrations/dav-server   | 0.0.3   | 0.0.4   |
| integrations/fuse3        | 0.0.0   | 0.0.1   |
| integrations/object_store | 0.44.1  | 0.44.2  |
| integrations/unftp-sbe    | 0.0.0   | 0.0.1   |
| integrations/virtiofs     | 0.0.0   | 0.0.0   |
| bin/oay                   | 0.41.4  | 0.41.5  |
| bin/ofs                   | 0.0.5   | 0.0.6   |
| bin/oli                   | 0.41.4  | 0.41.5  |
| bindings/c                | 0.44.6  | 0.44.7  |
| bindings/cpp              | 0.45.4  | 0.45.5  |
| bindings/dotnet           | 0.1.2   | 0.1.3   |
| bindings/go               | 0.0.0   | 0.0.0   |
| bindings/haskell          | 0.44.4  | 0.44.5  |
| bindings/java             | 0.46.1  | 0.46.2  |
| bindings/lua              | 0.1.2   | 0.1.3   |
| bindings/nodejs           | 0.46.2  | 0.47.0  |
| bindings/ocaml            | 0.0.0   | 0.0.0   |
| bindings/php              | 0.1.2   | 0.1.3   |
| bindings/python           | 0.45.4  | 0.45.5  |
| bindings/ruby             | 0.1.2   | 0.1.3   |
| bindings/swift            | 0.0.0   | 0.0.0   |
| bindings/zig              | 0.0.0   | 0.0.0   |