### PR TITLE
build(bindings/cpp): fetch and build dependencies instead of finding system libs

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -19,8 +19,8 @@ cmake_minimum_required(VERSION 3.22)
 project(opendal-cpp LANGUAGES CXX)
 
 include(FetchContent)
-set(GOOGLETEST_VERSION 1.15.2)
-set(BOOST_VERSION 1.86.0)
+set(OPENDAL_GOOGLETEST_VERSION 1.15.2 CACHE STRING "version of GoogleTest, 'external' to fallback to find_package()")
+set(OPENDAL_BOOST_VERSION 1.86.0 CACHE STRING "version of Boost, 'external' to fallback to find_package()")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -98,15 +98,19 @@ else()
     )
 endif()
 
-# fetch Boost
-FetchContent_Declare(
-  Boost
-  URL https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-cmake.zip
-)
+if(OPENDAL_BOOST_VERSION STREQUAL "external")
+    find_package(Boost REQUIRED COMPONENTS date_time iostreams)
+else()
+    # fetch Boost
+    FetchContent_Declare(
+    Boost
+    URL https://github.com/boostorg/boost/releases/download/boost-${OPENDAL_BOOST_VERSION}/boost-${OPENDAL_BOOST_VERSION}-cmake.zip
+    )
 
-set(BOOST_INCLUDE_LIBRARIES date_time iostreams system)
-set(BOOST_ENABLE_CMAKE ON)
-FetchContent_MakeAvailable(Boost)
+    set(BOOST_INCLUDE_LIBRARIES date_time iostreams system)
+    set(BOOST_ENABLE_CMAKE ON)
+    FetchContent_MakeAvailable(Boost)
+endif()
 
 add_library(opendal_cpp STATIC ${CPP_SOURCE_FILE} ${RUST_BRIDGE_CPP})
 target_sources(opendal_cpp PUBLIC ${CPP_HEADER_FILE})
@@ -139,19 +143,23 @@ endif()
 if (OPENDAL_ENABLE_TESTING)
     enable_testing()
     
-    # fetch GoogleTest
-    FetchContent_Declare(
-        googletest
-        URL https://github.com/google/googletest/archive/refs/tags/v${GOOGLETEST_VERSION}.zip
-    )
-    # For Windows: Prevent overriding the parent project's compiler/linker settings
-    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
+    if(OPENDAL_GOOGLETEST_VERSION STREQUAL "external")
+        find_package(GTest REQUIRED)
+    else()
+        # fetch GoogleTest
+        FetchContent_Declare(
+            googletest
+            URL https://github.com/google/googletest/archive/refs/tags/v${OPENDAL_GOOGLETEST_VERSION}.zip
+        )
+        # For Windows: Prevent overriding the parent project's compiler/linker settings
+        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+        FetchContent_MakeAvailable(googletest)
+    endif()
 
     file(GLOB_RECURSE TEST_SOURCE_FILE tests/*.cpp)
     add_executable(opendal_cpp_test ${TEST_SOURCE_FILE})
     target_include_directories(opendal_cpp_test PUBLIC ${CPP_INCLUDE_DIR} ${GTEST_INCLUDE_DIRS})
-    target_link_libraries(opendal_cpp_test ${GTEST_LDFLAGS} gtest_main opendal_cpp)
+    target_link_libraries(opendal_cpp_test ${GTEST_LDFLAGS} GTest::gtest_main opendal_cpp)
     target_compile_options(opendal_cpp_test PRIVATE ${GTEST_CFLAGS})
 
     # enable address sanitizers

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -15,8 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.10)
-project(opendal-cpp VERSION 0.45.10 LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.22)
+project(opendal-cpp LANGUAGES CXX)
+
+include(FetchContent)
+set(GOOGLETEST_VERSION 1.15.2)
+set(BOOST_VERSION 1.86.0)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -94,7 +98,15 @@ else()
     )
 endif()
 
-find_package(Boost REQUIRED COMPONENTS date_time iostreams)
+# fetch Boost
+FetchContent_Declare(
+  Boost
+  URL https://github.com/boostorg/boost/releases/download/boost-${BOOST_VERSION}/boost-${BOOST_VERSION}-cmake.zip
+)
+
+set(BOOST_INCLUDE_LIBRARIES date_time iostreams system)
+set(BOOST_ENABLE_CMAKE ON)
+FetchContent_MakeAvailable(Boost)
 
 add_library(opendal_cpp STATIC ${CPP_SOURCE_FILE} ${RUST_BRIDGE_CPP})
 target_sources(opendal_cpp PUBLIC ${CPP_HEADER_FILE})
@@ -126,11 +138,20 @@ endif()
 # Tests
 if (OPENDAL_ENABLE_TESTING)
     enable_testing()
-    find_package(GTest REQUIRED)
+    
+    # fetch GoogleTest
+    FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/refs/tags/v${GOOGLETEST_VERSION}.zip
+    )
+    # For Windows: Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+
     file(GLOB_RECURSE TEST_SOURCE_FILE tests/*.cpp)
     add_executable(opendal_cpp_test ${TEST_SOURCE_FILE})
     target_include_directories(opendal_cpp_test PUBLIC ${CPP_INCLUDE_DIR} ${GTEST_INCLUDE_DIRS})
-    target_link_libraries(opendal_cpp_test ${GTEST_LDFLAGS} GTest::gtest_main opendal_cpp)
+    target_link_libraries(opendal_cpp_test ${GTEST_LDFLAGS} gtest_main opendal_cpp)
     target_compile_options(opendal_cpp_test PRIVATE ${GTEST_CFLAGS})
 
     # enable address sanitizers

--- a/bindings/cpp/CONTRIBUTING.md
+++ b/bindings/cpp/CONTRIBUTING.md
@@ -30,9 +30,9 @@ To build OpenDAL C++ binding, the following is all you need:
 
 - To format the code, you need to install **clang-format**
 
-- **GTest(Google Test)**. It is used to run the tests. To see how to build, check [here](https://github.com/google/googletest).
+- **GTest(Google Test)**. It is used to run the tests. You do NOT need to build it manually.
 
-- **Boost**. It is one dependency of this library. To see how to build, check [here](https://www.boost.org/doc/libs/1_76_0/more/getting_started/unix-variants.html).
+- **Boost**. It is one dependency of this library. You do NOT need to build it manually.
 
 - **Doxygen**. It is used to generate the documentation. To see how to build, check [here](https://www.doxygen.nl/manual/install.html).
 
@@ -50,12 +50,6 @@ sudo apt install cmake ninja-build
 # install clang-format
 sudo apt install clang-format
 
-# install GTest library
-sudo apt-get install libgtest-dev
-
-# install Boost library
-sudo apt install libboost-all-dev
-
 # install Doxygen and Graphviz
 sudo apt install doxygen graphviz
 ```
@@ -71,12 +65,6 @@ brew install cmake ninja
 
 # install clang-format
 brew install clang-format
-
-# install GTest library
-brew install googletest
-
-# install Boost library
-brew install boost
 
 # install Doxygen and Graphviz
 brew install doxygen graphviz

--- a/bindings/cpp/README.md
+++ b/bindings/cpp/README.md
@@ -65,9 +65,8 @@ Support for more package managers is coming soon!
 
 ### Prerequisites
 
-- CMake >= 3.10
+- CMake >= 3.22
 - C++ compiler with C++17 support
-- The boost library
 
 ### Build
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5187.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Currently C++ binding uses find_package to locate system-wide libraries like GTest and Boost.

We can replace them by FetchContent to fetch them online and build them by needs (just like cargo) instead of using system libraries (which we cannot control versions and optional features.)

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- replace find_package with FetchContent (but still leave a fallback to find_package for dep-reusing purpose)
- docs for the changes

# Are there any user-facing changes?

None.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
