### PR TITLE
build: enable services-mysql for Java and Python bindings

### DIFF
--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -73,8 +73,7 @@ services-all = [
   "services-persy",
   "services-postgresql",
   "services-koofr",
-  # Workaround for https://github.com/apache/opendal/issues/5000
-  # "services-mysql",
+  "services-mysql",
   "services-redb",
   "services-redis",
   # FIXME: rocksdb will lead to "cannot allocate memory in static TLS block" while linking.

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -69,8 +69,7 @@ services-all = [
   "services-onedrive",
   "services-persy",
   "services-postgresql",
-  # Workaround for https://github.com/apache/opendal/issues/5000
-  # "services-mysql",
+  "services-mysql",
   "services-redb",
   "services-redis",
   # FIXME how to support rocksdb services in bindings?


### PR DESCRIPTION
Follow up https://github.com/apache/opendal/issues/5000 and https://github.com/apache/opendal/pull/5013

We're now using sqlx so that as long as services-postgres works, MySQL may be fine.