### PR TITLE
Feat(core): Add object versioning for OSS

### DIFF
--- a/core/src/raw/http_util/header.rs
+++ b/core/src/raw/http_util/header.rs
@@ -108,6 +108,11 @@ pub fn parse_content_disposition(headers: &HeaderMap) -> Result<Option<&str>> {
     parse_header_to_str(headers, CONTENT_DISPOSITION)
 }
 
+/// Parse version id for header map
+pub fn parse_version_id(headers: &HeaderMap) -> Result<Option<&str>> {
+    parse_header_to_str(headers, "x-oss-version-id")
+}
+
 /// Parse header value to string according to name.
 #[inline]
 pub fn parse_header_to_str<K>(headers: &HeaderMap, name: K) -> Result<Option<&str>>
@@ -184,6 +189,10 @@ pub fn parse_into_metadata(path: &str, headers: &HeaderMap) -> Result<Metadata> 
 
     if let Some(v) = parse_content_disposition(headers)? {
         m.set_content_disposition(v);
+    }
+
+    if let Some(v) = parse_version_id(headers)? {
+        m.set_version(v);
     }
 
     Ok(m)

--- a/core/src/services/oss/core.rs
+++ b/core/src/services/oss/core.rs
@@ -47,6 +47,8 @@ mod constants {
     pub const X_OSS_SERVER_SIDE_ENCRYPTION_KEY_ID: &str = "x-oss-server-side-encryption-key-id";
 
     pub const RESPONSE_CONTENT_DISPOSITION: &str = "response-content-disposition";
+
+    pub const OBJECT_VERSIONING: &str = "versionId";
 }
 
 pub struct OssCore {
@@ -236,12 +238,12 @@ impl OssCore {
     pub fn oss_get_object_request(
         &self,
         path: &str,
-        range: BytesRange,
         is_presign: bool,
         args: &OpRead,
     ) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
         let endpoint = self.get_endpoint(is_presign);
+        let range = args.range();
         let mut url = format!("{}/{}", endpoint, percent_encode_path(&p));
 
         // Add query arguments to the URL based on response overrides
@@ -251,6 +253,13 @@ impl OssCore {
                 "{}={}",
                 constants::RESPONSE_CONTENT_DISPOSITION,
                 percent_encode_path(override_content_disposition)
+            ))
+        }
+        if let Some(version) = args.version() {
+            query_args.push(format!(
+                "{}={}",
+                constants::OBJECT_VERSIONING,
+                percent_encode_path(version)
             ))
         }
 
@@ -280,10 +289,25 @@ impl OssCore {
         Ok(req)
     }
 
-    fn oss_delete_object_request(&self, path: &str) -> Result<Request<Buffer>> {
+    fn oss_delete_object_request(&self, path: &str, args: &OpDelete) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
         let endpoint = self.get_endpoint(false);
-        let url = format!("{}/{}", endpoint, percent_encode_path(&p));
+        let mut url = format!("{}/{}", endpoint, percent_encode_path(&p));
+
+        let mut query_args = Vec::new();
+
+        if let Some(version) = args.version() {
+            query_args.push(format!(
+                "{}={}",
+                constants::OBJECT_VERSIONING,
+                percent_encode_path(version)
+            ))
+        }
+
+        if !query_args.is_empty() {
+            url.push_str(&format!("?{}", query_args.join("&")));
+        }
+
         let req = Request::delete(&url);
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
@@ -295,18 +319,31 @@ impl OssCore {
         &self,
         path: &str,
         is_presign: bool,
-        if_match: Option<&str>,
-        if_none_match: Option<&str>,
+        args: &OpStat,
     ) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
         let endpoint = self.get_endpoint(is_presign);
-        let url = format!("{}/{}", endpoint, percent_encode_path(&p));
+        let mut url = format!("{}/{}", endpoint, percent_encode_path(&p));
+
+        let mut query_args = Vec::new();
+
+        if let Some(version) = args.version() {
+            query_args.push(format!(
+                "{}={}",
+                constants::OBJECT_VERSIONING,
+                percent_encode_path(version)
+            ))
+        }
+
+        if !query_args.is_empty() {
+            url.push_str(&format!("?{}", query_args.join("&")));
+        }
 
         let mut req = Request::head(&url);
-        if let Some(if_match) = if_match {
+        if let Some(if_match) = args.if_match() {
             req = req.header(IF_MATCH, if_match)
         }
-        if let Some(if_none_match) = if_none_match {
+        if let Some(if_none_match) = args.if_none_match() {
             req = req.header(IF_NONE_MATCH, if_none_match);
         }
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
@@ -358,24 +395,14 @@ impl OssCore {
         Ok(req)
     }
 
-    pub async fn oss_get_object(
-        &self,
-        path: &str,
-        range: BytesRange,
-        args: &OpRead,
-    ) -> Result<Response<HttpBody>> {
-        let mut req = self.oss_get_object_request(path, range, false, args)?;
+    pub async fn oss_get_object(&self, path: &str, args: &OpRead) -> Result<Response<HttpBody>> {
+        let mut req = self.oss_get_object_request(path, false, args)?;
         self.sign(&mut req).await?;
         self.client.fetch(req).await
     }
 
-    pub async fn oss_head_object(
-        &self,
-        path: &str,
-        if_match: Option<&str>,
-        if_none_match: Option<&str>,
-    ) -> Result<Response<Buffer>> {
-        let mut req = self.oss_head_object_request(path, false, if_match, if_none_match)?;
+    pub async fn oss_head_object(&self, path: &str, args: &OpStat) -> Result<Response<Buffer>> {
+        let mut req = self.oss_head_object_request(path, false, args)?;
 
         self.sign(&mut req).await?;
         self.send(req).await
@@ -431,8 +458,8 @@ impl OssCore {
         self.send(req).await
     }
 
-    pub async fn oss_delete_object(&self, path: &str) -> Result<Response<Buffer>> {
-        let mut req = self.oss_delete_object_request(path)?;
+    pub async fn oss_delete_object(&self, path: &str, args: &OpDelete) -> Result<Response<Buffer>> {
+        let mut req = self.oss_delete_object_request(path, args)?;
         self.sign(&mut req).await?;
         self.send(req).await
     }

--- a/core/src/services/oss/writer.rs
+++ b/core/src/services/oss/writer.rs
@@ -164,7 +164,10 @@ impl oio::MultipartWrite for OssWriter {
 
 impl oio::AppendWrite for OssWriter {
     async fn offset(&self) -> Result<u64> {
-        let resp = self.core.oss_head_object(&self.path, None, None).await?;
+        let resp = self
+            .core
+            .oss_head_object(&self.path, &OpStat::new())
+            .await?;
 
         let status = resp.status();
         match status {

--- a/core/src/types/read/reader.rs
+++ b/core/src/types/read/reader.rs
@@ -133,7 +133,7 @@ impl Reader {
                     let size = self
                         .ctx
                         .accessor()
-                        .stat(self.ctx.path(), OpStat::new())
+                        .stat(self.ctx.path(), get_stat_op_from_read_op(self.ctx.args()))
                         .await?
                         .into_metadata()
                         .content_length();
@@ -369,6 +369,31 @@ impl Reader {
         let range = self.parse_range(range).await?;
         Ok(FuturesBytesStream::new(self.ctx, range))
     }
+}
+
+fn get_stat_op_from_read_op(read: &OpRead) -> OpStat {
+    let mut op_stat = OpStat::new();
+
+    if let Some(v) = read.if_match() {
+        op_stat = op_stat.with_if_match(v);
+    }
+    if let Some(v) = read.if_none_match() {
+        op_stat = op_stat.with_if_none_match(v);
+    }
+    if let Some(v) = read.override_cache_control() {
+        op_stat = op_stat.with_override_cache_control(v);
+    }
+    if let Some(v) = read.override_content_disposition() {
+        op_stat = op_stat.with_override_content_disposition(v);
+    }
+    if let Some(v) = read.override_content_type() {
+        op_stat = op_stat.with_override_content_type(v);
+    }
+    if let Some(v) = read.version() {
+        op_stat = op_stat.with_version(v);
+    }
+
+    op_stat
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This pull request add support of object versioning for OSS

Part of #2611

Basically, done the following task

- [x] change the args of `oss_head_object` and `oss_head_object_request` to receive the version info
- [x] add `versionId` param of the url sent (get, head, del) to the oss server
- [x] change the reader in `types/read/reader` to let reader send head req with the same version info of get req