### PR TITLE
chore(core/layers): align `info` method of `trait Access` and `trait LayeredAccess`

### DIFF
--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -173,7 +173,7 @@ impl<A: Access> LayeredAccess for BlockingAccessor<A> {
         &self.inner
     }
 
-    fn metadata(&self) -> Arc<AccessorInfo> {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut meta = self.inner.info().as_ref().clone();
         meta.full_capability_mut().blocking = true;
         meta.into()

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -377,7 +377,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     // Todo: May move the logic to the implement of Layer::layer of CompleteAccessor<A>
-    fn metadata(&self) -> Arc<AccessorInfo> {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut meta = (*self.meta).clone();
         let cap = meta.full_capability_mut();
         if cap.list && cap.write_can_empty {

--- a/core/src/layers/complete.rs
+++ b/core/src/layers/complete.rs
@@ -110,7 +110,7 @@ impl<A: Access> Layer<A> for CompleteLayer {
 
     fn layer(&self, inner: A) -> Self::LayeredAccess {
         CompleteAccessor {
-            meta: inner.info(),
+            info: inner.info(),
             inner: Arc::new(inner),
         }
     }
@@ -118,7 +118,7 @@ impl<A: Access> Layer<A> for CompleteLayer {
 
 /// Provide complete wrapper for backend.
 pub struct CompleteAccessor<A: Access> {
-    meta: Arc<AccessorInfo>,
+    info: Arc<AccessorInfo>,
     inner: Arc<A>,
 }
 
@@ -130,7 +130,7 @@ impl<A: Access> Debug for CompleteAccessor<A> {
 
 impl<A: Access> CompleteAccessor<A> {
     fn new_unsupported_error(&self, op: impl Into<&'static str>) -> Error {
-        let scheme = self.meta.scheme();
+        let scheme = self.info.scheme();
         let op = op.into();
         Error::new(
             ErrorKind::Unsupported,
@@ -140,7 +140,7 @@ impl<A: Access> CompleteAccessor<A> {
     }
 
     async fn complete_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if capability.create_dir {
             return self.inner().create_dir(path, args).await;
         }
@@ -154,7 +154,7 @@ impl<A: Access> CompleteAccessor<A> {
     }
 
     fn complete_blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if capability.create_dir && capability.blocking {
             return self.inner().blocking_create_dir(path, args);
         }
@@ -168,7 +168,7 @@ impl<A: Access> CompleteAccessor<A> {
     }
 
     async fn complete_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.stat {
             return Err(self.new_unsupported_error(Operation::Stat));
         }
@@ -218,7 +218,7 @@ impl<A: Access> CompleteAccessor<A> {
     }
 
     fn complete_blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.stat {
             return Err(self.new_unsupported_error(Operation::Stat));
         }
@@ -271,7 +271,7 @@ impl<A: Access> CompleteAccessor<A> {
         path: &str,
         args: OpList,
     ) -> Result<(RpList, CompleteLister<A, A::Lister>)> {
-        let cap = self.meta.full_capability();
+        let cap = self.info.full_capability();
         if !cap.list {
             return Err(self.new_unsupported_error(Operation::List));
         }
@@ -319,7 +319,7 @@ impl<A: Access> CompleteAccessor<A> {
         path: &str,
         args: OpList,
     ) -> Result<(RpList, CompleteLister<A, A::BlockingLister>)> {
-        let cap = self.meta.full_capability();
+        let cap = self.info.full_capability();
         if !cap.list {
             return Err(self.new_unsupported_error(Operation::BlockingList));
         }
@@ -378,7 +378,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
 
     // Todo: May move the logic to the implement of Layer::layer of CompleteAccessor<A>
     fn info(&self) -> Arc<AccessorInfo> {
-        let mut meta = (*self.meta).clone();
+        let mut meta = (*self.info).clone();
         let cap = meta.full_capability_mut();
         if cap.list && cap.write_can_empty {
             cap.create_dir = true;
@@ -391,7 +391,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.read {
             return Err(self.new_unsupported_error(Operation::Read));
         }
@@ -404,7 +404,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.write {
             return Err(self.new_unsupported_error(Operation::Write));
         }
@@ -413,7 +413,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
                 ErrorKind::Unsupported,
                 format!(
                     "service {} doesn't support operation write with append",
-                    self.info().scheme()
+                    self.info.scheme()
                 ),
             ));
         }
@@ -424,7 +424,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     async fn copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.copy {
             return Err(self.new_unsupported_error(Operation::Copy));
         }
@@ -433,7 +433,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.rename {
             return Err(self.new_unsupported_error(Operation::Rename));
         }
@@ -446,7 +446,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     async fn delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.delete {
             return Err(self.new_unsupported_error(Operation::Delete));
         }
@@ -455,7 +455,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.list {
             return Err(self.new_unsupported_error(Operation::List));
         }
@@ -464,7 +464,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.batch {
             return Err(self.new_unsupported_error(Operation::Batch));
         }
@@ -473,7 +473,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.presign {
             return Err(self.new_unsupported_error(Operation::Presign));
         }
@@ -486,7 +486,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.read || !capability.blocking {
             return Err(self.new_unsupported_error(Operation::Read));
         }
@@ -498,7 +498,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.write || !capability.blocking {
             return Err(self.new_unsupported_error(Operation::BlockingWrite));
         }
@@ -508,7 +508,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
                 ErrorKind::Unsupported,
                 format!(
                     "service {} doesn't support operation write with append",
-                    self.info().scheme()
+                    self.info.scheme()
                 ),
             ));
         }
@@ -519,7 +519,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     fn blocking_copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.copy || !capability.blocking {
             return Err(self.new_unsupported_error(Operation::BlockingCopy));
         }
@@ -528,7 +528,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     fn blocking_rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.rename || !capability.blocking {
             return Err(self.new_unsupported_error(Operation::BlockingRename));
         }
@@ -541,7 +541,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     fn blocking_delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.delete || !capability.blocking {
             return Err(self.new_unsupported_error(Operation::BlockingDelete));
         }
@@ -550,7 +550,7 @@ impl<A: Access> LayeredAccess for CompleteAccessor<A> {
     }
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingLister)> {
-        let capability = self.meta.full_capability();
+        let capability = self.info.full_capability();
         if !capability.list || !capability.blocking {
             return Err(self.new_unsupported_error(Operation::BlockingList));
         }

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -75,7 +75,7 @@ impl<A: Access> LayeredAccess for ErrorContextAccessor<A> {
         &self.inner
     }
 
-    fn metadata(&self) -> Arc<AccessorInfo> {
+    fn info(&self) -> Arc<AccessorInfo> {
         self.meta.clone()
     }
 

--- a/core/src/layers/fastrace.rs
+++ b/core/src/layers/fastrace.rs
@@ -132,7 +132,7 @@ impl<A: Access> LayeredAccess for FastraceAccessor<A> {
     }
 
     #[trace]
-    fn metadata(&self) -> Arc<AccessorInfo> {
+    fn info(&self) -> Arc<AccessorInfo> {
         self.inner.info()
     }
 

--- a/core/src/layers/immutable_index.rs
+++ b/core/src/layers/immutable_index.rs
@@ -149,7 +149,7 @@ impl<A: Access> LayeredAccess for ImmutableIndexAccessor<A> {
     }
 
     /// Add list capabilities for underlying storage services.
-    fn metadata(&self) -> Arc<AccessorInfo> {
+    fn info(&self) -> Arc<AccessorInfo> {
         let mut meta = (*self.inner.info()).clone();
 
         let cap = meta.full_capability_mut();

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -266,7 +266,7 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
         &self.inner
     }
 
-    fn metadata(&self) -> Arc<AccessorInfo> {
+    fn info(&self) -> Arc<AccessorInfo> {
         self.logger
             .log(&self.info, Operation::Info, &[], "started", None);
 

--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -77,7 +77,7 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         &self.inner
     }
 
-    fn metadata(&self) -> Arc<AccessorInfo> {
+    fn info(&self) -> Arc<AccessorInfo> {
         let tracer = global::tracer("opendal");
         tracer.in_span("metadata", |_cx| self.inner.info())
     }

--- a/core/src/layers/tracing.rs
+++ b/core/src/layers/tracing.rs
@@ -165,7 +165,7 @@ impl<A: Access> LayeredAccess for TracingAccessor<A> {
     }
 
     #[tracing::instrument(level = "debug")]
-    fn metadata(&self) -> Arc<AccessorInfo> {
+    fn info(&self) -> Arc<AccessorInfo> {
         self.inner.info()
     }
 

--- a/core/src/raw/layer.rs
+++ b/core/src/raw/layer.rs
@@ -128,7 +128,6 @@ pub trait Layer<A: Access> {
 /// LayeredAccess is layered accessor that forward all not implemented
 /// method to inner.
 #[allow(missing_docs)]
-
 pub trait LayeredAccess: Send + Sync + Debug + Unpin + 'static {
     type Inner: Access;
     type Reader: oio::Read;
@@ -140,7 +139,7 @@ pub trait LayeredAccess: Send + Sync + Debug + Unpin + 'static {
 
     fn inner(&self) -> &Self::Inner;
 
-    fn metadata(&self) -> Arc<AccessorInfo> {
+    fn info(&self) -> Arc<AccessorInfo> {
         self.inner().info()
     }
 
@@ -241,86 +240,86 @@ pub trait LayeredAccess: Send + Sync + Debug + Unpin + 'static {
 
 impl<L: LayeredAccess> Access for L {
     type Reader = L::Reader;
-    type BlockingReader = L::BlockingReader;
     type Writer = L::Writer;
-    type BlockingWriter = L::BlockingWriter;
     type Lister = L::Lister;
+    type BlockingReader = L::BlockingReader;
+    type BlockingWriter = L::BlockingWriter;
     type BlockingLister = L::BlockingLister;
 
     fn info(&self) -> Arc<AccessorInfo> {
-        (self as &L).metadata()
+        LayeredAccess::info(self)
     }
 
     async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        (self as &L).create_dir(path, args).await
+        LayeredAccess::create_dir(self, path, args).await
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        (self as &L).read(path, args).await
+        LayeredAccess::read(self, path, args).await
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        (self as &L).write(path, args).await
+        LayeredAccess::write(self, path, args).await
     }
 
     async fn copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
-        (self as &L).copy(from, to, args).await
+        LayeredAccess::copy(self, from, to, args).await
     }
 
     async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
-        (self as &L).rename(from, to, args).await
+        LayeredAccess::rename(self, from, to, args).await
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        (self as &L).stat(path, args).await
+        LayeredAccess::stat(self, path, args).await
     }
 
     async fn delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
-        (self as &L).delete(path, args).await
+        LayeredAccess::delete(self, path, args).await
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
-        (self as &L).list(path, args).await
+        LayeredAccess::list(self, path, args).await
     }
 
     async fn batch(&self, args: OpBatch) -> Result<RpBatch> {
-        (self as &L).batch(args).await
+        LayeredAccess::batch(self, args).await
     }
 
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
-        (self as &L).presign(path, args).await
+        LayeredAccess::presign(self, path, args).await
     }
 
     fn blocking_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        (self as &L).blocking_create_dir(path, args)
+        LayeredAccess::blocking_create_dir(self, path, args)
     }
 
     fn blocking_read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::BlockingReader)> {
-        (self as &L).blocking_read(path, args)
+        LayeredAccess::blocking_read(self, path, args)
     }
 
     fn blocking_write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::BlockingWriter)> {
-        (self as &L).blocking_write(path, args)
+        LayeredAccess::blocking_write(self, path, args)
     }
 
     fn blocking_copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
-        (self as &L).blocking_copy(from, to, args)
+        LayeredAccess::blocking_copy(self, from, to, args)
     }
 
     fn blocking_rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
-        (self as &L).blocking_rename(from, to, args)
+        LayeredAccess::blocking_rename(self, from, to, args)
     }
 
     fn blocking_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        (self as &L).blocking_stat(path, args)
+        LayeredAccess::blocking_stat(self, path, args)
     }
 
     fn blocking_delete(&self, path: &str, args: OpDelete) -> Result<RpDelete> {
-        (self as &L).blocking_delete(path, args)
+        LayeredAccess::blocking_delete(self, path, args)
     }
 
     fn blocking_list(&self, path: &str, args: OpList) -> Result<(RpList, Self::BlockingLister)> {
-        (self as &L).blocking_list(path, args)
+        LayeredAccess::blocking_list(self, path, args)
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

No

# Rationale for this change

The `metadata` method of `LayeredAccess` and `info` method of `LayeredAccess` is misaligned.
we used to use `metadata` and changed it to `info`.

# What changes are included in this PR?

- rename `metadata` method of `trait LayeredAccess`:
   `fn metadata(&self) -> Arc<AccessorInfo>` => `fn info(&self) -> Arc<AccessorInfo>`

# Are there any user-facing changes?

`LayeredAccess::metadata` => `LayeredAccess::info`
