### PR TITLE
refactor(services/s3)!: renamed security_token to session_token

### DIFF
--- a/core/src/docs/rfcs/3197_config.md
+++ b/core/src/docs/rfcs/3197_config.md
@@ -33,7 +33,7 @@ let mut builder = services::S3::default();
 // Credential.
 builder.access_key_id(&cfg.access_key_id);
 builder.secret_access_key(&cfg.secret_access_key);
-builder.security_token(&cfg.security_token);
+builder.session_token(&cfg.session_token);
 builder.role_arn(&cfg.role_arn);
 builder.external_id(&cfg.external_id);
 

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -111,11 +111,11 @@ pub struct S3Config {
     /// - If secret_access_key is set, we will take user's input first.
     /// - If not, we will try to load it from environment.
     pub secret_access_key: Option<String>,
-    /// security_token (aka, session token) of this backend.
+    /// session_token (aka, security token) of this backend.
     ///
-    /// This token will expire after sometime, it's recommended to set security_token
+    /// This token will expire after sometime, it's recommended to set session_token
     /// by hand.
-    pub security_token: Option<String>,
+    pub session_token: Option<String>,
     /// role_arn for this backend.
     ///
     /// If `role_arn` is set, we will use already known config as source
@@ -523,12 +523,18 @@ impl S3Builder {
     ///
     /// # Warning
     ///
-    /// security token's lifetime is short and requires users to refresh in time.
-    pub fn security_token(&mut self, token: &str) -> &mut Self {
+    /// session token's lifetime is short and requires users to refresh in time.
+    pub fn session_token(&mut self, token: &str) -> &mut Self {
         if !token.is_empty() {
-            self.config.security_token = Some(token.to_string());
+            self.config.session_token = Some(token.to_string());
         }
         self
+    }
+
+    /// Set temporary credential used in AWS S3 connections
+    #[deprecated(note = "Please use `session_token` instead")]
+    pub fn security_token(&mut self, token: &str) -> &mut Self {
+        self.session_token(token);
     }
 
     /// Disable config load so that opendal will not load config from
@@ -930,7 +936,7 @@ impl Builder for S3Builder {
         if let Some(v) = self.config.secret_access_key.take() {
             cfg.secret_access_key = Some(v)
         }
-        if let Some(v) = self.config.security_token.take() {
+        if let Some(v) = self.config.session_token.take() {
             cfg.session_token = Some(v)
         }
 

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -534,7 +534,7 @@ impl S3Builder {
     /// Set temporary credential used in AWS S3 connections
     #[deprecated(note = "Please use `session_token` instead")]
     pub fn security_token(&mut self, token: &str) -> &mut Self {
-        self.session_token(token);
+        self.session_token(token)
     }
 
     /// Disable config load so that opendal will not load config from

--- a/core/src/services/s3/docs.md
+++ b/core/src/services/s3/docs.md
@@ -21,7 +21,7 @@ This service can be used to:
 - `region`: Set the region for backend.
 - `access_key_id`: Set the access_key_id for backend.
 - `secret_access_key`: Set the secret_access_key for backend.
-- `security_token`: Set the security_token for backend.
+- `session_token`: Set the session_token for backend.
 - `default_storage_class`: Set the default storage_class for backend.
 - `server_side_encryption`: Set the server_side_encryption for backend.
 - `server_side_encryption_aws_kms_key_id`: Set the server_side_encryption_aws_kms_key_id for backend.
@@ -37,7 +37,7 @@ Refer to [`S3Builder`]'s public API docs for more information.
 
 OpenDAL now provides support for S3 temporary security credentials in IAM.
 
-The way to take advantage of this feature is to build your S3 backend with `Builder::security_token`.
+The way to take advantage of this feature is to build your S3 backend with `Builder::session_token`.
 
 But OpenDAL will not refresh the temporary security credentials, please keep in mind to refresh those credentials in time.
 


### PR DESCRIPTION
Rename `security_token` field in S3Config to `session_token` to be coherent with AWS STS naming, and set `security_token` as deprecated.

Related Issue: https://github.com/apache/opendal/issues/4874