### PR TITLE
refactor(core): new type to print context and reduce allocations

### DIFF
--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::fmt::Debug;
+use std::fmt::Display;
 use std::sync::Arc;
 
 use futures::FutureExt;
@@ -193,16 +194,7 @@ impl LoggingInterceptor for DefaultLoggingInterceptor {
                 "service={} name={} {}: {operation} {message} {}",
                 info.scheme(),
                 info.name(),
-                format_args!(
-                    "{}",
-                    context.iter().enumerate().map(|(i, (k, v))| {
-                        if i > 0 {
-                            format!(" {}={}", k, v)
-                        } else {
-                            format!("{}={}", k, v)
-                        }
-                    }).collect::<String>()
-                ),
+                LoggingContext(context),
                 // Print error message with debug output while unexpected happened.
                 //
                 // It's super sad that we can't bind `format_args!()` here.
@@ -228,17 +220,23 @@ impl LoggingInterceptor for DefaultLoggingInterceptor {
             "service={} name={} {}: {operation} {message}",
             info.scheme(),
             info.name(),
-            format_args!(
-                "{}",
-                context.iter().enumerate().map(|(i, (k, v))| {
-                    if i > 0 {
-                        format!(" {}={}", k, v)
-                    } else {
-                        format!("{}={}", k, v)
-                    }
-                }).collect::<String>()
-            ),
+            LoggingContext(context),
         );
+    }
+}
+
+struct LoggingContext<'a>(&'a [(&'a str, &'a str)]);
+
+impl<'a> Display for LoggingContext<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (i, (k, v)) in self.0.iter().enumerate() {
+            if i > 0 {
+                write!(f, " {}={}", k, v)?;
+            } else {
+                write!(f, "{}={}", k, v)?;
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

As https://github.com/apache/opendal/pull/4986#discussion_r1716530358 mentioned, the default interceptor always requires some small allocations to print the log context.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds a new type `LoggingContext` to print context. It may reduce some allocations.


# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
