### PR TITLE
feat(types/buffer): skip copying in `to_bytes` when `NonContiguous` contains a single `Bytes`

### DIFF
--- a/core/src/types/buffer.rs
+++ b/core/src/types/buffer.rs
@@ -287,10 +287,19 @@ impl Buffer {
     pub fn to_bytes(&self) -> Bytes {
         match &self.0 {
             Inner::Contiguous(bytes) => bytes.clone(),
-            Inner::NonContiguous { .. } => {
-                let mut ret = BytesMut::with_capacity(self.len());
-                ret.put(self.clone());
-                ret.freeze()
+            Inner::NonContiguous {
+                parts,
+                size,
+                idx: _,
+                offset,
+            } => {
+                if parts.len() == 1 {
+                    parts[0].slice(*offset..(*offset + *size))
+                } else {
+                    let mut ret = BytesMut::with_capacity(self.len());
+                    ret.put(self.clone());
+                    ret.freeze()
+                }
             }
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5385

# Rationale for this change

The `Buffer::to_bytes` method currently performs unnecessary copying when the buffer is NonContiguous but contains only a single Bytes. This results in reduced performance due to redundant data duplication. By optimizing `to_bytes` to return the single `Bytes` directly without copying, we can improve the efficiency of buffer operations.

# What changes are included in this PR?

- Optimized the `Buffer::to_bytes` method to return the single `Bytes` directly when `NonContiguous` contains only one `Bytes`, avoiding unnecessary copying.

# Are there any user-facing changes?

No user-facing changes. This optimization improves internal performance without altering the public API or behavior visible to users.