### PR TITLE
refactor(layers/prometheus): use the same metrics as prometheus-client layer

### DIFF
--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -235,14 +235,14 @@ impl PrometheusMetricDefinitions {
             &labels,
             registry
         )
-            .unwrap();
+        .unwrap();
         let errors_total = register_int_counter_vec_with_registry!(
             "opendal_errors_total",
             "Total times of the specific operation be called but meet error",
             &labels_with_error,
             registry
         )
-            .unwrap();
+        .unwrap();
 
         let requests_duration_seconds = register_histogram_vec_with_registry!(
             histogram_opts!(
@@ -253,7 +253,7 @@ impl PrometheusMetricDefinitions {
             &labels,
             registry
         )
-            .unwrap();
+        .unwrap();
 
         let bytes_total = register_int_counter_vec_with_registry!(
             "opendal_bytes_total",
@@ -261,14 +261,14 @@ impl PrometheusMetricDefinitions {
             &labels,
             registry
         )
-            .unwrap();
+        .unwrap();
 
         let bytes = register_histogram_vec_with_registry!(
             histogram_opts!("opendal_bytes", "The size of bytes", bytes_buckets),
             &labels,
             registry
         )
-            .unwrap();
+        .unwrap();
 
         Self {
             requests_total,

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -29,7 +29,6 @@ use prometheus::HistogramTimer;
 use prometheus::HistogramVec;
 use prometheus::Registry;
 
-use crate::layers::PrometheusClientLayer;
 use crate::raw::Access;
 use crate::raw::*;
 use crate::*;


### PR DESCRIPTION
# Which issue does this PR close?

No

# Rationale for this change

part of #5042 

# What changes are included in this PR?

- unify the metrics, same as PrometheusClientLayer
- refactor LayeredAccess impl

# Are there any user-facing changes?

- rename
  - `PrometheusLayer::with_registry` => `PrometheusLayer::new`
  - `PrometheusLayer::bytes_total_buckets` => `PrometheusLayer::bytes_buckets`
- remove
  - `#[derive(Default)]` impl of  `PrometheusLayer`
