### PR TITLE
return unsupported for read/stat/delete with version when versioning is not enabled

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -958,6 +958,13 @@ impl Access for S3Backend {
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
+        if args.version().is_some() && !self.core.enable_versioning {
+            return Err(Error::new(
+                ErrorKind::Unsupported,
+                "the bucket doesn't enable versioning, cannot stat with version",
+            ));
+        }
+
         let resp = self.core.s3_head_object(path, args).await?;
 
         let status = resp.status();
@@ -994,6 +1001,13 @@ impl Access for S3Backend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        if args.version().is_some() && !self.core.enable_versioning {
+            return Err(Error::new(
+                ErrorKind::Unsupported,
+                "the bucket doesn't enable versioning, cannot read with version",
+            ));
+        }
+
         let resp = self.core.s3_get_object(path, args.range(), &args).await?;
 
         let status = resp.status();
@@ -1025,6 +1039,13 @@ impl Access for S3Backend {
             return Ok(RpDelete::default());
         }
 
+        if args.version().is_some() && !self.core.enable_versioning {
+            return Err(Error::new(
+                ErrorKind::Unsupported,
+                "the bucket doesn't enable versioning, cannot delete with version",
+            ));
+        }
+
         let resp = self.core.s3_delete_object(path, &args).await?;
 
         let status = resp.status();
@@ -1043,7 +1064,7 @@ impl Access for S3Backend {
         if args.version() && !self.core.enable_versioning {
             return Err(Error::new(
                 ErrorKind::Unsupported,
-                "the bucket doesn't enable versioning",
+                "the bucket doesn't enable versioning, cannot list with version",
             ));
         }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
None

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
As discussed in: https://github.com/apache/opendal/pull/5132#issuecomment-2371739376
We should return `Unsupported` error for every operation with version when` versioning` is not enabled

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
