### PR TITLE
refactor(core/raw): adjust setter methods of `AccessorInfo`

### DIFF
--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -176,7 +176,7 @@ impl<A: Access> LayeredAccess for BlockingAccessor<A> {
     fn metadata(&self) -> Arc<AccessorInfo> {
         let info = self.inner.info().as_ref().clone();
         let cap = info.full_capability();
-        info.set_full_capability(Capability {
+        info.with_full_capability(Capability {
             blocking: true,
             ..cap
         })

--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -174,9 +174,13 @@ impl<A: Access> LayeredAccess for BlockingAccessor<A> {
     }
 
     fn metadata(&self) -> Arc<AccessorInfo> {
-        let mut meta = self.inner.info().as_ref().clone();
-        meta.full_capability_mut().blocking = true;
-        meta.into()
+        let info = self.inner.info().as_ref().clone();
+        let cap = info.full_capability();
+        info.set_full_capability(Capability {
+            blocking: true,
+            ..cap
+        })
+        .into()
     }
 
     async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -380,7 +380,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     fn metadata(&self) -> Arc<AccessorInfo> {
         let info = (*self.meta).clone();
         let cap = info.full_capability();
-        info.set_full_capability(Capability {
+        info.with_full_capability(Capability {
             create_dir: cap.list && cap.write_can_empty,
             ..cap
         })
@@ -730,7 +730,7 @@ mod tests {
 
         fn info(&self) -> Arc<AccessorInfo> {
             AccessorInfo::default()
-                .set_native_capability(self.capability)
+                .with_native_capability(self.capability)
                 .into()
         }
 

--- a/core/src/layers/immutable_index.rs
+++ b/core/src/layers/immutable_index.rs
@@ -152,7 +152,7 @@ impl<A: Access> LayeredAccess for ImmutableIndexAccessor<A> {
     fn metadata(&self) -> Arc<AccessorInfo> {
         let info = (*self.inner.info()).clone();
         let cap = info.full_capability();
-        info.set_full_capability(Capability {
+        info.with_full_capability(Capability {
             list: true,
             list_with_recursive: true,
             ..cap

--- a/core/src/layers/immutable_index.rs
+++ b/core/src/layers/immutable_index.rs
@@ -150,13 +150,14 @@ impl<A: Access> LayeredAccess for ImmutableIndexAccessor<A> {
 
     /// Add list capabilities for underlying storage services.
     fn metadata(&self) -> Arc<AccessorInfo> {
-        let mut meta = (*self.inner.info()).clone();
-
-        let cap = meta.full_capability_mut();
-        cap.list = true;
-        cap.list_with_recursive = true;
-
-        meta.into()
+        let info = (*self.inner.info()).clone();
+        let cap = info.full_capability();
+        info.set_full_capability(Capability {
+            list: true,
+            list_with_recursive: true,
+            ..cap
+        })
+        .into()
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -799,7 +799,7 @@ mod tests {
 
         fn info(&self) -> Arc<AccessorInfo> {
             AccessorInfo::default()
-                .set_native_capability(Capability {
+                .with_native_capability(Capability {
                     read: true,
                     write: true,
                     write_can_multi: true,

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -798,19 +798,18 @@ mod tests {
         type BlockingLister = ();
 
         fn info(&self) -> Arc<AccessorInfo> {
-            let mut am = AccessorInfo::default();
-            am.set_native_capability(Capability {
-                read: true,
-                write: true,
-                write_can_multi: true,
-                stat: true,
-                list: true,
-                list_with_recursive: true,
-                batch: true,
-                ..Default::default()
-            });
-
-            am.into()
+            AccessorInfo::default()
+                .set_native_capability(Capability {
+                    read: true,
+                    write: true,
+                    write_can_multi: true,
+                    stat: true,
+                    list: true,
+                    list_with_recursive: true,
+                    batch: true,
+                    ..Default::default()
+                })
+                .into()
         }
 
         async fn stat(&self, _: &str, _: OpStat) -> Result<RpStat> {

--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -410,14 +410,13 @@ mod tests {
         type BlockingLister = ();
 
         fn info(&self) -> Arc<AccessorInfo> {
-            let mut am = AccessorInfo::default();
-            am.set_native_capability(Capability {
-                read: true,
-                delete: true,
-                ..Default::default()
-            });
-
-            am.into()
+            AccessorInfo::default()
+                .set_native_capability(Capability {
+                    read: true,
+                    delete: true,
+                    ..Default::default()
+                })
+                .into()
         }
 
         /// This function will build a reader that always return pending.

--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -411,7 +411,7 @@ mod tests {
 
         fn info(&self) -> Arc<AccessorInfo> {
             AccessorInfo::default()
-                .set_native_capability(Capability {
+                .with_native_capability(Capability {
                     read: true,
                     delete: true,
                     ..Default::default()

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -76,7 +76,7 @@ pub trait Access: Send + Sync + Debug + Unpin + 'static {
     /// This function is required to be implemented.
     ///
     /// By returning AccessorInfo, underlying services can declare
-    /// some useful information about it self.
+    /// some useful information about itself.
     ///
     /// - scheme: declare the scheme of backend.
     /// - capabilities: declare the capabilities of current backend.
@@ -110,7 +110,7 @@ pub trait Access: Send + Sync + Debug + Unpin + 'static {
     /// # Behavior
     ///
     /// - `stat` empty path means stat backend's root path.
-    /// - `stat` a path endswith "/" means stating a dir.
+    /// - `stat` a path ends with "/" means stating a dir.
     /// - `mode` and `content_length` must be set.
     fn stat(&self, path: &str, args: OpStat) -> impl Future<Output = Result<RpStat>> + MaybeSend {
         let (_, _) = (path, args);
@@ -601,10 +601,10 @@ where
 
 impl Access for dyn AccessDyn {
     type Reader = oio::Reader;
-    type BlockingReader = oio::BlockingReader;
     type Writer = oio::Writer;
-    type BlockingWriter = oio::BlockingWriter;
     type Lister = oio::Lister;
+    type BlockingReader = oio::BlockingReader;
+    type BlockingWriter = oio::BlockingWriter;
     type BlockingLister = oio::BlockingLister;
 
     fn info(&self) -> Arc<AccessorInfo> {
@@ -850,7 +850,7 @@ impl AccessorInfo {
     }
 
     /// Set [`Scheme`] for backend.
-    pub fn set_scheme(&mut self, scheme: Scheme) -> &mut Self {
+    pub fn set_scheme(mut self, scheme: Scheme) -> Self {
         self.scheme = scheme;
         self
     }
@@ -863,7 +863,7 @@ impl AccessorInfo {
     /// Set root for backend.
     ///
     /// Note: input root must be normalized.
-    pub fn set_root(&mut self, root: &str) -> &mut Self {
+    pub fn set_root(mut self, root: &str) -> Self {
         self.root = root.to_string();
         self
     }
@@ -879,7 +879,7 @@ impl AccessorInfo {
     }
 
     /// Set name of this backend.
-    pub fn set_name(&mut self, name: &str) -> &mut Self {
+    pub fn set_name(mut self, name: &str) -> Self {
         self.name = name.to_string();
         self
     }
@@ -893,9 +893,8 @@ impl AccessorInfo {
     ///
     /// # NOTES
     ///
-    /// Set native capability will also flush the full capability. The only way to change
-    /// full_capability is via `full_capability_mut`.
-    pub fn set_native_capability(&mut self, capability: Capability) -> &mut Self {
+    /// Set native capability will also flush the full capability.
+    pub fn set_native_capability(mut self, capability: Capability) -> Self {
         self.native_capability = capability;
         self.full_capability = capability;
         self
@@ -906,8 +905,9 @@ impl AccessorInfo {
         self.full_capability
     }
 
-    /// Get service's full capabilities.
-    pub fn full_capability_mut(&mut self) -> &mut Capability {
-        &mut self.full_capability
+    /// Set full capabilities for service.
+    pub fn set_full_capability(mut self, capability: Capability) -> Self {
+        self.full_capability = capability;
+        self
     }
 }

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -850,7 +850,7 @@ impl AccessorInfo {
     }
 
     /// Set [`Scheme`] for backend.
-    pub fn set_scheme(mut self, scheme: Scheme) -> Self {
+    pub fn with_scheme(mut self, scheme: Scheme) -> Self {
         self.scheme = scheme;
         self
     }
@@ -863,7 +863,7 @@ impl AccessorInfo {
     /// Set root for backend.
     ///
     /// Note: input root must be normalized.
-    pub fn set_root(mut self, root: &str) -> Self {
+    pub fn with_root(mut self, root: &str) -> Self {
         self.root = root.to_string();
         self
     }
@@ -879,7 +879,7 @@ impl AccessorInfo {
     }
 
     /// Set name of this backend.
-    pub fn set_name(mut self, name: &str) -> Self {
+    pub fn with_name(mut self, name: &str) -> Self {
         self.name = name.to_string();
         self
     }
@@ -894,7 +894,7 @@ impl AccessorInfo {
     /// # NOTES
     ///
     /// Set native capability will also flush the full capability.
-    pub fn set_native_capability(mut self, capability: Capability) -> Self {
+    pub fn with_native_capability(mut self, capability: Capability) -> Self {
         self.native_capability = capability;
         self.full_capability = capability;
         self
@@ -906,7 +906,7 @@ impl AccessorInfo {
     }
 
     /// Set full capabilities for service.
-    pub fn set_full_capability(mut self, capability: Capability) -> Self {
+    pub fn with_full_capability(mut self, capability: Capability) -> Self {
         self.full_capability = capability;
         self
     }

--- a/core/src/raw/adapters/kv/api.rs
+++ b/core/src/raw/adapters/kv/api.rs
@@ -105,8 +105,7 @@ pub trait Adapter: Send + Sync + Debug + Unpin + 'static {
 
     /// Append a key into service
     fn append(&self, path: &str, value: &[u8]) -> impl Future<Output = Result<()>> + MaybeSend {
-        let _ = path;
-        let _ = value;
+        let _ = (path, value);
 
         ready(Err(Error::new(
             ErrorKind::Unsupported,
@@ -118,8 +117,7 @@ pub trait Adapter: Send + Sync + Debug + Unpin + 'static {
     /// Append a key into service
     /// in blocking way.
     fn blocking_append(&self, path: &str, value: &[u8]) -> Result<()> {
-        let _ = path;
-        let _ = value;
+        let _ = (path, value);
 
         Err(Error::new(
             ErrorKind::Unsupported,
@@ -164,11 +162,9 @@ impl Metadata {
 
 impl From<Metadata> for AccessorInfo {
     fn from(m: Metadata) -> AccessorInfo {
-        let mut am = AccessorInfo::default();
-        am.set_name(m.name());
-        am.set_scheme(m.scheme());
-        am.set_native_capability(m.capabilities());
-
-        am
+        AccessorInfo::default()
+            .set_name(m.name())
+            .set_scheme(m.scheme())
+            .set_native_capability(m.capabilities())
     }
 }

--- a/core/src/raw/adapters/kv/api.rs
+++ b/core/src/raw/adapters/kv/api.rs
@@ -159,12 +159,3 @@ impl Metadata {
         self.capabilities
     }
 }
-
-impl From<Metadata> for AccessorInfo {
-    fn from(m: Metadata) -> AccessorInfo {
-        AccessorInfo::default()
-            .set_name(m.name())
-            .set_scheme(m.scheme())
-            .set_native_capability(m.capabilities())
-    }
-}

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -76,10 +76,10 @@ impl<S: Adapter> Access for Backend<S> {
         let kv_cap = kv_info.capabilities();
 
         AccessorInfo::default()
-            .set_scheme(kv_info.scheme())
-            .set_name(kv_info.name())
-            .set_root(&self.root)
-            .set_native_capability(Capability {
+            .with_scheme(kv_info.scheme())
+            .with_name(kv_info.name())
+            .with_root(&self.root)
+            .with_native_capability(Capability {
                 stat: kv_cap.read,
 
                 write_can_empty: kv_cap.write,

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -72,18 +72,22 @@ impl<S: Adapter> Access for Backend<S> {
     type BlockingLister = HierarchyLister<KvLister>;
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let info = AccessorInfo::from(self.kv.metadata());
-        let cap = info.native_capability();
-        info.set_root(&self.root)
+        let kv_info = self.kv.metadata();
+        let kv_cap = kv_info.capabilities();
+
+        AccessorInfo::default()
+            .set_scheme(kv_info.scheme())
+            .set_name(kv_info.name())
+            .set_root(&self.root)
             .set_native_capability(Capability {
-                stat: cap.read,
+                stat: kv_cap.read,
 
-                write_can_empty: cap.write,
-                delete: cap.write,
+                write_can_empty: kv_cap.write,
+                delete: kv_cap.write,
 
-                list_with_recursive: cap.list,
+                list_with_recursive: kv_cap.list,
 
-                ..cap
+                ..kv_cap
             })
             .into()
     }

--- a/core/src/raw/adapters/typed_kv/backend.rs
+++ b/core/src/raw/adapters/typed_kv/backend.rs
@@ -64,10 +64,10 @@ impl<S: Adapter> Access for Backend<S> {
         let kv_cap = kv_info.capabilities();
 
         AccessorInfo::default()
-            .set_root(&self.root)
-            .set_scheme(kv_info.scheme())
-            .set_name(kv_info.name())
-            .set_native_capability(Capability {
+            .with_root(&self.root)
+            .with_scheme(kv_info.scheme())
+            .with_name(kv_info.name())
+            .with_native_capability(Capability {
                 read: kv_cap.get,
                 stat: kv_cap.get,
 

--- a/core/src/raw/chrono_util.rs
+++ b/core/src/raw/chrono_util.rs
@@ -23,7 +23,7 @@ use chrono::Utc;
 
 use crate::*;
 
-/// Parse dateimt from rfc2822.
+/// Parse datetime from rfc2822.
 ///
 /// For example: `Fri, 28 Nov 2014 21:00:09 +0900`
 pub fn parse_datetime_from_rfc2822(s: &str) -> Result<DateTime<Utc>> {
@@ -34,7 +34,7 @@ pub fn parse_datetime_from_rfc2822(s: &str) -> Result<DateTime<Utc>> {
         })
 }
 
-/// Parse dateimt from rfc3339.
+/// Parse datetime from rfc3339.
 ///
 /// For example: `2014-11-28T21:00:09+09:00`
 pub fn parse_datetime_from_rfc3339(s: &str) -> Result<DateTime<Utc>> {

--- a/core/src/raw/layer.rs
+++ b/core/src/raw/layer.rs
@@ -359,7 +359,7 @@ mod tests {
         type BlockingLister = ();
 
         fn info(&self) -> Arc<AccessorInfo> {
-            Arc::new(AccessorInfo::default().set_scheme(Scheme::Custom("test")))
+            Arc::new(AccessorInfo::default().with_scheme(Scheme::Custom("test")))
         }
 
         async fn delete(&self, _: &str, _: OpDelete) -> Result<RpDelete> {

--- a/core/src/raw/layer.rs
+++ b/core/src/raw/layer.rs
@@ -128,7 +128,6 @@ pub trait Layer<A: Access> {
 /// LayeredAccess is layered accessor that forward all not implemented
 /// method to inner.
 #[allow(missing_docs)]
-
 pub trait LayeredAccess: Send + Sync + Debug + Unpin + 'static {
     type Inner: Access;
     type Reader: oio::Read;
@@ -241,86 +240,86 @@ pub trait LayeredAccess: Send + Sync + Debug + Unpin + 'static {
 
 impl<L: LayeredAccess> Access for L {
     type Reader = L::Reader;
-    type BlockingReader = L::BlockingReader;
     type Writer = L::Writer;
-    type BlockingWriter = L::BlockingWriter;
     type Lister = L::Lister;
+    type BlockingReader = L::BlockingReader;
+    type BlockingWriter = L::BlockingWriter;
     type BlockingLister = L::BlockingLister;
 
     fn info(&self) -> Arc<AccessorInfo> {
-        (self as &L).metadata()
+        LayeredAccess::metadata(self)
     }
 
     async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        (self as &L).create_dir(path, args).await
-    }
-
-    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        (self as &L).read(path, args).await
-    }
-
-    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        (self as &L).write(path, args).await
-    }
-
-    async fn copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
-        (self as &L).copy(from, to, args).await
-    }
-
-    async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
-        (self as &L).rename(from, to, args).await
+        LayeredAccess::create_dir(self, path, args).await
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        (self as &L).stat(path, args).await
+        LayeredAccess::stat(self, path, args).await
+    }
+
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        LayeredAccess::read(self, path, args).await
+    }
+
+    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
+        LayeredAccess::write(self, path, args).await
     }
 
     async fn delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
-        (self as &L).delete(path, args).await
+        LayeredAccess::delete(self, path, args).await
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
-        (self as &L).list(path, args).await
+        LayeredAccess::list(self, path, args).await
     }
 
-    async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
-        (self as &L).batch(args).await
+    async fn copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
+        LayeredAccess::copy(self, from, to, args).await
+    }
+
+    async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
+        LayeredAccess::rename(self, from, to, args).await
     }
 
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
-        (self as &L).presign(path, args).await
+        LayeredAccess::presign(self, path, args).await
+    }
+
+    async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
+        LayeredAccess::batch(self, args).await
     }
 
     fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        (self as &L).blocking_create_dir(path, args)
-    }
-
-    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
-        (self as &L).blocking_read(path, args)
-    }
-
-    fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
-        (self as &L).blocking_write(path, args)
-    }
-
-    fn blocking_copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
-        (self as &L).blocking_copy(from, to, args)
-    }
-
-    fn blocking_rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
-        (self as &L).blocking_rename(from, to, args)
+        LayeredAccess::blocking_create_dir(self, path, args)
     }
 
     fn blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        (self as &L).blocking_stat(path, args)
+        LayeredAccess::blocking_stat(self, path, args)
+    }
+
+    fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
+        LayeredAccess::blocking_read(self, path, args)
+    }
+
+    fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
+        LayeredAccess::blocking_write(self, path, args)
     }
 
     fn blocking_delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
-        (self as &L).blocking_delete(path, args)
+        LayeredAccess::blocking_delete(self, path, args)
     }
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingLister)> {
-        (self as &L).blocking_list(path, args)
+        LayeredAccess::blocking_list(self, path, args)
+    }
+
+    fn blocking_copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
+        LayeredAccess::blocking_copy(self, from, to, args)
+    }
+
+    fn blocking_rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
+        LayeredAccess::blocking_rename(self, from, to, args)
     }
 }
 
@@ -353,16 +352,14 @@ mod tests {
 
     impl<A: Access> Access for Test<A> {
         type Reader = ();
-        type BlockingReader = ();
         type Writer = ();
-        type BlockingWriter = ();
         type Lister = ();
+        type BlockingReader = ();
+        type BlockingWriter = ();
         type BlockingLister = ();
 
         fn info(&self) -> Arc<AccessorInfo> {
-            let mut am = AccessorInfo::default();
-            am.set_scheme(Scheme::Custom("test"));
-            am.into()
+            Arc::new(AccessorInfo::default().set_scheme(Scheme::Custom("test")))
         }
 
         async fn delete(&self, _: &str, _: OpDelete) -> Result<RpDelete> {

--- a/core/src/raw/oio/list/flat_list.rs
+++ b/core/src/raw/oio/list/flat_list.rs
@@ -202,17 +202,17 @@ mod tests {
 
     impl Access for MockService {
         type Reader = ();
-        type BlockingReader = ();
         type Writer = ();
-        type BlockingWriter = ();
         type Lister = ();
+        type BlockingReader = ();
+        type BlockingWriter = ();
         type BlockingLister = MockLister;
 
         fn info(&self) -> Arc<AccessorInfo> {
-            let mut am = AccessorInfo::default();
-            am.full_capability_mut().list = true;
-
-            am.into()
+            let info = AccessorInfo::default();
+            let cap = info.full_capability();
+            info.set_full_capability(Capability { list: true, ..cap })
+                .into()
         }
 
         fn blocking_list(&self, path: &str, _: OpList) -> Result<(RpList, Self::BlockingLister)> {

--- a/core/src/raw/oio/list/flat_list.rs
+++ b/core/src/raw/oio/list/flat_list.rs
@@ -211,7 +211,7 @@ mod tests {
         fn info(&self) -> Arc<AccessorInfo> {
             let info = AccessorInfo::default();
             let cap = info.full_capability();
-            info.set_full_capability(Capability { list: true, ..cap })
+            info.with_full_capability(Capability { list: true, ..cap })
                 .into()
         }
 

--- a/core/src/services/aliyun_drive/backend.rs
+++ b/core/src/services/aliyun_drive/backend.rs
@@ -209,9 +209,9 @@ impl Access for AliyunDriveBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::AliyunDrive)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::AliyunDrive)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
                 create_dir: true,
                 read: true,

--- a/core/src/services/aliyun_drive/backend.rs
+++ b/core/src/services/aliyun_drive/backend.rs
@@ -208,8 +208,8 @@ impl Access for AliyunDriveBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::AliyunDrive)
+        AccessorInfo::default()
+            .set_scheme(Scheme::AliyunDrive)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -232,8 +232,8 @@ impl Access for AliyunDriveBackend {
                 list_with_limit: true,
 
                 ..Default::default()
-            });
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _args: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/alluxio/backend.rs
+++ b/core/src/services/alluxio/backend.rs
@@ -150,9 +150,9 @@ impl Access for AlluxioBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Alluxio)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Alluxio)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 // FIXME:

--- a/core/src/services/alluxio/backend.rs
+++ b/core/src/services/alluxio/backend.rs
@@ -149,8 +149,8 @@ impl Access for AlluxioBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Alluxio)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Alluxio)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -170,9 +170,8 @@ impl Access for AlluxioBackend {
                 list: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -496,8 +496,8 @@ impl Access for AzblobBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Azblob)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Azblob)
             .set_root(&self.core.root)
             .set_name(&self.core.container)
             .set_native_capability(Capability {
@@ -534,9 +534,8 @@ impl Access for AzblobBackend {
                 batch_max_operations: Some(self.core.batch_max_operations),
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -497,10 +497,10 @@ impl Access for AzblobBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Azblob)
-            .set_root(&self.core.root)
-            .set_name(&self.core.container)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Azblob)
+            .with_root(&self.core.root)
+            .with_name(&self.core.container)
+            .with_native_capability(Capability {
                 stat: true,
                 stat_with_if_match: true,
                 stat_with_if_none_match: true,

--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -222,8 +222,8 @@ impl Access for AzdlsBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Azdls)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Azdls)
             .set_root(&self.core.root)
             .set_name(&self.core.filesystem)
             .set_native_capability(Capability {
@@ -240,9 +240,8 @@ impl Access for AzdlsBackend {
                 list: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -223,10 +223,10 @@ impl Access for AzdlsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Azdls)
-            .set_root(&self.core.root)
-            .set_name(&self.core.filesystem)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Azdls)
+            .with_root(&self.core.root)
+            .with_name(&self.core.filesystem)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/azfile/backend.rs
+++ b/core/src/services/azfile/backend.rs
@@ -238,8 +238,8 @@ impl Access for AzfileBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Azfile)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Azfile)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -254,9 +254,8 @@ impl Access for AzfileBackend {
                 list: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/azfile/backend.rs
+++ b/core/src/services/azfile/backend.rs
@@ -239,9 +239,9 @@ impl Access for AzfileBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Azfile)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Azfile)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/b2/backend.rs
+++ b/core/src/services/b2/backend.rs
@@ -221,8 +221,8 @@ impl Access for B2Backend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::B2)
+        AccessorInfo::default()
+            .set_scheme(Scheme::B2)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -260,9 +260,8 @@ impl Access for B2Backend {
                 presign_stat: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     /// B2 have a get_file_info api required a file_id field, but field_id need call list api, list api also return file info

--- a/core/src/services/b2/backend.rs
+++ b/core/src/services/b2/backend.rs
@@ -222,9 +222,9 @@ impl Access for B2Backend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::B2)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::B2)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/chainsafe/backend.rs
+++ b/core/src/services/chainsafe/backend.rs
@@ -172,9 +172,9 @@ impl Access for ChainsafeBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Chainsafe)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Chainsafe)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/chainsafe/backend.rs
+++ b/core/src/services/chainsafe/backend.rs
@@ -171,8 +171,8 @@ impl Access for ChainsafeBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Chainsafe)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Chainsafe)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -188,9 +188,8 @@ impl Access for ChainsafeBackend {
                 list: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/compfs/backend.rs
+++ b/core/src/services/compfs/backend.rs
@@ -112,9 +112,9 @@ impl Access for CompfsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Compfs)
-            .set_root(&self.core.root.to_string_lossy())
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Compfs)
+            .with_root(&self.core.root.to_string_lossy())
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/compfs/backend.rs
+++ b/core/src/services/compfs/backend.rs
@@ -111,8 +111,8 @@ impl Access for CompfsBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Compfs)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Compfs)
             .set_root(&self.core.root.to_string_lossy())
             .set_native_capability(Capability {
                 stat: true,
@@ -131,9 +131,8 @@ impl Access for CompfsBackend {
                 rename: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -237,8 +237,8 @@ impl Access for CosBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Cos)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Cos)
             .set_root(&self.core.root)
             .set_name(&self.core.bucket)
             .set_native_capability(Capability {
@@ -283,9 +283,8 @@ impl Access for CosBackend {
                 presign_write: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -238,10 +238,10 @@ impl Access for CosBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Cos)
-            .set_root(&self.core.root)
-            .set_name(&self.core.bucket)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Cos)
+            .with_root(&self.core.root)
+            .with_name(&self.core.bucket)
+            .with_native_capability(Capability {
                 stat: true,
                 stat_with_if_match: true,
                 stat_with_if_none_match: true,

--- a/core/src/services/dbfs/backend.rs
+++ b/core/src/services/dbfs/backend.rs
@@ -151,9 +151,9 @@ impl Access for DbfsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Dbfs)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Dbfs)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 write: true,

--- a/core/src/services/dbfs/backend.rs
+++ b/core/src/services/dbfs/backend.rs
@@ -150,8 +150,8 @@ impl Access for DbfsBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Dbfs)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Dbfs)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -164,8 +164,8 @@ impl Access for DbfsBackend {
                 list: true,
 
                 ..Default::default()
-            });
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/dropbox/backend.rs
+++ b/core/src/services/dropbox/backend.rs
@@ -45,9 +45,9 @@ impl Access for DropboxBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Dropbox)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Dropbox)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/dropbox/backend.rs
+++ b/core/src/services/dropbox/backend.rs
@@ -44,8 +44,8 @@ impl Access for DropboxBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut ma = AccessorInfo::default();
-        ma.set_scheme(Scheme::Dropbox)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Dropbox)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -69,8 +69,8 @@ impl Access for DropboxBackend {
                 batch_delete: true,
 
                 ..Default::default()
-            });
-        ma.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _args: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -170,8 +170,8 @@ impl Access for FsBackend {
     type BlockingLister = Option<FsLister<std::fs::ReadDir>>;
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Fs)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Fs)
             .set_root(&self.core.root.to_string_lossy())
             .set_native_capability(Capability {
                 stat: true,
@@ -192,9 +192,8 @@ impl Access for FsBackend {
                 blocking: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -171,9 +171,9 @@ impl Access for FsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Fs)
-            .set_root(&self.core.root.to_string_lossy())
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Fs)
+            .with_root(&self.core.root.to_string_lossy())
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -265,9 +265,9 @@ impl Access for FtpBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Ftp)
-            .set_root(&self.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Ftp)
+            .with_root(&self.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -264,8 +264,8 @@ impl Access for FtpBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Ftp)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Ftp)
             .set_root(&self.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -282,9 +282,8 @@ impl Access for FtpBackend {
                 list: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -345,8 +345,8 @@ impl Access for GcsBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Gcs)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Gcs)
             .set_root(&self.core.root)
             .set_name(&self.core.bucket)
             .set_native_capability(Capability {
@@ -392,8 +392,8 @@ impl Access for GcsBackend {
                 presign_write: true,
 
                 ..Default::default()
-            });
-        am.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -346,10 +346,10 @@ impl Access for GcsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Gcs)
-            .set_root(&self.core.root)
-            .set_name(&self.core.bucket)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Gcs)
+            .with_root(&self.core.root)
+            .with_name(&self.core.bucket)
+            .with_native_capability(Capability {
                 stat: true,
                 stat_with_if_match: true,
                 stat_with_if_none_match: true,

--- a/core/src/services/gdrive/backend.rs
+++ b/core/src/services/gdrive/backend.rs
@@ -49,9 +49,9 @@ impl Access for GdriveBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Gdrive)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Gdrive)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/gdrive/backend.rs
+++ b/core/src/services/gdrive/backend.rs
@@ -48,8 +48,8 @@ impl Access for GdriveBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut ma = AccessorInfo::default();
-        ma.set_scheme(Scheme::Gdrive)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Gdrive)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -65,9 +65,8 @@ impl Access for GdriveBackend {
                 rename: true,
                 copy: true,
                 ..Default::default()
-            });
-
-        ma.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _args: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -235,8 +235,8 @@ impl Access for GhacBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Ghac)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Ghac)
             .set_root(&self.root)
             .set_name(&self.version)
             .set_native_capability(Capability {
@@ -249,8 +249,8 @@ impl Access for GhacBackend {
                 delete: true,
 
                 ..Default::default()
-            });
-        am.into()
+            })
+            .into()
     }
 
     /// Some self-hosted GHES instances are backed by AWS S3 services which only returns

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -236,10 +236,10 @@ impl Access for GhacBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Ghac)
-            .set_root(&self.root)
-            .set_name(&self.version)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Ghac)
+            .with_root(&self.root)
+            .with_name(&self.version)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/github/backend.rs
+++ b/core/src/services/github/backend.rs
@@ -169,20 +169,15 @@ pub struct GithubBackend {
 
 impl Access for GithubBackend {
     type Reader = HttpBody;
-
     type Writer = GithubWriters;
-
     type Lister = oio::PageLister<GithubLister>;
-
     type BlockingReader = ();
-
     type BlockingWriter = ();
-
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Github)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Github)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -200,9 +195,8 @@ impl Access for GithubBackend {
                 list_with_recursive: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/github/backend.rs
+++ b/core/src/services/github/backend.rs
@@ -177,9 +177,9 @@ impl Access for GithubBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Github)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Github)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -211,8 +211,8 @@ impl Access for HdfsBackend {
     type BlockingLister = Option<HdfsLister>;
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Hdfs)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Hdfs)
             .set_root(&self.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -231,9 +231,8 @@ impl Access for HdfsBackend {
                 blocking: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -212,9 +212,9 @@ impl Access for HdfsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Hdfs)
-            .set_root(&self.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Hdfs)
+            .with_root(&self.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/hdfs_native/backend.rs
+++ b/core/src/services/hdfs_native/backend.rs
@@ -152,9 +152,9 @@ impl Access for HdfsNativeBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::HdfsNative)
-            .set_root(&self.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::HdfsNative)
+            .with_root(&self.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 delete: true,

--- a/core/src/services/hdfs_native/backend.rs
+++ b/core/src/services/hdfs_native/backend.rs
@@ -144,15 +144,15 @@ unsafe impl Sync for HdfsNativeBackend {}
 
 impl Access for HdfsNativeBackend {
     type Reader = HdfsNativeReader;
-    type BlockingReader = ();
     type Writer = HdfsNativeWriter;
-    type BlockingWriter = ();
     type Lister = Option<HdfsNativeLister>;
+    type BlockingReader = ();
+    type BlockingWriter = ();
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::HdfsNative)
+        AccessorInfo::default()
+            .set_scheme(Scheme::HdfsNative)
             .set_root(&self.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -162,9 +162,8 @@ impl Access for HdfsNativeBackend {
                 blocking: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _args: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -202,9 +202,9 @@ impl Access for HttpBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Http)
-            .set_root(&self.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Http)
+            .with_root(&self.root)
+            .with_native_capability(Capability {
                 stat: true,
                 stat_with_if_match: true,
                 stat_with_if_none_match: true,

--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -201,8 +201,8 @@ impl Access for HttpBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut ma = AccessorInfo::default();
-        ma.set_scheme(Scheme::Http)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Http)
             .set_root(&self.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -219,9 +219,8 @@ impl Access for HttpBackend {
                 presign_stat: !self.has_authorization(),
 
                 ..Default::default()
-            });
-
-        ma.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/huggingface/backend.rs
+++ b/core/src/services/huggingface/backend.rs
@@ -199,8 +199,8 @@ impl Access for HuggingfaceBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Huggingface)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Huggingface)
             .set_native_capability(Capability {
                 stat: true,
 
@@ -210,8 +210,8 @@ impl Access for HuggingfaceBackend {
                 list_with_recursive: true,
 
                 ..Default::default()
-            });
-        am.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, _: OpStat) -> Result<RpStat> {

--- a/core/src/services/huggingface/backend.rs
+++ b/core/src/services/huggingface/backend.rs
@@ -200,8 +200,8 @@ impl Access for HuggingfaceBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Huggingface)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Huggingface)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/icloud/backend.rs
+++ b/core/src/services/icloud/backend.rs
@@ -226,22 +226,22 @@ pub struct IcloudBackend {
 
 impl Access for IcloudBackend {
     type Reader = HttpBody;
-    type BlockingReader = ();
     type Writer = ();
-    type BlockingWriter = ();
     type Lister = ();
+    type BlockingReader = ();
+    type BlockingWriter = ();
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut ma = AccessorInfo::default();
-        ma.set_scheme(Scheme::Icloud)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Icloud)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
                 read: true,
                 ..Default::default()
-            });
-        ma.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, _: OpStat) -> Result<RpStat> {

--- a/core/src/services/icloud/backend.rs
+++ b/core/src/services/icloud/backend.rs
@@ -234,9 +234,9 @@ impl Access for IcloudBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Icloud)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Icloud)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
                 read: true,
                 ..Default::default()

--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -169,8 +169,8 @@ impl Access for IpfsBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut ma = AccessorInfo::default();
-        ma.set_scheme(Scheme::Ipfs)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Ipfs)
             .set_root(&self.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -180,9 +180,8 @@ impl Access for IpfsBackend {
                 list: true,
 
                 ..Default::default()
-            });
-
-        ma.into()
+            })
+            .into()
     }
 
     /// IPFS's stat behavior highly depends on its implementation.

--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -170,9 +170,9 @@ impl Access for IpfsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Ipfs)
-            .set_root(&self.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Ipfs)
+            .with_root(&self.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -69,8 +69,8 @@ impl Access for IpmfsBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Ipmfs)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Ipmfs)
             .set_root(&self.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -83,9 +83,8 @@ impl Access for IpmfsBackend {
                 list: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -70,9 +70,9 @@ impl Access for IpmfsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Ipmfs)
-            .set_root(&self.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Ipmfs)
+            .with_root(&self.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/koofr/backend.rs
+++ b/core/src/services/koofr/backend.rs
@@ -203,8 +203,8 @@ impl Access for KoofrBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Koofr)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Koofr)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -225,9 +225,8 @@ impl Access for KoofrBackend {
                 list: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/koofr/backend.rs
+++ b/core/src/services/koofr/backend.rs
@@ -204,9 +204,9 @@ impl Access for KoofrBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Koofr)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Koofr)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 create_dir: true,

--- a/core/src/services/lakefs/backend.rs
+++ b/core/src/services/lakefs/backend.rs
@@ -203,8 +203,8 @@ impl Access for LakefsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Lakefs)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Lakefs)
+            .with_native_capability(Capability {
                 stat: true,
                 list: true,
                 read: true,

--- a/core/src/services/lakefs/backend.rs
+++ b/core/src/services/lakefs/backend.rs
@@ -202,8 +202,8 @@ impl Access for LakefsBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Lakefs)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Lakefs)
             .set_native_capability(Capability {
                 stat: true,
                 list: true,
@@ -212,8 +212,8 @@ impl Access for LakefsBackend {
                 delete: true,
                 copy: true,
                 ..Default::default()
-            });
-        am.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, _: OpStat) -> Result<RpStat> {

--- a/core/src/services/monoiofs/backend.rs
+++ b/core/src/services/monoiofs/backend.rs
@@ -110,9 +110,9 @@ impl Access for MonoiofsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Monoiofs)
-            .set_root(&self.core.root().to_string_lossy())
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Monoiofs)
+            .with_root(&self.core.root().to_string_lossy())
+            .with_native_capability(Capability {
                 stat: true,
                 read: true,
                 write: true,

--- a/core/src/services/monoiofs/backend.rs
+++ b/core/src/services/monoiofs/backend.rs
@@ -109,8 +109,8 @@ impl Access for MonoiofsBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Monoiofs)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Monoiofs)
             .set_root(&self.core.root().to_string_lossy())
             .set_native_capability(Capability {
                 stat: true,
@@ -122,8 +122,8 @@ impl Access for MonoiofsBackend {
                 create_dir: true,
                 copy: true,
                 ..Default::default()
-            });
-        am.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -247,8 +247,8 @@ impl Access for ObsBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Obs)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Obs)
             .set_root(&self.core.root)
             .set_name(&self.core.bucket)
             .set_native_capability(Capability {
@@ -292,9 +292,8 @@ impl Access for ObsBackend {
                 presign_write: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -248,10 +248,10 @@ impl Access for ObsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Obs)
-            .set_root(&self.core.root)
-            .set_name(&self.core.bucket)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Obs)
+            .with_root(&self.core.root)
+            .with_name(&self.core.bucket)
+            .with_native_capability(Capability {
                 stat: true,
                 stat_with_if_match: true,
                 stat_with_if_none_match: true,

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -70,8 +70,8 @@ impl Access for OnedriveBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut ma = AccessorInfo::default();
-        ma.set_scheme(Scheme::Onedrive)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Onedrive)
             .set_root(&self.root)
             .set_native_capability(Capability {
                 read: true,
@@ -81,9 +81,8 @@ impl Access for OnedriveBackend {
                 create_dir: true,
                 list: true,
                 ..Default::default()
-            });
-
-        ma.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -71,9 +71,9 @@ impl Access for OnedriveBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Onedrive)
-            .set_root(&self.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Onedrive)
+            .with_root(&self.root)
+            .with_native_capability(Capability {
                 read: true,
                 write: true,
                 stat: true,

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -425,10 +425,10 @@ impl Access for OssBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Oss)
-            .set_root(&self.core.root)
-            .set_name(&self.core.bucket)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Oss)
+            .with_root(&self.core.root)
+            .with_name(&self.core.bucket)
+            .with_native_capability(Capability {
                 stat: true,
                 stat_with_if_match: true,
                 stat_with_if_none_match: true,

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -424,8 +424,8 @@ impl Access for OssBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Oss)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Oss)
             .set_root(&self.core.root)
             .set_name(&self.core.bucket)
             .set_native_capability(Capability {
@@ -476,9 +476,8 @@ impl Access for OssBackend {
                 batch_max_operations: Some(self.core.batch_max_operations),
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/pcloud/backend.rs
+++ b/core/src/services/pcloud/backend.rs
@@ -196,9 +196,9 @@ impl Access for PcloudBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Pcloud)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Pcloud)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 create_dir: true,

--- a/core/src/services/pcloud/backend.rs
+++ b/core/src/services/pcloud/backend.rs
@@ -195,8 +195,8 @@ impl Access for PcloudBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Pcloud)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Pcloud)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -214,9 +214,8 @@ impl Access for PcloudBackend {
                 list: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -893,8 +893,8 @@ impl Access for S3Backend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::S3)
+        AccessorInfo::default()
+            .set_scheme(Scheme::S3)
             .set_root(&self.core.root)
             .set_name(&self.core.bucket)
             .set_native_capability(Capability {
@@ -955,9 +955,8 @@ impl Access for S3Backend {
                 batch_max_operations: Some(self.core.batch_max_operations),
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -894,10 +894,10 @@ impl Access for S3Backend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::S3)
-            .set_root(&self.core.root)
-            .set_name(&self.core.bucket)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::S3)
+            .with_root(&self.core.root)
+            .with_name(&self.core.bucket)
+            .with_native_capability(Capability {
                 stat: true,
                 stat_with_if_match: true,
                 stat_with_if_none_match: true,

--- a/core/src/services/seafile/backend.rs
+++ b/core/src/services/seafile/backend.rs
@@ -217,8 +217,8 @@ impl Access for SeafileBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Seafile)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Seafile)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -233,9 +233,8 @@ impl Access for SeafileBackend {
                 list: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {

--- a/core/src/services/seafile/backend.rs
+++ b/core/src/services/seafile/backend.rs
@@ -218,9 +218,9 @@ impl Access for SeafileBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Seafile)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Seafile)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -325,9 +325,9 @@ impl Access for SftpBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_root(self.root.as_str())
-            .set_scheme(Scheme::Sftp)
-            .set_native_capability(Capability {
+            .with_root(self.root.as_str())
+            .with_scheme(Scheme::Sftp)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -324,8 +324,8 @@ impl Access for SftpBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_root(self.root.as_str())
+        AccessorInfo::default()
+            .set_root(self.root.as_str())
             .set_scheme(Scheme::Sftp)
             .set_native_capability(Capability {
                 stat: true,
@@ -345,9 +345,8 @@ impl Access for SftpBackend {
                 rename: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/supabase/backend.rs
+++ b/core/src/services/supabase/backend.rs
@@ -154,8 +154,8 @@ impl Access for SupabaseBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Supabase)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Supabase)
             .set_root(&self.core.root)
             .set_name(&self.core.bucket)
             .set_native_capability(Capability {
@@ -167,9 +167,8 @@ impl Access for SupabaseBackend {
                 delete: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {

--- a/core/src/services/supabase/backend.rs
+++ b/core/src/services/supabase/backend.rs
@@ -155,10 +155,10 @@ impl Access for SupabaseBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Supabase)
-            .set_root(&self.core.root)
-            .set_name(&self.core.bucket)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Supabase)
+            .with_root(&self.core.root)
+            .with_name(&self.core.bucket)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/swift/backend.rs
+++ b/core/src/services/swift/backend.rs
@@ -182,9 +182,9 @@ impl Access for SwiftBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Swift)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Swift)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/swift/backend.rs
+++ b/core/src/services/swift/backend.rs
@@ -181,8 +181,8 @@ impl Access for SwiftBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Swift)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Swift)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -197,8 +197,8 @@ impl Access for SwiftBackend {
                 list_with_recursive: true,
 
                 ..Default::default()
-            });
-        am.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {

--- a/core/src/services/upyun/backend.rs
+++ b/core/src/services/upyun/backend.rs
@@ -196,8 +196,8 @@ impl Access for UpyunBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Upyun)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Upyun)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -224,9 +224,8 @@ impl Access for UpyunBackend {
                 list_with_limit: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/upyun/backend.rs
+++ b/core/src/services/upyun/backend.rs
@@ -197,9 +197,9 @@ impl Access for UpyunBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Upyun)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Upyun)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 create_dir: true,

--- a/core/src/services/vercel_artifacts/backend.rs
+++ b/core/src/services/vercel_artifacts/backend.rs
@@ -52,8 +52,8 @@ impl Access for VercelArtifactsBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut ma = AccessorInfo::default();
-        ma.set_scheme(Scheme::VercelArtifacts)
+        AccessorInfo::default()
+            .set_scheme(Scheme::VercelArtifacts)
             .set_native_capability(Capability {
                 stat: true,
 
@@ -62,9 +62,8 @@ impl Access for VercelArtifactsBackend {
                 write: true,
 
                 ..Default::default()
-            });
-
-        ma.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {

--- a/core/src/services/vercel_artifacts/backend.rs
+++ b/core/src/services/vercel_artifacts/backend.rs
@@ -53,8 +53,8 @@ impl Access for VercelArtifactsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::VercelArtifacts)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::VercelArtifacts)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/vercel_blob/backend.rs
+++ b/core/src/services/vercel_blob/backend.rs
@@ -152,8 +152,8 @@ impl Access for VercelBlobBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::VercelBlob)
+        AccessorInfo::default()
+            .set_scheme(Scheme::VercelBlob)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -172,9 +172,8 @@ impl Access for VercelBlobBackend {
                 list_with_limit: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {

--- a/core/src/services/vercel_blob/backend.rs
+++ b/core/src/services/vercel_blob/backend.rs
@@ -153,9 +153,9 @@ impl Access for VercelBlobBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::VercelBlob)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::VercelBlob)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -210,8 +210,8 @@ impl Access for WebdavBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut ma = AccessorInfo::default();
-        ma.set_scheme(Scheme::Webdav)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Webdav)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -232,9 +232,8 @@ impl Access for WebdavBackend {
                 // We already support recursive list but some details still need to polish.
                 // list_with_recursive: true,
                 ..Default::default()
-            });
-
-        ma.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -211,9 +211,9 @@ impl Access for WebdavBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Webdav)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Webdav)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -523,9 +523,9 @@ impl Access for WebhdfsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::Webhdfs)
-            .set_root(&self.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::Webhdfs)
+            .with_root(&self.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -522,8 +522,8 @@ impl Access for WebhdfsBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::Webhdfs)
+        AccessorInfo::default()
+            .set_scheme(Scheme::Webhdfs)
             .set_root(&self.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -540,8 +540,8 @@ impl Access for WebhdfsBackend {
                 list: true,
 
                 ..Default::default()
-            });
-        am.into()
+            })
+            .into()
     }
 
     /// Create a file or directory

--- a/core/src/services/yandex_disk/backend.rs
+++ b/core/src/services/yandex_disk/backend.rs
@@ -154,9 +154,9 @@ impl Access for YandexDiskBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         AccessorInfo::default()
-            .set_scheme(Scheme::YandexDisk)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .with_scheme(Scheme::YandexDisk)
+            .with_root(&self.core.root)
+            .with_native_capability(Capability {
                 stat: true,
 
                 create_dir: true,

--- a/core/src/services/yandex_disk/backend.rs
+++ b/core/src/services/yandex_disk/backend.rs
@@ -153,8 +153,8 @@ impl Access for YandexDiskBackend {
     type BlockingLister = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut am = AccessorInfo::default();
-        am.set_scheme(Scheme::YandexDisk)
+        AccessorInfo::default()
+            .set_scheme(Scheme::YandexDisk)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,
@@ -174,9 +174,8 @@ impl Access for YandexDiskBackend {
                 list_with_limit: true,
 
                 ..Default::default()
-            });
-
-        am.into()
+            })
+            .into()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {


### PR DESCRIPTION
# Which issue does this PR close?

No

# Rationale for this change

In current usage scenarios, this change will provide a better experience in method chaining, 
although it will result in a breaking change.

# What changes are included in this PR?

adjust setter methods of `AccessorInfo`

- remove:
  - `fn full_capability_mut(&mut self) -> &mut Capability`
- add:
  - `fn with_full_capability(mut self, capability: Capability) -> Self`
- change:
  - `fn set_scheme(&mut self, scheme: Scheme) -> &mut Self` => `fn with_scheme(mut self, scheme: Scheme) -> Self`
  - `fn set_root(&mut self, root: &str) -> &mut Self` => `fn with_root(mut self, root: &str) -> Self`
  - `fn set_name(&mut self, name: &str) -> &mut Self` => `fn with_name(mut self, name: &str) -> Self`
  - `fn set_native_capability(&mut self, capability: Capability) -> &mut Self` => `fn with_native_capability(mut self, capability: Capability) -> Self`

# Are there any user-facing changes?

setter methods of `AccessorInfo` struct

