### PR TITLE
chore(core/layers): adjust await point to simplify combinator code

### DIFF
--- a/core/src/layers/async_backtrace.rs
+++ b/core/src/layers/async_backtrace.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use futures::FutureExt;
-
 use crate::raw::*;
 use crate::*;
 
@@ -76,16 +74,16 @@ impl<A: Access> LayeredAccess for AsyncBacktraceAccessor<A> {
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         self.inner
             .read(path, args)
-            .map(|v| v.map(|(rp, r)| (rp, AsyncBacktraceWrapper::new(r))))
             .await
+            .map(|(rp, r)| (rp, AsyncBacktraceWrapper::new(r)))
     }
 
     #[async_backtrace::framed]
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         self.inner
             .write(path, args)
-            .map(|v| v.map(|(rp, r)| (rp, AsyncBacktraceWrapper::new(r))))
             .await
+            .map(|(rp, r)| (rp, AsyncBacktraceWrapper::new(r)))
     }
 
     #[async_backtrace::framed]
@@ -112,8 +110,8 @@ impl<A: Access> LayeredAccess for AsyncBacktraceAccessor<A> {
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
         self.inner
             .list(path, args)
-            .map(|v| v.map(|(rp, r)| (rp, AsyncBacktraceWrapper::new(r))))
             .await
+            .map(|(rp, r)| (rp, AsyncBacktraceWrapper::new(r)))
     }
 
     #[async_backtrace::framed]

--- a/core/src/layers/await_tree.rs
+++ b/core/src/layers/await_tree.rs
@@ -17,7 +17,6 @@
 
 use await_tree::InstrumentAwait;
 use futures::Future;
-use futures::FutureExt;
 
 use crate::raw::*;
 use crate::*;
@@ -86,16 +85,16 @@ impl<A: Access> LayeredAccess for AwaitTreeAccessor<A> {
         self.inner
             .read(path, args)
             .instrument_await(format!("opendal::{}", Operation::Read))
-            .map(|v| v.map(|(rp, r)| (rp, AwaitTreeWrapper::new(r))))
             .await
+            .map(|(rp, r)| (rp, AwaitTreeWrapper::new(r)))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         self.inner
             .write(path, args)
             .instrument_await(format!("opendal::{}", Operation::Write))
-            .map(|v| v.map(|(rp, r)| (rp, AwaitTreeWrapper::new(r))))
             .await
+            .map(|(rp, r)| (rp, AwaitTreeWrapper::new(r)))
     }
 
     async fn copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
@@ -130,8 +129,8 @@ impl<A: Access> LayeredAccess for AwaitTreeAccessor<A> {
         self.inner
             .list(path, args)
             .instrument_await(format!("opendal::{}", Operation::List))
-            .map(|v| v.map(|(rp, r)| (rp, AwaitTreeWrapper::new(r))))
             .await
+            .map(|(rp, r)| (rp, AwaitTreeWrapper::new(r)))
     }
 
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {

--- a/core/src/layers/chaos.rs
+++ b/core/src/layers/chaos.rs
@@ -18,7 +18,6 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use futures::FutureExt;
 use rand::prelude::*;
 use rand::rngs::StdRng;
 
@@ -114,8 +113,8 @@ impl<A: Access> LayeredAccess for ChaosAccessor<A> {
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         self.inner
             .read(path, args)
-            .map(|v| v.map(|(rp, r)| (rp, ChaosReader::new(r, self.rng.clone(), self.error_ratio))))
             .await
+            .map(|(rp, r)| (rp, ChaosReader::new(r, self.rng.clone(), self.error_ratio)))
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {

--- a/core/src/layers/fastrace.rs
+++ b/core/src/layers/fastrace.rs
@@ -20,7 +20,6 @@ use std::future::Future;
 use std::sync::Arc;
 
 use fastrace::prelude::*;
-use futures::FutureExt;
 
 use crate::raw::*;
 use crate::*;
@@ -144,32 +143,22 @@ impl<A: Access> LayeredAccess for FastraceAccessor<A> {
 
     #[trace(enter_on_poll = true)]
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        self.inner
-            .read(path, args)
-            .map(|v| {
-                v.map(|(rp, r)| {
-                    (
-                        rp,
-                        FastraceWrapper::new(Span::enter_with_local_parent("ReadOperation"), r),
-                    )
-                })
-            })
-            .await
+        self.inner.read(path, args).await.map(|(rp, r)| {
+            (
+                rp,
+                FastraceWrapper::new(Span::enter_with_local_parent("ReadOperation"), r),
+            )
+        })
     }
 
     #[trace(enter_on_poll = true)]
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        self.inner
-            .write(path, args)
-            .map(|v| {
-                v.map(|(rp, r)| {
-                    (
-                        rp,
-                        FastraceWrapper::new(Span::enter_with_local_parent("WriteOperation"), r),
-                    )
-                })
-            })
-            .await
+        self.inner.write(path, args).await.map(|(rp, r)| {
+            (
+                rp,
+                FastraceWrapper::new(Span::enter_with_local_parent("WriteOperation"), r),
+            )
+        })
     }
 
     #[trace(enter_on_poll = true)]
@@ -194,17 +183,12 @@ impl<A: Access> LayeredAccess for FastraceAccessor<A> {
 
     #[trace(enter_on_poll = true)]
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
-        self.inner
-            .list(path, args)
-            .map(|v| {
-                v.map(|(rp, s)| {
-                    (
-                        rp,
-                        FastraceWrapper::new(Span::enter_with_local_parent("ListOperation"), s),
-                    )
-                })
-            })
-            .await
+        self.inner.list(path, args).await.map(|(rp, s)| {
+            (
+                rp,
+                FastraceWrapper::new(Span::enter_with_local_parent("ListOperation"), s),
+            )
+        })
     }
 
     #[trace(enter_on_poll = true)]

--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -18,7 +18,6 @@
 use std::future::Future;
 use std::sync::Arc;
 
-use futures::FutureExt;
 use opentelemetry::global;
 use opentelemetry::global::BoxedSpan;
 use opentelemetry::trace::FutureExt as TraceFutureExt;
@@ -99,8 +98,8 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         span.set_attribute(KeyValue::new("args", format!("{:?}", args)));
         self.inner
             .read(path, args)
-            .map(|v| v.map(|(rp, r)| (rp, OtelTraceWrapper::new(span, r))))
             .await
+            .map(|(rp, r)| (rp, OtelTraceWrapper::new(span, r)))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
@@ -159,8 +158,8 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         span.set_attribute(KeyValue::new("args", format!("{:?}", args)));
         self.inner
             .list(path, args)
-            .map(|v| v.map(|(rp, s)| (rp, OtelTraceWrapper::new(span, s))))
             .await
+            .map(|(rp, s)| (rp, OtelTraceWrapper::new(span, s)))
     }
 
     async fn batch(&self, args: OpBatch) -> Result<RpBatch> {

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -19,7 +19,6 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::sync::Arc;
 
-use futures::FutureExt;
 use tracing::Span;
 
 use crate::raw::*;
@@ -179,8 +178,8 @@ impl<A: Access> LayeredAccess for TracingAccessor<A> {
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         self.inner
             .read(path, args)
-            .map(|v| v.map(|(rp, r)| (rp, TracingWrapper::new(Span::current(), r))))
             .await
+            .map(|(rp, r)| (rp, TracingWrapper::new(Span::current(), r)))
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -215,8 +214,8 @@ impl<A: Access> LayeredAccess for TracingAccessor<A> {
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
         self.inner
             .list(path, args)
-            .map(|v| v.map(|(rp, s)| (rp, TracingWrapper::new(Span::current(), s))))
             .await
+            .map(|(rp, s)| (rp, TracingWrapper::new(Span::current(), s)))
     }
 
     #[tracing::instrument(level = "debug", skip(self))]


### PR DESCRIPTION
# Which issue does this PR close?

No

# Rationale for this change

# What changes are included in this PR?

Enter the await point before processing `Result` to simplify the combination code

# Are there any user-facing changes?

No
