### PR TITLE
Bump version to v0.51.0 rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- Release notes generated using configuration in .github/release.yml at main -->
 
+## [v0.51.0] - 2024-12-14
+
+### Added
+* feat(adapter/kv): support async iterating on scan results by @PragmaTwice in https://github.com/apache/opendal/pull/5208
+* feat(bindings/ruby): Add simple operators to Ruby binding by @erickguan in https://github.com/apache/opendal/pull/5246
+* feat(core/services-gcs): support user defined metadata by @jorgehermo9 in https://github.com/apache/opendal/pull/5276
+* feat(core): add `if_not_exist` in `OpWrite` by @kemingy in https://github.com/apache/opendal/pull/5305
+* feat: Add {stat,list}_has_* to carry the metadata that backend returns by @Xuanwo in https://github.com/apache/opendal/pull/5318
+* feat(core): Implement write if not exists for azblob,azdls,gcs,oss,cos by @Xuanwo in https://github.com/apache/opendal/pull/5321
+* feat(core): add new cap shared by @TennyZhuang in https://github.com/apache/opendal/pull/5328
+* feat(bindings/python): support pickle [de]serialization for Operator by @TennyZhuang in https://github.com/apache/opendal/pull/5324
+* feat(bindings/cpp): init the async support of C++ binding by @PragmaTwice in https://github.com/apache/opendal/pull/5195
+* feat(bindings/go): support darwin by @yuchanns in https://github.com/apache/opendal/pull/5334
+* feat(services/gdrive): List shows modified timestamp gdrive by @erickguan in https://github.com/apache/opendal/pull/5226
+* feat(service/s3): support delete with version by @Frank-III in https://github.com/apache/opendal/pull/5349
+* feat: upgrade pyo3 to 0.23 by @XmchxUp in https://github.com/apache/opendal/pull/5368
+* feat:  publish python3.13t free-threaded wheel by @XmchxUp in https://github.com/apache/opendal/pull/5387
+* feat: add progress bar for oli cp command by @waynexia in https://github.com/apache/opendal/pull/5369
+* feat(types/buffer): skip copying in `to_bytes` when `NonContiguous` contains a single `Bytes` by @ever0de in https://github.com/apache/opendal/pull/5388
+* feat(bin/oli): support command mv by @meteorgan in https://github.com/apache/opendal/pull/5370
+* feat(core): add if-match to `OpWrite` by @Frank-III in https://github.com/apache/opendal/pull/5360
+* feat(core/layers): add correctness_check and capability_check layer to verify whether the operation and arguments is supported by @meteorgan in https://github.com/apache/opendal/pull/5352
+* feat(bindings/ruby): Add I/O class for Ruby by @erickguan in https://github.com/apache/opendal/pull/5354
+* feat(core): Add `content_encoding` to `MetaData` by @Frank-III in https://github.com/apache/opendal/pull/5400
+* feat:(core): add `content encoding` to `Opwrite` by @Frank-III in https://github.com/apache/opendal/pull/5390
+* feat(services/obs): support user defined metadata by @Frank-III in https://github.com/apache/opendal/pull/5405
+### Changed
+* refactor (bindings/zig): Improvements by @kassane in https://github.com/apache/opendal/pull/5247
+* refactor: Remove metakey concept by @Xuanwo in https://github.com/apache/opendal/pull/5319
+* refactor(core)!: Remove not used cap write_multi_align_size by @Xuanwo in https://github.com/apache/opendal/pull/5322
+* refactor(core)!: Remove the range writer that has never been used by @Xuanwo in https://github.com/apache/opendal/pull/5323
+* refactor(core): MaybeSend does not need to be unsafe by @drmingdrmer in https://github.com/apache/opendal/pull/5338
+* refactor: Implement RFC-3911 Deleter API  by @Xuanwo in https://github.com/apache/opendal/pull/5392
+* refactor: Remove batch concept from opendal by @Xuanwo in https://github.com/apache/opendal/pull/5393
+### Fixed
+* fix(services/webdav): Fix lister failing when root contains spaces by @skrimix in https://github.com/apache/opendal/pull/5298
+* fix(bindings/c): Bump min CMake version to support CMP0135 by @palash25 in https://github.com/apache/opendal/pull/5308
+* fix(services/webhdfs): rename auth value by @notauserx in https://github.com/apache/opendal/pull/5342
+* fix(bindings/cpp): remove the warning of CMP0135 by @PragmaTwice in https://github.com/apache/opendal/pull/5346
+* build(python): fix pyproject meta file by @trim21 in https://github.com/apache/opendal/pull/5348
+* fix(services/unftp): add `/` when not presented by @Frank-III in https://github.com/apache/opendal/pull/5382
+* fix: update document against target format check and add hints by @waynexia in https://github.com/apache/opendal/pull/5361
+* fix: oli clippy and CI file by @waynexia in https://github.com/apache/opendal/pull/5389
+* fix(services/obs): support huawei.com by @FayeSpica in https://github.com/apache/opendal/pull/5399
+### Docs
+* docs: Enable force_orphan to reduce clone size by @Xuanwo in https://github.com/apache/opendal/pull/5289
+* docs: Establish VISION for "One Layer, All Storage" by @Xuanwo in https://github.com/apache/opendal/pull/5309
+* docs: Polish docs for write with if not exists by @Xuanwo in https://github.com/apache/opendal/pull/5320
+* docs(core): add the description of version parameter for operator by @meteorgan in https://github.com/apache/opendal/pull/5144
+* docs(core): Add upgrade to v0.51 by @Xuanwo in https://github.com/apache/opendal/pull/5406
+### CI
+* ci: Remove the token of codspeed by @Xuanwo in https://github.com/apache/opendal/pull/5283
+* ci: Allow force push for `gh-pages` by @Xuanwo in https://github.com/apache/opendal/pull/5290
+* build(bindings/java): fix lombok process by @tisonkun in https://github.com/apache/opendal/pull/5297
+* build(bindings/python): add python 3.10 back and remove pypy by @trim21 in https://github.com/apache/opendal/pull/5347
+### Chore
+* chore(core/layers): align `info` method of `trait Access` and `trait LayeredAccess` by @koushiro in https://github.com/apache/opendal/pull/5258
+* chore(core/raw): align `info` method of `kv::Adapter` and `typed_kv::Adapter` by @koushiro in https://github.com/apache/opendal/pull/5259
+* chore(layers/oteltrace): adjust tracer span name of info method by @koushiro in https://github.com/apache/opendal/pull/5285
+* chore(services/s3): remove versioning check for s3 by @meteorgan in https://github.com/apache/opendal/pull/5300
+* chore: Polish the debug output of capability by @Xuanwo in https://github.com/apache/opendal/pull/5315
+* chore: Update maturity.md by @tisonkun in https://github.com/apache/opendal/pull/5340
+* chore: remove flagset in cargo.lock by @meteorgan in https://github.com/apache/opendal/pull/5355
+* chore: add setup action for hadoop to avoid build failures by @meteorgan in https://github.com/apache/opendal/pull/5353
+* chore: fix cargo clippy by @meteorgan in https://github.com/apache/opendal/pull/5379
+* chore: fix cargo clippy by @meteorgan in https://github.com/apache/opendal/pull/5384
+* chore: fix Bindings OCaml CI  by @meteorgan in https://github.com/apache/opendal/pull/5386
+* chore: Add default vscode config for more friendly developer experience by @Zheaoli in https://github.com/apache/opendal/pull/5331
+* chore(website): remove outdated description by @meteorgan in https://github.com/apache/opendal/pull/5411
+* chore(deps): bump clap from 4.5.20 to 4.5.21 in /bin/ofs by @dependabot in https://github.com/apache/opendal/pull/5372
+* chore(deps): bump anyhow from 1.0.90 to 1.0.93 in /bin/oay by @dependabot in https://github.com/apache/opendal/pull/5375
+* chore(deps): bump serde from 1.0.210 to 1.0.215 in /bin/oli by @dependabot in https://github.com/apache/opendal/pull/5376
+* chore(deps): bump openssh-sftp-client from 0.15.1 to 0.15.2 in /core by @dependabot in https://github.com/apache/opendal/pull/5377
+
 ## [v0.50.2] - 2024-11-04
 
 ### Added

--- a/bin/oay/Cargo.lock
+++ b/bin/oay/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "dav-server-opendalfs"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "oay"
-version = "0.41.13"
+version = "0.41.14"
 dependencies = [
  "anyhow",
  "axum",
@@ -856,7 +856,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opendal"
-version = "0.50.2"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/oay/Cargo.toml
+++ b/bin/oay/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.41.13"
+version = "0.41.14"
 
 [features]
 default = ["frontends-webdav", "frontends-s3"]
@@ -46,7 +46,7 @@ chrono = "0.4.31"
 dav-server = { version = "0.7", optional = true }
 dav-server-opendalfs = { version = "0.2.1", path = "../../integrations/dav-server", optional = true }
 futures-util = { version = "0.3.29", optional = true }
-opendal = { version = "0.50.0", path = "../../core", features = [
+opendal = { version = "0.51.0", path = "../../core", features = [
   "services-fs",
 ] }
 quick-xml = { version = "0.36", features = ["serialize", "overlapped-lists"] }

--- a/bin/oay/DEPENDENCIES.rust.tsv
+++ b/bin/oay/DEPENDENCIES.rust.tsv
@@ -5,7 +5,7 @@ aho-corasick@1.1.3							X				X
 allocator-api2@0.2.18		X					X					
 android-tzdata@0.1.1		X					X					
 android_system_properties@0.1.5		X					X					
-anyhow@1.0.90		X					X					
+anyhow@1.0.93		X					X					
 async-trait@0.1.83		X					X					
 autocfg@1.4.0		X					X					
 axum@0.7.7							X					
@@ -25,12 +25,11 @@ core-foundation-sys@0.8.7		X					X
 cpufeatures@0.2.14		X					X					
 crypto-common@0.1.6		X					X					
 dav-server@0.7.0		X										
-dav-server-opendalfs@0.2.2		X										
+dav-server-opendalfs@0.2.3		X										
 deranged@0.3.11		X					X					
 digest@0.10.7		X					X					
 equivalent@1.0.1		X					X					
 fastrand@2.1.1		X					X					
-flagset@0.4.6		X										
 fnv@1.0.7		X					X					
 foldhash@0.1.3												X
 form_urlencoded@1.2.1		X					X					
@@ -83,10 +82,10 @@ mio@1.0.2							X
 nu-ansi-term@0.46.0							X					
 num-conv@0.1.0		X					X					
 num-traits@0.2.19		X					X					
-oay@0.41.13		X										
+oay@0.41.14		X										
 object@0.36.5		X					X					
 once_cell@1.20.2		X					X					
-opendal@0.50.2		X										
+opendal@0.51.0		X										
 overload@0.1.1							X					
 parking_lot@0.12.3		X					X					
 parking_lot_core@0.9.10		X					X					

--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "cloud_filter_opendal"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "fuse3_opendal"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "bytes",
  "fuse3",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "ofs"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -1021,7 +1021,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opendal"
-version = "0.50.2"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/ofs/Cargo.toml
+++ b/bin/ofs/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["filesystem"]
 description = "OpenDAL File System"
 keywords = ["storage", "data", "s3", "fs", "azblob"]
 name = "ofs"
-version = "0.0.14"
+version = "0.0.15"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -34,7 +34,7 @@ anyhow = "1"
 clap = { version = "4.5.21", features = ["derive", "env"] }
 env_logger = "0.11.2"
 log = "0.4.21"
-opendal = { version = "0.50.0", path = "../../core" }
+opendal = { version = "0.51.0", path = "../../core" }
 tokio = { version = "1.37.0", features = [
   "fs",
   "macros",
@@ -46,13 +46,13 @@ url = "2.5.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))'.dependencies]
 fuse3 = { version = "0.8.1", "features" = ["tokio-runtime", "unprivileged"] }
-fuse3_opendal = { version = "0.0.9", path = "../../integrations/fuse3" }
+fuse3_opendal = { version = "0.0.10", path = "../../integrations/fuse3" }
 libc = "0.2.154"
 nix = { version = "0.29.0", features = ["user"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 cloud-filter = { version = "0.0.5" }
-cloud_filter_opendal = { version = "0.0.3", path = "../../integrations/cloud_filter" }
+cloud_filter_opendal = { version = "0.0.4", path = "../../integrations/cloud_filter" }
 
 [features]
 default = ["services-fs", "services-s3"]
@@ -60,7 +60,7 @@ services-fs = ["opendal/services-fs"]
 services-s3 = ["opendal/services-s3"]
 
 [dev-dependencies]
-opendal = { version = "0.50.0", path = "../../core", features = ["tests"] }
+opendal = { version = "0.51.0", path = "../../core", features = ["tests"] }
 tempfile = "3.10.1"
 test-context = "0.3.0"
 walkdir = "2.5.0"

--- a/bin/ofs/DEPENDENCIES.rust.tsv
+++ b/bin/ofs/DEPENDENCIES.rust.tsv
@@ -26,12 +26,12 @@ cc@1.1.31		X							X
 cfg-if@1.0.0		X							X					
 cfg_aliases@0.2.1									X					
 chrono@0.4.38		X							X					
-clap@4.5.20		X							X					
-clap_builder@4.5.20		X							X					
+clap@4.5.21		X							X					
+clap_builder@4.5.21		X							X					
 clap_derive@4.5.18		X							X					
 clap_lex@0.7.2		X							X					
 cloud-filter@0.0.5									X					
-cloud_filter_opendal@0.0.3		X												
+cloud_filter_opendal@0.0.4		X												
 colorchoice@1.0.2		X							X					
 concurrent-queue@2.5.0		X							X					
 const-oid@0.9.6		X							X					
@@ -57,7 +57,7 @@ flagset@0.4.6		X
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 fuse3@0.8.1									X					
-fuse3_opendal@0.0.9		X												
+fuse3_opendal@0.0.10		X												
 futures@0.3.31		X							X					
 futures-channel@0.3.31		X							X					
 futures-core@0.3.31		X							X					
@@ -107,9 +107,9 @@ nt-time@0.8.1		X							X
 num-conv@0.1.0		X							X					
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
-ofs@0.0.14		X												
+ofs@0.0.15		X												
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
+opendal@0.51.0		X												
 ordered-multimap@0.7.3									X					
 parking@2.2.1		X							X					
 percent-encoding@2.3.1		X							X					

--- a/bin/oli/Cargo.lock
+++ b/bin/oli/Cargo.lock
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "oli"
-version = "0.41.13"
+version = "0.41.14"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1991,7 +1991,7 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opendal"
-version = "0.50.2"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "async-tls",

--- a/bin/oli/Cargo.toml
+++ b/bin/oli/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.41.13"
+version = "0.41.14"
 
 [features]
 # Enable services dashmap support
@@ -59,7 +59,7 @@ clap = { version = "4", features = ["cargo", "string", "derive", "deprecated"] }
 dirs = "5.0.1"
 futures = "0.3"
 indicatif = "0.17.9"
-opendal = { version = "0.50.0", path = "../../core", features = [
+opendal = { version = "0.51.0", path = "../../core", features = [
   # These are default features before v0.46. TODO: change to optional features
   "services-azblob",
   "services-azdls",

--- a/bin/oli/DEPENDENCIES.rust.tsv
+++ b/bin/oli/DEPENDENCIES.rust.tsv
@@ -33,6 +33,7 @@ clap_builder@4.5.20		X							X
 clap_derive@4.5.18		X							X					
 clap_lex@0.7.2		X							X					
 colorchoice@1.0.2		X							X					
+console@0.15.8									X					
 const-oid@0.9.6		X							X					
 const-random@0.1.18		X							X					
 const-random-macro@0.1.16		X							X					
@@ -47,9 +48,9 @@ digest@0.10.7		X							X
 dirs@5.0.1		X							X					
 dirs-sys@0.4.1		X							X					
 dlv-list@0.5.2		X							X					
+encode_unicode@0.3.6		X							X					
 equivalent@1.0.1		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 futures@0.3.31		X							X					
@@ -83,6 +84,7 @@ iana-time-zone@0.1.61		X							X
 iana-time-zone-haiku@0.1.2		X							X					
 idna@0.5.0		X							X					
 indexmap@2.6.0		X							X					
+indicatif@0.17.9									X					
 inout@0.1.3		X							X					
 ipnet@2.10.1		X							X					
 is_terminal_polyfill@1.70.1		X							X					
@@ -105,10 +107,11 @@ num-conv@0.1.0		X							X
 num-integer@0.1.46		X							X					
 num-iter@0.1.45		X							X					
 num-traits@0.2.19		X							X					
+number_prefix@0.4.0									X					
 object@0.36.5		X							X					
-oli@0.41.13		X												
+oli@0.41.14		X												
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
+opendal@0.51.0		X												
 option-ext@0.2.0										X				
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
@@ -120,6 +123,7 @@ pin-utils@0.1.0		X							X
 pkcs1@0.7.5		X							X					
 pkcs5@0.7.1		X							X					
 pkcs8@0.10.2		X							X					
+portable-atomic@1.10.0		X							X					
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
 proc-macro2@1.0.88		X							X					
@@ -145,8 +149,8 @@ ryu@1.0.18		X				X
 salsa20@0.10.2		X							X					
 scrypt@0.11.0		X							X					
 semver@1.0.23		X							X					
-serde@1.0.210		X							X					
-serde_derive@1.0.210		X							X					
+serde@1.0.215		X							X					
+serde_derive@1.0.215		X							X					
 serde_json@1.0.132		X							X					
 serde_spanned@0.6.8		X							X					
 serde_urlencoded@0.7.1		X							X					
@@ -188,6 +192,8 @@ typenum@1.17.0		X							X
 unicode-bidi@0.3.17		X							X					
 unicode-ident@1.0.13		X							X			X		
 unicode-normalization@0.1.24		X							X					
+unicode-width@0.1.14		X							X					
+unicode-width@0.2.0		X							X					
 untrusted@0.9.0								X						
 url@2.5.2		X							X					
 utf8parse@0.2.2		X							X					
@@ -203,6 +209,7 @@ wasm-bindgen-macro-support@0.2.95		X							X
 wasm-bindgen-shared@0.2.95		X							X					
 wasm-streams@0.4.1		X							X					
 web-sys@0.3.72		X							X					
+web-time@1.1.0		X							X					
 webpki-roots@0.26.6										X				
 windows-core@0.52.0		X							X					
 windows-registry@0.2.0		X							X					

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.46.0"
+version = "0.45.2"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.1"
+version = "0.46.0"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -42,7 +42,6 @@ digest@0.10.7		X							X
 dlv-list@0.5.2		X							X					
 errno@0.3.9		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 futures@0.3.31		X							X					
@@ -99,8 +98,8 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
-opendal-c@0.45.1		X												
+opendal@0.51.0		X												
+opendal-c@0.46.0		X												
 ordered-multimap@0.7.3									X					
 os_str_bytes@6.6.1		X							X					
 pbkdf2@0.12.2		X							X					

--- a/bindings/cpp/Cargo.toml
+++ b/bindings/cpp/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.46.0"
+version = "0.45.14"
 
 [lib]
 crate-type = ["staticlib"]

--- a/bindings/cpp/Cargo.toml
+++ b/bindings/cpp/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.13"
+version = "0.46.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/bindings/cpp/DEPENDENCIES.rust.tsv
+++ b/bindings/cpp/DEPENDENCIES.rust.tsv
@@ -40,7 +40,6 @@ deranged@0.3.11		X							X
 digest@0.10.7		X							X					
 dlv-list@0.5.2		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 futures@0.3.31		X							X					
@@ -93,8 +92,8 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
-opendal-cpp@0.45.13		X												
+opendal@0.51.0		X												
+opendal-cpp@0.46.0		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-dotnet"
 publish = false
-version = "0.1.11"
+version = "0.2.0"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-dotnet"
 publish = false
-version = "0.2.0"
+version = "0.1.12"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/dotnet/DEPENDENCIES.rust.tsv
+++ b/bindings/dotnet/DEPENDENCIES.rust.tsv
@@ -35,7 +35,6 @@ deranged@0.3.11		X							X
 digest@0.10.7		X							X					
 dlv-list@0.5.2		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 futures@0.3.31		X							X					
@@ -87,8 +86,8 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
-opendal-dotnet@0.1.11		X												
+opendal@0.51.0		X												
+opendal-dotnet@0.2.0		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					

--- a/bindings/haskell/Cargo.toml
+++ b/bindings/haskell/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.0"
+version = "0.44.14"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/haskell/Cargo.toml
+++ b/bindings/haskell/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.44.13"
+version = "0.45.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/haskell/DEPENDENCIES.rust.tsv
+++ b/bindings/haskell/DEPENDENCIES.rust.tsv
@@ -35,7 +35,6 @@ deranged@0.3.11		X							X
 digest@0.10.7		X							X					
 dlv-list@0.5.2		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 futures@0.3.31		X							X					
@@ -87,8 +86,8 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
-opendal-hs@0.44.13		X												
+opendal@0.51.0		X												
+opendal-hs@0.45.0		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.48.0"
+version = "0.47.6"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.47.5"
+version = "0.48.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -45,7 +45,6 @@ digest@0.10.7		X							X
 dlv-list@0.5.2		X							X					
 errno@0.3.9		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 futures@0.3.30		X							X					
@@ -102,12 +101,12 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.3		X							X					
 once_cell@1.19.0		X							X					
-opendal@0.50.2		X												
-opendal-java@0.47.5		X												
+opendal@0.51.0		X												
+opendal-java@0.48.0		X												
 openssh@0.11.2		X							X					
-openssh-sftp-client@0.15.1									X					
-openssh-sftp-client-lowlevel@0.7.0									X					
-openssh-sftp-error@0.5.0									X					
+openssh-sftp-client@0.15.2									X					
+openssh-sftp-client-lowlevel@0.7.1									X					
+openssh-sftp-error@0.5.1									X					
 openssh-sftp-protocol@0.24.0									X					
 openssh-sftp-protocol-error@0.1.0									X					
 ordered-multimap@0.7.3									X					
@@ -173,12 +172,14 @@ ssh_format_error@0.1.0									X
 stable_deref_trait@1.2.0		X							X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.76		X							X					
+syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
 tempfile@3.12.0		X							X					
 thin-vec@0.2.13		X							X					
 thiserror@1.0.63		X							X					
+thiserror@2.0.6		X							X					
 thiserror-impl@1.0.63		X							X					
+thiserror-impl@2.0.6		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					

--- a/bindings/lua/Cargo.toml
+++ b/bindings/lua/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-lua"
 publish = false
-version = "0.2.0"
+version = "0.1.12"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/lua/Cargo.toml
+++ b/bindings/lua/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-lua"
 publish = false
-version = "0.1.11"
+version = "0.2.0"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/lua/DEPENDENCIES.rust.tsv
+++ b/bindings/lua/DEPENDENCIES.rust.tsv
@@ -38,7 +38,6 @@ digest@0.10.7		X							X
 dlv-list@0.5.2		X							X					
 either@1.13.0		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 futures@0.3.31		X							X					
@@ -94,8 +93,8 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
-opendal-lua@0.1.11		X												
+opendal@0.51.0		X												
+opendal-lua@0.2.0		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					

--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.47.7"
+version = "0.48.0"
 
 [features]
 default = [

--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.48.0"
+version = "0.47.8"
 
 [features]
 default = [

--- a/bindings/nodejs/DEPENDENCIES.rust.tsv
+++ b/bindings/nodejs/DEPENDENCIES.rust.tsv
@@ -39,7 +39,6 @@ deranged@0.3.11		X							X
 digest@0.10.7		X							X					
 dlv-list@0.5.2		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 futures@0.3.31		X							X					
@@ -98,8 +97,8 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
-opendal-nodejs@0.47.7		X												
+opendal@0.51.0		X												
+opendal-nodejs@0.48.0		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					

--- a/bindings/ocaml/DEPENDENCIES.rust.tsv
+++ b/bindings/ocaml/DEPENDENCIES.rust.tsv
@@ -36,7 +36,6 @@ deranged@0.3.11		X							X
 digest@0.10.7		X							X					
 dlv-list@0.5.2		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 futures@0.3.31		X							X					
@@ -93,7 +92,7 @@ ocaml-build@1.0.0								X
 ocaml-derive@1.0.0								X						
 ocaml-sys@0.24.0								X						
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
+opendal@0.51.0		X												
 opendal-ocaml@0.0.0		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					

--- a/bindings/php/Cargo.toml
+++ b/bindings/php/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-php"
 publish = false
-version = "0.2.0"
+version = "0.1.11"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/php/Cargo.toml
+++ b/bindings/php/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-php"
 publish = false
-version = "0.1.11"
+version = "0.2.0"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/php/DEPENDENCIES.rust.tsv
+++ b/bindings/php/DEPENDENCIES.rust.tsv
@@ -57,7 +57,6 @@ error-chain@0.12.4		X							X
 ext-php-rs@0.11.2		X							X					
 ext-php-rs-derive@0.10.1		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 flate2@1.0.34		X							X					
 fnv@1.0.7		X							X					
 foreign-types@0.3.2		X							X					
@@ -122,8 +121,8 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
-opendal-php@0.1.11		X												
+opendal@0.51.0		X												
+opendal-php@0.2.0		X												
 openssl@0.10.68		X												
 openssl-macros@0.1.1		X							X					
 openssl-probe@0.1.5		X							X					

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.45.12"
+version = "0.46.0"
 
 [features]
 default = [

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.46.0"
+version = "0.45.13"
 
 [features]
 default = [

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -43,7 +43,6 @@ digest@0.10.7		X							X
 dlv-list@0.5.2		X							X					
 errno@0.3.9		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 futures@0.3.31		X							X					
@@ -102,12 +101,12 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
-opendal-python@0.45.12		X												
+opendal@0.51.0		X												
+opendal-python@0.46.0		X												
 openssh@0.11.2		X							X					
-openssh-sftp-client@0.15.1									X					
-openssh-sftp-client-lowlevel@0.7.0									X					
-openssh-sftp-error@0.5.0									X					
+openssh-sftp-client@0.15.2									X					
+openssh-sftp-client-lowlevel@0.7.1									X					
+openssh-sftp-error@0.5.1									X					
 openssh-sftp-protocol@0.24.0									X					
 openssh-sftp-protocol-error@0.1.0									X					
 ordered-multimap@0.7.3									X					
@@ -128,12 +127,13 @@ portable-atomic@1.9.0		X							X
 powerfmt@0.2.0		X							X					
 ppv-lite86@0.2.20		X							X					
 proc-macro2@1.0.89		X							X					
-pyo3@0.22.5		X							X					
-pyo3-async-runtimes@0.22.0		X												
-pyo3-build-config@0.22.5		X							X					
-pyo3-ffi@0.22.5		X							X					
-pyo3-macros@0.22.5		X							X					
-pyo3-macros-backend@0.22.5		X							X					
+pyo3@0.23.3		X							X					
+pyo3-async-runtimes@0.23.0		X												
+pyo3-build-config@0.23.3		X							X					
+pyo3-ffi@0.23.3		X							X					
+pyo3-macros@0.23.3		X							X					
+pyo3-macros-backend@0.23.3		X							X					
+python3-dll-a@0.2.11									X					
 quick-xml@0.35.0									X					
 quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
@@ -179,13 +179,15 @@ ssh_format_error@0.1.0									X
 stable_deref_trait@1.2.0		X							X					
 subtle@2.6.1					X									
 syn@1.0.109		X							X					
-syn@2.0.85		X							X					
+syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
 target-lexicon@0.12.16			X											
 tempfile@3.13.0		X							X					
 thin-vec@0.2.13		X							X					
 thiserror@1.0.65		X							X					
+thiserror@2.0.6		X							X					
 thiserror-impl@1.0.65		X							X					
+thiserror-impl@2.0.6		X							X					
 time@0.3.36		X							X					
 time-core@0.1.2		X							X					
 time-macros@0.2.18		X							X					

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-ruby"
 publish = false
-version = "0.2.0"
+version = "0.1.12"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "opendal-ruby"
 publish = false
-version = "0.1.11"
+version = "0.2.0"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -41,7 +41,6 @@ digest@0.10.7		X							X
 dlv-list@0.5.2		X							X					
 either@1.13.0		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 futures@0.3.31		X							X					
@@ -84,8 +83,8 @@ libc@0.2.161		X							X
 libloading@0.8.5								X						
 libm@0.2.11		X							X					
 log@0.4.22		X							X					
-magnus@0.5.5									X					
-magnus-macros@0.4.1									X					
+magnus@0.7.1									X					
+magnus-macros@0.6.0									X					
 md-5@0.10.6		X							X					
 memchr@2.7.4									X				X	
 mime@0.3.17		X							X					
@@ -101,8 +100,8 @@ num-iter@0.1.45		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
-opendal-ruby@0.1.11		X												
+opendal@0.51.0		X												
+opendal-ruby@0.2.0		X												
 ordered-multimap@0.7.3									X					
 pbkdf2@0.12.2		X							X					
 pem@3.0.4									X					
@@ -144,6 +143,7 @@ ryu@1.0.18		X				X
 salsa20@0.10.2		X							X					
 scrypt@0.11.0		X							X					
 semver@1.0.23		X							X					
+seq-macro@0.3.5		X							X					
 serde@1.0.214		X							X					
 serde_derive@1.0.214		X							X					
 serde_json@1.0.132		X							X					
@@ -160,7 +160,6 @@ socket2@0.5.7		X							X
 spin@0.9.8									X					
 spki@0.7.3		X							X					
 subtle@2.6.1					X									
-syn@1.0.109		X							X					
 syn@2.0.87		X							X					
 sync_wrapper@1.0.1		X												
 thiserror@1.0.67		X							X					

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -4989,7 +4989,7 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "opendal"
-version = "0.50.2"
+version = "0.51.0"
 dependencies = [
  "anyhow",
  "async-backtrace",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.50.2"
+version = "0.51.0"
 
 [lints.clippy]
 unused_async = "warn"

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -30,7 +30,6 @@ dlv-list@0.5.2		X							X
 dotenvy@0.15.7									X					
 equivalent@1.0.1		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
 futures@0.3.31		X							X					
@@ -77,13 +76,13 @@ mio@1.0.2									X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
+opendal@0.51.0		X												
 ordered-multimap@0.7.3									X					
 percent-encoding@2.3.1		X							X					
 pin-project-lite@0.2.14		X							X					
 pin-utils@0.1.0		X							X					
 ppv-lite86@0.2.20		X							X					
-proc-macro2@1.0.88		X							X					
+proc-macro2@1.0.92		X							X					
 quick-xml@0.35.0									X					
 quick-xml@0.36.2									X					
 quote@1.0.37		X							X					
@@ -114,7 +113,7 @@ smallvec@1.13.2		X							X
 socket2@0.5.7		X							X					
 spin@0.9.8									X					
 subtle@2.6.1					X									
-syn@2.0.81		X							X					
+syn@2.0.90		X							X					
 sync_wrapper@1.0.1		X												
 tiny-keccak@2.0.2							X							
 tinyvec@1.8.0		X							X					X

--- a/integrations/cloud_filter/Cargo.toml
+++ b/integrations/cloud_filter/Cargo.toml
@@ -24,7 +24,7 @@ license = "Apache-2.0"
 name = "cloud_filter_opendal"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.0.3"
+version = "0.0.4"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
@@ -35,13 +35,13 @@ bincode = "1.3.3"
 cloud-filter = "0.0.5"
 futures = "0.3.30"
 log = "0.4.17"
-opendal = { version = "0.50.0", path = "../../core" }
+opendal = { version = "0.51.0", path = "../../core" }
 serde = { version = "1.0.203", features = ["derive"] }
 
 [dev-dependencies]
 env_logger = "0.11.2"
 libtest-mimic = "0.7.3"
-opendal = { version = "0.50.0", path = "../../core", features = [
+opendal = { version = "0.51.0", path = "../../core", features = [
   "services-fs",
   "tests",
 ] }

--- a/integrations/cloud_filter/DEPENDENCIES.rust.tsv
+++ b/integrations/cloud_filter/DEPENDENCIES.rust.tsv
@@ -18,7 +18,7 @@ cc@1.1.34		X							X
 cfg-if@1.0.0		X							X					
 chrono@0.4.38		X							X					
 cloud-filter@0.0.5									X					
-cloud_filter_opendal@0.0.3		X												
+cloud_filter_opendal@0.0.4		X												
 const-oid@0.9.6		X							X					
 const-random@0.1.18		X							X					
 const-random-macro@0.1.16		X							X					
@@ -79,7 +79,7 @@ num-conv@0.1.0		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
+opendal@0.51.0		X												
 ordered-multimap@0.7.3									X					
 percent-encoding@2.3.1		X							X					
 pin-project-lite@0.2.15		X							X					

--- a/integrations/compat/Cargo.toml
+++ b/integrations/compat/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "1.0.1"
+version = "1.0.2"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/integrations/compat/DEPENDENCIES.rust.tsv
+++ b/integrations/compat/DEPENDENCIES.rust.tsv
@@ -1,6 +1,6 @@
 crate	Apache-2.0	MIT	Unicode-DFS-2016
 async-trait@0.1.83	X	X	
-opendal_compat@1.0.1	X		
+opendal_compat@1.0.2	X		
 proc-macro2@1.0.89	X	X	
 quote@1.0.37	X	X	
 syn@2.0.87	X	X	

--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 description = "Use OpenDAL as a backend to access data in various service with WebDAV protocol"
 name = "dav-server-opendalfs"
-version = "0.2.2"
+version = "0.2.3"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2021"
@@ -32,10 +32,10 @@ anyhow = "1"
 bytes = { version = "1.4.0" }
 dav-server = { version = "0.7.0" }
 futures = "0.3"
-opendal = { version = "0.50.0", path = "../../core" }
+opendal = { version = "0.51.0", path = "../../core" }
 
 [dev-dependencies]
-opendal = { version = "0.50.0", path = "../../core", features = [
+opendal = { version = "0.51.0", path = "../../core", features = [
   "services-fs",
 ] }
 tokio = { version = "1.27", features = ["macros", "rt-multi-thread", "io-std"] }

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -23,12 +23,11 @@ core-foundation-sys@0.8.7		X					X
 cpufeatures@0.2.14		X					X					
 crypto-common@0.1.6		X					X					
 dav-server@0.7.0		X										
-dav-server-opendalfs@0.2.2		X										
+dav-server-opendalfs@0.2.3		X										
 deranged@0.3.11		X					X					
 digest@0.10.7		X					X					
 equivalent@1.0.1		X					X					
 fastrand@2.1.1		X					X					
-flagset@0.4.6		X										
 fnv@1.0.7		X					X					
 foldhash@0.1.3												X
 form_urlencoded@1.2.1		X					X					
@@ -79,7 +78,7 @@ num-conv@0.1.0		X					X
 num-traits@0.2.19		X					X					
 object@0.36.5		X					X					
 once_cell@1.20.2		X					X					
-opendal@0.50.2		X										
+opendal@0.51.0		X										
 parking_lot@0.12.3		X					X					
 parking_lot_core@0.9.10		X					X					
 percent-encoding@2.3.1		X					X					

--- a/integrations/fuse3/Cargo.toml
+++ b/integrations/fuse3/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.0.9"
+version = "0.0.10"
 
 [dependencies]
 bytes = "1.6.0"
@@ -33,7 +33,7 @@ fuse3 = { version = "0.8.1", "features" = ["tokio-runtime", "unprivileged"] }
 futures-util = "0.3.30"
 libc = "0.2.155"
 log = "0.4.21"
-opendal = { version = "0.50.0", path = "../../core" }
+opendal = { version = "0.51.0", path = "../../core" }
 sharded-slab = "0.1.7"
 tokio = "1.38.0"
 

--- a/integrations/fuse3/DEPENDENCIES.rust.tsv
+++ b/integrations/fuse3/DEPENDENCIES.rust.tsv
@@ -28,11 +28,10 @@ either@1.13.0		X					X
 errno@0.3.9		X					X					
 event-listener@4.0.3		X					X					
 fastrand@2.1.1		X					X					
-flagset@0.4.6		X										
 fnv@1.0.7		X					X					
 form_urlencoded@1.2.1		X					X					
 fuse3@0.8.1							X					
-fuse3_opendal@0.0.9		X										
+fuse3_opendal@0.0.10		X										
 futures@0.3.31		X					X					
 futures-channel@0.3.31		X					X					
 futures-core@0.3.31		X					X					
@@ -74,7 +73,7 @@ nix@0.29.0							X
 num-traits@0.2.19		X					X					
 object@0.36.5		X					X					
 once_cell@1.20.2		X					X					
-opendal@0.50.2		X										
+opendal@0.51.0		X										
 parking@2.2.1		X					X					
 percent-encoding@2.3.1		X					X					
 pin-project-lite@0.2.15		X					X					

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.48.2"
+version = "0.48.3"
 
 [features]
 send_wrapper = ["dep:send_wrapper"]
@@ -37,13 +37,13 @@ flagset = "0.4"
 futures = "0.3"
 futures-util = "0.3"
 object_store = "0.11"
-opendal = { version = "0.50.0", path = "../../core" }
+opendal = { version = "0.51.0", path = "../../core" }
 pin-project = "1.1"
 send_wrapper = { version = "0.6", features = ["futures"], optional = true }
 tokio = { version = "1", default-features = false }
 
 [dev-dependencies]
-opendal = { version = "0.50.0", path = "../../core", features = [
+opendal = { version = "0.51.0", path = "../../core", features = [
   "services-memory",
   "services-s3",
 ] }

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -72,9 +72,9 @@ mio@1.0.2								X
 num-traits@0.2.19		X						X					
 object@0.36.5		X						X					
 object_store@0.11.1		X						X					
-object_store_opendal@0.48.2		X											
+object_store_opendal@0.48.3		X											
 once_cell@1.20.2		X						X					
-opendal@0.50.2		X											
+opendal@0.51.0		X											
 parking_lot@0.12.3		X						X					
 parking_lot_core@0.9.10		X						X					
 percent-encoding@2.3.1		X						X					

--- a/integrations/parquet/Cargo.toml
+++ b/integrations/parquet/Cargo.toml
@@ -25,13 +25,13 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.2.2"
+version = "0.2.3"
 
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
-opendal = { version = "0.50.0", path = "../../core" }
+opendal = { version = "0.51.0", path = "../../core" }
 parquet = { version = "53.1", default-features = false, features = [
   "async",
   "arrow",
@@ -39,7 +39,7 @@ parquet = { version = "53.1", default-features = false, features = [
 
 [dev-dependencies]
 arrow = { version = "53.1" }
-opendal = { version = "0.50.0", path = "../../core", features = [
+opendal = { version = "0.51.0", path = "../../core", features = [
   "services-memory",
   "services-s3",
 ] }

--- a/integrations/parquet/DEPENDENCIES.rust.tsv
+++ b/integrations/parquet/DEPENDENCIES.rust.tsv
@@ -36,7 +36,6 @@ crunchy@0.2.2									X
 crypto-common@0.1.6		X							X					
 digest@0.10.7		X							X					
 fastrand@2.1.1		X							X					
-flagset@0.4.6		X												
 flatbuffers@24.3.25		X												
 fnv@1.0.7		X							X					
 form_urlencoded@1.2.1		X							X					
@@ -96,10 +95,10 @@ num-rational@0.4.2		X							X
 num-traits@0.2.19		X							X					
 object@0.36.5		X							X					
 once_cell@1.20.2		X							X					
-opendal@0.50.2		X												
+opendal@0.51.0		X												
 ordered-float@2.10.1									X					
 parquet@53.2.0		X												
-parquet_opendal@0.2.2		X												
+parquet_opendal@0.2.3		X												
 paste@1.0.15		X							X					
 percent-encoding@2.3.1		X							X					
 pin-project-lite@0.2.15		X							X					

--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -24,18 +24,18 @@ license = "Apache-2.0"
 name = "unftp-sbe-opendal"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.75"
-version = "0.0.9"
+version = "0.0.10"
 
 [dependencies]
 async-trait = "0.1.80"
 libunftp = "0.20.0"
-opendal = { version = "0.50.0", path = "../../core" }
+opendal = { version = "0.51.0", path = "../../core" }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.7.11", features = ["compat"] }
 
 [dev-dependencies]
 anyhow = "1"
-opendal = { version = "0.50.0", path = "../../core", features = [
+opendal = { version = "0.51.0", path = "../../core", features = [
   "services-s3",
 ] }
 tokio = { version = "1.38.0", default-features = false, features = [

--- a/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
+++ b/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
@@ -49,7 +49,6 @@ dunce@1.0.5		X					X			X
 either@1.13.0		X							X						
 errno@0.3.9		X							X						
 fastrand@2.1.1		X							X						
-flagset@0.4.6		X													
 fnv@1.0.7		X							X						
 form_urlencoded@1.2.1		X							X						
 fs_extra@1.3.0									X						
@@ -111,7 +110,7 @@ num-traits@0.2.19		X							X
 object@0.36.5		X							X						
 oid-registry@0.7.1		X							X						
 once_cell@1.20.2		X							X						
-opendal@0.50.2		X													
+opendal@0.51.0		X													
 parking_lot@0.12.3		X							X						
 parking_lot_core@0.9.10		X							X						
 paste@1.0.15		X							X						
@@ -189,7 +188,7 @@ tracing-core@0.1.32									X
 triomphe@0.1.11		X							X						
 try-lock@0.2.5									X						
 typenum@1.17.0		X							X						
-unftp-sbe-opendal@0.0.9		X													
+unftp-sbe-opendal@0.0.10		X													
 unicode-bidi@0.3.17		X							X						
 unicode-ident@1.0.13		X							X				X		
 unicode-normalization@0.1.24		X							X						

--- a/integrations/virtiofs/Cargo.toml
+++ b/integrations/virtiofs/Cargo.toml
@@ -31,7 +31,7 @@ version = "0.0.0"
 anyhow = { version = "1.0.86", features = ["std"] }
 libc = "0.2.139"
 log = "0.4.22"
-opendal = { version = "0.50.0", path = "../../core" }
+opendal = { version = "0.51.0", path = "../../core" }
 sharded-slab = "0.1.7"
 snafu = "0.8.4"
 tokio = { version = "1.39.2", features = ["rt-multi-thread"] }

--- a/integrations/virtiofs/DEPENDENCIES.rust.tsv
+++ b/integrations/virtiofs/DEPENDENCIES.rust.tsv
@@ -22,7 +22,6 @@ core-foundation-sys@0.8.7		X					X
 crypto-common@0.1.6		X					X					
 digest@0.10.7		X					X					
 fastrand@2.1.1		X					X					
-flagset@0.4.6		X										
 fnv@1.0.7		X					X					
 form_urlencoded@1.2.1		X					X					
 futures@0.3.31		X					X					
@@ -63,7 +62,7 @@ mio@1.0.2							X
 num-traits@0.2.19		X					X					
 object@0.36.5		X					X					
 once_cell@1.20.2		X					X					
-opendal@0.50.2		X										
+opendal@0.51.0		X										
 percent-encoding@2.3.1		X					X					
 pin-project-lite@0.2.15		X					X					
 pin-utils@0.1.0		X					X					


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #5412 

# What changes are included in this PR?

| Name                      | Version | Next    |
| -                         | -       | -       |
| core                      | 0.50.2  | 0.51.0  |
| integrations/cloud_filter | 0.0.3   | 0.0.4   |
| integrations/compat       |1.0.1      | 1.0.2   |
| integrations/dav-server   | 0.2.2   | 0.2.3   |
| integrations/fuse3        | 0.0.9   | 0.0.10  |
| integrations/object_store | 0.48.2  | 0.48.3  |
| integrations/parquet      | 0.2.2   | 0.2.3   |
| integrations/spring       | -       | -       |
| integrations/unftp-sbe    | 0.0.9   | 0.0.10   |
| integrations/virtiofs     | -       | -       |
| bin/oay                   | 0.41.13 | 0.41.14 |
| bin/ofs                   | 0.0.14  | 0.0.15  |
| bin/oli                   | 0.41.13 | 0.41.14 |
| bindings/c                | 0.45.1 | 0.45.2 |
| bindings/cpp              | 0.45.13 | 0.45.14 |
| bindings/dotnet           | 0.1.11   | 0.1.12  |
| bindings/go               | 0.1.4   | 0.1.5   |
| bindings/haskell          | 0.44.13 | 0.44.14 |
| bindings/java             | 0.47.5  | 0.47.6  |
| bindings/lua              | 0.1.11   | 0.1.12  |
| bindings/nodejs           | 0.47.7  | 0.47.8  |
| bindings/ocaml            | -       | -       |
| bindings/php              | 0.1.11   | 0.1.12  |
| bindings/python           | 0.45.12 | 0.45.13 |
| bindings/ruby             | 0.1.11   | 0.1.12  |
| bindings/swift            | -       | -       |
| bindings/zig              | -       | -       |


