### PR TITLE
ci: Remove the token of codspeed

### DIFF
--- a/.github/workflows/test_benchmark.yml
+++ b/.github/workflows/test_benchmark.yml
@@ -44,15 +44,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
-      - uses: 1password/load-secrets-action/configure@v1
-        with:
-          connect-host: ${{ secrets.OP_CONNECT_HOST }}
-          connect-token: ${{ secrets.OP_CONNECT_TOKEN }}
-      - uses: 1password/load-secrets-action@v1
-        with:
-          export-env: true
-        env:
-          CODSPEED_TOKEN: op://services/codspeed/token
       - name: Setup codspeed
         run: cargo install cargo-codspeed
       - name: Setup Memory env
@@ -70,4 +61,3 @@ jobs:
         with:
           working-directory: core
           run: cargo codspeed run
-          token: ${{ env.CODSPEED_TOKEN }}


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

Publib repo doesn't need a token. We can allow forked repo to upload data by remove the token.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
