### PR TITLE
feat(service/s3): support delete with version

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -1109,7 +1109,10 @@ impl Access for S3Backend {
             .with_context("length", ops.len().to_string()));
         }
 
-        let paths = ops.into_iter().map(|(p, _)| p).collect();
+        let paths = ops
+            .into_iter()
+            .map(|(p, BatchOperation::Delete(del))| (p, del))
+            .collect();
 
         let resp = self.core.s3_delete_objects(paths).await?;
 


### PR DESCRIPTION
Hi, first-time contribution, let me know if there is anything I am missing!

# Which issue does this PR close?
close: #5329 


# Are there any user-facing changes?
user need to pass `Vec<(String, OpDelete)>` when deleting objects
