### PR TITLE
fix(bindings/python): Make sure read until EOF

### DIFF
--- a/bindings/python/tests/test_read.py
+++ b/bindings/python/tests/test_read.py
@@ -49,20 +49,27 @@ def test_sync_reader(service_name, operator, async_operator):
         assert not reader.writable()
         assert not reader.closed
 
-        read_content = reader.read()
+        read_content = bytearray()
+        while True:
+            chunk = reader.read(1024)  # Read in chunks, e.g., 1024 bytes at a time
+            if not chunk:
+                break
+            read_content.extend(chunk)
+
+        read_content = bytes(read_content)
         assert read_content is not None
         assert read_content == content
 
     with operator.open(filename, "rb") as reader:
-        read_content = reader.read(size + 1)
-        assert read_content is not None
-        assert read_content == content
-        read_content_eof = b""
+        read_content = bytearray()
         while True:
-            chunk = reader.read(size)
+            chunk = reader.read(size + 1)
             if not chunk:
                 break
-            read_content_eof += chunk
+            read_content.extend(chunk)
+
+        read_content = bytes(read_content)
+        assert read_content is not None
         assert read_content == content
 
     buf = bytearray(1)

--- a/bindings/python/tests/test_read.py
+++ b/bindings/python/tests/test_read.py
@@ -49,7 +49,7 @@ def test_sync_reader(service_name, operator, async_operator):
         assert not reader.writable()
         assert not reader.closed
 
-        read_content = bytearray()
+        read_content = reader.read()
         while True:
             chunk = reader.read(1024)  # Read in chunks, e.g., 1024 bytes at a time
             if not chunk:

--- a/bindings/python/tests/test_read.py
+++ b/bindings/python/tests/test_read.py
@@ -57,16 +57,13 @@ def test_sync_reader(service_name, operator, async_operator):
         read_content = reader.read(size + 1)
         assert read_content is not None
         assert read_content == content
-        
-    read_content = b""
-    with operator.open(filename, "rb") as reader:
+        read_content_eof = b""
         while True:
             chunk = reader.read(size)
             if not chunk:
                 break
-            read_content += chunk
-
-    assert read_content == content
+            read_content_eof += chunk
+        assert read_content == content
 
     buf = bytearray(1)
     with operator.open(filename, "rb") as reader:

--- a/bindings/python/tests/test_read.py
+++ b/bindings/python/tests/test_read.py
@@ -57,6 +57,16 @@ def test_sync_reader(service_name, operator, async_operator):
         read_content = reader.read(size + 1)
         assert read_content is not None
         assert read_content == content
+        
+    read_content = b""
+    with operator.open(filename, "rb") as reader:
+        while True:
+            chunk = reader.read(size)
+            if not chunk:
+                break
+            read_content += chunk
+
+    assert read_content == content
 
     buf = bytearray(1)
     with operator.open(filename, "rb") as reader:

--- a/bindings/python/tests/test_read.py
+++ b/bindings/python/tests/test_read.py
@@ -50,13 +50,6 @@ def test_sync_reader(service_name, operator, async_operator):
         assert not reader.closed
 
         read_content = reader.read()
-        while True:
-            chunk = reader.read(1024)  # Read in chunks, e.g., 1024 bytes at a time
-            if not chunk:
-                break
-            read_content.extend(chunk)
-
-        read_content = bytes(read_content)
         assert read_content is not None
         assert read_content == content
 


### PR DESCRIPTION
# Which issue does this PR close?
Closes #4990 

# Rationale for this change
There wasn't any warantee that the entire file would fit inside the size variable therfore read in chunks until EOF in the case that the file size is large