### PR TITLE
chore: cache hadoop-3.3.5 to avoid build failures

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -31,6 +31,8 @@ inputs:
   github-token:
     description: "Github Token"
     default: ""
+  need-hadoop:
+    description: "This setup needs hadoop or not"
 
 runs:
   using: "composite"
@@ -151,4 +153,19 @@ runs:
 
         rm foundationdb-clients_7.1.17-1_amd64.deb
         rm foundationdb-server_7.1.17-1_amd64.deb
+
+    - name: Cache hadoop
+      id: cache-hadoop
+      uses: actions/cache@v4
+      if: inputs.need-hadoop == 'true'
+      with:
+        path: /home/runner/hadoop-3.3.5
+        key: r0-hadoop-3.3.5
+
+    - name: Build hadoop if not cached
+      if: steps.cache-hadoop.outputs.cache-hit != 'true' && inputs.need-hadoop == 'true'
+      shell: bash
+      run: |
+        set -e
+        curl -LsSf https://dlcdn.apache.org/hadoop/common/hadoop-3.3.5/hadoop-3.3.5.tar.gz | tar zxf - -C /home/runner
 

--- a/.github/services/hdfs/hdfs_cluster/action.yml
+++ b/.github/services/hdfs/hdfs_cluster/action.yml
@@ -33,7 +33,6 @@ runs:
     - name: Setup hadoop env
       shell: bash
       run: |
-        curl -LsSf https://dlcdn.apache.org/hadoop/common/hadoop-3.3.5/hadoop-3.3.5.tar.gz | tar zxf - -C /home/runner
         export HADOOP_HOME=/home/runner/hadoop-3.3.5
         echo "HADOOP_HOME=${HADOOP_HOME}" >> $GITHUB_ENV
         echo "CLASSPATH=$(${HADOOP_HOME}/bin/hadoop classpath --glob)" >> $GITHUB_ENV 

--- a/.github/services/hdfs/hdfs_cluster_with_atomic_write_dir/action.yml
+++ b/.github/services/hdfs/hdfs_cluster_with_atomic_write_dir/action.yml
@@ -33,7 +33,6 @@ runs:
     - name: Setup hadoop env
       shell: bash
       run: |
-        curl -LsSf https://dlcdn.apache.org/hadoop/common/hadoop-3.3.5/hadoop-3.3.5.tar.gz | tar zxf - -C /home/runner
         export HADOOP_HOME=/home/runner/hadoop-3.3.5
         echo "HADOOP_HOME=${HADOOP_HOME}" >> $GITHUB_ENV
         echo "CLASSPATH=$(${HADOOP_HOME}/bin/hadoop classpath --glob)" >> $GITHUB_ENV 

--- a/.github/services/hdfs/hdfs_default/action.yml
+++ b/.github/services/hdfs/hdfs_default/action.yml
@@ -29,8 +29,6 @@ runs:
     - name: Setup
       shell: bash
       run: |
-        curl -LsSf https://dlcdn.apache.org/hadoop/common/hadoop-3.3.5/hadoop-3.3.5.tar.gz | tar zxf - -C /home/runner
-
         export HADOOP_HOME="/home/runner/hadoop-3.3.5"
         export CLASSPATH=$(${HADOOP_HOME}/bin/hadoop classpath --glob)
 

--- a/.github/services/hdfs/hdfs_default_gcs/action.yml
+++ b/.github/services/hdfs/hdfs_default_gcs/action.yml
@@ -37,8 +37,6 @@ runs:
     - name: Setup
       shell: bash
       run: |
-        curl -LsSf https://dlcdn.apache.org/hadoop/common/hadoop-3.3.5/hadoop-3.3.5.tar.gz | tar zxf - -C /home/runner
-
         export HADOOP_HOME="/home/runner/hadoop-3.3.5"
 
         curl -LsSf -o ${HADOOP_HOME}/share/hadoop/common/lib/gcs-connector-hadoop3-2.2.19-shaded.jar https://github.com/GoogleCloudDataproc/hadoop-connectors/releases/download/v2.2.19/gcs-connector-hadoop3-2.2.19-shaded.jar

--- a/.github/services/hdfs/hdfs_default_on_azurite_azblob/action.yml
+++ b/.github/services/hdfs/hdfs_default_on_azurite_azblob/action.yml
@@ -43,8 +43,6 @@ runs:
         OPENDAL_AZBLOB_ACCOUNT_NAME=devstoreaccount1
         OPENDAL_AZBLOB_ACCOUNT_KEY=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
 
-        curl -LsSf https://dlcdn.apache.org/hadoop/common/hadoop-3.3.5/hadoop-3.3.5.tar.gz | tar zxf - -C /home/runner
-
         export HADOOP_HOME="/home/runner/hadoop-3.3.5"
 
         curl -LsSf -o ${HADOOP_HOME}/share/hadoop/common/lib/hadoop-azure-3.3.5.jar https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-azure/3.3.5/hadoop-azure-3.3.5.jar

--- a/.github/services/hdfs/hdfs_default_on_minio_s3/action.yml
+++ b/.github/services/hdfs/hdfs_default_on_minio_s3/action.yml
@@ -40,8 +40,6 @@ runs:
     - name: Setup
       shell: bash
       run: |
-        curl -LsSf https://dlcdn.apache.org/hadoop/common/hadoop-3.3.5/hadoop-3.3.5.tar.gz | tar zxf - -C /home/runner
-
         export HADOOP_HOME="/home/runner/hadoop-3.3.5"
 
         curl -LsSf -o ${HADOOP_HOME}/share/hadoop/common/lib/hadoop-aws-3.3.5.jar https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.5/hadoop-aws-3.3.5.jar

--- a/.github/services/hdfs/hdfs_default_with_atomic_write_dir/action.yml
+++ b/.github/services/hdfs/hdfs_default_with_atomic_write_dir/action.yml
@@ -29,8 +29,6 @@ runs:
     - name: Setup
       shell: bash
       run: |
-        curl -LsSf https://dlcdn.apache.org/hadoop/common/hadoop-3.3.5/hadoop-3.3.5.tar.gz | tar zxf - -C /home/runner
-
         export HADOOP_HOME="/home/runner/hadoop-3.3.5"
         export CLASSPATH=$(${HADOOP_HOME}/bin/hadoop classpath --glob)
 

--- a/.github/workflows/test_behavior_binding_nodejs.yml
+++ b/.github/workflows/test_behavior_binding_nodejs.yml
@@ -43,6 +43,7 @@ jobs:
           need-nextest: true
           need-protoc: true
           need-rocksdb: true
+          need-hadoop: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: 1password is only supported on linux

--- a/.github/workflows/test_behavior_binding_python.yml
+++ b/.github/workflows/test_behavior_binding_python.yml
@@ -43,6 +43,7 @@ jobs:
           need-nextest: true
           need-protoc: true
           need-rocksdb: true
+          need-hadoop: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: 1password is only supported on linux

--- a/.github/workflows/test_behavior_core.yml
+++ b/.github/workflows/test_behavior_core.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           need-protoc: true
           need-rocksdb: true
+          need-hadoop: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # TODO: 1password is only supported on linux


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
The CI often fails because it cannot download hadoop-3.3.5, like this: https://github.com/apache/opendal/actions/runs/11973321010/job/33382084490?pr=5352

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
