### PR TITLE
feat(gcs): allow setting a token directly

### DIFF
--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -74,6 +74,8 @@ pub struct GcsConfig {
     pub disable_vm_metadata: bool,
     /// Disable loading configuration from the environment.
     pub disable_config_load: bool,
+    /// A Google Cloud OAuth2 token.
+    pub token: String,
 }
 
 impl Debug for GcsConfig {
@@ -211,6 +213,12 @@ impl GcsBuilder {
     /// Specify the customized token loader used by this service.
     pub fn customized_token_loader(mut self, token_load: Box<dyn GoogleTokenLoad>) -> Self {
         self.customized_token_loader = Some(token_load);
+        self
+    }
+
+    /// Provide the OAuth2 token to use.
+    pub fn token(mut self, token: String) -> Self {
+        self.config.token = token;
         self
     }
 

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -365,7 +365,7 @@ impl Builder for GcsBuilder {
                 signer,
                 token_loader,
                 token: self.config.token,
-                scope: self.config.scope,
+                scope: Some(scope.to_string()),
                 credential_loader: cred_loader,
                 predefined_acl: self.config.predefined_acl.clone(),
                 default_storage_class: self.config.default_storage_class.clone(),

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -75,7 +75,9 @@ pub struct GcsConfig {
     /// Disable loading configuration from the environment.
     pub disable_config_load: bool,
     /// A Google Cloud OAuth2 token.
-    pub token: String,
+    ///
+    /// Takes precedence over `credential` and `credential_path`.
+    pub token: Option<String>,
 }
 
 impl Debug for GcsConfig {
@@ -218,7 +220,7 @@ impl GcsBuilder {
 
     /// Provide the OAuth2 token to use.
     pub fn token(mut self, token: String) -> Self {
-        self.config.token = token;
+        self.config.token = Some(token);
         self
     }
 

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -365,7 +365,7 @@ impl Builder for GcsBuilder {
                 signer,
                 token_loader,
                 token: self.config.token,
-                scope: Some(scope.to_string()),
+                scope: scope.to_string(),
                 credential_loader: cred_loader,
                 predefined_acl: self.config.predefined_acl.clone(),
                 default_storage_class: self.config.default_storage_class.clone(),

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -365,6 +365,7 @@ impl Builder for GcsBuilder {
                 signer,
                 token_loader,
                 token: self.config.token,
+                scope: self.config.scope,
                 credential_loader: cred_loader,
                 predefined_acl: self.config.predefined_acl.clone(),
                 default_storage_class: self.config.default_storage_class.clone(),

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -362,6 +362,7 @@ impl Builder for GcsBuilder {
                 client,
                 signer,
                 token_loader,
+                token: self.config.token,
                 credential_loader: cred_loader,
                 predefined_acl: self.config.predefined_acl.clone(),
                 default_storage_class: self.config.default_storage_class.clone(),

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -24,7 +24,6 @@ use std::time::Duration;
 use backon::ExponentialBuilder;
 use backon::Retryable;
 use bytes::Bytes;
-use http::header;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
 use http::header::HOST;
@@ -143,15 +142,6 @@ impl GcsCore {
     }
 
     pub async fn sign_query<T>(&self, req: &mut Request<T>, duration: Duration) -> Result<()> {
-        if let Some(token) = &self.token {
-            req.headers_mut().remove(HOST);
-
-            let header_value = format!("Bearer {}", token);
-            req.headers_mut()
-                .insert(header::AUTHORIZATION, header_value.parse().unwrap());
-            return Ok(());
-        }
-
         if let Some(cred) = self.load_credential()? {
             self.signer
                 .sign_query(req, duration, &cred)

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -54,7 +54,7 @@ pub struct GcsCore {
     pub client: HttpClient,
     pub signer: GoogleSigner,
     pub token_loader: GoogleTokenLoader,
-    pub token: String,
+    pub token: Option<String>,
     pub credential_loader: GoogleCredentialLoader,
 
     pub predefined_acl: Option<String>,

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -55,6 +55,7 @@ pub struct GcsCore {
     pub signer: GoogleSigner,
     pub token_loader: GoogleTokenLoader,
     pub token: Option<String>,
+    pub scope: Option<String>,
     pub credential_loader: GoogleCredentialLoader,
 
     pub predefined_acl: Option<String>,

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -79,6 +79,17 @@ static BACKOFF: Lazy<ExponentialBuilder> =
 
 impl GcsCore {
     async fn load_token(&self) -> Result<Option<GoogleToken>> {
+        if let Some(token) = &self.token {
+            if let Some(scope) = &self.scope {
+                return Ok(Some(GoogleToken::new(token, usize::MAX, scope)));
+            } else {
+                return Err(Error::new(
+                    ErrorKind::ConfigInvalid,
+                    "Scope is required when token is set",
+                ));
+            }
+        }
+
         let cred = { || self.token_loader.load() }
             .retry(&*BACKOFF)
             .await

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -123,15 +123,6 @@ impl GcsCore {
     }
 
     pub async fn sign<T>(&self, req: &mut Request<T>) -> Result<()> {
-        if let Some(token) = &self.token {
-            req.headers_mut().remove(HOST);
-
-            let header_value = format!("Bearer {}", token);
-            req.headers_mut()
-                .insert(header::AUTHORIZATION, header_value.parse().unwrap());
-            return Ok(());
-        }
-
         if let Some(cred) = self.load_token().await? {
             self.signer
                 .sign(req, &cred)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/opendal/issues/4876

# Rationale for this change

An OAuth2 token cannot be set directly at the moment, instead other mechanisms are required such as the `credential` or `credential_path`.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Inclusion of a `token` within the `GcsConfig` and corresponding methods so that a bearer token is set within the signed requests to GCP.

# Are there any user-facing changes?

Direct `token` being available as a option for authentication


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
