### PR TITLE
feat(services/ftp): List dir shows last modified timestamp

### DIFF
--- a/core/src/services/ftp/lister.rs
+++ b/core/src/services/ftp/lister.rs
@@ -49,17 +49,22 @@ impl oio::List for FtpLister {
 
         let path = self.path.to_string() + de.name();
 
-        let entry = if de.is_file() {
-            oio::Entry::new(
-                &path,
-                Metadata::new(EntryMode::FILE)
-                    .with_content_length(de.size() as u64)
-                    .with_last_modified(de.modified().into()),
-            )
+        let mut meta = if de.is_file() {
+            Metadata::new(EntryMode::FILE)
         } else if de.is_directory() {
-            oio::Entry::new(&format!("{}/", &path), Metadata::new(EntryMode::DIR))
+            Metadata::new(EntryMode::DIR)
         } else {
-            oio::Entry::new(&path, Metadata::new(EntryMode::Unknown))
+            Metadata::new(EntryMode::Unknown)
+        };
+        meta.set_content_length(de.size() as u64);
+        meta.set_last_modified(de.modified().into());
+
+        let entry = if de.is_file() {
+            oio::Entry::new(&path, meta)
+        } else if de.is_directory() {
+            oio::Entry::new(&format!("{}/", &path), meta)
+        } else {
+            oio::Entry::new(&path, meta)
         };
 
         Ok(Some(entry))


### PR DESCRIPTION
# Which issue does this PR close?

Part of #4746.

# What changes are included in this PR?

ftp service will also return last modified timestamp.

# Are there any user-facing changes?

Nope.

# Questions

I found other problems that I want to change but they are not part of the issue.

1. I also found the underlying crate `suppaftp` supports async. I want to support it. This might be a breaking change for FTP service. Do you consider support async for ftp?

2. I also see sftp implementation uses another crate `openssh_sftp_client`. I have skimmed through these crates documentation and code. I don't want to expand this comparasion too much. In short, `suppaftp` depends tls implementation in Rust while `openssh_sftp_client` depends on OpenSSH. `suppaftp` has slightly less code. I am considering using `suppaftp` if that fulfill the current implementation. Happy to discuss more.

3. I tested this locally by using a FTP server in Docker. Roughly put, how much tests do you consider to have and where to start?