### PR TITLE
feat(prometheus-client): add metric label about `root` on using PrometheusClientLayer

### DIFF
--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -110,8 +110,8 @@ impl<A: Access> Layer<A> for PrometheusClientLayer {
     }
 }
 
-type OperationLabels = [(&'static str, &'static str); 2];
-type ErrorLabels = [(&'static str, &'static str); 3];
+type OperationLabels = [(&'static str, String); 2];
+type ErrorLabels = [(&'static str, String); 3];
 
 /// [`PrometheusClientMetrics`] provide the performance and IO metrics with the `prometheus-client` crate.
 #[derive(Debug, Clone)]
@@ -162,20 +162,20 @@ impl PrometheusClientMetrics {
 
     fn increment_errors_total(&self, scheme: Scheme, op: &'static str, err: ErrorKind) {
         let labels = [
-            ("scheme", scheme.into_static()),
-            ("op", op),
-            ("err", err.into_static()),
+            ("scheme", scheme.to_string()),
+            ("op", op.to_string()),
+            ("err", err.to_string()),
         ];
         self.errors_total.get_or_create(&labels).inc();
     }
 
     fn increment_request_total(&self, scheme: Scheme, op: &'static str) {
-        let labels = [("scheme", scheme.into_static()), ("op", op)];
+        let labels = [("scheme", scheme.to_string()), ("op", op.to_string())];
         self.requests_total.get_or_create(&labels).inc();
     }
 
     fn observe_bytes_total(&self, scheme: Scheme, op: &'static str, bytes: usize) {
-        let labels = [("scheme", scheme.into_static()), ("op", op)];
+        let labels = [("scheme", scheme.to_string()), ("op", op.to_string())];
         self.bytes_histogram
             .get_or_create(&labels)
             .observe(bytes as f64);
@@ -183,7 +183,7 @@ impl PrometheusClientMetrics {
     }
 
     fn observe_request_duration(&self, scheme: Scheme, op: &'static str, duration: Duration) {
-        let labels = [("scheme", scheme.into_static()), ("op", op)];
+        let labels = [("scheme", scheme.to_string()), ("op", op.to_string())];
         self.request_duration_seconds
             .get_or_create(&labels)
             .observe(duration.as_secs_f64());

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::borrow::Cow;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -24,6 +23,8 @@ use std::time::Instant;
 
 use bytes::Buf;
 use futures::TryFutureExt;
+use prometheus_client::encoding::EncodeLabel;
+use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::histogram;
@@ -114,8 +115,49 @@ impl<A: Access> Layer<A> for PrometheusClientLayer {
     }
 }
 
-type OperationLabels = [(&'static str, Cow<'static, str>); 4];
-type ErrorLabels = [(&'static str, Cow<'static, str>); 5];
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+struct OperationLabels {
+    op: &'static str,
+    scheme: &'static str,
+    root: Arc<String>,
+    namespace: Arc<String>,
+}
+
+impl EncodeLabelSet for OperationLabels {
+    fn encode(
+        &self,
+        mut encoder: prometheus_client::encoding::LabelSetEncoder,
+    ) -> std::result::Result<(), std::fmt::Error> {
+        ("op", self.op).encode(encoder.encode_label())?;
+        ("scheme", self.scheme).encode(encoder.encode_label())?;
+        ("namespace", self.namespace.as_str()).encode(encoder.encode_label())?;
+        ("root", self.root.as_str()).encode(encoder.encode_label())?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+struct ErrorLabels {
+    op: &'static str,
+    scheme: &'static str,
+    err: &'static str,
+    root: Arc<String>,
+    namespace: Arc<String>,
+}
+
+impl EncodeLabelSet for ErrorLabels {
+    fn encode(
+        &self,
+        mut encoder: prometheus_client::encoding::LabelSetEncoder,
+    ) -> std::result::Result<(), std::fmt::Error> {
+        ("op", self.op).encode(encoder.encode_label())?;
+        ("scheme", self.scheme).encode(encoder.encode_label())?;
+        ("error", self.err).encode(encoder.encode_label())?;
+        ("namespace", self.namespace.as_str()).encode(encoder.encode_label())?;
+        ("root", self.root.as_str()).encode(encoder.encode_label())?;
+        Ok(())
+    }
+}
 
 /// [`PrometheusClientMetricDefinitions`] provide the definition about RED(Rate/Error/Duration) metrics with the `prometheus-client` crate.
 #[derive(Debug, Clone)]
@@ -169,8 +211,8 @@ impl PrometheusClientMetricDefinitions {
 struct PrometheusClientMetrics {
     metrics: Arc<PrometheusClientMetricDefinitions>,
     scheme: Scheme,
-    root: String,
-    name: String,
+    root: Arc<String>,
+    name: Arc<String>,
 }
 
 impl PrometheusClientMetrics {
@@ -183,39 +225,39 @@ impl PrometheusClientMetrics {
         Self {
             metrics,
             scheme,
-            root,
-            name,
+            root: Arc::new(root),
+            name: Arc::new(name),
         }
     }
 
     fn increment_errors_total(&self, op: &'static str, err: ErrorKind) {
-        let labels = [
-            ("scheme", self.scheme.into_static().into()),
-            ("op", op.into()),
-            ("error", err.into_static().into()),
-            ("namespace", self.name.clone().into()),
-            ("root", self.root.clone().into()),
-        ];
+        let labels = ErrorLabels {
+            op,
+            scheme: self.scheme.into_static(),
+            err: err.into_static(),
+            root: self.root.clone(),
+            namespace: self.name.clone(),
+        };
         self.metrics.errors_total.get_or_create(&labels).inc();
     }
 
     fn increment_request_total(&self, scheme: Scheme, op: &'static str) {
-        let labels = [
-            ("scheme", scheme.into_static().into()),
-            ("op", op.into()),
-            ("namespace", self.name.clone().into()),
-            ("root", self.root.clone().into()),
-        ];
+        let labels = OperationLabels {
+            op,
+            scheme: scheme.into_static(),
+            root: self.root.clone(),
+            namespace: self.name.clone(),
+        };
         self.metrics.requests_total.get_or_create(&labels).inc();
     }
 
     fn observe_bytes_total(&self, scheme: Scheme, op: &'static str, bytes: usize) {
-        let labels = [
-            ("scheme", scheme.into_static().into()),
-            ("op", op.into()),
-            ("namespace", self.name.clone().into()),
-            ("root", self.root.clone().into()),
-        ];
+        let labels = OperationLabels {
+            op,
+            scheme: scheme.into_static(),
+            root: self.root.clone(),
+            namespace: self.name.clone(),
+        };
         self.metrics
             .bytes_histogram
             .get_or_create(&labels)
@@ -227,12 +269,12 @@ impl PrometheusClientMetrics {
     }
 
     fn observe_request_duration(&self, scheme: Scheme, op: &'static str, duration: Duration) {
-        let labels = [
-            ("scheme", scheme.into_static().into()),
-            ("op", op.into()),
-            ("namespace", self.name.clone().into()),
-            ("root", self.root.clone().into()),
-        ];
+        let labels = OperationLabels {
+            op,
+            scheme: scheme.into_static(),
+            root: self.root.clone(),
+            namespace: self.name.clone(),
+        };
         self.metrics
             .request_duration_seconds
             .get_or_create(&labels)

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -113,7 +113,7 @@ impl<A: Access> Layer<A> for PrometheusClientLayer {
 type OperationLabels = [(&'static str, String); 2];
 type ErrorLabels = [(&'static str, String); 3];
 
-/// [`PrometheusClientMetrics`] provide the performance and IO metrics with the `prometheus-client` crate.
+/// [`PrometheusClientMetricDefinitions`] provide the definition about RED(Rate/Error/Duration) metrics with the `prometheus-client` crate.
 #[derive(Debug, Clone)]
 struct PrometheusClientMetricDefinitions {
     /// Total counter of the specific operation be called.
@@ -172,9 +172,9 @@ impl PrometheusClientMetrics {
         Self { metrics, scheme }
     }
 
-    fn increment_errors_total(&self, scheme: Scheme, op: &'static str, err: ErrorKind) {
+    fn increment_errors_total(&self, op: &'static str, err: ErrorKind) {
         let labels = [
-            ("scheme", scheme.to_string()),
+            ("scheme", self.scheme.to_string()),
             ("op", op.to_string()),
             ("err", err.to_string()),
         ];
@@ -248,11 +248,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
             start_time.elapsed(),
         );
         create_res.map_err(|e| {
-            self.metrics.increment_errors_total(
-                self.scheme,
-                Operation::CreateDir.into_static(),
-                e.kind(),
-            );
+            self.metrics
+                .increment_errors_total(Operation::CreateDir.into_static(), e.kind());
             e
         })
     }
@@ -275,11 +272,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
                 PrometheusMetricWrapper::new(r, self.metrics.clone(), self.scheme),
             )),
             Err(err) => {
-                self.metrics.increment_errors_total(
-                    self.scheme,
-                    Operation::Read.into_static(),
-                    err.kind(),
-                );
+                self.metrics
+                    .increment_errors_total(Operation::Read.into_static(), err.kind());
                 Err(err)
             }
         }
@@ -306,11 +300,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
                 PrometheusMetricWrapper::new(w, self.metrics.clone(), self.scheme),
             )),
             Err(err) => {
-                self.metrics.increment_errors_total(
-                    self.scheme,
-                    Operation::Write.into_static(),
-                    err.kind(),
-                );
+                self.metrics
+                    .increment_errors_total(Operation::Write.into_static(), err.kind());
                 Err(err)
             }
         }
@@ -325,11 +316,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
             .inner
             .stat(path, args)
             .inspect_err(|e| {
-                self.metrics.increment_errors_total(
-                    self.scheme,
-                    Operation::Stat.into_static(),
-                    e.kind(),
-                );
+                self.metrics
+                    .increment_errors_total(Operation::Stat.into_static(), e.kind());
             })
             .await;
 
@@ -339,11 +327,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
             start_time.elapsed(),
         );
         stat_res.map_err(|e| {
-            self.metrics.increment_errors_total(
-                self.scheme,
-                Operation::Stat.into_static(),
-                e.kind(),
-            );
+            self.metrics
+                .increment_errors_total(Operation::Stat.into_static(), e.kind());
             e
         })
     }
@@ -361,11 +346,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
             start_time.elapsed(),
         );
         delete_res.map_err(|e| {
-            self.metrics.increment_errors_total(
-                self.scheme,
-                Operation::Delete.into_static(),
-                e.kind(),
-            );
+            self.metrics
+                .increment_errors_total(Operation::Delete.into_static(), e.kind());
             e
         })
     }
@@ -383,11 +365,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
             start_time.elapsed(),
         );
         list_res.map_err(|e| {
-            self.metrics.increment_errors_total(
-                self.scheme,
-                Operation::List.into_static(),
-                e.kind(),
-            );
+            self.metrics
+                .increment_errors_total(Operation::List.into_static(), e.kind());
             e
         })
     }
@@ -405,11 +384,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
             start_time.elapsed(),
         );
         result.map_err(|e| {
-            self.metrics.increment_errors_total(
-                self.scheme,
-                Operation::Batch.into_static(),
-                e.kind(),
-            );
+            self.metrics
+                .increment_errors_total(Operation::Batch.into_static(), e.kind());
             e
         })
     }
@@ -427,11 +403,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
             start_time.elapsed(),
         );
         result.map_err(|e| {
-            self.metrics.increment_errors_total(
-                self.scheme,
-                Operation::Presign.into_static(),
-                e.kind(),
-            );
+            self.metrics
+                .increment_errors_total(Operation::Presign.into_static(), e.kind());
             e
         })
     }
@@ -449,11 +422,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
             start_time.elapsed(),
         );
         result.map_err(|e| {
-            self.metrics.increment_errors_total(
-                self.scheme,
-                Operation::BlockingCreateDir.into_static(),
-                e.kind(),
-            );
+            self.metrics
+                .increment_errors_total(Operation::BlockingCreateDir.into_static(), e.kind());
             e
         })
     }
@@ -470,11 +440,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
         });
 
         result.map_err(|e| {
-            self.metrics.increment_errors_total(
-                self.scheme,
-                Operation::BlockingRead.into_static(),
-                e.kind(),
-            );
+            self.metrics
+                .increment_errors_total(Operation::BlockingRead.into_static(), e.kind());
             e
         })
     }
@@ -491,11 +458,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
         });
 
         result.map_err(|e| {
-            self.metrics.increment_errors_total(
-                self.scheme,
-                Operation::BlockingWrite.into_static(),
-                e.kind(),
-            );
+            self.metrics
+                .increment_errors_total(Operation::BlockingWrite.into_static(), e.kind());
             e
         })
     }
@@ -513,11 +477,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
         );
 
         result.map_err(|e| {
-            self.metrics.increment_errors_total(
-                self.scheme,
-                Operation::BlockingStat.into_static(),
-                e.kind(),
-            );
+            self.metrics
+                .increment_errors_total(Operation::BlockingStat.into_static(), e.kind());
             e
         })
     }
@@ -535,11 +496,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
             start_time.elapsed(),
         );
         result.map_err(|e| {
-            self.metrics.increment_errors_total(
-                self.scheme,
-                Operation::BlockingDelete.into_static(),
-                e.kind(),
-            );
+            self.metrics
+                .increment_errors_total(Operation::BlockingDelete.into_static(), e.kind());
             e
         })
     }
@@ -557,11 +515,8 @@ impl<A: Access> LayeredAccess for PrometheusAccessor<A> {
             start_time.elapsed(),
         );
         result.map_err(|e| {
-            self.metrics.increment_errors_total(
-                self.scheme,
-                Operation::BlockingList.into_static(),
-                e.kind(),
-            );
+            self.metrics
+                .increment_errors_total(Operation::BlockingList.into_static(), e.kind());
             e
         })
     }
@@ -603,11 +558,8 @@ impl<R: oio::Read> oio::Read for PrometheusMetricWrapper<R> {
                 Ok(bs)
             }
             Err(e) => {
-                self.metrics.increment_errors_total(
-                    self.scheme,
-                    ReadOperation::Read.into_static(),
-                    e.kind(),
-                );
+                self.metrics
+                    .increment_errors_total(ReadOperation::Read.into_static(), e.kind());
                 Err(e)
             }
         }
@@ -633,11 +585,8 @@ impl<R: oio::BlockingRead> oio::BlockingRead for PrometheusMetricWrapper<R> {
                 bs
             })
             .map_err(|e| {
-                self.metrics.increment_errors_total(
-                    self.scheme,
-                    ReadOperation::BlockingRead.into_static(),
-                    e.kind(),
-                );
+                self.metrics
+                    .increment_errors_total(ReadOperation::BlockingRead.into_static(), e.kind());
                 e
             })
     }
@@ -664,11 +613,8 @@ impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
                 );
             })
             .map_err(|err| {
-                self.metrics.increment_errors_total(
-                    self.scheme,
-                    WriteOperation::Write.into_static(),
-                    err.kind(),
-                );
+                self.metrics
+                    .increment_errors_total(WriteOperation::Write.into_static(), err.kind());
                 err
             })
     }
@@ -687,11 +633,8 @@ impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
                 );
             })
             .map_err(|err| {
-                self.metrics.increment_errors_total(
-                    self.scheme,
-                    WriteOperation::Abort.into_static(),
-                    err.kind(),
-                );
+                self.metrics
+                    .increment_errors_total(WriteOperation::Abort.into_static(), err.kind());
                 err
             })
     }
@@ -710,11 +653,8 @@ impl<R: oio::Write> oio::Write for PrometheusMetricWrapper<R> {
                 );
             })
             .map_err(|err| {
-                self.metrics.increment_errors_total(
-                    self.scheme,
-                    WriteOperation::Close.into_static(),
-                    err.kind(),
-                );
+                self.metrics
+                    .increment_errors_total(WriteOperation::Close.into_static(), err.kind());
                 err
             })
     }
@@ -741,7 +681,6 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for PrometheusMetricWrapper<R> {
             })
             .map_err(|err| {
                 self.metrics.increment_errors_total(
-                    self.scheme,
                     WriteOperation::BlockingWrite.into_static(),
                     err.kind(),
                 );
@@ -763,7 +702,6 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for PrometheusMetricWrapper<R> {
             })
             .map_err(|err| {
                 self.metrics.increment_errors_total(
-                    self.scheme,
                     WriteOperation::BlockingClose.into_static(),
                     err.kind(),
                 );

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -23,8 +24,6 @@ use std::time::Instant;
 
 use bytes::Buf;
 use futures::TryFutureExt;
-use prometheus_client::encoding::EncodeLabel;
-use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::histogram;
@@ -115,31 +114,8 @@ impl<A: Access> Layer<A> for PrometheusClientLayer {
     }
 }
 
-type OperationLabels = [(&'static str, String); 4];
-// type ErrorLabels = [(&'static str, String); 5];
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct ErrorLabels {
-    scheme: &'static str,
-    op: &'static str,
-    namespace: String,
-    root: String,
-    err: &'static str,
-}
-
-impl<'a> EncodeLabelSet for ErrorLabels {
-    fn encode(
-        &self,
-        mut encoder: prometheus_client::encoding::LabelSetEncoder,
-    ) -> std::result::Result<(), std::fmt::Error> {
-        ("scheme", self.scheme).encode(encoder.encode_label())?;
-        ("op", self.op).encode(encoder.encode_label())?;
-        ("namespace", self.namespace.as_str()).encode(encoder.encode_label())?;
-        ("root", self.root.as_str()).encode(encoder.encode_label())?;
-        ("err", self.err).encode(encoder.encode_label())?;
-        Ok(())
-    }
-}
+type OperationLabels = [(&'static str, Cow<'static, str>); 4];
+type ErrorLabels = [(&'static str, Cow<'static, str>); 5];
 
 /// [`PrometheusClientMetricDefinitions`] provide the definition about RED(Rate/Error/Duration) metrics with the `prometheus-client` crate.
 #[derive(Debug, Clone)]
@@ -213,32 +189,32 @@ impl PrometheusClientMetrics {
     }
 
     fn increment_errors_total(&self, op: &'static str, err: ErrorKind) {
-        let labels = ErrorLabels {
-            op: op,
-            err: err.into_static(),
-            scheme: self.scheme.into_static(),
-            root: self.root.clone(),
-            namespace: self.name.clone(),
-        };
+        let labels = [
+            ("scheme", self.scheme.into_static().into()),
+            ("op", op.into()),
+            ("error", err.into_static().into()),
+            ("namespace", self.name.clone().into()),
+            ("root", self.root.clone().into()),
+        ];
         self.metrics.errors_total.get_or_create(&labels).inc();
     }
 
     fn increment_request_total(&self, scheme: Scheme, op: &'static str) {
         let labels = [
-            ("scheme", scheme.to_string()),
-            ("op", op.to_string()),
-            ("namespace", self.name.to_string()),
-            ("root", self.root.to_string()),
+            ("scheme", scheme.into_static().into()),
+            ("op", op.into()),
+            ("namespace", self.name.clone().into()),
+            ("root", self.root.clone().into()),
         ];
         self.metrics.requests_total.get_or_create(&labels).inc();
     }
 
     fn observe_bytes_total(&self, scheme: Scheme, op: &'static str, bytes: usize) {
         let labels = [
-            ("scheme", scheme.to_string()),
-            ("op", op.to_string()),
-            ("namespace", self.name.to_string()),
-            ("root", self.root.to_string()),
+            ("scheme", scheme.into_static().into()),
+            ("op", op.into()),
+            ("namespace", self.name.clone().into()),
+            ("root", self.root.clone().into()),
         ];
         self.metrics
             .bytes_histogram
@@ -252,10 +228,10 @@ impl PrometheusClientMetrics {
 
     fn observe_request_duration(&self, scheme: Scheme, op: &'static str, duration: Duration) {
         let labels = [
-            ("scheme", scheme.to_string()),
-            ("op", op.to_string()),
-            ("namespace", self.name.to_string()),
-            ("root", self.root.to_string()),
+            ("scheme", scheme.into_static().into()),
+            ("op", op.into()),
+            ("namespace", self.name.clone().into()),
+            ("root", self.root.clone().into()),
         ];
         self.metrics
             .request_duration_seconds


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4909.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I did not found the bucket value in the accessor, but i found a parameter called `root` might be helpful on this case. To make this PR work as expected, I need to make sure that the bucket should be the prefix of the `root` parameter.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- refactor: seperate registering metrics and helpers to update metrics with the common labels
- feat: add root label to all the labels

# Are there any user-facing changes?

this PR adds a new label on the prometheus metrics, if you had an existed dashboard, this change may make additional data lines on your chart. however it would not change your chart if you use `sum(xx) by (op)` or other metric aggregation operations.

to make this change possible, we had to make the type of labels from `(&'static str, &'static str)` to `(&'static str, String)`, this may degrade a bit performance.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
