### PR TITLE
feat: Reduce stat operation if we are reading all

### DIFF
--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -404,7 +404,7 @@ impl Access for SftpBackend {
 
         Ok((
             RpRead::default(),
-            SftpReader::new(client, f, args.range().size().unwrap_or(u64::MAX) as _),
+            SftpReader::new(client, f, args.range().size()),
         ))
     }
 

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -396,8 +396,6 @@ impl Access for SftpBackend {
             .await
             .map_err(parse_sftp_error)?;
 
-        let meta = f.metadata().await.map_err(parse_sftp_error)?;
-
         if args.range().offset() != 0 {
             f.seek(SeekFrom::Start(args.range().offset()))
                 .await
@@ -406,7 +404,7 @@ impl Access for SftpBackend {
 
         Ok((
             RpRead::default(),
-            SftpReader::new(client, f, args.range().size().and(meta.len())),
+            SftpReader::new(client, f, args.range().size()),
         ))
     }
 

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -396,6 +396,8 @@ impl Access for SftpBackend {
             .await
             .map_err(parse_sftp_error)?;
 
+        let meta = f.metadata().await.map_err(parse_sftp_error)?;
+
         if args.range().offset() != 0 {
             f.seek(SeekFrom::Start(args.range().offset()))
                 .await
@@ -404,7 +406,7 @@ impl Access for SftpBackend {
 
         Ok((
             RpRead::default(),
-            SftpReader::new(client, f, args.range().size()),
+            SftpReader::new(client, f, args.range().size().and(meta.len())),
         ))
     }
 

--- a/core/src/services/sftp/reader.rs
+++ b/core/src/services/sftp/reader.rs
@@ -50,7 +50,7 @@ impl SftpReader {
 
 impl oio::Read for SftpReader {
     async fn read(&mut self) -> Result<Buffer> {
-        if Some(self.read) >= self.size {
+        if self.read >= self.size.unwrap_or(usize::MAX) {
             return Ok(Buffer::new());
         }
 
@@ -71,6 +71,8 @@ impl oio::Read for SftpReader {
         };
 
         self.read += bytes.len();
-        Ok(Buffer::from(bytes.freeze()))
+        self.buf = bytes;
+        let bs = self.buf.split();
+        Ok(Buffer::from(bs.freeze()))
     }
 }

--- a/core/src/services/sftp/reader.rs
+++ b/core/src/services/sftp/reader.rs
@@ -63,7 +63,7 @@ impl oio::Read for SftpReader {
 
         let Some(bytes) = self
             .file
-            .read(size as u32, self.buf.split_off(size))
+            .read(size as u32, self.buf.split_to(size))
             .await
             .map_err(parse_sftp_error)?
         else {

--- a/core/src/services/sftp/reader.rs
+++ b/core/src/services/sftp/reader.rs
@@ -63,7 +63,7 @@ impl oio::Read for SftpReader {
 
         let Some(bytes) = self
             .file
-            .read(size as u32, self.buf.split_to(size))
+            .read(size as u32, self.buf.split_off(0))
             .await
             .map_err(parse_sftp_error)?
         else {

--- a/core/src/types/blocking_read/buffer_iterator.rs
+++ b/core/src/types/blocking_read/buffer_iterator.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::ops::Range;
+use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use crate::raw::*;
@@ -30,8 +30,8 @@ struct IteratingReader {
 impl IteratingReader {
     /// Create a new iterating reader.
     #[inline]
-    fn new(ctx: Arc<ReadContext>, range: Range<u64>) -> Self {
-        let generator = ReadGenerator::new(ctx.clone(), range);
+    fn new(ctx: Arc<ReadContext>, range: BytesRange) -> Self {
+        let generator = ReadGenerator::new(ctx.clone(), range.offset(), range.size());
         Self {
             generator,
             reader: None,
@@ -73,9 +73,9 @@ pub struct BufferIterator {
 impl BufferIterator {
     /// Create a new buffer iterator.
     #[inline]
-    pub fn new(ctx: Arc<ReadContext>, range: Range<u64>) -> Self {
+    pub fn new(ctx: Arc<ReadContext>, range: impl RangeBounds<u64>) -> Self {
         Self {
-            inner: IteratingReader::new(ctx, range),
+            inner: IteratingReader::new(ctx, range.into()),
         }
     }
 }

--- a/core/src/types/context/read.rs
+++ b/core/src/types/context/read.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::ops::Range;
+use std::ops::{Bound, Range, RangeBounds};
 use std::sync::Arc;
 
 use crate::raw::*;
@@ -68,6 +68,38 @@ impl ReadContext {
     pub fn options(&self) -> &OpReader {
         &self.options
     }
+
+    /// Parse the range bounds into a range.
+    pub(crate) async fn parse_into_range(
+        &self,
+        range: impl RangeBounds<u64>,
+    ) -> Result<Range<u64>> {
+        let start = match range.start_bound() {
+            Bound::Included(v) => *v,
+            Bound::Excluded(v) => v + 1,
+            Bound::Unbounded => 0,
+        };
+
+        let end = match range.end_bound() {
+            Bound::Included(v) => v + 1,
+            Bound::Excluded(v) => *v,
+            Bound::Unbounded => {
+                let mut op_stat = OpStat::new();
+
+                if let Some(v) = self.args().version() {
+                    op_stat = op_stat.with_version(v);
+                }
+
+                self.accessor()
+                    .stat(self.path(), op_stat)
+                    .await?
+                    .into_metadata()
+                    .content_length()
+            }
+        };
+
+        Ok(start..end)
+    }
 }
 
 /// ReadGenerator is used to generate new readers.
@@ -83,62 +115,65 @@ pub struct ReadGenerator {
     ctx: Arc<ReadContext>,
 
     offset: u64,
-    end: u64,
+    size: Option<u64>,
 }
 
 impl ReadGenerator {
     /// Create a new ReadGenerator.
     #[inline]
-    pub fn new(ctx: Arc<ReadContext>, range: Range<u64>) -> Self {
-        Self {
-            ctx,
-            offset: range.start,
-            end: range.end,
+    pub fn new(ctx: Arc<ReadContext>, offset: u64, size: Option<u64>) -> Self {
+        Self { ctx, offset, size }
+    }
+
+    /// Generate next range to read.
+    fn next_range(&mut self) -> Option<BytesRange> {
+        if self.size == Some(0) {
+            return None;
         }
+
+        let next_offset = self.offset;
+        let next_size = match self.size {
+            // Given size is None, read all data.
+            None => {
+                // Update size to Some(0) to indicate that there is no more data to read.
+                self.size = Some(0);
+                None
+            }
+            Some(remaining) => {
+                // If chunk is set, read data in chunks.
+                let read_size = self
+                    .ctx
+                    .options
+                    .chunk()
+                    .map_or(remaining, |chunk| remaining.min(chunk as u64));
+                // Update (offset, size) before building future.
+                self.offset += read_size;
+                self.size = Some(remaining - read_size);
+                Some(read_size)
+            }
+        };
+
+        Some(BytesRange::new(next_offset, next_size))
     }
 
     /// Generate next reader.
     pub async fn next_reader(&mut self) -> Result<Option<oio::Reader>> {
-        if self.offset >= self.end {
+        let Some(range) = self.next_range() else {
             return Ok(None);
-        }
+        };
 
-        let offset = self.offset;
-        let mut size = (self.end - self.offset) as usize;
-        if let Some(chunk) = self.ctx.options.chunk() {
-            size = size.min(chunk)
-        }
-
-        // Update self.offset before building future.
-        self.offset += size as u64;
-        let args = self
-            .ctx
-            .args
-            .clone()
-            .with_range(BytesRange::new(offset, Some(size as u64)));
+        let args = self.ctx.args.clone().with_range(range);
         let (_, r) = self.ctx.acc.read(&self.ctx.path, args).await?;
         Ok(Some(r))
     }
 
     /// Generate next blocking reader.
     pub fn next_blocking_reader(&mut self) -> Result<Option<oio::BlockingReader>> {
-        if self.offset >= self.end {
+        let Some(range) = self.next_range() else {
             return Ok(None);
-        }
+        };
 
-        let offset = self.offset;
-        let mut size = (self.end - self.offset) as usize;
-        if let Some(chunk) = self.ctx.options.chunk() {
-            size = size.min(chunk)
-        }
-
-        // Update self.offset before building future.
-        self.offset += size as u64;
-        let args = self
-            .ctx
-            .args
-            .clone()
-            .with_range(BytesRange::new(offset, Some(size as u64)));
+        let args = self.ctx.args.clone().with_range(range);
         let (_, r) = self.ctx.acc.blocking_read(&self.ctx.path, args)?;
         Ok(Some(r))
     }
@@ -167,13 +202,39 @@ mod tests {
             OpRead::new(),
             OpReader::new().with_chunk(3),
         ));
-        let mut generator = ReadGenerator::new(ctx, 0..10);
+        let mut generator = ReadGenerator::new(ctx, 0, Some(10));
         let mut readers = vec![];
         while let Some(r) = generator.next_reader().await? {
             readers.push(r);
         }
 
         pretty_assertions::assert_eq!(readers.len(), 4);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_next_reader_without_size() -> Result<()> {
+        let op = Operator::via_iter(Scheme::Memory, [])?;
+        op.write(
+            "test",
+            Buffer::from(vec![Bytes::from("Hello"), Bytes::from("World")]),
+        )
+        .await?;
+
+        let acc = op.into_inner();
+        let ctx = Arc::new(ReadContext::new(
+            acc,
+            "test".to_string(),
+            OpRead::new(),
+            OpReader::new().with_chunk(3),
+        ));
+        let mut generator = ReadGenerator::new(ctx, 0, None);
+        let mut readers = vec![];
+        while let Some(r) = generator.next_reader().await? {
+            readers.push(r);
+        }
+
+        pretty_assertions::assert_eq!(readers.len(), 1);
         Ok(())
     }
 
@@ -192,7 +253,7 @@ mod tests {
             OpRead::new(),
             OpReader::new().with_chunk(3),
         ));
-        let mut generator = ReadGenerator::new(ctx, 0..10);
+        let mut generator = ReadGenerator::new(ctx, 0, Some(10));
         let mut readers = vec![];
         while let Some(r) = generator.next_blocking_reader()? {
             readers.push(r);

--- a/core/src/types/read/buffer_stream.rs
+++ b/core/src/types/read/buffer_stream.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::ops::Range;
+use std::ops::RangeBounds;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::Context;
@@ -40,8 +40,8 @@ pub struct StreamingReader {
 impl StreamingReader {
     /// Create a new streaming reader.
     #[inline]
-    fn new(ctx: Arc<ReadContext>, range: Range<u64>) -> Self {
-        let generator = ReadGenerator::new(ctx.clone(), range);
+    fn new(ctx: Arc<ReadContext>, range: BytesRange) -> Self {
+        let generator = ReadGenerator::new(ctx.clone(), range.offset(), range.size());
         Self {
             generator,
             reader: None,
@@ -86,7 +86,7 @@ impl ChunkedReader {
     /// # Notes
     ///
     /// We don't need to handle `Executor::timeout` since we are outside of the layer.
-    fn new(ctx: Arc<ReadContext>, range: Range<u64>) -> Self {
+    fn new(ctx: Arc<ReadContext>, range: BytesRange) -> Self {
         let tasks = ConcurrentTasks::new(
             ctx.args().executor().cloned().unwrap_or_default(),
             ctx.options().concurrent(),
@@ -99,7 +99,7 @@ impl ChunkedReader {
                 })
             },
         );
-        let generator = ReadGenerator::new(ctx, range);
+        let generator = ReadGenerator::new(ctx, range.offset(), range.size());
         Self {
             generator,
             tasks,
@@ -144,16 +144,39 @@ enum State {
 }
 
 impl BufferStream {
-    /// Create a new buffer stream.
-    pub fn new(ctx: Arc<ReadContext>, range: Range<u64>) -> Self {
+    /// Create a new buffer stream with already calculated offset and size.
+    pub fn new(ctx: Arc<ReadContext>, offset: u64, size: Option<u64>) -> Self {
+        debug_assert!(
+            size.is_some() || ctx.options().chunk().is_none(),
+            "size must be known if chunk is set"
+        );
+
         let reader = if ctx.options().chunk().is_some() {
-            TwoWays::Two(ChunkedReader::new(ctx, range))
+            TwoWays::Two(ChunkedReader::new(ctx, BytesRange::new(offset, size)))
         } else {
-            TwoWays::One(StreamingReader::new(ctx, range))
+            TwoWays::One(StreamingReader::new(ctx, BytesRange::new(offset, size)))
         };
+
         Self {
             state: State::Idle(Some(reader)),
         }
+    }
+
+    /// Create a new buffer stream with given range bound.
+    ///
+    /// If users is going to perform chunked read but the read size is unknown, we will parse
+    /// into range first.
+    pub async fn create(ctx: Arc<ReadContext>, range: impl RangeBounds<u64>) -> Result<Self> {
+        let reader = if ctx.options().chunk().is_some() {
+            let range = ctx.parse_into_range(range).await?;
+            TwoWays::Two(ChunkedReader::new(ctx, range.into()))
+        } else {
+            TwoWays::One(StreamingReader::new(ctx, range.into()))
+        };
+
+        Ok(Self {
+            state: State::Idle(Some(reader)),
+        })
     }
 }
 
@@ -198,8 +221,8 @@ mod tests {
 
     use super::*;
 
-    #[test]
-    fn test_trait() -> Result<()> {
+    #[tokio::test]
+    async fn test_trait() -> Result<()> {
         let acc = Operator::via_iter(Scheme::Memory, [])?.into_inner();
         let ctx = Arc::new(ReadContext::new(
             acc,
@@ -207,7 +230,7 @@ mod tests {
             OpRead::new(),
             OpReader::new(),
         ));
-        let v = BufferStream::new(ctx, 4..8);
+        let v = BufferStream::create(ctx, 4..8).await?;
 
         let _: Box<dyn Unpin + MaybeSend + 'static> = Box::new(v);
 
@@ -231,7 +254,7 @@ mod tests {
             OpReader::new(),
         ));
 
-        let s = BufferStream::new(ctx, 4..8);
+        let s = BufferStream::create(ctx, 4..8).await?;
         let bufs: Vec<_> = s.try_collect().await.unwrap();
         assert_eq!(bufs.len(), 1);
         assert_eq!(bufs[0].chunk(), "o".as_bytes());

--- a/core/src/types/read/reader.rs
+++ b/core/src/types/read/reader.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::ops::Bound;
 use std::ops::Range;
 use std::ops::RangeBounds;
 use std::sync::Arc;
@@ -25,7 +24,6 @@ use futures::stream;
 use futures::StreamExt;
 use futures::TryStreamExt;
 
-use crate::raw::*;
 use crate::*;
 
 /// Reader is designed to read data from given path in an asynchronous
@@ -94,9 +92,6 @@ use crate::*;
 #[derive(Clone)]
 pub struct Reader {
     ctx: Arc<ReadContext>,
-
-    /// Total size of the reader.
-    size: Arc<AtomicContentLength>,
 }
 
 impl Reader {
@@ -108,48 +103,7 @@ impl Reader {
     /// We don't want to expose those details to users so keep this function
     /// in crate only.
     pub(crate) fn new(ctx: ReadContext) -> Self {
-        Reader {
-            ctx: Arc::new(ctx),
-            size: Arc::new(AtomicContentLength::new()),
-        }
-    }
-
-    /// Parse users input range bounds into valid `Range<u64>`.
-    ///
-    /// To avoid duplicated stat call, we will cache the size of the reader.
-    async fn parse_range(&self, range: impl RangeBounds<u64>) -> Result<Range<u64>> {
-        let start = match range.start_bound() {
-            Bound::Included(v) => *v,
-            Bound::Excluded(v) => v + 1,
-            Bound::Unbounded => 0,
-        };
-
-        let end = match range.end_bound() {
-            Bound::Included(v) => v + 1,
-            Bound::Excluded(v) => *v,
-            Bound::Unbounded => match self.size.load() {
-                Some(v) => v,
-                None => {
-                    let mut op_stat = OpStat::new();
-
-                    if let Some(v) = self.ctx.args().version() {
-                        op_stat = op_stat.with_version(v);
-                    }
-
-                    let size = self
-                        .ctx
-                        .accessor()
-                        .stat(self.ctx.path(), op_stat)
-                        .await?
-                        .into_metadata()
-                        .content_length();
-                    self.size.store(size);
-                    size
-                }
-            },
-        };
-
-        Ok(start..end)
+        Reader { ctx: Arc::new(ctx) }
     }
 
     /// Read give range from reader into [`Buffer`].
@@ -246,8 +200,7 @@ impl Reader {
     /// And the name `BufferStream` is not good enough to expose to users.
     /// Let's keep it inside for now.
     async fn into_stream(self, range: impl RangeBounds<u64>) -> Result<BufferStream> {
-        let range = self.parse_range(range).await?;
-        Ok(BufferStream::new(self.ctx, range))
+        BufferStream::create(self.ctx, range).await
     }
 
     /// Convert reader into [`FuturesAsyncReader`] which implements [`futures::AsyncRead`],
@@ -312,7 +265,7 @@ impl Reader {
         self,
         range: impl RangeBounds<u64>,
     ) -> Result<FuturesAsyncReader> {
-        let range = self.parse_range(range).await?;
+        let range = self.ctx.parse_into_range(range).await?;
         Ok(FuturesAsyncReader::new(self.ctx, range))
     }
 
@@ -372,21 +325,19 @@ impl Reader {
         self,
         range: impl RangeBounds<u64>,
     ) -> Result<FuturesBytesStream> {
-        let range = self.parse_range(range).await?;
-        Ok(FuturesBytesStream::new(self.ctx, range))
+        FuturesBytesStream::new(self.ctx, range).await
     }
 }
 
 #[cfg(test)]
 mod tests {
-
     use bytes::Bytes;
     use rand::rngs::ThreadRng;
     use rand::Rng;
     use rand::RngCore;
 
     use super::*;
-    use crate::raw::MaybeSend;
+    use crate::raw::*;
     use crate::services;
     use crate::Operator;
 


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

We used to perform a `stat` operation to make sure we have the read size known. But in the `read_all` cases, we don't need to care about that.

# What changes are included in this PR?

This PR refactor the internal range parse logic so that we can read all without fetching it's metadata first.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
