### PR TITLE
fix: oli clippy and CI file

### DIFF
--- a/.github/workflows/ci_bin_oli.yml
+++ b/.github/workflows/ci_bin_oli.yml
@@ -25,7 +25,7 @@ on:
     branches:
       - main
     paths:
-      - "bin/oay/**"
+      - "bin/oli/**"
       - "core/**"
       - ".github/workflows/ci_bin_oli.yml"
 

--- a/bin/oli/src/commands/cp.rs
+++ b/bin/oli/src/commands/cp.rs
@@ -99,7 +99,7 @@ impl CopyCmd {
                 .into_futures_async_read(0..meta.content_length())
                 .await?;
 
-            let copy_progress = CopyProgress::new(&meta, de.path().to_string());
+            let copy_progress = CopyProgress::new(meta, de.path().to_string());
             let mut writer = dst_op
                 .writer(&dst_root.join(fp).to_string_lossy())
                 .await?


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

- Fix Clippy warning introduced in https://github.com/apache/opendal/pull/5369
- Fix GitHub Action file to run CI for `oli` correctly.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

CI-related changes

# Are there any user-facing changes?

no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
