### PR TITLE
docs(core): Fix comment for into_futures_async_write

### DIFF
--- a/core/src/types/write/writer.rs
+++ b/core/src/types/write/writer.rs
@@ -186,9 +186,8 @@ impl Writer {
     /// FuturesAsyncWriter is not a zero-cost abstraction. The underlying writer
     /// requires an owned [`Buffer`], which involves an extra copy operation.
     ///
-    /// FuturesAsyncWriters are automatically closed when they go out of scope. Errors detected on
-    /// closing are ignored by the implementation of Drop. Use the method `close` if these errors
-    /// must be manually handled.
+    /// FuturesAsyncWriter is required to call `close()` to make sure all
+    /// data have been written to the storage.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/opendal/issues/4926.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The comment is wrong. I'm guessing I copied it wrong from futures or std.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Fix the comment.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

No behavior changed. Just correct the comment.