### PR TITLE
refactor(core)!: Return `Arc<AccessInfo>` for metadata

### DIFF
--- a/core/src/docs/internals/accessor.rs
+++ b/core/src/docs/internals/accessor.rs
@@ -132,7 +132,7 @@
 //!                 ..Default::default()
 //!         });
 //!
-//!         am
+//!         am.into()
 //!     }
 //! }
 //! ```
@@ -302,7 +302,7 @@
 //!                     ..Default::default()
 //!             });
 //!
-//!         am
+//!         am.into()
 //!     }
 //!
 //!     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {

--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use tokio::runtime::Handle;
 
 use crate::raw::*;
@@ -178,10 +180,10 @@ impl<A: Access> LayeredAccess for BlockingAccessor<A> {
         &self.inner
     }
 
-    fn metadata(&self) -> AccessorInfo {
-        let mut meta = self.inner.info();
+    fn metadata(&self) -> Arc<AccessorInfo> {
+        let mut meta = self.inner.info().as_ref().clone();
         meta.full_capability_mut().blocking = true;
-        meta
+        meta.into()
     }
 
     async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -118,7 +118,7 @@ impl<A: Access> Layer<A> for CompleteLayer {
 
 /// Provide complete wrapper for backend.
 pub struct CompleteAccessor<A: Access> {
-    meta: AccessorInfo,
+    meta: Arc<AccessorInfo>,
     inner: Arc<A>,
 }
 
@@ -380,13 +380,14 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
         &self.inner
     }
 
-    fn metadata(&self) -> AccessorInfo {
-        let mut meta = self.meta.clone();
+    // Todo: May move the logic to the implement of Layer::layer of CompleteAccessor<A>
+    fn metadata(&self) -> Arc<AccessorInfo> {
+        let mut meta = (*self.meta).clone();
         let cap = meta.full_capability_mut();
         if cap.list && cap.write_can_empty {
             cap.create_dir = true;
         }
-        meta
+        meta.into()
     }
 
     async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
@@ -731,11 +732,11 @@ mod tests {
         type BlockingWriter = oio::BlockingWriter;
         type BlockingLister = oio::BlockingLister;
 
-        fn info(&self) -> AccessorInfo {
+        fn info(&self) -> Arc<AccessorInfo> {
             let mut info = AccessorInfo::default();
             info.set_native_capability(self.capability);
 
-            info
+            info.into()
         }
 
         async fn create_dir(&self, _: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -17,6 +17,7 @@
 
 use std::fmt::Debug;
 use std::fmt::Formatter;
+use std::sync::Arc;
 
 use futures::TryFutureExt;
 
@@ -56,7 +57,7 @@ impl<A: Access> Layer<A> for ErrorContextLayer {
 
 /// Provide error context wrapper for backend.
 pub struct ErrorContextAccessor<A: Access> {
-    meta: AccessorInfo,
+    meta: Arc<AccessorInfo>,
     inner: A,
 }
 
@@ -79,7 +80,7 @@ impl<A: Access> LayeredAccess for ErrorContextAccessor<A> {
         &self.inner
     }
 
-    fn metadata(&self) -> AccessorInfo {
+    fn metadata(&self) -> Arc<AccessorInfo> {
         self.meta.clone()
     }
 

--- a/core/src/layers/immutable_index.rs
+++ b/core/src/layers/immutable_index.rs
@@ -17,6 +17,7 @@
 
 use std::collections::HashSet;
 use std::fmt::Debug;
+use std::sync::Arc;
 use std::vec::IntoIter;
 
 use crate::raw::*;
@@ -145,14 +146,14 @@ impl<A: Access> LayeredAccess for ImmutableIndexAccessor<A> {
     }
 
     /// Add list capabilities for underlying storage services.
-    fn metadata(&self) -> AccessorInfo {
-        let mut meta = self.inner.info();
+    fn metadata(&self) -> Arc<AccessorInfo> {
+        let mut meta = (*self.inner.info()).clone();
 
         let cap = meta.full_capability_mut();
         cap.list = true;
         cap.list_with_recursive = true;
 
-        meta
+        meta.into()
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -18,6 +18,7 @@
 use std::fmt::Debug;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use bytes::Buf;
 use futures::FutureExt;
@@ -221,7 +222,7 @@ impl<A: Access> LayeredAccess for LoggingAccessor<A> {
         &self.inner
     }
 
-    fn metadata(&self) -> AccessorInfo {
+    fn metadata(&self) -> Arc<AccessorInfo> {
         debug!(
             target: LOGGING_TARGET,
             "service={} operation={} -> started",

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -414,7 +414,7 @@ impl<A: Access> LayeredAccess for MetricsAccessor<A> {
         &self.inner
     }
 
-    fn metadata(&self) -> AccessorInfo {
+    fn metadata(&self) -> Arc<AccessorInfo> {
         self.handle.requests_total_metadata.increment(1);
 
         let start = Instant::now();

--- a/core/src/layers/minitrace.rs
+++ b/core/src/layers/minitrace.rs
@@ -17,6 +17,7 @@
 
 use std::fmt::Debug;
 use std::future::Future;
+use std::sync::Arc;
 
 use futures::FutureExt;
 use minitrace::prelude::*;
@@ -139,7 +140,7 @@ impl<A: Access> LayeredAccess for MinitraceAccessor<A> {
     }
 
     #[trace]
-    fn metadata(&self) -> AccessorInfo {
+    fn metadata(&self) -> Arc<AccessorInfo> {
         self.inner.info()
     }
 

--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::future::Future;
+use std::sync::Arc;
 
 use futures::FutureExt;
 use opentelemetry::global;
@@ -75,7 +76,7 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         &self.inner
     }
 
-    fn metadata(&self) -> AccessorInfo {
+    fn metadata(&self) -> Arc<AccessorInfo> {
         let tracer = global::tracer("opendal");
         tracer.in_span("metadata", |_cx| self.inner.info())
     }

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -800,7 +800,7 @@ mod tests {
         type BlockingWriter = ();
         type BlockingLister = ();
 
-        fn info(&self) -> AccessorInfo {
+        fn info(&self) -> Arc<AccessorInfo> {
             let mut am = AccessorInfo::default();
             am.set_native_capability(Capability {
                 read: true,
@@ -813,7 +813,7 @@ mod tests {
                 ..Default::default()
             });
 
-            am
+            am.into()
         }
 
         async fn stat(&self, _: &str, _: OpStat) -> Result<RpStat> {

--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -400,7 +400,7 @@ mod tests {
         type BlockingWriter = ();
         type BlockingLister = ();
 
-        fn info(&self) -> AccessorInfo {
+        fn info(&self) -> Arc<AccessorInfo> {
             let mut am = AccessorInfo::default();
             am.set_native_capability(Capability {
                 read: true,
@@ -408,7 +408,7 @@ mod tests {
                 ..Default::default()
             });
 
-            am
+            am.into()
         }
 
         /// This function will build a reader that always return pending.

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -17,6 +17,7 @@
 
 use std::fmt::Debug;
 use std::future::Future;
+use std::sync::Arc;
 
 use futures::FutureExt;
 use tracing::Span;
@@ -140,7 +141,7 @@ impl<A: Access> LayeredAccess for TracingAccessor<A> {
     }
 
     #[tracing::instrument(level = "debug")]
-    fn metadata(&self) -> AccessorInfo {
+    fn metadata(&self) -> Arc<AccessorInfo> {
         self.inner.info()
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -153,7 +153,7 @@ mod tests {
     /// unexpected struct/enum size change.
     #[test]
     fn assert_size() {
-        assert_eq!(40, size_of::<Operator>());
+        assert_eq!(56, size_of::<Operator>());
         assert_eq!(256, size_of::<Entry>());
         assert_eq!(232, size_of::<Metadata>());
         assert_eq!(1, size_of::<EntryMode>());

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -153,7 +153,7 @@ mod tests {
     /// unexpected struct/enum size change.
     #[test]
     fn assert_size() {
-        assert_eq!(56, size_of::<Operator>());
+        assert_eq!(40, size_of::<Operator>());
         assert_eq!(256, size_of::<Entry>());
         assert_eq!(232, size_of::<Metadata>());
         assert_eq!(1, size_of::<EntryMode>());

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -80,7 +80,7 @@ pub trait Access: Send + Sync + Debug + Unpin + 'static {
     ///
     /// - scheme: declare the scheme of backend.
     /// - capabilities: declare the capabilities of current backend.
-    fn info(&self) -> AccessorInfo;
+    fn info(&self) -> Arc<AccessorInfo>;
 
     /// Invoke the `create` operation on the specified path
     ///
@@ -399,7 +399,7 @@ pub trait Access: Send + Sync + Debug + Unpin + 'static {
 /// `Box<dyn AccessDyn>`.
 pub trait AccessDyn: Send + Sync + Debug + Unpin {
     /// Dyn version of [`Accessor::info`]
-    fn info_dyn(&self) -> AccessorInfo;
+    fn info_dyn(&self) -> Arc<AccessorInfo>;
     /// Dyn version of [`Accessor::create_dir`]
     fn create_dir_dyn<'a>(
         &'a self,
@@ -484,7 +484,7 @@ where
         BlockingLister = oio::BlockingLister,
     >,
 {
-    fn info_dyn(&self) -> AccessorInfo {
+    fn info_dyn(&self) -> Arc<AccessorInfo> {
         self.info()
     }
 
@@ -607,7 +607,7 @@ impl Access for dyn AccessDyn {
     type Lister = oio::Lister;
     type BlockingLister = oio::BlockingLister;
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         self.info_dyn()
     }
 
@@ -693,7 +693,7 @@ impl Access for () {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo {
             scheme: Scheme::Custom("dummy"),
             root: "".to_string(),
@@ -701,6 +701,7 @@ impl Access for () {
             native_capability: Capability::default(),
             full_capability: Capability::default(),
         }
+        .into()
     }
 }
 
@@ -717,7 +718,7 @@ impl<T: Access + ?Sized> Access for Arc<T> {
     type BlockingWriter = T::BlockingWriter;
     type BlockingLister = T::BlockingLister;
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         self.as_ref().info()
     }
 

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -64,7 +64,7 @@ impl<S: Adapter> Access for Backend<S> {
     type Lister = HierarchyLister<KvLister>;
     type BlockingLister = HierarchyLister<KvLister>;
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am: AccessorInfo = self.kv.metadata().into();
         am.set_root(&self.root);
 
@@ -84,7 +84,7 @@ impl<S: Adapter> Access for Backend<S> {
 
         am.set_native_capability(cap);
 
-        am
+        am.into()
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {

--- a/core/src/raw/adapters/typed_kv/backend.rs
+++ b/core/src/raw/adapters/typed_kv/backend.rs
@@ -59,7 +59,7 @@ impl<S: Adapter> Access for Backend<S> {
     type Lister = HierarchyLister<KvLister>;
     type BlockingLister = HierarchyLister<KvLister>;
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let kv_info = self.kv.info();
         let mut am: AccessorInfo = AccessorInfo::default();
         am.set_root(&self.root);
@@ -91,7 +91,7 @@ impl<S: Adapter> Access for Backend<S> {
 
         am.set_native_capability(cap);
 
-        am
+        am.into()
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {

--- a/core/src/raw/layer.rs
+++ b/core/src/raw/layer.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use futures::Future;
 
@@ -139,7 +140,7 @@ pub trait LayeredAccess: Send + Sync + Debug + Unpin + 'static {
 
     fn inner(&self) -> &Self::Inner;
 
-    fn metadata(&self) -> AccessorInfo {
+    fn metadata(&self) -> Arc<AccessorInfo> {
         self.inner().info()
     }
 
@@ -246,7 +247,7 @@ impl<L: LayeredAccess> Access for L {
     type Lister = L::Lister;
     type BlockingLister = L::BlockingLister;
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         (self as &L).metadata()
     }
 
@@ -358,10 +359,10 @@ mod tests {
         type Lister = ();
         type BlockingLister = ();
 
-        fn info(&self) -> AccessorInfo {
+        fn info(&self) -> Arc<AccessorInfo> {
             let mut am = AccessorInfo::default();
             am.set_scheme(Scheme::Custom("test"));
-            am
+            am.into()
         }
 
         async fn delete(&self, _: &str, _: OpDelete) -> Result<RpDelete> {

--- a/core/src/raw/oio/list/flat_list.rs
+++ b/core/src/raw/oio/list/flat_list.rs
@@ -176,6 +176,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
     use std::vec;
     use std::vec::IntoIter;
 
@@ -216,11 +217,11 @@ mod tests {
         type Lister = ();
         type BlockingLister = MockLister;
 
-        fn info(&self) -> AccessorInfo {
+        fn info(&self) -> Arc<AccessorInfo> {
             let mut am = AccessorInfo::default();
             am.full_capability_mut().list = true;
 
-            am
+            am.into()
         }
 
         fn blocking_list(&self, path: &str, _: OpList) -> Result<(RpList, Self::BlockingLister)> {

--- a/core/src/services/aliyun_drive/backend.rs
+++ b/core/src/services/aliyun_drive/backend.rs
@@ -258,7 +258,7 @@ impl Access for AliyunDriveBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::AliyunDrive)
             .set_root(&self.core.root)
@@ -284,7 +284,7 @@ impl Access for AliyunDriveBackend {
 
                 ..Default::default()
             });
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _args: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/alluxio/backend.rs
+++ b/core/src/services/alluxio/backend.rs
@@ -188,7 +188,7 @@ impl Access for AlluxioBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Alluxio)
             .set_root(&self.core.root)
@@ -212,7 +212,7 @@ impl Access for AlluxioBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -557,7 +557,7 @@ impl Access for AzblobBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Azblob)
             .set_root(&self.core.root)
@@ -598,7 +598,7 @@ impl Access for AzblobBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -251,7 +251,7 @@ impl Access for AzdlsBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Azdls)
             .set_root(&self.core.root)
@@ -272,7 +272,7 @@ impl Access for AzdlsBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/azfile/backend.rs
+++ b/core/src/services/azfile/backend.rs
@@ -272,7 +272,7 @@ impl Access for AzfileBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Azfile)
             .set_root(&self.core.root)
@@ -291,7 +291,7 @@ impl Access for AzfileBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/b2/backend.rs
+++ b/core/src/services/b2/backend.rs
@@ -274,7 +274,7 @@ impl Access for B2Backend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::B2)
             .set_root(&self.core.root)
@@ -316,7 +316,7 @@ impl Access for B2Backend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     /// B2 have a get_file_info api required a file_id field, but field_id need call list api, list api also return file info

--- a/core/src/services/chainsafe/backend.rs
+++ b/core/src/services/chainsafe/backend.rs
@@ -210,7 +210,7 @@ impl Access for ChainsafeBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Chainsafe)
             .set_root(&self.core.root)
@@ -230,7 +230,7 @@ impl Access for ChainsafeBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/compfs/backend.rs
+++ b/core/src/services/compfs/backend.rs
@@ -106,7 +106,7 @@ impl Access for CompfsBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Compfs)
             .set_root(&self.core.root.to_string_lossy())
@@ -129,7 +129,7 @@ impl Access for CompfsBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -260,7 +260,7 @@ impl Access for CosBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Cos)
             .set_root(&self.core.root)
@@ -309,7 +309,7 @@ impl Access for CosBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/dbfs/backend.rs
+++ b/core/src/services/dbfs/backend.rs
@@ -172,7 +172,7 @@ impl Access for DbfsBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Dbfs)
             .set_root(&self.core.root)
@@ -188,7 +188,7 @@ impl Access for DbfsBackend {
 
                 ..Default::default()
             });
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/dropbox/backend.rs
+++ b/core/src/services/dropbox/backend.rs
@@ -43,7 +43,7 @@ impl Access for DropboxBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut ma = AccessorInfo::default();
         ma.set_scheme(Scheme::Dropbox)
             .set_root(&self.core.root)
@@ -70,7 +70,7 @@ impl Access for DropboxBackend {
 
                 ..Default::default()
             });
-        ma
+        ma.into()
     }
 
     async fn create_dir(&self, path: &str, _args: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -181,7 +181,7 @@ impl Access for FsBackend {
     type BlockingWriter = FsWriter<std::fs::File>;
     type BlockingLister = Option<FsLister<std::fs::ReadDir>>;
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Fs)
             .set_root(&self.core.root.to_string_lossy())
@@ -206,7 +206,7 @@ impl Access for FsBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::str;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use async_tls::TlsConnector;
 use bb8::PooledConnection;
@@ -289,7 +290,7 @@ impl Access for FtpBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Ftp)
             .set_root(&self.root)
@@ -310,7 +311,7 @@ impl Access for FtpBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -338,7 +338,7 @@ impl Access for GcsBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Gcs)
             .set_root(&self.core.root)
@@ -387,7 +387,7 @@ impl Access for GcsBackend {
 
                 ..Default::default()
             });
-        am
+        am.into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/gdrive/backend.rs
+++ b/core/src/services/gdrive/backend.rs
@@ -47,7 +47,7 @@ impl Access for GdriveBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut ma = AccessorInfo::default();
         ma.set_scheme(Scheme::Gdrive)
             .set_root(&self.core.root)
@@ -67,7 +67,7 @@ impl Access for GdriveBackend {
                 ..Default::default()
             });
 
-        ma
+        ma.into()
     }
 
     async fn create_dir(&self, path: &str, _args: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -17,6 +17,7 @@
 
 use std::collections::HashMap;
 use std::env;
+use std::sync::Arc;
 
 use bytes::Buf;
 use bytes::Bytes;
@@ -233,7 +234,7 @@ impl Access for GhacBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Ghac)
             .set_root(&self.root)
@@ -249,7 +250,7 @@ impl Access for GhacBackend {
 
                 ..Default::default()
             });
-        am
+        am.into()
     }
 
     /// Some self-hosted GHES instances are backed by AWS S3 services which only returns

--- a/core/src/services/github/backend.rs
+++ b/core/src/services/github/backend.rs
@@ -229,7 +229,7 @@ impl Access for GithubBackend {
 
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Github)
             .set_root(&self.core.root)
@@ -251,7 +251,7 @@ impl Access for GithubBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -252,7 +252,7 @@ impl Access for HdfsBackend {
     type BlockingWriter = HdfsWriter<hdrs::File>;
     type BlockingLister = Option<HdfsLister>;
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Hdfs)
             .set_root(&self.root)
@@ -275,7 +275,7 @@ impl Access for HdfsBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/hdfs_native/backend.rs
+++ b/core/src/services/hdfs_native/backend.rs
@@ -178,7 +178,7 @@ impl Access for HdfsNativeBackend {
     type Lister = Option<HdfsNativeLister>;
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::HdfsNative)
             .set_root(&self.root)
@@ -192,7 +192,7 @@ impl Access for HdfsNativeBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _args: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -18,6 +18,7 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
+use std::sync::Arc;
 
 use http::header;
 use http::header::IF_MATCH;
@@ -228,7 +229,7 @@ impl Access for HttpBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut ma = AccessorInfo::default();
         ma.set_scheme(Scheme::Http)
             .set_root(&self.root)
@@ -245,7 +246,7 @@ impl Access for HttpBackend {
                 ..Default::default()
             });
 
-        ma
+        ma.into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/huggingface/backend.rs
+++ b/core/src/services/huggingface/backend.rs
@@ -250,7 +250,7 @@ impl Access for HuggingfaceBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Huggingface)
             .set_native_capability(Capability {
@@ -263,7 +263,7 @@ impl Access for HuggingfaceBackend {
 
                 ..Default::default()
             });
-        am
+        am.into()
     }
 
     async fn stat(&self, path: &str, _: OpStat) -> Result<RpStat> {

--- a/core/src/services/icloud/backend.rs
+++ b/core/src/services/icloud/backend.rs
@@ -273,7 +273,7 @@ impl Access for IcloudBackend {
     type Lister = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut ma = AccessorInfo::default();
         ma.set_scheme(Scheme::Icloud)
             .set_root(&self.core.root)
@@ -282,7 +282,7 @@ impl Access for IcloudBackend {
                 read: true,
                 ..Default::default()
             });
-        ma
+        ma.into()
     }
 
     async fn stat(&self, path: &str, _: OpStat) -> Result<RpStat> {

--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -166,7 +166,7 @@ impl Access for IpfsBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut ma = AccessorInfo::default();
         ma.set_scheme(Scheme::Ipfs)
             .set_root(&self.root)
@@ -180,7 +180,7 @@ impl Access for IpfsBackend {
                 ..Default::default()
             });
 
-        ma
+        ma.into()
     }
 
     /// IPFS's stat behavior highly depends on its implementation.

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -68,7 +68,7 @@ impl Access for IpmfsBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Ipmfs)
             .set_root(&self.root)
@@ -85,7 +85,7 @@ impl Access for IpmfsBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/koofr/backend.rs
+++ b/core/src/services/koofr/backend.rs
@@ -242,7 +242,7 @@ impl Access for KoofrBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Koofr)
             .set_root(&self.core.root)
@@ -267,7 +267,7 @@ impl Access for KoofrBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/monoiofs/backend.rs
+++ b/core/src/services/monoiofs/backend.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use serde::Deserialize;
 
@@ -85,7 +86,7 @@ impl Access for MonoiofsBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         todo!()
     }
 }

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -254,7 +254,7 @@ impl Access for ObsBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Obs)
             .set_root(&self.core.root)
@@ -302,7 +302,7 @@ impl Access for ObsBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use bytes::Buf;
 use bytes::Bytes;
@@ -68,7 +69,7 @@ impl Access for OnedriveBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut ma = AccessorInfo::default();
         ma.set_scheme(Scheme::Onedrive)
             .set_root(&self.root)
@@ -82,7 +83,7 @@ impl Access for OnedriveBackend {
                 ..Default::default()
             });
 
-        ma
+        ma.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -382,7 +382,7 @@ impl Access for OssBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Oss)
             .set_root(&self.core.root)
@@ -436,7 +436,7 @@ impl Access for OssBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/pcloud/backend.rs
+++ b/core/src/services/pcloud/backend.rs
@@ -235,7 +235,7 @@ impl Access for PcloudBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Pcloud)
             .set_root(&self.core.root)
@@ -257,7 +257,7 @@ impl Access for PcloudBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -1032,7 +1032,7 @@ impl Access for S3Backend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::S3)
             .set_root(&self.core.root)
@@ -1090,7 +1090,7 @@ impl Access for S3Backend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/seafile/backend.rs
+++ b/core/src/services/seafile/backend.rs
@@ -262,7 +262,7 @@ impl Access for SeafileBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Seafile)
             .set_root(&self.core.root)
@@ -281,7 +281,7 @@ impl Access for SeafileBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -21,6 +21,7 @@ use std::fmt::Formatter;
 use std::io::SeekFrom;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use bb8::PooledConnection;
 use bb8::RunError;
@@ -351,7 +352,7 @@ impl Access for SftpBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_root(self.root.as_str())
             .set_scheme(Scheme::Sftp)
@@ -375,7 +376,7 @@ impl Access for SftpBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/supabase/backend.rs
+++ b/core/src/services/supabase/backend.rs
@@ -163,7 +163,7 @@ impl Access for SupabaseBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Supabase)
             .set_root(&self.core.root)
@@ -179,7 +179,7 @@ impl Access for SupabaseBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {

--- a/core/src/services/swift/backend.rs
+++ b/core/src/services/swift/backend.rs
@@ -193,7 +193,7 @@ impl Access for SwiftBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Swift)
             .set_root(&self.core.root)
@@ -211,7 +211,7 @@ impl Access for SwiftBackend {
 
                 ..Default::default()
             });
-        am
+        am.into()
     }
 
     async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {

--- a/core/src/services/upyun/backend.rs
+++ b/core/src/services/upyun/backend.rs
@@ -239,7 +239,7 @@ impl Access for UpyunBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Upyun)
             .set_root(&self.core.root)
@@ -270,7 +270,7 @@ impl Access for UpyunBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/vercel_artifacts/backend.rs
+++ b/core/src/services/vercel_artifacts/backend.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use http::header;
 use http::Request;
@@ -50,7 +51,7 @@ impl Access for VercelArtifactsBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut ma = AccessorInfo::default();
         ma.set_scheme(Scheme::VercelArtifacts)
             .set_native_capability(Capability {
@@ -63,7 +64,7 @@ impl Access for VercelArtifactsBackend {
                 ..Default::default()
             });
 
-        ma
+        ma.into()
     }
 
     async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {

--- a/core/src/services/vercel_blob/backend.rs
+++ b/core/src/services/vercel_blob/backend.rs
@@ -185,7 +185,7 @@ impl Access for VercelBlobBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::VercelBlob)
             .set_root(&self.core.root)
@@ -208,7 +208,7 @@ impl Access for VercelBlobBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -243,7 +243,7 @@ impl Access for WebdavBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut ma = AccessorInfo::default();
         ma.set_scheme(Scheme::Webdav)
             .set_root(&self.core.root)
@@ -268,7 +268,7 @@ impl Access for WebdavBackend {
                 ..Default::default()
             });
 
-        ma
+        ma.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -17,6 +17,7 @@
 
 use core::fmt::Debug;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use bytes::Buf;
 use http::header::CONTENT_LENGTH;
@@ -536,7 +537,7 @@ impl Access for WebhdfsBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::Webhdfs)
             .set_root(&self.root)
@@ -556,7 +557,7 @@ impl Access for WebhdfsBackend {
 
                 ..Default::default()
             });
-        am
+        am.into()
     }
 
     /// Create a file or directory

--- a/core/src/services/yandex_disk/backend.rs
+++ b/core/src/services/yandex_disk/backend.rs
@@ -187,7 +187,7 @@ impl Access for YandexDiskBackend {
     type BlockingWriter = ();
     type BlockingLister = ();
 
-    fn info(&self) -> AccessorInfo {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut am = AccessorInfo::default();
         am.set_scheme(Scheme::YandexDisk)
             .set_root(&self.core.root)
@@ -211,7 +211,7 @@ impl Access for YandexDiskBackend {
                 ..Default::default()
             });
 
-        am
+        am.into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/types/operator/metadata.rs
+++ b/core/src/types/operator/metadata.rs
@@ -15,15 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use crate::raw::*;
 use crate::*;
 
 /// Metadata for operator, users can use this metadata to get information of operator.
 #[derive(Clone, Debug, Default)]
-pub struct OperatorInfo(AccessorInfo);
+pub struct OperatorInfo(Arc<AccessorInfo>);
 
 impl OperatorInfo {
-    pub(super) fn new(acc: AccessorInfo) -> Self {
+    pub(super) fn new(acc: Arc<AccessorInfo>) -> Self {
         OperatorInfo(acc)
     }
 

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -16,14 +16,12 @@
 // under the License.
 
 use std::future::Future;
-use std::sync::Arc;
 use std::time::Duration;
 
 use futures::stream;
 use futures::Stream;
 use futures::StreamExt;
 use futures::TryStreamExt;
-use once_cell::sync::OnceCell;
 
 use super::BlockingOperator;
 use crate::operator_futures::*;
@@ -66,8 +64,6 @@ use crate::*;
 pub struct Operator {
     // accessor is what Operator delegates for
     accessor: Accessor,
-    // info stores the metadata for operator, users can use this metadata to get information of operator.
-    info: OnceCell<Arc<OperatorInfo>>,
 
     // limit is usually the maximum size of data that operator will handle in one operation
     limit: usize,
@@ -89,7 +85,6 @@ impl Operator {
             .unwrap_or(1000);
         Self {
             accessor,
-            info: OnceCell::new(),
             limit,
             default_executor: None,
         }
@@ -140,9 +135,8 @@ impl Operator {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn info(&self) -> &OperatorInfo {
-        self.info
-            .get_or_init(|| Arc::new(OperatorInfo::new(self.accessor.info())))
+    pub fn info(&self) -> OperatorInfo {
+        OperatorInfo::new(self.accessor.info())
     }
 
     /// Create a new blocking operator.


### PR DESCRIPTION
Just add a field inside the `Operator` struct and wrap the `OperatorInfo` with `OnceCell<Arc<T>>` for lazy initialize and avoid other memory allocation.

#4845 