### PR TITLE
chore(services/rocksdb): fix misuse rocksdb prefix iterator

### DIFF
--- a/core/src/services/rocksdb/backend.rs
+++ b/core/src/services/rocksdb/backend.rs
@@ -181,9 +181,8 @@ impl kv::Adapter for Adapter {
         for key in it {
             let key = key.map_err(parse_rocksdb_error)?;
             let key = String::from_utf8_lossy(&key);
-            // FIXME: it's must a bug that rocksdb returns key that not start with path.
             if !key.starts_with(path) {
-                continue;
+                break;
             }
             res.push(key.to_string());
         }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
According to https://github.com/facebook/rocksdb/wiki/Prefix-Seek#transition-to-the-new-usage. rocksdb will return keys equal or larger than the prefix


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
