### PR TITLE
feat:(core): add `content encoding` to `Opwrite`

### DIFF
--- a/core/src/raw/ops.rs
+++ b/core/src/raw/ops.rs
@@ -541,6 +541,7 @@ pub struct OpWrite {
     concurrent: usize,
     content_type: Option<String>,
     content_disposition: Option<String>,
+    content_encoding: Option<String>,
     cache_control: Option<String>,
     executor: Option<Executor>,
     if_match: Option<String>,
@@ -595,6 +596,17 @@ impl OpWrite {
     /// Set the content disposition of option
     pub fn with_content_disposition(mut self, content_disposition: &str) -> Self {
         self.content_disposition = Some(content_disposition.to_string());
+        self
+    }
+
+    /// Get the content encoding from option
+    pub fn content_encoding(&self) -> Option<&str> {
+        self.content_encoding.as_deref()
+    }
+
+    /// Set the content encoding of option
+    pub fn with_content_encoding(mut self, content_encoding: &str) -> Self {
+        self.content_encoding = Some(content_encoding.to_string());
         self
     }
 

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -944,6 +944,7 @@ impl Access for S3Backend {
                 write_can_multi: true,
                 write_with_cache_control: true,
                 write_with_content_type: true,
+                write_with_content_encoding: true,
                 write_with_if_match: !self.core.disable_write_with_if_match,
                 write_with_if_not_exists: true,
                 write_with_user_metadata: true,

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -31,6 +31,7 @@ use constants::X_AMZ_META_PREFIX;
 use http::header::HeaderName;
 use http::header::CACHE_CONTROL;
 use http::header::CONTENT_DISPOSITION;
+use http::header::CONTENT_ENCODING;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
 use http::header::HOST;
@@ -446,6 +447,10 @@ impl S3Core {
 
         if let Some(mime) = args.content_type() {
             req = req.header(CONTENT_TYPE, mime)
+        }
+
+        if let Some(encoding) = args.content_encoding() {
+            req = req.header(CONTENT_ENCODING, encoding);
         }
 
         if let Some(pos) = args.content_disposition() {

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -449,12 +449,12 @@ impl S3Core {
             req = req.header(CONTENT_TYPE, mime)
         }
 
-        if let Some(encoding) = args.content_encoding() {
-            req = req.header(CONTENT_ENCODING, encoding);
-        }
-
         if let Some(pos) = args.content_disposition() {
             req = req.header(CONTENT_DISPOSITION, pos)
+        }
+
+        if let Some(encoding) = args.content_encoding() {
+            req = req.header(CONTENT_ENCODING, encoding);
         }
 
         if let Some(cache_control) = args.cache_control() {

--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -128,6 +128,8 @@ pub struct Capability {
     pub write_with_content_type: bool,
     /// Indicates if Content-Disposition can be specified during write operations.
     pub write_with_content_disposition: bool,
+    /// Indicates if Content-Encoding can be specified during write operations.
+    pub write_with_content_encoding: bool,
     /// Indicates if Cache-Control can be specified during write operations.
     pub write_with_cache_control: bool,
     /// Indicates if conditional write operations using If-Match are supported.

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -1407,9 +1407,38 @@ impl Operator {
     /// # }
     /// ```
     ///
-    /// ## `if_none_match`
+    /// ## `content_encoding`
     ///
-    /// Sets an `if none match` condition with specified ETag for this write request.
+    /// Sets Content-Encoding header for this write request.
+    ///
+    /// ### Capability
+    ///
+    /// Check [`Capability::write_with_content_encoding`] before using this feature.
+    ///
+    /// ### Behavior
+    ///
+    /// - If supported, sets Content-Encoding as system metadata on the target file
+    /// - The value should follow HTTP Content-Encoding header format
+    /// - If not supported, the value will be ignored
+    ///
+    /// This operation allows specifying the content encoding for the written content.
+    ///
+    /// ## Example
+    ///
+    /// ```no_run
+    /// # use opendal::Result;
+    /// # use opendal::Operator;
+    /// use bytes::Bytes;
+    /// # async fn test(op: Operator) -> Result<()> {
+    ///     let _ = op
+    ///         .write_with("path/to/file", bs)
+    ///         .content_encoding("br")
+    ///         .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ## `if_none_match`
     ///
     /// ### Capability
     ///

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -1430,15 +1430,18 @@ impl Operator {
     /// # use opendal::Operator;
     /// use bytes::Bytes;
     /// # async fn test(op: Operator) -> Result<()> {
-    ///     let _ = op
-    ///         .write_with("path/to/file", bs)
-    ///         .content_encoding("br")
-    ///         .await?;
+    /// let bs = b"hello, world!".to_vec();
+    /// let _ = op
+    ///     .write_with("path/to/file", bs)
+    ///     .content_encoding("br")
+    ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
     ///
     /// ## `if_none_match`
+    ///
+    /// Sets an `if none match` condition with specified ETag for this write request.
     ///
     /// ### Capability
     ///

--- a/core/src/types/operator/operator_futures.rs
+++ b/core/src/types/operator/operator_futures.rs
@@ -318,6 +318,11 @@ impl<F: Future<Output = Result<()>>> FutureWrite<F> {
         self.map(|(args, options, bs)| (args.with_content_disposition(v), options, bs))
     }
 
+    /// Set the content encoding of option
+    pub fn content_encoding(self, v: &str) -> Self {
+        self.map(|(args, options, bs)| (args.with_content_encoding(v), options, bs))
+    }
+
     /// Set the executor for this operation.
     pub fn executor(self, executor: Executor) -> Self {
         self.map(|(args, options, bs)| (args.with_executor(executor), options, bs))

--- a/core/tests/behavior/async_write.rs
+++ b/core/tests/behavior/async_write.rs
@@ -225,8 +225,12 @@ pub async fn test_write_with_content_encoding(op: Operator) -> Result<()> {
         .content_encoding(target_content_encoding)
         .await?;
 
-    // TODO: check the content encoding in the stat op response?
-
+    let meta = op.stat(&path).await.expect("stat must succeed");
+    assert_eq!(
+        meta.content_encoding()
+            .expect("content encoding must exist"),
+        target_content_encoding
+    );
     Ok(())
 }
 

--- a/core/tests/behavior/async_write.rs
+++ b/core/tests/behavior/async_write.rs
@@ -218,7 +218,7 @@ pub async fn test_write_with_content_encoding(op: Operator) -> Result<()> {
         return Ok(());
     }
 
-    let (path, content, size) = TEST_FIXTURE.new_file(op.clone());
+    let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
     let target_content_encoding = "gzip";
     op.write_with(&path, content)

--- a/core/tests/behavior/async_write.rs
+++ b/core/tests/behavior/async_write.rs
@@ -44,6 +44,7 @@ pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
             test_write_with_cache_control,
             test_write_with_content_type,
             test_write_with_content_disposition,
+            test_write_with_content_encoding,
             test_write_with_if_none_match,
             test_write_with_if_not_exists,
             test_write_with_if_match,
@@ -207,6 +208,24 @@ pub async fn test_write_with_content_disposition(op: Operator) -> Result<()> {
         target_content_disposition
     );
     assert_eq!(meta.content_length(), size as u64);
+
+    Ok(())
+}
+
+/// Write a single file with content encoding should succeed.
+pub async fn test_write_with_content_encoding(op: Operator) -> Result<()> {
+    if !op.info().full_capability().write_with_content_encoding {
+        return Ok(());
+    }
+
+    let (path, content, size) = TEST_FIXTURE.new_file(op.clone());
+
+    let target_content_encoding = "gzip";
+    op.write_with(&path, content)
+        .content_encoding(target_content_encoding)
+        .await?;
+
+    // TODO: check the content encoding in the stat op response?
 
     Ok(())
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5378 

I think we need to add `content_encoding` to the metadata to properly test it? https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_ResponseSyntax

# Are there any user-facing changes?

Add `op.write_with(path, content).content_encoding("encoding")`