### PR TITLE
fix(bindings/c): use `ManuallyDrop` instead of `forget` to make sure pointer is valid

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -99,6 +99,10 @@ typedef struct opendal_bytes {
    * The length of the byte array
    */
   uintptr_t len;
+  /**
+   * The capacity of the byte array
+   */
+  uintptr_t capacity;
 } opendal_bytes;
 
 /**

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -49,6 +49,7 @@ var (
 		Elements: &[]*ffi.Type{
 			&ffi.TypePointer,
 			&ffi.TypePointer,
+			&ffi.TypePointer,
 			nil,
 		}[0],
 	}
@@ -257,8 +258,9 @@ type resultStat struct {
 type opendalMetadata struct{}
 
 type opendalBytes struct {
-	data *byte
-	len  uintptr
+	data     *byte
+	len      uintptr
+	capacity uintptr
 }
 
 type opendalError struct {
@@ -292,8 +294,9 @@ func toOpendalBytes(data []byte) opendalBytes {
 		ptr = &b
 	}
 	return opendalBytes{
-		data: ptr,
-		len:  uintptr(l),
+		data:     ptr,
+		len:      uintptr(l),
+		capacity: uintptr(l),
 	}
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5165.

# Rationale for this change

> `forget` does not guarantee that pointers to this memory will remain valid. The need comes up in some specialized use cases for FFI or unsafe code, but even then, [ManuallyDrop](https://doc.rust-lang.org/std/mem/struct.ManuallyDrop.html) is typically preferred.

refer to https://doc.rust-lang.org/std/mem/fn.forget.html

the implementation of `Vec::into_raw_parts`
https://doc.rust-lang.org/1.81.0/src/alloc/vec/mod.rs.html#883

Also, transmute `*const _` to `* mut _` is an undefined behavior in any cases, it is fixed in this commit.
