### PR TITLE
feat(bindings/cpp): rename is_exist to exists as core did

### DIFF
--- a/bindings/cpp/include/opendal.hpp
+++ b/bindings/cpp/include/opendal.hpp
@@ -137,7 +137,16 @@ class Operator {
    * @param path The path to check
    * @return true if the path exists, false otherwise
    */
+  [[deprecated("Use exists() instead.")]]
   bool is_exist(std::string_view path);
+
+  /**
+   * @brief Check if the path exists
+   *
+   * @param path The path to check
+   * @return true if the path exists, false otherwise
+   */
+  bool exists(std::string_view path);
 
   /**
    * @brief Create a directory

--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -80,7 +80,7 @@ mod ffi {
         fn new_operator(scheme: &str, configs: Vec<HashMapValue>) -> Result<Box<Operator>>;
         fn read(self: &Operator, path: &str) -> Result<Vec<u8>>;
         fn write(self: &Operator, path: &str, bs: &'static [u8]) -> Result<()>;
-        fn is_exist(self: &Operator, path: &str) -> Result<bool>;
+        fn exists(self: &Operator, path: &str) -> Result<bool>;
         fn create_dir(self: &Operator, path: &str) -> Result<()>;
         fn copy(self: &Operator, src: &str, dst: &str) -> Result<()>;
         fn rename(self: &Operator, src: &str, dst: &str) -> Result<()>;
@@ -125,8 +125,8 @@ impl Operator {
         Ok(self.0.write(path, bs)?)
     }
 
-    fn is_exist(&self, path: &str) -> Result<bool> {
-        Ok(self.0.is_exist(path)?)
+    fn exists(&self, path: &str) -> Result<bool> {
+        Ok(self.0.exists(path)?)
     }
 
     fn create_dir(&self, path: &str) -> Result<()> {

--- a/bindings/cpp/src/opendal.cpp
+++ b/bindings/cpp/src/opendal.cpp
@@ -52,8 +52,12 @@ void Operator::write(std::string_view path, const std::vector<uint8_t> &data) {
       RUST_STR(path), rust::Slice<const uint8_t>(data.data(), data.size()));
 }
 
+bool Operator::exists(std::string_view path) {
+  return operator_.value()->exists(RUST_STR(path));
+}
+
 bool Operator::is_exist(std::string_view path) {
-  return operator_.value()->is_exist(RUST_STR(path));
+  return exists(path);
 }
 
 void Operator::create_dir(std::string_view path) {

--- a/bindings/cpp/tests/basic_test.cpp
+++ b/bindings/cpp/tests/basic_test.cpp
@@ -62,11 +62,11 @@ TEST_F(OpendalTest, BasicTest) {
   EXPECT_EQ(res, data);
 
   // is_exist
-  EXPECT_TRUE(op.is_exist(file_path));
+  EXPECT_TRUE(op.exists(file_path));
 
   // create_dir
   op.create_dir(dir_path);
-  EXPECT_TRUE(op.is_exist(dir_path));
+  EXPECT_TRUE(op.exists(dir_path));
 
   // stat
   auto metadata = op.stat(file_path);
@@ -88,7 +88,7 @@ TEST_F(OpendalTest, BasicTest) {
   // remove
   op.remove(file_path_renamed);
   op.remove(dir_path);
-  EXPECT_FALSE(op.is_exist(file_path_renamed));
+  EXPECT_FALSE(op.exists(file_path_renamed));
 }
 
 TEST_F(OpendalTest, ReaderTest) {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

Since `opendal::types::operator::blocking_operator::BlockingOperator::is_exist` is deprecated and renamed to `exists`, we should also rename it in c++ binding.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Add `Operator::exists` and mark `Operator::is_exist` deprecated.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Users who still use `is_exist` will receive deprecated warnings issued by compilers.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
