### PR TITLE
fix(integrations/compat): Capability has different fields

### DIFF
--- a/integrations/compat/Cargo.toml
+++ b/integrations/compat/Cargo.toml
@@ -34,3 +34,6 @@ v0_50_to_v0_49 = ["dep:opendal_v0_49", "dep:opendal_v0_50"]
 async-trait = "0.1"
 opendal_v0_49 = { package = "opendal", version = "0.49", optional = true }
 opendal_v0_50 = { package = "opendal", version = "0.50", optional = true, path = "../../core" }
+
+[dev-dependencies]
+tokio = { version = "1.41", features = ["full"] }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/opendal/issues/5235

# Rationale for this change

opendal v0.50's `Capability` has a new field called `write_with_if_none_match`, we can't transmute it.

# What changes are included in this PR?

Add convert between `Capability`.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
