### PR TITLE
fix(services/s3): NoSuchBucket is a ConfigInvalid for OpenDAL

### DIFF
--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
  "md-5",
  "once_cell",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.31.0",
  "rand",
  "reqsign",
  "reqwest",
@@ -1096,6 +1096,16 @@ name = "quick-xml"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e446ed58cef1bbfe847bc2fda0e2e4ea9f0e57b90c507d4781292590d72a4e"
 dependencies = [
  "memchr",
  "serde",
@@ -1218,9 +1228,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqsign"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70fe66d4cd0b5ed9b1abbfe639bf6baeaaf509f7da2d51b31111ba945be59286"
+checksum = "03dd4ba7c3901dd43e6b8c7446a760d45bc1ea4301002e1a6fa48f97c3a796fa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1234,7 +1244,7 @@ dependencies = [
  "http",
  "log",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.35.0",
  "rand",
  "reqwest",
  "rust-ini",

--- a/core/src/services/s3/error.rs
+++ b/core/src/services/s3/error.rs
@@ -87,6 +87,11 @@ pub(crate) fn from_s3_error(s3_error: S3Error, parts: Parts) -> Error {
 /// All possible error code: <https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList>
 pub fn parse_s3_error_code(code: &str) -> Option<(ErrorKind, bool)> {
     match code {
+        // > The specified bucket does not exist.
+        //
+        // Although the status code is 404, NoSuchBucket is
+        // a config invalid error, and it's not retryable from OpenDAL.
+        "NoSuchBucket" => Some((ErrorKind::ConfigInvalid, false)),
         // > Your socket connection to the server was not read from
         // > or written to within the timeout period."
         //
@@ -147,7 +152,7 @@ mod tests {
 <CompleteMultipartUploadResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <Location>http://Example-Bucket.s3.ap-southeast-1.amazonaws.com/Example-Object</Location>
   <Bucket>Example-Bucket</Bucket>
-  <Key>Example-Object</Key> 
+  <Key>Example-Object</Key>
   <ETag>"3858f62230ac3c915f300c664312c11f-9"</ETag>
 </CompleteMultipartUploadResult>
 "#,


### PR DESCRIPTION
# Which issue does this PR close?

This refers to #4894. It doesn't "fix" the stat part, but fix the `check` method as a workaround.

# What changes are included in this PR?

OpenDAL doesn't

# Are there any user-facing changes?

`check` on S3 service will now fail if bucket misconfigured or bucket is yet to be created..