### PR TITLE
feat(services/monoiofs): append, create_dir, copy and rename

### DIFF
--- a/core/src/services/monoiofs/docs.md
+++ b/core/src/services/monoiofs/docs.md
@@ -5,11 +5,11 @@ This service can be used to:
 - [x] stat
 - [x] read
 - [x] write
-- [ ] append
-- [ ] create_dir
+- [x] append
+- [x] create_dir
 - [x] delete
-- [ ] copy
-- [ ] rename
+- [x] copy
+- [x] rename
 - [ ] list
 - [ ] ~~presign~~
 - [ ] blocking


### PR DESCRIPTION
Part of #4552.

This PR implements write append, create_dir, copy and rename operations for `monoiofs`.