### PR TITLE
feat(core/services-s3): support user defined metadata

### DIFF
--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -47,7 +47,7 @@ use serde::Serialize;
 use crate::raw::*;
 use crate::*;
 
-mod constants {
+pub mod constants {
     pub const X_AMZ_COPY_SOURCE: &str = "x-amz-copy-source";
 
     pub const X_AMZ_SERVER_SIDE_ENCRYPTION: &str = "x-amz-server-side-encryption";
@@ -67,6 +67,8 @@ mod constants {
         "x-amz-copy-source-server-side-encryption-customer-key";
     pub const X_AMZ_COPY_SOURCE_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5: &str =
         "x-amz-copy-source-server-side-encryption-customer-key-md5";
+
+    pub const X_AMZ_META_PREFIX: &str = "x-amz-meta-";
 
     pub const RESPONSE_CONTENT_DISPOSITION: &str = "response-content-disposition";
     pub const RESPONSE_CONTENT_TYPE: &str = "response-content-type";
@@ -454,6 +456,13 @@ impl S3Core {
         // Set storage class header
         if let Some(v) = &self.default_storage_class {
             req = req.header(HeaderName::from_static(constants::X_AMZ_STORAGE_CLASS), v);
+        }
+
+        // Set user metadata headers.
+        if let Some(user_metadata) = args.user_metadata() {
+            for (key, value) in user_metadata {
+                req = req.header(format!("{}{}", constants::X_AMZ_META_PREFIX, key), value)
+            }
         }
 
         // Set SSE headers.


### PR DESCRIPTION
# Which issue does this PR close?

Support user defined metadata for `services-s3`.

Part of #4842. 