### PR TITLE
feat(core/services-gcs): support user defined metadata

### DIFF
--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -628,7 +628,10 @@ mod tests {
   "etag": "CKWasoTgyPkCEAE=",
   "timeCreated": "2022-08-15T11:33:34.866Z",
   "updated": "2022-08-15T11:33:34.866Z",
-  "timeStorageClassUpdated": "2022-08-15T11:33:34.866Z"
+  "timeStorageClassUpdated": "2022-08-15T11:33:34.866Z",
+  "metadata" : {
+    "location" : "everywhere"
+  }
 }"#;
 
         let meta: GetObjectJsonResponse =
@@ -639,5 +642,12 @@ mod tests {
         assert_eq!(meta.md5_hash, "fHcEH1vPwA6eTPqxuasXcg==");
         assert_eq!(meta.etag, "CKWasoTgyPkCEAE=");
         assert_eq!(meta.content_type, "image/png");
+        assert_eq!(
+            meta.metadata,
+            Some(HashMap::from_iter([(
+                "location".to_string(),
+                "everywhere".to_string()
+            )]))
+        );
     }
 }

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -426,7 +426,7 @@ impl Access for GcsBackend {
 
         m.set_last_modified(parse_datetime_from_rfc3339(&meta.updated)?);
 
-        if let Some(user_metadata) = meta.metadata {
+        if !meta.metadata.is_empty() {
             m.with_user_metadata(user_metadata);
         }
 
@@ -602,7 +602,7 @@ struct GetObjectJsonResponse {
     /// Custom metadata of this object.
     ///
     /// For example: `"metadata" : { "my-key": "my-value" }`
-    metadata: Option<HashMap<String, String>>,
+    metadata: HashMap<String, String>,
 }
 
 #[cfg(test)]
@@ -644,10 +644,7 @@ mod tests {
         assert_eq!(meta.content_type, "image/png");
         assert_eq!(
             meta.metadata,
-            Some(HashMap::from_iter([(
-                "location".to_string(),
-                "everywhere".to_string()
-            )]))
+            HashMap::from_iter([("location".to_string(), "everywhere".to_string())])
         );
     }
 }

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -363,6 +364,7 @@ impl Access for GcsBackend {
                 write_can_empty: true,
                 write_can_multi: true,
                 write_with_content_type: true,
+                write_with_user_metadata: true,
                 // The min multipart size of Gcs is 5 MiB.
                 //
                 // ref: <https://cloud.google.com/storage/docs/xml-api/put-object-multipart>
@@ -423,6 +425,10 @@ impl Access for GcsBackend {
         }
 
         m.set_last_modified(parse_datetime_from_rfc3339(&meta.updated)?);
+
+        if let Some(user_metadata) = meta.metadata {
+            m.with_user_metadata(user_metadata);
+        }
 
         Ok(RpStat::new(m))
     }
@@ -593,6 +599,15 @@ struct GetObjectJsonResponse {
     ///
     /// For example: `"contentType": "image/png",`
     content_type: String,
+    /// Custom metadata of this object.
+    ///
+    /// For example:
+    /// ```
+    /// "metadata" : {
+    ///  "my-key": "my-value"
+    /// }
+    /// ```
+    metadata: Option<HashMap<String, String>>,
 }
 
 #[cfg(test)]

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -427,7 +427,7 @@ impl Access for GcsBackend {
         m.set_last_modified(parse_datetime_from_rfc3339(&meta.updated)?);
 
         if !meta.metadata.is_empty() {
-            m.with_user_metadata(user_metadata);
+            m.with_user_metadata(meta.metadata);
         }
 
         Ok(RpStat::new(m))

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -601,12 +601,7 @@ struct GetObjectJsonResponse {
     content_type: String,
     /// Custom metadata of this object.
     ///
-    /// For example:
-    /// ```
-    /// "metadata" : {
-    ///  "my-key": "my-value"
-    /// }
-    /// ```
+    /// For example: `"metadata" : { "my-key": "my-value" }`
     metadata: Option<HashMap<String, String>>,
 }
 

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -41,7 +41,6 @@ use reqsign::GoogleToken;
 use reqsign::GoogleTokenLoader;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_json::json;
 
 use super::uri::percent_encode_path;
 use crate::raw::*;
@@ -250,19 +249,18 @@ impl GcsCore {
     ) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
-        let mut metadata = HashMap::new();
-        if let Some(storage_class) = &self.default_storage_class {
-            metadata.insert("storageClass", storage_class.as_str());
-        }
-        if let Some(cache_control) = op.cache_control() {
-            metadata.insert("cacheControl", cache_control);
-        }
+        let mut request_metadata = InsertRequestMetadata::default();
+
+        request_metadata.storage_class = self.default_storage_class.as_ref().map(String::as_str);
+        request_metadata.cache_control = op.cache_control();
+        request_metadata.content_type = op.content_type();
+        request_metadata.metadata = op.user_metadata();
 
         let mut url = format!(
             "{}/upload/storage/v1/b/{}/o?uploadType={}&name={}",
             self.endpoint,
             self.bucket,
-            if metadata.is_empty() {
+            if request_metadata.is_empty() {
                 "media"
             } else {
                 "multipart"
@@ -276,45 +274,30 @@ impl GcsCore {
 
         let mut req = Request::post(&url);
 
-        if let Some(user_metadata) = op.user_metadata() {
-            for (key, value) in user_metadata {
-                req = req.header(format!("{X_GOOG_META_PREFIX}{key}"), value)
-            }
-        }
-
         req = req.header(CONTENT_LENGTH, size.unwrap_or_default());
 
-        if metadata.is_empty() {
-            if let Some(content_type) = op.content_type() {
-                req = req.header(CONTENT_TYPE, content_type);
-            }
-
+        if request_metadata.is_empty() {
+            // If the metadata is empty, we do not set any `Content-Type` header,
+            // since if we had it in the `op.content_type()`, it would be alrady set in the
+            // `multipart` metadata body and this branch won't be executed.
             let req = req.body(body).map_err(new_request_build_error)?;
             Ok(req)
         } else {
             let mut multipart = Multipart::new();
-
-            multipart = multipart.part(
-                FormDataPart::new("metadata")
-                    .header(
-                        CONTENT_TYPE,
-                        "application/json; charset=UTF-8".parse().unwrap(),
-                    )
-                    .content(json!(metadata).to_string()),
-            );
-
-            let mut media_part = FormDataPart::new("media").content(body);
-
-            if let Some(content_type) = op.content_type() {
-                media_part = media_part.header(
+            let metadata_part = FormDataPart::new("metadata")
+                .header(
                     CONTENT_TYPE,
-                    content_type
-                        .parse()
-                        .map_err(|_| Error::new(ErrorKind::Unexpected, "invalid header value"))?,
+                    "application/json; charset=UTF-8".parse().unwrap(),
+                )
+                .content(
+                    serde_json::to_string(&request_metadata)
+                        .expect("metadata serialization should success"),
                 );
-            }
+            multipart = multipart.part(metadata_part);
 
+            let media_part = FormDataPart::new("media").content(body);
             multipart = multipart.part(media_part);
+
             let req = multipart.apply(Request::post(url))?;
             Ok(req)
         }
@@ -629,6 +612,38 @@ impl GcsCore {
     }
 }
 
+#[derive(Debug, Serialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct InsertRequestMetadata<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content_type: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    storage_class: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cache_control: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<&'a HashMap<String, String>>,
+}
+
+impl Default for InsertRequestMetadata<'_> {
+    fn default() -> Self {
+        Self {
+            content_type: None,
+            storage_class: None,
+            cache_control: None,
+            metadata: None,
+        }
+    }
+}
+
+impl InsertRequestMetadata<'_> {
+    pub fn is_empty(&self) -> bool {
+        self.content_type.is_none()
+            && self.storage_class.is_none()
+            && self.cache_control.is_none()
+            && self.metadata.is_none()
+    }
+}
 /// Response JSON from GCS list objects API.
 ///
 /// refer to https://cloud.google.com/storage/docs/json_api/v1/objects/list for details

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -288,7 +288,7 @@ impl GcsCore {
                     "application/json; charset=UTF-8".parse().unwrap(),
                 )
                 .content(
-                    serde_json::to_string(&request_metadata)
+                    serde_json::to_vec(&request_metadata)
                         .expect("metadata serialization should success"),
                 );
             multipart = multipart.part(metadata_part);

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -278,7 +278,7 @@ impl GcsCore {
 
         if request_metadata.is_empty() {
             // If the metadata is empty, we do not set any `Content-Type` header,
-            // since if we had it in the `op.content_type()`, it would be alrady set in the
+            // since if we had it in the `op.content_type()`, it would be already set in the
             // `multipart` metadata body and this branch won't be executed.
             let req = req.body(body).map_err(new_request_build_error)?;
             Ok(req)

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -247,7 +247,7 @@ impl GcsCore {
     ) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
-        let mut request_metadata = InsertRequestMetadata {
+        let request_metadata = InsertRequestMetadata {
             storage_class: self.default_storage_class.as_deref(),
             cache_control: op.cache_control(),
             content_type: op.content_type(),

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -247,12 +247,12 @@ impl GcsCore {
     ) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
-        let mut request_metadata = InsertRequestMetadata::default();
-
-        request_metadata.storage_class = self.default_storage_class.as_ref().map(String::as_str);
-        request_metadata.cache_control = op.cache_control();
-        request_metadata.content_type = op.content_type();
-        request_metadata.metadata = op.user_metadata();
+        let mut request_metadata = InsertRequestMetadata {
+            storage_class: self.default_storage_class.as_deref(),
+            cache_control: op.cache_control(),
+            content_type: op.content_type(),
+            metadata: op.user_metadata(),
+        };
 
         let mut url = format!(
             "{}/upload/storage/v1/b/{}/o?uploadType={}&name={}",
@@ -610,7 +610,7 @@ impl GcsCore {
     }
 }
 
-#[derive(Debug, Serialize, Default)]
+#[derive(Debug, Serialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct InsertRequestMetadata<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -610,7 +610,7 @@ impl GcsCore {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Default)]
 #[serde(default, rename_all = "camelCase")]
 pub struct InsertRequestMetadata<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -621,17 +621,6 @@ pub struct InsertRequestMetadata<'a> {
     cache_control: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<&'a HashMap<String, String>>,
-}
-
-impl Default for InsertRequestMetadata<'_> {
-    fn default() -> Self {
-        Self {
-            content_type: None,
-            storage_class: None,
-            cache_control: None,
-            metadata: None,
-        }
-    }
 }
 
 impl InsertRequestMetadata<'_> {

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -24,8 +24,6 @@ use std::time::Duration;
 use backon::ExponentialBuilder;
 use backon::Retryable;
 use bytes::Bytes;
-use constants::X_GOOG_ACL;
-use constants::X_GOOG_STORAGE_CLASS;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
 use http::header::HOST;


### PR DESCRIPTION
Relates to https://github.com/apache/opendal/issues/4842

Please do not merge yet, I'm not sure this works.

I didn't see the CI for GCS behaviour tests. Im not sure that this PR is ok, as I do not have a GCP account and couldn't find out how to test it locally. Tried it with https://github.com/fsouza/fake-gcs-server and I also couldn't figure it out. Also, I can't get the gcs behavior tests running in local
![image](https://github.com/user-attachments/assets/d9195470-f40a-4fde-a1d6-ea9570aeb19e)


Is the behaviour test plan ok? https://github.com/apache/opendal/actions/runs/11652657364/job/32444123433#step:3:39

It seems that the gcs service is being filtered out in this condition https://github.com/apache/opendal/blob/330bd74f3ace74f15966dfb2465191aa7c1ae5a6/.github/scripts/test_behavior/plan.py#L59
Maybe a maintainer has to manually run that check?