### PR TITLE
feat:  publish python3.13t free-threaded wheel

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -84,6 +84,16 @@ jobs:
           args: --release -o dist -i python3.10 --features=pyo3/extension-module,services-all
           sccache: true
           manylinux: auto
+      - name: Build free-threaded wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          maturin-version: "1.7.7"
+          working-directory: "bindings/python"
+          target: "${{ matrix.target }}"
+          command: build
+          args: --release -o dist -i python3.13t --features=pyo3/extension-module,services-all
+          sccache: true
+          manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5383.

Hi @messense, is it necessary to use [pymodule(gil_used = false)], or will maturin set it automatically? Or does adding it not break backward compatibility?