### PR TITLE
refactor(*): remove unneeded async and result on parse_error

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,6 +30,9 @@ repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
 version = "0.50.0"
 
+[lints.clippy]
+unused_async = "warn"
+
 [package.metadata.docs.rs]
 all-features = true
 
@@ -178,7 +181,7 @@ services-pcloud = []
 services-persy = ["dep:persy", "internal-tokio-rt"]
 services-postgresql = ["dep:sqlx", "sqlx?/postgres"]
 services-redb = ["dep:redb", "internal-tokio-rt"]
-services-redis = ["dep:redis","dep:bb8","redis?/tokio-rustls-comp"]
+services-redis = ["dep:redis", "dep:bb8", "redis?/tokio-rustls-comp"]
 services-redis-native-tls = ["services-redis", "redis?/tokio-native-tls-comp"]
 services-rocksdb = ["dep:rocksdb", "internal-tokio-rt"]
 services-s3 = [

--- a/core/src/services/aliyun_drive/backend.rs
+++ b/core/src/services/aliyun_drive/backend.rs
@@ -371,7 +371,7 @@ impl Access for AliyunDriveBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }

--- a/core/src/services/aliyun_drive/core.rs
+++ b/core/src/services/aliyun_drive/core.rs
@@ -101,7 +101,7 @@ impl AliyunDriveCore {
         }
         let res = self.client.send(req).await?;
         if !res.status().is_success() {
-            return Err(parse_error(res).await?);
+            return Err(parse_error(res));
         }
         Ok(res.into_body())
     }

--- a/core/src/services/aliyun_drive/error.rs
+++ b/core/src/services/aliyun_drive/error.rs
@@ -22,12 +22,12 @@ use serde::Deserialize;
 use crate::*;
 
 #[derive(Default, Debug, Deserialize)]
-pub struct AliyunDriveError {
+struct AliyunDriveError {
     code: String,
     message: String,
 }
 
-pub async fn parse_error(res: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(res: Response<Buffer>) -> Error {
     let (parts, mut body) = res.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
     let (code, message) = serde_json::from_reader::<_, AliyunDriveError>(bs.clone().reader())
@@ -52,5 +52,5 @@ pub async fn parse_error(res: Response<Buffer>) -> Result<Error> {
     if retryable {
         err = err.set_temporary();
     }
-    Ok(err)
+    err
 }

--- a/core/src/services/alluxio/backend.rs
+++ b/core/src/services/alluxio/backend.rs
@@ -193,7 +193,7 @@ impl Access for AlluxioBackend {
         if !resp.status().is_success() {
             let (part, mut body) = resp.into_parts();
             let buf = body.to_buffer().await?;
-            return Err(parse_error(Response::from_parts(part, buf)).await?);
+            return Err(parse_error(Response::from_parts(part, buf)));
         }
         Ok((RpRead::new(), resp.into_body()))
     }

--- a/core/src/services/alluxio/core.rs
+++ b/core/src/services/alluxio/core.rs
@@ -125,7 +125,7 @@ impl AlluxioCore {
         let status = resp.status();
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -160,7 +160,7 @@ impl AlluxioCore {
                     serde_json::from_reader(body.reader()).map_err(new_json_serialize_error)?;
                 Ok(steam_id)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -184,7 +184,7 @@ impl AlluxioCore {
                     serde_json::from_reader(body.reader()).map_err(new_json_serialize_error)?;
                 Ok(steam_id)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -204,7 +204,7 @@ impl AlluxioCore {
         match status {
             StatusCode::OK => Ok(()),
             _ => {
-                let err = parse_error(resp).await?;
+                let err = parse_error(resp);
                 if err.kind() == ErrorKind::NotFound {
                     return Ok(());
                 }
@@ -232,7 +232,7 @@ impl AlluxioCore {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -258,7 +258,7 @@ impl AlluxioCore {
                     serde_json::from_reader(body.reader()).map_err(new_json_serialize_error)?;
                 Ok(file_info)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -284,7 +284,7 @@ impl AlluxioCore {
                     serde_json::from_reader(body.reader()).map_err(new_json_deserialize_error)?;
                 Ok(file_infos)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -320,7 +320,7 @@ impl AlluxioCore {
                     serde_json::from_reader(body.reader()).map_err(new_json_serialize_error)?;
                 Ok(size)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -337,7 +337,7 @@ impl AlluxioCore {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/atomicserver/backend.rs
+++ b/core/src/services/atomicserver/backend.rs
@@ -244,11 +244,7 @@ impl Adapter {
         Ok(req)
     }
 
-    async fn atomic_post_object_request(
-        &self,
-        path: &str,
-        value: Buffer,
-    ) -> Result<Request<Buffer>> {
+    fn atomic_post_object_request(&self, path: &str, value: Buffer) -> Result<Request<Buffer>> {
         let path = normalize_path(path);
         let path = path.as_str();
 
@@ -405,7 +401,7 @@ impl kv::Adapter for Adapter {
 
         let _ = self.wait_for_resource(path, false).await;
 
-        let req = self.atomic_post_object_request(path, value).await?;
+        let req = self.atomic_post_object_request(path, value)?;
         let _res = self.client.send(req).await?;
         let _ = self.wait_for_resource(path, true).await;
 

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -546,7 +546,7 @@ impl Access for AzblobBackend {
 
         match status {
             StatusCode::OK => parse_into_metadata(path, resp.headers()).map(RpStat::new),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -559,7 +559,7 @@ impl Access for AzblobBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -586,7 +586,7 @@ impl Access for AzblobBackend {
 
         match status {
             StatusCode::ACCEPTED | StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -608,7 +608,7 @@ impl Access for AzblobBackend {
 
         match status {
             StatusCode::ACCEPTED => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -651,7 +651,7 @@ impl Access for AzblobBackend {
 
         // check response status
         if resp.status() != StatusCode::ACCEPTED {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         // get boundary from response header
@@ -701,7 +701,7 @@ impl Access for AzblobBackend {
             if resp.status() == StatusCode::ACCEPTED || resp.status() == StatusCode::NOT_FOUND {
                 results.push((path, Ok(RpDelete::default().into())));
             } else {
-                results.push((path, Err(parse_error(resp).await?)));
+                results.push((path, Err(parse_error(resp))));
             }
         }
         Ok(RpBatch::new(results))

--- a/core/src/services/azblob/core.rs
+++ b/core/src/services/azblob/core.rs
@@ -421,7 +421,7 @@ impl AzblobCore {
         self.send(req).await
     }
 
-    pub async fn azblob_complete_put_block_list_request(
+    pub fn azblob_complete_put_block_list_request(
         &self,
         path: &str,
         block_ids: Vec<Uuid>,
@@ -469,9 +469,7 @@ impl AzblobCore {
         block_ids: Vec<Uuid>,
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let mut req = self
-            .azblob_complete_put_block_list_request(path, block_ids, args)
-            .await?;
+        let mut req = self.azblob_complete_put_block_list_request(path, block_ids, args)?;
 
         self.sign(&mut req).await?;
 

--- a/core/src/services/azblob/error.rs
+++ b/core/src/services/azblob/error.rs
@@ -59,7 +59,7 @@ impl Debug for AzblobError {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -104,7 +104,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]

--- a/core/src/services/azblob/lister.rs
+++ b/core/src/services/azblob/lister.rs
@@ -55,7 +55,7 @@ impl oio::PageList for AzblobLister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();

--- a/core/src/services/azblob/writer.rs
+++ b/core/src/services/azblob/writer.rs
@@ -79,12 +79,12 @@ impl oio::AppendWrite for AzblobWriter {
                         // do nothing
                     }
                     _ => {
-                        return Err(parse_error(resp).await?);
+                        return Err(parse_error(resp));
                     }
                 }
                 Ok(0)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -100,7 +100,7 @@ impl oio::AppendWrite for AzblobWriter {
         let status = resp.status();
         match status {
             StatusCode::CREATED => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }
@@ -118,7 +118,7 @@ impl oio::BlockWrite for AzblobWriter {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -131,7 +131,7 @@ impl oio::BlockWrite for AzblobWriter {
         let status = resp.status();
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -144,7 +144,7 @@ impl oio::BlockWrite for AzblobWriter {
         let status = resp.status();
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -261,7 +261,7 @@ impl Access for AzdlsBackend {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(RpCreateDir::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -274,7 +274,7 @@ impl Access for AzdlsBackend {
         let resp = self.core.azdls_get_properties(path).await?;
 
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let mut meta = parse_into_metadata(path, resp.headers())?;
@@ -320,7 +320,7 @@ impl Access for AzdlsBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -342,7 +342,7 @@ impl Access for AzdlsBackend {
 
         match status {
             StatusCode::OK | StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -357,7 +357,7 @@ impl Access for AzdlsBackend {
             let status = resp.status();
             match status {
                 StatusCode::CREATED | StatusCode::CONFLICT => {}
-                _ => return Err(parse_error(resp).await?),
+                _ => return Err(parse_error(resp)),
             }
         }
 
@@ -367,7 +367,7 @@ impl Access for AzdlsBackend {
 
         match status {
             StatusCode::CREATED => Ok(RpRename::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/azdls/error.rs
+++ b/core/src/services/azdls/error.rs
@@ -59,7 +59,7 @@ impl Debug for AzdlsError {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -101,5 +101,5 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }

--- a/core/src/services/azdls/lister.rs
+++ b/core/src/services/azdls/lister.rs
@@ -53,7 +53,7 @@ impl oio::PageList for AzdlsLister {
         }
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         // Return self at the first page.

--- a/core/src/services/azdls/writer.rs
+++ b/core/src/services/azdls/writer.rs
@@ -53,9 +53,7 @@ impl oio::OneShotWrite for AzdlsWriter {
         match status {
             StatusCode::CREATED | StatusCode::OK => {}
             _ => {
-                return Err(parse_error(resp)
-                    .await?
-                    .with_operation("Backend::azdls_create_request"));
+                return Err(parse_error(resp).with_operation("Backend::azdls_create_request"));
             }
         }
 
@@ -70,9 +68,7 @@ impl oio::OneShotWrite for AzdlsWriter {
         let status = resp.status();
         match status {
             StatusCode::OK | StatusCode::ACCEPTED => Ok(()),
-            _ => Err(parse_error(resp)
-                .await?
-                .with_operation("Backend::azdls_update_request")),
+            _ => Err(parse_error(resp).with_operation("Backend::azdls_update_request")),
         }
     }
 }
@@ -87,7 +83,7 @@ impl oio::AppendWrite for AzdlsWriter {
         match status {
             StatusCode::OK => Ok(parse_content_length(headers)?.unwrap_or_default()),
             StatusCode::NOT_FOUND => Ok(0),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -105,9 +101,7 @@ impl oio::AppendWrite for AzdlsWriter {
             match status {
                 StatusCode::CREATED | StatusCode::OK => {}
                 _ => {
-                    return Err(parse_error(resp)
-                        .await?
-                        .with_operation("Backend::azdls_create_request"));
+                    return Err(parse_error(resp).with_operation("Backend::azdls_create_request"));
                 }
             }
         }
@@ -123,9 +117,7 @@ impl oio::AppendWrite for AzdlsWriter {
         let status = resp.status();
         match status {
             StatusCode::OK | StatusCode::ACCEPTED => Ok(()),
-            _ => Err(parse_error(resp)
-                .await?
-                .with_operation("Backend::azdls_update_request")),
+            _ => Err(parse_error(resp).with_operation("Backend::azdls_update_request")),
         }
     }
 }

--- a/core/src/services/azfile/backend.rs
+++ b/core/src/services/azfile/backend.rs
@@ -281,7 +281,7 @@ impl Access for AzfileBackend {
                 {
                     Ok(RpCreateDir::default())
                 } else {
-                    Err(parse_error(resp).await?)
+                    Err(parse_error(resp))
                 }
             }
         }
@@ -300,7 +300,7 @@ impl Access for AzfileBackend {
                 let meta = parse_into_metadata(path, resp.headers())?;
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -313,7 +313,7 @@ impl Access for AzfileBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -339,7 +339,7 @@ impl Access for AzfileBackend {
         let status = resp.status();
         match status {
             StatusCode::ACCEPTED | StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -355,7 +355,7 @@ impl Access for AzfileBackend {
         let status = resp.status();
         match status {
             StatusCode::OK => Ok(RpRename::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/azfile/core.rs
+++ b/core/src/services/azfile/core.rs
@@ -402,7 +402,7 @@ impl AzfileCore {
                 continue;
             }
 
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         Ok(())

--- a/core/src/services/azfile/error.rs
+++ b/core/src/services/azfile/error.rs
@@ -59,7 +59,7 @@ impl Debug for AzfileError {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -104,5 +104,5 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }

--- a/core/src/services/azfile/lister.rs
+++ b/core/src/services/azfile/lister.rs
@@ -53,7 +53,7 @@ impl oio::PageList for AzfileLister {
                 ctx.done = true;
                 return Ok(());
             }
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         // Return self at the first page.

--- a/core/src/services/azfile/writer.rs
+++ b/core/src/services/azfile/writer.rs
@@ -49,9 +49,7 @@ impl oio::OneShotWrite for AzfileWriter {
         match status {
             StatusCode::OK | StatusCode::CREATED => {}
             _ => {
-                return Err(parse_error(resp)
-                    .await?
-                    .with_operation("Backend::azfile_create_file"));
+                return Err(parse_error(resp).with_operation("Backend::azfile_create_file"));
             }
         }
 
@@ -62,9 +60,7 @@ impl oio::OneShotWrite for AzfileWriter {
         let status = resp.status();
         match status {
             StatusCode::OK | StatusCode::CREATED => Ok(()),
-            _ => Err(parse_error(resp)
-                .await?
-                .with_operation("Backend::azfile_update")),
+            _ => Err(parse_error(resp).with_operation("Backend::azfile_update")),
         }
     }
 }
@@ -77,7 +73,7 @@ impl oio::AppendWrite for AzfileWriter {
 
         match status {
             StatusCode::OK => Ok(parse_content_length(resp.headers())?.unwrap_or_default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -90,9 +86,7 @@ impl oio::AppendWrite for AzfileWriter {
         let status = resp.status();
         match status {
             StatusCode::OK | StatusCode::CREATED => Ok(()),
-            _ => Err(parse_error(resp)
-                .await?
-                .with_operation("Backend::azfile_update")),
+            _ => Err(parse_error(resp).with_operation("Backend::azfile_update")),
         }
     }
 }

--- a/core/src/services/b2/backend.rs
+++ b/core/src/services/b2/backend.rs
@@ -293,7 +293,7 @@ impl Access for B2Backend {
                 let meta = parse_file_info(&resp.files[0]);
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -311,7 +311,7 @@ impl Access for B2Backend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -334,7 +334,7 @@ impl Access for B2Backend {
         match status {
             StatusCode::OK => Ok(RpDelete::default()),
             _ => {
-                let err = parse_error(resp).await?;
+                let err = parse_error(resp);
                 match err.kind() {
                     ErrorKind::NotFound => Ok(RpDelete::default()),
                     // Representative deleted
@@ -379,7 +379,7 @@ impl Access for B2Backend {
                 let file_id = resp.files[0].clone().file_id;
                 Ok(file_id)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }?;
 
         let Some(source_file_id) = source_file_id else {
@@ -392,7 +392,7 @@ impl Access for B2Backend {
 
         match status {
             StatusCode::OK => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/b2/core.rs
+++ b/core/src/services/b2/core.rs
@@ -120,7 +120,7 @@ impl B2Core {
                     };
                 }
                 _ => {
-                    return Err(parse_error(resp).await?);
+                    return Err(parse_error(resp));
                 }
             }
             Ok(signer.auth_info.clone())
@@ -184,7 +184,7 @@ impl B2Core {
                     .map_err(new_json_deserialize_error)?;
                 Ok(resp)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -228,7 +228,7 @@ impl B2Core {
                     .map_err(new_json_deserialize_error)?;
                 Ok(resp)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -328,7 +328,7 @@ impl B2Core {
                     .map_err(new_json_deserialize_error)?;
                 Ok(resp)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/b2/error.rs
+++ b/core/src/services/b2/error.rs
@@ -32,7 +32,7 @@ struct B2Error {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -63,11 +63,11 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 /// Returns the `Error kind` of this code and whether the error is retryable.
-pub fn parse_b2_error_code(code: &str) -> Option<(ErrorKind, bool)> {
+pub(crate) fn parse_b2_error_code(code: &str) -> Option<(ErrorKind, bool)> {
     match code {
         "already_hidden" => Some((ErrorKind::AlreadyExists, false)),
         "no_such_file" => Some((ErrorKind::NotFound, false)),
@@ -124,10 +124,9 @@ mod test {
             let body = Buffer::from(bs);
             let resp = Response::builder().status(res.2).body(body).unwrap();
 
-            let err = parse_error(resp).await;
+            let err = parse_error(resp);
 
-            assert!(err.is_ok());
-            assert_eq!(err.unwrap().kind(), res.1);
+            assert_eq!(err.kind(), res.1);
         }
     }
 }

--- a/core/src/services/b2/lister.rs
+++ b/core/src/services/b2/lister.rs
@@ -76,7 +76,7 @@ impl oio::PageList for B2Lister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();

--- a/core/src/services/b2/writer.rs
+++ b/core/src/services/b2/writer.rs
@@ -57,7 +57,7 @@ impl oio::MultipartWrite for B2Writer {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -75,7 +75,7 @@ impl oio::MultipartWrite for B2Writer {
 
                 Ok(result.file_id)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -109,7 +109,7 @@ impl oio::MultipartWrite for B2Writer {
                     checksum: None,
                 })
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -135,7 +135,7 @@ impl oio::MultipartWrite for B2Writer {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -144,7 +144,7 @@ impl oio::MultipartWrite for B2Writer {
         match resp.status() {
             // b2 returns code 200 if abort succeeds.
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/chainsafe/backend.rs
+++ b/core/src/services/chainsafe/backend.rs
@@ -202,7 +202,7 @@ impl Access for ChainsafeBackend {
             StatusCode::OK => Ok(RpCreateDir::default()),
             // Allow 409 when creating a existing dir
             StatusCode::CONFLICT => Ok(RpCreateDir::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -219,7 +219,7 @@ impl Access for ChainsafeBackend {
                     serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
                 Ok(RpStat::new(parse_info(output.content)))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -232,7 +232,7 @@ impl Access for ChainsafeBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -254,7 +254,7 @@ impl Access for ChainsafeBackend {
             StatusCode::OK => Ok(RpDelete::default()),
             // Allow 404 when deleting a non-existing object
             StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/chainsafe/error.rs
+++ b/core/src/services/chainsafe/error.rs
@@ -36,7 +36,7 @@ struct ChainsafeSubError {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -68,7 +68,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]
@@ -77,8 +77,8 @@ mod test {
 
     use super::*;
 
-    #[tokio::test]
-    async fn test_parse_error() {
+    #[test]
+    fn test_parse_error() {
         let err_res = vec![(
             r#"{
                     "error": {
@@ -95,10 +95,9 @@ mod test {
             let body = Buffer::from(bs);
             let resp = Response::builder().status(res.2).body(body).unwrap();
 
-            let err = parse_error(resp).await;
+            let err = parse_error(resp);
 
-            assert!(err.is_ok());
-            assert_eq!(err.unwrap().kind(), res.1);
+            assert_eq!(err.kind(), res.1);
         }
     }
 }

--- a/core/src/services/chainsafe/lister.rs
+++ b/core/src/services/chainsafe/lister.rs
@@ -70,7 +70,7 @@ impl oio::PageList for ChainsafeLister {
 
                 Ok(())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/chainsafe/writer.rs
+++ b/core/src/services/chainsafe/writer.rs
@@ -50,7 +50,7 @@ impl oio::OneShotWrite for ChainsafeWriter {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -295,7 +295,7 @@ impl Access for CosBackend {
 
         match status {
             StatusCode::OK => parse_into_metadata(path, resp.headers()).map(RpStat::new),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -311,7 +311,7 @@ impl Access for CosBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -341,7 +341,7 @@ impl Access for CosBackend {
             StatusCode::NO_CONTENT | StatusCode::ACCEPTED | StatusCode::NOT_FOUND => {
                 Ok(RpDelete::default())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -357,7 +357,7 @@ impl Access for CosBackend {
 
         match status {
             StatusCode::OK => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/cos/error.rs
+++ b/core/src/services/cos/error.rs
@@ -36,7 +36,7 @@ struct CosError {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -68,7 +68,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
     if retryable {
         err = err.set_temporary();
     }
-    Ok(err)
+    err
 }
 
 #[cfg(test)]

--- a/core/src/services/cos/lister.rs
+++ b/core/src/services/cos/lister.rs
@@ -54,7 +54,7 @@ impl oio::PageList for CosLister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();

--- a/core/src/services/cos/writer.rs
+++ b/core/src/services/cos/writer.rs
@@ -57,7 +57,7 @@ impl oio::MultipartWrite for CosWriter {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -79,7 +79,7 @@ impl oio::MultipartWrite for CosWriter {
 
                 Ok(result.upload_id)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -117,7 +117,7 @@ impl oio::MultipartWrite for CosWriter {
                     checksum: None,
                 })
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -139,7 +139,7 @@ impl oio::MultipartWrite for CosWriter {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -152,7 +152,7 @@ impl oio::MultipartWrite for CosWriter {
             // cos returns code 204 if abort succeeds.
             // Reference: https://www.tencentcloud.com/document/product/436/7740
             StatusCode::NO_CONTENT => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }
@@ -176,7 +176,7 @@ impl oio::AppendWrite for CosWriter {
                 Ok(content_length)
             }
             StatusCode::NOT_FOUND => Ok(0),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -193,7 +193,7 @@ impl oio::AppendWrite for CosWriter {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/d1/backend.rs
+++ b/core/src/services/d1/backend.rs
@@ -289,7 +289,7 @@ impl kv::Adapter for Adapter {
                 let d1_response = D1Response::parse(&bs)?;
                 Ok(d1_response.get_result(&self.value_field))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -311,7 +311,7 @@ impl kv::Adapter for Adapter {
         let status = resp.status();
         match status {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -323,7 +323,7 @@ impl kv::Adapter for Adapter {
         let status = resp.status();
         match status {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/d1/error.rs
+++ b/core/src/services/d1/error.rs
@@ -26,7 +26,7 @@ use crate::raw::*;
 use crate::*;
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -59,7 +59,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 pub fn parse_d1_error_code(errors: Vec<D1Error>) -> Option<(ErrorKind, bool)> {

--- a/core/src/services/dbfs/backend.rs
+++ b/core/src/services/dbfs/backend.rs
@@ -175,7 +175,7 @@ impl Access for DbfsBackend {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(RpCreateDir::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -210,7 +210,7 @@ impl Access for DbfsBackend {
             StatusCode::NOT_FOUND if path.ends_with('/') => {
                 Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -229,7 +229,7 @@ impl Access for DbfsBackend {
 
         match status {
             StatusCode::OK => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -248,7 +248,7 @@ impl Access for DbfsBackend {
 
         match status {
             StatusCode::OK => Ok(RpRename::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/dbfs/core.rs
+++ b/core/src/services/dbfs/core.rs
@@ -184,7 +184,7 @@ impl DbfsCore {
             StatusCode::NOT_FOUND => {
                 self.dbfs_create_dir(path).await?;
             }
-            _ => return Err(parse_error(resp).await?),
+            _ => return Err(parse_error(resp)),
         }
         Ok(())
     }

--- a/core/src/services/dbfs/error.rs
+++ b/core/src/services/dbfs/error.rs
@@ -43,7 +43,7 @@ impl Debug for DbfsError {
     }
 }
 
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -71,5 +71,5 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }

--- a/core/src/services/dbfs/lister.rs
+++ b/core/src/services/dbfs/lister.rs
@@ -47,7 +47,7 @@ impl oio::PageList for DbfsLister {
                 ctx.done = true;
                 return Ok(());
             }
-            let error = parse_error(response).await?;
+            let error = parse_error(response);
             return Err(error);
         }
 

--- a/core/src/services/dbfs/writer.rs
+++ b/core/src/services/dbfs/writer.rs
@@ -58,7 +58,7 @@ impl oio::OneShotWrite for DbfsWriter {
         let status = resp.status();
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/dropbox/backend.rs
+++ b/core/src/services/dropbox/backend.rs
@@ -138,7 +138,7 @@ impl Access for DropboxBackend {
                 }
                 Ok(RpStat::new(metadata))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -153,7 +153,7 @@ impl Access for DropboxBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -177,7 +177,7 @@ impl Access for DropboxBackend {
         match status {
             StatusCode::OK => Ok(RpDelete::default()),
             _ => {
-                let err = parse_error(resp).await?;
+                let err = parse_error(resp);
                 match err.kind() {
                     ErrorKind::NotFound => Ok(RpDelete::default()),
                     _ => Err(err),
@@ -206,7 +206,7 @@ impl Access for DropboxBackend {
         match status {
             StatusCode::OK => Ok(RpCopy::default()),
             _ => {
-                let err = parse_error(resp).await?;
+                let err = parse_error(resp);
                 match err.kind() {
                     ErrorKind::NotFound => Ok(RpCopy::default()),
                     _ => Err(err),
@@ -223,7 +223,7 @@ impl Access for DropboxBackend {
         match status {
             StatusCode::OK => Ok(RpRename::default()),
             _ => {
-                let err = parse_error(resp).await?;
+                let err = parse_error(resp);
                 match err.kind() {
                     ErrorKind::NotFound => Ok(RpRename::default()),
                     _ => Err(err),
@@ -246,7 +246,7 @@ impl Access for DropboxBackend {
 
         let resp = self.core.dropbox_delete_batch(paths).await?;
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();

--- a/core/src/services/dropbox/core.rs
+++ b/core/src/services/dropbox/core.rs
@@ -241,7 +241,7 @@ impl DropboxCore {
 
         let resp = self.client.send(request).await?;
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();
@@ -289,7 +289,7 @@ impl DropboxCore {
         match status {
             StatusCode::OK => Ok(RpCreateDir::default()),
             _ => {
-                let err = parse_error(resp).await?;
+                let err = parse_error(resp);
                 match err.kind() {
                     ErrorKind::AlreadyExists => Ok(RpCreateDir::default()),
                     _ => Err(err),

--- a/core/src/services/dropbox/error.rs
+++ b/core/src/services/dropbox/error.rs
@@ -30,7 +30,7 @@ pub struct DropboxErrorResponse {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -62,7 +62,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 /// We cannot get the error type from the response header when the status code is 409.

--- a/core/src/services/dropbox/lister.rs
+++ b/core/src/services/dropbox/lister.rs
@@ -63,7 +63,7 @@ impl oio::PageList for DropboxLister {
         let status_code = response.status();
 
         if !status_code.is_success() {
-            let error = parse_error(response).await?;
+            let error = parse_error(response);
 
             let result = match error.kind() {
                 ErrorKind::NotFound => Ok(()),

--- a/core/src/services/dropbox/writer.rs
+++ b/core/src/services/dropbox/writer.rs
@@ -45,7 +45,7 @@ impl oio::OneShotWrite for DropboxWriter {
         let status = resp.status();
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/ftp/err.rs
+++ b/core/src/services/ftp/err.rs
@@ -21,7 +21,7 @@ use suppaftp::Status;
 use crate::Error;
 use crate::ErrorKind;
 
-pub fn parse_error(err: FtpError) -> Error {
+pub(super) fn parse_error(err: FtpError) -> Error {
     let (kind, retryable) = match err {
         // Allow retry for error
         //

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -497,7 +497,7 @@ impl Access for GcsBackend {
             }
         };
 
-        self.core.sign_query(&mut req, args.expire()).await?;
+        self.core.sign_query(&mut req, args.expire())?;
 
         // We don't need this request anymore, consume it directly.
         let (parts, _) = req.into_parts();

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -141,7 +141,7 @@ impl GcsCore {
         Ok(())
     }
 
-    pub async fn sign_query<T>(&self, req: &mut Request<T>, duration: Duration) -> Result<()> {
+    pub fn sign_query<T>(&self, req: &mut Request<T>, duration: Duration) -> Result<()> {
         if let Some(cred) = self.load_credential()? {
             self.signer
                 .sign_query(req, duration, &cred)

--- a/core/src/services/gcs/error.rs
+++ b/core/src/services/gcs/error.rs
@@ -48,7 +48,7 @@ struct GcsErrorDetail {
 }
 
 /// Parse error response into Error.
-pub fn parse_error(resp: Response<Buffer>) -> Error {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, body) = resp.into_parts();
     let bs = body.to_bytes();
 

--- a/core/src/services/gdrive/backend.rs
+++ b/core/src/services/gdrive/backend.rs
@@ -81,7 +81,7 @@ impl Access for GdriveBackend {
         let resp = self.core.gdrive_stat(path).await?;
 
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();
@@ -115,7 +115,7 @@ impl Access for GdriveBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -145,7 +145,7 @@ impl Access for GdriveBackend {
         let resp = self.core.gdrive_trash(&file_id).await?;
         let status = resp.status();
         if status != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         self.core.path_cache.remove(&path).await;
@@ -180,7 +180,7 @@ impl Access for GdriveBackend {
             let resp = self.core.gdrive_trash(&id).await?;
             let status = resp.status();
             if status != StatusCode::OK {
-                return Err(parse_error(resp).await?);
+                return Err(parse_error(resp));
             }
 
             self.core.path_cache.remove(&to_path).await;
@@ -206,7 +206,7 @@ impl Access for GdriveBackend {
 
         match resp.status() {
             StatusCode::OK => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -219,7 +219,7 @@ impl Access for GdriveBackend {
             let resp = self.core.gdrive_trash(&id).await?;
             let status = resp.status();
             if status != StatusCode::OK {
-                return Err(parse_error(resp).await?);
+                return Err(parse_error(resp));
             }
 
             self.core.path_cache.remove(&target).await;
@@ -247,7 +247,7 @@ impl Access for GdriveBackend {
 
                 Ok(RpRename::default())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/gdrive/core.rs
+++ b/core/src/services/gdrive/core.rs
@@ -320,7 +320,7 @@ impl GdriveSigner {
                         - chrono::TimeDelta::try_seconds(120).expect("120 must be valid seconds");
                 }
                 _ => {
-                    return Err(parse_error(resp).await?);
+                    return Err(parse_error(resp));
                 }
             }
         }
@@ -389,7 +389,7 @@ impl PathQuery for GdrivePathQuery {
                     Ok(None)
                 }
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -413,7 +413,7 @@ impl PathQuery for GdrivePathQuery {
 
         let resp = self.client.send(req).await?;
         if !resp.status().is_success() {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let body = resp.into_body();

--- a/core/src/services/gdrive/error.rs
+++ b/core/src/services/gdrive/error.rs
@@ -34,7 +34,7 @@ struct GdriveInnerError {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -67,7 +67,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 pub fn parse_gdrive_error_code(message: &str) -> Option<(ErrorKind, bool)> {

--- a/core/src/services/gdrive/lister.rs
+++ b/core/src/services/gdrive/lister.rs
@@ -55,7 +55,7 @@ impl oio::PageList for GdriveLister {
 
         let bytes = match resp.status() {
             StatusCode::OK => resp.into_body().to_bytes(),
-            _ => return Err(parse_error(resp).await?),
+            _ => return Err(parse_error(resp)),
         };
 
         // Gdrive returns empty content when this dir is not exist.

--- a/core/src/services/gdrive/writer.rs
+++ b/core/src/services/gdrive/writer.rs
@@ -71,7 +71,7 @@ impl oio::OneShotWrite for GdriveWriter {
                 }
                 Ok(())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -269,7 +269,7 @@ impl Access for GhacBackend {
                 serde_json::from_reader(slc.reader()).map_err(new_json_deserialize_error)?;
             query_resp.archive_location
         } else {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         };
 
         let req = Request::get(location)
@@ -292,7 +292,7 @@ impl Access for GhacBackend {
 
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -307,7 +307,7 @@ impl Access for GhacBackend {
                 serde_json::from_reader(slc.reader()).map_err(new_json_deserialize_error)?;
             query_resp.archive_location
         } else {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         };
 
         let req = self.ghac_get_location(&location, args.range()).await?;
@@ -321,7 +321,7 @@ impl Access for GhacBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -337,9 +337,7 @@ impl Access for GhacBackend {
                 serde_json::from_reader(slc.reader()).map_err(new_json_deserialize_error)?;
             reserve_resp.cache_id
         } else {
-            return Err(parse_error(resp)
-                .await
-                .map(|err| err.with_operation("Backend::ghac_reserve"))?);
+            return Err(parse_error(resp).map(|err| err.with_operation("Backend::ghac_reserve")));
         };
 
         Ok((RpWrite::default(), GhacWriter::new(self.clone(), cache_id)))
@@ -359,7 +357,7 @@ impl Access for GhacBackend {
         if resp.status().is_success() || resp.status() == StatusCode::NOT_FOUND {
             Ok(RpDelete::default())
         } else {
-            Err(parse_error(resp).await?)
+            Err(parse_error(resp))
         }
     }
 }

--- a/core/src/services/ghac/error.rs
+++ b/core/src/services/ghac/error.rs
@@ -23,7 +23,7 @@ use crate::raw::*;
 use crate::*;
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
 
     let (kind, retryable) = match parts.status {
@@ -49,5 +49,5 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }

--- a/core/src/services/ghac/writer.rs
+++ b/core/src/services/ghac/writer.rs
@@ -55,9 +55,7 @@ impl oio::Write for GhacWriter {
         let resp = self.backend.client.send(req).await?;
 
         if !resp.status().is_success() {
-            return Err(parse_error(resp)
-                .await
-                .map(|err| err.with_operation("Backend::ghac_upload"))?);
+            return Err(parse_error(resp).map(|err| err.with_operation("Backend::ghac_upload")));
         }
 
         self.size += size as u64;
@@ -75,9 +73,7 @@ impl oio::Write for GhacWriter {
         if resp.status().is_success() {
             Ok(())
         } else {
-            Err(parse_error(resp)
-                .await
-                .map(|err| err.with_operation("Backend::ghac_commit"))?)
+            Err(parse_error(resp).map(|err| err.with_operation("Backend::ghac_commit")))
         }
     }
 }

--- a/core/src/services/ghac/writer.rs
+++ b/core/src/services/ghac/writer.rs
@@ -42,15 +42,12 @@ impl oio::Write for GhacWriter {
         let size = bs.len();
         let offset = self.size;
 
-        let req = self
-            .backend
-            .ghac_upload(
-                self.cache_id,
-                offset,
-                size as u64,
-                Buffer::from(bs.to_bytes()),
-            )
-            .await?;
+        let req = self.backend.ghac_upload(
+            self.cache_id,
+            offset,
+            size as u64,
+            Buffer::from(bs.to_bytes()),
+        )?;
 
         let resp = self.backend.client.send(req).await?;
 
@@ -67,7 +64,7 @@ impl oio::Write for GhacWriter {
     }
 
     async fn close(&mut self) -> Result<()> {
-        let req = self.backend.ghac_commit(self.cache_id, self.size).await?;
+        let req = self.backend.ghac_commit(self.cache_id, self.size)?;
         let resp = self.backend.client.send(req).await?;
 
         if resp.status().is_success() {

--- a/core/src/services/github/backend.rs
+++ b/core/src/services/github/backend.rs
@@ -217,7 +217,7 @@ impl Access for GithubBackend {
 
         match status {
             StatusCode::OK | StatusCode::CREATED => Ok(RpCreateDir::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -242,7 +242,7 @@ impl Access for GithubBackend {
 
                 Ok(RpStat::new(m))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -258,7 +258,7 @@ impl Access for GithubBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }

--- a/core/src/services/github/core.rs
+++ b/core/src/services/github/core.rs
@@ -102,7 +102,7 @@ impl GithubCore {
                 Ok(Some(resp.sha))
             }
             StatusCode::NOT_FOUND => Ok(None),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -230,7 +230,7 @@ impl GithubCore {
         match resp.status() {
             StatusCode::OK => Ok(()),
             StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -264,7 +264,7 @@ impl GithubCore {
                 Ok(resp)
             }
             StatusCode::NOT_FOUND => Ok(ListResponse::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -291,7 +291,7 @@ impl GithubCore {
 
                 Ok(resp.tree)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/github/error.rs
+++ b/core/src/services/github/error.rs
@@ -36,7 +36,7 @@ struct GithubSubError {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -68,7 +68,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]
@@ -93,10 +93,9 @@ mod test {
             let body = Buffer::from(bs);
             let resp = Response::builder().status(res.2).body(body).unwrap();
 
-            let err = parse_error(resp).await;
+            let err = parse_error(resp);
 
-            assert!(err.is_ok());
-            assert_eq!(err.unwrap().kind(), res.1);
+            assert_eq!(err.kind(), res.1);
         }
     }
 }

--- a/core/src/services/github/writer.rs
+++ b/core/src/services/github/writer.rs
@@ -45,7 +45,7 @@ impl oio::OneShotWrite for GithubWriter {
 
         match status {
             StatusCode::OK | StatusCode::CREATED => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -241,7 +241,7 @@ impl Access for HttpBackend {
             StatusCode::NOT_FOUND | StatusCode::FORBIDDEN if path.ends_with('/') => {
                 Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -257,7 +257,7 @@ impl Access for HttpBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }

--- a/core/src/services/http/error.rs
+++ b/core/src/services/http/error.rs
@@ -23,7 +23,7 @@ use crate::raw::*;
 use crate::*;
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -50,5 +50,5 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }

--- a/core/src/services/huggingface/backend.rs
+++ b/core/src/services/huggingface/backend.rs
@@ -253,7 +253,7 @@ impl Access for HuggingfaceBackend {
 
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -269,7 +269,7 @@ impl Access for HuggingfaceBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }

--- a/core/src/services/huggingface/error.rs
+++ b/core/src/services/huggingface/error.rs
@@ -40,7 +40,7 @@ impl Debug for HuggingfaceError {
     }
 }
 
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -68,7 +68,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]

--- a/core/src/services/huggingface/lister.rs
+++ b/core/src/services/huggingface/lister.rs
@@ -47,7 +47,7 @@ impl oio::PageList for HuggingfaceLister {
 
         let status_code = response.status();
         if !status_code.is_success() {
-            let error = parse_error(response).await?;
+            let error = parse_error(response);
             return Err(error);
         }
 

--- a/core/src/services/icloud/backend.rs
+++ b/core/src/services/icloud/backend.rs
@@ -278,7 +278,7 @@ impl Access for IcloudBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }

--- a/core/src/services/icloud/core.rs
+++ b/core/src/services/icloud/core.rs
@@ -164,13 +164,13 @@ impl IcloudSigner {
 
         let resp = self.client.send(req).await?;
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         if let Some(rscd) = resp.headers().get(APPLE_RESPONSE_HEADER) {
             let status_code = StatusCode::from_bytes(rscd.as_bytes()).unwrap();
             if status_code != StatusCode::CONFLICT {
-                return Err(parse_error(resp).await?);
+                return Err(parse_error(resp));
             }
         }
 
@@ -191,7 +191,7 @@ impl IcloudSigner {
 
         let resp = self.client.send(req).await?;
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         // Update SessionData cookies.We need obtain `X-APPLE-WEBAUTH-USER` cookie to get file.
@@ -358,7 +358,7 @@ impl IcloudCore {
 
         let resp = signer.send(req).await?;
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let body = resp.into_body();
@@ -389,7 +389,7 @@ impl IcloudCore {
 
         let resp = signer.send(req).await?;
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let body = resp.into_body();
@@ -517,7 +517,7 @@ impl PathQuery for IcloudPathQuery {
 
         let resp = signer.send(req).await?;
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let body = resp.into_body();
@@ -558,7 +558,7 @@ impl PathQuery for IcloudPathQuery {
 
         let resp = signer.send(req).await?;
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let body = resp.into_body();
@@ -568,7 +568,7 @@ impl PathQuery for IcloudPathQuery {
     }
 }
 
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -594,7 +594,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
 
     err = with_error_response_context(err, parts);
 
-    Ok(err)
+    err
 }
 
 #[derive(Default, Debug, Deserialize)]

--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -332,7 +332,7 @@ impl Access for IpfsBackend {
             StatusCode::FOUND | StatusCode::MOVED_PERMANENTLY => {
                 Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -348,7 +348,7 @@ impl Access for IpfsBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -426,7 +426,7 @@ impl oio::PageList for DirStream {
         let resp = self.backend.ipfs_list(&self.path).await?;
 
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();

--- a/core/src/services/ipfs/error.rs
+++ b/core/src/services/ipfs/error.rs
@@ -23,7 +23,7 @@ use crate::raw::*;
 use crate::*;
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -49,5 +49,5 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -95,7 +95,7 @@ impl Access for IpmfsBackend {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(RpCreateDir::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -127,7 +127,7 @@ impl Access for IpmfsBackend {
 
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -143,7 +143,7 @@ impl Access for IpmfsBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -162,7 +162,7 @@ impl Access for IpmfsBackend {
 
         match status {
             StatusCode::OK => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/ipmfs/error.rs
+++ b/core/src/services/ipmfs/error.rs
@@ -44,7 +44,7 @@ struct IpfsError {
 /// > (if no error, check the daemon logs).
 ///
 /// ref: https://docs.ipfs.tech/reference/kubo/rpc/#http-status-codes
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -80,5 +80,5 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }

--- a/core/src/services/ipmfs/lister.rs
+++ b/core/src/services/ipmfs/lister.rs
@@ -49,7 +49,7 @@ impl oio::PageList for IpmfsLister {
         let resp = self.backend.ipmfs_ls(&self.path).await?;
 
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();

--- a/core/src/services/ipmfs/writer.rs
+++ b/core/src/services/ipmfs/writer.rs
@@ -42,7 +42,7 @@ impl oio::OneShotWrite for IpmfsWriter {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/koofr/backend.rs
+++ b/core/src/services/koofr/backend.rs
@@ -265,7 +265,7 @@ impl Access for KoofrBackend {
 
                 Ok(RpStat::new(md))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -280,7 +280,7 @@ impl Access for KoofrBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -302,7 +302,7 @@ impl Access for KoofrBackend {
             StatusCode::OK => Ok(RpDelete::default()),
             // Allow 404 when deleting a non-existing object
             StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -323,7 +323,7 @@ impl Access for KoofrBackend {
         let status = resp.status();
 
         if status != StatusCode::OK && status != StatusCode::NOT_FOUND {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let resp = self.core.copy(from, to).await?;
@@ -332,7 +332,7 @@ impl Access for KoofrBackend {
 
         match status {
             StatusCode::OK => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -348,7 +348,7 @@ impl Access for KoofrBackend {
         let status = resp.status();
 
         if status != StatusCode::OK && status != StatusCode::NOT_FOUND {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let resp = self.core.move_object(from, to).await?;
@@ -357,7 +357,7 @@ impl Access for KoofrBackend {
 
         match status {
             StatusCode::OK => Ok(RpRename::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/koofr/core.rs
+++ b/core/src/services/koofr/core.rs
@@ -86,7 +86,7 @@ impl KoofrCore {
                 let status = resp.status();
 
                 if status != StatusCode::OK {
-                    return Err(parse_error(resp).await?);
+                    return Err(parse_error(resp));
                 }
 
                 let bs = resp.into_body();
@@ -133,7 +133,7 @@ impl KoofrCore {
         let status = resp.status();
 
         if status != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();
@@ -211,11 +211,11 @@ impl KoofrCore {
                     // When the directory already exists, Koofr returns 400 Bad Request.
                     // We should treat it as success.
                     StatusCode::OK | StatusCode::CREATED | StatusCode::BAD_REQUEST => Ok(()),
-                    _ => Err(parse_error(resp).await?),
+                    _ => Err(parse_error(resp)),
                 }
             }
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/koofr/error.rs
+++ b/core/src/services/koofr/error.rs
@@ -22,7 +22,7 @@ use crate::raw::*;
 use crate::*;
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -47,7 +47,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]
@@ -65,10 +65,9 @@ mod test {
             let body = Buffer::from(bs);
             let resp = Response::builder().status(res.2).body(body).unwrap();
 
-            let err = parse_error(resp).await;
+            let err = parse_error(resp);
 
-            assert!(err.is_ok());
-            assert_eq!(err.unwrap().kind(), res.1);
+            assert_eq!(err.kind(), res.1);
         }
     }
 }

--- a/core/src/services/koofr/lister.rs
+++ b/core/src/services/koofr/lister.rs
@@ -55,7 +55,7 @@ impl oio::PageList for KoofrLister {
         match resp.status() {
             http::StatusCode::OK => {}
             _ => {
-                return Err(parse_error(resp).await?);
+                return Err(parse_error(resp));
             }
         }
 

--- a/core/src/services/koofr/writer.rs
+++ b/core/src/services/koofr/writer.rs
@@ -47,7 +47,7 @@ impl oio::OneShotWrite for KoofrWriter {
 
         match status {
             StatusCode::OK | StatusCode::CREATED => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/lakefs/backend.rs
+++ b/core/src/services/lakefs/backend.rs
@@ -245,7 +245,7 @@ impl Access for LakefsBackend {
 
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -264,7 +264,7 @@ impl Access for LakefsBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -301,7 +301,7 @@ impl Access for LakefsBackend {
         match status {
             StatusCode::NO_CONTENT => Ok(RpDelete::default()),
             StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -312,7 +312,7 @@ impl Access for LakefsBackend {
 
         match status {
             StatusCode::CREATED => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/lakefs/error.rs
+++ b/core/src/services/lakefs/error.rs
@@ -40,7 +40,7 @@ impl Debug for LakefsError {
     }
 }
 
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -68,7 +68,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]

--- a/core/src/services/lakefs/lister.rs
+++ b/core/src/services/lakefs/lister.rs
@@ -73,7 +73,7 @@ impl oio::PageList for LakefsLister {
 
         let status_code = response.status();
         if !status_code.is_success() {
-            let error = parse_error(response).await?;
+            let error = parse_error(response);
             return Err(error);
         }
 

--- a/core/src/services/lakefs/writer.rs
+++ b/core/src/services/lakefs/writer.rs
@@ -44,7 +44,7 @@ impl oio::OneShotWrite for LakefsWriter {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/libsql/backend.rs
+++ b/core/src/services/libsql/backend.rs
@@ -277,7 +277,7 @@ impl Adapter {
         let resp = self.client.send(req).await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();

--- a/core/src/services/libsql/error.rs
+++ b/core/src/services/libsql/error.rs
@@ -23,7 +23,7 @@ use crate::raw::*;
 use crate::*;
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -55,5 +55,5 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }

--- a/core/src/services/monoiofs/core.rs
+++ b/core/src/services/monoiofs/core.rs
@@ -223,7 +223,7 @@ mod tests {
     async fn dispatch_concurrent(core: Arc<MonoiofsCore>) {
         let (tx, mut rx) = mpsc::unbounded();
 
-        async fn spawn_task(core: Arc<MonoiofsCore>, tx: UnboundedSender<u64>, sleep_millis: u64) {
+        fn spawn_task(core: Arc<MonoiofsCore>, tx: UnboundedSender<u64>, sleep_millis: u64) {
             tokio::spawn(async move {
                 let result = core
                     .dispatch(move || async move {
@@ -236,8 +236,8 @@ mod tests {
             });
         }
 
-        spawn_task(core.clone(), tx.clone(), 200).await;
-        spawn_task(core.clone(), tx.clone(), 20).await;
+        spawn_task(core.clone(), tx.clone(), 200);
+        spawn_task(core.clone(), tx.clone(), 20);
         drop(tx);
         let first = rx.next().await;
         let second = rx.next().await;

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -308,7 +308,7 @@ impl Access for ObsBackend {
             StatusCode::NOT_FOUND if path.ends_with('/') => {
                 Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -324,7 +324,7 @@ impl Access for ObsBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -354,7 +354,7 @@ impl Access for ObsBackend {
             StatusCode::NO_CONTENT | StatusCode::ACCEPTED | StatusCode::NOT_FOUND => {
                 Ok(RpDelete::default())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -370,7 +370,7 @@ impl Access for ObsBackend {
 
         match status {
             StatusCode::OK => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/obs/error.rs
+++ b/core/src/services/obs/error.rs
@@ -36,7 +36,7 @@ struct ObsError {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -69,7 +69,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]

--- a/core/src/services/obs/lister.rs
+++ b/core/src/services/obs/lister.rs
@@ -55,7 +55,7 @@ impl oio::PageList for ObsLister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();

--- a/core/src/services/obs/writer.rs
+++ b/core/src/services/obs/writer.rs
@@ -58,7 +58,7 @@ impl oio::MultipartWrite for ObsWriter {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -80,7 +80,7 @@ impl oio::MultipartWrite for ObsWriter {
 
                 Ok(result.upload_id)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -118,7 +118,7 @@ impl oio::MultipartWrite for ObsWriter {
                     checksum: None,
                 })
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -140,7 +140,7 @@ impl oio::MultipartWrite for ObsWriter {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -153,7 +153,7 @@ impl oio::MultipartWrite for ObsWriter {
             // Obs returns code 204 No Content if abort succeeds.
             // Reference: https://support.huaweicloud.com/intl/en-us/api-obs/obs_04_0103.html
             StatusCode::NO_CONTENT => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }
@@ -177,7 +177,7 @@ impl oio::AppendWrite for ObsWriter {
                 Ok(content_length)
             }
             StatusCode::NOT_FOUND => Ok(0),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -194,7 +194,7 @@ impl oio::AppendWrite for ObsWriter {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -106,7 +106,7 @@ impl Access for OnedriveBackend {
         let status = response.status();
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(RpCreateDir::default()),
-            _ => Err(parse_error(response).await?),
+            _ => Err(parse_error(response)),
         }
     }
 
@@ -144,7 +144,7 @@ impl Access for OnedriveBackend {
                 StatusCode::NOT_FOUND if path.ends_with('/') => {
                     Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
                 }
-                _ => Err(parse_error(resp).await?),
+                _ => Err(parse_error(resp)),
             }
         }
     }
@@ -161,7 +161,7 @@ impl Access for OnedriveBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -184,7 +184,7 @@ impl Access for OnedriveBackend {
 
         match status {
             StatusCode::NO_CONTENT | StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/onedrive/error.rs
+++ b/core/src/services/onedrive/error.rs
@@ -23,7 +23,7 @@ use crate::raw::*;
 use crate::*;
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -47,5 +47,5 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }

--- a/core/src/services/onedrive/lister.rs
+++ b/core/src/services/onedrive/lister.rs
@@ -74,7 +74,7 @@ impl oio::PageList for OnedriveLister {
                 ctx.done = true;
                 return Ok(());
             }
-            let error = parse_error(resp).await?;
+            let error = parse_error(resp);
             return Err(error);
         }
 

--- a/core/src/services/onedrive/writer.rs
+++ b/core/src/services/onedrive/writer.rs
@@ -70,7 +70,7 @@ impl OneDriveWriter {
             // Typical response code: 201 Created
             // Reference: https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_put_content?view=odsp-graph-online#response
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -112,7 +112,7 @@ impl OneDriveWriter {
                 // Typical response code: 202 Accepted
                 // Reference: https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_put_content?view=odsp-graph-online#response
                 StatusCode::ACCEPTED | StatusCode::CREATED | StatusCode::OK => {}
-                _ => return Err(parse_error(resp).await?),
+                _ => return Err(parse_error(resp)),
             }
 
             offset += OneDriveWriter::CHUNK_SIZE_FACTOR;
@@ -150,7 +150,7 @@ impl OneDriveWriter {
                     serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
                 Ok(result)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -499,7 +499,7 @@ impl Access for OssBackend {
 
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -515,7 +515,7 @@ impl Access for OssBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -541,7 +541,7 @@ impl Access for OssBackend {
         let status = resp.status();
         match status {
             StatusCode::NO_CONTENT | StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -562,7 +562,7 @@ impl Access for OssBackend {
 
         match status {
             StatusCode::OK => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -641,7 +641,7 @@ impl Access for OssBackend {
 
             Ok(RpBatch::new(batched_result))
         } else {
-            Err(parse_error(resp).await?)
+            Err(parse_error(resp))
         }
     }
 }

--- a/core/src/services/oss/error.rs
+++ b/core/src/services/oss/error.rs
@@ -35,7 +35,7 @@ struct OssError {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -65,7 +65,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]

--- a/core/src/services/oss/lister.rs
+++ b/core/src/services/oss/lister.rs
@@ -73,7 +73,7 @@ impl oio::PageList for OssLister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();

--- a/core/src/services/oss/writer.rs
+++ b/core/src/services/oss/writer.rs
@@ -57,7 +57,7 @@ impl oio::MultipartWrite for OssWriter {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -85,7 +85,7 @@ impl oio::MultipartWrite for OssWriter {
 
                 Ok(result.upload_id)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -123,7 +123,7 @@ impl oio::MultipartWrite for OssWriter {
                     checksum: None,
                 })
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -145,7 +145,7 @@ impl oio::MultipartWrite for OssWriter {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -157,7 +157,7 @@ impl oio::MultipartWrite for OssWriter {
         match resp.status() {
             // OSS returns code 204 if abort succeeds.
             StatusCode::NO_CONTENT => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }
@@ -181,7 +181,7 @@ impl oio::AppendWrite for OssWriter {
                 Ok(content_length)
             }
             StatusCode::NOT_FOUND => Ok(0),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -198,7 +198,7 @@ impl oio::AppendWrite for OssWriter {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/pcloud/backend.rs
+++ b/core/src/services/pcloud/backend.rs
@@ -249,7 +249,7 @@ impl Access for PcloudBackend {
 
                 Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -267,7 +267,7 @@ impl Access for PcloudBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -303,7 +303,7 @@ impl Access for PcloudBackend {
 
                 Ok(RpDelete::default())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -338,7 +338,7 @@ impl Access for PcloudBackend {
 
                 Ok(RpCopy::default())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -368,7 +368,7 @@ impl Access for PcloudBackend {
 
                 Ok(RpRename::default())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/pcloud/core.rs
+++ b/core/src/services/pcloud/core.rs
@@ -103,7 +103,7 @@ impl PcloudCore {
                 }
                 Err(Error::new(ErrorKind::Unexpected, "hosts is empty"))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -147,7 +147,7 @@ impl PcloudCore {
                         return Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")));
                     }
                 }
-                _ => return Err(parse_error(resp).await?),
+                _ => return Err(parse_error(resp)),
             }
         }
         Ok(())

--- a/core/src/services/pcloud/error.rs
+++ b/core/src/services/pcloud/error.rs
@@ -42,7 +42,7 @@ impl Debug for PcloudError {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
     let message = String::from_utf8_lossy(&bs).into_owned();
@@ -51,7 +51,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
 
     err = with_error_response_context(err, parts);
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]
@@ -81,10 +81,9 @@ mod test {
             let body = Buffer::from(bs);
             let resp = Response::builder().status(res.2).body(body).unwrap();
 
-            let err = parse_error(resp).await;
+            let err = parse_error(resp);
 
-            assert!(err.is_ok());
-            assert_eq!(err.unwrap().kind(), res.1);
+            assert_eq!(err.kind(), res.1);
         }
     }
 }

--- a/core/src/services/pcloud/lister.rs
+++ b/core/src/services/pcloud/lister.rs
@@ -89,7 +89,7 @@ impl oio::PageList for PcloudLister {
                     String::from_utf8_lossy(&bs.to_bytes()),
                 ));
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/pcloud/writer.rs
+++ b/core/src/services/pcloud/writer.rs
@@ -60,7 +60,7 @@ impl oio::OneShotWrite for PcloudWriter {
 
                 Ok(())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/s3/error.rs
+++ b/core/src/services/s3/error.rs
@@ -35,7 +35,7 @@ pub(crate) struct S3Error {
 }
 
 /// Parse error response into Error.
-pub fn parse_error(resp: Response<Buffer>) -> Error {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, body) = resp.into_parts();
 
     let (mut kind, mut retryable) = match parts.status.as_u16() {

--- a/core/src/services/seafile/backend.rs
+++ b/core/src/services/seafile/backend.rs
@@ -267,7 +267,7 @@ impl Access for SeafileBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }

--- a/core/src/services/seafile/core.rs
+++ b/core/src/services/seafile/core.rs
@@ -107,7 +107,7 @@ impl SeafileCore {
                     };
                 }
                 _ => {
-                    return Err(parse_error(resp).await?);
+                    return Err(parse_error(resp));
                 }
             }
 
@@ -148,7 +148,7 @@ impl SeafileCore {
                     }
                 }
                 _ => {
-                    return Err(parse_error(resp).await?);
+                    return Err(parse_error(resp));
                 }
             }
             Ok(signer.auth_info.clone())
@@ -181,7 +181,7 @@ impl SeafileCore {
                     .map_err(new_json_deserialize_error)?;
                 Ok(upload_url)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -213,7 +213,7 @@ impl SeafileCore {
 
                 Ok(download_url)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -258,7 +258,7 @@ impl SeafileCore {
                     .map_err(new_json_deserialize_error)?;
                 Ok(file_detail)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -289,7 +289,7 @@ impl SeafileCore {
                     .map_err(new_json_deserialize_error)?;
                 Ok(dir_detail)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -325,7 +325,7 @@ impl SeafileCore {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/seafile/error.rs
+++ b/core/src/services/seafile/error.rs
@@ -30,7 +30,7 @@ struct SeafileError {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -49,7 +49,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
 
     err = with_error_response_context(err, parts);
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]
@@ -78,10 +78,9 @@ mod test {
             let body = Buffer::from(bs);
             let resp = Response::builder().status(res.2).body(body).unwrap();
 
-            let err = parse_error(resp).await;
+            let err = parse_error(resp);
 
-            assert!(err.is_ok());
-            assert_eq!(err.unwrap().kind(), res.1);
+            assert_eq!(err.kind(), res.1);
         }
     }
 }

--- a/core/src/services/seafile/lister.rs
+++ b/core/src/services/seafile/lister.rs
@@ -108,7 +108,7 @@ impl oio::PageList for SeafileLister {
                 ctx.done = true;
                 Ok(())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/seafile/writer.rs
+++ b/core/src/services/seafile/writer.rs
@@ -80,7 +80,7 @@ impl oio::OneShotWrite for SeafileWriter {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/supabase/backend.rs
+++ b/core/src/services/supabase/backend.rs
@@ -186,7 +186,7 @@ impl Access for SupabaseBackend {
                     StatusCode::NOT_FOUND if path.ends_with('/') => {
                         Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
                     }
-                    _ => Err(parse_error(resp).await?),
+                    _ => Err(parse_error(resp)),
                 }
             }
         }
@@ -202,7 +202,7 @@ impl Access for SupabaseBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -221,7 +221,7 @@ impl Access for SupabaseBackend {
             Ok(RpDelete::default())
         } else {
             // deleting not existing objects is ok
-            let e = parse_error(resp).await?;
+            let e = parse_error(resp);
             if e.kind() == ErrorKind::NotFound {
                 Ok(RpDelete::default())
             } else {

--- a/core/src/services/supabase/error.rs
+++ b/core/src/services/supabase/error.rs
@@ -34,7 +34,7 @@ struct SupabaseError {
 }
 
 /// Parse the supabase error type to the OpenDAL error type
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -60,7 +60,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 // Return the error kind and whether it is retryable

--- a/core/src/services/supabase/writer.rs
+++ b/core/src/services/supabase/writer.rs
@@ -56,7 +56,7 @@ impl oio::OneShotWrite for SupabaseWriter {
 
         match resp.status() {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/swift/backend.rs
+++ b/core/src/services/swift/backend.rs
@@ -211,7 +211,7 @@ impl Access for SwiftBackend {
                 let meta = parse_into_metadata(path, resp.headers())?;
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -225,7 +225,7 @@ impl Access for SwiftBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -246,7 +246,7 @@ impl Access for SwiftBackend {
         match status {
             StatusCode::NO_CONTENT | StatusCode::OK => Ok(RpDelete::default()),
             StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -270,7 +270,7 @@ impl Access for SwiftBackend {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/swift/error.rs
+++ b/core/src/services/swift/error.rs
@@ -32,7 +32,7 @@ struct ErrorResponse {
     p: String,
 }
 
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -57,7 +57,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 fn parse_error_response(resp: &Bytes) -> String {

--- a/core/src/services/swift/lister.rs
+++ b/core/src/services/swift/lister.rs
@@ -53,7 +53,7 @@ impl oio::PageList for SwiftLister {
         let status_code = response.status();
 
         if !status_code.is_success() {
-            let error = parse_error(response).await?;
+            let error = parse_error(response);
             return Err(error);
         }
 

--- a/core/src/services/swift/writer.rs
+++ b/core/src/services/swift/writer.rs
@@ -46,7 +46,7 @@ impl oio::OneShotWrite for SwiftWriter {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/upyun/backend.rs
+++ b/core/src/services/upyun/backend.rs
@@ -236,7 +236,7 @@ impl Access for UpyunBackend {
 
         match status {
             StatusCode::OK => Ok(RpCreateDir::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -247,7 +247,7 @@ impl Access for UpyunBackend {
 
         match status {
             StatusCode::OK => parse_info(resp.headers()).map(RpStat::new),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -263,7 +263,7 @@ impl Access for UpyunBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -287,7 +287,7 @@ impl Access for UpyunBackend {
             StatusCode::OK => Ok(RpDelete::default()),
             // Allow 404 when deleting a non-existing object
             StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -303,7 +303,7 @@ impl Access for UpyunBackend {
 
         match status {
             StatusCode::OK => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -314,7 +314,7 @@ impl Access for UpyunBackend {
 
         match status {
             StatusCode::OK => Ok(RpRename::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/upyun/core.rs
+++ b/core/src/services/upyun/core.rs
@@ -84,7 +84,7 @@ impl UpyunCore {
         self.client.send(req).await
     }
 
-    pub async fn sign(&self, req: &mut Request<Buffer>) -> Result<()> {
+    pub fn sign(&self, req: &mut Request<Buffer>) -> Result<()> {
         // get rfc1123 date
         let date = chrono::Utc::now()
             .format("%a, %d %b %Y %H:%M:%S GMT")
@@ -118,7 +118,7 @@ impl UpyunCore {
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
-        self.sign(&mut req).await?;
+        self.sign(&mut req)?;
 
         self.client.fetch(req).await
     }
@@ -136,12 +136,12 @@ impl UpyunCore {
 
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
-        self.sign(&mut req).await?;
+        self.sign(&mut req)?;
 
         self.send(req).await
     }
 
-    pub async fn upload(
+    pub fn upload(
         &self,
         path: &str,
         size: Option<u64>,
@@ -177,7 +177,7 @@ impl UpyunCore {
         // Set body
         let mut req = req.body(body).map_err(new_request_build_error)?;
 
-        self.sign(&mut req).await?;
+        self.sign(&mut req)?;
 
         Ok(req)
     }
@@ -195,7 +195,7 @@ impl UpyunCore {
 
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
-        self.sign(&mut req).await?;
+        self.sign(&mut req)?;
 
         self.send(req).await
     }
@@ -221,7 +221,7 @@ impl UpyunCore {
         // Set body
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
-        self.sign(&mut req).await?;
+        self.sign(&mut req)?;
 
         self.send(req).await
     }
@@ -247,7 +247,7 @@ impl UpyunCore {
         // Set body
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
-        self.sign(&mut req).await?;
+        self.sign(&mut req)?;
 
         self.send(req).await
     }
@@ -270,7 +270,7 @@ impl UpyunCore {
 
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
-        self.sign(&mut req).await?;
+        self.sign(&mut req)?;
 
         self.send(req).await
     }
@@ -308,12 +308,12 @@ impl UpyunCore {
 
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
-        self.sign(&mut req).await?;
+        self.sign(&mut req)?;
 
         self.send(req).await
     }
 
-    pub async fn upload_part(
+    pub fn upload_part(
         &self,
         path: &str,
         upload_id: &str,
@@ -342,7 +342,7 @@ impl UpyunCore {
         // Set body
         let mut req = req.body(body).map_err(new_request_build_error)?;
 
-        self.sign(&mut req).await?;
+        self.sign(&mut req)?;
 
         Ok(req)
     }
@@ -368,7 +368,7 @@ impl UpyunCore {
 
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
-        self.sign(&mut req).await?;
+        self.sign(&mut req)?;
 
         self.send(req).await
     }
@@ -405,7 +405,7 @@ impl UpyunCore {
         // Set body
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
-        self.sign(&mut req).await?;
+        self.sign(&mut req)?;
 
         self.send(req).await
     }

--- a/core/src/services/upyun/error.rs
+++ b/core/src/services/upyun/error.rs
@@ -33,7 +33,7 @@ struct UpyunError {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -60,7 +60,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]
@@ -89,10 +89,9 @@ mod test {
             let body = Buffer::from(bs);
             let resp = Response::builder().status(res.2).body(body).unwrap();
 
-            let err = parse_error(resp).await;
+            let err = parse_error(resp);
 
-            assert!(err.is_ok());
-            assert_eq!(err.unwrap().kind(), res.1);
+            assert_eq!(err.kind(), res.1);
         }
     }
 }

--- a/core/src/services/upyun/lister.rs
+++ b/core/src/services/upyun/lister.rs
@@ -64,7 +64,7 @@ impl oio::PageList for UpyunLister {
                 return Ok(());
             }
             _ => {
-                return Err(parse_error(resp).await?);
+                return Err(parse_error(resp));
             }
         }
 

--- a/core/src/services/upyun/writer.rs
+++ b/core/src/services/upyun/writer.rs
@@ -41,10 +41,7 @@ impl UpyunWriter {
 
 impl oio::MultipartWrite for UpyunWriter {
     async fn write_once(&self, size: u64, body: Buffer) -> Result<()> {
-        let req = self
-            .core
-            .upload(&self.path, Some(size), &self.op, body)
-            .await?;
+        let req = self.core.upload(&self.path, Some(size), &self.op, body)?;
 
         let resp = self.core.send(req).await?;
 
@@ -87,8 +84,7 @@ impl oio::MultipartWrite for UpyunWriter {
     ) -> Result<oio::MultipartPart> {
         let req = self
             .core
-            .upload_part(&self.path, upload_id, part_number, size, body)
-            .await?;
+            .upload_part(&self.path, upload_id, part_number, size, body)?;
 
         let resp = self.core.send(req).await?;
 

--- a/core/src/services/upyun/writer.rs
+++ b/core/src/services/upyun/writer.rs
@@ -52,7 +52,7 @@ impl oio::MultipartWrite for UpyunWriter {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -74,7 +74,7 @@ impl oio::MultipartWrite for UpyunWriter {
 
                 Ok(id.to_string())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -100,7 +100,7 @@ impl oio::MultipartWrite for UpyunWriter {
                 etag: "".to_string(),
                 checksum: None,
             }),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -114,7 +114,7 @@ impl oio::MultipartWrite for UpyunWriter {
 
         match status {
             StatusCode::NO_CONTENT => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/vercel_artifacts/backend.rs
+++ b/core/src/services/vercel_artifacts/backend.rs
@@ -78,7 +78,7 @@ impl Access for VercelArtifactsBackend {
                 Ok(RpStat::new(meta))
             }
 
-            _ => Err(parse_error(res).await?),
+            _ => Err(parse_error(res)),
         }
     }
 
@@ -92,7 +92,7 @@ impl Access for VercelArtifactsBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }

--- a/core/src/services/vercel_artifacts/error.rs
+++ b/core/src/services/vercel_artifacts/error.rs
@@ -23,7 +23,7 @@ use crate::raw::*;
 use crate::*;
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -47,5 +47,5 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }

--- a/core/src/services/vercel_artifacts/writer.rs
+++ b/core/src/services/vercel_artifacts/writer.rs
@@ -50,7 +50,7 @@ impl oio::OneShotWrite for VercelArtifactsWriter {
 
         match status {
             StatusCode::OK | StatusCode::ACCEPTED => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/vercel_blob/backend.rs
+++ b/core/src/services/vercel_blob/backend.rs
@@ -191,7 +191,7 @@ impl Access for VercelBlobBackend {
 
                 parse_blob(&resp).map(RpStat::new)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -207,7 +207,7 @@ impl Access for VercelBlobBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -233,7 +233,7 @@ impl Access for VercelBlobBackend {
 
         match status {
             StatusCode::OK => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/vercel_blob/core.rs
+++ b/core/src/services/vercel_blob/core.rs
@@ -178,7 +178,7 @@ impl VercelBlobCore {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -259,7 +259,7 @@ impl VercelBlobCore {
         let status = resp.status();
 
         if status != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let body = resp.into_body();

--- a/core/src/services/vercel_blob/core.rs
+++ b/core/src/services/vercel_blob/core.rs
@@ -114,7 +114,7 @@ impl VercelBlobCore {
         self.client.fetch(req).await
     }
 
-    pub async fn get_put_request(
+    pub fn get_put_request(
         &self,
         path: &str,
         size: Option<u64>,

--- a/core/src/services/vercel_blob/error.rs
+++ b/core/src/services/vercel_blob/error.rs
@@ -38,7 +38,7 @@ struct VercelBlobErrorDetail {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -61,7 +61,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]
@@ -87,10 +87,9 @@ mod test {
             let body = Buffer::from(res.0.as_bytes().to_vec());
             let resp = Response::builder().status(res.2).body(body).unwrap();
 
-            let err = parse_error(resp).await;
+            let err = parse_error(resp);
 
-            assert!(err.is_ok());
-            assert_eq!(err.unwrap().kind(), res.1);
+            assert_eq!(err.kind(), res.1);
         }
 
         let bs = bytes::Bytes::from(

--- a/core/src/services/vercel_blob/writer.rs
+++ b/core/src/services/vercel_blob/writer.rs
@@ -46,8 +46,7 @@ impl oio::MultipartWrite for VercelBlobWriter {
     async fn write_once(&self, size: u64, body: Buffer) -> Result<()> {
         let req = self
             .core
-            .get_put_request(&self.path, Some(size), &self.op, body)
-            .await?;
+            .get_put_request(&self.path, Some(size), &self.op, body)?;
 
         let resp = self.core.send(req).await?;
 

--- a/core/src/services/vercel_blob/writer.rs
+++ b/core/src/services/vercel_blob/writer.rs
@@ -55,7 +55,7 @@ impl oio::MultipartWrite for VercelBlobWriter {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -76,7 +76,7 @@ impl oio::MultipartWrite for VercelBlobWriter {
 
                 Ok(resp.upload_id)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -109,7 +109,7 @@ impl oio::MultipartWrite for VercelBlobWriter {
                     checksum: None,
                 })
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -131,7 +131,7 @@ impl oio::MultipartWrite for VercelBlobWriter {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -259,7 +259,7 @@ impl Access for WebdavBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -280,7 +280,7 @@ impl Access for WebdavBackend {
         let status = resp.status();
         match status {
             StatusCode::NO_CONTENT | StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -298,7 +298,7 @@ impl Access for WebdavBackend {
 
         match status {
             StatusCode::CREATED | StatusCode::NO_CONTENT => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -310,7 +310,7 @@ impl Access for WebdavBackend {
             StatusCode::CREATED | StatusCode::NO_CONTENT | StatusCode::OK => {
                 Ok(RpRename::default())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/webdav/core.rs
+++ b/core/src/services/webdav/core.rs
@@ -113,7 +113,7 @@ impl WebdavCore {
 
         let resp = self.client.send(req).await?;
         if !resp.status().is_success() {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();
@@ -346,7 +346,7 @@ impl WebdavCore {
 
                 Ok(())
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/webdav/error.rs
+++ b/core/src/services/webdav/error.rs
@@ -23,7 +23,7 @@ use crate::raw::*;
 use crate::*;
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -50,5 +50,5 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }

--- a/core/src/services/webdav/lister.rs
+++ b/core/src/services/webdav/lister.rs
@@ -61,7 +61,7 @@ impl oio::PageList for WebdavLister {
             ctx.done = true;
             return Ok(());
         } else {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         };
 
         let result: Multistatus = deserialize_multistatus(&bs.to_bytes())?;

--- a/core/src/services/webdav/writer.rs
+++ b/core/src/services/webdav/writer.rs
@@ -48,7 +48,7 @@ impl oio::OneShotWrite for WebdavWriter {
 
         match status {
             StatusCode::CREATED | StatusCode::OK | StatusCode::NO_CONTENT => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -250,7 +250,7 @@ impl WebhdfsBackend {
         let status = resp.status();
 
         if status != StatusCode::CREATED && status != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         let bs = resp.into_body();
@@ -299,7 +299,7 @@ impl WebhdfsBackend {
 
                 Ok(resp.location)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -511,7 +511,7 @@ impl WebhdfsBackend {
             StatusCode::NOT_FOUND => {
                 self.create_dir("/", OpCreateDir::new()).await?;
             }
-            _ => return Err(parse_error(resp).await?),
+            _ => return Err(parse_error(resp)),
         }
         Ok(())
     }
@@ -576,7 +576,7 @@ impl Access for WebhdfsBackend {
                     ))
                 }
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -608,7 +608,7 @@ impl Access for WebhdfsBackend {
                 Ok(RpStat::new(meta))
             }
 
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -624,7 +624,7 @@ impl Access for WebhdfsBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -650,7 +650,7 @@ impl Access for WebhdfsBackend {
 
         match resp.status() {
             StatusCode::OK => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -325,7 +325,7 @@ impl WebhdfsBackend {
         self.client.send(req).await
     }
 
-    pub async fn webhdfs_append_request(
+    pub fn webhdfs_append_request(
         &self,
         location: &str,
         size: u64,
@@ -374,11 +374,7 @@ impl WebhdfsBackend {
         req.body(Buffer::new()).map_err(new_request_build_error)
     }
 
-    async fn webhdfs_open_request(
-        &self,
-        path: &str,
-        range: &BytesRange,
-    ) -> Result<Request<Buffer>> {
+    fn webhdfs_open_request(&self, path: &str, range: &BytesRange) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
         let mut url = format!(
             "{}/webhdfs/v1/{}?op=OPEN",
@@ -450,7 +446,7 @@ impl WebhdfsBackend {
         path: &str,
         range: BytesRange,
     ) -> Result<Response<HttpBody>> {
-        let req = self.webhdfs_open_request(path, &range).await?;
+        let req = self.webhdfs_open_request(path, &range)?;
         self.client.fetch(req).await
     }
 

--- a/core/src/services/webhdfs/error.rs
+++ b/core/src/services/webhdfs/error.rs
@@ -40,14 +40,14 @@ struct WebHdfsError {
     java_class_name: String,
 }
 
-pub(super) async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
     let s = String::from_utf8_lossy(&bs);
     parse_error_msg(parts, &s)
 }
 
-pub(super) fn parse_error_msg(parts: Parts, body: &str) -> Result<Error> {
+pub(super) fn parse_error_msg(parts: Parts, body: &str) -> Error {
     let (kind, retryable) = match parts.status {
         StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
         StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
@@ -74,7 +74,7 @@ pub(super) fn parse_error_msg(parts: Parts, body: &str) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]
@@ -105,7 +105,7 @@ mod tests {
             .body(body)
             .unwrap();
 
-        let err = parse_error(resp).await?;
+        let err = parse_error(resp);
         assert_eq!(err.kind(), ErrorKind::Unexpected);
         assert!(!err.is_temporary());
 

--- a/core/src/services/webhdfs/lister.rs
+++ b/core/src/services/webhdfs/lister.rs
@@ -60,7 +60,7 @@ impl oio::PageList for WebhdfsLister {
                     ctx.done = true;
                     return Ok(());
                 }
-                _ => return Err(parse_error(resp).await?),
+                _ => return Err(parse_error(resp)),
             }
         } else {
             let resp = self
@@ -93,7 +93,7 @@ impl oio::PageList for WebhdfsLister {
                     ctx.done = true;
                     return Ok(());
                 }
-                _ => return Err(parse_error(resp).await?),
+                _ => return Err(parse_error(resp)),
             }
         };
 

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -51,7 +51,7 @@ impl oio::BlockWrite for WebhdfsWriter {
         let status = resp.status();
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -77,7 +77,7 @@ impl oio::BlockWrite for WebhdfsWriter {
         let status = resp.status();
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -104,14 +104,14 @@ impl oio::BlockWrite for WebhdfsWriter {
             let status = resp.status();
 
             if status != StatusCode::OK {
-                return Err(parse_error(resp).await?);
+                return Err(parse_error(resp));
             }
         }
         // delete the path file
         let resp = self.backend.webhdfs_delete(&self.path).await?;
         let status = resp.status();
         if status != StatusCode::OK {
-            return Err(parse_error(resp).await?);
+            return Err(parse_error(resp));
         }
 
         // rename concat file to path
@@ -124,7 +124,7 @@ impl oio::BlockWrite for WebhdfsWriter {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -133,7 +133,7 @@ impl oio::BlockWrite for WebhdfsWriter {
             let resp = self.backend.webhdfs_delete(&block_id.to_string()).await?;
             match resp.status() {
                 StatusCode::OK => {}
-                _ => return Err(parse_error(resp).await?),
+                _ => return Err(parse_error(resp)),
             }
         }
         Ok(())
@@ -170,10 +170,10 @@ impl oio::AppendWrite for WebhdfsWriter {
                     StatusCode::CREATED | StatusCode::OK => {
                         location = self.backend.webhdfs_init_append_request(&self.path).await?;
                     }
-                    _ => return Err(parse_error(resp).await?),
+                    _ => return Err(parse_error(resp)),
                 }
             }
-            _ => return Err(parse_error(resp).await?),
+            _ => return Err(parse_error(resp)),
         }
 
         let req = self
@@ -186,7 +186,7 @@ impl oio::AppendWrite for WebhdfsWriter {
         let status = resp.status();
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -176,10 +176,7 @@ impl oio::AppendWrite for WebhdfsWriter {
             _ => return Err(parse_error(resp)),
         }
 
-        let req = self
-            .backend
-            .webhdfs_append_request(&location, size, body)
-            .await?;
+        let req = self.backend.webhdfs_append_request(&location, size, body)?;
 
         let resp = self.backend.client.send(req).await?;
 

--- a/core/src/services/yandex_disk/backend.rs
+++ b/core/src/services/yandex_disk/backend.rs
@@ -194,7 +194,7 @@ impl Access for YandexDiskBackend {
 
         match status {
             StatusCode::OK | StatusCode::CREATED => Ok(RpRename::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -207,7 +207,7 @@ impl Access for YandexDiskBackend {
 
         match status {
             StatusCode::OK | StatusCode::CREATED => Ok(RpCopy::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -227,7 +227,7 @@ impl Access for YandexDiskBackend {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                Err(parse_error(Response::from_parts(part, buf)).await?)
+                Err(parse_error(Response::from_parts(part, buf)))
             }
         }
     }
@@ -246,7 +246,7 @@ impl Access for YandexDiskBackend {
 
                 parse_info(mf).map(RpStat::new)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -271,7 +271,7 @@ impl Access for YandexDiskBackend {
             StatusCode::ACCEPTED => Ok(RpDelete::default()),
             // Allow 404 when deleting a non-existing object
             StatusCode::NOT_FOUND => Ok(RpDelete::default()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 

--- a/core/src/services/yandex_disk/core.rs
+++ b/core/src/services/yandex_disk/core.rs
@@ -93,7 +93,7 @@ impl YandexDiskCore {
 
                 Ok(resp.href)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -125,7 +125,7 @@ impl YandexDiskCore {
 
                 Ok(resp.href)
             }
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 
@@ -142,7 +142,7 @@ impl YandexDiskCore {
 
             match status {
                 StatusCode::CREATED | StatusCode::CONFLICT => {}
-                _ => return Err(parse_error(resp).await?),
+                _ => return Err(parse_error(resp)),
             }
         }
         Ok(())

--- a/core/src/services/yandex_disk/error.rs
+++ b/core/src/services/yandex_disk/error.rs
@@ -33,7 +33,7 @@ struct YandexDiskError {
 }
 
 /// Parse error response into Error.
-pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
+pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, mut body) = resp.into_parts();
     let bs = body.copy_to_bytes(body.remaining());
 
@@ -59,7 +59,7 @@ pub async fn parse_error(resp: Response<Buffer>) -> Result<Error> {
         err = err.set_temporary();
     }
 
-    Ok(err)
+    err
 }
 
 #[cfg(test)]
@@ -96,10 +96,9 @@ mod test {
             let body = Buffer::from(bs);
             let resp = Response::builder().status(res.2).body(body).unwrap();
 
-            let err = parse_error(resp).await;
+            let err = parse_error(resp);
 
-            assert!(err.is_ok());
-            assert_eq!(err.unwrap().kind(), res.1);
+            assert_eq!(err.kind(), res.1);
         }
     }
 }

--- a/core/src/services/yandex_disk/lister.rs
+++ b/core/src/services/yandex_disk/lister.rs
@@ -104,7 +104,7 @@ impl oio::PageList for YandexDiskLister {
                 return Ok(());
             }
             _ => {
-                return Err(parse_error(resp).await?);
+                return Err(parse_error(resp));
             }
         }
 

--- a/core/src/services/yandex_disk/writer.rs
+++ b/core/src/services/yandex_disk/writer.rs
@@ -54,7 +54,7 @@ impl oio::OneShotWrite for YandexDiskWriter {
 
         match status {
             StatusCode::CREATED => Ok(()),
-            _ => Err(parse_error(resp).await?),
+            _ => Err(parse_error(resp)),
         }
     }
 }


### PR DESCRIPTION
# Rationale for this change

- No need for parse_error to be async
- No need to return a Result

# What changes are included in this PR?

removes unneeded async and Result from parse_error()
improve encapsulation of parse_error

# Are there any user-facing changes?

No
