### PR TITLE
refactor(core): MaybeSend does not need to be unsafe

### DIFF
--- a/core/src/raw/futures_util.rs
+++ b/core/src/raw/futures_util.rs
@@ -49,17 +49,17 @@ pub type BoxedStaticFuture<T> = futures::future::LocalBoxFuture<'static, T>;
 ///
 /// # Safety
 ///
-/// MaybeSend equivalent to `Send` on non-wasm32 target. And it's empty
-/// on wasm32 target.
+/// [`MaybeSend`] is equivalent to `Send` on non-wasm32 target.
+/// And it's empty trait on wasm32 target to indicate that a type is not `Send`.
 #[cfg(not(target_arch = "wasm32"))]
-pub unsafe trait MaybeSend: Send {}
+pub trait MaybeSend: Send {}
 #[cfg(target_arch = "wasm32")]
-pub unsafe trait MaybeSend {}
+pub trait MaybeSend {}
 
 #[cfg(not(target_arch = "wasm32"))]
-unsafe impl<T: Send> MaybeSend for T {}
+impl<T: Send> MaybeSend for T {}
 #[cfg(target_arch = "wasm32")]
-unsafe impl<T> MaybeSend for T {}
+impl<T> MaybeSend for T {}
 
 /// ConcurrentTasks is used to execute tasks concurrently.
 ///


### PR DESCRIPTION
# Which issue does this PR close?

Remove `unsafe` from trait `unsafe trait MaybeSend`

Closes #.

# Rationale for this change

A safe trait provides the same functionality as its unsafe counterpart but requires no safety guarantees from the implementor, making the unsafe keyword unnecessary.

# What changes are included in this PR?

Remove `unsafe` from the trait declaration.

# Are there any user-facing changes?

This change is backward compatible
