### PR TITLE
fix(bindings/c): Bump min CMake version to support CMP0135

### DIFF
--- a/bindings/c/CMakeLists.txt
+++ b/bindings/c/CMakeLists.txt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.24)
 cmake_policy(SET CMP0135 NEW)
 
 project(opendal-c)


### PR DESCRIPTION
# Which issue does this PR close?


Closes #5307 

# Rationale for this change

Currently the build is broken and leads to an error

# What changes are included in this PR?

Bumps the min version of CMake required to build the code

# Are there any user-facing changes?

No

