### PR TITLE
Update to upload-artifact@v4

### DIFF
--- a/.github/workflows/ci_bindings_nodejs.yml
+++ b/.github/workflows/ci_bindings_nodejs.yml
@@ -153,7 +153,7 @@ jobs:
         shell: bash
         working-directory: .
         run: ${{ matrix.settings.build }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: bindings-linux-${{ matrix.settings.target }}
           path: bindings/nodejs/*.node
@@ -201,7 +201,7 @@ jobs:
       - name: Build
         shell: bash
         run: ${{ matrix.settings.build }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: bindings-windows-${{ matrix.settings.target }}
           path: bindings/nodejs/*.node
@@ -223,7 +223,7 @@ jobs:
             build: |
               rustup target add x86_64-apple-darwin;
               export NAPI_TARGET=x86_64-apple-darwin;
-              
+
               pnpm build
               strip -x *.node
           - target: aarch64-apple-darwin
@@ -291,7 +291,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: bindings/nodejs/artifacts
       - name: Move artifacts

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,7 +73,7 @@ jobs:
           LD_LIBRARY_PATH: ${{ env.JAVA_HOME }}/lib/server:${{ env.LD_LIBRARY_PATH }}
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rust-docs
           path: ./core/target/doc
@@ -94,7 +94,7 @@ jobs:
         run: mvn javadoc:javadoc
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: java-docs
           path: ./bindings/java/target/site/apidocs
@@ -131,7 +131,7 @@ jobs:
         run: pnpm run docs
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nodejs-docs
           path: ./bindings/nodejs/docs
@@ -158,7 +158,7 @@ jobs:
         run: pdoc -t ./template --output-dir ./docs opendal
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-docs
           path: ./bindings/python/docs
@@ -182,7 +182,7 @@ jobs:
         run: make doc
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: C-docs
           path: ./bindings/c/docs/doxygen/html
@@ -201,7 +201,7 @@ jobs:
         run: ldoc ./src
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: lua-docs
           path: ./bindings/lua/doc/
@@ -241,7 +241,7 @@ jobs:
           find dist-newstyle -path '**/build/**/doc' -exec cp -r {}/html/opendal/ doc \;
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: haskell-docs
           path: ./bindings/haskell/doc/
@@ -270,7 +270,7 @@ jobs:
           ninja docs
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cpp-docs
           path: ./bindings/cpp/build/docs_doxygen/html
@@ -315,7 +315,7 @@ jobs:
           dune build @doc
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ocaml-docs
           path: ./bindings/ocaml/_build/default/_doc/_html
@@ -338,7 +338,7 @@ jobs:
         run: cargo +${{ env.RUST_DOC_TOOLCHAIN }} doc --lib --no-deps --all-features
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: object-store-opendal-docs
           path: ./integrations/object_store/target/doc
@@ -362,7 +362,7 @@ jobs:
         run: cargo +${{ env.RUST_DOC_TOOLCHAIN }} doc --lib --no-deps --all-features
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dav-server-opendalfs-docs
           path: ./integrations/dav-server/target/doc
@@ -385,7 +385,7 @@ jobs:
         run: cargo +${{ env.RUST_DOC_TOOLCHAIN }} doc --lib --no-deps --all-features
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: fuse3-opendal-docs
           path: ./integrations/fuse3/target/doc
@@ -408,7 +408,7 @@ jobs:
         run: cargo +${{ env.RUST_DOC_TOOLCHAIN }} doc --lib --no-deps --all-features
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: unftp-sbe-opendal-docs
           path: ./integrations/unftp-sbe/target/doc
@@ -431,7 +431,7 @@ jobs:
         run: cargo +${{ env.RUST_DOC_TOOLCHAIN }} doc --lib --no-deps --all-features
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: virtiofs-opendal-docs
           path: ./integrations/virtiofs/target/doc
@@ -454,7 +454,7 @@ jobs:
         run: cargo +${{ env.RUST_DOC_TOOLCHAIN }} doc --lib --no-deps --all-features
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: object-parquet-docs
           path: ./integrations/parquet/target/doc
@@ -477,7 +477,7 @@ jobs:
         run: cargo +${{ env.RUST_DOC_TOOLCHAIN }} doc --lib --no-deps --all-features
 
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: opendal-compat-docs
           path: ./integrations/compat/target/doc
@@ -524,91 +524,91 @@ jobs:
         run: corepack enable
 
       - name: Download rust docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: rust-docs
           path: ./website/static/docs/rust
 
       - name: Download nodejs docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nodejs-docs
           path: ./website/static/docs/nodejs
 
       - name: Download python docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-docs
           path: ./website/static/docs/python
 
       - name: Download java docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: java-docs
           path: ./website/static/docs/java
 
       - name: Download C docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: C-docs
           path: ./website/static/docs/c
 
       - name: Download lua docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: lua-docs
           path: ./website/static/docs/lua
 
       - name: Download haskell docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: haskell-docs
           path: ./website/static/docs/haskell
 
       - name: Download cpp docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cpp-docs
           path: ./website/static/docs/cpp
 
       - name: Download ocaml docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ocaml-docs
           path: ./website/static/docs/ocaml
 
       - name: Download object-store-opendal docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: object-store-opendal-docs
           path: ./website/static/docs/object-store-opendal
 
       - name: Download opendal_compat docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: opendal-compat-docs
           path: ./website/static/docs/opendal_compat
 
       - name: Download dav-server-opendalfs docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dav-server-opendalfs-docs
           path: ./website/static/docs/dav-server-opendalfs
 
       - name: Download fuse3-opendal docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: fuse3-opendal-docs
           path: ./website/static/docs/fuse3-opendal
 
       - name: Download unftp-sbe-opendal docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: unftp-sbe-opendal-docs
           path: ./website/static/docs/unftp-sbe-opendal
 
       - name: Download virtiofs-opendal docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: virtiofs-opendal-docs
           path: ./website/static/docs/virtiofs-opendal


### PR DESCRIPTION
# Which issue does this PR close?

I can create a ticket if required.

# Rationale for this change

GitHub will deprecate `upload-artifact@v3` in coming weeks. v3 will no longer work. Read annocument [here](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). This PR bumps the `upload-artifact` to v4.

# Are there any user-facing changes?

No.