### PR TITLE
chore(bindings/go): bump ffi and sys version

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -23,6 +23,6 @@ toolchain go1.22.5
 
 require (
 	github.com/ebitengine/purego v0.7.1
-	github.com/jupiterrider/ffi v0.1.0-beta.9
-	golang.org/x/sys v0.22.0
+	github.com/jupiterrider/ffi v0.1.0
+	golang.org/x/sys v0.24.0
 )

--- a/bindings/go/go.sum
+++ b/bindings/go/go.sum
@@ -1,6 +1,6 @@
 github.com/ebitengine/purego v0.7.1 h1:6/55d26lG3o9VCZX8lping+bZcmShseiqlh2bnUDiPA=
 github.com/ebitengine/purego v0.7.1/go.mod h1:ah1In8AOtksoNK6yk5z1HTJeUkC1Ez4Wk2idgGslMwQ=
-github.com/jupiterrider/ffi v0.1.0-beta.9 h1:HCeAPTsTFgwvcfavyJwy1L2ANz0c85W+ZE7LfzjZi3A=
-github.com/jupiterrider/ffi v0.1.0-beta.9/go.mod h1:sOp6VJGFaYyr4APi8gwy6g20QNHv5F8Iq1CVbtC900s=
-golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
-golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+github.com/jupiterrider/ffi v0.1.0 h1:OI6ZHZJW1Io1PcfqGeLk/CBLj+//8aNdOuo558ykQQo=
+github.com/jupiterrider/ffi v0.1.0/go.mod h1:tyr9EitV+PW99I6137IDwdO6ZzNyFp/noXNSfU3OYqk=
+golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
+golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/bindings/go/tests/go.work.sum
+++ b/bindings/go/tests/go.work.sum
@@ -1,0 +1,2 @@
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=


### PR DESCRIPTION
Main Issue #5051 

# Rationale for this change

This is part of #5051. I prefer to bump the version first, followed by adding Golang Windows CI to continuously monitor this feature.