### PR TITLE
chore(deps): bump fastrace to 0.7.1

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1431,12 +1431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cache-padded"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "981520c98f422fcc584dc1a95c334e6953900b9106bc47a9839b81790009eb21"
-
-[[package]]
 name = "camino"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,9 +2670,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrace"
-version = "0.6.8"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfd798348670042f0628810b10bc11b767c1f42aafbd3b1ae31f282740c549fe"
+checksum = "01bdb5c59912525f75feba878196c9aa5c3e41bfb3f3566e103e39bd39651a33"
 dependencies = [
  "fastrace-macro",
  "minstant",
@@ -2691,14 +2685,14 @@ dependencies = [
 
 [[package]]
 name = "fastrace-macro"
-version = "0.6.8"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea27de901dc6b14aa952aeefcc41144da4dc97e4db3eb3593c19f3b80406786"
+checksum = "809c42c4001c2a46b4b755deb1500f369b1598246624a1ea7aaf34e677886390"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -6581,12 +6575,9 @@ dependencies = [
 
 [[package]]
 name = "rtrb"
-version = "0.2.3"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e704dd104faf2326a320140f70f0b736d607c1caa1b1748a6c568a79819109"
-dependencies = [
- "cache-padded",
-]
+checksum = "f3f94e84c073f3b85d4012b44722fa8842b9986d741590d4f2636ad0a5b14143"
 
 [[package]]
 name = "rusqlite"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -364,7 +364,7 @@ metrics = { version = "0.23", optional = true }
 # for layers-mime-guess
 mime_guess = { version = "2.0.5", optional = true }
 # for layers-fastrace
-fastrace = { version = "0.6", optional = true }
+fastrace = { version = "0.7.1", optional = true }
 # for layers-opentelemetry
 opentelemetry = { version = "0.24", optional = true }
 # for layers-prometheus
@@ -382,7 +382,7 @@ getrandom = { version = "0.2", features = ["js"] }
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async", "async_tokio"] }
 dotenvy = "0.15"
-fastrace = { version = "0.6", features = ["enable"] }
+fastrace = { version = "0.7", features = ["enable"] }
 libtest-mimic = "0.7"
 opentelemetry = { version = "0.24", default-features = false, features = [
   "trace",


### PR DESCRIPTION
Bump [fastrace](https://crates.io/crates/fastrace) from 0.6 to 0.7.1