### PR TITLE
fix(services/webhdfs): rename auth value

### DIFF
--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -171,10 +171,7 @@ impl Builder for WebhdfsBuilder {
 
         let atomic_write_dir = self.config.atomic_write_dir;
 
-        let auth = self
-            .config
-            .delegation
-            .map(|dt| format!("delegation={dt}"));
+        let auth = self.config.delegation.map(|dt| format!("delegation={dt}"));
 
         let client = HttpClient::new()?;
 

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -174,7 +174,7 @@ impl Builder for WebhdfsBuilder {
         let auth = self
             .config
             .delegation
-            .map(|dt| format!("delegation_token={dt}"));
+            .map(|dt| format!("delegation={dt}"));
 
         let client = HttpClient::new()?;
 


### PR DESCRIPTION
Closes #5267.

Renames the auth value from "delegation_token" to "delegation" based on [doc](https://hadoop.apache.org/docs/r3.3.2/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Authentication)

