### PR TITLE
refactor(core/services-oss): remove the `starts_with`

### DIFF
--- a/core/src/services/oss/core.rs
+++ b/core/src/services/oss/core.rs
@@ -224,16 +224,13 @@ impl OssCore {
         let data: HashMap<String, String> = headers
             .iter()
             .filter_map(|(key, _)| {
-                if key.as_str().starts_with(user_metadata_prefix) {
-                    if let Ok(Some(value)) = parse_header_to_str(headers, key) {
-                        let key_str = key.to_string();
-                        let stripped_key = key_str
-                            .strip_prefix(user_metadata_prefix)
-                            .expect("strip prefix must succeed");
-                        return Some((stripped_key.to_string(), value.to_string()));
-                    }
-                }
-                None
+                key.as_str()
+                    .strip_prefix(user_metadata_prefix)
+                    .and_then(|stripped_key| {
+                        parse_header_to_str(headers, key)
+                            .unwrap_or(None)
+                            .map(|val| (stripped_key.to_string(), val.to_string()))
+                    })
             })
             .collect();
         if !data.is_empty() {


### PR DESCRIPTION
# What changes are included in this PR?

The `strip_prefix()` method returns `None` if the string doesn't start with the prefix, so we don't need to check the prefix before stripping.

This change removes the `starts_with()` and simplifies codes.