### PR TITLE
chore: Bump version for 0.47.3

### DIFF
--- a/.github/workflows/release_rust.yml
+++ b/.github/workflows/release_rust.yml
@@ -45,7 +45,6 @@ jobs:
           - "integrations/dav-server"
           - "integrations/fuse3"
           - "integrations/unftp-sbe"
-          - "integrations/virtiofs"
           - "bin/oay" # depends on integrations/dav-server
           - "bin/oli"
           - "bin/ofs" # depends on integrations/fuse3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- Release notes generated using configuration in .github/release.yml at main -->
 
+## [v0.47.3] - 2024-07-03
+
+### Changed
+* refactor: Move ChunkedWrite logic into WriteContext by @Xuanwo in https://github.com/apache/opendal/pull/4826
+* refactor(services/aliyun-drive): directly implement `oio::Write`. by @yuchanns in https://github.com/apache/opendal/pull/4821
+### Fixed
+* fix(integration/object_store): Avoid calling  API inside debug by @Xuanwo in https://github.com/apache/opendal/pull/4846
+* fix(integration/object_store): Fix metakey requested is incomplete by @Xuanwo in https://github.com/apache/opendal/pull/4844
+### Docs
+* docs(integration/unftp-sbe): Polish docs for unftp-sbe by @Xuanwo in https://github.com/apache/opendal/pull/4838
+* docs(bin): Polish README for all bin by @Xuanwo in https://github.com/apache/opendal/pull/4839
+### Chore
+* chore(deps): bump crate-ci/typos from 1.22.7 to 1.22.9 by @dependabot in https://github.com/apache/opendal/pull/4836
+* chore(deps): bump quick-xml from 0.32.0 to 0.35.0 in /bin/oay by @dependabot in https://github.com/apache/opendal/pull/4835
+* chore(deps): bump nix from 0.28.0 to 0.29.0 in /bin/ofs by @dependabot in https://github.com/apache/opendal/pull/4833
+* chore(deps): bump metrics from 0.20.1 to 0.23.0 in /core by @TennyZhuang in https://github.com/apache/opendal/pull/4843
+
 ## [v0.47.2] - 2024-06-30
 
 ### Added
@@ -3804,6 +3821,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 Hello, OpenDAL!
 
+[v0.47.3]: https://github.com/apache/opendal/compare/v0.47.2...v0.47.3
 [v0.47.2]: https://github.com/apache/opendal/compare/v0.47.1...v0.47.2
 [v0.47.1]: https://github.com/apache/opendal/compare/v0.47.0...v0.47.1
 [v0.47.0]: https://github.com/apache/opendal/compare/v0.46.0...v0.47.0

--- a/bin/oay/Cargo.lock
+++ b/bin/oay/Cargo.lock
@@ -254,9 +254,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2755ff20a1d93490d26ba33a6f092a38a508398a5320df5d4b3014fcccce9410"
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 
 [[package]]
 name = "cfg-if"
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "dav-server-opendalfs"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -664,9 +664,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "oay"
-version = "0.41.5"
+version = "0.41.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -983,7 +983,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1423,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",
@@ -2225,18 +2225,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bin/oay/Cargo.toml
+++ b/bin/oay/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.41.5"
+version = "0.41.6"
 
 [features]
 default = ["frontends-webdav", "frontends-s3"]
@@ -47,7 +47,7 @@ bytes = { version = "1.5.0", optional = true }
 chrono = "0.4.31"
 clap = { version = "4", features = ["cargo", "string"] }
 dav-server = { version = "0.6", optional = true }
-dav-server-opendalfs = { version = "0.0.4", path = "../../integrations/dav-server", optional = true }
+dav-server-opendalfs = { version = "0.0.5", path = "../../integrations/dav-server", optional = true }
 dirs = "5.0.1"
 futures = "0.3"
 futures-util = { version = "0.3.29", optional = true }

--- a/bin/oay/DEPENDENCIES.rust.tsv
+++ b/bin/oay/DEPENDENCIES.rust.tsv
@@ -24,7 +24,7 @@ bitflags@2.6.0		X						X
 block-buffer@0.10.4		X						X					
 bumpalo@3.16.0		X						X					
 bytes@1.6.0								X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 clap@4.5.8		X						X					
@@ -35,7 +35,7 @@ core-foundation-sys@0.8.6		X						X
 cpufeatures@0.2.12		X						X					
 crypto-common@0.1.6		X						X					
 dav-server@0.6.0		X											
-dav-server-opendalfs@0.0.4		X											
+dav-server-opendalfs@0.0.5		X											
 deranged@0.3.11		X						X					
 digest@0.10.7		X						X					
 dirs@5.0.1		X						X					
@@ -67,9 +67,9 @@ http-body@1.0.0								X
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
 httpdate@1.0.3		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -96,10 +96,10 @@ nu-ansi-term@0.46.0								X
 num-conv@0.1.0		X						X					
 num-traits@0.2.19		X						X					
 num_cpus@1.16.0		X						X					
-oay@0.41.5		X											
+oay@0.41.6		X											
 object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
+opendal@0.47.3		X											
 option-ext@0.2.0									X				
 overload@0.1.1								X					
 parking_lot@0.12.3		X						X					
@@ -113,7 +113,7 @@ powerfmt@0.2.0		X						X
 ppv-lite86@0.2.17		X						X					
 proc-macro2@1.0.86		X						X					
 quick-xml@0.31.0								X					
-quick-xml@0.32.0								X					
+quick-xml@0.35.0								X					
 quote@1.0.36		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
@@ -137,7 +137,7 @@ ryu@1.0.18		X				X
 scopeguard@1.2.0		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_path_to_error@0.1.16		X						X					
 serde_spanned@0.6.6		X						X					
 serde_urlencoded@0.7.1		X						X					
@@ -226,5 +226,5 @@ winnow@0.6.13								X
 winreg@0.52.0								X					
 xml-rs@0.8.20								X					
 xmltree@0.10.3								X					
-zerocopy@0.7.34		X		X				X					
+zerocopy@0.7.35		X		X				X					
 zeroize@1.8.1		X						X					

--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -195,9 +195,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2755ff20a1d93490d26ba33a6f092a38a508398a5320df5d4b3014fcccce9410"
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 
 [[package]]
 name = "cfg-if"
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "fuse3_opendal"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "bytes",
  "fuse3",
@@ -716,9 +716,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -753,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "ofs"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -993,7 +993,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1432,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",

--- a/bin/ofs/Cargo.toml
+++ b/bin/ofs/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["filesystem"]
 description = "OpenDAL File System"
 keywords = ["storage", "data", "s3", "fs", "azblob"]
 name = "ofs"
-version = "0.0.6"
+version = "0.0.7"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -36,7 +36,7 @@ chrono = "0.4.34"
 clap = { version = "4.5.7", features = ["derive", "env"] }
 env_logger = "0.11.2"
 fuse3 = { "version" = "0.7.2", "features" = ["tokio-runtime", "unprivileged"] }
-fuse3_opendal = { version = "0.0.1", path = "../../integrations/fuse3" }
+fuse3_opendal = { version = "0.0.2", path = "../../integrations/fuse3" }
 futures-util = "0.3.30"
 libc = "0.2.154"
 log = "0.4.21"

--- a/bin/ofs/DEPENDENCIES.rust.tsv
+++ b/bin/ofs/DEPENDENCIES.rust.tsv
@@ -21,9 +21,10 @@ bitflags@2.6.0		X						X
 block-buffer@0.10.4		X						X					
 bumpalo@3.16.0		X						X					
 bytes@1.6.0								X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cfg-if@1.0.0		X						X					
 cfg_aliases@0.1.1								X					
+cfg_aliases@0.2.1								X					
 chrono@0.4.38		X						X					
 clap@4.5.8		X						X					
 clap_builder@4.5.8		X						X					
@@ -54,7 +55,7 @@ flagset@0.4.5		X
 fnv@1.0.7		X						X					
 form_urlencoded@1.2.1		X						X					
 fuse3@0.7.2								X					
-fuse3_opendal@0.0.1		X											
+fuse3_opendal@0.0.2		X											
 futures@0.3.30		X						X					
 futures-channel@0.3.30		X						X					
 futures-core@0.3.30		X						X					
@@ -78,9 +79,9 @@ http-body@1.0.0								X
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
 humantime@2.1.0		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -99,12 +100,13 @@ mime@0.3.17		X						X
 miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
 nix@0.28.0								X					
+nix@0.29.0								X					
 num-traits@0.2.19		X						X					
 num_cpus@1.16.0		X						X					
 object@0.36.1		X						X					
-ofs@0.0.6		X											
+ofs@0.0.7		X											
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
+opendal@0.47.3		X											
 ordered-multimap@0.7.3								X					
 parking@2.2.0		X						X					
 percent-encoding@2.3.1		X						X					
@@ -137,7 +139,7 @@ ryu@1.0.18		X			X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					

--- a/bin/oli/Cargo.lock
+++ b/bin/oli/Cargo.lock
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2755ff20a1d93490d26ba33a6f092a38a508398a5320df5d4b3014fcccce9410"
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 dependencies = [
  "jobserver",
  "libc",
@@ -1427,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1452,7 +1452,7 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.0",
  "hyper-util",
  "rustls 0.23.10",
  "rustls-pki-types",
@@ -1476,16 +1476,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.3.1",
+ "hyper 1.4.0",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "oli"
-version = "0.41.5"
+version = "0.41.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2016,7 +2016,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "async-tls",
@@ -2700,7 +2700,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.0",
  "hyper-rustls",
  "hyper-util",
  "ipnet",
@@ -3040,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",

--- a/bin/oli/Cargo.toml
+++ b/bin/oli/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.41.5"
+version = "0.41.6"
 
 [features]
 # Enable services dashmap support

--- a/bin/oli/DEPENDENCIES.rust.tsv
+++ b/bin/oli/DEPENDENCIES.rust.tsv
@@ -25,7 +25,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -76,9 +76,9 @@ http-body@1.0.0								X
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
 humantime@2.1.0		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -107,9 +107,9 @@ num-iter@0.1.45		X						X
 num-traits@0.2.19		X						X					
 num_cpus@1.16.0		X						X					
 object@0.36.1		X						X					
-oli@0.41.5		X											
+oli@0.41.6		X											
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
+opendal@0.47.3		X											
 option-ext@0.2.0									X				
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
@@ -152,7 +152,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_spanned@0.6.6		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.44.7"
+version = "0.44.8"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -22,7 +22,7 @@ byteorder@1.5.0								X				X
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
 cbindgen@0.26.0									X				
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -68,9 +68,9 @@ http@1.1.0		X						X
 http-body@1.0.0								X					
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -99,8 +99,8 @@ num-traits@0.2.19		X						X
 num_cpus@1.16.0		X						X					
 object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
-opendal-c@0.44.7		X											
+opendal@0.47.3		X											
+opendal-c@0.44.8		X											
 ordered-multimap@0.7.3								X					
 os_str_bytes@6.6.1		X						X					
 pbkdf2@0.12.2		X						X					
@@ -140,7 +140,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -16,7 +16,7 @@
 # under the License.
 
 cmake_minimum_required(VERSION 3.10)
-project(opendal-cpp VERSION 0.45.5 LANGUAGES CXX)
+project(opendal-cpp VERSION 0.45.6 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/bindings/cpp/Cargo.toml
+++ b/bindings/cpp/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.5"
+version = "0.45.6"
 
 [lib]
 crate-type = ["staticlib"]

--- a/bindings/cpp/DEPENDENCIES.rust.tsv
+++ b/bindings/cpp/DEPENDENCIES.rust.tsv
@@ -18,7 +18,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -62,9 +62,9 @@ http@1.1.0		X						X
 http-body@1.0.0								X					
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -91,8 +91,8 @@ num-iter@0.1.45		X						X
 num-traits@0.2.19		X						X					
 object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
-opendal-cpp@0.45.5		X											
+opendal@0.47.3		X											
+opendal-cpp@0.45.6		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
 pem@3.0.4								X					
@@ -131,7 +131,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-dotnet"
 publish = false
-version = "0.1.3"
+version = "0.1.4"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/dotnet/DEPENDENCIES.rust.tsv
+++ b/bindings/dotnet/DEPENDENCIES.rust.tsv
@@ -18,7 +18,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -57,9 +57,9 @@ http@1.1.0		X						X
 http-body@1.0.0								X					
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -85,8 +85,8 @@ num-iter@0.1.45		X						X
 num-traits@0.2.19		X						X					
 object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
-opendal-dotnet@0.1.3		X											
+opendal@0.47.3		X											
+opendal-dotnet@0.1.4		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
 pem@3.0.4								X					
@@ -124,7 +124,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					

--- a/bindings/haskell/Cargo.toml
+++ b/bindings/haskell/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.44.5"
+version = "0.44.6"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/haskell/DEPENDENCIES.rust.tsv
+++ b/bindings/haskell/DEPENDENCIES.rust.tsv
@@ -18,7 +18,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -57,9 +57,9 @@ http@1.1.0		X						X
 http-body@1.0.0								X					
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -85,8 +85,8 @@ num-iter@0.1.45		X						X
 num-traits@0.2.19		X						X					
 object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
-opendal-hs@0.44.5		X											
+opendal@0.47.3		X											
+opendal-hs@0.44.6		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
 pem@3.0.4								X					
@@ -124,7 +124,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.46.2"
+version = "0.46.3"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -23,7 +23,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cesu8@1.1.0		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
@@ -68,9 +68,9 @@ http@1.1.0		X						X
 http-body@1.0.0								X					
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -102,8 +102,8 @@ num-traits@0.2.19		X						X
 num_cpus@1.16.0		X						X					
 object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
-opendal-java@0.46.2		X											
+opendal@0.47.3		X											
+opendal-java@0.46.3		X											
 openssh@0.10.4		X						X					
 openssh-sftp-client@0.14.4								X					
 openssh-sftp-client-lowlevel@0.6.0								X					
@@ -153,7 +153,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal-java</artifactId>
-    <version>0.46.2</version>
+    <version>0.46.3</version>
 
     <name>Apache OpenDAL™</name>
     <description>

--- a/bindings/lua/Cargo.toml
+++ b/bindings/lua/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-lua"
 publish = false
-version = "0.1.3"
+version = "0.1.4"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/lua/DEPENDENCIES.rust.tsv
+++ b/bindings/lua/DEPENDENCIES.rust.tsv
@@ -20,7 +20,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -60,9 +60,9 @@ http@1.1.0		X						X
 http-body@1.0.0								X					
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -92,8 +92,8 @@ num-iter@0.1.45		X						X
 num-traits@0.2.19		X						X					
 object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
-opendal-lua@0.1.3		X											
+opendal@0.47.3		X											
+opendal-lua@0.1.4		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
 pem@3.0.4								X					
@@ -138,7 +138,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					

--- a/bindings/lua/opendal-0.1.3-1.rockspec
+++ b/bindings/lua/opendal-0.1.3-1.rockspec
@@ -1,5 +1,5 @@
 package = "opendal"
-version = "0.1.2-1"
+version = "0.1.3-1"
 
 source = {
     url = "git+https://github.com/apache/opendal/",

--- a/bindings/nodejs/DEPENDENCIES.rust.tsv
+++ b/bindings/nodejs/DEPENDENCIES.rust.tsv
@@ -20,7 +20,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -63,9 +63,9 @@ http@1.1.0		X						X
 http-body@1.0.0								X					
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -86,8 +86,8 @@ miniz_oxide@0.7.4		X						X					X
 mio@0.8.11								X					
 napi@2.16.8								X					
 napi-build@2.1.3								X					
-napi-derive@2.16.6								X					
-napi-derive-backend@1.0.68								X					
+napi-derive@2.16.8								X					
+napi-derive-backend@1.0.70								X					
 napi-sys@2.4.0								X					
 num-bigint@0.4.6		X						X					
 num-bigint-dig@0.8.4		X						X					
@@ -98,7 +98,7 @@ num-traits@0.2.19		X						X
 num_cpus@1.16.0		X						X					
 object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
+opendal@0.47.3		X											
 opendal-nodejs@0.47.0		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
@@ -140,7 +140,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "Apache OpenDAL <dev@opendal.apache.org>",
-  "version": "0.46.2",
+  "version": "0.47.0",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",

--- a/bindings/ocaml/DEPENDENCIES.rust.tsv
+++ b/bindings/ocaml/DEPENDENCIES.rust.tsv
@@ -18,7 +18,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -58,9 +58,9 @@ http@1.1.0		X						X
 http-body@1.0.0								X					
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -93,7 +93,7 @@ ocaml-interop@0.8.8								X
 ocaml-sys@0.22.3							X						
 ocaml-sys@0.23.0							X						
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
+opendal@0.47.3		X											
 opendal-ocaml@0.0.0		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
@@ -132,7 +132,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					

--- a/bindings/php/Cargo.toml
+++ b/bindings/php/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-php"
 publish = false
-version = "0.1.3"
+version = "0.1.4"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/php/DEPENDENCIES.rust.tsv
+++ b/bindings/php/DEPENDENCIES.rust.tsv
@@ -26,7 +26,7 @@ camino@1.1.7		X						X
 cargo-platform@0.1.8		X						X					
 cargo_metadata@0.14.2								X					
 cbc@0.1.2		X						X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cexpr@0.6.0		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
@@ -83,9 +83,9 @@ http@1.1.0		X						X
 http-body@1.0.0								X					
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 ident_case@1.0.1		X						X					
@@ -120,8 +120,8 @@ num-iter@0.1.45		X						X
 num-traits@0.2.19		X						X					
 object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
-opendal-php@0.1.3		X											
+opendal@0.47.3		X											
+opendal-php@0.1.4		X											
 openssl@0.10.64		X											
 openssl-macros@0.1.1		X						X					
 openssl-probe@0.1.5		X						X					
@@ -182,7 +182,7 @@ security-framework-sys@2.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.5"
+version = "0.45.6"
 
 [features]
 default = [

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -23,7 +23,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 cipher@0.4.4		X						X					
@@ -68,9 +68,9 @@ http@1.1.0		X						X
 http-body@1.0.0								X					
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -102,8 +102,8 @@ num-traits@0.2.19		X						X
 num_cpus@1.16.0		X						X					
 object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
-opendal-python@0.45.5		X											
+opendal@0.47.3		X											
+opendal-python@0.45.6		X											
 openssh@0.10.4		X						X					
 openssh-sftp-client@0.14.4								X					
 openssh-sftp-client-lowlevel@0.6.0								X					
@@ -159,7 +159,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-ruby"
 publish = false
-version = "0.1.3"
+version = "0.1.4"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -21,7 +21,7 @@ bumpalo@3.16.0		X						X
 byteorder@1.5.0								X				X	
 bytes@1.6.0								X					
 cbc@0.1.2		X						X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cexpr@0.6.0		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
@@ -64,9 +64,9 @@ http@1.1.0		X						X
 http-body@1.0.0								X					
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -99,8 +99,8 @@ num-iter@0.1.45		X						X
 num-traits@0.2.19		X						X					
 object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
-opendal-ruby@0.1.3		X											
+opendal@0.47.3		X											
+opendal-ruby@0.1.4		X											
 ordered-multimap@0.7.3								X					
 pbkdf2@0.12.2		X						X					
 pem@3.0.4								X					
@@ -121,8 +121,8 @@ quote@1.0.36		X						X
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
-rb-sys@0.9.97		X						X					
-rb-sys-build@0.9.97		X						X					
+rb-sys@0.9.98		X						X					
+rb-sys-build@0.9.98		X						X					
 rb-sys-env@0.1.2		X						X					
 regex@1.10.5		X						X					
 regex-automata@0.4.7		X						X					
@@ -145,7 +145,7 @@ scrypt@0.11.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1412,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2755ff20a1d93490d26ba33a6f092a38a508398a5320df5d4b3014fcccce9410"
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 dependencies = [
  "jobserver",
  "libc",
@@ -1455,7 +1455,7 @@ dependencies = [
  "rustc_lexer",
  "serde",
  "serde_json",
- "serde_with 3.8.1",
+ "serde_with 3.8.2",
  "smol_str",
  "stacker",
  "thiserror",
@@ -1471,7 +1471,7 @@ dependencies = [
  "itertools 0.10.5",
  "serde",
  "serde_json",
- "serde_with 3.8.1",
+ "serde_with 3.8.2",
  "smol_str",
  "stacker",
  "thiserror",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_aws_s3_assume_role_with_web_identity"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "opendal",
  "tokio",
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_file_write_on_full_disk"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "futures",
  "opendal",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_s3_read_on_wasm"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "opendal",
  "wasm-bindgen",
@@ -3511,9 +3511,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3552,7 +3552,7 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.0",
  "hyper-util",
  "rustls 0.23.10",
  "rustls-pki-types",
@@ -3576,16 +3576,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.3.1",
+ "hyper 1.4.0",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
@@ -4709,7 +4709,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "anyhow",
  "async-backtrace",
@@ -4814,7 +4814,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-basic"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "futures",
  "opendal",
@@ -4823,7 +4823,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-concurrent-upload"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "futures",
  "opendal",
@@ -4832,7 +4832,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-multipart-upload"
-version = "0.47.2"
+version = "0.47.3"
 dependencies = [
  "futures",
  "opendal",
@@ -6231,7 +6231,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.3.1",
+ "hyper 1.4.0",
  "hyper-rustls 0.27.2",
  "hyper-util",
  "ipnet",
@@ -6375,9 +6375,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7699249cc2c7d71939f30868f47e9d7add0bdc030d90ee10bfd16887ff8bb1c8"
+checksum = "8f4b84ba6e838ceb47b41de5194a60244fac43d9fe03b71dbe8c5a201081d6d1"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -6877,9 +6877,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.118"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
@@ -6911,9 +6911,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.8.1"
+version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+checksum = "079f3a42cd87588d924ed95b533f8d30a483388c4e400ab736a7058e34f16169"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6923,7 +6923,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.8.1",
+ "serde_with_macros 3.8.2",
  "time",
 ]
 
@@ -6941,9 +6941,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.8.1"
+version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+checksum = "bc03aad67c1d26b7de277d51c86892e7d9a0110a2fe44bf6b26cc569fba302d6"
 dependencies = [
  "darling 0.20.9",
  "proc-macro2",
@@ -9020,18 +9020,18 @@ checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.47.2"
+version = "0.47.3"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -42,7 +42,7 @@ members = [".", "examples/*", "fuzz", "edge/*", "benches/vs_*"]
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.75"
-version = "0.47.2"
+version = "0.47.3"
 
 [features]
 default = ["reqwest/rustls-tls", "executors-tokio", "services-memory"]

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -12,7 +12,7 @@ base64@0.22.1		X						X
 block-buffer@0.10.4		X						X					
 bumpalo@3.16.0		X						X					
 bytes@1.6.0								X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 const-oid@0.9.6		X						X					
@@ -50,9 +50,9 @@ http@1.1.0		X						X
 http-body@1.0.0								X					
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -70,7 +70,7 @@ num-traits@0.2.19		X						X
 num_cpus@1.16.0		X						X					
 object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
+opendal@0.47.3		X											
 ordered-multimap@0.7.3								X					
 percent-encoding@2.3.1		X						X					
 pin-project@1.1.5		X						X					
@@ -98,7 +98,7 @@ ryu@1.0.18		X			X
 semver@1.0.23		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					

--- a/integrations/cloudfilter/DEPENDENCIES.rust.tsv
+++ b/integrations/cloudfilter/DEPENDENCIES.rust.tsv
@@ -12,7 +12,7 @@ base64@0.22.1		X					X
 block-buffer@0.10.4		X					X					
 bumpalo@3.16.0		X					X					
 bytes@1.6.0							X					
-cc@1.0.103		X					X					
+cc@1.0.104		X					X					
 cfg-if@1.0.0		X					X					
 chrono@0.4.38		X					X					
 cloudfilter_opendal@0.0.0		X										
@@ -38,9 +38,9 @@ http@1.1.0		X					X
 http-body@1.0.0							X					
 http-body-util@0.1.2							X					
 httparse@1.9.4		X					X					
-hyper@1.3.1							X					
+hyper@1.4.0							X					
 hyper-rustls@0.27.2		X				X	X					
-hyper-util@0.1.5							X					
+hyper-util@0.1.6							X					
 iana-time-zone@0.1.60		X					X					
 iana-time-zone-haiku@0.1.2		X					X					
 idna@0.5.0		X					X					
@@ -57,7 +57,7 @@ mio@0.8.11							X
 num-traits@0.2.19		X					X					
 object@0.36.1		X					X					
 once_cell@1.19.0		X					X					
-opendal@0.47.2		X										
+opendal@0.47.3		X										
 percent-encoding@2.3.1		X					X					
 pin-project@1.1.5		X					X					
 pin-project-internal@1.1.5		X					X					
@@ -76,7 +76,7 @@ rustls-webpki@0.102.4						X
 ryu@1.0.18		X			X							
 serde@1.0.203		X					X					
 serde_derive@1.0.203		X					X					
-serde_json@1.0.118		X					X					
+serde_json@1.0.120		X					X					
 serde_urlencoded@0.7.1		X					X					
 slab@0.4.9							X					
 smallvec@1.13.2		X					X					

--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 description = "Use OpenDAL as a backend to access data in various service with WebDAV protocol"
 name = "dav-server-opendalfs"
-version = "0.0.4"
+version = "0.0.5"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -17,14 +17,14 @@ bitflags@2.6.0		X						X
 block-buffer@0.10.4		X						X					
 bumpalo@3.16.0		X						X					
 bytes@1.6.0								X					
-cc@1.0.103		X						X					
+cc@1.0.104		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 core-foundation-sys@0.8.6		X						X					
 cpufeatures@0.2.12		X						X					
 crypto-common@0.1.6		X						X					
 dav-server@0.6.0		X											
-dav-server-opendalfs@0.0.4		X											
+dav-server-opendalfs@0.0.5		X											
 deranged@0.3.11		X						X					
 digest@0.10.7		X						X					
 fastrand@2.1.0		X						X					
@@ -53,9 +53,9 @@ http-body@1.0.0								X
 http-body-util@0.1.2								X					
 httparse@1.9.4		X						X					
 httpdate@1.0.3		X						X					
-hyper@1.3.1								X					
+hyper@1.4.0								X					
 hyper-rustls@0.27.2		X					X	X					
-hyper-util@0.1.5								X					
+hyper-util@0.1.6								X					
 iana-time-zone@0.1.60		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -78,7 +78,7 @@ num-traits@0.2.19		X						X
 num_cpus@1.16.0		X						X					
 object@0.36.1		X						X					
 once_cell@1.19.0		X						X					
-opendal@0.47.2		X											
+opendal@0.47.3		X											
 parking_lot@0.12.3		X						X					
 parking_lot_core@0.9.10		X						X					
 percent-encoding@2.3.1		X						X					
@@ -105,7 +105,7 @@ ryu@1.0.18		X				X
 scopeguard@1.2.0		X						X					
 serde@1.0.203		X						X					
 serde_derive@1.0.203		X						X					
-serde_json@1.0.118		X						X					
+serde_json@1.0.120		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 slab@0.4.9								X					
@@ -173,5 +173,5 @@ windows_x86_64_msvc@0.52.5		X						X
 winreg@0.52.0								X					
 xml-rs@0.8.20								X					
 xmltree@0.10.3								X					
-zerocopy@0.7.34		X		X				X					
+zerocopy@0.7.35		X		X				X					
 zeroize@1.8.1		X						X					

--- a/integrations/fuse3/Cargo.toml
+++ b/integrations/fuse3/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.0.1"
+version = "0.0.2"
 
 [dependencies]
 bytes = "1.6.0"

--- a/integrations/fuse3/DEPENDENCIES.rust.tsv
+++ b/integrations/fuse3/DEPENDENCIES.rust.tsv
@@ -15,7 +15,7 @@ bitflags@2.6.0		X					X
 block-buffer@0.10.4		X					X					
 bumpalo@3.16.0		X					X					
 bytes@1.6.0							X					
-cc@1.0.103		X					X					
+cc@1.0.104		X					X					
 cfg-if@1.0.0		X					X					
 cfg_aliases@0.1.1							X					
 chrono@0.4.38		X					X					
@@ -33,7 +33,7 @@ flagset@0.4.5		X
 fnv@1.0.7		X					X					
 form_urlencoded@1.2.1		X					X					
 fuse3@0.7.2							X					
-fuse3_opendal@0.0.1		X										
+fuse3_opendal@0.0.2		X										
 futures@0.3.30		X					X					
 futures-channel@0.3.30		X					X					
 futures-core@0.3.30		X					X					
@@ -50,9 +50,9 @@ http@1.1.0		X					X
 http-body@1.0.0							X					
 http-body-util@0.1.2							X					
 httparse@1.9.4		X					X					
-hyper@1.3.1							X					
+hyper@1.4.0							X					
 hyper-rustls@0.27.2		X				X	X					
-hyper-util@0.1.5							X					
+hyper-util@0.1.6							X					
 iana-time-zone@0.1.60		X					X					
 iana-time-zone-haiku@0.1.2		X					X					
 idna@0.5.0		X					X					
@@ -73,7 +73,7 @@ nix@0.28.0							X
 num-traits@0.2.19		X					X					
 object@0.36.1		X					X					
 once_cell@1.19.0		X					X					
-opendal@0.47.2		X										
+opendal@0.47.3		X										
 parking@2.2.0		X					X					
 percent-encoding@2.3.1		X					X					
 pin-project@1.1.5		X					X					
@@ -94,7 +94,7 @@ rustls-webpki@0.102.4						X
 ryu@1.0.18		X			X							
 serde@1.0.203		X					X					
 serde_derive@1.0.203		X					X					
-serde_json@1.0.118		X					X					
+serde_json@1.0.120		X					X					
 serde_urlencoded@0.7.1		X					X					
 sharded-slab@0.1.7							X					
 signal-hook-registry@1.4.2		X					X					

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.44.2"
+version = "0.44.3"
 
 [features]
 send_wrapper = ["dep:send_wrapper"]

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -13,7 +13,7 @@ bitflags@2.6.0		X					X
 block-buffer@0.10.4		X					X					
 bumpalo@3.16.0		X					X					
 bytes@1.6.0							X					
-cc@1.0.103		X					X					
+cc@1.0.104		X					X					
 cfg-if@1.0.0		X					X					
 chrono@0.4.38		X					X					
 const-oid@0.9.6		X					X					
@@ -50,9 +50,9 @@ http-body@1.0.0							X
 http-body-util@0.1.2							X					
 httparse@1.9.4		X					X					
 humantime@2.1.0		X					X					
-hyper@1.3.1							X					
+hyper@1.4.0							X					
 hyper-rustls@0.27.2		X				X	X					
-hyper-util@0.1.5							X					
+hyper-util@0.1.6							X					
 iana-time-zone@0.1.60		X					X					
 iana-time-zone-haiku@0.1.2		X					X					
 idna@0.5.0		X					X					
@@ -72,9 +72,9 @@ num-traits@0.2.19		X					X
 num_cpus@1.16.0		X					X					
 object@0.36.1		X					X					
 object_store@0.10.1		X					X					
-object_store_opendal@0.44.2		X										
+object_store_opendal@0.44.3		X										
 once_cell@1.19.0		X					X					
-opendal@0.47.2		X										
+opendal@0.47.3		X										
 parking_lot@0.12.3		X					X					
 parking_lot_core@0.9.10		X					X					
 percent-encoding@2.3.1		X					X					
@@ -105,7 +105,7 @@ scopeguard@1.2.0		X					X
 semver@1.0.23		X					X					
 serde@1.0.203		X					X					
 serde_derive@1.0.203		X					X					
-serde_json@1.0.118		X					X					
+serde_json@1.0.120		X					X					
 serde_urlencoded@0.7.1		X					X					
 sha1@0.10.6		X					X					
 sha2@0.10.8		X					X					

--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 name = "unftp-sbe-opendal"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.0.1"
+version = "0.0.2"
 
 [dependencies]
 async-trait = "0.1.80"

--- a/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
+++ b/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
@@ -20,15 +20,18 @@ bitflags@2.6.0		X						X
 block-buffer@0.10.4		X						X						
 bumpalo@3.16.0		X						X						
 bytes@1.6.0								X						
-cc@1.0.103		X						X						
+cc@1.0.104		X						X						
 cexpr@0.6.0		X						X						
 cfg-if@1.0.0		X						X						
 cfg_aliases@0.2.1								X						
 chrono@0.4.38		X						X						
 clang-sys@1.8.1		X												
 cmake@0.1.50		X						X						
+const-oid@0.9.6		X						X						
 convert_case@0.4.0								X						
 core-foundation-sys@0.8.6		X						X						
+cpufeatures@0.2.12		X						X						
+crc32c@0.6.8		X						X						
 crossbeam-channel@0.5.13		X						X						
 crossbeam-epoch@0.9.18		X						X						
 crossbeam-utils@0.8.20		X						X						
@@ -62,14 +65,17 @@ getrandom@0.2.15		X						X
 gimli@0.29.0		X						X						
 glob@0.3.1		X						X						
 hashbrown@0.14.5		X						X						
+hermit-abi@0.3.9		X						X						
+hex@0.4.3		X						X						
+hmac@0.12.1		X						X						
 home@0.5.9		X						X						
 http@1.1.0		X						X						
 http-body@1.0.0								X						
 http-body-util@0.1.2								X						
 httparse@1.9.4		X						X						
-hyper@1.3.1								X						
+hyper@1.4.0								X						
 hyper-rustls@0.27.2		X					X	X						
-hyper-util@0.1.5								X						
+hyper-util@0.1.6								X						
 iana-time-zone@0.1.60		X						X						
 iana-time-zone-haiku@0.1.2		X						X						
 idna@0.5.0		X						X						
@@ -100,10 +106,11 @@ num-bigint@0.4.6		X						X
 num-conv@0.1.0		X						X						
 num-integer@0.1.46		X						X						
 num-traits@0.2.19		X						X						
+num_cpus@1.16.0		X						X						
 object@0.36.1		X						X						
 oid-registry@0.7.0		X						X						
 once_cell@1.19.0		X						X						
-opendal@0.47.2		X												
+opendal@0.47.3		X												
 parking_lot@0.12.3		X						X						
 parking_lot_core@0.9.10		X						X						
 paste@1.0.15		X						X						
@@ -113,16 +120,21 @@ pin-project-internal@1.1.5		X						X
 pin-project-lite@0.2.14		X						X						
 pin-utils@0.1.0		X						X						
 powerfmt@0.2.0		X						X						
+ppv-lite86@0.2.17		X						X						
 prettyplease@0.2.20		X						X						
 proc-macro2@1.0.86		X						X						
 prometheus@0.13.4		X												
 proxy-protocol@0.5.0		X						X						
 quick-xml@0.31.0								X						
 quote@1.0.36		X						X						
+rand@0.8.5		X						X						
+rand_chacha@0.3.1		X						X						
+rand_core@0.6.4		X						X						
 redox_syscall@0.5.2								X						
 regex@1.10.5		X						X						
 regex-automata@0.4.7		X						X						
 regex-syntax@0.8.4		X						X						
+reqsign@0.15.2		X												
 reqwest@0.12.5		X						X						
 ring@0.17.8											X			
 rustc-demangle@0.1.24		X						X						
@@ -139,8 +151,10 @@ scopeguard@1.2.0		X						X
 semver@1.0.23		X						X						
 serde@1.0.203		X						X						
 serde_derive@1.0.203		X						X						
-serde_json@1.0.118		X						X						
+serde_json@1.0.120		X						X						
 serde_urlencoded@0.7.1		X						X						
+sha1@0.10.6		X						X						
+sha2@0.10.8		X						X						
 shlex@1.3.0		X						X						
 signal-hook-registry@1.4.2		X						X						
 slab@0.4.9								X						
@@ -178,7 +192,7 @@ tracing-core@0.1.32								X
 triomphe@0.1.13		X						X						
 try-lock@0.2.5								X						
 typenum@1.17.0		X						X						
-unftp-sbe-opendal@0.0.1		X												
+unftp-sbe-opendal@0.0.2		X												
 unicode-bidi@0.3.15		X						X						
 unicode-ident@1.0.12		X						X				X		
 unicode-normalization@0.1.23		X						X						


### PR DESCRIPTION
This quick release is used to address https://github.com/apache/opendal/issues/4850

This PR will bump the following releases:

| Name                      | Version | Next    |
| -                         | -       | -       |
| core                      | 0.47.2  | 0.47.3  |
| integrations/dav-server   | 0.0.4   | 0.0.5   |
| integrations/fuse3        | 0.0.1   | 0.0.2   |
| integrations/object_store | 0.44.2  | 0.44.3  |
| integrations/unftp-sbe    | 0.0.1   | 0.0.2   |
| bin/oay                   | 0.41.5  | 0.41.6  |
| bin/ofs                   | 0.0.6   | 0.0.7   |
| bin/oli                   | 0.41.5  | 0.41.6  |
| bindings/c                | 0.44.7  | 0.44.8  |
| bindings/cpp              | 0.45.5  | 0.45.6  |
| bindings/dotnet           | 0.1.3   | 0.1.4   |
| bindings/haskell          | 0.44.5  | 0.44.6  |
| bindings/java             | 0.46.2  | 0.46.3  |
| bindings/lua              | 0.1.3   | 0.1.4   |
| bindings/nodejs           | 0.47.0  | 0.47.0  |
| bindings/php              | 0.1.3   | 0.1.4   |
| bindings/python           | 0.45.5  | 0.45.6  |
| bindings/ruby             | 0.1.3   | 0.1.4   |