### PR TITLE
feat(services/s3): add role_session_name in assume roles

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -124,6 +124,8 @@ pub struct S3Config {
     pub role_arn: Option<String>,
     /// external_id for this backend.
     pub external_id: Option<String>,
+    /// role_session_name for this backend.
+    pub role_session_name: Option<String>,
     /// Disable config load so that opendal will not load config from
     /// environment.
     ///
@@ -353,6 +355,15 @@ impl S3Builder {
     pub fn external_id(mut self, v: &str) -> Self {
         if !v.is_empty() {
             self.config.external_id = Some(v.to_string())
+        }
+
+        self
+    }
+
+    /// Set role_session_name for this backend.
+    pub fn role_session_name(mut self, v: &str) -> Self {
+        if !v.is_empty() {
+            self.config.role_session_name = Some(v.to_string())
         }
 
         self
@@ -948,13 +959,19 @@ impl Builder for S3Builder {
             let default_loader = AwsDefaultLoader::new(client.client(), cfg.clone());
 
             // Build the config for assume role.
-            let assume_role_cfg = AwsConfig {
+            let mut assume_role_cfg = AwsConfig {
                 region: Some(region.clone()),
                 role_arn: Some(role_arn),
                 external_id: self.config.external_id.clone(),
                 sts_regional_endpoints: "regional".to_string(),
                 ..Default::default()
             };
+
+            // override default role_session_name if set
+            if let Some(name) = self.config.role_session_name {
+                assume_role_cfg.role_session_name = name;
+            }
+
             let assume_role_loader = AwsAssumeRoleLoader::new(
                 client.client(),
                 assume_role_cfg,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #4974.

# Rationale for this change

# What changes are included in this PR?

Simple exposure of the `role_session_name` from `reqsign` in opendal's s3 config builder.

# Are there any user-facing changes?

No.