### PR TITLE
chore(core/blocking_operator): deduplicate deprecated `is_exist` logic

### DIFF
--- a/core/src/types/operator/blocking_operator.rs
+++ b/core/src/types/operator/blocking_operator.rs
@@ -306,14 +306,7 @@ impl BlockingOperator {
     /// ```
     #[deprecated(note = "rename to `exists` for consistence with `std::fs::exists`")]
     pub fn is_exist(&self, path: &str) -> Result<bool> {
-        let r = self.stat(path);
-        match r {
-            Ok(_) => Ok(true),
-            Err(err) => match err.kind() {
-                ErrorKind::NotFound => Ok(false),
-                _ => Err(err),
-            },
-        }
+        self.exists(path)
     }
 
     /// Create a dir at given path.


### PR DESCRIPTION
Closes #5260

# Rationale for this change

The logic for `is_exist` has been kept in place, although it is deprecated and the new method `exists` has been created. To keep it DRY and I think it makes sense, to let `is_exist` call `exists` internally.

# What changes are included in this PR?

We call `exists` from `is_exist`.

# Are there any user-facing changes?

No.