### PR TITLE
feat(core): Add `content_encoding` to `MetaData`

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -144,7 +144,6 @@ mod tests {
     use std::mem::size_of;
 
     use super::*;
-
     /// This is not a real test case.
     ///
     /// We assert our public structs here to make sure we don't introduce
@@ -152,8 +151,8 @@ mod tests {
     #[test]
     fn assert_size() {
         assert_eq!(32, size_of::<Operator>());
-        assert_eq!(296, size_of::<Entry>());
-        assert_eq!(272, size_of::<Metadata>());
+        assert_eq!(320, size_of::<Entry>());
+        assert_eq!(296, size_of::<Metadata>());
         assert_eq!(1, size_of::<EntryMode>());
         assert_eq!(24, size_of::<Scheme>());
     }

--- a/core/src/raw/http_util/header.rs
+++ b/core/src/raw/http_util/header.rs
@@ -173,6 +173,10 @@ pub fn parse_into_metadata(path: &str, headers: &HeaderMap) -> Result<Metadata> 
         m.set_content_type(v);
     }
 
+    if let Some(v) = parse_content_encoding(headers)? {
+        m.set_content_encoding(v);
+    }
+
     if let Some(v) = parse_content_range(headers)? {
         m.set_content_range(v);
     }

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -923,6 +923,7 @@ impl Access for S3Backend {
             .set_name(&self.core.bucket)
             .set_native_capability(Capability {
                 stat: true,
+                stat_has_content_encoding: true,
                 stat_with_if_match: true,
                 stat_with_if_none_match: true,
                 stat_with_override_cache_control: !self.core.disable_stat_with_override,

--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -90,6 +90,8 @@ pub struct Capability {
     pub stat_has_content_range: bool,
     /// Indicates whether content type information is available in stat response
     pub stat_has_content_type: bool,
+    /// Indicates whether content encoding information is available in stat response
+    pub stat_has_content_encoding: bool,
     /// Indicates whether entity tag is available in stat response
     pub stat_has_etag: bool,
     /// Indicates whether last modified timestamp is available in stat response

--- a/core/src/types/metadata.rs
+++ b/core/src/types/metadata.rs
@@ -205,15 +205,11 @@ impl Metadata {
     }
 
     /// Content Encoding of this entry.
-    ///
-    /// Content Encoding is defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#field.content-encoding).
     pub fn content_encoding(&self) -> Option<&str> {
         self.content_encoding.as_deref()
     }
 
     /// Set Content Encoding of this entry.
-    ///
-    /// Content Encoding is defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#field.content-encoding).
     pub fn set_content_encoding(&mut self, v: &str) -> &mut Self {
         self.content_encoding = Some(v.to_string());
         self

--- a/core/src/types/metadata.rs
+++ b/core/src/types/metadata.rs
@@ -39,6 +39,7 @@ pub struct Metadata {
     content_md5: Option<String>,
     content_range: Option<BytesContentRange>,
     content_type: Option<String>,
+    content_encoding: Option<String>,
     etag: Option<String>,
     last_modified: Option<DateTime<Utc>>,
     version: Option<String>,
@@ -56,6 +57,7 @@ impl Metadata {
             content_length: None,
             content_md5: None,
             content_type: None,
+            content_encoding: None,
             content_range: None,
             last_modified: None,
             etag: None,
@@ -199,6 +201,21 @@ impl Metadata {
     /// Content Type is defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#field.content-type).
     pub fn with_content_type(mut self, v: String) -> Self {
         self.content_type = Some(v);
+        self
+    }
+
+    /// Content Encoding of this entry.
+    ///
+    /// Content Encoding is defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#field.content-encoding).
+    pub fn content_encoding(&self) -> Option<&str> {
+        self.content_encoding.as_deref()
+    }
+
+    /// Set Content Encoding of this entry.
+    ///
+    /// Content Encoding is defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#field.content-encoding).
+    pub fn set_content_encoding(&mut self, v: &str) -> &mut Self {
+        self.content_encoding = Some(v.to_string());
         self
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

follow #5390, 
> I think we need to add content_encoding to the metadata to properly test it? [docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_ResponseSyntax](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html#API_HeadObject_ResponseSyntax)

# Are there any user-facing changes?

`MetaData` now includes a field `content_encoding`