### PR TITLE
fix(services/webdav): Fix lister failing when root contains spaces

### DIFF
--- a/core/src/services/webdav/lister.rs
+++ b/core/src/services/webdav/lister.rs
@@ -80,13 +80,14 @@ impl oio::PageList for WebdavLister {
                 path += "/"
             }
 
+            let decoded_path = percent_decode_path(&path);
+
             // Ignore the root path itself.
-            if self.core.root == path {
+            if self.core.root == decoded_path {
                 continue;
             }
 
-            let normalized_path = build_rel_path(&self.core.root, &path);
-            let decoded_path = percent_decode_path(&normalized_path);
+            let normalized_path = build_rel_path(&self.core.root, &decoded_path);
 
             // HACKS! HACKS! HACKS!
             //
@@ -97,7 +98,8 @@ impl oio::PageList for WebdavLister {
                 continue;
             }
 
-            ctx.entries.push_back(oio::Entry::new(&decoded_path, meta))
+            ctx.entries
+                .push_back(oio::Entry::new(&normalized_path, meta))
         }
         ctx.done = true;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5293.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Moved href path decoding to be used before the code that expects path to contain (not encoded) root.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
