### PR TITLE
feat: support root path for moka and mini-moka

### DIFF
--- a/core/src/services/dashmap/backend.rs
+++ b/core/src/services/dashmap/backend.rs
@@ -50,7 +50,12 @@ pub struct DashmapBuilder {
 impl DashmapBuilder {
     /// Set the root for dashmap.
     pub fn root(mut self, path: &str) -> Self {
-        self.config.root = Some(path.into());
+        self.config.root = if path.is_empty() {
+            None
+        } else {
+            Some(path.to_string())
+        };
+
         self
     }
 }
@@ -60,10 +65,14 @@ impl Builder for DashmapBuilder {
     type Config = DashmapConfig;
 
     fn build(self) -> Result<impl Access> {
-        Ok(DashmapBackend::new(Adapter {
+        let mut backend = DashmapBackend::new(Adapter {
             inner: DashMap::default(),
-        })
-        .with_root(self.config.root.as_deref().unwrap_or_default()))
+        });
+        if let Some(v) = self.config.root {
+            backend = backend.with_root(&v);
+        }
+
+        Ok(backend)
     }
 }
 

--- a/core/src/services/mini_moka/backend.rs
+++ b/core/src/services/mini_moka/backend.rs
@@ -45,6 +45,9 @@ pub struct MiniMokaConfig {
     ///
     /// Refer to [`mini-moka::sync::CacheBuilder::time_to_idle`](https://docs.rs/mini-moka/latest/mini_moka/sync/struct.CacheBuilder.html#method.time_to_idle)
     pub time_to_idle: Option<Duration>,
+
+    /// root path of this backend
+    pub root: Option<String>,
 }
 
 impl Configurator for MiniMokaConfig {
@@ -91,6 +94,17 @@ impl MiniMokaBuilder {
         }
         self
     }
+
+    /// Set root path of this backend
+    pub fn root(mut self, path: &str) -> Self {
+        self.config.root = if path.is_empty() {
+            None
+        } else {
+            Some(path.to_string())
+        };
+
+        self
+    }
 }
 
 impl Builder for MiniMokaBuilder {
@@ -114,9 +128,14 @@ impl Builder for MiniMokaBuilder {
         }
 
         debug!("backend build finished: {:?}", &self);
-        Ok(MiniMokaBackend::new(Adapter {
+        let mut backend = MiniMokaBackend::new(Adapter {
             inner: builder.build(),
-        }))
+        });
+        if let Some(v) = self.config.root {
+            backend = backend.with_root(&v);
+        }
+
+        Ok(backend)
     }
 }
 

--- a/core/src/services/moka/backend.rs
+++ b/core/src/services/moka/backend.rs
@@ -52,6 +52,9 @@ pub struct MokaConfig {
     ///
     /// Refer to [`moka::sync::CacheBuilder::segments`](https://docs.rs/moka/latest/moka/sync/struct.CacheBuilder.html#method.segments)
     pub num_segments: Option<usize>,
+
+    /// root path of this backend
+    pub root: Option<String>,
 }
 
 impl Debug for MokaConfig {
@@ -62,6 +65,7 @@ impl Debug for MokaConfig {
             .field("time_to_live", &self.time_to_live)
             .field("time_to_idle", &self.time_to_idle)
             .field("num_segments", &self.num_segments)
+            .field("root", &self.root)
             .finish_non_exhaustive()
     }
 }
@@ -127,6 +131,17 @@ impl MokaBuilder {
         self.config.num_segments = Some(v);
         self
     }
+
+    /// Set root path of this backend
+    pub fn root(mut self, path: &str) -> Self {
+        self.config.root = if path.is_empty() {
+            None
+        } else {
+            Some(path.to_string())
+        };
+
+        self
+    }
 }
 
 impl Builder for MokaBuilder {
@@ -154,9 +169,15 @@ impl Builder for MokaBuilder {
         }
 
         debug!("backend build finished: {:?}", &self);
-        Ok(MokaBackend::new(Adapter {
+
+        let mut backend = MokaBackend::new(Adapter {
             inner: builder.build(),
-        }))
+        });
+        if let Some(v) = self.config.root {
+            backend = backend.with_root(&v);
+        }
+
+        Ok(backend)
     }
 }
 

--- a/core/src/types/builder.rs
+++ b/core/src/types/builder.rs
@@ -103,7 +103,7 @@ impl Builder for () {
 /// use std::collections::HashMap;
 ///
 /// use opendal::services::S3Config;
-/// use opendal::{Configurator, Operator};///
+/// use opendal::{Configurator, Operator};
 /// use opendal::raw::HttpClient;
 ///
 /// async fn test() -> Result<()> {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
currently, the root path of service-moka and service-mini-moka can't be set(only has the default value "/").
in this PR, we add root path for moka and mini-moka


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
1. add root path for moka
2. add root path for mini-moka
3. fix the logic of root path for dashmap


# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
