### PR TITLE
release: Bump to version 0.50.2 Round 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,122 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- Release notes generated using configuration in .github/release.yml at main -->
 
+## [v0.50.2] - 2024-11-04
+
+## What's Changed
+### Added
+* feat(core)!: make list return path itself by @meteorgan in https://github.com/apache/opendal/pull/4959
+* feat(services/oss): support role_arn and oidc_provider_arn by @tisonkun in https://github.com/apache/opendal/pull/5063
+* feat(services): add lakefs support by @liugddx in https://github.com/apache/opendal/pull/5086
+* feat: add list api for lakefs service. by @liugddx in https://github.com/apache/opendal/pull/5092
+* feat: add write api for lakefs service. by @liugddx in https://github.com/apache/opendal/pull/5100
+* feat: add delete api for lakefs service. by @liugddx in https://github.com/apache/opendal/pull/5107
+* feat(core/redis): Replace client requests with connection pool by @jackyyyyyssss in https://github.com/apache/opendal/pull/5117
+* feat: add copy api for lakefs service.  by @liugddx in https://github.com/apache/opendal/pull/5114
+* feat(core): add version(bool) for List operation to include version d… by @meteorgan in https://github.com/apache/opendal/pull/5106
+* feat(bindings/python): export ConcurrentLimitLayer by @TennyZhuang in https://github.com/apache/opendal/pull/5140
+* feat(bindings/c): add writer operation for Bindings C and Go by @yuchanns in https://github.com/apache/opendal/pull/5141
+* feat(ofs): introduce ofs macos support by @oowl in https://github.com/apache/opendal/pull/5136
+* feat: Reduce stat operation if we are reading all by @Xuanwo in https://github.com/apache/opendal/pull/5146
+* feat: add NebulaGraph config by @GG2002 in https://github.com/apache/opendal/pull/5147
+* feat(integrations/spring): add spring serialize method by @shoothzj in https://github.com/apache/opendal/pull/5154
+* feat: support write,read,delete with template by @shoothzj in https://github.com/apache/opendal/pull/5156
+* feat(bindings/java): support ConcurrentLimitLayer by @tisonkun in https://github.com/apache/opendal/pull/5168
+* feat: Add if_none_match for write by @ForestLH in https://github.com/apache/opendal/pull/5129
+* feat: Add OpenDAL Compat by @Xuanwo in https://github.com/apache/opendal/pull/5185
+* feat(core): abstract HttpFetch trait for raw http client by @everpcpc in https://github.com/apache/opendal/pull/5184
+* feat: Support NebulaGraph by @GG2002 in https://github.com/apache/opendal/pull/5116
+* feat(bindings/cpp): rename is_exist to exists as core did by @PragmaTwice in https://github.com/apache/opendal/pull/5198
+* feat(bindings/c): add opendal_operator_exists and mark is_exist deprecated by @PragmaTwice in https://github.com/apache/opendal/pull/5199
+* feat(binding/java): prefix thread name with opendal-tokio-worker by @tisonkun in https://github.com/apache/opendal/pull/5197
+* feat(services/ftp): List dir shows last modified timestamp by @erickguan in https://github.com/apache/opendal/pull/5213
+* feat(bindings/d): add D bindings support by @kassane in https://github.com/apache/opendal/pull/5181
+* feat(bindings/python): add sync `File.readline` by @TennyZhuang in https://github.com/apache/opendal/pull/5271
+* feat(core/services-azblob): support user defined metadata by @jorgehermo9 in https://github.com/apache/opendal/pull/5274
+### Changed
+* refactor: use sqlx for sql services  by @tisonkun in https://github.com/apache/opendal/pull/5040
+* refactor(core)!: Add observe layer as building block by @Xuanwo in https://github.com/apache/opendal/pull/5064
+* refactor(layers/prometheus): rewrite prometheus layer based on observe mod by @koushiro in https://github.com/apache/opendal/pull/5069
+* refactor(bindings/java): replace `num_cpus` with `std::thread::available_parallelism` by @miroim in https://github.com/apache/opendal/pull/5080
+* refactor(layers/prometheus): provide builder APIs by @koushiro in https://github.com/apache/opendal/pull/5072
+* refactor(layers/prometheus-client): provide builder APIs by @koushiro in https://github.com/apache/opendal/pull/5073
+* refactor(layers/metrics): rewrite metrics layer using observe layer by @koushiro in https://github.com/apache/opendal/pull/5098
+* refactor(services/cloudflare-kv): remove unneeded async and result on parse_error by @tsfotis in https://github.com/apache/opendal/pull/5128
+* refactor(*): remove unneeded async and result on parse_error by @tsfotis in https://github.com/apache/opendal/pull/5131
+* refactor: align C binding pattern by @tisonkun in https://github.com/apache/opendal/pull/5160
+* refactor: more consistent C binding pattern by @tisonkun in https://github.com/apache/opendal/pull/5162
+* refactor(integration/parquet): Use ParquetMetaDataReader instead by @Xuanwo in https://github.com/apache/opendal/pull/5170
+* refactor: resolve c pointers const by @tisonkun in https://github.com/apache/opendal/pull/5171
+* refactor(types/operator): rename is_exist to exists by @photino in https://github.com/apache/opendal/pull/5193
+* refactor(bin/oli): use `clap_derive` to reduce boilerplate code by @koushiro in https://github.com/apache/opendal/pull/5233
+### Fixed
+* fix(core): TimeoutLayer now needs enable tokio time by @Xuanwo in https://github.com/apache/opendal/pull/5057
+* fix(core): Fix failed list related tests by @Xuanwo in https://github.com/apache/opendal/pull/5058
+* fix(services/memory): blocking_scan right range by @meteorgan in https://github.com/apache/opendal/pull/5062
+* fix(core/services/mysql): Fix mysql Capability by @jackyyyyyssss in https://github.com/apache/opendal/pull/5067
+* fix: fix rust 1.76 error due to temporary value being dropped by @aawsome in https://github.com/apache/opendal/pull/5071
+* fix(service/fs): error due to temporary value being dropped by @miroim in https://github.com/apache/opendal/pull/5079
+* fix(core/services/hdfs): Fix the HDFS write failure when atomic_write_dir is set by @meteorgan in https://github.com/apache/opendal/pull/5039
+* fix(services/icloud): adjust error handling code to avoid having to write out result type explicitly by @koushiro in https://github.com/apache/opendal/pull/5091
+* fix(services/monoiofs): handle async cancel during file open by @NKID00 in https://github.com/apache/opendal/pull/5094
+* fix(services/huggingface): Align with latest HuggingFace API by @morristai in https://github.com/apache/opendal/pull/5123
+* fix(bindings/c): use `ManuallyDrop` instead of `forget` to make sure pointer is valid by @ethe in https://github.com/apache/opendal/pull/5166
+* fix(services/s3): Mark xml deserialize error as temporary during list by @Xuanwo in https://github.com/apache/opendal/pull/5178
+* fix: add all-features flag for opendal_compat doc build by @XmchxUp in https://github.com/apache/opendal/pull/5234
+* fix(integrations/compat): Capability has different fields by @Xuanwo in https://github.com/apache/opendal/pull/5236
+* fix(integration/compat): Fix opendal 0.50 OpList has new field by @Xuanwo in https://github.com/apache/opendal/pull/5238
+* fix(integrations/compat): Fix dead loop happened during list by @Xuanwo in https://github.com/apache/opendal/pull/5240
+### Docs
+* docs: Update binding-java.md by @tisonkun in https://github.com/apache/opendal/pull/5087
+* docs: add spring integration configuration doc by @shoothzj in https://github.com/apache/opendal/pull/5053
+* docs: improve Node.js binding's test doc by @tisonkun in https://github.com/apache/opendal/pull/5159
+* docs(bindings/c): update docs for CMake replacing by @PragmaTwice in https://github.com/apache/opendal/pull/5186
+* docs: Move our release process to github discussions by @Xuanwo in https://github.com/apache/opendal/pull/5217
+* docs: change "Github" to "GitHub" by @MohammadLotfiA in https://github.com/apache/opendal/pull/5250
+### CI
+* ci(bindings/go): add golangci-lint by @yuchanns in https://github.com/apache/opendal/pull/5060
+* ci(bindings/zig): Fix build and test of zig on 0.13 by @Xuanwo in https://github.com/apache/opendal/pull/5102
+* ci: Don't publish with all features by @Xuanwo in https://github.com/apache/opendal/pull/5108
+* ci: Fix upload-artifacts doesn't include hidden files by @Xuanwo in https://github.com/apache/opendal/pull/5112
+* ci(bindings/nodejs): Fix diff introduced by napi by @Xuanwo in https://github.com/apache/opendal/pull/5121
+* ci: Disable aliyun drive test until #5163 addressed by @Xuanwo in https://github.com/apache/opendal/pull/5164
+* ci: add package cache for build-haskell-doc by @XmchxUp in https://github.com/apache/opendal/pull/5173
+* ci: add cache action for ci_bindings_ocaml & build-ocaml-doc by @XmchxUp in https://github.com/apache/opendal/pull/5174
+* ci: Fix failing CI on ocaml and python by @Xuanwo in https://github.com/apache/opendal/pull/5177
+* build(bindings/c): replace the build system with CMake by @PragmaTwice in https://github.com/apache/opendal/pull/5182
+* build(bindings/cpp): fetch and build dependencies instead of finding system libs by @PragmaTwice in https://github.com/apache/opendal/pull/5188
+* ci: Remove not needed --break-system-packages by @Xuanwo in https://github.com/apache/opendal/pull/5196
+* ci: Send discussions to dev@o.a.o by @Xuanwo in https://github.com/apache/opendal/pull/5201
+* ci(asf): Don't add `[DISCUSS]` prefix for discussion by @Xuanwo in https://github.com/apache/opendal/pull/5210
+* build: enable services-mysql for Java and Python bindings by @tisonkun in https://github.com/apache/opendal/pull/5222
+* build(binding/python): Support Python 3.13 by @Zheaoli in https://github.com/apache/opendal/pull/5248
+### Chore
+* chore(bindings/go): bump ffi and sys version by @shoothzj in https://github.com/apache/opendal/pull/5055
+* chore: Bump backon to 1.0.0 by @Xuanwo in https://github.com/apache/opendal/pull/5056
+* chore(services/rocksdb): fix misuse rocksdb prefix iterator by @meteorgan in https://github.com/apache/opendal/pull/5059
+* chore(README): add Go binding badge by @yuchanns in https://github.com/apache/opendal/pull/5074
+* chore(deps): bump crate-ci/typos from 1.23.6 to 1.24.3 by @dependabot in https://github.com/apache/opendal/pull/5085
+* chore(layers/prometheus-client): export `PrometheusClientLayerBuilder` type by @koushiro in https://github.com/apache/opendal/pull/5093
+* chore(layers): check the examples when running tests by @koushiro in https://github.com/apache/opendal/pull/5104
+* chore(integrations/parquet): Bump parquet to 53 by @Xuanwo in https://github.com/apache/opendal/pull/5109
+* chore: Bump OpenDAL to 0.50.0 by @Xuanwo in https://github.com/apache/opendal/pull/5110
+* chore(bindings/python): deprecate via_map method by @TennyZhuang in https://github.com/apache/opendal/pull/5134
+* chore: update binding java artifact name in README by @tisonkun in https://github.com/apache/opendal/pull/5137
+* chore(fixtures/s3): Upgrade MinIO version by @ForestLH in https://github.com/apache/opendal/pull/5142
+* chore(deps): bump clap from 4.5.17 to 4.5.18 in /bin/ofs by @dependabot in https://github.com/apache/opendal/pull/5149
+* chore(deps): bump crate-ci/typos from 1.24.3 to 1.24.6 by @dependabot in https://github.com/apache/opendal/pull/5150
+* chore(deps): bump anyhow from 1.0.87 to 1.0.89 in /bin/oay by @dependabot in https://github.com/apache/opendal/pull/5151
+* chore(deps): bump anyhow from 1.0.87 to 1.0.89 in /bin/oli by @dependabot in https://github.com/apache/opendal/pull/5152
+* chore: fix typos in tokio_executor.rs by @tisonkun in https://github.com/apache/opendal/pull/5157
+* chore: hint when java tests are skipped by @tisonkun in https://github.com/apache/opendal/pull/5158
+* chore: Include license in the packaged crate by @davide125 in https://github.com/apache/opendal/pull/5176
+* chore(bin/*): remove useless deps by @koushiro in https://github.com/apache/opendal/pull/5212
+* chore: tidy up c binding build and docs by @tisonkun in https://github.com/apache/opendal/pull/5243
+* chore(core/layers): adjust await point to simplify combinator code by @koushiro in https://github.com/apache/opendal/pull/5255
+* chore(core/blocking_operator): deduplicate deprecated `is_exist` logic by @simonsan in https://github.com/apache/opendal/pull/5261
+* chore(deps): bump actions/cache from 3 to 4 by @dependabot in https://github.com/apache/opendal/pull/5262
+* chore: run object_store tests in CI by @jorgehermo9 in https://github.com/apache/opendal/pull/5268
+
 ## [v0.50.1] - 2024-10-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 * feat(bindings/d): add D bindings support by @kassane in https://github.com/apache/opendal/pull/5181
 * feat(bindings/python): add sync `File.readline` by @TennyZhuang in https://github.com/apache/opendal/pull/5271
 * feat(core/services-azblob): support user defined metadata by @jorgehermo9 in https://github.com/apache/opendal/pull/5274
+* feat(core/services-s3): try load endpoint from config by @TennyZhuang in https://github.com/apache/opendal/pull/5279
 ### Changed
 * refactor(bin/oli): use `clap_derive` to reduce boilerplate code by @koushiro in https://github.com/apache/opendal/pull/5233
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,113 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [v0.50.2] - 2024-11-04
 
-## What's Changed
 ### Added
-* feat(core)!: make list return path itself by @meteorgan in https://github.com/apache/opendal/pull/4959
-* feat(services/oss): support role_arn and oidc_provider_arn by @tisonkun in https://github.com/apache/opendal/pull/5063
-* feat(services): add lakefs support by @liugddx in https://github.com/apache/opendal/pull/5086
-* feat: add list api for lakefs service. by @liugddx in https://github.com/apache/opendal/pull/5092
-* feat: add write api for lakefs service. by @liugddx in https://github.com/apache/opendal/pull/5100
-* feat: add delete api for lakefs service. by @liugddx in https://github.com/apache/opendal/pull/5107
-* feat(core/redis): Replace client requests with connection pool by @jackyyyyyssss in https://github.com/apache/opendal/pull/5117
-* feat: add copy api for lakefs service.  by @liugddx in https://github.com/apache/opendal/pull/5114
-* feat(core): add version(bool) for List operation to include version d… by @meteorgan in https://github.com/apache/opendal/pull/5106
-* feat(bindings/python): export ConcurrentLimitLayer by @TennyZhuang in https://github.com/apache/opendal/pull/5140
-* feat(bindings/c): add writer operation for Bindings C and Go by @yuchanns in https://github.com/apache/opendal/pull/5141
-* feat(ofs): introduce ofs macos support by @oowl in https://github.com/apache/opendal/pull/5136
-* feat: Reduce stat operation if we are reading all by @Xuanwo in https://github.com/apache/opendal/pull/5146
-* feat: add NebulaGraph config by @GG2002 in https://github.com/apache/opendal/pull/5147
-* feat(integrations/spring): add spring serialize method by @shoothzj in https://github.com/apache/opendal/pull/5154
-* feat: support write,read,delete with template by @shoothzj in https://github.com/apache/opendal/pull/5156
-* feat(bindings/java): support ConcurrentLimitLayer by @tisonkun in https://github.com/apache/opendal/pull/5168
-* feat: Add if_none_match for write by @ForestLH in https://github.com/apache/opendal/pull/5129
-* feat: Add OpenDAL Compat by @Xuanwo in https://github.com/apache/opendal/pull/5185
-* feat(core): abstract HttpFetch trait for raw http client by @everpcpc in https://github.com/apache/opendal/pull/5184
-* feat: Support NebulaGraph by @GG2002 in https://github.com/apache/opendal/pull/5116
-* feat(bindings/cpp): rename is_exist to exists as core did by @PragmaTwice in https://github.com/apache/opendal/pull/5198
-* feat(bindings/c): add opendal_operator_exists and mark is_exist deprecated by @PragmaTwice in https://github.com/apache/opendal/pull/5199
-* feat(binding/java): prefix thread name with opendal-tokio-worker by @tisonkun in https://github.com/apache/opendal/pull/5197
 * feat(services/ftp): List dir shows last modified timestamp by @erickguan in https://github.com/apache/opendal/pull/5213
 * feat(bindings/d): add D bindings support by @kassane in https://github.com/apache/opendal/pull/5181
 * feat(bindings/python): add sync `File.readline` by @TennyZhuang in https://github.com/apache/opendal/pull/5271
 * feat(core/services-azblob): support user defined metadata by @jorgehermo9 in https://github.com/apache/opendal/pull/5274
 ### Changed
-* refactor: use sqlx for sql services  by @tisonkun in https://github.com/apache/opendal/pull/5040
-* refactor(core)!: Add observe layer as building block by @Xuanwo in https://github.com/apache/opendal/pull/5064
-* refactor(layers/prometheus): rewrite prometheus layer based on observe mod by @koushiro in https://github.com/apache/opendal/pull/5069
-* refactor(bindings/java): replace `num_cpus` with `std::thread::available_parallelism` by @miroim in https://github.com/apache/opendal/pull/5080
-* refactor(layers/prometheus): provide builder APIs by @koushiro in https://github.com/apache/opendal/pull/5072
-* refactor(layers/prometheus-client): provide builder APIs by @koushiro in https://github.com/apache/opendal/pull/5073
-* refactor(layers/metrics): rewrite metrics layer using observe layer by @koushiro in https://github.com/apache/opendal/pull/5098
-* refactor(services/cloudflare-kv): remove unneeded async and result on parse_error by @tsfotis in https://github.com/apache/opendal/pull/5128
-* refactor(*): remove unneeded async and result on parse_error by @tsfotis in https://github.com/apache/opendal/pull/5131
-* refactor: align C binding pattern by @tisonkun in https://github.com/apache/opendal/pull/5160
-* refactor: more consistent C binding pattern by @tisonkun in https://github.com/apache/opendal/pull/5162
-* refactor(integration/parquet): Use ParquetMetaDataReader instead by @Xuanwo in https://github.com/apache/opendal/pull/5170
-* refactor: resolve c pointers const by @tisonkun in https://github.com/apache/opendal/pull/5171
-* refactor(types/operator): rename is_exist to exists by @photino in https://github.com/apache/opendal/pull/5193
 * refactor(bin/oli): use `clap_derive` to reduce boilerplate code by @koushiro in https://github.com/apache/opendal/pull/5233
 ### Fixed
-* fix(core): TimeoutLayer now needs enable tokio time by @Xuanwo in https://github.com/apache/opendal/pull/5057
-* fix(core): Fix failed list related tests by @Xuanwo in https://github.com/apache/opendal/pull/5058
-* fix(services/memory): blocking_scan right range by @meteorgan in https://github.com/apache/opendal/pull/5062
-* fix(core/services/mysql): Fix mysql Capability by @jackyyyyyssss in https://github.com/apache/opendal/pull/5067
-* fix: fix rust 1.76 error due to temporary value being dropped by @aawsome in https://github.com/apache/opendal/pull/5071
-* fix(service/fs): error due to temporary value being dropped by @miroim in https://github.com/apache/opendal/pull/5079
-* fix(core/services/hdfs): Fix the HDFS write failure when atomic_write_dir is set by @meteorgan in https://github.com/apache/opendal/pull/5039
-* fix(services/icloud): adjust error handling code to avoid having to write out result type explicitly by @koushiro in https://github.com/apache/opendal/pull/5091
-* fix(services/monoiofs): handle async cancel during file open by @NKID00 in https://github.com/apache/opendal/pull/5094
-* fix(services/huggingface): Align with latest HuggingFace API by @morristai in https://github.com/apache/opendal/pull/5123
-* fix(bindings/c): use `ManuallyDrop` instead of `forget` to make sure pointer is valid by @ethe in https://github.com/apache/opendal/pull/5166
-* fix(services/s3): Mark xml deserialize error as temporary during list by @Xuanwo in https://github.com/apache/opendal/pull/5178
 * fix: add all-features flag for opendal_compat doc build by @XmchxUp in https://github.com/apache/opendal/pull/5234
 * fix(integrations/compat): Capability has different fields by @Xuanwo in https://github.com/apache/opendal/pull/5236
 * fix(integration/compat): Fix opendal 0.50 OpList has new field by @Xuanwo in https://github.com/apache/opendal/pull/5238
 * fix(integrations/compat): Fix dead loop happened during list by @Xuanwo in https://github.com/apache/opendal/pull/5240
 ### Docs
-* docs: Update binding-java.md by @tisonkun in https://github.com/apache/opendal/pull/5087
-* docs: add spring integration configuration doc by @shoothzj in https://github.com/apache/opendal/pull/5053
-* docs: improve Node.js binding's test doc by @tisonkun in https://github.com/apache/opendal/pull/5159
-* docs(bindings/c): update docs for CMake replacing by @PragmaTwice in https://github.com/apache/opendal/pull/5186
 * docs: Move our release process to github discussions by @Xuanwo in https://github.com/apache/opendal/pull/5217
 * docs: change "Github" to "GitHub" by @MohammadLotfiA in https://github.com/apache/opendal/pull/5250
 ### CI
-* ci(bindings/go): add golangci-lint by @yuchanns in https://github.com/apache/opendal/pull/5060
-* ci(bindings/zig): Fix build and test of zig on 0.13 by @Xuanwo in https://github.com/apache/opendal/pull/5102
-* ci: Don't publish with all features by @Xuanwo in https://github.com/apache/opendal/pull/5108
-* ci: Fix upload-artifacts doesn't include hidden files by @Xuanwo in https://github.com/apache/opendal/pull/5112
-* ci(bindings/nodejs): Fix diff introduced by napi by @Xuanwo in https://github.com/apache/opendal/pull/5121
-* ci: Disable aliyun drive test until #5163 addressed by @Xuanwo in https://github.com/apache/opendal/pull/5164
-* ci: add package cache for build-haskell-doc by @XmchxUp in https://github.com/apache/opendal/pull/5173
-* ci: add cache action for ci_bindings_ocaml & build-ocaml-doc by @XmchxUp in https://github.com/apache/opendal/pull/5174
-* ci: Fix failing CI on ocaml and python by @Xuanwo in https://github.com/apache/opendal/pull/5177
-* build(bindings/c): replace the build system with CMake by @PragmaTwice in https://github.com/apache/opendal/pull/5182
-* build(bindings/cpp): fetch and build dependencies instead of finding system libs by @PragmaTwice in https://github.com/apache/opendal/pull/5188
-* ci: Remove not needed --break-system-packages by @Xuanwo in https://github.com/apache/opendal/pull/5196
-* ci: Send discussions to dev@o.a.o by @Xuanwo in https://github.com/apache/opendal/pull/5201
 * ci(asf): Don't add `[DISCUSS]` prefix for discussion by @Xuanwo in https://github.com/apache/opendal/pull/5210
 * build: enable services-mysql for Java and Python bindings by @tisonkun in https://github.com/apache/opendal/pull/5222
 * build(binding/python): Support Python 3.13 by @Zheaoli in https://github.com/apache/opendal/pull/5248
 ### Chore
-* chore(bindings/go): bump ffi and sys version by @shoothzj in https://github.com/apache/opendal/pull/5055
-* chore: Bump backon to 1.0.0 by @Xuanwo in https://github.com/apache/opendal/pull/5056
-* chore(services/rocksdb): fix misuse rocksdb prefix iterator by @meteorgan in https://github.com/apache/opendal/pull/5059
-* chore(README): add Go binding badge by @yuchanns in https://github.com/apache/opendal/pull/5074
-* chore(deps): bump crate-ci/typos from 1.23.6 to 1.24.3 by @dependabot in https://github.com/apache/opendal/pull/5085
-* chore(layers/prometheus-client): export `PrometheusClientLayerBuilder` type by @koushiro in https://github.com/apache/opendal/pull/5093
-* chore(layers): check the examples when running tests by @koushiro in https://github.com/apache/opendal/pull/5104
-* chore(integrations/parquet): Bump parquet to 53 by @Xuanwo in https://github.com/apache/opendal/pull/5109
-* chore: Bump OpenDAL to 0.50.0 by @Xuanwo in https://github.com/apache/opendal/pull/5110
-* chore(bindings/python): deprecate via_map method by @TennyZhuang in https://github.com/apache/opendal/pull/5134
-* chore: update binding java artifact name in README by @tisonkun in https://github.com/apache/opendal/pull/5137
-* chore(fixtures/s3): Upgrade MinIO version by @ForestLH in https://github.com/apache/opendal/pull/5142
-* chore(deps): bump clap from 4.5.17 to 4.5.18 in /bin/ofs by @dependabot in https://github.com/apache/opendal/pull/5149
-* chore(deps): bump crate-ci/typos from 1.24.3 to 1.24.6 by @dependabot in https://github.com/apache/opendal/pull/5150
-* chore(deps): bump anyhow from 1.0.87 to 1.0.89 in /bin/oay by @dependabot in https://github.com/apache/opendal/pull/5151
-* chore(deps): bump anyhow from 1.0.87 to 1.0.89 in /bin/oli by @dependabot in https://github.com/apache/opendal/pull/5152
-* chore: fix typos in tokio_executor.rs by @tisonkun in https://github.com/apache/opendal/pull/5157
-* chore: hint when java tests are skipped by @tisonkun in https://github.com/apache/opendal/pull/5158
-* chore: Include license in the packaged crate by @davide125 in https://github.com/apache/opendal/pull/5176
 * chore(bin/*): remove useless deps by @koushiro in https://github.com/apache/opendal/pull/5212
 * chore: tidy up c binding build and docs by @tisonkun in https://github.com/apache/opendal/pull/5243
 * chore(core/layers): adjust await point to simplify combinator code by @koushiro in https://github.com/apache/opendal/pull/5255

--- a/bin/oay/Cargo.lock
+++ b/bin/oay/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "dav-server-opendalfs"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "oay"
-version = "0.41.12"
+version = "0.41.13"
 dependencies = [
  "anyhow",
  "axum",

--- a/bin/oay/Cargo.lock
+++ b/bin/oay/Cargo.lock
@@ -862,7 +862,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opendal"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/oay/Cargo.toml
+++ b/bin/oay/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.41.12"
+version = "0.41.13"
 
 [features]
 default = ["frontends-webdav", "frontends-s3"]

--- a/bin/oay/DEPENDENCIES.rust.tsv
+++ b/bin/oay/DEPENDENCIES.rust.tsv
@@ -1,235 +1,199 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.2		X						X					
-adler2@2.0.0	X	X						X					
-aho-corasick@1.1.3								X				X	
-allocator-api2@0.2.18		X						X					
-android-tzdata@0.1.1		X						X					
-android_system_properties@0.1.5		X						X					
-anstream@0.6.15		X						X					
-anstyle@1.0.8		X						X					
-anstyle-parse@0.2.5		X						X					
-anstyle-query@1.1.1		X						X					
-anstyle-wincon@3.0.4		X						X					
-anyhow@1.0.90		X						X					
-async-trait@0.1.83		X						X					
-autocfg@1.4.0		X						X					
-axum@0.7.7								X					
-axum-core@0.4.5								X					
-backon@1.2.0		X											
-backtrace@0.3.74		X						X					
-base64@0.21.7		X						X					
-base64@0.22.1		X						X					
-bitflags@2.6.0		X						X					
-block-buffer@0.10.4		X						X					
-bumpalo@3.16.0		X						X					
-byteorder@1.5.0								X				X	
-bytes@1.7.2								X					
-cc@1.1.31		X						X					
-cfg-if@1.0.0		X						X					
-chrono@0.4.38		X						X					
-clap@4.5.20		X						X					
-clap_builder@4.5.20		X						X					
-clap_lex@0.7.2		X						X					
-colorchoice@1.0.2		X						X					
-core-foundation-sys@0.8.7		X						X					
-cpufeatures@0.2.14		X						X					
-crypto-common@0.1.6		X						X					
-dav-server@0.7.0		X											
-dav-server-opendalfs@0.2.1		X											
-deranged@0.3.11		X						X					
-digest@0.10.7		X						X					
-dirs@5.0.1		X						X					
-dirs-sys@0.4.1		X						X					
-equivalent@1.0.1		X						X					
-fastrand@2.1.1		X						X					
-flagset@0.4.6		X											
-fnv@1.0.7		X						X					
-foldhash@0.1.3													X
-form_urlencoded@1.2.1		X						X					
-futures@0.3.31		X						X					
-futures-channel@0.3.31		X						X					
-futures-core@0.3.31		X						X					
-futures-executor@0.3.31		X						X					
-futures-io@0.3.31		X						X					
-futures-macro@0.3.31		X						X					
-futures-sink@0.3.31		X						X					
-futures-task@0.3.31		X						X					
-futures-util@0.3.31		X						X					
-generic-array@0.14.7								X					
-getrandom@0.2.15		X						X					
-gimli@0.31.1		X						X					
-gloo-timers@0.3.0		X						X					
-hashbrown@0.15.0		X						X					
-headers@0.4.0								X					
-headers-core@0.3.0								X					
-hermit-abi@0.3.9		X						X					
-htmlescape@0.3.1		X						X	X				
-http@1.1.0		X						X					
-http-body@1.0.1								X					
-http-body-util@0.1.2								X					
-httparse@1.9.5		X						X					
-httpdate@1.0.3		X						X					
-hyper@1.5.0								X					
-hyper-rustls@0.27.3		X					X	X					
-hyper-util@0.1.9								X					
-iana-time-zone@0.1.61		X						X					
-iana-time-zone-haiku@0.1.2		X						X					
-idna@0.5.0		X						X					
-indexmap@2.6.0		X						X					
-ipnet@2.10.1		X						X					
-is_terminal_polyfill@1.70.1		X						X					
-itoa@1.0.11		X						X					
-js-sys@0.3.72		X						X					
-lazy_static@1.5.0		X						X					
-libc@0.2.161		X						X					
-libredox@0.1.3								X					
-lock_api@0.4.12		X						X					
-log@0.4.22		X						X					
-lru@0.12.5								X					
-matchers@0.1.0								X					
-matchit@0.7.3					X			X					
-md-5@0.10.6		X						X					
-memchr@2.7.4								X				X	
-mime@0.3.17		X						X					
-mime_guess@2.0.5								X					
-miniz_oxide@0.8.0		X						X					X
-mio@1.0.2								X					
-nu-ansi-term@0.46.0								X					
-num-conv@0.1.0		X						X					
-num-traits@0.2.19		X						X					
-oay@0.41.12		X											
-object@0.36.5		X						X					
-once_cell@1.20.2		X						X					
-opendal@0.50.1		X											
-option-ext@0.2.0									X				
-overload@0.1.1								X					
-parking_lot@0.12.3		X						X					
-parking_lot_core@0.9.10		X						X					
-percent-encoding@2.3.1		X						X					
-pin-project@1.1.6		X						X					
-pin-project-internal@1.1.6		X						X					
-pin-project-lite@0.2.14		X						X					
-pin-utils@0.1.0		X						X					
-powerfmt@0.2.0		X						X					
-ppv-lite86@0.2.20		X						X					
-proc-macro2@1.0.88		X						X					
-quick-xml@0.36.2								X					
-quote@1.0.37		X						X					
-rand@0.8.5		X						X					
-rand_chacha@0.3.1		X						X					
-rand_core@0.6.4		X						X					
-redox_syscall@0.5.7								X					
-redox_users@0.4.6								X					
-regex@1.11.0		X						X					
-regex-automata@0.1.10								X				X	
-regex-automata@0.4.8		X						X					
-regex-syntax@0.6.29		X						X					
-regex-syntax@0.8.5		X						X					
-reqwest@0.12.8		X						X					
-ring@0.17.8										X			
-rustc-demangle@0.1.24		X						X					
-rustls@0.23.15		X					X	X					
-rustls-pemfile@2.2.0		X					X	X					
-rustls-pki-types@1.10.0		X						X					
-rustls-webpki@0.102.8							X						
-rustversion@1.0.18		X						X					
-ryu@1.0.18		X				X							
-scopeguard@1.2.0		X						X					
-serde@1.0.210		X						X					
-serde_derive@1.0.210		X						X					
-serde_json@1.0.132		X						X					
-serde_path_to_error@0.1.16		X						X					
-serde_spanned@0.6.8		X						X					
-serde_urlencoded@0.7.1		X						X					
-sha1@0.10.6		X						X					
-sharded-slab@0.1.7								X					
-shlex@1.3.0		X						X					
-slab@0.4.9								X					
-smallvec@1.13.2		X						X					
-socket2@0.5.7		X						X					
-spin@0.9.8								X					
-strsim@0.11.1								X					
-subtle@2.6.1					X								
-syn@2.0.81		X						X					
-sync_wrapper@0.1.2		X											
-sync_wrapper@1.0.1		X											
-thiserror@1.0.64		X						X					
-thiserror-impl@1.0.64		X						X					
-thread_local@1.1.8		X						X					
-time@0.3.36		X						X					
-time-core@0.1.2		X						X					
-time-macros@0.2.18		X						X					
-tinyvec@1.8.0		X						X					X
-tinyvec_macros@0.1.1		X						X					X
-tokio@1.40.0								X					
-tokio-macros@2.4.0								X					
-tokio-rustls@0.26.0		X						X					
-tokio-util@0.7.12								X					
-toml@0.8.19		X						X					
-toml_datetime@0.6.8		X						X					
-toml_edit@0.22.22		X						X					
-tower@0.4.13								X					
-tower@0.5.1								X					
-tower-http@0.5.2								X					
-tower-layer@0.3.3								X					
-tower-service@0.3.3								X					
-tracing@0.1.40								X					
-tracing-attributes@0.1.27								X					
-tracing-core@0.1.32								X					
-tracing-log@0.2.0								X					
-tracing-subscriber@0.3.18								X					
-try-lock@0.2.5								X					
-typenum@1.17.0		X						X					
-unicase@2.8.0		X						X					
-unicode-bidi@0.3.17		X						X					
-unicode-ident@1.0.13		X						X			X		
-unicode-normalization@0.1.24		X						X					
-untrusted@0.9.0							X						
-url@2.5.2		X						X					
-utf8parse@0.2.2		X						X					
-uuid@1.11.0		X						X					
-valuable@0.1.0								X					
-version_check@0.9.5		X						X					
-want@0.3.1								X					
-wasi@0.11.0+wasi-snapshot-preview1		X	X					X					
-wasm-bindgen@0.2.95		X						X					
-wasm-bindgen-backend@0.2.95		X						X					
-wasm-bindgen-futures@0.4.45		X						X					
-wasm-bindgen-macro@0.2.95		X						X					
-wasm-bindgen-macro-support@0.2.95		X						X					
-wasm-bindgen-shared@0.2.95		X						X					
-wasm-streams@0.4.1		X						X					
-web-sys@0.3.72		X						X					
-webpki-roots@0.26.6									X				
-winapi@0.3.9		X						X					
-winapi-i686-pc-windows-gnu@0.4.0		X						X					
-winapi-x86_64-pc-windows-gnu@0.4.0		X						X					
-windows-core@0.52.0		X						X					
-windows-registry@0.2.0		X						X					
-windows-result@0.2.0		X						X					
-windows-strings@0.1.0		X						X					
-windows-sys@0.48.0		X						X					
-windows-sys@0.52.0		X						X					
-windows-targets@0.48.5		X						X					
-windows-targets@0.52.6		X						X					
-windows_aarch64_gnullvm@0.48.5		X						X					
-windows_aarch64_gnullvm@0.52.6		X						X					
-windows_aarch64_msvc@0.48.5		X						X					
-windows_aarch64_msvc@0.52.6		X						X					
-windows_i686_gnu@0.48.5		X						X					
-windows_i686_gnu@0.52.6		X						X					
-windows_i686_gnullvm@0.52.6		X						X					
-windows_i686_msvc@0.48.5		X						X					
-windows_i686_msvc@0.52.6		X						X					
-windows_x86_64_gnu@0.48.5		X						X					
-windows_x86_64_gnu@0.52.6		X						X					
-windows_x86_64_gnullvm@0.48.5		X						X					
-windows_x86_64_gnullvm@0.52.6		X						X					
-windows_x86_64_msvc@0.48.5		X						X					
-windows_x86_64_msvc@0.52.6		X						X					
-winnow@0.6.20								X					
-xml-rs@0.8.22								X					
-xmltree@0.10.3								X					
-zerocopy@0.7.35		X		X				X					
-zerocopy-derive@0.7.35		X		X				X					
-zeroize@1.8.1		X						X					
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
+addr2line@0.24.2		X					X					
+adler2@2.0.0	X	X					X					
+aho-corasick@1.1.3							X				X	
+allocator-api2@0.2.18		X					X					
+android-tzdata@0.1.1		X					X					
+android_system_properties@0.1.5		X					X					
+anyhow@1.0.90		X					X					
+async-trait@0.1.83		X					X					
+autocfg@1.4.0		X					X					
+axum@0.7.7							X					
+axum-core@0.4.5							X					
+backon@1.2.0		X										
+backtrace@0.3.74		X					X					
+base64@0.21.7		X					X					
+base64@0.22.1		X					X					
+bitflags@2.6.0		X					X					
+block-buffer@0.10.4		X					X					
+bumpalo@3.16.0		X					X					
+bytes@1.7.2							X					
+cc@1.1.31		X					X					
+cfg-if@1.0.0		X					X					
+chrono@0.4.38		X					X					
+core-foundation-sys@0.8.7		X					X					
+cpufeatures@0.2.14		X					X					
+crypto-common@0.1.6		X					X					
+dav-server@0.7.0		X										
+dav-server-opendalfs@0.2.1		X										
+deranged@0.3.11		X					X					
+digest@0.10.7		X					X					
+equivalent@1.0.1		X					X					
+fastrand@2.1.1		X					X					
+flagset@0.4.6		X										
+fnv@1.0.7		X					X					
+foldhash@0.1.3												X
+form_urlencoded@1.2.1		X					X					
+futures@0.3.31		X					X					
+futures-channel@0.3.31		X					X					
+futures-core@0.3.31		X					X					
+futures-executor@0.3.31		X					X					
+futures-io@0.3.31		X					X					
+futures-macro@0.3.31		X					X					
+futures-sink@0.3.31		X					X					
+futures-task@0.3.31		X					X					
+futures-util@0.3.31		X					X					
+generic-array@0.14.7							X					
+getrandom@0.2.15		X					X					
+gimli@0.31.1		X					X					
+gloo-timers@0.3.0		X					X					
+hashbrown@0.15.0		X					X					
+headers@0.4.0							X					
+headers-core@0.3.0							X					
+hermit-abi@0.3.9		X					X					
+htmlescape@0.3.1		X					X	X				
+http@1.1.0		X					X					
+http-body@1.0.1							X					
+http-body-util@0.1.2							X					
+httparse@1.9.5		X					X					
+httpdate@1.0.3		X					X					
+hyper@1.5.0							X					
+hyper-rustls@0.27.3		X				X	X					
+hyper-util@0.1.9							X					
+iana-time-zone@0.1.61		X					X					
+iana-time-zone-haiku@0.1.2		X					X					
+idna@0.5.0		X					X					
+indexmap@2.6.0		X					X					
+ipnet@2.10.1		X					X					
+itoa@1.0.11		X					X					
+js-sys@0.3.72		X					X					
+lazy_static@1.5.0		X					X					
+libc@0.2.161		X					X					
+lock_api@0.4.12		X					X					
+log@0.4.22		X					X					
+lru@0.12.5							X					
+matchers@0.1.0							X					
+matchit@0.7.3				X			X					
+md-5@0.10.6		X					X					
+memchr@2.7.4							X				X	
+mime@0.3.17		X					X					
+mime_guess@2.0.5							X					
+miniz_oxide@0.8.0		X					X					X
+mio@1.0.2							X					
+nu-ansi-term@0.46.0							X					
+num-conv@0.1.0		X					X					
+num-traits@0.2.19		X					X					
+oay@0.41.12		X										
+object@0.36.5		X					X					
+once_cell@1.20.2		X					X					
+opendal@0.50.2		X										
+overload@0.1.1							X					
+parking_lot@0.12.3		X					X					
+parking_lot_core@0.9.10		X					X					
+percent-encoding@2.3.1		X					X					
+pin-project@1.1.6		X					X					
+pin-project-internal@1.1.6		X					X					
+pin-project-lite@0.2.14		X					X					
+pin-utils@0.1.0		X					X					
+powerfmt@0.2.0		X					X					
+proc-macro2@1.0.88		X					X					
+quick-xml@0.36.2							X					
+quote@1.0.37		X					X					
+redox_syscall@0.5.7							X					
+regex@1.11.0		X					X					
+regex-automata@0.1.10							X				X	
+regex-automata@0.4.8		X					X					
+regex-syntax@0.6.29		X					X					
+regex-syntax@0.8.5		X					X					
+reqwest@0.12.8		X					X					
+ring@0.17.8									X			
+rustc-demangle@0.1.24		X					X					
+rustls@0.23.15		X				X	X					
+rustls-pemfile@2.2.0		X				X	X					
+rustls-pki-types@1.10.0		X					X					
+rustls-webpki@0.102.8						X						
+rustversion@1.0.18		X					X					
+ryu@1.0.18		X			X							
+scopeguard@1.2.0		X					X					
+serde@1.0.210		X					X					
+serde_derive@1.0.210		X					X					
+serde_json@1.0.132		X					X					
+serde_path_to_error@0.1.16		X					X					
+serde_spanned@0.6.8		X					X					
+serde_urlencoded@0.7.1		X					X					
+sha1@0.10.6		X					X					
+sharded-slab@0.1.7							X					
+shlex@1.3.0		X					X					
+slab@0.4.9							X					
+smallvec@1.13.2		X					X					
+socket2@0.5.7		X					X					
+spin@0.9.8							X					
+subtle@2.6.1				X								
+syn@2.0.81		X					X					
+sync_wrapper@0.1.2		X										
+sync_wrapper@1.0.1		X										
+thread_local@1.1.8		X					X					
+time@0.3.36		X					X					
+time-core@0.1.2		X					X					
+time-macros@0.2.18		X					X					
+tinyvec@1.8.0		X					X					X
+tinyvec_macros@0.1.1		X					X					X
+tokio@1.40.0							X					
+tokio-macros@2.4.0							X					
+tokio-rustls@0.26.0		X					X					
+tokio-util@0.7.12							X					
+toml@0.8.19		X					X					
+toml_datetime@0.6.8		X					X					
+toml_edit@0.22.22		X					X					
+tower@0.4.13							X					
+tower@0.5.1							X					
+tower-layer@0.3.3							X					
+tower-service@0.3.3							X					
+tracing@0.1.40							X					
+tracing-attributes@0.1.27							X					
+tracing-core@0.1.32							X					
+tracing-log@0.2.0							X					
+tracing-subscriber@0.3.18							X					
+try-lock@0.2.5							X					
+typenum@1.17.0		X					X					
+unicase@2.8.0		X					X					
+unicode-bidi@0.3.17		X					X					
+unicode-ident@1.0.13		X					X			X		
+unicode-normalization@0.1.24		X					X					
+untrusted@0.9.0						X						
+url@2.5.2		X					X					
+uuid@1.11.0		X					X					
+valuable@0.1.0							X					
+version_check@0.9.5		X					X					
+want@0.3.1							X					
+wasi@0.11.0+wasi-snapshot-preview1		X	X				X					
+wasm-bindgen@0.2.95		X					X					
+wasm-bindgen-backend@0.2.95		X					X					
+wasm-bindgen-futures@0.4.45		X					X					
+wasm-bindgen-macro@0.2.95		X					X					
+wasm-bindgen-macro-support@0.2.95		X					X					
+wasm-bindgen-shared@0.2.95		X					X					
+wasm-streams@0.4.1		X					X					
+web-sys@0.3.72		X					X					
+webpki-roots@0.26.6								X				
+winapi@0.3.9		X					X					
+winapi-i686-pc-windows-gnu@0.4.0		X					X					
+winapi-x86_64-pc-windows-gnu@0.4.0		X					X					
+windows-core@0.52.0		X					X					
+windows-registry@0.2.0		X					X					
+windows-result@0.2.0		X					X					
+windows-strings@0.1.0		X					X					
+windows-sys@0.52.0		X					X					
+windows-targets@0.52.6		X					X					
+windows_aarch64_gnullvm@0.52.6		X					X					
+windows_aarch64_msvc@0.52.6		X					X					
+windows_i686_gnu@0.52.6		X					X					
+windows_i686_gnullvm@0.52.6		X					X					
+windows_i686_msvc@0.52.6		X					X					
+windows_x86_64_gnu@0.52.6		X					X					
+windows_x86_64_gnullvm@0.52.6		X					X					
+windows_x86_64_msvc@0.52.6		X					X					
+winnow@0.6.20							X					
+xml-rs@0.8.22							X					
+xmltree@0.10.3							X					
+zeroize@1.8.1		X					X					

--- a/bin/oay/DEPENDENCIES.rust.tsv
+++ b/bin/oay/DEPENDENCIES.rust.tsv
@@ -25,7 +25,7 @@ core-foundation-sys@0.8.7		X					X
 cpufeatures@0.2.14		X					X					
 crypto-common@0.1.6		X					X					
 dav-server@0.7.0		X										
-dav-server-opendalfs@0.2.1		X										
+dav-server-opendalfs@0.2.2		X										
 deranged@0.3.11		X					X					
 digest@0.10.7		X					X					
 equivalent@1.0.1		X					X					
@@ -83,7 +83,7 @@ mio@1.0.2							X
 nu-ansi-term@0.46.0							X					
 num-conv@0.1.0		X					X					
 num-traits@0.2.19		X					X					
-oay@0.41.12		X										
+oay@0.41.13		X										
 object@0.36.5		X					X					
 once_cell@1.20.2		X					X					
 opendal@0.50.2		X										

--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -1246,9 +1246,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqsign"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03dd4ba7c3901dd43e6b8c7446a760d45bc1ea4301002e1a6fa48f97c3a796fa"
+checksum = "eb0075a66c8bfbf4cc8b70dca166e722e1f55a3ea9250ecbb85f4d92a5f64149"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -1021,7 +1021,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opendal"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "cloud_filter_opendal"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "fuse3_opendal"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "bytes",
  "fuse3",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "ofs"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "clap",

--- a/bin/ofs/Cargo.toml
+++ b/bin/ofs/Cargo.toml
@@ -34,7 +34,7 @@ anyhow = "1"
 clap = { version = "4.5.18", features = ["derive", "env"] }
 env_logger = "0.11.2"
 log = "0.4.21"
-opendal = { version = "0.50.2", path = "../../core" }
+opendal = { version = "0.50.0", path = "../../core" }
 tokio = { version = "1.37.0", features = [
   "fs",
   "macros",

--- a/bin/ofs/Cargo.toml
+++ b/bin/ofs/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["filesystem"]
 description = "OpenDAL File System"
 keywords = ["storage", "data", "s3", "fs", "azblob"]
 name = "ofs"
-version = "0.0.13"
+version = "0.0.14"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -34,7 +34,7 @@ anyhow = "1"
 clap = { version = "4.5.18", features = ["derive", "env"] }
 env_logger = "0.11.2"
 log = "0.4.21"
-opendal = { version = "0.50.0", path = "../../core" }
+opendal = { version = "0.50.2", path = "../../core" }
 tokio = { version = "1.37.0", features = [
   "fs",
   "macros",
@@ -46,13 +46,13 @@ url = "2.5.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))'.dependencies]
 fuse3 = { version = "0.8.1", "features" = ["tokio-runtime", "unprivileged"] }
-fuse3_opendal = { version = "0.0.8", path = "../../integrations/fuse3" }
+fuse3_opendal = { version = "0.0.9", path = "../../integrations/fuse3" }
 libc = "0.2.154"
 nix = { version = "0.29.0", features = ["user"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 cloud-filter = { version = "0.0.5" }
-cloud_filter_opendal = { version = "0.0.2", path = "../../integrations/cloud_filter" }
+cloud_filter_opendal = { version = "0.0.3", path = "../../integrations/cloud_filter" }
 
 [features]
 default = ["services-fs", "services-s3"]

--- a/bin/ofs/DEPENDENCIES.rust.tsv
+++ b/bin/ofs/DEPENDENCIES.rust.tsv
@@ -31,7 +31,7 @@ clap_builder@4.5.20		X							X
 clap_derive@4.5.18		X							X					
 clap_lex@0.7.2		X							X					
 cloud-filter@0.0.5									X					
-cloud_filter_opendal@0.0.2		X												
+cloud_filter_opendal@0.0.3		X												
 colorchoice@1.0.2		X							X					
 concurrent-queue@2.5.0		X							X					
 const-oid@0.9.6		X							X					
@@ -57,7 +57,7 @@ flagset@0.4.6		X
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 fuse3@0.8.1									X					
-fuse3_opendal@0.0.8		X												
+fuse3_opendal@0.0.9		X												
 futures@0.3.31		X							X					
 futures-channel@0.3.31		X							X					
 futures-core@0.3.31		X							X					
@@ -107,7 +107,7 @@ nt-time@0.8.1		X							X
 num-conv@0.1.0		X							X					
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
-ofs@0.0.13		X												
+ofs@0.0.14		X												
 once_cell@1.20.2		X							X					
 opendal@0.50.2		X												
 ordered-multimap@0.7.3									X					

--- a/bin/ofs/DEPENDENCIES.rust.tsv
+++ b/bin/ofs/DEPENDENCIES.rust.tsv
@@ -127,7 +127,7 @@ rand_core@0.6.4		X							X
 regex@1.11.0		X							X					
 regex-automata@0.4.8		X							X					
 regex-syntax@0.8.5		X							X					
-reqsign@0.16.0		X												
+reqsign@0.16.1		X												
 reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rust-ini@0.21.1									X					

--- a/bin/ofs/DEPENDENCIES.rust.tsv
+++ b/bin/ofs/DEPENDENCIES.rust.tsv
@@ -109,7 +109,7 @@ num-traits@0.2.19		X							X
 object@0.36.5		X							X					
 ofs@0.0.13		X												
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
+opendal@0.50.2		X												
 ordered-multimap@0.7.3									X					
 parking@2.2.1		X							X					
 percent-encoding@2.3.1		X							X					

--- a/bin/oli/Cargo.lock
+++ b/bin/oli/Cargo.lock
@@ -2581,9 +2581,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqsign"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03dd4ba7c3901dd43e6b8c7446a760d45bc1ea4301002e1a6fa48f97c3a796fa"
+checksum = "eb0075a66c8bfbf4cc8b70dca166e722e1f55a3ea9250ecbb85f4d92a5f64149"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/oli/Cargo.lock
+++ b/bin/oli/Cargo.lock
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "oli"
-version = "0.41.12"
+version = "0.41.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/bin/oli/Cargo.lock
+++ b/bin/oli/Cargo.lock
@@ -1958,7 +1958,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opendal"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "anyhow",
  "async-tls",

--- a/bin/oli/Cargo.toml
+++ b/bin/oli/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.41.12"
+version = "0.41.13"
 
 [features]
 # Enable services dashmap support

--- a/bin/oli/DEPENDENCIES.rust.tsv
+++ b/bin/oli/DEPENDENCIES.rust.tsv
@@ -2,7 +2,6 @@ crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	B
 addr2line@0.24.2		X							X					
 adler2@2.0.0	X	X							X					
 aes@0.8.4		X							X					
-aho-corasick@1.1.3									X				X	
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
 anstream@0.6.15		X							X					
@@ -31,6 +30,7 @@ chrono@0.4.38		X							X
 cipher@0.4.4		X							X					
 clap@4.5.20		X							X					
 clap_builder@4.5.20		X							X					
+clap_derive@4.5.18		X							X					
 clap_lex@0.7.2		X							X					
 colorchoice@1.0.2		X							X					
 const-oid@0.9.6		X							X					
@@ -47,8 +47,6 @@ digest@0.10.7		X							X
 dirs@5.0.1		X							X					
 dirs-sys@0.4.1		X							X					
 dlv-list@0.5.2		X							X					
-env_filter@0.1.2		X							X					
-env_logger@0.11.5		X							X					
 equivalent@1.0.1		X							X					
 fastrand@2.1.1		X							X					
 flagset@0.4.6		X												
@@ -69,6 +67,7 @@ gimli@0.31.1		X							X
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
 hashbrown@0.15.0		X							X					
+heck@0.5.0		X							X					
 hermit-abi@0.3.9		X							X					
 hex@0.4.3		X							X					
 hmac@0.12.1		X							X					
@@ -77,7 +76,6 @@ http@1.1.0		X							X
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
 httparse@1.9.5		X							X					
-humantime@2.1.0		X							X					
 hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
 hyper-util@0.1.9									X					
@@ -110,7 +108,7 @@ num-traits@0.2.19		X							X
 object@0.36.5		X							X					
 oli@0.41.12		X												
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
+opendal@0.50.2		X												
 option-ext@0.2.0										X				
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
@@ -132,9 +130,6 @@ rand@0.8.5		X							X
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 redox_users@0.4.6									X					
-regex@1.11.0		X							X					
-regex-automata@0.4.8		X							X					
-regex-syntax@0.8.5		X							X					
 reqsign@0.16.0		X												
 reqwest@0.12.8		X							X					
 ring@0.17.8											X			

--- a/bin/oli/DEPENDENCIES.rust.tsv
+++ b/bin/oli/DEPENDENCIES.rust.tsv
@@ -106,7 +106,7 @@ num-integer@0.1.46		X							X
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
-oli@0.41.12		X												
+oli@0.41.13		X												
 once_cell@1.20.2		X							X					
 opendal@0.50.2		X												
 option-ext@0.2.0										X				

--- a/bin/oli/DEPENDENCIES.rust.tsv
+++ b/bin/oli/DEPENDENCIES.rust.tsv
@@ -130,7 +130,7 @@ rand@0.8.5		X							X
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 redox_users@0.4.6									X					
-reqsign@0.16.0		X												
+reqsign@0.16.1		X												
 reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.0"
+version = "0.45.1"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -4,7 +4,7 @@ adler2@2.0.0	X	X							X
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.90		X							X					
+anyhow@1.0.92		X							X					
 async-trait@0.1.83		X							X					
 atty@0.2.14									X					
 autocfg@1.4.0		X							X					
@@ -19,10 +19,10 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.2									X					
+bytes@1.8.0									X					
 cbc@0.1.2		X							X					
 cbindgen@0.26.0										X				
-cc@1.1.31		X							X					
+cc@1.1.34		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -71,7 +71,7 @@ http-body-util@0.1.2									X
 httparse@1.9.5		X							X					
 hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.9									X					
+hyper-util@0.1.10									X					
 iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
@@ -83,7 +83,7 @@ js-sys@0.3.72		X							X
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
 libc@0.2.161		X							X					
-libm@0.2.8		X							X					
+libm@0.2.11		X							X					
 linux-raw-sys@0.4.14		X	X						X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
@@ -99,37 +99,37 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
-opendal-c@0.45.0		X												
+opendal@0.50.2		X												
+opendal-c@0.45.1		X												
 ordered-multimap@0.7.3									X					
 os_str_bytes@6.6.1		X							X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project-lite@0.2.14		X							X					
+pin-project-lite@0.2.15		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.88		X							X					
+proc-macro2@1.0.89		X							X					
 quick-xml@0.35.0									X					
 quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-reqsign@0.16.0		X												
-reqwest@0.12.8		X							X					
+reqsign@0.16.1		X												
+reqwest@0.12.9		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustix@0.38.37		X	X						X					
-rustls@0.23.15		X						X	X					
+rustix@0.38.38		X	X						X					
+rustls@0.23.16		X						X	X					
 rustls-pemfile@2.2.0		X						X	X					
 rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
@@ -137,8 +137,8 @@ ryu@1.0.18		X				X
 salsa20@0.10.2		X							X					
 scrypt@0.11.0		X							X					
 semver@1.0.23		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
+serde@1.0.214		X							X					
+serde_derive@1.0.214		X							X					
 serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
@@ -154,20 +154,20 @@ spki@0.7.3		X							X
 strsim@0.10.0									X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.81		X							X					
+syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
 tempfile@3.13.0		X							X					
 termcolor@1.4.1									X				X	
 textwrap@0.16.1									X					
-thiserror@1.0.64		X							X					
-thiserror-impl@1.0.64		X							X					
+thiserror@1.0.67		X							X					
+thiserror-impl@1.0.67		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.40.0									X					
+tokio@1.41.0									X					
 tokio-macros@2.4.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
@@ -193,7 +193,7 @@ wasm-bindgen-futures@0.4.45		X							X
 wasm-bindgen-macro@0.2.95		X							X					
 wasm-bindgen-macro-support@0.2.95		X							X					
 wasm-bindgen-shared@0.2.95		X							X					
-wasm-streams@0.4.1		X							X					
+wasm-streams@0.4.2		X							X					
 web-sys@0.3.72		X							X					
 webpki-roots@0.26.6										X				
 winapi@0.3.9		X							X					

--- a/bindings/cpp/Cargo.toml
+++ b/bindings/cpp/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.12"
+version = "0.45.13"
 
 [lib]
 crate-type = ["staticlib"]

--- a/bindings/cpp/DEPENDENCIES.rust.tsv
+++ b/bindings/cpp/DEPENDENCIES.rust.tsv
@@ -4,7 +4,7 @@ adler2@2.0.0	X	X							X
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.90		X							X					
+anyhow@1.0.92		X							X					
 async-trait@0.1.83		X							X					
 autocfg@1.4.0		X							X					
 backon@1.2.0		X												
@@ -16,9 +16,9 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.2									X					
+bytes@1.8.0									X					
 cbc@0.1.2		X							X					
-cc@1.1.31		X							X					
+cc@1.1.34		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -66,7 +66,7 @@ http-body-util@0.1.2									X
 httparse@1.9.5		X							X					
 hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.9									X					
+hyper-util@0.1.10									X					
 iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
@@ -77,7 +77,7 @@ js-sys@0.3.72		X							X
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
 libc@0.2.161		X							X					
-libm@0.2.8		X							X					
+libm@0.2.11		X							X					
 link-cplusplus@1.0.9		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
@@ -93,35 +93,35 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
-opendal-cpp@0.45.12		X												
+opendal@0.50.2		X												
+opendal-cpp@0.45.13		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project-lite@0.2.14		X							X					
+pin-project-lite@0.2.15		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.88		X							X					
+proc-macro2@1.0.89		X							X					
 quick-xml@0.35.0									X					
 quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-reqsign@0.16.0		X												
-reqwest@0.12.8		X							X					
+reqsign@0.16.1		X												
+reqwest@0.12.9		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.15		X						X	X					
+rustls@0.23.16		X						X	X					
 rustls-pemfile@2.2.0		X						X	X					
 rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
@@ -130,8 +130,8 @@ salsa20@0.10.2		X							X
 scratch@1.0.7		X							X					
 scrypt@0.11.0		X							X					
 semver@1.0.23		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
+serde@1.0.214		X							X					
+serde_derive@1.0.214		X							X					
 serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
@@ -145,18 +145,18 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
-syn@2.0.81		X							X					
+syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
 termcolor@1.4.1									X				X	
-thiserror@1.0.64		X							X					
-thiserror-impl@1.0.64		X							X					
+thiserror@1.0.67		X							X					
+thiserror-impl@1.0.67		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.40.0									X					
+tokio@1.41.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
 tower-service@0.3.3									X					
@@ -181,7 +181,7 @@ wasm-bindgen-futures@0.4.45		X							X
 wasm-bindgen-macro@0.2.95		X							X					
 wasm-bindgen-macro-support@0.2.95		X							X					
 wasm-bindgen-shared@0.2.95		X							X					
-wasm-streams@0.4.1		X							X					
+wasm-streams@0.4.2		X							X					
 web-sys@0.3.72		X							X					
 webpki-roots@0.26.6										X				
 winapi-util@0.1.9									X				X	

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-dotnet"
 publish = false
-version = "0.1.10"
+version = "0.1.11"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/dotnet/DEPENDENCIES.rust.tsv
+++ b/bindings/dotnet/DEPENDENCIES.rust.tsv
@@ -4,7 +4,7 @@ adler2@2.0.0	X	X							X
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.90		X							X					
+anyhow@1.0.92		X							X					
 async-trait@0.1.83		X							X					
 autocfg@1.4.0		X							X					
 backon@1.2.0		X												
@@ -16,9 +16,9 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.2									X					
+bytes@1.8.0									X					
 cbc@0.1.2		X							X					
-cc@1.1.31		X							X					
+cc@1.1.34		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -61,7 +61,7 @@ http-body-util@0.1.2									X
 httparse@1.9.5		X							X					
 hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.9									X					
+hyper-util@0.1.10									X					
 iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
@@ -72,7 +72,7 @@ js-sys@0.3.72		X							X
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
 libc@0.2.161		X							X					
-libm@0.2.8		X							X					
+libm@0.2.11		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
 memchr@2.7.4									X				X	
@@ -87,35 +87,35 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
-opendal-dotnet@0.1.10		X												
+opendal@0.50.2		X												
+opendal-dotnet@0.1.11		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project-lite@0.2.14		X							X					
+pin-project-lite@0.2.15		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.88		X							X					
+proc-macro2@1.0.89		X							X					
 quick-xml@0.35.0									X					
 quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-reqsign@0.16.0		X												
-reqwest@0.12.8		X							X					
+reqsign@0.16.1		X												
+reqwest@0.12.9		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.15		X						X	X					
+rustls@0.23.16		X						X	X					
 rustls-pemfile@2.2.0		X						X	X					
 rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
@@ -123,8 +123,8 @@ ryu@1.0.18		X				X
 salsa20@0.10.2		X							X					
 scrypt@0.11.0		X							X					
 semver@1.0.23		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
+serde@1.0.214		X							X					
+serde_derive@1.0.214		X							X					
 serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
@@ -138,17 +138,17 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
-syn@2.0.81		X							X					
+syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
-thiserror@1.0.64		X							X					
-thiserror-impl@1.0.64		X							X					
+thiserror@1.0.67		X							X					
+thiserror-impl@1.0.67		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.40.0									X					
+tokio@1.41.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
 tower-service@0.3.3									X					
@@ -172,7 +172,7 @@ wasm-bindgen-futures@0.4.45		X							X
 wasm-bindgen-macro@0.2.95		X							X					
 wasm-bindgen-macro-support@0.2.95		X							X					
 wasm-bindgen-shared@0.2.95		X							X					
-wasm-streams@0.4.1		X							X					
+wasm-streams@0.4.2		X							X					
 web-sys@0.3.72		X							X					
 webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					

--- a/bindings/haskell/Cargo.toml
+++ b/bindings/haskell/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.44.12"
+version = "0.44.13"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/haskell/DEPENDENCIES.rust.tsv
+++ b/bindings/haskell/DEPENDENCIES.rust.tsv
@@ -4,7 +4,7 @@ adler2@2.0.0	X	X							X
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.90		X							X					
+anyhow@1.0.92		X							X					
 async-trait@0.1.83		X							X					
 autocfg@1.4.0		X							X					
 backon@1.2.0		X												
@@ -16,9 +16,9 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.2									X					
+bytes@1.8.0									X					
 cbc@0.1.2		X							X					
-cc@1.1.31		X							X					
+cc@1.1.34		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -61,7 +61,7 @@ http-body-util@0.1.2									X
 httparse@1.9.5		X							X					
 hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.9									X					
+hyper-util@0.1.10									X					
 iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
@@ -72,7 +72,7 @@ js-sys@0.3.72		X							X
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
 libc@0.2.161		X							X					
-libm@0.2.8		X							X					
+libm@0.2.11		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
 memchr@2.7.4									X				X	
@@ -87,35 +87,35 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
-opendal-hs@0.44.12		X												
+opendal@0.50.2		X												
+opendal-hs@0.44.13		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project-lite@0.2.14		X							X					
+pin-project-lite@0.2.15		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.88		X							X					
+proc-macro2@1.0.89		X							X					
 quick-xml@0.35.0									X					
 quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-reqsign@0.16.0		X												
-reqwest@0.12.8		X							X					
+reqsign@0.16.1		X												
+reqwest@0.12.9		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.15		X						X	X					
+rustls@0.23.16		X						X	X					
 rustls-pemfile@2.2.0		X						X	X					
 rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
@@ -123,8 +123,8 @@ ryu@1.0.18		X				X
 salsa20@0.10.2		X							X					
 scrypt@0.11.0		X							X					
 semver@1.0.23		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
+serde@1.0.214		X							X					
+serde_derive@1.0.214		X							X					
 serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
@@ -138,17 +138,17 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
-syn@2.0.81		X							X					
+syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
-thiserror@1.0.64		X							X					
-thiserror-impl@1.0.64		X							X					
+thiserror@1.0.67		X							X					
+thiserror-impl@1.0.67		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.40.0									X					
+tokio@1.41.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
 tower-service@0.3.3									X					
@@ -172,7 +172,7 @@ wasm-bindgen-futures@0.4.45		X							X
 wasm-bindgen-macro@0.2.95		X							X					
 wasm-bindgen-macro-support@0.2.95		X							X					
 wasm-bindgen-shared@0.2.95		X							X					
-wasm-streams@0.4.1		X							X					
+wasm-streams@0.4.2		X							X					
 web-sys@0.3.72		X							X					
 webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.47.4"
+version = "0.47.5"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -134,7 +134,7 @@ rand@0.8.5		X							X
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 redox_syscall@0.5.3									X					
-reqsign@0.16.0		X												
+reqsign@0.16.1		X												
 reqwest@0.12.7		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -1,40 +1,40 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	ISC	MIT	MPL-2.0	OpenSSL	Unicode-DFS-2016	Unlicense	Zlib
-addr2line@0.24.2		X							X					
-adler2@2.0.0	X	X							X					
+addr2line@0.22.0		X							X					
+adler@1.0.2	X	X							X					
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.90		X							X					
+anyhow@1.0.86		X							X					
 arc-swap@1.7.1		X							X					
-async-trait@0.1.83		X							X					
-autocfg@1.4.0		X							X					
+async-trait@0.1.81		X							X					
+autocfg@1.3.0		X							X					
 awaitable@0.4.0									X					
 awaitable-error@0.1.0									X					
 backon@1.2.0		X												
-backtrace@0.3.74		X							X					
+backtrace@0.3.73		X							X					
 base64@0.21.7		X							X					
 base64@0.22.1		X							X					
 base64ct@1.6.0		X							X					
-bb8@0.8.6									X					
+bb8@0.8.5									X					
 bitflags@2.6.0		X							X					
 block-buffer@0.10.4		X							X					
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.2									X					
+bytes@1.7.1									X					
 cbc@0.1.2		X							X					
-cc@1.1.31		X							X					
+cc@1.1.15		X							X					
 cesu8@1.1.0		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
 combine@4.6.7									X					
-concurrent_arena@0.1.10									X					
+concurrent_arena@0.1.8									X					
 const-oid@0.9.6		X							X					
 const-random@0.1.18		X							X					
 const-random-macro@0.1.16		X							X					
 core-foundation-sys@0.8.7		X							X					
-cpufeatures@0.2.14		X							X					
+cpufeatures@0.2.13		X							X					
 crc32c@0.6.8		X							X					
 crunchy@0.2.2									X					
 crypto-common@0.1.6		X							X					
@@ -48,17 +48,17 @@ fastrand@2.1.1		X							X
 flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
-futures@0.3.31		X							X					
-futures-channel@0.3.31		X							X					
-futures-core@0.3.31		X							X					
-futures-io@0.3.31		X							X					
-futures-macro@0.3.31		X							X					
-futures-sink@0.3.31		X							X					
-futures-task@0.3.31		X							X					
-futures-util@0.3.31		X							X					
+futures@0.3.30		X							X					
+futures-channel@0.3.30		X							X					
+futures-core@0.3.30		X							X					
+futures-io@0.3.30		X							X					
+futures-macro@0.3.30		X							X					
+futures-sink@0.3.30		X							X					
+futures-task@0.3.30		X							X					
+futures-util@0.3.30		X							X					
 generic-array@0.14.7									X					
 getrandom@0.2.15		X							X					
-gimli@0.31.1		X							X					
+gimli@0.29.0		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
 hermit-abi@0.3.9		X							X					
@@ -68,22 +68,22 @@ home@0.5.9		X							X
 http@1.1.0		X							X					
 http-body@1.0.1									X					
 http-body-util@0.1.2									X					
-httparse@1.9.5		X							X					
-hyper@1.5.0									X					
-hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.9									X					
-iana-time-zone@0.1.61		X							X					
+httparse@1.9.4		X							X					
+hyper@1.4.1									X					
+hyper-rustls@0.27.2		X						X	X					
+hyper-util@0.1.7									X					
+iana-time-zone@0.1.60		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
 inout@0.1.3		X							X					
-ipnet@2.10.1		X							X					
+ipnet@2.9.0		X							X					
 itoa@1.0.11		X							X					
 jni@0.21.1		X							X					
 jni-sys@0.3.0		X							X					
-js-sys@0.3.72		X							X					
+js-sys@0.3.70		X							X					
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
-libc@0.2.161		X							X					
+libc@0.2.158		X							X					
 libm@0.2.8		X							X					
 linux-raw-sys@0.4.14		X	X						X					
 lock_api@0.4.12		X							X					
@@ -91,7 +91,7 @@ log@0.4.22		X							X
 md-5@0.10.6		X							X					
 memchr@2.7.4									X				X	
 mime@0.3.17		X							X					
-miniz_oxide@0.8.0		X							X					X
+miniz_oxide@0.7.4		X							X					X
 mio@1.0.2									X					
 num-bigint@0.4.6		X							X					
 num-bigint-dig@0.8.4		X							X					
@@ -100,10 +100,10 @@ num-derive@0.3.3		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
-object@0.36.5		X							X					
-once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
-opendal-java@0.47.4		X												
+object@0.36.3		X							X					
+once_cell@1.19.0		X							X					
+opendal@0.50.2		X												
+opendal-java@0.47.5		X												
 openssh@0.11.2		X							X					
 openssh-sftp-client@0.15.1									X					
 openssh-sftp-client-lowlevel@0.7.0									X					
@@ -117,8 +117,8 @@ pbkdf2@0.12.2		X							X
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.6		X							X					
-pin-project-internal@1.1.6		X							X					
+pin-project@1.1.5		X							X					
+pin-project-internal@1.1.5		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
@@ -126,35 +126,35 @@ pkcs5@0.7.1		X							X
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.88		X							X					
+proc-macro2@1.0.86		X							X					
 quick-xml@0.35.0									X					
-quick-xml@0.36.2									X					
+quick-xml@0.36.1									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-redox_syscall@0.5.7									X					
+redox_syscall@0.5.3									X					
 reqsign@0.16.0		X												
-reqwest@0.12.8		X							X					
+reqwest@0.12.7		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustix@0.38.37		X	X						X					
-rustls@0.23.15		X						X	X					
-rustls-pemfile@2.2.0		X						X	X					
-rustls-pki-types@1.10.0		X							X					
-rustls-webpki@0.102.8								X						
+rustix@0.38.35		X	X						X					
+rustls@0.23.12		X						X	X					
+rustls-pemfile@2.1.3		X						X	X					
+rustls-pki-types@1.8.0		X							X					
+rustls-webpki@0.102.7								X						
 ryu@1.0.18		X				X								
 salsa20@0.10.2		X							X					
 same-file@1.0.6									X				X	
 scopeguard@1.2.0		X							X					
 scrypt@0.11.0		X							X					
 semver@1.0.23		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
-serde_json@1.0.132		X							X					
+serde@1.0.209		X							X					
+serde_derive@1.0.209		X							X					
+serde_json@1.0.127		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
 sha2@0.10.8		X							X					
@@ -173,12 +173,12 @@ ssh_format_error@0.1.0									X
 stable_deref_trait@1.2.0		X							X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.81		X							X					
+syn@2.0.76		X							X					
 sync_wrapper@1.0.1		X												
-tempfile@3.13.0		X							X					
+tempfile@3.12.0		X							X					
 thin-vec@0.2.13		X							X					
-thiserror@1.0.64		X							X					
-thiserror-impl@1.0.64		X							X					
+thiserror@1.0.63		X							X					
+thiserror-impl@1.0.63		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
@@ -189,7 +189,9 @@ tokio@1.40.0									X
 tokio-io-utility@0.7.6									X					
 tokio-macros@2.4.0									X					
 tokio-rustls@0.26.0		X							X					
-tokio-util@0.7.12									X					
+tokio-util@0.7.11									X					
+tower@0.4.13									X					
+tower-layer@0.3.3									X					
 tower-service@0.3.3									X					
 tracing@0.1.40									X					
 tracing-attributes@0.1.27									X					
@@ -198,26 +200,26 @@ trim-in-place@0.1.7									X
 triomphe@0.1.11		X							X					
 try-lock@0.2.5									X					
 typenum@1.17.0		X							X					
-unicode-bidi@0.3.17		X							X					
-unicode-ident@1.0.13		X							X			X		
-unicode-normalization@0.1.24		X							X					
+unicode-bidi@0.3.15		X							X					
+unicode-ident@1.0.12		X							X			X		
+unicode-normalization@0.1.23		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
-uuid@1.11.0		X							X					
+uuid@1.10.0		X							X					
 vec-strings@0.4.8									X					
 version_check@0.9.5		X							X					
 walkdir@2.5.0									X				X	
 want@0.3.1									X					
 wasi@0.11.0+wasi-snapshot-preview1		X	X						X					
-wasm-bindgen@0.2.95		X							X					
-wasm-bindgen-backend@0.2.95		X							X					
-wasm-bindgen-futures@0.4.45		X							X					
-wasm-bindgen-macro@0.2.95		X							X					
-wasm-bindgen-macro-support@0.2.95		X							X					
-wasm-bindgen-shared@0.2.95		X							X					
-wasm-streams@0.4.1		X							X					
-web-sys@0.3.72		X							X					
-webpki-roots@0.26.6										X				
+wasm-bindgen@0.2.93		X							X					
+wasm-bindgen-backend@0.2.93		X							X					
+wasm-bindgen-futures@0.4.43		X							X					
+wasm-bindgen-macro@0.2.93		X							X					
+wasm-bindgen-macro-support@0.2.93		X							X					
+wasm-bindgen-shared@0.2.93		X							X					
+wasm-streams@0.4.0		X							X					
+web-sys@0.3.70		X							X					
+webpki-roots@0.26.3										X				
 winapi-util@0.1.9									X				X	
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					

--- a/bindings/lua/Cargo.toml
+++ b/bindings/lua/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-lua"
 publish = false
-version = "0.1.10"
+version = "0.1.11"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/lua/DEPENDENCIES.rust.tsv
+++ b/bindings/lua/DEPENDENCIES.rust.tsv
@@ -5,7 +5,7 @@ aes@0.8.4		X							X
 aho-corasick@1.1.3									X				X	
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.90		X							X					
+anyhow@1.0.92		X							X					
 async-trait@0.1.83		X							X					
 autocfg@1.4.0		X							X					
 backon@1.2.0		X												
@@ -18,9 +18,9 @@ block-padding@0.3.3		X							X
 bstr@1.10.0		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.2									X					
+bytes@1.8.0									X					
 cbc@0.1.2		X							X					
-cc@1.1.31		X							X					
+cc@1.1.34		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -64,7 +64,7 @@ http-body-util@0.1.2									X
 httparse@1.9.5		X							X					
 hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.9									X					
+hyper-util@0.1.10									X					
 iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
@@ -76,7 +76,7 @@ js-sys@0.3.72		X							X
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
 libc@0.2.161		X							X					
-libm@0.2.8		X							X					
+libm@0.2.11		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
 memchr@2.7.4									X				X	
@@ -84,7 +84,7 @@ mime@0.3.17		X							X
 miniz_oxide@0.8.0		X							X					X
 mio@1.0.2									X					
 mlua@0.9.9									X					
-mlua-sys@0.6.3									X					
+mlua-sys@0.6.4									X					
 mlua_derive@0.9.3									X					
 num-bigint@0.4.6		X							X					
 num-bigint-dig@0.8.4		X							X					
@@ -94,14 +94,14 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
-opendal-lua@0.1.10		X												
+opendal@0.50.2		X												
+opendal-lua@0.1.11		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project-lite@0.2.14		X							X					
+pin-project-lite@0.2.15		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
@@ -111,25 +111,25 @@ powerfmt@0.2.0		X							X
 ppv-lite86@0.2.20		X							X					
 proc-macro-error@1.0.4		X							X					
 proc-macro-error-attr@1.0.4		X							X					
-proc-macro2@1.0.88		X							X					
+proc-macro2@1.0.89		X							X					
 quick-xml@0.35.0									X					
 quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-regex@1.11.0		X							X					
+regex@1.11.1		X							X					
 regex-automata@0.4.8		X							X					
 regex-syntax@0.8.5		X							X					
-reqsign@0.16.0		X												
-reqwest@0.12.8		X							X					
+reqsign@0.16.1		X												
+reqwest@0.12.9		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc-hash@2.0.0		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.15		X						X	X					
+rustls@0.23.16		X						X	X					
 rustls-pemfile@2.2.0		X						X	X					
 rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
@@ -137,8 +137,8 @@ ryu@1.0.18		X				X
 salsa20@0.10.2		X							X					
 scrypt@0.11.0		X							X					
 semver@1.0.23		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
+serde@1.0.214		X							X					
+serde_derive@1.0.214		X							X					
 serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
@@ -153,17 +153,17 @@ spin@0.9.8									X
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.81		X							X					
+syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
-thiserror@1.0.64		X							X					
-thiserror-impl@1.0.64		X							X					
+thiserror@1.0.67		X							X					
+thiserror-impl@1.0.67		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.40.0									X					
+tokio@1.41.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
 tower-service@0.3.3									X					
@@ -187,7 +187,7 @@ wasm-bindgen-futures@0.4.45		X							X
 wasm-bindgen-macro@0.2.95		X							X					
 wasm-bindgen-macro-support@0.2.95		X							X					
 wasm-bindgen-shared@0.2.95		X							X					
-wasm-streams@0.4.1		X							X					
+wasm-streams@0.4.2		X							X					
 web-sys@0.3.72		X							X					
 webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					

--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.47.6"
+version = "0.47.7"
 
 [features]
 default = [

--- a/bindings/nodejs/DEPENDENCIES.rust.tsv
+++ b/bindings/nodejs/DEPENDENCIES.rust.tsv
@@ -5,7 +5,7 @@ aes@0.8.4		X							X
 aho-corasick@1.1.3									X				X	
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.90		X							X					
+anyhow@1.0.92		X							X					
 async-trait@0.1.83		X							X					
 autocfg@1.4.0		X							X					
 backon@1.2.0		X												
@@ -18,9 +18,9 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.2									X					
+bytes@1.8.0									X					
 cbc@0.1.2		X							X					
-cc@1.1.31		X							X					
+cc@1.1.34		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -66,7 +66,7 @@ http-body-util@0.1.2									X
 httparse@1.9.5		X							X					
 hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.9									X					
+hyper-util@0.1.10									X					
 iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
@@ -78,14 +78,14 @@ jsonwebtoken@9.3.0									X
 lazy_static@1.5.0		X							X					
 libc@0.2.161		X							X					
 libloading@0.8.5								X						
-libm@0.2.8		X							X					
+libm@0.2.11		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
 memchr@2.7.4									X				X	
 mime@0.3.17		X							X					
 miniz_oxide@0.8.0		X							X					X
 mio@1.0.2									X					
-napi@2.16.12									X					
+napi@2.16.13									X					
 napi-build@2.1.3									X					
 napi-derive@2.16.12									X					
 napi-derive-backend@1.0.74									X					
@@ -98,38 +98,38 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
-opendal-nodejs@0.47.6		X												
+opendal@0.50.2		X												
+opendal-nodejs@0.47.7		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project-lite@0.2.14		X							X					
+pin-project-lite@0.2.15		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.88		X							X					
+proc-macro2@1.0.89		X							X					
 quick-xml@0.35.0									X					
 quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-regex@1.11.0		X							X					
+regex@1.11.1		X							X					
 regex-automata@0.4.8		X							X					
 regex-syntax@0.8.5		X							X					
-reqsign@0.16.0		X												
-reqwest@0.12.8		X							X					
+reqsign@0.16.1		X												
+reqwest@0.12.9		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.15		X						X	X					
+rustls@0.23.16		X						X	X					
 rustls-pemfile@2.2.0		X						X	X					
 rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
@@ -137,8 +137,8 @@ ryu@1.0.18		X				X
 salsa20@0.10.2		X							X					
 scrypt@0.11.0		X							X					
 semver@1.0.23		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
+serde@1.0.214		X							X					
+serde_derive@1.0.214		X							X					
 serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
@@ -152,17 +152,17 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
-syn@2.0.81		X							X					
+syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
-thiserror@1.0.64		X							X					
-thiserror-impl@1.0.64		X							X					
+thiserror@1.0.67		X							X					
+thiserror-impl@1.0.67		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.40.0									X					
+tokio@1.41.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
 tower-service@0.3.3									X					
@@ -187,7 +187,7 @@ wasm-bindgen-futures@0.4.45		X							X
 wasm-bindgen-macro@0.2.95		X							X					
 wasm-bindgen-macro-support@0.2.95		X							X					
 wasm-bindgen-shared@0.2.95		X							X					
-wasm-streams@0.4.1		X							X					
+wasm-streams@0.4.2		X							X					
 web-sys@0.3.72		X							X					
 webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opendal/lib-darwin-arm64",
   "repository": "git@github.com/apache/opendal.git",
-  "version": "0.47.6",
+  "version": "0.47.7",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-x64",
-  "version": "0.47.6",
+  "version": "0.47.7",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "darwin"

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-gnu",
-  "version": "0.47.6",
+  "version": "0.47.7",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-musl",
-  "version": "0.47.6",
+  "version": "0.47.7",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.47.6",
+  "version": "0.47.7",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "linux"

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-arm64-msvc",
-  "version": "0.47.6",
+  "version": "0.47.7",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.47.6",
+  "version": "0.47.7",
   "repository": "git@github.com/apache/opendal.git",
   "os": [
     "win32"

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "Apache OpenDAL <dev@opendal.apache.org>",
-  "version": "0.47.6",
+  "version": "0.47.7",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",

--- a/bindings/ocaml/DEPENDENCIES.rust.tsv
+++ b/bindings/ocaml/DEPENDENCIES.rust.tsv
@@ -4,7 +4,7 @@ adler2@2.0.0	X	X							X
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.90		X							X					
+anyhow@1.0.92		X							X					
 async-trait@0.1.83		X							X					
 autocfg@1.4.0		X							X					
 backon@1.2.0		X												
@@ -16,9 +16,9 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.2									X					
+bytes@1.8.0									X					
 cbc@0.1.2		X							X					
-cc@1.1.31		X							X					
+cc@1.1.34		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cipher@0.4.4		X							X					
@@ -62,7 +62,7 @@ http-body-util@0.1.2									X
 httparse@1.9.5		X							X					
 hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.9									X					
+hyper-util@0.1.10									X					
 iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
@@ -73,7 +73,7 @@ js-sys@0.3.72		X							X
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
 libc@0.2.161		X							X					
-libm@0.2.8		X							X					
+libm@0.2.11		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
 memchr@2.7.4									X				X	
@@ -93,35 +93,35 @@ ocaml-build@1.0.0								X
 ocaml-derive@1.0.0								X						
 ocaml-sys@0.24.0								X						
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
+opendal@0.50.2		X												
 opendal-ocaml@0.0.0		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project-lite@0.2.14		X							X					
+pin-project-lite@0.2.15		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.88		X							X					
+proc-macro2@1.0.89		X							X					
 quick-xml@0.35.0									X					
 quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-reqsign@0.16.0		X												
-reqwest@0.12.8		X							X					
+reqsign@0.16.1		X												
+reqwest@0.12.9		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.15		X						X	X					
+rustls@0.23.16		X						X	X					
 rustls-pemfile@2.2.0		X						X	X					
 rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
@@ -129,8 +129,8 @@ ryu@1.0.18		X				X
 salsa20@0.10.2		X							X					
 scrypt@0.11.0		X							X					
 semver@1.0.23		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
+serde@1.0.214		X							X					
+serde_derive@1.0.214		X							X					
 serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
@@ -144,17 +144,17 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
-syn@2.0.81		X							X					
+syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
-thiserror@1.0.64		X							X					
-thiserror-impl@1.0.64		X							X					
+thiserror@1.0.67		X							X					
+thiserror-impl@1.0.67		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.40.0									X					
+tokio@1.41.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
 tower-service@0.3.3									X					
@@ -178,7 +178,7 @@ wasm-bindgen-futures@0.4.45		X							X
 wasm-bindgen-macro@0.2.95		X							X					
 wasm-bindgen-macro-support@0.2.95		X							X					
 wasm-bindgen-shared@0.2.95		X							X					
-wasm-streams@0.4.1		X							X					
+wasm-streams@0.4.2		X							X					
 web-sys@0.3.72		X							X					
 webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					

--- a/bindings/php/Cargo.toml
+++ b/bindings/php/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-php"
 publish = false
-version = "0.1.10"
+version = "0.1.11"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/php/DEPENDENCIES.rust.tsv
+++ b/bindings/php/DEPENDENCIES.rust.tsv
@@ -4,7 +4,7 @@ adler2@2.0.0	X	X							X
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.90		X							X					
+anyhow@1.0.92		X							X					
 async-trait@0.1.83		X							X					
 autocfg@1.4.0		X							X					
 backon@1.2.0		X												
@@ -19,14 +19,14 @@ block-padding@0.3.3		X							X
 bumpalo@3.16.0		X							X					
 bytecount@0.6.8		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.2									X					
+bytes@1.8.0									X					
 bzip2@0.4.4		X							X					
 bzip2-sys@0.1.11+1.0.8		X							X					
 camino@1.1.9		X							X					
 cargo-platform@0.1.8		X							X					
 cargo_metadata@0.14.2									X					
 cbc@0.1.2		X							X					
-cc@1.1.31		X							X					
+cc@1.1.34		X							X					
 cexpr@0.6.0		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
@@ -87,7 +87,7 @@ http-body-util@0.1.2									X
 httparse@1.9.5		X							X					
 hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.9									X					
+hyper-util@0.1.10									X					
 iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 ident_case@1.0.1		X							X					
@@ -102,7 +102,7 @@ lazy_static@1.5.0		X							X
 lazycell@1.3.0		X							X					
 libc@0.2.161		X							X					
 libloading@0.8.5								X						
-libm@0.2.8		X							X					
+libm@0.2.11		X							X					
 linux-raw-sys@0.4.14		X	X						X					
 lock_api@0.4.12		X							X					
 log@0.4.22		X							X					
@@ -122,8 +122,8 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
-opendal-php@0.1.10		X												
+opendal@0.50.2		X												
+opendal-php@0.1.11		X												
 openssl@0.10.68		X												
 openssl-macros@0.1.1		X							X					
 openssl-probe@0.1.5		X							X					
@@ -138,7 +138,7 @@ peeking_take_while@0.1.2		X							X
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project-lite@0.2.14		X							X					
+pin-project-lite@0.2.15		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
@@ -146,8 +146,8 @@ pkcs8@0.10.2		X							X
 pkg-config@0.3.31		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-prettyplease@0.2.24		X							X					
-proc-macro2@1.0.88		X							X					
+prettyplease@0.2.25		X							X					
+proc-macro2@1.0.89		X							X					
 pulldown-cmark@0.9.6									X					
 quick-xml@0.35.0									X					
 quick-xml@0.36.2									X					
@@ -156,19 +156,19 @@ rand@0.8.5		X							X
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 redox_syscall@0.5.7									X					
-regex@1.11.0		X							X					
+regex@1.11.1		X							X					
 regex-automata@0.4.8		X							X					
 regex-syntax@0.8.5		X							X					
-reqsign@0.16.0		X												
-reqwest@0.12.8		X							X					
+reqsign@0.16.1		X												
+reqwest@0.12.9		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc-hash@1.1.0		X							X					
 rustc_version@0.4.1		X							X					
-rustix@0.38.37		X	X						X					
-rustls@0.23.15		X						X	X					
+rustix@0.38.38		X	X						X					
+rustls@0.23.16		X						X	X					
 rustls-pemfile@2.2.0		X						X	X					
 rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
@@ -181,8 +181,8 @@ scrypt@0.11.0		X							X
 security-framework@2.11.1		X							X					
 security-framework-sys@2.12.0		X							X					
 semver@1.0.23		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
+serde@1.0.214		X							X					
+serde_derive@1.0.214		X							X					
 serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
@@ -199,18 +199,18 @@ spki@0.7.3		X							X
 strsim@0.10.0									X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.81		X							X					
+syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
 tempfile@3.13.0		X							X					
-thiserror@1.0.64		X							X					
-thiserror-impl@1.0.64		X							X					
+thiserror@1.0.67		X							X					
+thiserror-impl@1.0.67		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.40.0									X					
+tokio@1.41.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
 tower-service@0.3.3									X					
@@ -238,7 +238,7 @@ wasm-bindgen-futures@0.4.45		X							X
 wasm-bindgen-macro@0.2.95		X							X					
 wasm-bindgen-macro-support@0.2.95		X							X					
 wasm-bindgen-shared@0.2.95		X							X					
-wasm-streams@0.4.1		X							X					
+wasm-streams@0.4.2		X							X					
 web-sys@0.3.72		X							X					
 webpki-roots@0.26.6										X				
 which@4.4.2									X					

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.11"
+version = "0.45.12"
 
 [features]
 default = [

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -141,7 +141,7 @@ rand@0.8.5		X							X
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
 redox_syscall@0.5.7									X					
-reqsign@0.16.0		X												
+reqsign@0.16.1		X												
 reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -4,7 +4,7 @@ adler2@2.0.0	X	X							X
 aes@0.8.4		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.90		X							X					
+anyhow@1.0.91		X							X					
 arc-swap@1.7.1		X							X					
 async-trait@0.1.83		X							X					
 autocfg@1.4.0		X							X					
@@ -21,7 +21,7 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.2									X					
+bytes@1.8.0									X					
 cbc@0.1.2		X							X					
 cc@1.1.31		X							X					
 cfg-if@1.0.0		X							X					
@@ -60,7 +60,7 @@ getrandom@0.2.15		X							X
 gimli@0.31.1		X							X					
 gloo-timers@0.3.0		X							X					
 hashbrown@0.14.5		X							X					
-heck@0.4.1		X							X					
+heck@0.5.0		X							X					
 hermit-abi@0.3.9		X							X					
 hex@0.4.3		X							X					
 hmac@0.12.1		X							X					
@@ -83,7 +83,7 @@ js-sys@0.3.72		X							X
 jsonwebtoken@9.3.0									X					
 lazy_static@1.5.0		X							X					
 libc@0.2.161		X							X					
-libm@0.2.8		X							X					
+libm@0.2.10		X							X					
 linux-raw-sys@0.4.14		X	X						X					
 lock_api@0.4.12		X							X					
 log@0.4.22		X							X					
@@ -102,8 +102,8 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
-opendal-python@0.45.11		X												
+opendal@0.50.2		X												
+opendal-python@0.45.12		X												
 openssh@0.11.2		X							X					
 openssh-sftp-client@0.15.1									X					
 openssh-sftp-client-lowlevel@0.7.0									X					
@@ -117,9 +117,9 @@ pbkdf2@0.12.2		X							X
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project@1.1.6		X							X					
-pin-project-internal@1.1.6		X							X					
-pin-project-lite@0.2.14		X							X					
+pin-project@1.1.7		X							X					
+pin-project-internal@1.1.7		X							X					
+pin-project-lite@0.2.15		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
@@ -127,13 +127,13 @@ pkcs8@0.10.2		X							X
 portable-atomic@1.9.0		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.88		X							X					
-pyo3@0.21.2		X							X					
-pyo3-asyncio-0-21@0.21.0		X												
-pyo3-build-config@0.21.2		X							X					
-pyo3-ffi@0.21.2		X							X					
-pyo3-macros@0.21.2		X							X					
-pyo3-macros-backend@0.21.2		X							X					
+proc-macro2@1.0.89		X							X					
+pyo3@0.22.5		X							X					
+pyo3-async-runtimes@0.22.0		X												
+pyo3-build-config@0.22.5		X							X					
+pyo3-ffi@0.22.5		X							X					
+pyo3-macros@0.22.5		X							X					
+pyo3-macros-backend@0.22.5		X							X					
 quick-xml@0.35.0									X					
 quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
@@ -148,7 +148,7 @@ rsa@0.9.6		X							X
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustix@0.38.37		X	X						X					
+rustix@0.38.38		X	X						X					
 rustls@0.23.15		X						X	X					
 rustls-pemfile@2.2.0		X						X	X					
 rustls-pki-types@1.10.0		X							X					
@@ -158,8 +158,8 @@ salsa20@0.10.2		X							X
 scopeguard@1.2.0		X							X					
 scrypt@0.11.0		X							X					
 semver@1.0.23		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
+serde@1.0.213		X							X					
+serde_derive@1.0.213		X							X					
 serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
@@ -179,20 +179,20 @@ ssh_format_error@0.1.0									X
 stable_deref_trait@1.2.0		X							X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.81		X							X					
+syn@2.0.85		X							X					
 sync_wrapper@1.0.1		X												
 target-lexicon@0.12.16			X											
 tempfile@3.13.0		X							X					
 thin-vec@0.2.13		X							X					
-thiserror@1.0.64		X							X					
-thiserror-impl@1.0.64		X							X					
+thiserror@1.0.65		X							X					
+thiserror-impl@1.0.65		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.40.0									X					
+tokio@1.41.0									X					
 tokio-io-utility@0.7.6									X					
 tokio-macros@2.4.0									X					
 tokio-rustls@0.26.0		X							X					
@@ -222,7 +222,7 @@ wasm-bindgen-futures@0.4.45		X							X
 wasm-bindgen-macro@0.2.95		X							X					
 wasm-bindgen-macro-support@0.2.95		X							X					
 wasm-bindgen-shared@0.2.95		X							X					
-wasm-streams@0.4.1		X							X					
+wasm-streams@0.4.2		X							X					
 web-sys@0.3.72		X							X					
 webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-ruby"
 publish = false
-version = "0.1.10"
+version = "0.1.11"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -5,7 +5,7 @@ aes@0.8.4		X							X
 aho-corasick@1.1.3									X				X	
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.90		X							X					
+anyhow@1.0.92		X							X					
 async-trait@0.1.83		X							X					
 autocfg@1.4.0		X							X					
 backon@1.2.0		X												
@@ -19,9 +19,9 @@ block-buffer@0.10.4		X							X
 block-padding@0.3.3		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.2									X					
+bytes@1.8.0									X					
 cbc@0.1.2		X							X					
-cc@1.1.31		X							X					
+cc@1.1.34		X							X					
 cexpr@0.6.0		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
@@ -68,7 +68,7 @@ http-body-util@0.1.2									X
 httparse@1.9.5		X							X					
 hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.9									X					
+hyper-util@0.1.10									X					
 iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
@@ -82,7 +82,7 @@ lazy_static@1.5.0		X							X
 lazycell@1.3.0		X							X					
 libc@0.2.161		X							X					
 libloading@0.8.5								X						
-libm@0.2.8		X							X					
+libm@0.2.11		X							X					
 log@0.4.22		X							X					
 magnus@0.5.5									X					
 magnus-macros@0.4.1									X					
@@ -101,21 +101,21 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
-opendal-ruby@0.1.10		X												
+opendal@0.50.2		X												
+opendal-ruby@0.1.11		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
 pem-rfc7468@0.7.0		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project-lite@0.2.14		X							X					
+pin-project-lite@0.2.15		X							X					
 pin-utils@0.1.0		X							X					
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
 pkcs8@0.10.2		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.88		X							X					
+proc-macro2@1.0.89		X							X					
 quick-xml@0.35.0									X					
 quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
@@ -125,18 +125,18 @@ rand_core@0.6.4		X							X
 rb-sys@0.9.102		X							X					
 rb-sys-build@0.9.102		X							X					
 rb-sys-env@0.1.2		X							X					
-regex@1.11.0		X							X					
+regex@1.11.1		X							X					
 regex-automata@0.4.8		X							X					
 regex-syntax@0.8.5		X							X					
-reqsign@0.16.0		X												
-reqwest@0.12.8		X							X					
+reqsign@0.16.1		X												
+reqwest@0.12.9		X							X					
 ring@0.17.8											X			
 rsa@0.9.6		X							X					
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc-hash@1.1.0		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.15		X						X	X					
+rustls@0.23.16		X						X	X					
 rustls-pemfile@2.2.0		X						X	X					
 rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
@@ -144,8 +144,8 @@ ryu@1.0.18		X				X
 salsa20@0.10.2		X							X					
 scrypt@0.11.0		X							X					
 semver@1.0.23		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
+serde@1.0.214		X							X					
+serde_derive@1.0.214		X							X					
 serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
@@ -161,17 +161,17 @@ spin@0.9.8									X
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.81		X							X					
+syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
-thiserror@1.0.64		X							X					
-thiserror-impl@1.0.64		X							X					
+thiserror@1.0.67		X							X					
+thiserror-impl@1.0.67		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.40.0									X					
+tokio@1.41.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
 tower-service@0.3.3									X					
@@ -195,7 +195,7 @@ wasm-bindgen-futures@0.4.45		X							X
 wasm-bindgen-macro@0.2.95		X							X					
 wasm-bindgen-macro-support@0.2.95		X							X					
 wasm-bindgen-shared@0.2.95		X							X					
-wasm-streams@0.4.1		X							X					
+wasm-streams@0.4.2		X							X					
 web-sys@0.3.72		X							X					
 webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -6513,9 +6513,9 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03dd4ba7c3901dd43e6b8c7446a760d45bc1ea4301002e1a6fa48f97c3a796fa"
+checksum = "eb0075a66c8bfbf4cc8b70dca166e722e1f55a3ea9250ecbb85f4d92a5f64149"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -4989,7 +4989,7 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "opendal"
-version = "0.50.1"
+version = "0.50.2"
 dependencies = [
  "anyhow",
  "async-backtrace",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.50.1"
+version = "0.50.2"
 
 [lints.clippy]
 unused_async = "warn"

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -77,7 +77,7 @@ mio@1.0.2									X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
+opendal@0.50.2		X												
 ordered-multimap@0.7.3									X					
 percent-encoding@2.3.1		X							X					
 pin-project-lite@0.2.14		X							X					

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -90,7 +90,7 @@ quote@1.0.37		X							X
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-reqsign@0.16.0		X												
+reqsign@0.16.1		X												
 reqwest@0.12.8		X							X					
 ring@0.17.8											X			
 rust-ini@0.21.1									X					

--- a/integrations/cloud_filter/Cargo.toml
+++ b/integrations/cloud_filter/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 name = "cloud_filter_opendal"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.0.2"
+version = "0.0.3"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/integrations/cloud_filter/DEPENDENCIES.rust.tsv
+++ b/integrations/cloud_filter/DEPENDENCIES.rust.tsv
@@ -18,7 +18,7 @@ cc@1.1.34		X							X
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cloud-filter@0.0.5									X					
-cloud_filter_opendal@0.0.2		X												
+cloud_filter_opendal@0.0.3		X												
 const-oid@0.9.6		X							X					
 const-random@0.1.18		X							X					
 const-random-macro@0.1.16		X							X					

--- a/integrations/cloud_filter/DEPENDENCIES.rust.tsv
+++ b/integrations/cloud_filter/DEPENDENCIES.rust.tsv
@@ -3,7 +3,7 @@ addr2line@0.24.2		X							X
 adler2@2.0.0	X	X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.90		X							X					
+anyhow@1.0.92		X							X					
 async-trait@0.1.83		X							X					
 autocfg@1.4.0		X							X					
 backon@1.2.0		X												
@@ -13,8 +13,8 @@ bincode@1.3.3									X
 block-buffer@0.10.4		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.2									X					
-cc@1.1.31		X							X					
+bytes@1.8.0									X					
+cc@1.1.34		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cloud-filter@0.0.5									X					
@@ -59,7 +59,7 @@ http-body-util@0.1.2									X
 httparse@1.9.5		X							X					
 hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.9									X					
+hyper-util@0.1.10									X					
 iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
@@ -79,34 +79,34 @@ num-conv@0.1.0		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
+opendal@0.50.2		X												
 ordered-multimap@0.7.3									X					
 percent-encoding@2.3.1		X							X					
-pin-project-lite@0.2.14		X							X					
+pin-project-lite@0.2.15		X							X					
 pin-utils@0.1.0		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.88		X							X					
+proc-macro2@1.0.89		X							X					
 quick-xml@0.35.0									X					
 quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-reqsign@0.16.0		X												
-reqwest@0.12.8		X							X					
+reqsign@0.16.1		X												
+reqwest@0.12.9		X							X					
 ring@0.17.8											X			
 rust-ini@0.21.1									X					
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.15		X						X	X					
+rustls@0.23.16		X						X	X					
 rustls-pemfile@2.2.0		X						X	X					
 rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 semver@1.0.23		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
+serde@1.0.214		X							X					
+serde_derive@1.0.214		X							X					
 serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
@@ -118,7 +118,7 @@ smallvec@1.13.2		X							X
 socket2@0.5.7		X							X					
 spin@0.9.8									X					
 subtle@2.6.1					X									
-syn@2.0.81		X							X					
+syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
@@ -126,7 +126,7 @@ time-macros@0.2.18		X							X
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.40.0									X					
+tokio@1.41.0									X					
 tokio-macros@2.4.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
@@ -151,7 +151,7 @@ wasm-bindgen-futures@0.4.45		X							X
 wasm-bindgen-macro@0.2.95		X							X					
 wasm-bindgen-macro-support@0.2.95		X							X					
 wasm-bindgen-shared@0.2.95		X							X					
-wasm-streams@0.4.1		X							X					
+wasm-streams@0.4.2		X							X					
 web-sys@0.3.72		X							X					
 webpki-roots@0.26.6										X				
 widestring@1.1.0		X							X					

--- a/integrations/compat/Cargo.toml
+++ b/integrations/compat/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "1.0.0"
+version = "1.0.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/integrations/compat/DEPENDENCIES.rust.tsv
+++ b/integrations/compat/DEPENDENCIES.rust.tsv
@@ -1,7 +1,7 @@
 crate	Apache-2.0	MIT	Unicode-DFS-2016
 async-trait@0.1.83	X	X	
 opendal_compat@1.0.0	X		
-proc-macro2@1.0.88	X	X	
+proc-macro2@1.0.89	X	X	
 quote@1.0.37	X	X	
-syn@2.0.81	X	X	
+syn@2.0.87	X	X	
 unicode-ident@1.0.13	X	X	X

--- a/integrations/compat/DEPENDENCIES.rust.tsv
+++ b/integrations/compat/DEPENDENCIES.rust.tsv
@@ -1,6 +1,6 @@
 crate	Apache-2.0	MIT	Unicode-DFS-2016
 async-trait@0.1.83	X	X	
-opendal_compat@1.0.0	X		
+opendal_compat@1.0.1	X		
 proc-macro2@1.0.89	X	X	
 quote@1.0.37	X	X	
 syn@2.0.87	X	X	

--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 description = "Use OpenDAL as a backend to access data in various service with WebDAV protocol"
 name = "dav-server-opendalfs"
-version = "0.2.1"
+version = "0.2.2"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -23,7 +23,7 @@ core-foundation-sys@0.8.7		X					X
 cpufeatures@0.2.14		X					X					
 crypto-common@0.1.6		X					X					
 dav-server@0.7.0		X										
-dav-server-opendalfs@0.2.1		X										
+dav-server-opendalfs@0.2.2		X										
 deranged@0.3.11		X					X					
 digest@0.10.7		X					X					
 equivalent@1.0.1		X					X					

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -5,7 +5,7 @@ aho-corasick@1.1.3							X				X
 allocator-api2@0.2.18		X					X					
 android-tzdata@0.1.1		X					X					
 android_system_properties@0.1.5		X					X					
-anyhow@1.0.90		X					X					
+anyhow@1.0.92		X					X					
 async-trait@0.1.83		X					X					
 autocfg@1.4.0		X					X					
 backon@1.2.0		X										
@@ -15,8 +15,8 @@ base64@0.22.1		X					X
 bitflags@2.6.0		X					X					
 block-buffer@0.10.4		X					X					
 bumpalo@3.16.0		X					X					
-bytes@1.7.2							X					
-cc@1.1.31		X					X					
+bytes@1.8.0							X					
+cc@1.1.34		X					X					
 cfg-if@1.0.0		X					X					
 chrono@0.4.38		X					X					
 core-foundation-sys@0.8.7		X					X					
@@ -57,7 +57,7 @@ httparse@1.9.5		X					X
 httpdate@1.0.3		X					X					
 hyper@1.5.0							X					
 hyper-rustls@0.27.3		X				X	X					
-hyper-util@0.1.9							X					
+hyper-util@0.1.10							X					
 iana-time-zone@0.1.61		X					X					
 iana-time-zone-haiku@0.1.2		X					X					
 idna@0.5.0		X					X					
@@ -79,33 +79,33 @@ num-conv@0.1.0		X					X
 num-traits@0.2.19		X					X					
 object@0.36.5		X					X					
 once_cell@1.20.2		X					X					
-opendal@0.50.1		X										
+opendal@0.50.2		X										
 parking_lot@0.12.3		X					X					
 parking_lot_core@0.9.10		X					X					
 percent-encoding@2.3.1		X					X					
-pin-project@1.1.6		X					X					
-pin-project-internal@1.1.6		X					X					
-pin-project-lite@0.2.14		X					X					
+pin-project@1.1.7		X					X					
+pin-project-internal@1.1.7		X					X					
+pin-project-lite@0.2.15		X					X					
 pin-utils@0.1.0		X					X					
 powerfmt@0.2.0		X					X					
-proc-macro2@1.0.88		X					X					
+proc-macro2@1.0.89		X					X					
 quick-xml@0.36.2							X					
 quote@1.0.37		X					X					
 redox_syscall@0.5.7							X					
-regex@1.11.0		X					X					
+regex@1.11.1		X					X					
 regex-automata@0.4.8		X					X					
 regex-syntax@0.8.5		X					X					
-reqwest@0.12.8		X					X					
+reqwest@0.12.9		X					X					
 ring@0.17.8									X			
 rustc-demangle@0.1.24		X					X					
-rustls@0.23.15		X				X	X					
+rustls@0.23.16		X				X	X					
 rustls-pemfile@2.2.0		X				X	X					
 rustls-pki-types@1.10.0		X					X					
 rustls-webpki@0.102.8						X						
 ryu@1.0.18		X			X							
 scopeguard@1.2.0		X					X					
-serde@1.0.210		X					X					
-serde_derive@1.0.210		X					X					
+serde@1.0.214		X					X					
+serde_derive@1.0.214		X					X					
 serde_json@1.0.132		X					X					
 serde_urlencoded@0.7.1		X					X					
 sha1@0.10.6		X					X					
@@ -115,14 +115,14 @@ smallvec@1.13.2		X					X
 socket2@0.5.7		X					X					
 spin@0.9.8							X					
 subtle@2.6.1				X								
-syn@2.0.81		X					X					
+syn@2.0.87		X					X					
 sync_wrapper@1.0.1		X										
 time@0.3.36		X					X					
 time-core@0.1.2		X					X					
 time-macros@0.2.18		X					X					
 tinyvec@1.8.0		X					X					X
 tinyvec_macros@0.1.1		X					X					X
-tokio@1.40.0							X					
+tokio@1.41.0							X					
 tokio-macros@2.4.0							X					
 tokio-rustls@0.26.0		X					X					
 tokio-util@0.7.12							X					
@@ -147,7 +147,7 @@ wasm-bindgen-futures@0.4.45		X					X
 wasm-bindgen-macro@0.2.95		X					X					
 wasm-bindgen-macro-support@0.2.95		X					X					
 wasm-bindgen-shared@0.2.95		X					X					
-wasm-streams@0.4.1		X					X					
+wasm-streams@0.4.2		X					X					
 web-sys@0.3.72		X					X					
 webpki-roots@0.26.6								X				
 windows-core@0.52.0		X					X					

--- a/integrations/fuse3/Cargo.toml
+++ b/integrations/fuse3/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.0.8"
+version = "0.0.9"
 
 [dependencies]
 bytes = "1.6.0"

--- a/integrations/fuse3/DEPENDENCIES.rust.tsv
+++ b/integrations/fuse3/DEPENDENCIES.rust.tsv
@@ -32,7 +32,7 @@ flagset@0.4.6		X
 fnv@1.0.7		X					X					
 form_urlencoded@1.2.1		X					X					
 fuse3@0.8.1							X					
-fuse3_opendal@0.0.8		X										
+fuse3_opendal@0.0.9		X										
 futures@0.3.31		X					X					
 futures-channel@0.3.31		X					X					
 futures-core@0.3.31		X					X					

--- a/integrations/fuse3/DEPENDENCIES.rust.tsv
+++ b/integrations/fuse3/DEPENDENCIES.rust.tsv
@@ -3,7 +3,7 @@ addr2line@0.24.2		X					X
 adler2@2.0.0	X	X					X					
 android-tzdata@0.1.1		X					X					
 android_system_properties@0.1.5		X					X					
-anyhow@1.0.90		X					X					
+anyhow@1.0.92		X					X					
 async-notify@0.3.0							X					
 async-trait@0.1.83		X					X					
 autocfg@1.4.0		X					X					
@@ -14,8 +14,8 @@ bincode@1.3.3							X
 bitflags@2.6.0		X					X					
 block-buffer@0.10.4		X					X					
 bumpalo@3.16.0		X					X					
-bytes@1.7.2							X					
-cc@1.1.31		X					X					
+bytes@1.8.0							X					
+cc@1.1.34		X					X					
 cfg-if@1.0.0		X					X					
 cfg_aliases@0.2.1							X					
 chrono@0.4.38		X					X					
@@ -53,7 +53,7 @@ http-body-util@0.1.2							X
 httparse@1.9.5		X					X					
 hyper@1.5.0							X					
 hyper-rustls@0.27.3		X				X	X					
-hyper-util@0.1.9							X					
+hyper-util@0.1.10							X					
 iana-time-zone@0.1.61		X					X					
 iana-time-zone-haiku@0.1.2		X					X					
 idna@0.5.0		X					X					
@@ -74,25 +74,25 @@ nix@0.29.0							X
 num-traits@0.2.19		X					X					
 object@0.36.5		X					X					
 once_cell@1.20.2		X					X					
-opendal@0.50.1		X										
+opendal@0.50.2		X										
 parking@2.2.1		X					X					
 percent-encoding@2.3.1		X					X					
-pin-project-lite@0.2.14		X					X					
+pin-project-lite@0.2.15		X					X					
 pin-utils@0.1.0		X					X					
-proc-macro2@1.0.88		X					X					
+proc-macro2@1.0.89		X					X					
 quick-xml@0.36.2							X					
 quote@1.0.37		X					X					
-reqwest@0.12.8		X					X					
+reqwest@0.12.9		X					X					
 ring@0.17.8									X			
 rustc-demangle@0.1.24		X					X					
-rustix@0.38.37		X	X				X					
-rustls@0.23.15		X				X	X					
+rustix@0.38.38		X	X				X					
+rustls@0.23.16		X				X	X					
 rustls-pemfile@2.2.0		X				X	X					
 rustls-pki-types@1.10.0		X					X					
 rustls-webpki@0.102.8						X						
 ryu@1.0.18		X			X							
-serde@1.0.210		X					X					
-serde_derive@1.0.210		X					X					
+serde@1.0.214		X					X					
+serde_derive@1.0.214		X					X					
 serde_json@1.0.132		X					X					
 serde_urlencoded@0.7.1		X					X					
 sharded-slab@0.1.7							X					
@@ -103,11 +103,11 @@ smallvec@1.13.2		X					X
 socket2@0.5.7		X					X					
 spin@0.9.8							X					
 subtle@2.6.1				X								
-syn@2.0.81		X					X					
+syn@2.0.87		X					X					
 sync_wrapper@1.0.1		X										
 tinyvec@1.8.0		X					X					X
 tinyvec_macros@0.1.1		X					X					X
-tokio@1.40.0							X					
+tokio@1.41.0							X					
 tokio-macros@2.4.0							X					
 tokio-rustls@0.26.0		X					X					
 tokio-util@0.7.12							X					
@@ -133,7 +133,7 @@ wasm-bindgen-futures@0.4.45		X					X
 wasm-bindgen-macro@0.2.95		X					X					
 wasm-bindgen-macro-support@0.2.95		X					X					
 wasm-bindgen-shared@0.2.95		X					X					
-wasm-streams@0.4.1		X					X					
+wasm-streams@0.4.2		X					X					
 web-sys@0.3.72		X					X					
 webpki-roots@0.26.6								X				
 which@6.0.3							X					

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.48.1"
+version = "0.48.2"
 
 [features]
 send_wrapper = ["dep:send_wrapper"]

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -72,7 +72,7 @@ mio@1.0.2								X
 num-traits@0.2.19		X						X					
 object@0.36.5		X						X					
 object_store@0.11.1		X						X					
-object_store_opendal@0.48.1		X											
+object_store_opendal@0.48.2		X											
 once_cell@1.20.2		X						X					
 opendal@0.50.2		X											
 parking_lot@0.12.3		X						X					

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -3,7 +3,7 @@ addr2line@0.24.2		X						X
 adler2@2.0.0	X	X						X					
 android-tzdata@0.1.1		X						X					
 android_system_properties@0.1.5		X						X					
-anyhow@1.0.90		X						X					
+anyhow@1.0.92		X						X					
 async-trait@0.1.83		X						X					
 autocfg@1.4.0		X						X					
 backon@1.2.0		X											
@@ -13,8 +13,8 @@ bitflags@2.6.0		X						X
 block-buffer@0.10.4		X						X					
 bumpalo@3.16.0		X						X					
 byteorder@1.5.0								X				X	
-bytes@1.7.2								X					
-cc@1.1.31		X						X					
+bytes@1.8.0								X					
+cc@1.1.34		X						X					
 cfg-if@1.0.0		X						X					
 chrono@0.4.38		X						X					
 const-oid@0.9.6		X						X					
@@ -53,7 +53,7 @@ httparse@1.9.5		X						X
 humantime@2.1.0		X						X					
 hyper@1.5.0								X					
 hyper-rustls@0.27.3		X					X	X					
-hyper-util@0.1.9								X					
+hyper-util@0.1.10								X					
 iana-time-zone@0.1.61		X						X					
 iana-time-zone-haiku@0.1.2		X						X					
 idna@0.5.0		X						X					
@@ -71,31 +71,31 @@ miniz_oxide@0.8.0		X						X					X
 mio@1.0.2								X					
 num-traits@0.2.19		X						X					
 object@0.36.5		X						X					
-object_store@0.11.0		X						X					
+object_store@0.11.1		X						X					
 object_store_opendal@0.48.1		X											
 once_cell@1.20.2		X						X					
-opendal@0.50.1		X											
+opendal@0.50.2		X											
 parking_lot@0.12.3		X						X					
 parking_lot_core@0.9.10		X						X					
 percent-encoding@2.3.1		X						X					
-pin-project@1.1.6		X						X					
-pin-project-internal@1.1.6		X						X					
-pin-project-lite@0.2.14		X						X					
+pin-project@1.1.7		X						X					
+pin-project-internal@1.1.7		X						X					
+pin-project-lite@0.2.15		X						X					
 pin-utils@0.1.0		X						X					
 ppv-lite86@0.2.20		X						X					
-proc-macro2@1.0.88		X						X					
+proc-macro2@1.0.89		X						X					
 quick-xml@0.36.2								X					
 quote@1.0.37		X						X					
 rand@0.8.5		X						X					
 rand_chacha@0.3.1		X						X					
 rand_core@0.6.4		X						X					
 redox_syscall@0.5.7								X					
-reqsign@0.16.0		X											
-reqwest@0.12.8		X						X					
+reqsign@0.16.1		X											
+reqwest@0.12.9		X						X					
 ring@0.17.8										X			
 rustc-demangle@0.1.24		X						X					
 rustc_version@0.4.1		X						X					
-rustls@0.23.15		X					X	X					
+rustls@0.23.16		X					X	X					
 rustls-pemfile@2.2.0		X					X	X					
 rustls-pki-types@1.10.0		X						X					
 rustls-webpki@0.102.8							X						
@@ -103,8 +103,8 @@ ryu@1.0.18		X				X
 same-file@1.0.6								X				X	
 scopeguard@1.2.0		X						X					
 semver@1.0.23		X						X					
-serde@1.0.210		X						X					
-serde_derive@1.0.210		X						X					
+serde@1.0.214		X						X					
+serde_derive@1.0.214		X						X					
 serde_json@1.0.132		X						X					
 serde_urlencoded@0.7.1		X						X					
 sha1@0.10.6		X						X					
@@ -117,11 +117,11 @@ snafu-derive@0.8.5		X						X
 socket2@0.5.7		X						X					
 spin@0.9.8								X					
 subtle@2.6.1					X								
-syn@2.0.81		X						X					
+syn@2.0.87		X						X					
 sync_wrapper@1.0.1		X											
 tinyvec@1.8.0		X						X					X
 tinyvec_macros@0.1.1		X						X					X
-tokio@1.40.0								X					
+tokio@1.41.0								X					
 tokio-macros@2.4.0								X					
 tokio-rustls@0.26.0		X						X					
 tokio-util@0.7.12								X					
@@ -147,7 +147,7 @@ wasm-bindgen-futures@0.4.45		X						X
 wasm-bindgen-macro@0.2.95		X						X					
 wasm-bindgen-macro-support@0.2.95		X						X					
 wasm-bindgen-shared@0.2.95		X						X					
-wasm-streams@0.4.1		X						X					
+wasm-streams@0.4.2		X						X					
 web-sys@0.3.72		X						X					
 webpki-roots@0.26.6									X				
 winapi-util@0.1.9								X				X	

--- a/integrations/parquet/Cargo.toml
+++ b/integrations/parquet/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies]
 async-trait = "0.1"

--- a/integrations/parquet/DEPENDENCIES.rust.tsv
+++ b/integrations/parquet/DEPENDENCIES.rust.tsv
@@ -99,7 +99,7 @@ once_cell@1.20.2		X							X
 opendal@0.50.2		X												
 ordered-float@2.10.1									X					
 parquet@53.2.0		X												
-parquet_opendal@0.2.1		X												
+parquet_opendal@0.2.2		X												
 paste@1.0.15		X							X					
 percent-encoding@2.3.1		X							X					
 pin-project-lite@0.2.15		X							X					

--- a/integrations/parquet/DEPENDENCIES.rust.tsv
+++ b/integrations/parquet/DEPENDENCIES.rust.tsv
@@ -4,14 +4,14 @@ adler2@2.0.0	X	X							X
 ahash@0.8.11		X							X					
 android-tzdata@0.1.1		X							X					
 android_system_properties@0.1.5		X							X					
-anyhow@1.0.90		X							X					
-arrow-array@53.1.0		X												
-arrow-buffer@53.1.0		X												
-arrow-cast@53.1.0		X												
-arrow-data@53.1.0		X												
-arrow-ipc@53.1.0		X												
-arrow-schema@53.1.0		X												
-arrow-select@53.1.0		X												
+anyhow@1.0.92		X							X					
+arrow-array@53.2.0		X												
+arrow-buffer@53.2.0		X												
+arrow-cast@53.2.0		X												
+arrow-data@53.2.0		X												
+arrow-ipc@53.2.0		X												
+arrow-schema@53.2.0		X												
+arrow-select@53.2.0		X												
 async-trait@0.1.83		X							X					
 atoi@2.0.0									X					
 autocfg@1.4.0		X							X					
@@ -22,8 +22,8 @@ bitflags@1.3.2		X							X
 block-buffer@0.10.4		X							X					
 bumpalo@3.16.0		X							X					
 byteorder@1.5.0									X				X	
-bytes@1.7.2									X					
-cc@1.1.31		X							X					
+bytes@1.8.0									X					
+cc@1.1.34		X							X					
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 const-oid@0.9.6		X							X					
@@ -65,7 +65,7 @@ http-body-util@0.1.2									X
 httparse@1.9.5		X							X					
 hyper@1.5.0									X					
 hyper-rustls@0.27.3		X						X	X					
-hyper-util@0.1.9									X					
+hyper-util@0.1.10									X					
 iana-time-zone@0.1.61		X							X					
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
@@ -80,7 +80,7 @@ lexical-util@1.0.3		X							X
 lexical-write-float@1.0.2		X							X					
 lexical-write-integer@1.0.2		X							X					
 libc@0.2.161		X							X					
-libm@0.2.8		X							X					
+libm@0.2.11		X							X					
 log@0.4.22		X							X					
 md-5@0.10.6		X							X					
 memchr@2.7.4									X				X	
@@ -96,35 +96,35 @@ num-rational@0.4.2		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.1		X												
+opendal@0.50.2		X												
 ordered-float@2.10.1									X					
-parquet@53.1.0		X												
+parquet@53.2.0		X												
 parquet_opendal@0.2.1		X												
 paste@1.0.15		X							X					
 percent-encoding@2.3.1		X							X					
-pin-project-lite@0.2.14		X							X					
+pin-project-lite@0.2.15		X							X					
 pin-utils@0.1.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.88		X							X					
+proc-macro2@1.0.89		X							X					
 quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
 rand@0.8.5		X							X					
 rand_chacha@0.3.1		X							X					
 rand_core@0.6.4		X							X					
-reqsign@0.16.0		X												
-reqwest@0.12.8		X							X					
+reqsign@0.16.1		X												
+reqwest@0.12.9		X							X					
 ring@0.17.8											X			
 rustc-demangle@0.1.24		X							X					
 rustc_version@0.4.1		X							X					
-rustls@0.23.15		X						X	X					
+rustls@0.23.16		X						X	X					
 rustls-pemfile@2.2.0		X						X	X					
 rustls-pki-types@1.10.0		X							X					
 rustls-webpki@0.102.8								X						
 ryu@1.0.18		X				X								
 semver@1.0.23		X							X					
 seq-macro@0.3.5		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
+serde@1.0.214		X							X					
+serde_derive@1.0.214		X							X					
 serde_json@1.0.132		X							X					
 serde_urlencoded@0.7.1		X							X					
 sha1@0.10.6		X							X					
@@ -136,13 +136,13 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 static_assertions@1.1.0		X							X					
 subtle@2.6.1					X									
-syn@2.0.81		X							X					
+syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
 thrift@0.17.0		X												
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X
 tinyvec_macros@0.1.1		X							X					X
-tokio@1.40.0									X					
+tokio@1.41.0									X					
 tokio-macros@2.4.0									X					
 tokio-rustls@0.26.0		X							X					
 tokio-util@0.7.12									X					
@@ -167,7 +167,7 @@ wasm-bindgen-futures@0.4.45		X							X
 wasm-bindgen-macro@0.2.95		X							X					
 wasm-bindgen-macro-support@0.2.95		X							X					
 wasm-bindgen-shared@0.2.95		X							X					
-wasm-streams@0.4.1		X							X					
+wasm-streams@0.4.2		X							X					
 web-sys@0.3.72		X							X					
 webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					

--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 name = "unftp-sbe-opendal"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.0.8"
+version = "0.0.9"
 
 [dependencies]
 async-trait = "0.1.80"

--- a/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
+++ b/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
@@ -3,7 +3,7 @@ addr2line@0.24.2		X							X
 adler2@2.0.0	X	X							X						
 android-tzdata@0.1.1		X							X						
 android_system_properties@0.1.5		X							X						
-anyhow@1.0.90		X							X						
+anyhow@1.0.92		X							X						
 arc-swap@1.7.1		X							X						
 asn1-rs@0.6.2		X							X						
 asn1-rs-derive@0.5.1		X							X						
@@ -20,8 +20,8 @@ bitflags@2.6.0		X							X
 block-buffer@0.10.4		X							X						
 bumpalo@3.16.0		X							X						
 byteorder@1.5.0									X					X	
-bytes@1.7.2									X						
-cc@1.1.31		X							X						
+bytes@1.8.0									X						
+cc@1.1.34		X							X						
 cexpr@0.6.0		X							X						
 cfg-if@1.0.0		X							X						
 cfg_aliases@0.2.1									X						
@@ -77,7 +77,7 @@ http-body-util@0.1.2									X
 httparse@1.9.5		X							X						
 hyper@1.5.0									X						
 hyper-rustls@0.27.3		X						X	X						
-hyper-util@0.1.9									X						
+hyper-util@0.1.10									X						
 iana-time-zone@0.1.61		X							X						
 iana-time-zone-haiku@0.1.2		X							X						
 idna@0.5.0		X							X						
@@ -111,17 +111,17 @@ num-traits@0.2.19		X							X
 object@0.36.5		X							X						
 oid-registry@0.7.1		X							X						
 once_cell@1.20.2		X							X						
-opendal@0.50.1		X													
+opendal@0.50.2		X													
 parking_lot@0.12.3		X							X						
 parking_lot_core@0.9.10		X							X						
 paste@1.0.15		X							X						
 percent-encoding@2.3.1		X							X						
-pin-project-lite@0.2.14		X							X						
+pin-project-lite@0.2.15		X							X						
 pin-utils@0.1.0		X							X						
 powerfmt@0.2.0		X							X						
 ppv-lite86@0.2.20		X							X						
-prettyplease@0.2.24		X							X						
-proc-macro2@1.0.88		X							X						
+prettyplease@0.2.25		X							X						
+proc-macro2@1.0.89		X							X						
 prometheus@0.13.4		X													
 proxy-protocol@0.5.0		X							X						
 quick-xml@0.36.2									X						
@@ -130,26 +130,26 @@ rand@0.8.5		X							X
 rand_chacha@0.3.1		X							X						
 rand_core@0.6.4		X							X						
 redox_syscall@0.5.7									X						
-regex@1.11.0		X							X						
+regex@1.11.1		X							X						
 regex-automata@0.4.8		X							X						
 regex-syntax@0.8.5		X							X						
-reqsign@0.16.0		X													
-reqwest@0.12.8		X							X						
+reqsign@0.16.1		X													
+reqwest@0.12.9		X							X						
 ring@0.17.8												X			
 rustc-demangle@0.1.24		X							X						
 rustc-hash@1.1.0		X							X						
 rustc_version@0.4.1		X							X						
 rusticata-macros@4.1.0		X							X						
-rustix@0.38.37		X	X						X						
-rustls@0.23.15		X						X	X						
+rustix@0.38.38		X	X						X						
+rustls@0.23.16		X						X	X						
 rustls-pemfile@2.2.0		X						X	X						
 rustls-pki-types@1.10.0		X							X						
 rustls-webpki@0.102.8								X							
 ryu@1.0.18		X				X									
 scopeguard@1.2.0		X							X						
 semver@1.0.23		X							X						
-serde@1.0.210		X							X						
-serde_derive@1.0.210		X							X						
+serde@1.0.214		X							X						
+serde_derive@1.0.214		X							X						
 serde_json@1.0.132		X							X						
 serde_urlencoded@0.7.1		X							X						
 sha1@0.10.6		X							X						
@@ -167,18 +167,18 @@ socket2@0.5.7		X							X
 spin@0.9.8									X						
 subtle@2.6.1					X										
 syn@1.0.109		X							X						
-syn@2.0.81		X							X						
+syn@2.0.87		X							X						
 sync_wrapper@1.0.1		X													
 synstructure@0.13.1									X						
 tagptr@0.2.0		X							X						
-thiserror@1.0.64		X							X						
-thiserror-impl@1.0.64		X							X						
+thiserror@1.0.67		X							X						
+thiserror-impl@1.0.67		X							X						
 time@0.3.36		X							X						
 time-core@0.1.2		X							X						
 time-macros@0.2.18		X							X						
 tinyvec@1.8.0		X							X						X
 tinyvec_macros@0.1.1		X							X						X
-tokio@1.40.0									X						
+tokio@1.41.0									X						
 tokio-macros@2.4.0									X						
 tokio-rustls@0.26.0		X							X						
 tokio-util@0.7.12									X						
@@ -205,7 +205,7 @@ wasm-bindgen-futures@0.4.45		X							X
 wasm-bindgen-macro@0.2.95		X							X						
 wasm-bindgen-macro-support@0.2.95		X							X						
 wasm-bindgen-shared@0.2.95		X							X						
-wasm-streams@0.4.1		X							X						
+wasm-streams@0.4.2		X							X						
 web-sys@0.3.72		X							X						
 webpki-roots@0.26.6											X				
 which@4.4.2									X						

--- a/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
+++ b/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
@@ -189,7 +189,7 @@ tracing-core@0.1.32									X
 triomphe@0.1.11		X							X						
 try-lock@0.2.5									X						
 typenum@1.17.0		X							X						
-unftp-sbe-opendal@0.0.8		X													
+unftp-sbe-opendal@0.0.9		X													
 unicode-bidi@0.3.17		X							X						
 unicode-ident@1.0.13		X							X				X		
 unicode-normalization@0.1.24		X							X						

--- a/integrations/virtiofs/DEPENDENCIES.rust.tsv
+++ b/integrations/virtiofs/DEPENDENCIES.rust.tsv
@@ -3,7 +3,7 @@ addr2line@0.24.2		X					X
 adler2@2.0.0	X	X					X					
 android-tzdata@0.1.1		X					X					
 android_system_properties@0.1.5		X					X					
-anyhow@1.0.90		X					X					
+anyhow@1.0.92		X					X					
 arc-swap@1.7.1		X					X					
 async-trait@0.1.83		X					X					
 autocfg@1.4.0		X					X					
@@ -14,8 +14,8 @@ bitflags@1.3.2		X					X
 bitflags@2.6.0		X					X					
 block-buffer@0.10.4		X					X					
 bumpalo@3.16.0		X					X					
-bytes@1.7.2							X					
-cc@1.1.31		X					X					
+bytes@1.8.0							X					
+cc@1.1.34		X					X					
 cfg-if@1.0.0		X					X					
 chrono@0.4.38		X					X					
 core-foundation-sys@0.8.7		X					X					
@@ -45,7 +45,7 @@ http-body-util@0.1.2							X
 httparse@1.9.5		X					X					
 hyper@1.5.0							X					
 hyper-rustls@0.27.3		X				X	X					
-hyper-util@0.1.9							X					
+hyper-util@0.1.10							X					
 iana-time-zone@0.1.61		X					X					
 iana-time-zone-haiku@0.1.2		X					X					
 idna@0.5.0		X					X					
@@ -63,23 +63,23 @@ mio@1.0.2							X
 num-traits@0.2.19		X					X					
 object@0.36.5		X					X					
 once_cell@1.20.2		X					X					
-opendal@0.50.1		X										
+opendal@0.50.2		X										
 percent-encoding@2.3.1		X					X					
-pin-project-lite@0.2.14		X					X					
+pin-project-lite@0.2.15		X					X					
 pin-utils@0.1.0		X					X					
-proc-macro2@1.0.88		X					X					
+proc-macro2@1.0.89		X					X					
 quick-xml@0.36.2							X					
 quote@1.0.37		X					X					
-reqwest@0.12.8		X					X					
+reqwest@0.12.9		X					X					
 ring@0.17.8									X			
 rustc-demangle@0.1.24		X					X					
-rustls@0.23.15		X				X	X					
+rustls@0.23.16		X				X	X					
 rustls-pemfile@2.2.0		X				X	X					
 rustls-pki-types@1.10.0		X					X					
 rustls-webpki@0.102.8						X						
 ryu@1.0.18		X			X							
-serde@1.0.210		X					X					
-serde_derive@1.0.210		X					X					
+serde@1.0.214		X					X					
+serde_derive@1.0.214		X					X					
 serde_json@1.0.132		X					X					
 serde_urlencoded@0.7.1		X					X					
 sharded-slab@0.1.7							X					
@@ -91,13 +91,13 @@ snafu-derive@0.8.5		X					X
 socket2@0.5.7		X					X					
 spin@0.9.8							X					
 subtle@2.6.1				X								
-syn@2.0.81		X					X					
+syn@2.0.87		X					X					
 sync_wrapper@1.0.1		X										
-thiserror@1.0.64		X					X					
-thiserror-impl@1.0.64		X					X					
+thiserror@1.0.67		X					X					
+thiserror-impl@1.0.67		X					X					
 tinyvec@1.8.0		X					X					X
 tinyvec_macros@0.1.1		X					X					X
-tokio@1.40.0							X					
+tokio@1.41.0							X					
 tokio-rustls@0.26.0		X					X					
 tokio-util@0.7.12							X					
 tower-service@0.3.3							X					
@@ -114,7 +114,7 @@ uuid@1.11.0		X					X
 version_check@0.9.5		X					X					
 vhost@0.10.0		X		X								
 vhost-user-backend@0.13.1		X										
-virtio-bindings@0.2.3		X		X								
+virtio-bindings@0.2.4		X		X								
 virtio-queue@0.11.0		X		X								
 virtiofs_opendal@0.0.0		X										
 vm-memory@0.14.1		X		X								
@@ -127,7 +127,7 @@ wasm-bindgen-futures@0.4.45		X					X
 wasm-bindgen-macro@0.2.95		X					X					
 wasm-bindgen-macro-support@0.2.95		X					X					
 wasm-bindgen-shared@0.2.95		X					X					
-wasm-streams@0.4.1		X					X					
+wasm-streams@0.4.2		X					X					
 web-sys@0.3.72		X					X					
 webpki-roots@0.26.6								X				
 winapi@0.3.9		X					X					


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #5277 

# What changes are included in this PR?

| Name                      | Version | Next    |
| -                         | -       | -       |
| core                      | 0.50.1  | 0.50.2  |
| integrations/cloud_filter | 0.0.2   | 0.0.3   |
| integrations/compat       |1.0.0      | 1.0.1   |
| integrations/dav-server   | 0.2.1   | 0.2.2   |
| integrations/fuse3        | 0.0.8   | 0.0.9  |
| integrations/object_store | 0.48.1  | 0.48.2  |
| integrations/parquet      | 0.2.1   | 0.2.2   |
| integrations/spring       | -       | -       |
| integrations/unftp-sbe    | 0.0.8   | 0.0.9   |
| integrations/virtiofs     | -       | -       |
| bin/oay                   | 0.41.12 | 0.41.13 |
| bin/ofs                   | 0.0.13  | 0.0.14  |
| bin/oli                   | 0.41.12 | 0.41.13 |
| bindings/c                | 0.45.0 | 0.45.1 |
| bindings/cpp              | 0.45.12 | 0.45.13 |
| bindings/dotnet           | 0.1.10   | 0.1.11  |
| bindings/go               | 0.1.4   | 0.1.5   |
| bindings/haskell          | 0.44.12 | 0.44.13 |
| bindings/java             | 0.47.4  | 0.47.5  |
| bindings/lua              | 0.1.10   | 0.1.11  |
| bindings/nodejs           | 0.47.6  | 0.47.7  |
| bindings/ocaml            | -       | -       |
| bindings/php              | 0.1.10   | 0.1.11  |
| bindings/python           | 0.45.11 | 0.45.12 |
| bindings/ruby             | 0.1.10   | 0.1.11  |
| bindings/swift            | -       | -       |
| bindings/zig              | -       | -       |


