### PR TITLE
feat(ovfs): support getattr and setattr

### DIFF
--- a/integrations/virtiofs/Cargo.toml
+++ b/integrations/virtiofs/Cargo.toml
@@ -32,10 +32,12 @@ anyhow = { version = "1.0.86", features = ["std"] }
 libc = "0.2.139"
 log = "0.4.22"
 opendal = { version = "0.48.0", path = "../../core" }
-snafu = "0.8.3"
-vhost = "0.11.0"
-vhost-user-backend = "0.14.0"
-virtio-bindings = "0.2.1"
+sharded-slab = "0.1.7"
+snafu = "0.8.4"
+tokio = { version = "1.39.2", features = ["rt-multi-thread"] }
+vhost = "0.10.0"
+vhost-user-backend = "0.13.1"
+virtio-bindings = { version = "0.2.1", features = ["virtio-v5_0_0"] }
 virtio-queue = "0.11.0"
 vm-memory = { version = "0.14.0", features = [
   "backend-mmap",

--- a/integrations/virtiofs/src/filesystem.rs
+++ b/integrations/virtiofs/src/filesystem.rs
@@ -41,7 +41,7 @@ const MIN_KERNEL_MINOR_VERSION: u32 = 27;
 const BUFFER_HEADER_SIZE: u32 = 4096;
 /// The maximum length of the data part of the message, used for read/write data.
 const MAX_BUFFER_SIZE: u32 = 1 << 20;
-/// The deafult time to live of the attributes.
+/// The default time to live of the attributes.
 const DEFAULT_TTL: Duration = Duration::from_secs(1);
 /// The default mode of the opened file.
 const DEFAULT_OPENED_FILE_MODE: u32 = 0o755;
@@ -144,7 +144,7 @@ impl Filesystem {
         if let Ok(opcode) = Opcode::try_from(in_header.opcode) {
             match opcode {
                 Opcode::Init => self.init(in_header, r, w),
-                Opcode::Destroy => self.destory(in_header, r, w),
+                Opcode::Destroy => self.destroy(in_header, r, w),
                 Opcode::Getattr => self.getattr(in_header, r, w),
                 Opcode::Setattr => self.setattr(in_header, r, w),
             }
@@ -222,8 +222,8 @@ impl Filesystem {
         Filesystem::reply_ok(Some(out), None, in_header.unique, w)
     }
 
-    fn destory(&self, _in_header: InHeader, _r: Reader, _w: Writer) -> Result<usize> {
-        // do nothing for destory.
+    fn destroy(&self, _in_header: InHeader, _r: Reader, _w: Writer) -> Result<usize> {
+        // do nothing for destroy.
         Ok(0)
     }
 

--- a/integrations/virtiofs/src/filesystem_message.rs
+++ b/integrations/virtiofs/src/filesystem_message.rs
@@ -23,7 +23,10 @@ use crate::error::*;
 /// The corresponding value needs to be aligned with the specification.
 #[non_exhaustive]
 pub enum Opcode {
+    Getattr = 3,
+    Setattr = 4,
     Init = 26,
+    Destroy = 38,
 }
 
 impl TryFrom<u32> for Opcode {
@@ -31,10 +34,39 @@ impl TryFrom<u32> for Opcode {
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
+            3 => Ok(Opcode::Getattr),
+            4 => Ok(Opcode::Setattr),
             26 => Ok(Opcode::Init),
+            38 => Ok(Opcode::Destroy),
             _ => Err(new_vhost_user_fs_error("failed to decode opcode", None)),
         }
     }
+}
+
+/// Attr represents the file attributes in virtiofs.
+///
+/// The fields of the struct need to conform to the specific format of the virtiofs message.
+/// Currently, we only need to align them exactly with virtiofsd.
+/// Reference: https://gitlab.com/virtio-fs/virtiofsd/-/blob/main/src/fuse.rs?ref_type=heads#L577
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Attr {
+    pub ino: u64,
+    pub size: u64,
+    pub blocks: u64,
+    pub atime: u64,
+    pub mtime: u64,
+    pub ctime: u64,
+    pub atimensec: u32,
+    pub mtimensec: u32,
+    pub ctimensec: u32,
+    pub mode: u32,
+    pub nlink: u32,
+    pub uid: u32,
+    pub gid: u32,
+    pub rdev: u32,
+    pub blksize: u32,
+    pub flags: u32,
 }
 
 /// InHeader represents the incoming message header in the filesystem call.
@@ -105,9 +137,25 @@ pub struct InitOut {
     pub unused: [u32; 7],
 }
 
+/// AttrOut is used to return the file attributes in the filesystem call.
+///
+/// The fields of the struct need to conform to the specific format of the virtiofs message.
+/// Currently, we only need to align them exactly with virtiofsd.
+/// Reference: https://gitlab.com/virtio-fs/virtiofsd/-/blob/main/src/fuse.rs?ref_type=heads#L782
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AttrOut {
+    pub attr_valid: u64,
+    pub attr_valid_nsec: u32,
+    pub dummy: u32,
+    pub attr: Attr,
+}
+
 /// We will use ByteValued to implement the encoding and decoding
 /// of these structures in shared memory.
+unsafe impl ByteValued for Attr {}
 unsafe impl ByteValued for InHeader {}
 unsafe impl ByteValued for OutHeader {}
 unsafe impl ByteValued for InitIn {}
 unsafe impl ByteValued for InitOut {}
+unsafe impl ByteValued for AttrOut {}


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

Advancing support for virtiofs integration.

# What changes are included in this PR?

Related: #4786.

Add getattr and setattr support to virtiofs, add opened file metadata representation and conversion.

# Are there any user-facing changes?

None.