### PR TITLE
refactor(integration/parquet): Use ParquetMetaDataReader instead

### DIFF
--- a/integrations/parquet/Cargo.toml
+++ b/integrations/parquet/Cargo.toml
@@ -32,13 +32,13 @@ async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
 opendal = { version = "0.50.0", path = "../../core" }
-parquet = { version = "53.0", default-features = false, features = [
+parquet = { version = "53.1", default-features = false, features = [
   "async",
   "arrow",
 ] }
 
 [dev-dependencies]
-arrow = { version = "53.0" }
+arrow = { version = "53.1" }
 opendal = { version = "0.50.0", path = "../../core", features = [
   "services-memory",
   "services-s3",


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

Use newly added ParquetMetaDataReader to replace our own metadata parse logic.

ref: https://github.com/apache/arrow-rs/issues/6002


# Are there any user-facing changes?


None