### PR TITLE
docs: change "Github" to "GitHub"

### DIFF
--- a/website/community/pmc_members/nominate-committer.md
+++ b/website/community/pmc_members/nominate-committer.md
@@ -31,9 +31,9 @@ ${candidate_contributions}
 
 ${candidate_name}'s great contributions could be found:
 
-- Github Account: https://github.com/${candidate_github_id}
-- Github Pull Requests: https://github.com/apache/opendal/pulls?q=is%3Apr+author%3A${candidate_github_id}+is%3Aclosed
-- Github Issues: https://github.com/apache/opendal/issues?q=is%3Aopen+mentions%3A${candidate_github_id}
+- GitHub Account: https://github.com/${candidate_github_id}
+- GitHub Pull Requests: https://github.com/apache/opendal/pulls?q=is%3Apr+author%3A${candidate_github_id}+is%3Aclosed
+- GitHub Issues: https://github.com/apache/opendal/issues?q=is%3Aopen+mentions%3A${candidate_github_id}
 
 Please make your valuable evaluation on whether we could invite ${candidate_name} as a
 committer:


### PR DESCRIPTION
# Which issue does this PR close?
It's a typo fix.

# Rationale for this change
This is the proper way to spell the GitHub brand name.

# What changes are included in this PR?
Fixed a typo in the description.

# Are there any user-facing changes?
No, there are no user-facing or API changes.
