### PR TITLE
fix: fix rust 1.76 error due to temporary value being dropped

### DIFF
--- a/core/src/services/fs/lister.rs
+++ b/core/src/services/fs/lister.rs
@@ -152,13 +152,13 @@ impl oio::BlockingList for FsLister<std::fs::ReadDir> {
             meta
         };
 
-        let p = if metadata.is_dir() {
+        let entry = if metadata.is_dir() {
             // Make sure we are returning the correct path.
-            &format!("{rel_path}/")
+            oio::Entry::new(&format!("{rel_path}/"), metadata)
         } else {
-            &rel_path
+            oio::Entry::new(&rel_path, metadata)
         };
 
-        Ok(Some(oio::Entry::new(p, metadata)))
+        Ok(Some(entry))
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5061.

# Rationale for this change

The compiler error kills the CD of rustic. We hope you can include this fix soon in a release.

# Are there any user-facing changes?

no
