### PR TITLE
refactor(core): move move logic from fn metadata(&self) -> Arc<AccessorInfo> to impl<A: Access> Layer<A> for CompleteLayer

### DIFF
--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -151,7 +151,7 @@ impl<A: Access> Layer<A> for BlockingLayer {
 
         BlockingAccessor {
             inner,
-            meta: meta.into(),
+            meta: Arc::new(meta),
             handle: self.handle.clone(),
         }
     }

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -117,7 +117,7 @@ impl<A: Access> Layer<A> for CompleteLayer {
         }
 
         CompleteAccessor {
-            meta: meta.into(),
+            meta: Arc::new(meta),
             inner: Arc::new(inner),
         }
     }

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -20,8 +20,6 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use quick_xml::se;
-
 use crate::raw::oio::FlatLister;
 use crate::raw::oio::PrefixLister;
 use crate::raw::*;
@@ -111,8 +109,15 @@ impl<A: Access> Layer<A> for CompleteLayer {
     type LayeredAccess = CompleteAccessor<A>;
 
     fn layer(&self, inner: A) -> Self::LayeredAccess {
+        let mut meta = inner.info().as_ref().clone();
+        let cap = meta.full_capability_mut();
+
+        if cap.list && cap.write_can_empty {
+            cap.create_dir = true;
+        }
+
         CompleteAccessor {
-            meta: inner.info(),
+            meta: meta.into(),
             inner: Arc::new(inner),
         }
     }

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -20,6 +20,8 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
+use quick_xml::se;
+
 use crate::raw::oio::FlatLister;
 use crate::raw::oio::PrefixLister;
 use crate::raw::*;
@@ -109,15 +111,8 @@ impl<A: Access> Layer<A> for CompleteLayer {
     type LayeredAccess = CompleteAccessor<A>;
 
     fn layer(&self, inner: A) -> Self::LayeredAccess {
-        let mut meta = inner.info().as_ref().clone();
-
-        let cap = meta.full_capability_mut();
-        if cap.list && cap.write_can_empty {
-            cap.create_dir = true;
-        }
-
         CompleteAccessor {
-            meta: Arc::new(meta),
+            meta: inner.info(),
             inner: Arc::new(inner),
         }
     }
@@ -383,8 +378,14 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
         &self.inner
     }
 
+    // Todo: May move the logic to the implement of Layer::layer of CompleteAccessor<A>
     fn metadata(&self) -> Arc<AccessorInfo> {
-        self.meta.clone()
+        let mut meta = self.meta.as_ref().clone();
+        let cap = meta.full_capability_mut();
+        if cap.list && cap.write_can_empty {
+            cap.create_dir = true;
+        }
+        meta.into()
     }
 
     async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -383,14 +383,8 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
         &self.inner
     }
 
-    // Todo: May move the logic to the implement of Layer::layer of CompleteAccessor<A>
     fn metadata(&self) -> Arc<AccessorInfo> {
-        let mut meta = self.meta.as_ref().clone();
-        let cap = meta.full_capability_mut();
-        if cap.list && cap.write_can_empty {
-            cap.create_dir = true;
-        }
-        meta.into()
+        self.meta.clone()
     }
 
     async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/layers/immutable_index.rs
+++ b/core/src/layers/immutable_index.rs
@@ -82,7 +82,7 @@ impl<A: Access> Layer<A> for ImmutableIndexLayer {
 
         ImmutableIndexAccessor {
             vec: self.vec.clone(),
-            meta: meta.into(),
+            meta: Arc::new(meta),
             inner,
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4888 

# What changes are included in this PR?

mentioned in #4888 

# Are there any user-facing changes?

No
