### PR TITLE
chore: Add default vscode config for more friendly developer experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # IDE and editor
-.vscode
 .idea
 
 **/target

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # IDE and editor
 .idea
-
+.vscode
+!.vscode/settings.json
 **/target
 **/vendor
 dist/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "rust-analyzer.cargo.allTargets": true,
+  "rust-analyzer.cargo.features": "all",
+  "rust-analyzer.linkedProjects": [
+    "${workspaceFolder}/core/Cargo.toml",
+    "${workspaceFolder}/bin/oay/Cargo.toml",
+    "${workspaceFolder}/bin/ofs/Cargo.toml",
+    "${workspaceFolder}/bin/oli/Cargo.toml",
+    "${workspaceFolder}/bindings/python/Cargo.toml",
+    "${workspaceFolder}/bindings/java/Cargo.toml",
+    "${workspaceFolder}/bindings/nodejs/Cargo.toml",
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,9 +3,6 @@
   "rust-analyzer.cargo.features": "all",
   "rust-analyzer.linkedProjects": [
     "${workspaceFolder}/core/Cargo.toml",
-    "${workspaceFolder}/bin/oay/Cargo.toml",
-    "${workspaceFolder}/bin/ofs/Cargo.toml",
-    "${workspaceFolder}/bin/oli/Cargo.toml",
     "${workspaceFolder}/bindings/python/Cargo.toml",
     "${workspaceFolder}/bindings/java/Cargo.toml",
     "${workspaceFolder}/bindings/nodejs/Cargo.toml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     "${workspaceFolder}/bindings/python/Cargo.toml",
     "${workspaceFolder}/bindings/java/Cargo.toml",
     "${workspaceFolder}/bindings/nodejs/Cargo.toml",
-  ]
+  ],
+  "java.compile.nullAnalysis.mode": "automatic"
 }


### PR DESCRIPTION
For now, our project structure is not similar with default rust project. 

The developer need to extra config the rust-analyzer before they start to write the code.

I would like to make the config right out of the box