### PR TITLE
fix(services/monoiofs): handle async cancel during file open

### DIFF
--- a/core/src/services/monoiofs/core.rs
+++ b/core/src/services/monoiofs/core.rs
@@ -145,7 +145,7 @@ impl MonoiofsCore {
     pub async fn spawn<F, Fut, T>(&self, f: F)
     where
         F: FnOnce() -> Fut + 'static + Send,
-        Fut: Future<Output = T>,
+        Fut: Future<Output = T> + 'static,
         T: 'static,
     {
         let result = self
@@ -153,7 +153,7 @@ impl MonoiofsCore {
             .send_async(Box::new(move || {
                 // task will be spawned on current thread, task panic
                 // will cause current worker thread panic
-                monoio::spawn(async move { f().await });
+                monoio::spawn(f());
             }))
             .await;
         self.unwrap(result);


### PR DESCRIPTION
# Rationale for this change

Async cancellation during file open is not handled in monoiofs that worker thread tries to send result back even if main task cancelled.

# What changes are included in this PR?

Exit worker task if main task cancelled, instead of panic.

# Are there any user-facing changes?

None.
