### PR TITLE
chore(layers/oteltrace): adjust tracer span name of info method

### DIFF
--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -79,7 +79,7 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
 
     fn info(&self) -> Arc<AccessorInfo> {
         let tracer = global::tracer("opendal");
-        tracer.in_span("metadata", |_cx| self.inner.info())
+        tracer.in_span("info", |_cx| self.inner.info())
     }
 
     async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {


### PR DESCRIPTION
# Which issue does this PR close?

No

# Rationale for this change


# What changes are included in this PR?

- rename tracer span name of info method in `oteltrace` layer: `metadata` => `info`

# Are there any user-facing changes?


No
