### PR TITLE
chore(bindings/python): deprecate via_map method

### DIFF
--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -30,7 +30,7 @@ fn build_operator(
     scheme: ocore::Scheme,
     map: HashMap<String, String>,
 ) -> PyResult<ocore::Operator> {
-    let mut op = ocore::Operator::via_map(scheme, map).map_err(format_pyerr)?;
+    let mut op = ocore::Operator::via_iter(scheme, map).map_err(format_pyerr)?;
     if !op.info().full_capability().blocking {
         let runtime = pyo3_asyncio::tokio::get_runtime();
         let _guard = runtime.enter();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change

The API is deprecated from #4921 

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
