### PR TITLE
feat(core/types): avoid a copy in `Buffer::to_bytes()` by cloning contiguous bytes

### DIFF
--- a/core/src/types/buffer.rs
+++ b/core/src/types/buffer.rs
@@ -289,6 +289,17 @@ impl Buffer {
         ret.freeze()
     }
 
+    /// Combine all bytes together into one single [`Bytes`].
+    ///
+    /// Unlike [`to_bytes`](Self::to_bytes), this operation is zero copy if the underlying bytes are contiguous.
+    #[inline]
+    pub fn into_bytes(self) -> Bytes {
+        match self.0 {
+            Inner::Contiguous(bytes) => bytes,
+            Inner::NonContiguous { .. } => self.to_bytes(),
+        }
+    }
+
     /// Combine all bytes together into one single [`Vec<u8>`].
     ///
     /// This operation is not zero copy, it will copy all bytes into one single [`Vec<u8>`].
@@ -317,6 +328,12 @@ impl Buffer {
                 ret
             }
         }
+    }
+}
+
+impl From<Buffer> for Bytes {
+    fn from(buffer: Buffer) -> Self {
+        buffer.into_bytes()
     }
 }
 

--- a/core/src/types/buffer.rs
+++ b/core/src/types/buffer.rs
@@ -280,23 +280,18 @@ impl Buffer {
 
     /// Combine all bytes together into one single [`Bytes`].
     ///
-    /// This operation is not zero copy, it will copy all bytes into one single [`Bytes`].
+    /// This operation is zero copy if the underlying bytes are contiguous.
+    /// Otherwise, it will copy all bytes into one single [`Bytes`].
     /// Please use API from [`Buf`], [`Iterator`] or [`Stream`] whenever possible.
     #[inline]
     pub fn to_bytes(&self) -> Bytes {
-        let mut ret = BytesMut::with_capacity(self.len());
-        ret.put(self.clone());
-        ret.freeze()
-    }
-
-    /// Combine all bytes together into one single [`Bytes`].
-    ///
-    /// Unlike [`to_bytes`](Self::to_bytes), this operation is zero copy if the underlying bytes are contiguous.
-    #[inline]
-    pub fn into_bytes(self) -> Bytes {
-        match self.0 {
-            Inner::Contiguous(bytes) => bytes,
-            Inner::NonContiguous { .. } => self.to_bytes(),
+        match &self.0 {
+            Inner::Contiguous(bytes) => bytes.clone(),
+            Inner::NonContiguous { .. } => {
+                let mut ret = BytesMut::with_capacity(self.len());
+                ret.put(self.clone());
+                ret.freeze()
+            }
         }
     }
 
@@ -328,12 +323,6 @@ impl Buffer {
                 ret
             }
         }
-    }
-}
-
-impl From<Buffer> for Bytes {
-    fn from(buffer: Buffer) -> Self {
-        buffer.into_bytes()
     }
 }
 


### PR DESCRIPTION
`Buffer::into_bytes` is zero copy if the underlying bytes are contiguous. Also implements `From<Buffer>` for `Bytes`.

Fixes #4857.