### PR TITLE
Add contributing docs for Golang

### DIFF
--- a/.github/workflows/ci_bindings_go.yml
+++ b/.github/workflows/ci_bindings_go.yml
@@ -123,6 +123,9 @@ jobs:
           SERVICE: ${{ matrix.service }}
         working-directory: bindings/go/tests
         run: |
+          go work init
+          go work use ..
+          go work use ./behavior_tests
           go work use $GITHUB_WORKSPACE/$(echo $SERVICE | sed 's/-/_/g')
       - name: Run tests
         env:

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -210,7 +210,7 @@ geomean          129.7µ
 
 ## Development
 
-The guid is based on Linux. For other platforms, please adjust the commands accordingly.
+The guide is based on Linux. For other platforms, please adjust the commands accordingly.
 
 To develop the Go binding, you need to have the following dependencies installed:
 

--- a/bindings/go/tests/go.work
+++ b/bindings/go/tests/go.work
@@ -1,6 +1,0 @@
-go 1.22.5
-
-use (
-	..
-	./behavior_tests
-)

--- a/bindings/go/tests/go.work.sum
+++ b/bindings/go/tests/go.work.sum
@@ -1,2 +1,0 @@
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=


### PR DESCRIPTION
Part of #4892 

Add contributing docs for Golang.

Currently, it is hard for community members to maintain the Go binding, see: https://github.com/apache/opendal/pull/5171#issuecomment-2399225899