### PR TITLE
chore(core): use stabilized `LazyLock` instead of `once_cell::sync::Lazy`

### DIFF
--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -80,8 +80,8 @@ jobs:
   check_msrv:
     runs-on: ubuntu-latest
     env:
-      # OpenDAL's MSRV is 1.75.
-      OPENDAL_MSRV: "1.75"
+      # OpenDAL's MSRV is 1.80.
+      OPENDAL_MSRV: "1.80"
     steps:
       - uses: actions/checkout@v4
       - name: Setup msrv of rust

--- a/bin/oay/Cargo.lock
+++ b/bin/oay/Cargo.lock
@@ -876,7 +876,6 @@ dependencies = [
  "http",
  "log",
  "md-5",
- "once_cell",
  "percent-encoding",
  "quick-xml",
  "reqwest",

--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -1037,7 +1037,6 @@ dependencies = [
  "http",
  "log",
  "md-5",
- "once_cell",
  "percent-encoding",
  "quick-xml 0.36.2",
  "rand",

--- a/bin/oli/Cargo.lock
+++ b/bin/oli/Cargo.lock
@@ -1980,7 +1980,6 @@ dependencies = [
  "md-5",
  "mini-moka",
  "moka",
- "once_cell",
  "percent-encoding",
  "prost",
  "quick-xml 0.36.2",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -5031,7 +5031,6 @@ dependencies = [
  "moka",
  "mongodb",
  "monoio",
- "once_cell",
  "openssh",
  "openssh-sftp-client",
  "opentelemetry",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -43,7 +43,7 @@ members = [".", "examples/*", "fuzz", "edge/*", "benches/vs_*"]
 [workspace.package]
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.50.1"
 
 [features]
@@ -246,8 +246,6 @@ futures = { version = "0.3", default-features = false, features = [
 http = "1.1"
 log = "0.4"
 md-5 = "0.10"
-# TODO: remove once_cell when lazy_lock is stable: https://doc.rust-lang.org/std/cell/struct.LazyCell.html
-once_cell = "1"
 percent-encoding = "2"
 quick-xml = { version = "0.36", features = ["serialize", "overlapped-lists"] }
 reqwest = { version = "0.12.2", features = [

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.50.1"
 
 [lints.clippy]

--- a/core/benches/types/concurrent_tasks.rs
+++ b/core/benches/types/concurrent_tasks.rs
@@ -15,16 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use criterion::BatchSize;
 use criterion::Criterion;
-use once_cell::sync::Lazy;
 use opendal::raw::ConcurrentTasks;
 use opendal::Executor;
 
-pub static TOKIO: Lazy<tokio::runtime::Runtime> =
-    Lazy::new(|| tokio::runtime::Runtime::new().expect("build tokio runtime"));
+pub static TOKIO: LazyLock<tokio::runtime::Runtime> =
+    LazyLock::new(|| tokio::runtime::Runtime::new().expect("build tokio runtime"));
 
 pub fn bench_concurrent_tasks(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench_concurrent_tasks");

--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -98,14 +98,15 @@ use crate::*;
 /// > runtime on demand.
 ///
 /// ```rust,no_run
-/// # use once_cell::sync::Lazy;
+/// # use std::sync::LazyLock;
+/// #
 /// # use opendal::layers::BlockingLayer;
 /// # use opendal::services;
 /// # use opendal::BlockingOperator;
 /// # use opendal::Operator;
 /// # use opendal::Result;
 ///
-/// static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+/// static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
 ///     tokio::runtime::Builder::new_multi_thread()
 ///         .enable_all()
 ///         .build()
@@ -300,12 +301,12 @@ impl<I: oio::List> oio::BlockingList for BlockingWrapper<I> {
 
 #[cfg(test)]
 mod tests {
-    use once_cell::sync::Lazy;
+    use std::sync::LazyLock;
 
     use super::*;
     use crate::types::Result;
 
-    static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
         tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -22,12 +22,12 @@ use std::mem;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::LazyLock;
 
 use futures::Future;
 use futures::TryStreamExt;
 use http::Request;
 use http::Response;
-use once_cell::sync::Lazy;
 use raw::oio::Read;
 
 use super::parse_content_encoding;
@@ -40,7 +40,8 @@ use crate::*;
 /// This is merely a temporary solution because reqsign requires a reqwest client to be passed.
 /// We will remove it after the next major version of reqsign, which will enable users to provide their own client.
 #[allow(dead_code)]
-pub(crate) static GLOBAL_REQWEST_CLIENT: Lazy<reqwest::Client> = Lazy::new(reqwest::Client::new);
+pub(crate) static GLOBAL_REQWEST_CLIENT: LazyLock<reqwest::Client> =
+    LazyLock::new(reqwest::Client::new);
 
 /// HttpFetcher is a type erased [`HttpFetch`].
 pub type HttpFetcher = Arc<dyn HttpFetchDyn>;

--- a/core/src/raw/tests/utils.rs
+++ b/core/src/raw/tests/utils.rs
@@ -18,13 +18,12 @@
 use std::collections::HashMap;
 use std::env;
 use std::str::FromStr;
-
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 use crate::*;
 
 /// TEST_RUNTIME is the runtime used for running tests.
-pub static TEST_RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+pub static TEST_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/core/src/services/dropbox/core.rs
+++ b/core/src/services/dropbox/core.rs
@@ -20,6 +20,7 @@ use std::default::Default;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use backon::ExponentialBuilder;
@@ -33,7 +34,6 @@ use http::header::CONTENT_TYPE;
 use http::Request;
 use http::Response;
 use http::StatusCode;
-use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::Mutex;
@@ -43,7 +43,7 @@ use crate::raw::*;
 use crate::*;
 
 /// BACKOFF is the backoff used inside dropbox to make sure dropbox async task succeed.
-pub static BACKOFF: Lazy<ExponentialBuilder> = Lazy::new(|| {
+pub static BACKOFF: LazyLock<ExponentialBuilder> = LazyLock::new(|| {
     ExponentialBuilder::default()
         .with_max_delay(Duration::from_secs(10))
         .with_max_times(10)

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Write;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use backon::ExponentialBuilder;
@@ -31,7 +32,6 @@ use http::header::IF_MATCH;
 use http::header::IF_NONE_MATCH;
 use http::Request;
 use http::Response;
-use once_cell::sync::Lazy;
 use reqsign::GoogleCredential;
 use reqsign::GoogleCredentialLoader;
 use reqsign::GoogleSigner;
@@ -73,8 +73,8 @@ impl Debug for GcsCore {
     }
 }
 
-static BACKOFF: Lazy<ExponentialBuilder> =
-    Lazy::new(|| ExponentialBuilder::default().with_jitter());
+static BACKOFF: LazyLock<ExponentialBuilder> =
+    LazyLock::new(|| ExponentialBuilder::default().with_jitter());
 
 impl GcsCore {
     async fn load_token(&self) -> Result<Option<GoogleToken>> {

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -22,6 +22,7 @@ use std::fmt::Write;
 use std::str::FromStr;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::LazyLock;
 
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
@@ -32,7 +33,6 @@ use log::debug;
 use log::warn;
 use md5::Digest;
 use md5::Md5;
-use once_cell::sync::Lazy;
 use reqsign::AwsAssumeRoleLoader;
 use reqsign::AwsConfig;
 use reqsign::AwsCredentialLoad;
@@ -52,7 +52,7 @@ use crate::services::S3Config;
 use crate::*;
 
 /// Allow constructing correct region endpoint if user gives a global endpoint.
-static ENDPOINT_TEMPLATES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
+static ENDPOINT_TEMPLATES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
     let mut m = HashMap::new();
     // AWS S3 Service.
     m.insert(

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -416,13 +416,14 @@ impl From<Error> for io::Error {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::LazyLock;
+
     use anyhow::anyhow;
-    use once_cell::sync::Lazy;
     use pretty_assertions::assert_eq;
 
     use super::*;
 
-    static TEST_ERROR: Lazy<Error> = Lazy::new(|| Error {
+    static TEST_ERROR: LazyLock<Error> = LazyLock::new(|| Error {
         kind: ErrorKind::Unexpected,
         message: "something wrong happened".to_string(),
         status: ErrorStatus::Permanent,
@@ -437,17 +438,17 @@ mod tests {
 
     #[test]
     fn test_error_display() {
-        let s = format!("{}", Lazy::force(&TEST_ERROR));
+        let s = format!("{}", LazyLock::force(&TEST_ERROR));
         assert_eq!(
             s,
             r#"Unexpected (permanent) at Read, context: { path: /path/to/file, called: send_async } => something wrong happened, source: networking error"#
         );
-        println!("{:#?}", Lazy::force(&TEST_ERROR));
+        println!("{:#?}", LazyLock::force(&TEST_ERROR));
     }
 
     #[test]
     fn test_error_debug() {
-        let s = format!("{:?}", Lazy::force(&TEST_ERROR));
+        let s = format!("{:?}", LazyLock::force(&TEST_ERROR));
         assert_eq!(
             s,
             r#"Unexpected (permanent) at Read => something wrong happened

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -1965,7 +1965,7 @@ impl Operator {
     }
 }
 
-/// Operator presign API.
+/// # Operator presign API.
 impl Operator {
     /// Presign an operation for stat(head).
     ///


### PR DESCRIPTION
# Which issue does this PR close?

No

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- use stabilized `std::sync::LazyLock` instead of `once_cell::sync::Lazy`
- remove `once_cell` dependency from `opendal` core

# Are there any user-facing changes?

MSRV: 1.75 => 1.80
