### PR TITLE
release: Bump to version 0.50.1 Round 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- Release notes generated using configuration in .github/release.yml at main -->
 
+## [v0.50.1] - 2024-10-20
+
+### Added
+* feat(core/redis): Replace client requests with connection pool by @jackyyyyyssss in https://github.com/apache/opendal/pull/5117
+* feat: add copy api for lakefs service.  by @liugddx in https://github.com/apache/opendal/pull/5114
+* feat(core): add version(bool) for List operation to include version d… by @meteorgan in https://github.com/apache/opendal/pull/5106
+* feat(bindings/python): export ConcurrentLimitLayer by @TennyZhuang in https://github.com/apache/opendal/pull/5140
+* feat(bindings/c): add writer operation for Bindings C and Go by @yuchanns in https://github.com/apache/opendal/pull/5141
+* feat(ofs): introduce ofs macos support by @oowl in https://github.com/apache/opendal/pull/5136
+* feat: Reduce stat operation if we are reading all by @Xuanwo in https://github.com/apache/opendal/pull/5146
+* feat: add NebulaGraph config by @GG2002 in https://github.com/apache/opendal/pull/5147
+* feat(integrations/spring): add spring serialize method by @shoothzj in https://github.com/apache/opendal/pull/5154
+* feat: support write,read,delete with template by @shoothzj in https://github.com/apache/opendal/pull/5156
+* feat(bindings/java): support ConcurrentLimitLayer by @tisonkun in https://github.com/apache/opendal/pull/5168
+* feat: Add if_none_match for write by @ForestLH in https://github.com/apache/opendal/pull/5129
+* feat: Add OpenDAL Compat by @Xuanwo in https://github.com/apache/opendal/pull/5185
+* feat(core): abstract HttpFetch trait for raw http client by @everpcpc in https://github.com/apache/opendal/pull/5184
+* feat: Support NebulaGraph by @GG2002 in https://github.com/apache/opendal/pull/5116
+* feat(bindings/cpp): rename is_exist to exists as core did by @PragmaTwice in https://github.com/apache/opendal/pull/5198
+* feat(bindings/c): add opendal_operator_exists and mark is_exist deprecated by @PragmaTwice in https://github.com/apache/opendal/pull/5199
+* feat(binding/java): prefix thread name with opendal-tokio-worker by @tisonkun in https://github.com/apache/opendal/pull/5197
+### Changed
+* refactor(services/cloudflare-kv): remove unneeded async and result on parse_error by @tsfotis in https://github.com/apache/opendal/pull/5128
+* refactor(*): remove unneeded async and result on parse_error by @tsfotis in https://github.com/apache/opendal/pull/5131
+* refactor: align C binding pattern by @tisonkun in https://github.com/apache/opendal/pull/5160
+* refactor: more consistent C binding pattern by @tisonkun in https://github.com/apache/opendal/pull/5162
+* refactor(integration/parquet): Use ParquetMetaDataReader instead by @Xuanwo in https://github.com/apache/opendal/pull/5170
+* refactor: resolve c pointers const by @tisonkun in https://github.com/apache/opendal/pull/5171
+* refactor(types/operator): rename is_exist to exists by @photino in https://github.com/apache/opendal/pull/5193
+### Fixed
+* fix(services/huggingface): Align with latest HuggingFace API by @morristai in https://github.com/apache/opendal/pull/5123
+* fix(bindings/c): use `ManuallyDrop` instead of `forget` to make sure pointer is valid by @ethe in https://github.com/apache/opendal/pull/5166
+* fix(services/s3): Mark xml deserialize error as temporary during list by @Xuanwo in https://github.com/apache/opendal/pull/5178
+### Docs
+* docs: add spring integration configuration doc by @shoothzj in https://github.com/apache/opendal/pull/5053
+* docs: improve Node.js binding's test doc by @tisonkun in https://github.com/apache/opendal/pull/5159
+* docs(bindings/c): update docs for CMake replacing by @PragmaTwice in https://github.com/apache/opendal/pull/5186
+### CI
+* ci(bindings/nodejs): Fix diff introduced by napi by @Xuanwo in https://github.com/apache/opendal/pull/5121
+* ci: Disable aliyun drive test until #5163 addressed by @Xuanwo in https://github.com/apache/opendal/pull/5164
+* ci: add package cache for build-haskell-doc by @XmchxUp in https://github.com/apache/opendal/pull/5173
+* ci: add cache action for ci_bindings_ocaml & build-ocaml-doc by @XmchxUp in https://github.com/apache/opendal/pull/5174
+* ci: Fix failing CI on ocaml and python by @Xuanwo in https://github.com/apache/opendal/pull/5177
+* build(bindings/c): replace the build system with CMake by @PragmaTwice in https://github.com/apache/opendal/pull/5182
+* build(bindings/cpp): fetch and build dependencies instead of finding system libs by @PragmaTwice in https://github.com/apache/opendal/pull/5188
+* ci: Remove not needed --break-system-packages by @Xuanwo in https://github.com/apache/opendal/pull/5196
+* ci: Send discussions to dev@o.a.o by @Xuanwo in https://github.com/apache/opendal/pull/5201
+### Chore
+* chore(bindings/python): deprecate via_map method by @TennyZhuang in https://github.com/apache/opendal/pull/5134
+* chore: update binding java artifact name in README by @tisonkun in https://github.com/apache/opendal/pull/5137
+* chore(fixtures/s3): Upgrade MinIO version by @ForestLH in https://github.com/apache/opendal/pull/5142
+* chore(deps): bump clap from 4.5.17 to 4.5.18 in /bin/ofs by @dependabot in https://github.com/apache/opendal/pull/5149
+* chore(deps): bump crate-ci/typos from 1.24.3 to 1.24.6 by @dependabot in https://github.com/apache/opendal/pull/5150
+* chore(deps): bump anyhow from 1.0.87 to 1.0.89 in /bin/oay by @dependabot in https://github.com/apache/opendal/pull/5151
+* chore(deps): bump anyhow from 1.0.87 to 1.0.89 in /bin/oli by @dependabot in https://github.com/apache/opendal/pull/5152
+* chore: fix typos in tokio_executor.rs by @tisonkun in https://github.com/apache/opendal/pull/5157
+* chore: hint when java tests are skipped by @tisonkun in https://github.com/apache/opendal/pull/5158
+* chore: Include license in the packaged crate by @davide125 in https://github.com/apache/opendal/pull/5176
+
 ## [v0.50.0] - 2024-09-11
 
 ### Added
@@ -4005,6 +4064,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 Hello, OpenDAL!
 
+[v0.50.1]: https://github.com/apache/opendal/compare/v0.50.0...v0.50.1
 [v0.50.0]: https://github.com/apache/opendal/compare/v0.49.2...v0.50.0
 [v0.49.2]: https://github.com/apache/opendal/compare/v0.49.1...v0.49.2
 [v0.49.1]: https://github.com/apache/opendal/compare/v0.49.0...v0.49.1

--- a/bin/oay/Cargo.lock
+++ b/bin/oay/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "async-trait"
@@ -247,9 +247,9 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "shlex",
 ]
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "dav-server-opendalfs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "oay"
-version = "0.41.11"
+version = "0.41.12"
 dependencies = [
  "anyhow",
  "axum",
@@ -988,7 +988,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opendal"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1421,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.129"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -1533,9 +1533,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "198514704ca887dd5a1e408c6c6cdcba43672f9b4062e1b24aa34e74e6d7faae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1854,12 +1854,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"

--- a/bin/oay/Cargo.toml
+++ b/bin/oay/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.41.11"
+version = "0.41.12"
 
 [features]
 default = ["frontends-webdav", "frontends-s3"]
@@ -47,7 +47,7 @@ bytes = { version = "1.5.0", optional = true }
 chrono = "0.4.31"
 clap = { version = "4", features = ["cargo", "string"] }
 dav-server = { version = "0.7", optional = true }
-dav-server-opendalfs = { version = "0.2.0", path = "../../integrations/dav-server", optional = true }
+dav-server-opendalfs = { version = "0.2.1", path = "../../integrations/dav-server", optional = true }
 dirs = "5.0.1"
 futures = "0.3"
 futures-util = { version = "0.3.29", optional = true }

--- a/bin/oay/DEPENDENCIES.rust.tsv
+++ b/bin/oay/DEPENDENCIES.rust.tsv
@@ -1,7 +1,6 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X						X					
+addr2line@0.24.2		X						X					
 adler2@2.0.0	X	X						X					
-ahash@0.8.11		X						X					
 aho-corasick@1.1.3								X				X	
 allocator-api2@0.2.18		X						X					
 android-tzdata@0.1.1		X						X					
@@ -11,11 +10,11 @@ anstyle@1.0.8		X						X
 anstyle-parse@0.2.5		X						X					
 anstyle-query@1.1.1		X						X					
 anstyle-wincon@3.0.4		X						X					
-anyhow@1.0.87		X						X					
-async-trait@0.1.82		X						X					
-autocfg@1.3.0		X						X					
-axum@0.7.5								X					
-axum-core@0.4.3								X					
+anyhow@1.0.90		X						X					
+async-trait@0.1.83		X						X					
+autocfg@1.4.0		X						X					
+axum@0.7.7								X					
+axum-core@0.4.5								X					
 backon@1.2.0		X											
 backtrace@0.3.74		X						X					
 base64@0.21.7		X						X					
@@ -24,19 +23,19 @@ bitflags@2.6.0		X						X
 block-buffer@0.10.4		X						X					
 bumpalo@3.16.0		X						X					
 byteorder@1.5.0								X				X	
-bytes@1.7.1								X					
-cc@1.1.18		X						X					
+bytes@1.7.2								X					
+cc@1.1.31		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
-clap@4.5.17		X						X					
-clap_builder@4.5.17		X						X					
+clap@4.5.20		X						X					
+clap_builder@4.5.20		X						X					
 clap_lex@0.7.2		X						X					
 colorchoice@1.0.2		X						X					
 core-foundation-sys@0.8.7		X						X					
 cpufeatures@0.2.14		X						X					
 crypto-common@0.1.6		X						X					
 dav-server@0.7.0		X											
-dav-server-opendalfs@0.2.0		X											
+dav-server-opendalfs@0.2.1		X											
 deranged@0.3.11		X						X					
 digest@0.10.7		X						X					
 dirs@5.0.1		X						X					
@@ -45,21 +44,22 @@ equivalent@1.0.1		X						X
 fastrand@2.1.1		X						X					
 flagset@0.4.6		X											
 fnv@1.0.7		X						X					
+foldhash@0.1.3													X
 form_urlencoded@1.2.1		X						X					
-futures@0.3.30		X						X					
-futures-channel@0.3.30		X						X					
-futures-core@0.3.30		X						X					
-futures-executor@0.3.30		X						X					
-futures-io@0.3.30		X						X					
-futures-macro@0.3.30		X						X					
-futures-sink@0.3.30		X						X					
-futures-task@0.3.30		X						X					
-futures-util@0.3.30		X						X					
+futures@0.3.31		X						X					
+futures-channel@0.3.31		X						X					
+futures-core@0.3.31		X						X					
+futures-executor@0.3.31		X						X					
+futures-io@0.3.31		X						X					
+futures-macro@0.3.31		X						X					
+futures-sink@0.3.31		X						X					
+futures-task@0.3.31		X						X					
+futures-util@0.3.31		X						X					
 generic-array@0.14.7								X					
 getrandom@0.2.15		X						X					
-gimli@0.31.0		X						X					
+gimli@0.31.1		X						X					
 gloo-timers@0.3.0		X						X					
-hashbrown@0.14.5		X						X					
+hashbrown@0.15.0		X						X					
 headers@0.4.0								X					
 headers-core@0.3.0								X					
 hermit-abi@0.3.9		X						X					
@@ -67,25 +67,25 @@ htmlescape@0.3.1		X						X	X
 http@1.1.0		X						X					
 http-body@1.0.1								X					
 http-body-util@0.1.2								X					
-httparse@1.9.4		X						X					
+httparse@1.9.5		X						X					
 httpdate@1.0.3		X						X					
-hyper@1.4.1								X					
+hyper@1.5.0								X					
 hyper-rustls@0.27.3		X					X	X					
-hyper-util@0.1.8								X					
-iana-time-zone@0.1.60		X						X					
+hyper-util@0.1.9								X					
+iana-time-zone@0.1.61		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
-indexmap@2.5.0		X						X					
-ipnet@2.10.0		X						X					
+indexmap@2.6.0		X						X					
+ipnet@2.10.1		X						X					
 is_terminal_polyfill@1.70.1		X						X					
 itoa@1.0.11		X						X					
-js-sys@0.3.70		X						X					
+js-sys@0.3.72		X						X					
 lazy_static@1.5.0		X						X					
-libc@0.2.158		X						X					
+libc@0.2.161		X						X					
 libredox@0.1.3								X					
 lock_api@0.4.12		X						X					
 log@0.4.22		X						X					
-lru@0.12.4								X					
+lru@0.12.5								X					
 matchers@0.1.0								X					
 matchit@0.7.3					X			X					
 md-5@0.10.6		X						X					
@@ -97,49 +97,49 @@ mio@1.0.2								X
 nu-ansi-term@0.46.0								X					
 num-conv@0.1.0		X						X					
 num-traits@0.2.19		X						X					
-oay@0.41.11		X											
-object@0.36.4		X						X					
-once_cell@1.19.0		X						X					
-opendal@0.50.0		X											
+oay@0.41.12		X											
+object@0.36.5		X						X					
+once_cell@1.20.2		X						X					
+opendal@0.50.1		X											
 option-ext@0.2.0									X				
 overload@0.1.1								X					
 parking_lot@0.12.3		X						X					
 parking_lot_core@0.9.10		X						X					
 percent-encoding@2.3.1		X						X					
-pin-project@1.1.5		X						X					
-pin-project-internal@1.1.5		X						X					
+pin-project@1.1.6		X						X					
+pin-project-internal@1.1.6		X						X					
 pin-project-lite@0.2.14		X						X					
 pin-utils@0.1.0		X						X					
 powerfmt@0.2.0		X						X					
 ppv-lite86@0.2.20		X						X					
-proc-macro2@1.0.86		X						X					
-quick-xml@0.36.1								X					
+proc-macro2@1.0.88		X						X					
+quick-xml@0.36.2								X					
 quote@1.0.37		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
-redox_syscall@0.5.3								X					
+redox_syscall@0.5.7								X					
 redox_users@0.4.6								X					
-regex@1.10.6		X						X					
+regex@1.11.0		X						X					
 regex-automata@0.1.10								X				X	
-regex-automata@0.4.7		X						X					
+regex-automata@0.4.8		X						X					
 regex-syntax@0.6.29		X						X					
-regex-syntax@0.8.4		X						X					
-reqwest@0.12.7		X						X					
+regex-syntax@0.8.5		X						X					
+reqwest@0.12.8		X						X					
 ring@0.17.8										X			
 rustc-demangle@0.1.24		X						X					
-rustls@0.23.13		X					X	X					
-rustls-pemfile@2.1.3		X					X	X					
-rustls-pki-types@1.8.0		X						X					
+rustls@0.23.15		X					X	X					
+rustls-pemfile@2.2.0		X					X	X					
+rustls-pki-types@1.10.0		X						X					
 rustls-webpki@0.102.8							X						
-rustversion@1.0.17		X						X					
+rustversion@1.0.18		X						X					
 ryu@1.0.18		X				X							
 scopeguard@1.2.0		X						X					
 serde@1.0.210		X						X					
 serde_derive@1.0.210		X						X					
-serde_json@1.0.128		X						X					
+serde_json@1.0.132		X						X					
 serde_path_to_error@0.1.16		X						X					
-serde_spanned@0.6.7		X						X					
+serde_spanned@0.6.8		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sharded-slab@0.1.7								X					
@@ -150,11 +150,11 @@ socket2@0.5.7		X						X
 spin@0.9.8								X					
 strsim@0.11.1								X					
 subtle@2.6.1					X								
-syn@2.0.77		X						X					
+syn@2.0.81		X						X					
 sync_wrapper@0.1.2		X											
 sync_wrapper@1.0.1		X											
-thiserror@1.0.63		X						X					
-thiserror-impl@1.0.63		X						X					
+thiserror@1.0.64		X						X					
+thiserror-impl@1.0.64		X						X					
 thread_local@1.1.8		X						X					
 time@0.3.36		X						X					
 time-core@0.1.2		X						X					
@@ -167,8 +167,9 @@ tokio-rustls@0.26.0		X						X
 tokio-util@0.7.12								X					
 toml@0.8.19		X						X					
 toml_datetime@0.6.8		X						X					
-toml_edit@0.22.20		X						X					
+toml_edit@0.22.22		X						X					
 tower@0.4.13								X					
+tower@0.5.1								X					
 tower-http@0.5.2								X					
 tower-layer@0.3.3								X					
 tower-service@0.3.3								X					
@@ -179,27 +180,27 @@ tracing-log@0.2.0								X
 tracing-subscriber@0.3.18								X					
 try-lock@0.2.5								X					
 typenum@1.17.0		X						X					
-unicase@2.7.0		X						X					
-unicode-bidi@0.3.15		X						X					
+unicase@2.8.0		X						X					
+unicode-bidi@0.3.17		X						X					
 unicode-ident@1.0.13		X						X			X		
-unicode-normalization@0.1.23		X						X					
+unicode-normalization@0.1.24		X						X					
 untrusted@0.9.0							X						
 url@2.5.2		X						X					
 utf8parse@0.2.2		X						X					
-uuid@1.10.0		X						X					
+uuid@1.11.0		X						X					
 valuable@0.1.0								X					
 version_check@0.9.5		X						X					
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
-wasm-bindgen@0.2.93		X						X					
-wasm-bindgen-backend@0.2.93		X						X					
-wasm-bindgen-futures@0.4.43		X						X					
-wasm-bindgen-macro@0.2.93		X						X					
-wasm-bindgen-macro-support@0.2.93		X						X					
-wasm-bindgen-shared@0.2.93		X						X					
-wasm-streams@0.4.0		X						X					
-web-sys@0.3.70		X						X					
-webpki-roots@0.26.5									X				
+wasm-bindgen@0.2.95		X						X					
+wasm-bindgen-backend@0.2.95		X						X					
+wasm-bindgen-futures@0.4.45		X						X					
+wasm-bindgen-macro@0.2.95		X						X					
+wasm-bindgen-macro-support@0.2.95		X						X					
+wasm-bindgen-shared@0.2.95		X						X					
+wasm-streams@0.4.1		X						X					
+web-sys@0.3.72		X						X					
+webpki-roots@0.26.6									X				
 winapi@0.3.9		X						X					
 winapi-i686-pc-windows-gnu@0.4.0		X						X					
 winapi-x86_64-pc-windows-gnu@0.4.0		X						X					
@@ -226,7 +227,7 @@ windows_x86_64_gnullvm@0.48.5		X						X
 windows_x86_64_gnullvm@0.52.6		X						X					
 windows_x86_64_msvc@0.48.5		X						X					
 windows_x86_64_msvc@0.52.6		X						X					
-winnow@0.6.18								X					
+winnow@0.6.20								X					
 xml-rs@0.8.22								X					
 xmltree@0.10.3								X					
 zerocopy@0.7.35		X		X				X					

--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "async-notify"
@@ -200,9 +200,9 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "shlex",
 ]
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "cloud_filter_opendal"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "fuse3_opendal"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "bytes",
  "fuse3",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "ofs"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -1025,7 +1025,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opendal"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1463,9 +1463,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.129"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -1576,9 +1576,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "198514704ca887dd5a1e408c6c6cdcba43672f9b4062e1b24aa34e74e6d7faae"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bin/ofs/Cargo.toml
+++ b/bin/ofs/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["filesystem"]
 description = "OpenDAL File System"
 keywords = ["storage", "data", "s3", "fs", "azblob"]
 name = "ofs"
-version = "0.0.12"
+version = "0.0.13"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -48,13 +48,13 @@ url = "2.5.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))'.dependencies]
 fuse3 = { version = "0.8.1", "features" = ["tokio-runtime", "unprivileged"] }
-fuse3_opendal = { version = "0.0.7", path = "../../integrations/fuse3" }
+fuse3_opendal = { version = "0.0.8", path = "../../integrations/fuse3" }
 libc = "0.2.154"
 nix = { version = "0.29.0", features = ["user"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 cloud-filter = { version = "0.0.5" }
-cloud_filter_opendal = { version = "0.0.1", path = "../../integrations/cloud_filter" }
+cloud_filter_opendal = { version = "0.0.2", path = "../../integrations/cloud_filter" }
 
 [features]
 default = ["services-fs", "services-s3"]

--- a/bin/ofs/DEPENDENCIES.rust.tsv
+++ b/bin/ofs/DEPENDENCIES.rust.tsv
@@ -1,5 +1,5 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aho-corasick@1.1.3									X				X	
 android-tzdata@0.1.1		X							X					
@@ -9,10 +9,10 @@ anstyle@1.0.8		X							X
 anstyle-parse@0.2.5		X							X					
 anstyle-query@1.1.1		X							X					
 anstyle-wincon@3.0.4		X							X					
-anyhow@1.0.87		X							X					
+anyhow@1.0.90		X							X					
 async-notify@0.3.0									X					
-async-trait@0.1.82		X							X					
-autocfg@1.3.0		X							X					
+async-trait@0.1.83		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.22.1		X							X					
@@ -21,18 +21,17 @@ bitflags@2.6.0		X							X
 block-buffer@0.10.4		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
-cc@1.1.18		X							X					
+bytes@1.7.2									X					
+cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
-cfg_aliases@0.1.1									X					
 cfg_aliases@0.2.1									X					
 chrono@0.4.38		X							X					
-clap@4.5.17		X							X					
-clap_builder@4.5.17		X							X					
-clap_derive@4.5.13		X							X					
+clap@4.5.20		X							X					
+clap_builder@4.5.20		X							X					
+clap_derive@4.5.18		X							X					
 clap_lex@0.7.2		X							X					
 cloud-filter@0.0.5									X					
-cloud_filter_opendal@0.0.1		X												
+cloud_filter_opendal@0.0.2		X												
 colorchoice@1.0.2		X							X					
 concurrent-queue@2.5.0		X							X					
 const-oid@0.9.6		X							X					
@@ -44,7 +43,6 @@ crc32c@0.6.8		X							X
 crossbeam-utils@0.8.20		X							X					
 crunchy@0.2.2									X					
 crypto-common@0.1.6		X							X					
-cstr@0.2.12									X					
 deranged@0.3.11		X							X					
 digest@0.10.7		X							X					
 dlv-list@0.5.2		X							X					
@@ -58,20 +56,20 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-fuse3@0.7.2									X					
-fuse3_opendal@0.0.7		X												
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-executor@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+fuse3@0.8.1									X					
+fuse3_opendal@0.0.8		X												
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-executor@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
 heck@0.5.0		X							X					
@@ -82,20 +80,20 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
+httparse@1.9.5		X							X					
 humantime@2.1.0		X							X					
-hyper@1.4.1									X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 is_terminal_polyfill@1.70.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
+js-sys@0.3.72		X							X					
 lazy_static@1.5.0		X							X					
-libc@0.2.158		X							X					
+libc@0.2.161		X							X					
 linux-raw-sys@0.4.14		X	X						X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
@@ -104,50 +102,47 @@ memoffset@0.9.1									X
 mime@0.3.17		X							X					
 miniz_oxide@0.8.0		X							X					X
 mio@1.0.2									X					
-nix@0.28.0									X					
 nix@0.29.0									X					
 nt-time@0.8.1		X							X					
 num-conv@0.1.0		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-ofs@0.0.12		X												
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
+object@0.36.5		X							X					
+ofs@0.0.13		X												
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
 ordered-multimap@0.7.3									X					
 parking@2.2.1		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-regex@1.10.6		X							X					
-regex-automata@0.4.7		X							X					
-regex-syntax@0.8.4		X							X					
+regex@1.11.0		X							X					
+regex-automata@0.4.8		X							X					
+regex-syntax@0.8.5		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustix@0.38.36		X	X						X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustix@0.38.37		X	X						X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -160,7 +155,7 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 strsim@0.11.1									X					
 subtle@2.6.1					X									
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
@@ -172,8 +167,6 @@ tokio@1.40.0									X
 tokio-macros@2.4.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-attributes@0.1.27									X					
@@ -182,25 +175,25 @@ trait-make@0.1.0		X							X
 trim-in-place@0.1.7									X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
 utf8parse@0.2.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 which@6.0.3									X					
 widestring@1.1.0		X							X					
 windows@0.58.0		X							X					

--- a/bin/oli/Cargo.lock
+++ b/bin/oli/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "arc-swap"
@@ -605,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "oli"
-version = "0.41.11"
+version = "0.41.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1992,7 +1992,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opendal"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "async-tls",
@@ -2313,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "910d41a655dac3b764f1ade94821093d3610248694320cd072303a8eedcf221d"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -2995,9 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.129"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -3186,9 +3186,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "198514704ca887dd5a1e408c6c6cdcba43672f9b4062e1b24aa34e74e6d7faae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3567,12 +3567,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"

--- a/bin/oli/Cargo.toml
+++ b/bin/oli/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.41.11"
+version = "0.41.12"
 
 [features]
 # Enable services dashmap support

--- a/bin/oli/DEPENDENCIES.rust.tsv
+++ b/bin/oli/DEPENDENCIES.rust.tsv
@@ -1,5 +1,5 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aes@0.8.4		X							X					
 aho-corasick@1.1.3									X				X	
@@ -10,9 +10,9 @@ anstyle@1.0.8		X							X
 anstyle-parse@0.2.5		X							X					
 anstyle-query@1.1.1		X							X					
 anstyle-wincon@3.0.4		X							X					
-anyhow@1.0.87		X							X					
-async-trait@0.1.82		X							X					
-autocfg@1.3.0		X							X					
+anyhow@1.0.90		X							X					
+async-trait@0.1.83		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.21.7		X							X					
@@ -23,14 +23,14 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
+bytes@1.7.2									X					
 cbc@0.1.2		X							X					
-cc@1.1.18		X							X					
+cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
-clap@4.5.17		X							X					
-clap_builder@4.5.17		X							X					
+clap@4.5.20		X							X					
+clap_builder@4.5.20		X							X					
 clap_lex@0.7.2		X							X					
 colorchoice@1.0.2		X							X					
 const-oid@0.9.6		X							X					
@@ -54,20 +54,21 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-executor@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-executor@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
+hashbrown@0.15.0		X							X					
 hermit-abi@0.3.9		X							X					
 hex@0.4.3		X							X					
 hmac@0.12.1		X							X					
@@ -75,23 +76,23 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
+httparse@1.9.5		X							X					
 humantime@2.1.0		X							X					
-hyper@1.4.1									X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
-indexmap@2.5.0		X							X					
+indexmap@2.6.0		X							X					
 inout@0.1.3		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 is_terminal_polyfill@1.70.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
+js-sys@0.3.72		X							X					
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
-libc@0.2.158		X							X					
+libc@0.2.161		X							X					
 libm@0.2.8		X							X					
 libredox@0.1.3									X					
 log@0.4.22		X							X					
@@ -106,18 +107,16 @@ num-conv@0.1.0		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-oli@0.41.11		X												
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
+object@0.36.5		X							X					
+oli@0.41.12		X												
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
 option-ext@0.2.0										X				
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
@@ -125,27 +124,27 @@ pkcs5@0.7.1		X							X
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 redox_users@0.4.6									X					
-regex@1.10.6		X							X					
-regex-automata@0.4.7		X							X					
-regex-syntax@0.8.4		X							X					
+regex@1.11.0		X							X					
+regex-automata@0.4.8		X							X					
+regex-syntax@0.8.5		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 salsa20@0.10.2		X							X					
@@ -153,8 +152,8 @@ scrypt@0.11.0		X							X
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
-serde_spanned@0.6.7		X							X					
+serde_json@1.0.132		X							X					
+serde_spanned@0.6.8		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -168,10 +167,10 @@ spin@0.9.8									X
 spki@0.7.3		X							X					
 strsim@0.11.1									X					
 subtle@2.6.1					X									
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
-thiserror@1.0.63		X							X					
-thiserror-impl@1.0.63		X							X					
+thiserror@1.0.64		X							X					
+thiserror-impl@1.0.64		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
@@ -184,34 +183,32 @@ tokio-rustls@0.26.0		X							X
 tokio-util@0.7.12									X					
 toml@0.8.19		X							X					
 toml_datetime@0.6.8		X							X					
-toml_edit@0.22.20		X							X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
+toml_edit@0.22.22		X							X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-core@0.1.32									X					
 trim-in-place@0.1.7									X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
 utf8parse@0.2.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					
 windows-result@0.2.0		X							X					
@@ -235,7 +232,7 @@ windows_x86_64_gnullvm@0.48.5		X							X
 windows_x86_64_gnullvm@0.52.6		X							X					
 windows_x86_64_msvc@0.48.5		X							X					
 windows_x86_64_msvc@0.52.6		X							X					
-winnow@0.6.18									X					
+winnow@0.6.20									X					
 zerocopy@0.7.35		X		X					X					
 zerocopy-derive@0.7.35		X		X					X					
 zeroize@1.8.1		X							X					

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.44.13"
+version = "0.45.0"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -1,13 +1,13 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
-async-trait@0.1.82		X							X					
+anyhow@1.0.90		X							X					
+async-trait@0.1.83		X							X					
 atty@0.2.14									X					
-autocfg@1.3.0		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.21.7		X							X					
@@ -19,10 +19,10 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
+bytes@1.7.2									X					
 cbc@0.1.2		X							X					
 cbindgen@0.26.0										X				
-cc@1.1.18		X							X					
+cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -45,17 +45,17 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.12.3		X							X					
 hashbrown@0.14.5		X							X					
@@ -68,21 +68,21 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
-hyper@1.4.1									X					
+httparse@1.9.5		X							X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
 indexmap@1.9.3		X							X					
 inout@0.1.3		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
+js-sys@0.3.72		X							X					
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
-libc@0.2.158		X							X					
+libc@0.2.161		X							X					
 libm@0.2.8		X							X					
 linux-raw-sys@0.4.14		X	X						X					
 log@0.4.22		X							X					
@@ -97,18 +97,16 @@ num-conv@0.1.0		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
-opendal-c@0.44.13		X												
+object@0.36.5		X							X					
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
+opendal-c@0.45.0		X												
 ordered-multimap@0.7.3									X					
 os_str_bytes@6.6.1		X							X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
@@ -116,24 +114,24 @@ pkcs5@0.7.1		X							X
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustix@0.38.36		X	X						X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustix@0.38.37		X	X						X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 salsa20@0.10.2		X							X					
@@ -141,7 +139,7 @@ scrypt@0.11.0		X							X
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -156,13 +154,13 @@ spki@0.7.3		X							X
 strsim@0.10.0									X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
-tempfile@3.12.0		X							X					
+tempfile@3.13.0		X							X					
 termcolor@1.4.1									X				X	
 textwrap@0.16.1									X					
-thiserror@1.0.63		X							X					
-thiserror-impl@1.0.63		X							X					
+thiserror@1.0.64		X							X					
+thiserror-impl@1.0.64		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
@@ -174,32 +172,30 @@ tokio-macros@2.4.0									X
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
 toml@0.5.11		X							X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-core@0.1.32									X					
 trim-in-place@0.1.7									X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 winapi@0.3.9		X							X					
 winapi-i686-pc-windows-gnu@0.4.0		X							X					
 winapi-util@0.1.9									X				X	

--- a/bindings/c/upgrade.md
+++ b/bindings/c/upgrade.md
@@ -1,3 +1,7 @@
+# Upgrade to v0.45
+
+Change to use `Cmake` to build the C binding.
+
 # Upgrade to v0.42
 
 The naming convention for C binding has been altered.

--- a/bindings/cpp/Cargo.toml
+++ b/bindings/cpp/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.11"
+version = "0.45.12"
 
 [lib]
 crate-type = ["staticlib"]

--- a/bindings/cpp/DEPENDENCIES.rust.tsv
+++ b/bindings/cpp/DEPENDENCIES.rust.tsv
@@ -1,12 +1,12 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
-async-trait@0.1.82		X							X					
-autocfg@1.3.0		X							X					
+anyhow@1.0.90		X							X					
+async-trait@0.1.83		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.21.7		X							X					
@@ -16,9 +16,9 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
+bytes@1.7.2									X					
 cbc@0.1.2		X							X					
-cc@1.1.18		X							X					
+cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -31,10 +31,10 @@ cpufeatures@0.2.14		X							X
 crc32c@0.6.8		X							X					
 crunchy@0.2.2									X					
 crypto-common@0.1.6		X							X					
-cxx@1.0.128		X							X					
-cxx-build@1.0.128		X							X					
-cxxbridge-flags@1.0.128		X							X					
-cxxbridge-macro@1.0.128		X							X					
+cxx@1.0.129		X							X					
+cxx-build@1.0.129		X							X					
+cxxbridge-flags@1.0.129		X							X					
+cxxbridge-macro@1.0.129		X							X					
 der@0.7.9		X							X					
 deranged@0.3.11		X							X					
 digest@0.10.7		X							X					
@@ -43,17 +43,17 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
 hermit-abi@0.3.9		X							X					
@@ -63,20 +63,20 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
-hyper@1.4.1									X					
+httparse@1.9.5		X							X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
 inout@0.1.3		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
+js-sys@0.3.72		X							X					
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
-libc@0.2.158		X							X					
+libc@0.2.161		X							X					
 libm@0.2.8		X							X					
 link-cplusplus@1.0.9		X							X					
 log@0.4.22		X							X					
@@ -91,17 +91,15 @@ num-conv@0.1.0		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
-opendal-cpp@0.45.11		X												
+object@0.36.5		X							X					
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
+opendal-cpp@0.45.12		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
@@ -109,23 +107,23 @@ pkcs5@0.7.1		X							X
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 salsa20@0.10.2		X							X					
@@ -134,7 +132,7 @@ scrypt@0.11.0		X							X
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -147,11 +145,11 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
 termcolor@1.4.1									X				X	
-thiserror@1.0.63		X							X					
-thiserror-impl@1.0.63		X							X					
+thiserror@1.0.64		X							X					
+thiserror-impl@1.0.64		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
@@ -161,33 +159,31 @@ tinyvec_macros@0.1.1		X							X					X
 tokio@1.40.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-core@0.1.32									X					
 trim-in-place@0.1.7									X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
-unicode-width@0.1.13		X							X					
+unicode-normalization@0.1.24		X							X					
+unicode-width@0.1.14		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 winapi-util@0.1.9									X				X	
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-dotnet"
 publish = false
-version = "0.1.9"
+version = "0.1.10"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/dotnet/DEPENDENCIES.rust.tsv
+++ b/bindings/dotnet/DEPENDENCIES.rust.tsv
@@ -1,12 +1,12 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
-async-trait@0.1.82		X							X					
-autocfg@1.3.0		X							X					
+anyhow@1.0.90		X							X					
+async-trait@0.1.83		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.21.7		X							X					
@@ -16,9 +16,9 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
+bytes@1.7.2									X					
 cbc@0.1.2		X							X					
-cc@1.1.18		X							X					
+cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -38,17 +38,17 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
 hermit-abi@0.3.9		X							X					
@@ -58,20 +58,20 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
-hyper@1.4.1									X					
+httparse@1.9.5		X							X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
 inout@0.1.3		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
+js-sys@0.3.72		X							X					
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
-libc@0.2.158		X							X					
+libc@0.2.161		X							X					
 libm@0.2.8		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
@@ -85,17 +85,15 @@ num-conv@0.1.0		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
-opendal-dotnet@0.1.9		X												
+object@0.36.5		X							X					
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
+opendal-dotnet@0.1.10		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
@@ -103,23 +101,23 @@ pkcs5@0.7.1		X							X
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 salsa20@0.10.2		X							X					
@@ -127,7 +125,7 @@ scrypt@0.11.0		X							X
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -140,10 +138,10 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
-thiserror@1.0.63		X							X					
-thiserror-impl@1.0.63		X							X					
+thiserror@1.0.64		X							X					
+thiserror-impl@1.0.64		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
@@ -153,32 +151,30 @@ tinyvec_macros@0.1.1		X							X					X
 tokio@1.40.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-core@0.1.32									X					
 trim-in-place@0.1.7									X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					
 windows-result@0.2.0		X							X					

--- a/bindings/haskell/Cargo.toml
+++ b/bindings/haskell/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.44.11"
+version = "0.44.12"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/haskell/DEPENDENCIES.rust.tsv
+++ b/bindings/haskell/DEPENDENCIES.rust.tsv
@@ -1,12 +1,12 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
-async-trait@0.1.82		X							X					
-autocfg@1.3.0		X							X					
+anyhow@1.0.90		X							X					
+async-trait@0.1.83		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.21.7		X							X					
@@ -16,9 +16,9 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
+bytes@1.7.2									X					
 cbc@0.1.2		X							X					
-cc@1.1.18		X							X					
+cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -38,17 +38,17 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
 hermit-abi@0.3.9		X							X					
@@ -58,20 +58,20 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
-hyper@1.4.1									X					
+httparse@1.9.5		X							X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
 inout@0.1.3		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
+js-sys@0.3.72		X							X					
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
-libc@0.2.158		X							X					
+libc@0.2.161		X							X					
 libm@0.2.8		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
@@ -85,17 +85,15 @@ num-conv@0.1.0		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
-opendal-hs@0.44.11		X												
+object@0.36.5		X							X					
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
+opendal-hs@0.44.12		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
@@ -103,23 +101,23 @@ pkcs5@0.7.1		X							X
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 salsa20@0.10.2		X							X					
@@ -127,7 +125,7 @@ scrypt@0.11.0		X							X
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -140,10 +138,10 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
-thiserror@1.0.63		X							X					
-thiserror-impl@1.0.63		X							X					
+thiserror@1.0.64		X							X					
+thiserror-impl@1.0.64		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
@@ -153,32 +151,30 @@ tinyvec_macros@0.1.1		X							X					X
 tokio@1.40.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-core@0.1.32									X					
 trim-in-place@0.1.7									X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					
 windows-result@0.2.0		X							X					

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.47.3"
+version = "0.47.4"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -1,13 +1,13 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
+anyhow@1.0.90		X							X					
 arc-swap@1.7.1		X							X					
-async-trait@0.1.82		X							X					
-autocfg@1.3.0		X							X					
+async-trait@0.1.83		X							X					
+autocfg@1.4.0		X							X					
 awaitable@0.4.0									X					
 awaitable-error@0.1.0									X					
 backon@1.2.0		X												
@@ -15,21 +15,21 @@ backtrace@0.3.74		X							X
 base64@0.21.7		X							X					
 base64@0.22.1		X							X					
 base64ct@1.6.0		X							X					
-bb8@0.8.5									X					
+bb8@0.8.6									X					
 bitflags@2.6.0		X							X					
 block-buffer@0.10.4		X							X					
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
+bytes@1.7.2									X					
 cbc@0.1.2		X							X					
-cc@1.1.18		X							X					
+cc@1.1.31		X							X					
 cesu8@1.1.0		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
 combine@4.6.7									X					
-concurrent_arena@0.1.8									X					
+concurrent_arena@0.1.10									X					
 const-oid@0.9.6		X							X					
 const-random@0.1.18		X							X					
 const-random-macro@0.1.16		X							X					
@@ -48,17 +48,17 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
 hermit-abi@0.3.9		X							X					
@@ -68,22 +68,22 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
-hyper@1.4.1									X					
+httparse@1.9.5		X							X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
 inout@0.1.3		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 itoa@1.0.11		X							X					
 jni@0.21.1		X							X					
 jni-sys@0.3.0		X							X					
-js-sys@0.3.70		X							X					
+js-sys@0.3.72		X							X					
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
-libc@0.2.158		X							X					
+libc@0.2.161		X							X					
 libm@0.2.8		X							X					
 linux-raw-sys@0.4.14		X	X						X					
 lock_api@0.4.12		X							X					
@@ -100,12 +100,12 @@ num-derive@0.3.3		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
-opendal-java@0.47.3		X												
+object@0.36.5		X							X					
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
+opendal-java@0.47.4		X												
 openssh@0.11.2		X							X					
-openssh-sftp-client@0.15.0									X					
+openssh-sftp-client@0.15.1									X					
 openssh-sftp-client-lowlevel@0.7.0									X					
 openssh-sftp-error@0.5.0									X					
 openssh-sftp-protocol@0.24.0									X					
@@ -117,8 +117,8 @@ pbkdf2@0.12.2		X							X
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
+pin-project@1.1.6		X							X					
+pin-project-internal@1.1.6		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
@@ -126,25 +126,25 @@ pkcs5@0.7.1		X							X
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-redox_syscall@0.5.3									X					
+redox_syscall@0.5.7									X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustix@0.38.36		X	X						X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustix@0.38.37		X	X						X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 salsa20@0.10.2		X							X					
@@ -154,7 +154,7 @@ scrypt@0.11.0		X							X
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -173,12 +173,12 @@ ssh_format_error@0.1.0									X
 stable_deref_trait@1.2.0		X							X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
-tempfile@3.12.0		X							X					
+tempfile@3.13.0		X							X					
 thin-vec@0.2.13		X							X					
-thiserror@1.0.63		X							X					
-thiserror-impl@1.0.63		X							X					
+thiserror@1.0.64		X							X					
+thiserror-impl@1.0.64		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
@@ -190,8 +190,6 @@ tokio-io-utility@0.7.6									X
 tokio-macros@2.4.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-attributes@0.1.27									X					
@@ -200,26 +198,26 @@ trim-in-place@0.1.7									X
 triomphe@0.1.11		X							X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 vec-strings@0.4.8									X					
 version_check@0.9.5		X							X					
 walkdir@2.5.0									X				X	
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 winapi-util@0.1.9									X				X	
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal</artifactId>
-    <version>0.47.3</version>
+    <version>0.47.4</version>
 
     <name>Apache OpenDAL™</name>
     <description>

--- a/bindings/lua/Cargo.toml
+++ b/bindings/lua/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-lua"
 publish = false
-version = "0.1.9"
+version = "0.1.10"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/lua/DEPENDENCIES.rust.tsv
+++ b/bindings/lua/DEPENDENCIES.rust.tsv
@@ -1,13 +1,13 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aes@0.8.4		X							X					
 aho-corasick@1.1.3									X				X	
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
-async-trait@0.1.82		X							X					
-autocfg@1.3.0		X							X					
+anyhow@1.0.90		X							X					
+async-trait@0.1.83		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.21.7		X							X					
@@ -18,9 +18,9 @@ block-padding@0.3.3		X							X
 bstr@1.10.0		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
+bytes@1.7.2									X					
 cbc@0.1.2		X							X					
-cc@1.1.18		X							X					
+cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -41,17 +41,17 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
 hermit-abi@0.3.9		X							X					
@@ -61,21 +61,21 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
-hyper@1.4.1									X					
+httparse@1.9.5		X							X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
 inout@0.1.3		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 itertools@0.12.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
+js-sys@0.3.72		X							X					
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
-libc@0.2.158		X							X					
+libc@0.2.161		X							X					
 libm@0.2.8		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
@@ -92,48 +92,46 @@ num-conv@0.1.0		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
-opendal-lua@0.1.9		X												
+object@0.36.5		X							X					
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
+opendal-lua@0.1.10		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
 pkcs8@0.10.2		X							X					
-pkg-config@0.3.30		X							X					
+pkg-config@0.3.31		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
 proc-macro-error@1.0.4		X							X					
 proc-macro-error-attr@1.0.4		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-regex@1.10.6		X							X					
-regex-automata@0.4.7		X							X					
-regex-syntax@0.8.4		X							X					
+regex@1.11.0		X							X					
+regex-automata@0.4.8		X							X					
+regex-syntax@0.8.5		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc-hash@2.0.0		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 salsa20@0.10.2		X							X					
@@ -141,7 +139,7 @@ scrypt@0.11.0		X							X
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -155,10 +153,10 @@ spin@0.9.8									X
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
-thiserror@1.0.63		X							X					
-thiserror-impl@1.0.63		X							X					
+thiserror@1.0.64		X							X					
+thiserror-impl@1.0.64		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
@@ -168,32 +166,30 @@ tinyvec_macros@0.1.1		X							X					X
 tokio@1.40.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-core@0.1.32									X					
 trim-in-place@0.1.7									X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					
 windows-result@0.2.0		X							X					

--- a/bindings/lua/opendal-0.1.10-1.rockspec
+++ b/bindings/lua/opendal-0.1.10-1.rockspec
@@ -1,5 +1,5 @@
 package = "opendal"
-version = "0.1.9-1"
+version = "0.1.10-1"
 
 source = {
     url = "git+https://github.com/apache/opendal/",

--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.47.5"
+version = "0.47.6"
 
 [features]
 default = [

--- a/bindings/nodejs/DEPENDENCIES.rust.tsv
+++ b/bindings/nodejs/DEPENDENCIES.rust.tsv
@@ -1,13 +1,13 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aes@0.8.4		X							X					
 aho-corasick@1.1.3									X				X	
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
-async-trait@0.1.82		X							X					
-autocfg@1.3.0		X							X					
+anyhow@1.0.90		X							X					
+async-trait@0.1.83		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.21.7		X							X					
@@ -18,9 +18,9 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
+bytes@1.7.2									X					
 cbc@0.1.2		X							X					
-cc@1.1.18		X							X					
+cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -42,18 +42,18 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-executor@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-executor@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
 hermit-abi@0.3.9		X							X					
@@ -63,20 +63,20 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
-hyper@1.4.1									X					
+httparse@1.9.5		X							X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
 inout@0.1.3		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
+js-sys@0.3.72		X							X					
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
-libc@0.2.158		X							X					
+libc@0.2.161		X							X					
 libloading@0.8.5								X						
 libm@0.2.8		X							X					
 log@0.4.22		X							X					
@@ -85,10 +85,10 @@ memchr@2.7.4									X				X
 mime@0.3.17		X							X					
 miniz_oxide@0.8.0		X							X					X
 mio@1.0.2									X					
-napi@2.16.9									X					
+napi@2.16.12									X					
 napi-build@2.1.3									X					
-napi-derive@2.16.11									X					
-napi-derive-backend@1.0.73									X					
+napi-derive@2.16.12									X					
+napi-derive-backend@1.0.74									X					
 napi-sys@2.4.0									X					
 num-bigint@0.4.6		X							X					
 num-bigint-dig@0.8.4		X							X					
@@ -96,17 +96,15 @@ num-conv@0.1.0		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
-opendal-nodejs@0.47.5		X												
+object@0.36.5		X							X					
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
+opendal-nodejs@0.47.6		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
@@ -114,26 +112,26 @@ pkcs5@0.7.1		X							X
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-regex@1.10.6		X							X					
-regex-automata@0.4.7		X							X					
-regex-syntax@0.8.4		X							X					
+regex@1.11.0		X							X					
+regex-automata@0.4.8		X							X					
+regex-syntax@0.8.5		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 salsa20@0.10.2		X							X					
@@ -141,7 +139,7 @@ scrypt@0.11.0		X							X
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -154,10 +152,10 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
-thiserror@1.0.63		X							X					
-thiserror-impl@1.0.63		X							X					
+thiserror@1.0.64		X							X					
+thiserror-impl@1.0.64		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
@@ -167,33 +165,31 @@ tinyvec_macros@0.1.1		X							X					X
 tokio@1.40.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-core@0.1.32									X					
 trim-in-place@0.1.7									X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
-unicode-segmentation@1.11.0		X							X					
+unicode-normalization@0.1.24		X							X					
+unicode-segmentation@1.12.0		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					
 windows-result@0.2.0		X							X					

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-arm64",
   "repository": "git@github.com/apache/opendal.git",
-  "version": "0.47.5",
+  "version": "0.47.6",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-x64",
-  "version": "0.47.5",
+  "version": "0.47.6",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "darwin"

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-gnu",
-  "version": "0.47.5",
+  "version": "0.47.6",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-musl",
-  "version": "0.47.5",
+  "version": "0.47.6",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.47.5",
+  "version": "0.47.6",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-arm64-msvc",
-  "version": "0.47.5",
+  "version": "0.47.6",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.47.5",
+  "version": "0.47.6",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "Apache OpenDAL <dev@opendal.apache.org>",
-  "version": "0.47.5",
+  "version": "0.47.6",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",

--- a/bindings/ocaml/DEPENDENCIES.rust.tsv
+++ b/bindings/ocaml/DEPENDENCIES.rust.tsv
@@ -1,12 +1,12 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
-async-trait@0.1.82		X							X					
-autocfg@1.3.0		X							X					
+anyhow@1.0.90		X							X					
+async-trait@0.1.83		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.21.7		X							X					
@@ -16,9 +16,9 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
+bytes@1.7.2									X					
 cbc@0.1.2		X							X					
-cc@1.1.18		X							X					
+cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -39,17 +39,17 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
 hermit-abi@0.3.9		X							X					
@@ -59,20 +59,20 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
-hyper@1.4.1									X					
+httparse@1.9.5		X							X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
 inout@0.1.3		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
+js-sys@0.3.72		X							X					
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
-libc@0.2.158		X							X					
+libc@0.2.161		X							X					
 libm@0.2.8		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
@@ -86,22 +86,20 @@ num-conv@0.1.0		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
+object@0.36.5		X							X					
 ocaml@1.0.1								X						
 ocaml-boxroot-sys@0.3.1									X					
 ocaml-build@1.0.0								X						
 ocaml-derive@1.0.0								X						
 ocaml-sys@0.24.0								X						
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
 opendal-ocaml@0.0.0		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
@@ -109,23 +107,23 @@ pkcs5@0.7.1		X							X
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 salsa20@0.10.2		X							X					
@@ -133,7 +131,7 @@ scrypt@0.11.0		X							X
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -146,10 +144,10 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
-thiserror@1.0.63		X							X					
-thiserror-impl@1.0.63		X							X					
+thiserror@1.0.64		X							X					
+thiserror-impl@1.0.64		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
@@ -159,32 +157,30 @@ tinyvec_macros@0.1.1		X							X					X
 tokio@1.40.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-core@0.1.32									X					
 trim-in-place@0.1.7									X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					
 windows-result@0.2.0		X							X					

--- a/bindings/php/Cargo.toml
+++ b/bindings/php/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-php"
 publish = false
-version = "0.1.9"
+version = "0.1.10"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/php/DEPENDENCIES.rust.tsv
+++ b/bindings/php/DEPENDENCIES.rust.tsv
@@ -1,12 +1,12 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
-async-trait@0.1.82		X							X					
-autocfg@1.3.0		X							X					
+anyhow@1.0.90		X							X					
+async-trait@0.1.83		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.21.7		X							X					
@@ -19,14 +19,14 @@ block-padding@0.3.3		X							X
 bumpalo@3.16.0		X							X					
 bytecount@0.6.8		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
+bytes@1.7.2									X					
 bzip2@0.4.4		X							X					
 bzip2-sys@0.1.11+1.0.8		X							X					
 camino@1.1.9		X							X					
 cargo-platform@0.1.8		X							X					
 cargo_metadata@0.14.2									X					
 cbc@0.1.2		X							X					
-cc@1.1.18		X							X					
+cc@1.1.31		X							X					
 cexpr@0.6.0		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
@@ -58,22 +58,22 @@ ext-php-rs@0.11.2		X							X
 ext-php-rs-derive@0.10.1		X							X					
 fastrand@2.1.1		X							X					
 flagset@0.4.6		X												
-flate2@1.0.33		X							X					
+flate2@1.0.34		X							X					
 fnv@1.0.7		X							X					
 foreign-types@0.3.2		X							X					
 foreign-types-shared@0.1.1		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 glob@0.3.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
@@ -84,23 +84,23 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
-hyper@1.4.1									X					
+httparse@1.9.5		X							X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 ident_case@1.0.1		X							X					
 idna@0.5.0		X							X					
 inout@0.1.3		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 itoa@1.0.11		X							X					
 jobserver@0.1.32		X							X					
-js-sys@0.3.70		X							X					
+js-sys@0.3.72		X							X					
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
 lazycell@1.3.0		X							X					
-libc@0.2.158		X							X					
+libc@0.2.161		X							X					
 libloading@0.8.5								X						
 libm@0.2.8		X							X					
 linux-raw-sys@0.4.14		X	X						X					
@@ -120,14 +120,14 @@ num-conv@0.1.0		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
-opendal-php@0.1.9		X												
-openssl@0.10.66		X												
+object@0.36.5		X							X					
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
+opendal-php@0.1.10		X												
+openssl@0.10.68		X												
 openssl-macros@0.1.1		X							X					
 openssl-probe@0.1.5		X							X					
-openssl-sys@0.9.103									X					
+openssl-sys@0.9.104									X					
 ordered-multimap@0.7.3									X					
 parking_lot@0.12.3		X							X					
 parking_lot_core@0.9.10		X							X					
@@ -138,54 +138,52 @@ peeking_take_while@0.1.2		X							X
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
 pkcs8@0.10.2		X							X					
-pkg-config@0.3.30		X							X					
+pkg-config@0.3.31		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-prettyplease@0.2.22		X							X					
-proc-macro2@1.0.86		X							X					
+prettyplease@0.2.24		X							X					
+proc-macro2@1.0.88		X							X					
 pulldown-cmark@0.9.6									X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-redox_syscall@0.5.3									X					
-regex@1.10.6		X							X					
-regex-automata@0.4.7		X							X					
-regex-syntax@0.8.4		X							X					
+redox_syscall@0.5.7									X					
+regex@1.11.0		X							X					
+regex-automata@0.4.8		X							X					
+regex-syntax@0.8.5		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc-hash@1.1.0		X							X					
 rustc_version@0.4.1		X							X					
-rustix@0.38.36		X	X						X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustix@0.38.37		X	X						X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 salsa20@0.10.2		X							X					
 same-file@1.0.6									X				X	
-schannel@0.1.24									X					
+schannel@0.1.26									X					
 scopeguard@1.2.0		X							X					
 scrypt@0.11.0		X							X					
 security-framework@2.11.1		X							X					
-security-framework-sys@2.11.1		X							X					
+security-framework-sys@2.12.0		X							X					
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -201,11 +199,11 @@ spki@0.7.3		X							X
 strsim@0.10.0									X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
-tempfile@3.12.0		X							X					
-thiserror@1.0.63		X							X					
-thiserror-impl@1.0.63		X							X					
+tempfile@3.13.0		X							X					
+thiserror@1.0.64		X							X					
+thiserror-impl@1.0.64		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
@@ -215,36 +213,34 @@ tinyvec_macros@0.1.1		X							X					X
 tokio@1.40.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-core@0.1.32									X					
 trim-in-place@0.1.7									X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicase@2.7.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicase@2.8.0		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 untrusted@0.9.0								X						
 ureq@2.10.1		X							X					
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 vcpkg@0.2.15		X							X					
 version_check@0.9.5		X							X					
 walkdir@2.5.0									X				X	
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 which@4.4.2									X					
 winapi-util@0.1.9									X				X	
 windows-core@0.52.0		X							X					

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.10"
+version = "0.45.11"
 
 [features]
 default = [

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -1,13 +1,13 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
+anyhow@1.0.90		X							X					
 arc-swap@1.7.1		X							X					
-async-trait@0.1.82		X							X					
-autocfg@1.3.0		X							X					
+async-trait@0.1.83		X							X					
+autocfg@1.4.0		X							X					
 awaitable@0.4.0									X					
 awaitable-error@0.1.0									X					
 backon@1.2.0		X												
@@ -15,19 +15,19 @@ backtrace@0.3.74		X							X
 base64@0.21.7		X							X					
 base64@0.22.1		X							X					
 base64ct@1.6.0		X							X					
-bb8@0.8.5									X					
+bb8@0.8.6									X					
 bitflags@2.6.0		X							X					
 block-buffer@0.10.4		X							X					
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
+bytes@1.7.2									X					
 cbc@0.1.2		X							X					
-cc@1.1.18		X							X					
+cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
-concurrent_arena@0.1.8									X					
+concurrent_arena@0.1.10									X					
 const-oid@0.9.6		X							X					
 const-random@0.1.18		X							X					
 const-random-macro@0.1.16		X							X					
@@ -46,18 +46,18 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-executor@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-executor@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
 heck@0.4.1		X							X					
@@ -68,21 +68,21 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
-hyper@1.4.1									X					
+httparse@1.9.5		X							X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
 indoc@2.0.5		X							X					
 inout@0.1.3		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
+js-sys@0.3.72		X							X					
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
-libc@0.2.158		X							X					
+libc@0.2.161		X							X					
 libm@0.2.8		X							X					
 linux-raw-sys@0.4.14		X	X						X					
 lock_api@0.4.12		X							X					
@@ -100,12 +100,12 @@ num-derive@0.3.3		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
-opendal-python@0.45.10		X												
+object@0.36.5		X							X					
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
+opendal-python@0.45.11		X												
 openssh@0.11.2		X							X					
-openssh-sftp-client@0.15.0									X					
+openssh-sftp-client@0.15.1									X					
 openssh-sftp-client-lowlevel@0.7.0									X					
 openssh-sftp-error@0.5.0									X					
 openssh-sftp-protocol@0.24.0									X					
@@ -117,17 +117,17 @@ pbkdf2@0.12.2		X							X
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
+pin-project@1.1.6		X							X					
+pin-project-internal@1.1.6		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
 pkcs8@0.10.2		X							X					
-portable-atomic@1.7.0		X							X					
+portable-atomic@1.9.0		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 pyo3@0.21.2		X							X					
 pyo3-asyncio-0-21@0.21.0		X												
 pyo3-build-config@0.21.2		X							X					
@@ -135,23 +135,23 @@ pyo3-ffi@0.21.2		X							X
 pyo3-macros@0.21.2		X							X					
 pyo3-macros-backend@0.21.2		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-redox_syscall@0.5.3									X					
+redox_syscall@0.5.7									X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustix@0.38.36		X	X						X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustix@0.38.37		X	X						X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 salsa20@0.10.2		X							X					
@@ -160,7 +160,7 @@ scrypt@0.11.0		X							X
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -179,13 +179,13 @@ ssh_format_error@0.1.0									X
 stable_deref_trait@1.2.0		X							X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
 target-lexicon@0.12.16			X											
-tempfile@3.12.0		X							X					
+tempfile@3.13.0		X							X					
 thin-vec@0.2.13		X							X					
-thiserror@1.0.63		X							X					
-thiserror-impl@1.0.63		X							X					
+thiserror@1.0.64		X							X					
+thiserror-impl@1.0.64		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
@@ -197,8 +197,6 @@ tokio-io-utility@0.7.6									X
 tokio-macros@2.4.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-attributes@0.1.27									X					
@@ -207,26 +205,26 @@ trim-in-place@0.1.7									X
 triomphe@0.1.11		X							X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 unindent@0.2.3		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 vec-strings@0.4.8									X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					
 windows-result@0.2.0		X							X					

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-ruby"
 publish = false
-version = "0.1.9"
+version = "0.1.10"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -1,27 +1,27 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aes@0.8.4		X							X					
 aho-corasick@1.1.3									X				X	
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
-async-trait@0.1.82		X							X					
-autocfg@1.3.0		X							X					
+anyhow@1.0.90		X							X					
+async-trait@0.1.83		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.21.7		X							X					
 base64@0.22.1		X							X					
 base64ct@1.6.0		X							X					
-bindgen@0.69.4					X									
+bindgen@0.69.5					X									
 bitflags@2.6.0		X							X					
 block-buffer@0.10.4		X							X					
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
+bytes@1.7.2									X					
 cbc@0.1.2		X							X					
-cc@1.1.18		X							X					
+cc@1.1.31		X							X					
 cexpr@0.6.0		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
@@ -44,17 +44,17 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 glob@0.3.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
@@ -65,22 +65,22 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
-hyper@1.4.1									X					
+httparse@1.9.5		X							X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
 inout@0.1.3		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 itertools@0.12.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
+js-sys@0.3.72		X							X					
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
 lazycell@1.3.0		X							X					
-libc@0.2.158		X							X					
+libc@0.2.161		X							X					
 libloading@0.8.5								X						
 libm@0.2.8		X							X					
 log@0.4.22		X							X					
@@ -99,17 +99,15 @@ num-conv@0.1.0		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
-opendal-ruby@0.1.9		X												
+object@0.36.5		X							X					
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
+opendal-ruby@0.1.10		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
@@ -117,9 +115,9 @@ pkcs5@0.7.1		X							X
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
@@ -127,20 +125,20 @@ rand_core@0.6.4		X							X
 rb-sys@0.9.102		X							X					
 rb-sys-build@0.9.102		X							X					
 rb-sys-env@0.1.2		X							X					
-regex@1.10.6		X							X					
-regex-automata@0.4.7		X							X					
-regex-syntax@0.8.4		X							X					
+regex@1.11.0		X							X					
+regex-automata@0.4.8		X							X					
+regex-syntax@0.8.5		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc-hash@1.1.0		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 salsa20@0.10.2		X							X					
@@ -148,7 +146,7 @@ scrypt@0.11.0		X							X
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -163,10 +161,10 @@ spin@0.9.8									X
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
-thiserror@1.0.63		X							X					
-thiserror-impl@1.0.63		X							X					
+thiserror@1.0.64		X							X					
+thiserror-impl@1.0.64		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
@@ -176,32 +174,30 @@ tinyvec_macros@0.1.1		X							X					X
 tokio@1.40.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-core@0.1.32									X					
 trim-in-place@0.1.7									X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					
 windows-result@0.2.0		X							X					

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -186,9 +186,9 @@ checksum = "ea50b14b7a4b9343f8c627a7a53c52076482bd4bdad0a24fd3ec533ed616cc2c"
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
 
 [[package]]
 name = "approx"
@@ -280,7 +280,7 @@ checksum = "affbba0d438add06462a0371997575927bc05052f7ec486e7a4ca405c956c3d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -391,7 +391,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.79",
+ "syn 2.0.81",
  "thiserror",
 ]
 
@@ -468,7 +468,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -526,7 +526,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -556,7 +556,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -613,7 +613,7 @@ checksum = "62f7df18977a1ee03650ee4b31b4aefed6d56bac188760b6e37610400fe8d4bb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1274,7 +1274,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1296,7 +1296,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.79",
+ "syn 2.0.81",
  "which",
 ]
 
@@ -1317,7 +1317,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -1445,7 +1445,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
  "syn_derive",
 ]
 
@@ -1639,9 +1639,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
@@ -1820,7 +1820,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2037,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "concurrent_arena"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388754cc71073ef0e6f1f72d84ac424c12c05d88eaad708c7bc55ee5dcb4e549"
+checksum = "4ef19a8d27aefd2a86b39ee61a6e83bc98ee97dacc93ce87770adab2413392a6"
 dependencies = [
  "arc-swap",
  "parking_lot 0.12.3",
@@ -2323,7 +2323,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2334,7 +2334,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2431,7 +2431,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2452,7 +2452,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2462,7 +2462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2473,7 +2473,7 @@ checksum = "64b697ac90ff296f0fc031ee5a61c7ac31fb9fff50e3fb32873b09223613fc0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2486,7 +2486,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_aws_s3_assume_role_with_web_identity"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "opendal",
  "tokio",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_file_write_on_full_disk"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "futures",
  "opendal",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_s3_read_on_wasm"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "opendal",
  "wasm-bindgen",
@@ -2710,7 +2710,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2844,7 +2844,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -2902,9 +2902,9 @@ checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flume"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2986,7 +2986,7 @@ checksum = "afc84a5ff0dba78222551017f5625f3365aa09551c78cfaa44136fc6818c2611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
  "try_map",
 ]
 
@@ -3118,7 +3118,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -3184,7 +3184,7 @@ dependencies = [
  "g2poly",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -3298,7 +3298,7 @@ checksum = "b0e085ded9f1267c32176b40921b9754c474f7dd96f7e808d4a982e48aa1e854"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -3327,14 +3327,15 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+checksum = "7a7ecdc5898f6a43e08a7e2c9e2266beb98fd4dfbf2634182540fbb715245093"
 dependencies = [
  "cfg-if",
  "dashmap 5.5.3",
- "futures",
+ "futures-sink",
  "futures-timer",
+ "futures-util",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot 0.12.3",
@@ -3662,7 +3663,7 @@ dependencies = [
  "markup5ever",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -3953,7 +3954,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.79",
+ "syn 2.0.81",
  "thiserror",
 ]
 
@@ -4166,7 +4167,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -4479,7 +4480,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -4658,7 +4659,7 @@ checksum = "3a6dbc533e93429a71c44a14c04547ac783b56d3f22e6c4f12b1b994cf93844e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -4692,7 +4693,7 @@ checksum = "176a5f5e69613d9e88337cf2a65e11135332b4efbcc628404a7c555e4452084c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -4988,7 +4989,7 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "opendal"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "anyhow",
  "async-backtrace",
@@ -5098,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-basic"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "futures",
  "opendal",
@@ -5107,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-concurrent-upload"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "futures",
  "opendal",
@@ -5116,7 +5117,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-multipart-upload"
-version = "0.50.0"
+version = "0.50.1"
 dependencies = [
  "futures",
  "opendal",
@@ -5254,7 +5255,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5623,7 +5624,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
  "unicase",
 ]
 
@@ -5669,7 +5670,7 @@ checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5831,12 +5832,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "910d41a655dac3b764f1ade94821093d3610248694320cd072303a8eedcf221d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5896,7 +5897,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -5968,7 +5969,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6008,7 +6009,7 @@ dependencies = [
  "prost 0.13.3",
  "prost-types 0.13.3",
  "regex",
- "syn 2.0.79",
+ "syn 2.0.81",
  "tempfile",
 ]
 
@@ -6022,7 +6023,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6035,7 +6036,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6437,7 +6438,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -6619,7 +6620,7 @@ checksum = "5f0ec466e5d8dca9965eb6871879677bef5590cf7525ad96cae14376efb75073"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -7171,7 +7172,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -7187,9 +7188,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.129"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "indexmap 2.6.0",
  "itoa",
@@ -7237,7 +7238,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -7589,7 +7590,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -7612,7 +7613,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.79",
+ "syn 2.0.81",
  "tempfile",
  "tokio",
  "url",
@@ -7863,7 +7864,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -8036,9 +8037,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "198514704ca887dd5a1e408c6c6cdcba43672f9b4062e1b24aa34e74e6d7faae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8054,7 +8055,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -8148,7 +8149,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -8318,7 +8319,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -8494,7 +8495,7 @@ dependencies = [
  "prost-build",
  "prost-types 0.13.3",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -8563,7 +8564,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -8740,12 +8741,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
+checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
 
 [[package]]
 name = "unicode-bidi"
@@ -8984,7 +8982,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
  "wasm-bindgen-shared",
 ]
 
@@ -9018,7 +9016,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9052,7 +9050,7 @@ checksum = "c97b2ef2c8d627381e51c071c2ab328eac606d3f69dd82bcbca20a9e389d95f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -9250,7 +9248,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -9261,7 +9259,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]
@@ -9531,7 +9529,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.81",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.50.0"
+version = "0.50.1"
 
 [lints.clippy]
 unused_async = "warn"
@@ -44,7 +44,7 @@ members = [".", "examples/*", "fuzz", "edge/*", "benches/vs_*"]
 edition = "2021"
 license = "Apache-2.0"
 rust-version = "1.75"
-version = "0.50.0"
+version = "0.50.1"
 
 [features]
 default = ["reqwest/rustls-tls", "executors-tokio", "services-memory"]
@@ -56,16 +56,16 @@ default = ["reqwest/rustls-tls", "executors-tokio", "services-memory"]
 #
 # You should never enable this feature unless you are developing opendal.
 tests = [
-    "dep:rand",
-    "dep:sha2",
-    "dep:dotenvy",
-    "layers-blocking",
-    "services-azblob",
-    "services-fs",
-    "services-http",
-    "services-memory",
-    "internal-tokio-rt",
-    "services-s3",
+  "dep:rand",
+  "dep:sha2",
+  "dep:dotenvy",
+  "layers-blocking",
+  "services-azblob",
+  "services-fs",
+  "services-http",
+  "services-memory",
+  "internal-tokio-rt",
+  "services-s3",
 ]
 
 # Enable path cache.
@@ -107,20 +107,20 @@ services-aliyun-drive = []
 services-alluxio = []
 services-atomicserver = ["dep:atomic_lib"]
 services-azblob = [
-    "dep:sha2",
-    "dep:reqsign",
-    "reqsign?/services-azblob",
-    "reqsign?/reqwest_request",
+  "dep:sha2",
+  "dep:reqsign",
+  "reqsign?/services-azblob",
+  "reqsign?/reqwest_request",
 ]
 services-azdls = [
-    "dep:reqsign",
-    "reqsign?/services-azblob",
-    "reqsign?/reqwest_request",
+  "dep:reqsign",
+  "reqsign?/services-azblob",
+  "reqsign?/reqwest_request",
 ]
 services-azfile = [
-    "dep:reqsign",
-    "reqsign?/services-azblob",
-    "reqsign?/reqwest_request",
+  "dep:reqsign",
+  "reqsign?/services-azblob",
+  "reqsign?/reqwest_request",
 ]
 services-b2 = []
 services-cacache = ["dep:cacache"]
@@ -128,9 +128,9 @@ services-chainsafe = []
 services-cloudflare-kv = []
 services-compfs = ["dep:compio"]
 services-cos = [
-    "dep:reqsign",
-    "reqsign?/services-tencent",
-    "reqsign?/reqwest_request",
+  "dep:reqsign",
+  "reqsign?/services-tencent",
+  "reqsign?/reqwest_request",
 ]
 services-d1 = []
 services-dashmap = ["dep:dashmap"]
@@ -141,9 +141,9 @@ services-foundationdb = ["dep:foundationdb"]
 services-fs = ["tokio/fs", "internal-tokio-rt"]
 services-ftp = ["dep:suppaftp", "dep:bb8", "dep:async-tls"]
 services-gcs = [
-    "dep:reqsign",
-    "reqsign?/services-google",
-    "reqsign?/reqwest_request",
+  "dep:reqsign",
+  "reqsign?/services-google",
+  "reqsign?/reqwest_request",
 ]
 services-gdrive = ["internal-path-cache"]
 services-ghac = []
@@ -168,15 +168,15 @@ services-monoiofs = ["dep:monoio", "dep:flume"]
 services-mysql = ["dep:sqlx", "sqlx?/mysql"]
 services-nebula-graph = ["dep:rust-nebula", "dep:bb8", "dep:snowflaked"]
 services-obs = [
-    "dep:reqsign",
-    "reqsign?/services-huaweicloud",
-    "reqsign?/reqwest_request",
+  "dep:reqsign",
+  "reqsign?/services-huaweicloud",
+  "reqsign?/reqwest_request",
 ]
 services-onedrive = []
 services-oss = [
-    "dep:reqsign",
-    "reqsign?/services-aliyun",
-    "reqsign?/reqwest_request",
+  "dep:reqsign",
+  "reqsign?/services-aliyun",
+  "reqsign?/reqwest_request",
 ]
 services-pcloud = []
 services-persy = ["dep:persy", "internal-tokio-rt"]
@@ -186,10 +186,10 @@ services-redis = ["dep:redis", "dep:bb8", "redis?/tokio-rustls-comp"]
 services-redis-native-tls = ["services-redis", "redis?/tokio-native-tls-comp"]
 services-rocksdb = ["dep:rocksdb", "internal-tokio-rt"]
 services-s3 = [
-    "dep:reqsign",
-    "reqsign?/services-aws",
-    "reqsign?/reqwest_request",
-    "dep:crc32c",
+  "dep:reqsign",
+  "reqsign?/services-aws",
+  "reqsign?/reqwest_request",
+  "dep:crc32c",
 ]
 services-seafile = []
 services-sftp = ["dep:openssh", "dep:openssh-sftp-client", "dep:bb8"]
@@ -235,13 +235,13 @@ backon = { version = "1.2", features = ["tokio-sleep"] }
 base64 = "0.22"
 bytes = "1.6"
 chrono = { version = "0.4.28", default-features = false, features = [
-    "clock",
-    "std",
+  "clock",
+  "std",
 ] }
 flagset = "0.4"
 futures = { version = "0.3", default-features = false, features = [
-    "std",
-    "async-await",
+  "std",
+  "async-await",
 ] }
 http = "1.1"
 log = "0.4"
@@ -251,7 +251,7 @@ once_cell = "1"
 percent-encoding = "2"
 quick-xml = { version = "0.36", features = ["serialize", "overlapped-lists"] }
 reqwest = { version = "0.12.2", features = [
-    "stream",
+  "stream",
 ], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -271,7 +271,7 @@ prost = { version = "0.13", optional = true }
 sha1 = { version = "0.10.6", optional = true }
 sha2 = { version = "0.10", optional = true }
 sqlx = { version = "0.8.0", features = [
-    "runtime-tokio-rustls",
+  "runtime-tokio-rustls",
 ], optional = true }
 
 # For http based services.
@@ -281,8 +281,8 @@ reqsign = { version = "0.16", default-features = false, optional = true }
 atomic_lib = { version = "0.39.0", optional = true }
 # for services-cacache
 cacache = { version = "13.0", default-features = false, features = [
-    "tokio-runtime",
-    "mmap",
+  "tokio-runtime",
+  "mmap",
 ], optional = true }
 # for services-dashmap
 dashmap = { version = "6", optional = true }
@@ -290,8 +290,8 @@ dashmap = { version = "6", optional = true }
 etcd-client = { version = "0.14", optional = true, features = ["tls"] }
 # for services-foundationdb
 foundationdb = { version = "0.9.0", features = [
-    "embedded-fdb-include",
-    "fdb-7_3",
+  "embedded-fdb-include",
+  "fdb-7_3",
 ], optional = true }
 # for services-hdfs
 hdrs = { version = "0.3.2", optional = true, features = ["async_file"] }
@@ -308,8 +308,8 @@ mongodb = { version = "3", optional = true }
 # for services-sftp
 openssh = { version = "0.11.0", optional = true }
 openssh-sftp-client = { version = "0.15.0", optional = true, features = [
-    "openssh",
-    "tracing",
+  "openssh",
+  "tracing",
 ] }
 # for services-persy
 persy = { version = "1.4.6", optional = true }
@@ -317,9 +317,9 @@ persy = { version = "1.4.6", optional = true }
 redb = { version = "2", optional = true }
 # for services-redis
 redis = { version = "0.27", features = [
-    "cluster-async",
-    "tokio-comp",
-    "connection-manager",
+  "cluster-async",
+  "tokio-comp",
+  "connection-manager",
 ], optional = true }
 # for services-rocksdb
 rocksdb = { version = "0.21.0", default-features = false, optional = true }
@@ -327,9 +327,9 @@ rocksdb = { version = "0.21.0", default-features = false, optional = true }
 sled = { version = "0.34.7", optional = true }
 # for services-ftp
 suppaftp = { version = "6.0.3", default-features = false, features = [
-    "async-secure",
-    "rustls",
-    "async-rustls",
+  "async-secure",
+  "rustls",
+  "async-rustls",
 ], optional = true }
 # for services-tikv
 tikv-client = { version = "0.3.0", optional = true, default-features = false }
@@ -339,10 +339,10 @@ hdfs-native = { version = "0.10", optional = true }
 surrealdb = { version = "2", optional = true, features = ["protocol-http"] }
 # for services-compfs
 compio = { version = "0.12.0", optional = true, features = [
-    "runtime",
-    "bytes",
-    "polling",
-    "dispatcher",
+  "runtime",
+  "bytes",
+  "polling",
+  "dispatcher",
 ] }
 # for services-s3
 crc32c = { version = "0.6.6", optional = true }
@@ -352,10 +352,10 @@ snowflaked = { version = "1", optional = true, features = ["sync"] }
 # for services-monoiofs
 flume = { version = "0.11", optional = true }
 monoio = { version = "0.2.4", optional = true, features = [
-    "sync",
-    "mkdirat",
-    "unlinkat",
-    "renameat",
+  "sync",
+  "mkdirat",
+  "unlinkat",
+  "renameat",
 ] }
 
 # Layers
@@ -394,7 +394,7 @@ fastrace = { version = "0.7", features = ["enable"] }
 fastrace-jaeger = "0.7"
 libtest-mimic = "0.8"
 opentelemetry = { version = "0.26", default-features = false, features = [
-    "trace",
+  "trace",
 ] }
 opentelemetry-otlp = "0.26"
 opentelemetry_sdk = "0.26"
@@ -405,6 +405,6 @@ size = "0.4"
 tokio = { version = "1.27", features = ["fs", "macros", "rt-multi-thread"] }
 tracing-opentelemetry = "0.27.0"
 tracing-subscriber = { version = "0.3", features = [
-    "env-filter",
-    "tracing-log",
+  "env-filter",
+  "tracing-log",
 ] }

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -1,20 +1,20 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
-async-trait@0.1.82		X							X					
+anyhow@1.0.90		X							X					
+async-trait@0.1.83		X							X					
 atomic-waker@1.1.2		X							X					
-autocfg@1.3.0		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.22.1		X							X					
 block-buffer@0.10.4		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
-cc@1.1.18		X							X					
+bytes@1.7.2									X					
+cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 const-oid@0.9.6		X							X					
@@ -33,21 +33,21 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 h2@0.4.6									X					
-hashbrown@0.12.3		X							X					
 hashbrown@0.14.5		X							X					
+hashbrown@0.15.0		X							X					
 hermit-abi@0.3.9		X							X					
 hex@0.4.3		X							X					
 hmac@0.12.1		X							X					
@@ -55,60 +55,56 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
+httparse@1.9.5		X							X					
 httpdate@1.0.3		X							X					
-hyper@1.4.1									X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
-indexmap@1.9.3		X							X					
-indexmap@2.5.0		X							X					
-ipnet@2.10.0		X							X					
+indexmap@2.6.0		X							X					
+ipnet@2.10.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
-libc@0.2.158		X							X					
+js-sys@0.3.72		X							X					
+libc@0.2.161		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
 memchr@2.7.4									X				X	
 mime@0.3.17		X							X					
 miniz_oxide@0.8.0		X							X					X
-mio@0.8.11									X					
+mio@1.0.2									X					
 num-traits@0.2.19		X							X					
-num_cpus@1.16.0		X							X					
-object@0.36.4		X							X					
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
+object@0.36.5		X							X					
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
 ordered-multimap@0.7.3									X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -118,17 +114,15 @@ smallvec@1.13.2		X							X
 socket2@0.5.7		X							X					
 spin@0.9.8									X					
 subtle@2.6.1					X									
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.38.1									X					
-tokio-macros@2.3.0									X					
+tokio@1.40.0									X					
+tokio-macros@2.4.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-attributes@0.1.27									X					
@@ -136,47 +130,38 @@ tracing-core@0.1.32									X
 trim-in-place@0.1.7									X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 valuable@0.1.0									X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					
 windows-result@0.2.0		X							X					
 windows-strings@0.1.0		X							X					
-windows-sys@0.48.0		X							X					
 windows-sys@0.52.0		X							X					
-windows-targets@0.48.5		X							X					
 windows-targets@0.52.6		X							X					
-windows_aarch64_gnullvm@0.48.5		X							X					
 windows_aarch64_gnullvm@0.52.6		X							X					
-windows_aarch64_msvc@0.48.5		X							X					
 windows_aarch64_msvc@0.52.6		X							X					
-windows_i686_gnu@0.48.5		X							X					
 windows_i686_gnu@0.52.6		X							X					
 windows_i686_gnullvm@0.52.6		X							X					
-windows_i686_msvc@0.48.5		X							X					
 windows_i686_msvc@0.52.6		X							X					
-windows_x86_64_gnu@0.48.5		X							X					
 windows_x86_64_gnu@0.52.6		X							X					
-windows_x86_64_gnullvm@0.48.5		X							X					
 windows_x86_64_gnullvm@0.52.6		X							X					
-windows_x86_64_msvc@0.48.5		X							X					
 windows_x86_64_msvc@0.52.6		X							X					
 zerocopy@0.7.35		X		X					X					
 zerocopy-derive@0.7.35		X		X					X					

--- a/integrations/cloud_filter/Cargo.toml
+++ b/integrations/cloud_filter/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 name = "cloud_filter_opendal"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.0.1"
+version = "0.0.2"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/integrations/cloud_filter/DEPENDENCIES.rust.tsv
+++ b/integrations/cloud_filter/DEPENDENCIES.rust.tsv
@@ -1,11 +1,11 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
-async-trait@0.1.82		X							X					
-autocfg@1.3.0		X							X					
+anyhow@1.0.90		X							X					
+async-trait@0.1.83		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.22.1		X							X					
@@ -13,12 +13,12 @@ bincode@1.3.3									X
 block-buffer@0.10.4		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
-cc@1.1.18		X							X					
+bytes@1.7.2									X					
+cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cloud-filter@0.0.5									X					
-cloud_filter_opendal@0.0.1		X												
+cloud_filter_opendal@0.0.2		X												
 const-oid@0.9.6		X							X					
 const-random@0.1.18		X							X					
 const-random-macro@0.1.16		X							X					
@@ -35,18 +35,18 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-executor@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-executor@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
 hermit-abi@0.3.9		X							X					
@@ -56,17 +56,17 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
-hyper@1.4.1									X					
+httparse@1.9.5		X							X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
-libc@0.2.158		X							X					
+js-sys@0.3.72		X							X					
+libc@0.2.161		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
 memchr@2.7.4									X				X	
@@ -77,39 +77,37 @@ mio@1.0.2									X
 nt-time@0.8.1		X							X					
 num-conv@0.1.0		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
+object@0.36.5		X							X					
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
 ordered-multimap@0.7.3									X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
+proc-macro2@1.0.88		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.1									X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 semver@1.0.23		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -120,7 +118,7 @@ smallvec@1.13.2		X							X
 socket2@0.5.7		X							X					
 spin@0.9.8									X					
 subtle@2.6.1					X									
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
@@ -132,32 +130,30 @@ tokio@1.40.0									X
 tokio-macros@2.4.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-core@0.1.32									X					
 trim-in-place@0.1.7									X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 widestring@1.1.0		X							X					
 windows@0.58.0		X							X					
 windows-core@0.52.0		X							X					

--- a/integrations/compat/DEPENDENCIES.rust.tsv
+++ b/integrations/compat/DEPENDENCIES.rust.tsv
@@ -1,0 +1,7 @@
+crate	Apache-2.0	MIT	Unicode-DFS-2016
+async-trait@0.1.83	X	X	
+opendal_compat@1.0.0	X		
+proc-macro2@1.0.88	X	X	
+quote@1.0.37	X	X	
+syn@2.0.81	X	X	
+unicode-ident@1.0.13	X	X	X

--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 description = "Use OpenDAL as a backend to access data in various service with WebDAV protocol"
 name = "dav-server-opendalfs"
-version = "0.2.0"
+version = "0.2.1"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -1,171 +1,169 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X						X					
-adler2@2.0.0	X	X						X					
-ahash@0.8.11		X						X					
-aho-corasick@1.1.3								X				X	
-allocator-api2@0.2.18		X						X					
-android-tzdata@0.1.1		X						X					
-android_system_properties@0.1.5		X						X					
-anyhow@1.0.87		X						X					
-async-trait@0.1.82		X						X					
-autocfg@1.3.0		X						X					
-backon@1.2.0		X											
-backtrace@0.3.74		X						X					
-base64@0.21.7		X						X					
-base64@0.22.1		X						X					
-bitflags@2.6.0		X						X					
-block-buffer@0.10.4		X						X					
-bumpalo@3.16.0		X						X					
-bytes@1.7.1								X					
-cc@1.1.18		X						X					
-cfg-if@1.0.0		X						X					
-chrono@0.4.38		X						X					
-core-foundation-sys@0.8.7		X						X					
-cpufeatures@0.2.14		X						X					
-crypto-common@0.1.6		X						X					
-dav-server@0.7.0		X											
-dav-server-opendalfs@0.2.0		X											
-deranged@0.3.11		X						X					
-digest@0.10.7		X						X					
-fastrand@2.1.1		X						X					
-flagset@0.4.6		X											
-fnv@1.0.7		X						X					
-form_urlencoded@1.2.1		X						X					
-futures@0.3.30		X						X					
-futures-channel@0.3.30		X						X					
-futures-core@0.3.30		X						X					
-futures-executor@0.3.30		X						X					
-futures-io@0.3.30		X						X					
-futures-macro@0.3.30		X						X					
-futures-sink@0.3.30		X						X					
-futures-task@0.3.30		X						X					
-futures-util@0.3.30		X						X					
-generic-array@0.14.7								X					
-getrandom@0.2.15		X						X					
-gimli@0.31.0		X						X					
-gloo-timers@0.3.0		X						X					
-hashbrown@0.14.5		X						X					
-headers@0.4.0								X					
-headers-core@0.3.0								X					
-hermit-abi@0.3.9		X						X					
-htmlescape@0.3.1		X						X	X				
-http@1.1.0		X						X					
-http-body@1.0.1								X					
-http-body-util@0.1.2								X					
-httparse@1.9.4		X						X					
-httpdate@1.0.3		X						X					
-hyper@1.4.1								X					
-hyper-rustls@0.27.3		X					X	X					
-hyper-util@0.1.8								X					
-iana-time-zone@0.1.60		X						X					
-iana-time-zone-haiku@0.1.2		X						X					
-idna@0.5.0		X						X					
-ipnet@2.10.0		X						X					
-itoa@1.0.11		X						X					
-js-sys@0.3.70		X						X					
-lazy_static@1.5.0		X						X					
-libc@0.2.158		X						X					
-lock_api@0.4.12		X						X					
-log@0.4.22		X						X					
-lru@0.12.4								X					
-md-5@0.10.6		X						X					
-memchr@2.7.4								X				X	
-mime@0.3.17		X						X					
-mime_guess@2.0.5								X					
-miniz_oxide@0.8.0		X						X					X
-mio@1.0.2								X					
-num-conv@0.1.0		X						X					
-num-traits@0.2.19		X						X					
-object@0.36.4		X						X					
-once_cell@1.19.0		X						X					
-opendal@0.50.0		X											
-parking_lot@0.12.3		X						X					
-parking_lot_core@0.9.10		X						X					
-percent-encoding@2.3.1		X						X					
-pin-project@1.1.5		X						X					
-pin-project-internal@1.1.5		X						X					
-pin-project-lite@0.2.14		X						X					
-pin-utils@0.1.0		X						X					
-powerfmt@0.2.0		X						X					
-proc-macro2@1.0.86		X						X					
-quick-xml@0.36.1								X					
-quote@1.0.37		X						X					
-redox_syscall@0.5.3								X					
-regex@1.10.6		X						X					
-regex-automata@0.4.7		X						X					
-regex-syntax@0.8.4		X						X					
-reqwest@0.12.7		X						X					
-ring@0.17.8										X			
-rustc-demangle@0.1.24		X						X					
-rustls@0.23.13		X					X	X					
-rustls-pemfile@2.1.3		X					X	X					
-rustls-pki-types@1.8.0		X						X					
-rustls-webpki@0.102.8							X						
-ryu@1.0.18		X				X							
-scopeguard@1.2.0		X						X					
-serde@1.0.210		X						X					
-serde_derive@1.0.210		X						X					
-serde_json@1.0.128		X						X					
-serde_urlencoded@0.7.1		X						X					
-sha1@0.10.6		X						X					
-shlex@1.3.0		X						X					
-slab@0.4.9								X					
-smallvec@1.13.2		X						X					
-socket2@0.5.7		X						X					
-spin@0.9.8								X					
-subtle@2.6.1					X								
-syn@2.0.77		X						X					
-sync_wrapper@1.0.1		X											
-time@0.3.36		X						X					
-time-core@0.1.2		X						X					
-time-macros@0.2.18		X						X					
-tinyvec@1.8.0		X						X					X
-tinyvec_macros@0.1.1		X						X					X
-tokio@1.40.0								X					
-tokio-macros@2.4.0								X					
-tokio-rustls@0.26.0		X						X					
-tokio-util@0.7.12								X					
-tower@0.4.13								X					
-tower-layer@0.3.3								X					
-tower-service@0.3.3								X					
-tracing@0.1.40								X					
-tracing-core@0.1.32								X					
-try-lock@0.2.5								X					
-typenum@1.17.0		X						X					
-unicase@2.7.0		X						X					
-unicode-bidi@0.3.15		X						X					
-unicode-ident@1.0.13		X						X			X		
-unicode-normalization@0.1.23		X						X					
-untrusted@0.9.0							X						
-url@2.5.2		X						X					
-uuid@1.10.0		X						X					
-version_check@0.9.5		X						X					
-want@0.3.1								X					
-wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
-wasm-bindgen@0.2.93		X						X					
-wasm-bindgen-backend@0.2.93		X						X					
-wasm-bindgen-futures@0.4.43		X						X					
-wasm-bindgen-macro@0.2.93		X						X					
-wasm-bindgen-macro-support@0.2.93		X						X					
-wasm-bindgen-shared@0.2.93		X						X					
-wasm-streams@0.4.0		X						X					
-web-sys@0.3.70		X						X					
-webpki-roots@0.26.5									X				
-windows-core@0.52.0		X						X					
-windows-registry@0.2.0		X						X					
-windows-result@0.2.0		X						X					
-windows-strings@0.1.0		X						X					
-windows-sys@0.52.0		X						X					
-windows-targets@0.52.6		X						X					
-windows_aarch64_gnullvm@0.52.6		X						X					
-windows_aarch64_msvc@0.52.6		X						X					
-windows_i686_gnu@0.52.6		X						X					
-windows_i686_gnullvm@0.52.6		X						X					
-windows_i686_msvc@0.52.6		X						X					
-windows_x86_64_gnu@0.52.6		X						X					
-windows_x86_64_gnullvm@0.52.6		X						X					
-windows_x86_64_msvc@0.52.6		X						X					
-xml-rs@0.8.22								X					
-xmltree@0.10.3								X					
-zerocopy@0.7.35		X		X				X					
-zeroize@1.8.1		X						X					
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
+addr2line@0.24.2		X					X					
+adler2@2.0.0	X	X					X					
+aho-corasick@1.1.3							X				X	
+allocator-api2@0.2.18		X					X					
+android-tzdata@0.1.1		X					X					
+android_system_properties@0.1.5		X					X					
+anyhow@1.0.90		X					X					
+async-trait@0.1.83		X					X					
+autocfg@1.4.0		X					X					
+backon@1.2.0		X										
+backtrace@0.3.74		X					X					
+base64@0.21.7		X					X					
+base64@0.22.1		X					X					
+bitflags@2.6.0		X					X					
+block-buffer@0.10.4		X					X					
+bumpalo@3.16.0		X					X					
+bytes@1.7.2							X					
+cc@1.1.31		X					X					
+cfg-if@1.0.0		X					X					
+chrono@0.4.38		X					X					
+core-foundation-sys@0.8.7		X					X					
+cpufeatures@0.2.14		X					X					
+crypto-common@0.1.6		X					X					
+dav-server@0.7.0		X										
+dav-server-opendalfs@0.2.1		X										
+deranged@0.3.11		X					X					
+digest@0.10.7		X					X					
+equivalent@1.0.1		X					X					
+fastrand@2.1.1		X					X					
+flagset@0.4.6		X										
+fnv@1.0.7		X					X					
+foldhash@0.1.3												X
+form_urlencoded@1.2.1		X					X					
+futures@0.3.31		X					X					
+futures-channel@0.3.31		X					X					
+futures-core@0.3.31		X					X					
+futures-executor@0.3.31		X					X					
+futures-io@0.3.31		X					X					
+futures-macro@0.3.31		X					X					
+futures-sink@0.3.31		X					X					
+futures-task@0.3.31		X					X					
+futures-util@0.3.31		X					X					
+generic-array@0.14.7							X					
+getrandom@0.2.15		X					X					
+gimli@0.31.1		X					X					
+gloo-timers@0.3.0		X					X					
+hashbrown@0.15.0		X					X					
+headers@0.4.0							X					
+headers-core@0.3.0							X					
+hermit-abi@0.3.9		X					X					
+htmlescape@0.3.1		X					X	X				
+http@1.1.0		X					X					
+http-body@1.0.1							X					
+http-body-util@0.1.2							X					
+httparse@1.9.5		X					X					
+httpdate@1.0.3		X					X					
+hyper@1.5.0							X					
+hyper-rustls@0.27.3		X				X	X					
+hyper-util@0.1.9							X					
+iana-time-zone@0.1.61		X					X					
+iana-time-zone-haiku@0.1.2		X					X					
+idna@0.5.0		X					X					
+ipnet@2.10.1		X					X					
+itoa@1.0.11		X					X					
+js-sys@0.3.72		X					X					
+lazy_static@1.5.0		X					X					
+libc@0.2.161		X					X					
+lock_api@0.4.12		X					X					
+log@0.4.22		X					X					
+lru@0.12.5							X					
+md-5@0.10.6		X					X					
+memchr@2.7.4							X				X	
+mime@0.3.17		X					X					
+mime_guess@2.0.5							X					
+miniz_oxide@0.8.0		X					X					X
+mio@1.0.2							X					
+num-conv@0.1.0		X					X					
+num-traits@0.2.19		X					X					
+object@0.36.5		X					X					
+once_cell@1.20.2		X					X					
+opendal@0.50.1		X										
+parking_lot@0.12.3		X					X					
+parking_lot_core@0.9.10		X					X					
+percent-encoding@2.3.1		X					X					
+pin-project@1.1.6		X					X					
+pin-project-internal@1.1.6		X					X					
+pin-project-lite@0.2.14		X					X					
+pin-utils@0.1.0		X					X					
+powerfmt@0.2.0		X					X					
+proc-macro2@1.0.88		X					X					
+quick-xml@0.36.2							X					
+quote@1.0.37		X					X					
+redox_syscall@0.5.7							X					
+regex@1.11.0		X					X					
+regex-automata@0.4.8		X					X					
+regex-syntax@0.8.5		X					X					
+reqwest@0.12.8		X					X					
+ring@0.17.8									X			
+rustc-demangle@0.1.24		X					X					
+rustls@0.23.15		X				X	X					
+rustls-pemfile@2.2.0		X				X	X					
+rustls-pki-types@1.10.0		X					X					
+rustls-webpki@0.102.8						X						
+ryu@1.0.18		X			X							
+scopeguard@1.2.0		X					X					
+serde@1.0.210		X					X					
+serde_derive@1.0.210		X					X					
+serde_json@1.0.132		X					X					
+serde_urlencoded@0.7.1		X					X					
+sha1@0.10.6		X					X					
+shlex@1.3.0		X					X					
+slab@0.4.9							X					
+smallvec@1.13.2		X					X					
+socket2@0.5.7		X					X					
+spin@0.9.8							X					
+subtle@2.6.1				X								
+syn@2.0.81		X					X					
+sync_wrapper@1.0.1		X										
+time@0.3.36		X					X					
+time-core@0.1.2		X					X					
+time-macros@0.2.18		X					X					
+tinyvec@1.8.0		X					X					X
+tinyvec_macros@0.1.1		X					X					X
+tokio@1.40.0							X					
+tokio-macros@2.4.0							X					
+tokio-rustls@0.26.0		X					X					
+tokio-util@0.7.12							X					
+tower-service@0.3.3							X					
+tracing@0.1.40							X					
+tracing-core@0.1.32							X					
+try-lock@0.2.5							X					
+typenum@1.17.0		X					X					
+unicase@2.8.0		X					X					
+unicode-bidi@0.3.17		X					X					
+unicode-ident@1.0.13		X					X			X		
+unicode-normalization@0.1.24		X					X					
+untrusted@0.9.0						X						
+url@2.5.2		X					X					
+uuid@1.11.0		X					X					
+version_check@0.9.5		X					X					
+want@0.3.1							X					
+wasi@0.11.0+wasi-snapshot-preview1		X	X				X					
+wasm-bindgen@0.2.95		X					X					
+wasm-bindgen-backend@0.2.95		X					X					
+wasm-bindgen-futures@0.4.45		X					X					
+wasm-bindgen-macro@0.2.95		X					X					
+wasm-bindgen-macro-support@0.2.95		X					X					
+wasm-bindgen-shared@0.2.95		X					X					
+wasm-streams@0.4.1		X					X					
+web-sys@0.3.72		X					X					
+webpki-roots@0.26.6								X				
+windows-core@0.52.0		X					X					
+windows-registry@0.2.0		X					X					
+windows-result@0.2.0		X					X					
+windows-strings@0.1.0		X					X					
+windows-sys@0.52.0		X					X					
+windows-targets@0.52.6		X					X					
+windows_aarch64_gnullvm@0.52.6		X					X					
+windows_aarch64_msvc@0.52.6		X					X					
+windows_i686_gnu@0.52.6		X					X					
+windows_i686_gnullvm@0.52.6		X					X					
+windows_i686_msvc@0.52.6		X					X					
+windows_x86_64_gnu@0.52.6		X					X					
+windows_x86_64_gnullvm@0.52.6		X					X					
+windows_x86_64_msvc@0.52.6		X					X					
+xml-rs@0.8.22							X					
+xmltree@0.10.3							X					
+zeroize@1.8.1		X					X					

--- a/integrations/fuse3/Cargo.toml
+++ b/integrations/fuse3/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.0.7"
+version = "0.0.8"
 
 [dependencies]
 bytes = "1.6.0"

--- a/integrations/fuse3/DEPENDENCIES.rust.tsv
+++ b/integrations/fuse3/DEPENDENCIES.rust.tsv
@@ -1,12 +1,12 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X					X					
+addr2line@0.24.2		X					X					
 adler2@2.0.0	X	X					X					
 android-tzdata@0.1.1		X					X					
 android_system_properties@0.1.5		X					X					
-anyhow@1.0.87		X					X					
+anyhow@1.0.90		X					X					
 async-notify@0.3.0							X					
-async-trait@0.1.82		X					X					
-autocfg@1.3.0		X					X					
+async-trait@0.1.83		X					X					
+autocfg@1.4.0		X					X					
 backon@1.2.0		X										
 backtrace@0.3.74		X					X					
 base64@0.22.1		X					X					
@@ -14,16 +14,15 @@ bincode@1.3.3							X
 bitflags@2.6.0		X					X					
 block-buffer@0.10.4		X					X					
 bumpalo@3.16.0		X					X					
-bytes@1.7.1							X					
-cc@1.1.18		X					X					
+bytes@1.7.2							X					
+cc@1.1.31		X					X					
 cfg-if@1.0.0		X					X					
-cfg_aliases@0.1.1							X					
+cfg_aliases@0.2.1							X					
 chrono@0.4.38		X					X					
 concurrent-queue@2.5.0		X					X					
 core-foundation-sys@0.8.7		X					X					
 crossbeam-utils@0.8.20		X					X					
 crypto-common@0.1.6		X					X					
-cstr@0.2.12							X					
 digest@0.10.7		X					X					
 either@1.13.0		X					X					
 errno@0.3.9		X					X					
@@ -32,37 +31,37 @@ fastrand@2.1.1		X					X
 flagset@0.4.6		X										
 fnv@1.0.7		X					X					
 form_urlencoded@1.2.1		X					X					
-fuse3@0.7.2							X					
-fuse3_opendal@0.0.7		X										
-futures@0.3.30		X					X					
-futures-channel@0.3.30		X					X					
-futures-core@0.3.30		X					X					
-futures-io@0.3.30		X					X					
-futures-macro@0.3.30		X					X					
-futures-sink@0.3.30		X					X					
-futures-task@0.3.30		X					X					
-futures-util@0.3.30		X					X					
+fuse3@0.8.1							X					
+fuse3_opendal@0.0.8		X										
+futures@0.3.31		X					X					
+futures-channel@0.3.31		X					X					
+futures-core@0.3.31		X					X					
+futures-io@0.3.31		X					X					
+futures-macro@0.3.31		X					X					
+futures-sink@0.3.31		X					X					
+futures-task@0.3.31		X					X					
+futures-util@0.3.31		X					X					
 generic-array@0.14.7							X					
 getrandom@0.2.15		X					X					
-gimli@0.31.0		X					X					
+gimli@0.31.1		X					X					
 gloo-timers@0.3.0		X					X					
 hermit-abi@0.3.9		X					X					
 home@0.5.9		X					X					
 http@1.1.0		X					X					
 http-body@1.0.1							X					
 http-body-util@0.1.2							X					
-httparse@1.9.4		X					X					
-hyper@1.4.1							X					
+httparse@1.9.5		X					X					
+hyper@1.5.0							X					
 hyper-rustls@0.27.3		X				X	X					
-hyper-util@0.1.8							X					
-iana-time-zone@0.1.60		X					X					
+hyper-util@0.1.9							X					
+iana-time-zone@0.1.61		X					X					
 iana-time-zone-haiku@0.1.2		X					X					
 idna@0.5.0		X					X					
-ipnet@2.10.0		X					X					
+ipnet@2.10.1		X					X					
 itoa@1.0.11		X					X					
-js-sys@0.3.70		X					X					
+js-sys@0.3.72		X					X					
 lazy_static@1.5.0		X					X					
-libc@0.2.158		X					X					
+libc@0.2.161		X					X					
 linux-raw-sys@0.4.14		X	X				X					
 log@0.4.22		X					X					
 md-5@0.10.6		X					X					
@@ -71,32 +70,30 @@ memoffset@0.9.1							X
 mime@0.3.17		X					X					
 miniz_oxide@0.8.0		X					X					X
 mio@1.0.2							X					
-nix@0.28.0							X					
+nix@0.29.0							X					
 num-traits@0.2.19		X					X					
-object@0.36.4		X					X					
-once_cell@1.19.0		X					X					
-opendal@0.50.0		X										
+object@0.36.5		X					X					
+once_cell@1.20.2		X					X					
+opendal@0.50.1		X										
 parking@2.2.1		X					X					
 percent-encoding@2.3.1		X					X					
-pin-project@1.1.5		X					X					
-pin-project-internal@1.1.5		X					X					
 pin-project-lite@0.2.14		X					X					
 pin-utils@0.1.0		X					X					
-proc-macro2@1.0.86		X					X					
-quick-xml@0.36.1							X					
+proc-macro2@1.0.88		X					X					
+quick-xml@0.36.2							X					
 quote@1.0.37		X					X					
-reqwest@0.12.7		X					X					
+reqwest@0.12.8		X					X					
 ring@0.17.8									X			
 rustc-demangle@0.1.24		X					X					
-rustix@0.38.36		X	X				X					
-rustls@0.23.13		X				X	X					
-rustls-pemfile@2.1.3		X				X	X					
-rustls-pki-types@1.8.0		X					X					
+rustix@0.38.37		X	X				X					
+rustls@0.23.15		X				X	X					
+rustls-pemfile@2.2.0		X				X	X					
+rustls-pki-types@1.10.0		X					X					
 rustls-webpki@0.102.8						X						
 ryu@1.0.18		X			X							
 serde@1.0.210		X					X					
 serde_derive@1.0.210		X					X					
-serde_json@1.0.128		X					X					
+serde_json@1.0.132		X					X					
 serde_urlencoded@0.7.1		X					X					
 sharded-slab@0.1.7							X					
 shlex@1.3.0		X					X					
@@ -106,7 +103,7 @@ smallvec@1.13.2		X					X
 socket2@0.5.7		X					X					
 spin@0.9.8							X					
 subtle@2.6.1				X								
-syn@2.0.77		X					X					
+syn@2.0.81		X					X					
 sync_wrapper@1.0.1		X										
 tinyvec@1.8.0		X					X					X
 tinyvec_macros@0.1.1		X					X					X
@@ -114,8 +111,6 @@ tokio@1.40.0							X
 tokio-macros@2.4.0							X					
 tokio-rustls@0.26.0		X					X					
 tokio-util@0.7.12							X					
-tower@0.4.13							X					
-tower-layer@0.3.3							X					
 tower-service@0.3.3							X					
 tracing@0.1.40							X					
 tracing-attributes@0.1.27							X					
@@ -123,24 +118,24 @@ tracing-core@0.1.32							X
 trait-make@0.1.0		X					X					
 try-lock@0.2.5							X					
 typenum@1.17.0		X					X					
-unicode-bidi@0.3.15		X					X					
+unicode-bidi@0.3.17		X					X					
 unicode-ident@1.0.13		X					X			X		
-unicode-normalization@0.1.23		X					X					
+unicode-normalization@0.1.24		X					X					
 untrusted@0.9.0						X						
 url@2.5.2		X					X					
-uuid@1.10.0		X					X					
+uuid@1.11.0		X					X					
 version_check@0.9.5		X					X					
 want@0.3.1							X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X				X					
-wasm-bindgen@0.2.93		X					X					
-wasm-bindgen-backend@0.2.93		X					X					
-wasm-bindgen-futures@0.4.43		X					X					
-wasm-bindgen-macro@0.2.93		X					X					
-wasm-bindgen-macro-support@0.2.93		X					X					
-wasm-bindgen-shared@0.2.93		X					X					
-wasm-streams@0.4.0		X					X					
-web-sys@0.3.70		X					X					
-webpki-roots@0.26.5								X				
+wasm-bindgen@0.2.95		X					X					
+wasm-bindgen-backend@0.2.95		X					X					
+wasm-bindgen-futures@0.4.45		X					X					
+wasm-bindgen-macro@0.2.95		X					X					
+wasm-bindgen-macro-support@0.2.95		X					X					
+wasm-bindgen-shared@0.2.95		X					X					
+wasm-streams@0.4.1		X					X					
+web-sys@0.3.72		X					X					
+webpki-roots@0.26.6								X				
 which@6.0.3							X					
 windows-core@0.52.0		X					X					
 windows-registry@0.2.0		X					X					

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.48.0"
+version = "0.48.1"
 
 [features]
 send_wrapper = ["dep:send_wrapper"]

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -1,11 +1,11 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X						X					
+addr2line@0.24.2		X						X					
 adler2@2.0.0	X	X						X					
 android-tzdata@0.1.1		X						X					
 android_system_properties@0.1.5		X						X					
-anyhow@1.0.87		X						X					
-async-trait@0.1.82		X						X					
-autocfg@1.3.0		X						X					
+anyhow@1.0.90		X						X					
+async-trait@0.1.83		X						X					
+autocfg@1.4.0		X						X					
 backon@1.2.0		X											
 backtrace@0.3.74		X						X					
 base64@0.22.1		X						X					
@@ -13,8 +13,8 @@ bitflags@2.6.0		X						X
 block-buffer@0.10.4		X						X					
 bumpalo@3.16.0		X						X					
 byteorder@1.5.0								X				X	
-bytes@1.7.1								X					
-cc@1.1.18		X						X					
+bytes@1.7.2								X					
+cc@1.1.31		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 const-oid@0.9.6		X						X					
@@ -28,18 +28,18 @@ fastrand@2.1.1		X						X
 flagset@0.4.6		X											
 fnv@1.0.7		X						X					
 form_urlencoded@1.2.1		X						X					
-futures@0.3.30		X						X					
-futures-channel@0.3.30		X						X					
-futures-core@0.3.30		X						X					
-futures-executor@0.3.30		X						X					
-futures-io@0.3.30		X						X					
-futures-macro@0.3.30		X						X					
-futures-sink@0.3.30		X						X					
-futures-task@0.3.30		X						X					
-futures-util@0.3.30		X						X					
+futures@0.3.31		X						X					
+futures-channel@0.3.31		X						X					
+futures-core@0.3.31		X						X					
+futures-executor@0.3.31		X						X					
+futures-io@0.3.31		X						X					
+futures-macro@0.3.31		X						X					
+futures-sink@0.3.31		X						X					
+futures-task@0.3.31		X						X					
+futures-util@0.3.31		X						X					
 generic-array@0.14.7								X					
 getrandom@0.2.15		X						X					
-gimli@0.31.0		X						X					
+gimli@0.31.1		X						X					
 gloo-timers@0.3.0		X						X					
 heck@0.5.0		X						X					
 hermit-abi@0.3.9		X						X					
@@ -49,19 +49,19 @@ home@0.5.9		X						X
 http@1.1.0		X						X					
 http-body@1.0.1								X					
 http-body-util@0.1.2								X					
-httparse@1.9.4		X						X					
+httparse@1.9.5		X						X					
 humantime@2.1.0		X						X					
-hyper@1.4.1								X					
+hyper@1.5.0								X					
 hyper-rustls@0.27.3		X					X	X					
-hyper-util@0.1.8								X					
-iana-time-zone@0.1.60		X						X					
+hyper-util@0.1.9								X					
+iana-time-zone@0.1.61		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
-ipnet@2.10.0		X						X					
+ipnet@2.10.1		X						X					
 itertools@0.13.0		X						X					
 itoa@1.0.11		X						X					
-js-sys@0.3.70		X						X					
-libc@0.2.158		X						X					
+js-sys@0.3.72		X						X					
+libc@0.2.161		X						X					
 lock_api@0.4.12		X						X					
 log@0.4.22		X						X					
 md-5@0.10.6		X						X					
@@ -70,34 +70,34 @@ mime@0.3.17		X						X
 miniz_oxide@0.8.0		X						X					X
 mio@1.0.2								X					
 num-traits@0.2.19		X						X					
-object@0.36.4		X						X					
+object@0.36.5		X						X					
 object_store@0.11.0		X						X					
-object_store_opendal@0.48.0		X											
-once_cell@1.19.0		X						X					
-opendal@0.50.0		X											
+object_store_opendal@0.48.1		X											
+once_cell@1.20.2		X						X					
+opendal@0.50.1		X											
 parking_lot@0.12.3		X						X					
 parking_lot_core@0.9.10		X						X					
 percent-encoding@2.3.1		X						X					
-pin-project@1.1.5		X						X					
-pin-project-internal@1.1.5		X						X					
+pin-project@1.1.6		X						X					
+pin-project-internal@1.1.6		X						X					
 pin-project-lite@0.2.14		X						X					
 pin-utils@0.1.0		X						X					
 ppv-lite86@0.2.20		X						X					
-proc-macro2@1.0.86		X						X					
-quick-xml@0.36.1								X					
+proc-macro2@1.0.88		X						X					
+quick-xml@0.36.2								X					
 quote@1.0.37		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
-redox_syscall@0.5.3								X					
+redox_syscall@0.5.7								X					
 reqsign@0.16.0		X											
-reqwest@0.12.7		X						X					
+reqwest@0.12.8		X						X					
 ring@0.17.8										X			
 rustc-demangle@0.1.24		X						X					
 rustc_version@0.4.1		X						X					
-rustls@0.23.13		X					X	X					
-rustls-pemfile@2.1.3		X					X	X					
-rustls-pki-types@1.8.0		X						X					
+rustls@0.23.15		X					X	X					
+rustls-pemfile@2.2.0		X					X	X					
+rustls-pki-types@1.10.0		X						X					
 rustls-webpki@0.102.8							X						
 ryu@1.0.18		X				X							
 same-file@1.0.6								X				X	
@@ -105,19 +105,19 @@ scopeguard@1.2.0		X						X
 semver@1.0.23		X						X					
 serde@1.0.210		X						X					
 serde_derive@1.0.210		X						X					
-serde_json@1.0.128		X						X					
+serde_json@1.0.132		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
 sha2@0.10.8		X						X					
 shlex@1.3.0		X						X					
 slab@0.4.9								X					
 smallvec@1.13.2		X						X					
-snafu@0.8.4		X						X					
-snafu-derive@0.8.4		X						X					
+snafu@0.8.5		X						X					
+snafu-derive@0.8.5		X						X					
 socket2@0.5.7		X						X					
 spin@0.9.8								X					
 subtle@2.6.1					X								
-syn@2.0.77		X						X					
+syn@2.0.81		X						X					
 sync_wrapper@1.0.1		X											
 tinyvec@1.8.0		X						X					X
 tinyvec_macros@0.1.1		X						X					X
@@ -125,33 +125,31 @@ tokio@1.40.0								X
 tokio-macros@2.4.0								X					
 tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.12								X					
-tower@0.4.13								X					
-tower-layer@0.3.3								X					
 tower-service@0.3.3								X					
 tracing@0.1.40								X					
 tracing-attributes@0.1.27								X					
 tracing-core@0.1.32								X					
 try-lock@0.2.5								X					
 typenum@1.17.0		X						X					
-unicode-bidi@0.3.15		X						X					
+unicode-bidi@0.3.17		X						X					
 unicode-ident@1.0.13		X						X			X		
-unicode-normalization@0.1.23		X						X					
+unicode-normalization@0.1.24		X						X					
 untrusted@0.9.0							X						
 url@2.5.2		X						X					
-uuid@1.10.0		X						X					
+uuid@1.11.0		X						X					
 version_check@0.9.5		X						X					
 walkdir@2.5.0								X				X	
 want@0.3.1								X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
-wasm-bindgen@0.2.93		X						X					
-wasm-bindgen-backend@0.2.93		X						X					
-wasm-bindgen-futures@0.4.43		X						X					
-wasm-bindgen-macro@0.2.93		X						X					
-wasm-bindgen-macro-support@0.2.93		X						X					
-wasm-bindgen-shared@0.2.93		X						X					
-wasm-streams@0.4.0		X						X					
-web-sys@0.3.70		X						X					
-webpki-roots@0.26.5									X				
+wasm-bindgen@0.2.95		X						X					
+wasm-bindgen-backend@0.2.95		X						X					
+wasm-bindgen-futures@0.4.45		X						X					
+wasm-bindgen-macro@0.2.95		X						X					
+wasm-bindgen-macro-support@0.2.95		X						X					
+wasm-bindgen-shared@0.2.95		X						X					
+wasm-streams@0.4.1		X						X					
+web-sys@0.3.72		X						X					
+webpki-roots@0.26.6									X				
 winapi-util@0.1.9								X				X	
 windows-core@0.52.0		X						X					
 windows-registry@0.2.0		X						X					

--- a/integrations/parquet/Cargo.toml
+++ b/integrations/parquet/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 async-trait = "0.1"

--- a/integrations/parquet/DEPENDENCIES.rust.tsv
+++ b/integrations/parquet/DEPENDENCIES.rust.tsv
@@ -1,20 +1,20 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X					
+addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 ahash@0.8.11		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.87		X							X					
-arrow-array@53.0.0		X												
-arrow-buffer@53.0.0		X												
-arrow-cast@53.0.0		X												
-arrow-data@53.0.0		X												
-arrow-ipc@53.0.0		X												
-arrow-schema@53.0.0		X												
-arrow-select@53.0.0		X												
-async-trait@0.1.82		X							X					
+anyhow@1.0.90		X							X					
+arrow-array@53.1.0		X												
+arrow-buffer@53.1.0		X												
+arrow-cast@53.1.0		X												
+arrow-data@53.1.0		X												
+arrow-ipc@53.1.0		X												
+arrow-schema@53.1.0		X												
+arrow-select@53.1.0		X												
+async-trait@0.1.83		X							X					
 atoi@2.0.0									X					
-autocfg@1.3.0		X							X					
+autocfg@1.4.0		X							X					
 backon@1.2.0		X												
 backtrace@0.3.74		X							X					
 base64@0.22.1		X							X					
@@ -22,8 +22,8 @@ bitflags@1.3.2		X							X
 block-buffer@0.10.4		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.1									X					
-cc@1.1.18		X							X					
+bytes@1.7.2									X					
+cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 const-oid@0.9.6		X							X					
@@ -40,18 +40,18 @@ flagset@0.4.6		X
 flatbuffers@24.3.25		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.30		X							X					
-futures-channel@0.3.30		X							X					
-futures-core@0.3.30		X							X					
-futures-executor@0.3.30		X							X					
-futures-io@0.3.30		X							X					
-futures-macro@0.3.30		X							X					
-futures-sink@0.3.30		X							X					
-futures-task@0.3.30		X							X					
-futures-util@0.3.30		X							X					
+futures@0.3.31		X							X					
+futures-channel@0.3.31		X							X					
+futures-core@0.3.31		X							X					
+futures-executor@0.3.31		X							X					
+futures-io@0.3.31		X							X					
+futures-macro@0.3.31		X							X					
+futures-sink@0.3.31		X							X					
+futures-task@0.3.31		X							X					
+futures-util@0.3.31		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.0		X							X					
+gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 half@2.4.1		X							X					
 hashbrown@0.14.5		X							X					
@@ -62,24 +62,24 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.4		X							X					
-hyper@1.4.1									X					
+httparse@1.9.5		X							X					
+hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.8									X					
-iana-time-zone@0.1.60		X							X					
+hyper-util@0.1.9									X					
+iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
 integer-encoding@3.0.4									X					
-ipnet@2.10.0		X							X					
+ipnet@2.10.1		X							X					
 itoa@1.0.11		X							X					
-js-sys@0.3.70		X							X					
-lexical-core@0.8.5		X							X					
-lexical-parse-float@0.8.5		X							X					
-lexical-parse-integer@0.8.6		X							X					
-lexical-util@0.8.5		X							X					
-lexical-write-float@0.8.5		X							X					
-lexical-write-integer@0.8.5		X							X					
-libc@0.2.158		X							X					
+js-sys@0.3.72		X							X					
+lexical-core@1.0.2		X							X					
+lexical-parse-float@1.0.2		X							X					
+lexical-parse-integer@1.0.2		X							X					
+lexical-util@1.0.3		X							X					
+lexical-write-float@1.0.2		X							X					
+lexical-write-integer@1.0.2		X							X					
+libc@0.2.161		X							X					
 libm@0.2.8		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
@@ -94,40 +94,38 @@ num-integer@0.1.46		X							X
 num-iter@0.1.45		X							X					
 num-rational@0.4.2		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.4		X							X					
-once_cell@1.19.0		X							X					
-opendal@0.50.0		X												
+object@0.36.5		X							X					
+once_cell@1.20.2		X							X					
+opendal@0.50.1		X												
 ordered-float@2.10.1									X					
-parquet@53.0.0		X												
-parquet_opendal@0.2.0		X												
+parquet@53.1.0		X												
+parquet_opendal@0.2.1		X												
 paste@1.0.15		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.5		X							X					
-pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.86		X							X					
-quick-xml@0.36.1									X					
+proc-macro2@1.0.88		X							X					
+quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 reqsign@0.16.0		X												
-reqwest@0.12.7		X							X					
+reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.13		X						X	X					
-rustls-pemfile@2.1.3		X						X	X					
-rustls-pki-types@1.8.0		X							X					
+rustls@0.23.15		X						X	X					
+rustls-pemfile@2.2.0		X						X	X					
+rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 semver@1.0.23		X							X					
 seq-macro@0.3.5		X							X					
 serde@1.0.210		X							X					
 serde_derive@1.0.210		X							X					
-serde_json@1.0.128		X							X					
+serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -138,7 +136,7 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 static_assertions@1.1.0		X							X					
 subtle@2.6.1					X									
-syn@2.0.77		X							X					
+syn@2.0.81		X							X					
 sync_wrapper@1.0.1		X												
 thrift@0.17.0		X												
 tiny-keccak@2.0.2							X							
@@ -148,32 +146,30 @@ tokio@1.40.0									X
 tokio-macros@2.4.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
-tower@0.4.13									X					
-tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-core@0.1.32									X					
 try-lock@0.2.5									X					
 twox-hash@1.6.3									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.15		X							X					
+unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.23		X							X					
+unicode-normalization@0.1.24		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.10.0		X							X					
+uuid@1.11.0		X							X					
 version_check@0.9.5		X							X					
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.93		X							X					
-wasm-bindgen-backend@0.2.93		X							X					
-wasm-bindgen-futures@0.4.43		X							X					
-wasm-bindgen-macro@0.2.93		X							X					
-wasm-bindgen-macro-support@0.2.93		X							X					
-wasm-bindgen-shared@0.2.93		X							X					
-wasm-streams@0.4.0		X							X					
-web-sys@0.3.70		X							X					
-webpki-roots@0.26.5										X				
+wasm-bindgen@0.2.95		X							X					
+wasm-bindgen-backend@0.2.95		X							X					
+wasm-bindgen-futures@0.4.45		X							X					
+wasm-bindgen-macro@0.2.95		X							X					
+wasm-bindgen-macro-support@0.2.95		X							X					
+wasm-bindgen-shared@0.2.95		X							X					
+wasm-streams@0.4.1		X							X					
+web-sys@0.3.72		X							X					
+webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					
 windows-result@0.2.0		X							X					

--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 name = "unftp-sbe-opendal"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.0.7"
+version = "0.0.8"
 
 [dependencies]
 async-trait = "0.1.80"

--- a/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
+++ b/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
@@ -1,27 +1,27 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MIT-0	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X							X						
+addr2line@0.24.2		X							X						
 adler2@2.0.0	X	X							X						
 android-tzdata@0.1.1		X							X						
 android_system_properties@0.1.5		X							X						
-anyhow@1.0.87		X							X						
+anyhow@1.0.90		X							X						
 arc-swap@1.7.1		X							X						
 asn1-rs@0.6.2		X							X						
 asn1-rs-derive@0.5.1		X							X						
 asn1-rs-impl@0.2.0		X							X						
-async-trait@0.1.82		X							X						
-autocfg@1.3.0		X							X						
-aws-lc-rs@1.9.0		X						X							
-aws-lc-sys@0.21.1		X						X				X			
+async-trait@0.1.83		X							X						
+autocfg@1.4.0		X							X						
+aws-lc-rs@1.10.0		X						X							
+aws-lc-sys@0.22.0		X						X				X			
 backon@1.2.0		X													
 backtrace@0.3.74		X							X						
 base64@0.22.1		X							X						
-bindgen@0.69.4					X										
+bindgen@0.69.5					X										
 bitflags@2.6.0		X							X						
 block-buffer@0.10.4		X							X						
 bumpalo@3.16.0		X							X						
 byteorder@1.5.0									X					X	
-bytes@1.7.1									X						
-cc@1.1.18		X							X						
+bytes@1.7.2									X						
+cc@1.1.31		X							X						
 cexpr@0.6.0		X							X						
 cfg-if@1.0.0		X							X						
 cfg_aliases@0.2.1									X						
@@ -53,17 +53,17 @@ flagset@0.4.6		X
 fnv@1.0.7		X							X						
 form_urlencoded@1.2.1		X							X						
 fs_extra@1.3.0									X						
-futures@0.3.30		X							X						
-futures-channel@0.3.30		X							X						
-futures-core@0.3.30		X							X						
-futures-io@0.3.30		X							X						
-futures-macro@0.3.30		X							X						
-futures-sink@0.3.30		X							X						
-futures-task@0.3.30		X							X						
-futures-util@0.3.30		X							X						
+futures@0.3.31		X							X						
+futures-channel@0.3.31		X							X						
+futures-core@0.3.31		X							X						
+futures-io@0.3.31		X							X						
+futures-macro@0.3.31		X							X						
+futures-sink@0.3.31		X							X						
+futures-task@0.3.31		X							X						
+futures-util@0.3.31		X							X						
 generic-array@0.14.7									X						
 getrandom@0.2.15		X							X						
-gimli@0.31.0		X							X						
+gimli@0.31.1		X							X						
 glob@0.3.1		X							X						
 gloo-timers@0.3.0		X							X						
 hashbrown@0.14.5		X							X						
@@ -74,21 +74,21 @@ home@0.5.9		X							X
 http@1.1.0		X							X						
 http-body@1.0.1									X						
 http-body-util@0.1.2									X						
-httparse@1.9.4		X							X						
-hyper@1.4.1									X						
+httparse@1.9.5		X							X						
+hyper@1.5.0									X						
 hyper-rustls@0.27.3		X						X	X						
-hyper-util@0.1.8									X						
-iana-time-zone@0.1.60		X							X						
+hyper-util@0.1.9									X						
+iana-time-zone@0.1.61		X							X						
 iana-time-zone-haiku@0.1.2		X							X						
 idna@0.5.0		X							X						
-ipnet@2.10.0		X							X						
+ipnet@2.10.1		X							X						
 itertools@0.12.1		X							X						
 itoa@1.0.11		X							X						
 jobserver@0.1.32		X							X						
-js-sys@0.3.70		X							X						
+js-sys@0.3.72		X							X						
 lazy_static@1.5.0		X							X						
 lazycell@1.3.0		X							X						
-libc@0.2.158		X							X						
+libc@0.2.161		X							X						
 libloading@0.8.5								X							
 libunftp@0.20.1		X													
 linux-raw-sys@0.4.14		X	X						X						
@@ -108,51 +108,49 @@ num-bigint@0.4.6		X							X
 num-conv@0.1.0		X							X						
 num-integer@0.1.46		X							X						
 num-traits@0.2.19		X							X						
-object@0.36.4		X							X						
+object@0.36.5		X							X						
 oid-registry@0.7.1		X							X						
-once_cell@1.19.0		X							X						
-opendal@0.50.0		X													
+once_cell@1.20.2		X							X						
+opendal@0.50.1		X													
 parking_lot@0.12.3		X							X						
 parking_lot_core@0.9.10		X							X						
 paste@1.0.15		X							X						
 percent-encoding@2.3.1		X							X						
-pin-project@1.1.5		X							X						
-pin-project-internal@1.1.5		X							X						
 pin-project-lite@0.2.14		X							X						
 pin-utils@0.1.0		X							X						
 powerfmt@0.2.0		X							X						
 ppv-lite86@0.2.20		X							X						
-prettyplease@0.2.22		X							X						
-proc-macro2@1.0.86		X							X						
+prettyplease@0.2.24		X							X						
+proc-macro2@1.0.88		X							X						
 prometheus@0.13.4		X													
 proxy-protocol@0.5.0		X							X						
-quick-xml@0.36.1									X						
+quick-xml@0.36.2									X						
 quote@1.0.37		X							X						
 rand@0.8.5		X							X						
 rand_chacha@0.3.1		X							X						
 rand_core@0.6.4		X							X						
-redox_syscall@0.5.3									X						
-regex@1.10.6		X							X						
-regex-automata@0.4.7		X							X						
-regex-syntax@0.8.4		X							X						
+redox_syscall@0.5.7									X						
+regex@1.11.0		X							X						
+regex-automata@0.4.8		X							X						
+regex-syntax@0.8.5		X							X						
 reqsign@0.16.0		X													
-reqwest@0.12.7		X							X						
+reqwest@0.12.8		X							X						
 ring@0.17.8												X			
 rustc-demangle@0.1.24		X							X						
 rustc-hash@1.1.0		X							X						
 rustc_version@0.4.1		X							X						
 rusticata-macros@4.1.0		X							X						
-rustix@0.38.36		X	X						X						
-rustls@0.23.13		X						X	X						
-rustls-pemfile@2.1.3		X						X	X						
-rustls-pki-types@1.8.0		X							X						
+rustix@0.38.37		X	X						X						
+rustls@0.23.15		X						X	X						
+rustls-pemfile@2.2.0		X						X	X						
+rustls-pki-types@1.10.0		X							X						
 rustls-webpki@0.102.8								X							
 ryu@1.0.18		X				X									
 scopeguard@1.2.0		X							X						
 semver@1.0.23		X							X						
 serde@1.0.210		X							X						
 serde_derive@1.0.210		X							X						
-serde_json@1.0.128		X							X						
+serde_json@1.0.132		X							X						
 serde_urlencoded@0.7.1		X							X						
 sha1@0.10.6		X							X						
 sha2@0.10.8		X							X						
@@ -169,12 +167,12 @@ socket2@0.5.7		X							X
 spin@0.9.8									X						
 subtle@2.6.1					X										
 syn@1.0.109		X							X						
-syn@2.0.77		X							X						
+syn@2.0.81		X							X						
 sync_wrapper@1.0.1		X													
 synstructure@0.13.1									X						
 tagptr@0.2.0		X							X						
-thiserror@1.0.63		X							X						
-thiserror-impl@1.0.63		X							X						
+thiserror@1.0.64		X							X						
+thiserror-impl@1.0.64		X							X						
 time@0.3.36		X							X						
 time-core@0.1.2		X							X						
 time-macros@0.2.18		X							X						
@@ -184,8 +182,6 @@ tokio@1.40.0									X
 tokio-macros@2.4.0									X						
 tokio-rustls@0.26.0		X							X						
 tokio-util@0.7.12									X						
-tower@0.4.13									X						
-tower-layer@0.3.3									X						
 tower-service@0.3.3									X						
 tracing@0.1.40									X						
 tracing-attributes@0.1.27									X						
@@ -193,25 +189,25 @@ tracing-core@0.1.32									X
 triomphe@0.1.11		X							X						
 try-lock@0.2.5									X						
 typenum@1.17.0		X							X						
-unftp-sbe-opendal@0.0.7		X													
-unicode-bidi@0.3.15		X							X						
+unftp-sbe-opendal@0.0.8		X													
+unicode-bidi@0.3.17		X							X						
 unicode-ident@1.0.13		X							X				X		
-unicode-normalization@0.1.23		X							X						
+unicode-normalization@0.1.24		X							X						
 untrusted@0.9.0								X							
 url@2.5.2		X							X						
-uuid@1.10.0		X							X						
+uuid@1.11.0		X							X						
 version_check@0.9.5		X							X						
 want@0.3.1									X						
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X						
-wasm-bindgen@0.2.93		X							X						
-wasm-bindgen-backend@0.2.93		X							X						
-wasm-bindgen-futures@0.4.43		X							X						
-wasm-bindgen-macro@0.2.93		X							X						
-wasm-bindgen-macro-support@0.2.93		X							X						
-wasm-bindgen-shared@0.2.93		X							X						
-wasm-streams@0.4.0		X							X						
-web-sys@0.3.70		X							X						
-webpki-roots@0.26.5											X				
+wasm-bindgen@0.2.95		X							X						
+wasm-bindgen-backend@0.2.95		X							X						
+wasm-bindgen-futures@0.4.45		X							X						
+wasm-bindgen-macro@0.2.95		X							X						
+wasm-bindgen-macro-support@0.2.95		X							X						
+wasm-bindgen-shared@0.2.95		X							X						
+wasm-streams@0.4.1		X							X						
+web-sys@0.3.72		X							X						
+webpki-roots@0.26.6											X				
 which@4.4.2									X						
 windows-core@0.52.0		X							X						
 windows-registry@0.2.0		X							X						

--- a/integrations/virtiofs/DEPENDENCIES.rust.tsv
+++ b/integrations/virtiofs/DEPENDENCIES.rust.tsv
@@ -1,12 +1,12 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.1		X					X					
+addr2line@0.24.2		X					X					
 adler2@2.0.0	X	X					X					
 android-tzdata@0.1.1		X					X					
 android_system_properties@0.1.5		X					X					
-anyhow@1.0.87		X					X					
+anyhow@1.0.90		X					X					
 arc-swap@1.7.1		X					X					
-async-trait@0.1.82		X					X					
-autocfg@1.3.0		X					X					
+async-trait@0.1.83		X					X					
+autocfg@1.4.0		X					X					
 backon@1.2.0		X										
 backtrace@0.3.74		X					X					
 base64@0.22.1		X					X					
@@ -14,8 +14,8 @@ bitflags@1.3.2		X					X
 bitflags@2.6.0		X					X					
 block-buffer@0.10.4		X					X					
 bumpalo@3.16.0		X					X					
-bytes@1.7.1							X					
-cc@1.1.18		X					X					
+bytes@1.7.2							X					
+cc@1.1.31		X					X					
 cfg-if@1.0.0		X					X					
 chrono@0.4.38		X					X					
 core-foundation-sys@0.8.7		X					X					
@@ -25,35 +25,35 @@ fastrand@2.1.1		X					X
 flagset@0.4.6		X										
 fnv@1.0.7		X					X					
 form_urlencoded@1.2.1		X					X					
-futures@0.3.30		X					X					
-futures-channel@0.3.30		X					X					
-futures-core@0.3.30		X					X					
-futures-io@0.3.30		X					X					
-futures-macro@0.3.30		X					X					
-futures-sink@0.3.30		X					X					
-futures-task@0.3.30		X					X					
-futures-util@0.3.30		X					X					
+futures@0.3.31		X					X					
+futures-channel@0.3.31		X					X					
+futures-core@0.3.31		X					X					
+futures-io@0.3.31		X					X					
+futures-macro@0.3.31		X					X					
+futures-sink@0.3.31		X					X					
+futures-task@0.3.31		X					X					
+futures-util@0.3.31		X					X					
 generic-array@0.14.7							X					
 getrandom@0.2.15		X					X					
-gimli@0.31.0		X					X					
+gimli@0.31.1		X					X					
 gloo-timers@0.3.0		X					X					
 heck@0.5.0		X					X					
 hermit-abi@0.3.9		X					X					
 http@1.1.0		X					X					
 http-body@1.0.1							X					
 http-body-util@0.1.2							X					
-httparse@1.9.4		X					X					
-hyper@1.4.1							X					
+httparse@1.9.5		X					X					
+hyper@1.5.0							X					
 hyper-rustls@0.27.3		X				X	X					
-hyper-util@0.1.8							X					
-iana-time-zone@0.1.60		X					X					
+hyper-util@0.1.9							X					
+iana-time-zone@0.1.61		X					X					
 iana-time-zone-haiku@0.1.2		X					X					
 idna@0.5.0		X					X					
-ipnet@2.10.0		X					X					
+ipnet@2.10.1		X					X					
 itoa@1.0.11		X					X					
-js-sys@0.3.70		X					X					
+js-sys@0.3.72		X					X					
 lazy_static@1.5.0		X					X					
-libc@0.2.158		X					X					
+libc@0.2.161		X					X					
 log@0.4.22		X					X					
 md-5@0.10.6		X					X					
 memchr@2.7.4							X				X	
@@ -61,60 +61,56 @@ mime@0.3.17		X					X
 miniz_oxide@0.8.0		X					X					X
 mio@1.0.2							X					
 num-traits@0.2.19		X					X					
-object@0.36.4		X					X					
-once_cell@1.19.0		X					X					
-opendal@0.50.0		X										
+object@0.36.5		X					X					
+once_cell@1.20.2		X					X					
+opendal@0.50.1		X										
 percent-encoding@2.3.1		X					X					
-pin-project@1.1.5		X					X					
-pin-project-internal@1.1.5		X					X					
 pin-project-lite@0.2.14		X					X					
 pin-utils@0.1.0		X					X					
-proc-macro2@1.0.86		X					X					
-quick-xml@0.36.1							X					
+proc-macro2@1.0.88		X					X					
+quick-xml@0.36.2							X					
 quote@1.0.37		X					X					
-reqwest@0.12.7		X					X					
+reqwest@0.12.8		X					X					
 ring@0.17.8									X			
 rustc-demangle@0.1.24		X					X					
-rustls@0.23.13		X				X	X					
-rustls-pemfile@2.1.3		X				X	X					
-rustls-pki-types@1.8.0		X					X					
+rustls@0.23.15		X				X	X					
+rustls-pemfile@2.2.0		X				X	X					
+rustls-pki-types@1.10.0		X					X					
 rustls-webpki@0.102.8						X						
 ryu@1.0.18		X			X							
 serde@1.0.210		X					X					
 serde_derive@1.0.210		X					X					
-serde_json@1.0.128		X					X					
+serde_json@1.0.132		X					X					
 serde_urlencoded@0.7.1		X					X					
 sharded-slab@0.1.7							X					
 shlex@1.3.0		X					X					
 slab@0.4.9							X					
 smallvec@1.13.2		X					X					
-snafu@0.8.4		X					X					
-snafu-derive@0.8.4		X					X					
+snafu@0.8.5		X					X					
+snafu-derive@0.8.5		X					X					
 socket2@0.5.7		X					X					
 spin@0.9.8							X					
 subtle@2.6.1				X								
-syn@2.0.77		X					X					
+syn@2.0.81		X					X					
 sync_wrapper@1.0.1		X										
-thiserror@1.0.63		X					X					
-thiserror-impl@1.0.63		X					X					
+thiserror@1.0.64		X					X					
+thiserror-impl@1.0.64		X					X					
 tinyvec@1.8.0		X					X					X
 tinyvec_macros@0.1.1		X					X					X
 tokio@1.40.0							X					
 tokio-rustls@0.26.0		X					X					
 tokio-util@0.7.12							X					
-tower@0.4.13							X					
-tower-layer@0.3.3							X					
 tower-service@0.3.3							X					
 tracing@0.1.40							X					
 tracing-core@0.1.32							X					
 try-lock@0.2.5							X					
 typenum@1.17.0		X					X					
-unicode-bidi@0.3.15		X					X					
+unicode-bidi@0.3.17		X					X					
 unicode-ident@1.0.13		X					X			X		
-unicode-normalization@0.1.23		X					X					
+unicode-normalization@0.1.24		X					X					
 untrusted@0.9.0						X						
 url@2.5.2		X					X					
-uuid@1.10.0		X					X					
+uuid@1.11.0		X					X					
 version_check@0.9.5		X					X					
 vhost@0.10.0		X		X								
 vhost-user-backend@0.13.1		X										
@@ -125,15 +121,15 @@ vm-memory@0.14.1		X		X
 vmm-sys-util@0.12.1				X								
 want@0.3.1							X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X				X					
-wasm-bindgen@0.2.93		X					X					
-wasm-bindgen-backend@0.2.93		X					X					
-wasm-bindgen-futures@0.4.43		X					X					
-wasm-bindgen-macro@0.2.93		X					X					
-wasm-bindgen-macro-support@0.2.93		X					X					
-wasm-bindgen-shared@0.2.93		X					X					
-wasm-streams@0.4.0		X					X					
-web-sys@0.3.70		X					X					
-webpki-roots@0.26.5								X				
+wasm-bindgen@0.2.95		X					X					
+wasm-bindgen-backend@0.2.95		X					X					
+wasm-bindgen-futures@0.4.45		X					X					
+wasm-bindgen-macro@0.2.95		X					X					
+wasm-bindgen-macro-support@0.2.95		X					X					
+wasm-bindgen-shared@0.2.95		X					X					
+wasm-streams@0.4.1		X					X					
+web-sys@0.3.72		X					X					
+webpki-roots@0.26.6								X				
 winapi@0.3.9		X					X					
 winapi-i686-pc-windows-gnu@0.4.0		X					X					
 winapi-x86_64-pc-windows-gnu@0.4.0		X					X					


### PR DESCRIPTION
# Which issue does this PR close?

part of https://github.com/apache/opendal/issues/5203

# What changes are included in this PR?

| Name                      | Version | Next    |
| -                         | -       | -       |
| core                      | 0.50.0  | 0.50.1  |
| integrations/cloud_filter | 0.0.1   | 0.0.2   |
| integrations/compat       | -       | 1.0.0   |
| integrations/dav-server   | 0.2.0   | 0.2.1   |
| integrations/fuse3        | 0.0.7   | 0.0.8   |
| integrations/object_store | 0.48.0  | 0.48.1  |
| integrations/parquet      | 0.2.0   | 0.2.1   |
| integrations/spring       | -       | -       |
| integrations/unftp-sbe    | 0.0.7   | 0.0.8   |
| integrations/virtiofs     | -       | -       |
| bin/oay                   | 0.41.11 | 0.41.12 |
| bin/ofs                   | 0.0.12  | 0.0.13  |
| bin/oli                   | 0.41.11 | 0.41.12 |
| bindings/c                | 0.44.13 | 0.45.0 |
| bindings/cpp              | 0.45.11 | 0.45.12 |
| bindings/dotnet           | 0.1.9   | 0.1.10  |
| bindings/go               | 0.1.3   | 0.1.4   |
| bindings/haskell          | 0.44.11 | 0.44.12 |
| bindings/java             | 0.47.3  | 0.47.4  |
| bindings/lua              | 0.1.9   | 0.1.10  |
| bindings/nodejs           | 0.47.5  | 0.47.6  |
| bindings/ocaml            | -       | -       |
| bindings/php              | 0.1.9   | 0.1.10  |
| bindings/python           | 0.45.10 | 0.45.11 |
| bindings/ruby             | 0.1.9   | 0.1.10  |
| bindings/swift            | -       | -       |
| bindings/zig              | -       | -       |
