### PR TITLE
ci: Send discussions to dev@o.a.o

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,12 +38,21 @@ github:
         required_approving_review_count: 1
     gh-pages:
       whatever: Just a placeholder to make it take effects
+  custom_subjects:
+    new_discussion: "[DISCUSS] {title}"
+    edit_discussion: "Re: [DISCUSS] {title}"
+    close_discussion: "Re: [DISCUSS] {title}"
+    close_discussion_with_comment: "Re: [DISCUSS] {title}"
+    reopen_discussion: "Re: [DISCUSS] {title}"
+    new_comment_discussion: "Re: [DISCUSS] {title}"
+    edit_comment_discussion: "Re: [DISCUSS] {title}"
+    delete_comment_discussion: "Re: [DISCUSS] {title}"
 
 notifications:
   commits: commits@opendal.apache.org
   issues: commits@opendal.apache.org
   pullrequests: commits@opendal.apache.org
-  discussions: commits@opendal.apache.org
+  discussions: dev@opendal.apache.org
 
 staging:
   profile: ~


### PR DESCRIPTION
As discussed at https://lists.apache.org/thread/d9nz51qvy59y2vnqcrrr1skgomhcl11f

---

Hello, everyone

I'm initiating this thread to explore the feasibility of integrating GitHub discussions into dev@o.a.o.

There is a growing number of discussions[1] regarding whether the ASF should continue to rely on mailing lists. Provided that all our discussions remain public, searchable, and archivable, it might be worthwhile to consider adopting new methods.

Personally, I would like to establish a discourse for OpenDAL, but we currently lack the necessary resources. Therefore, I am considering the use of GitHub discussions as an alternative.

Currently, we are utilizing GitHub discussions. The primary difference is that we do not yet recognize it as our official main channel. By redirecting GitHub discussions to dev@o.a.o, we would officially adopt it.

The mailing list will remain available and active; it simply won't be the preferred method within our community. Should this new approach not meet our expectations, we may revert to the previous system. Moreover, integrating GitHub discussions with dev@o.a.o ensures that, even in less favorable outcomes, all discussions are preserved here.

What are your thoughts on this?

[1]: https://lists.apache.org/thread/fzwd3lj0x53hkq3od5ot0y719dn3kj1j