### PR TITLE
fix(services/icloud): adjust error handling code to avoid having to write out result type explicitly

### DIFF
--- a/core/src/services/icloud/core.rs
+++ b/core/src/services/icloud/core.rs
@@ -526,11 +526,11 @@ impl PathQuery for IcloudPathQuery {
 
         let node = &root[0];
 
-        let id = match node.items.iter().find(|it| it.name == name) {
-            Some(it) => Ok(Some(it.drivewsid.clone())),
-            None => Ok(None),
-        }?;
-        Ok(id)
+        Ok(node
+            .items
+            .iter()
+            .find(|it| it.name == name)
+            .map(|it| it.drivewsid.clone()))
     }
 
     async fn create_dir(&self, parent_id: &str, name: &str) -> Result<String> {


### PR DESCRIPTION
# Which issue does this PR close?

https://github.com/apache/opendal/pull/5072#issuecomment-2326644773

# Rationale for this change

# What changes are included in this PR?

- adjust the error handling code

# Are there any user-facing changes?

No
