### PR TITLE
chore(core): upgrade msrv of opendal core to 1.80

### DIFF
--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -80,8 +80,8 @@ jobs:
   check_msrv:
     runs-on: ubuntu-latest
     env:
-      # OpenDAL's MSRV is 1.75.
-      OPENDAL_MSRV: "1.75"
+      # OpenDAL's MSRV is 1.80.
+      OPENDAL_MSRV: "1.80"
     steps:
       - uses: actions/checkout@v4
       - name: Setup msrv of rust

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.50.1"
 
 [lints.clippy]
@@ -43,7 +43,7 @@ members = [".", "examples/*", "fuzz", "edge/*", "benches/vs_*"]
 [workspace.package]
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.50.1"
 
 [features]

--- a/core/src/layers/dtrace.rs
+++ b/core/src/layers/dtrace.rs
@@ -358,18 +358,16 @@ impl<R: oio::BlockingRead> oio::BlockingRead for DtraceLayerWrapper<R> {
         probe_lazy!(opendal, blocking_reader_read_start, c_path.as_ptr());
         self.inner
             .read()
-            .map(|bs| {
+            .inspect(|bs| {
                 probe_lazy!(
                     opendal,
                     blocking_reader_read_ok,
                     c_path.as_ptr(),
                     bs.remaining()
                 );
-                bs
             })
-            .map_err(|e| {
+            .inspect_err(|_| {
                 probe_lazy!(opendal, blocking_reader_read_error, c_path.as_ptr());
-                e
             })
     }
 }
@@ -381,12 +379,11 @@ impl<R: oio::Write> oio::Write for DtraceLayerWrapper<R> {
         self.inner
             .write(bs)
             .await
-            .map(|_| {
+            .inspect(|_| {
                 probe_lazy!(opendal, writer_write_ok, c_path.as_ptr());
             })
-            .map_err(|err| {
+            .inspect_err(|_| {
                 probe_lazy!(opendal, writer_write_error, c_path.as_ptr());
-                err
             })
     }
 
@@ -396,12 +393,11 @@ impl<R: oio::Write> oio::Write for DtraceLayerWrapper<R> {
         self.inner
             .abort()
             .await
-            .map(|_| {
+            .inspect(|_| {
                 probe_lazy!(opendal, writer_poll_abort_ok, c_path.as_ptr());
             })
-            .map_err(|err| {
+            .inspect_err(|_| {
                 probe_lazy!(opendal, writer_poll_abort_error, c_path.as_ptr());
-                err
             })
     }
 
@@ -411,12 +407,11 @@ impl<R: oio::Write> oio::Write for DtraceLayerWrapper<R> {
         self.inner
             .close()
             .await
-            .map(|_| {
+            .inspect(|_| {
                 probe_lazy!(opendal, writer_close_ok, c_path.as_ptr());
             })
-            .map_err(|err| {
+            .inspect_err(|_| {
                 probe_lazy!(opendal, writer_close_error, c_path.as_ptr());
-                err
             })
     }
 }
@@ -427,12 +422,11 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for DtraceLayerWrapper<R> {
         probe_lazy!(opendal, blocking_writer_write_start, c_path.as_ptr());
         self.inner
             .write(bs)
-            .map(|_| {
+            .inspect(|_| {
                 probe_lazy!(opendal, blocking_writer_write_ok, c_path.as_ptr());
             })
-            .map_err(|err| {
+            .inspect_err(|_| {
                 probe_lazy!(opendal, blocking_writer_write_error, c_path.as_ptr());
-                err
             })
     }
 
@@ -441,12 +435,11 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for DtraceLayerWrapper<R> {
         probe_lazy!(opendal, blocking_writer_close_start, c_path.as_ptr());
         self.inner
             .close()
-            .map(|_| {
+            .inspect(|_| {
                 probe_lazy!(opendal, blocking_writer_close_ok, c_path.as_ptr());
             })
-            .map_err(|err| {
+            .inspect_err(|_| {
                 probe_lazy!(opendal, blocking_writer_close_error, c_path.as_ptr());
-                err
             })
     }
 }

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -350,9 +350,8 @@ impl<T: oio::Read> oio::Read for ErrorContextWrapper<T> {
         self.inner
             .read()
             .await
-            .map(|bs| {
+            .inspect(|bs| {
                 self.processed += bs.len() as u64;
-                bs
             })
             .map_err(|err| {
                 err.with_operation(Operation::ReaderRead)
@@ -368,9 +367,8 @@ impl<T: oio::BlockingRead> oio::BlockingRead for ErrorContextWrapper<T> {
     fn read(&mut self) -> Result<Buffer> {
         self.inner
             .read()
-            .map(|bs| {
+            .inspect(|bs| {
                 self.processed += bs.len() as u64;
-                bs
             })
             .map_err(|err| {
                 err.with_operation(Operation::BlockingReaderRead)
@@ -451,9 +449,8 @@ impl<T: oio::List> oio::List for ErrorContextWrapper<T> {
         self.inner
             .next()
             .await
-            .map(|bs| {
+            .inspect(|bs| {
                 self.processed += bs.is_some() as u64;
-                bs
             })
             .map_err(|err| {
                 err.with_operation(Operation::ListerNext)
@@ -468,9 +465,8 @@ impl<T: oio::BlockingList> oio::BlockingList for ErrorContextWrapper<T> {
     fn next(&mut self) -> Result<Option<oio::Entry>> {
         self.inner
             .next()
-            .map(|bs| {
+            .inspect(|bs| {
                 self.processed += bs.is_some() as u64;
-                bs
             })
             .map_err(|err| {
                 err.with_operation(Operation::BlockingListerNext)

--- a/core/src/layers/observe/metrics.rs
+++ b/core/src/layers/observe/metrics.rs
@@ -191,7 +191,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         self.inner()
             .create_dir(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -200,9 +200,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -211,7 +210,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -223,7 +221,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
             .inner
             .read(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -232,9 +230,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -243,7 +240,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((
@@ -267,7 +263,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
             .inner
             .write(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -276,9 +272,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -287,7 +282,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((
@@ -310,7 +304,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         self.inner()
             .copy(from, to, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -319,9 +313,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -330,7 +323,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -341,7 +333,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         self.inner()
             .rename(from, to, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -350,9 +342,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -361,7 +352,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -372,7 +362,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         self.inner()
             .stat(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -381,9 +371,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -392,7 +381,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -403,7 +391,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         self.inner()
             .delete(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -412,9 +400,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -423,7 +410,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -435,7 +421,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
             .inner
             .list(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -444,9 +430,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -455,7 +440,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((
@@ -478,7 +462,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         self.inner()
             .batch(args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -487,9 +471,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -498,7 +481,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -509,7 +491,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         self.inner()
             .presign(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -518,9 +500,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -529,7 +510,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -539,7 +519,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let start = Instant::now();
         self.inner()
             .blocking_create_dir(path, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -548,9 +528,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -559,7 +538,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -570,7 +548,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let (rp, reader) = self
             .inner
             .blocking_read(path, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -579,9 +557,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -590,7 +567,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((
@@ -613,7 +589,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let (rp, writer) = self
             .inner
             .blocking_write(path, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -622,9 +598,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -633,7 +608,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((
@@ -655,7 +629,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let start = Instant::now();
         self.inner()
             .blocking_copy(from, to, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -664,9 +638,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -675,7 +648,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -685,7 +657,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let start = Instant::now();
         self.inner()
             .blocking_rename(from, to, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -694,9 +666,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -705,7 +676,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -715,7 +685,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let start = Instant::now();
         self.inner()
             .blocking_stat(path, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -724,9 +694,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -735,7 +704,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -745,7 +713,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let start = Instant::now();
         self.inner()
             .blocking_delete(path, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -754,9 +722,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -765,7 +732,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -776,7 +742,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let (rp, lister) = self
             .inner
             .blocking_list(path, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.scheme,
                     self.namespace.clone(),
@@ -785,9 +751,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.scheme,
                     self.namespace.clone(),
@@ -796,7 +761,6 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((


### PR DESCRIPTION
# Which issue does this PR close?

Close https://github.com/apache/opendal/discussions/5253

# Rationale for this change

This is a pre-modification of #5252. I want to keep the modification of #5252 as pure as possible.

# What changes are included in this PR?

- upgrade MSRV of opendal core: 1.75 => 1.80
- use `inspect` and `inspect_err` instead of `map` and `map_err` to fix clippy warnings

# Are there any user-facing changes?

MSRV: 1.75 => 1.80