### PR TITLE
feat(ovfs): export VirtioFs struct

### DIFF
--- a/integrations/virtiofs/Cargo.toml
+++ b/integrations/virtiofs/Cargo.toml
@@ -30,6 +30,8 @@ version = "0.0.0"
 [dependencies]
 anyhow = { version = "1.0.86", features = ["std"] }
 libc = "0.2.139"
+log = "0.4.22"
+opendal = { version = "0.48.0", path = "../../core" }
 snafu = "0.8.3"
 vhost = "0.11.0"
 vhost-user-backend = "0.14.0"

--- a/integrations/virtiofs/src/filesystem.rs
+++ b/integrations/virtiofs/src/filesystem.rs
@@ -18,6 +18,7 @@
 use std::io::Write;
 use std::mem::size_of;
 
+use opendal::Operator;
 use vm_memory::ByteValued;
 
 use crate::error::*;
@@ -37,12 +38,15 @@ const MAX_BUFFER_SIZE: u32 = 1 << 20;
 
 /// Filesystem is a filesystem implementation with opendal backend,
 /// and will decode and process messages from VMs.
-pub struct Filesystem {}
+pub struct Filesystem {
+    // FIXME: #[allow(dead_code)] here should be removed in the future.
+    #[allow(dead_code)]
+    core: Operator,
+}
 
-#[allow(dead_code)]
 impl Filesystem {
-    pub fn new() -> Filesystem {
-        Filesystem {}
+    pub fn new(core: Operator) -> Filesystem {
+        Filesystem { core }
     }
 
     pub fn handle_message(&self, mut r: Reader, w: Writer) -> Result<usize> {

--- a/integrations/virtiofs/src/lib.rs
+++ b/integrations/virtiofs/src/lib.rs
@@ -20,3 +20,5 @@ mod filesystem;
 mod filesystem_message;
 mod virtiofs;
 mod virtiofs_util;
+
+pub use virtiofs::VirtioFs;

--- a/integrations/virtiofs/src/virtiofs.rs
+++ b/integrations/virtiofs/src/virtiofs.rs
@@ -96,10 +96,8 @@ impl VhostUserFsThread {
         if event_idx {
             match vring_state.needs_notification() {
                 Ok(needs_notification) => {
-                    if needs_notification {
-                        if vring_state.signal_used_queue().is_err() {
-                            warn!("Failed to signal used queue.");
-                        };
+                    if needs_notification && vring_state.signal_used_queue().is_err() {
+                        warn!("Failed to signal used queue.");
                     }
                 }
                 Err(_) => {
@@ -108,10 +106,8 @@ impl VhostUserFsThread {
                     };
                 }
             }
-        } else {
-            if vring_state.signal_used_queue().is_err() {
-                warn!("Failed to signal used queue.");
-            };
+        } else if vring_state.signal_used_queue().is_err() {
+            warn!("Failed to signal used queue.");
         }
     }
 
@@ -228,12 +224,11 @@ impl VhostUserBackend for VhostUserFsBackend {
     /// Get available vhost protocol features.
     fn protocol_features(&self) -> VhostUserProtocolFeatures {
         // Align to the virtiofsd's protocol features here.
-        let protocol_features = VhostUserProtocolFeatures::MQ
+        VhostUserProtocolFeatures::MQ
             | VhostUserProtocolFeatures::BACKEND_REQ
             | VhostUserProtocolFeatures::BACKEND_SEND_FD
             | VhostUserProtocolFeatures::REPLY_ACK
-            | VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS;
-        protocol_features
+            | VhostUserProtocolFeatures::CONFIGURE_MEM_SLOTS
     }
 
     /// Enable or disabled the virtio EVENT_IDX feature.

--- a/integrations/virtiofs/src/virtiofs_util.rs
+++ b/integrations/virtiofs/src/virtiofs_util.rs
@@ -96,7 +96,6 @@ pub struct Reader<'a, B = ()> {
     buffer: DescriptorChainConsumer<'a, B>,
 }
 
-#[allow(dead_code)]
 impl<'a, B: Bitmap + BitmapSlice + 'static> Reader<'a, B> {
     pub fn new<M>(
         mem: &'a GuestMemoryMmap<B>,
@@ -174,7 +173,6 @@ pub struct Writer<'a, B = ()> {
     buffer: DescriptorChainConsumer<'a, B>,
 }
 
-#[allow(dead_code)]
 impl<'a, B: Bitmap + BitmapSlice + 'static> Writer<'a, B> {
     pub fn new<M>(
         mem: &'a GuestMemoryMmap<B>,


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

Advancing support for virtiofs integration.

# What changes are included in this PR?

Related: #4786.

This PR exposes a structure in the virtiofs integration. Users can use this structure to use the virtiofs service.

The current integration will be a dummy service that can run but does not implement any file system operations. More features will be added later.

# Are there any user-facing changes?

Yes.