### PR TITLE
chore: Polish the debug output of capability

### DIFF
--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -169,42 +169,22 @@ pub struct Capability {
 
 impl Debug for Capability {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut s = vec![];
-
-        if self.stat {
-            s.push("Stat");
-        }
+        // NOTE: All services in opendal are readable.
         if self.read {
-            s.push("Read");
+            f.write_str("Read")?;
         }
         if self.write {
-            s.push("Write");
-        }
-        if self.create_dir {
-            s.push("CreateDir");
-        }
-        if self.delete {
-            s.push("Delete");
-        }
-        if self.copy {
-            s.push("Copy");
-        }
-        if self.rename {
-            s.push("Rename");
+            f.write_str("| Write")?;
         }
         if self.list {
-            s.push("List");
+            f.write_str("| List")?;
         }
         if self.presign {
-            s.push("Presign");
-        }
-        if self.batch {
-            s.push("Batch");
+            f.write_str("| Presign")?;
         }
         if self.blocking {
-            s.push("Blocking");
+            f.write_str("| Blocking")?;
         }
-
-        write!(f, "{{ {} }}", s.join(" | "))
+        Ok(())
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Nope

# Rationale for this change

The old debug output of capability requires multiple alloc.

# What changes are included in this PR?

This PR makes it zero cost and removes some not useful debug output.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
