### PR TITLE
feat(core)!: implement an interceptor for the logging layer

### DIFF
--- a/bindings/haskell/test/BasicTest.hs
+++ b/bindings/haskell/test/BasicTest.hs
@@ -109,7 +109,7 @@ testLogger = do
   let logFn = LogAction $ logger state
   Right _ <- newOperator "memory" {ocLogAction = Just logFn}
   logStr <- readIORef state
-  T.take 77 logStr @?= "service=memory operation=metadata -> startedservice=memory operation=metadata"
+  T.take 78 logStr @?= "service=memory operation=metadata  -> startedservice=memory operation=metadata"
 
 -- helper function
 

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -1181,7 +1181,7 @@ impl<P: oio::List, I: LoggingInterceptor> oio::List for LoggingLister<P, I> {
             }
             Err(err) => {
                 self.ctx
-                    .log(self.op.into_static(), &self.path, "->", Some(&err));
+                    .log(self.op.into_static(), &self.path, "->", Some(err));
             }
         };
 
@@ -1209,7 +1209,7 @@ impl<P: oio::BlockingList, I: LoggingInterceptor> oio::BlockingList for LoggingL
             }
             Err(err) => {
                 self.ctx
-                    .log(self.op.into_static(), &self.path, "->", Some(&err));
+                    .log(self.op.into_static(), &self.path, "->", Some(err));
             }
         };
 

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -84,13 +84,13 @@ use crate::*;
 /// You can implement your own logging interceptor to customize the logging behavior.
 ///
 /// ```no_run
-/// use crate::layers::LoggingInterceptor;
-/// use crate::layers::LoggingLayer;
-/// use crate::raw::Operation;
-/// use crate::services;
-/// use crate::Error;
-/// use crate::Operator;
-/// use crate::Scheme;
+/// use opendal::layers::LoggingInterceptor;
+/// use opendal::layers::LoggingLayer;
+/// use opendal::raw::Operation;
+/// use opendal::services;
+/// use opendal::Error;
+/// use opendal::Operator;
+/// use opendal::Scheme;
 ///
 /// #[derive(Debug, Clone)]
 /// struct MyLoggingInterceptor;

--- a/core/src/layers/mod.rs
+++ b/core/src/layers/mod.rs
@@ -34,6 +34,7 @@ pub use immutable_index::ImmutableIndexLayer;
 
 mod logging;
 pub use logging::DefaultLoggingInterceptor;
+pub use logging::LoggingInterceptor;
 pub use logging::LoggingLayer;
 
 mod timeout;

--- a/core/src/layers/mod.rs
+++ b/core/src/layers/mod.rs
@@ -33,6 +33,7 @@ mod immutable_index;
 pub use immutable_index::ImmutableIndexLayer;
 
 mod logging;
+pub use logging::DefaultLoggingInterceptor;
 pub use logging::LoggingLayer;
 
 mod timeout;

--- a/core/src/layers/mod.rs
+++ b/core/src/layers/mod.rs
@@ -33,7 +33,6 @@ mod immutable_index;
 pub use immutable_index::ImmutableIndexLayer;
 
 mod logging;
-pub use logging::DefaultLoggingInterceptor;
 pub use logging::LoggingInterceptor;
 pub use logging::LoggingLayer;
 

--- a/core/src/raw/tests/utils.rs
+++ b/core/src/raw/tests/utils.rs
@@ -19,8 +19,11 @@ use std::collections::HashMap;
 use std::env;
 use std::str::FromStr;
 
+use log::{log, Level};
 use once_cell::sync::Lazy;
 
+use crate::layers::LoggingInterceptor;
+use crate::raw::Operation;
 use crate::*;
 
 /// TEST_RUNTIME is the runtime used for running tests.
@@ -73,9 +76,7 @@ pub fn init_test_service() -> Result<Option<Operator>> {
     let op = { op.layer(layers::ChaosLayer::new(0.1)) };
 
     let mut op = op
-        .layer(layers::LoggingLayer::new(
-            layers::DefaultLoggingInterceptor::default().with_backtrace_output(true),
-        ))
+        .layer(layers::LoggingLayer::new(BacktraceLoggingInterceptor))
         .layer(layers::TimeoutLayer::new())
         .layer(layers::RetryLayer::new().with_max_times(4));
 
@@ -89,4 +90,70 @@ pub fn init_test_service() -> Result<Option<Operator>> {
     }
 
     Ok(Some(op))
+}
+
+/// A logging interceptor that logs the backtrace.
+#[derive(Debug, Clone)]
+struct BacktraceLoggingInterceptor;
+
+impl LoggingInterceptor for BacktraceLoggingInterceptor {
+    fn log(
+        &self,
+        scheme: Scheme,
+        operation: raw::Operation,
+        path: &str,
+        context: &str,
+        message: &str,
+        err: Option<&Error>,
+    ) {
+        let Some(err) = err else {
+            let lvl = self.operation_level(operation);
+            log!(
+                target: "opendal::services",
+                lvl,
+                "service={} operation={} path={} {} -> {}",
+                scheme,
+                operation,
+                path,
+                context,
+                message,
+            );
+            return;
+        };
+
+        let err_msg = if err.kind() != ErrorKind::Unexpected {
+            format!("{err}")
+        } else {
+            format!("{err:?}")
+        };
+        let lvl = if err.kind() == ErrorKind::Unexpected {
+            Level::Error
+        } else {
+            Level::Warn
+        };
+
+        log!(
+            target: "opendal::services",
+            lvl,
+            "service={} operation={} path={} {} -> {} {}",
+            scheme,
+            operation,
+            path,
+            context,
+            message,
+            err_msg,
+        );
+    }
+}
+
+impl BacktraceLoggingInterceptor {
+    fn operation_level(&self, operation: Operation) -> Level {
+        match operation {
+            Operation::ReaderRead
+            | Operation::BlockingReaderRead
+            | Operation::WriterWrite
+            | Operation::BlockingWriterWrite => Level::Trace,
+            _ => Level::Debug,
+        }
+    }
 }

--- a/core/src/raw/tests/utils.rs
+++ b/core/src/raw/tests/utils.rs
@@ -101,7 +101,6 @@ impl LoggingInterceptor for BacktraceLoggingInterceptor {
         &self,
         scheme: Scheme,
         operation: raw::Operation,
-        path: &str,
         context: &str,
         message: &str,
         err: Option<&Error>,
@@ -111,10 +110,9 @@ impl LoggingInterceptor for BacktraceLoggingInterceptor {
             log!(
                 target: "opendal::services",
                 lvl,
-                "service={} operation={} path={} {} -> {}",
+                "service={} operation={} {} -> {}",
                 scheme,
                 operation,
-                path,
                 context,
                 message,
             );
@@ -135,10 +133,9 @@ impl LoggingInterceptor for BacktraceLoggingInterceptor {
         log!(
             target: "opendal::services",
             lvl,
-            "service={} operation={} path={} {} -> {} {}",
+            "service={} operation={} {} -> {} {}",
             scheme,
             operation,
-            path,
             context,
             message,
             err_msg,

--- a/core/src/raw/tests/utils.rs
+++ b/core/src/raw/tests/utils.rs
@@ -73,11 +73,9 @@ pub fn init_test_service() -> Result<Option<Operator>> {
     let op = { op.layer(layers::ChaosLayer::new(0.1)) };
 
     let mut op = op
-        .layer(
-            layers::LoggingLayer::default().with_notify(
-                layers::DefaultLoggingInterceptor::default().with_backtrace_output(true),
-            ),
-        )
+        .layer(layers::LoggingLayer::new(
+            layers::DefaultLoggingInterceptor::default().with_backtrace_output(true),
+        ))
         .layer(layers::TimeoutLayer::new())
         .layer(layers::RetryLayer::new().with_max_times(4));
 

--- a/core/src/raw/tests/utils.rs
+++ b/core/src/raw/tests/utils.rs
@@ -73,7 +73,11 @@ pub fn init_test_service() -> Result<Option<Operator>> {
     let op = { op.layer(layers::ChaosLayer::new(0.1)) };
 
     let mut op = op
-        .layer(layers::LoggingLayer::default().with_backtrace_output(true))
+        .layer(
+            layers::LoggingLayer::default().with_notify(
+                layers::DefaultLoggingInterceptor::default().with_backtrace_output(true),
+            ),
+        )
         .layer(layers::TimeoutLayer::new())
         .layer(layers::RetryLayer::new().with_max_times(4));
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #4918.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Breaking changes: This PR removes `with_error_level()`, `with_failure_level()` and `with_backtrace_output()` from the `DefaultLoggingLayer`.

It adds a new trait `LoggingInterceptor` to log messages.
```rust
pub trait LoggingInterceptor: Debug + Send + Sync + 'static {
    fn log(
        &self,
        scheme: Scheme,
        operation: Operation,
        path: &str,
        context: &str,
        message: &str,
        err: Option<&Error>,
    );
}
```

The `LoggingLayer` has a new method to construct a new layer from an interceptor.
```rust
fn new<I: LoggingInterceptor>(notify: I) -> LoggingLayer<I> {}
```

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
