### PR TITLE
ci(asf): Don't add `[DISCUSS]` prefix for discussion

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,14 +39,14 @@ github:
     gh-pages:
       whatever: Just a placeholder to make it take effects
   custom_subjects:
-    new_discussion: "[DISCUSS] {title}"
-    edit_discussion: "Re: [DISCUSS] {title}"
-    close_discussion: "Re: [DISCUSS] {title}"
-    close_discussion_with_comment: "Re: [DISCUSS] {title}"
-    reopen_discussion: "Re: [DISCUSS] {title}"
-    new_comment_discussion: "Re: [DISCUSS] {title}"
-    edit_comment_discussion: "Re: [DISCUSS] {title}"
-    delete_comment_discussion: "Re: [DISCUSS] {title}"
+    new_discussion: "{title}"
+    edit_discussion: "Re: {title}"
+    close_discussion: "Re: {title}"
+    close_discussion_with_comment: "Re: {title}"
+    reopen_discussion: "Re: {title}"
+    new_comment_discussion: "Re: {title}"
+    edit_comment_discussion: "Re: {title}"
+    delete_comment_discussion: "Re: {title}"
 
 notifications:
   commits: commits@opendal.apache.org


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

Remove the `[DISCUSS]` prefix so that we can start voting like normal.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
