### PR TITLE
chore(ci): fix invalid Behavior Test Integration Cloud Filter trigger

### DIFF
--- a/.github/workflows/test_behavior_integration_cloud_filter.yml
+++ b/.github/workflows/test_behavior_integration_cloud_filter.yml
@@ -20,13 +20,13 @@ name: Behavior Test Integration Cloud Filter
 on:
   push:
     paths:
-      - "integrations/cloudfilter/**.rs"
-      - "integrations/cloudfilter/Cargo.toml"
+      - "integrations/cloud_filter/**.rs"
+      - "integrations/cloud_filter/Cargo.toml"
       - ".github/workflows/test_behavior_integration_cloud_filter.yml"
   pull_request:
     paths:
-      - "integrations/cloudfilter/**.rs"
-      - "integrations/cloudfilter/Cargo.toml"
+      - "integrations/cloud_filter/**.rs"
+      - "integrations/cloud_filter/Cargo.toml"
       - ".github/workflows/test_behavior_integration_cloud_filter.yml"
 
 jobs:

--- a/.github/workflows/test_behavior_integration_cloud_filter.yml
+++ b/.github/workflows/test_behavior_integration_cloud_filter.yml
@@ -19,11 +19,11 @@ name: Behavior Test Integration Cloud Filter
 
 on:
   push:
-    paths:
-      - "integrations/cloud_filter/**.rs"
-      - "integrations/cloud_filter/Cargo.toml"
-      - ".github/workflows/test_behavior_integration_cloud_filter.yml"
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
     paths:
       - "integrations/cloud_filter/**.rs"
       - "integrations/cloud_filter/Cargo.toml"

--- a/integrations/cloud_filter/tests/behavior/utils.rs
+++ b/integrations/cloud_filter/tests/behavior/utils.rs
@@ -35,8 +35,7 @@ pub fn file_content(path: impl Display) -> anyhow::Result<String> {
     let content = powershell_script::run(&format!("Get-Content \"{path}\""))
         .context("run powershell")?
         .stdout()
-        .unwrap_or_default()
-        .replace("\r\n", "\n"); // powershell returns CRLF, but the fixtures use LF
+        .unwrap_or_default();
     Ok(content)
 }
 


### PR DESCRIPTION
When I try to release the v0.51.0-rc.1, I found "Behavior Test Integration Cloud Filter" failed and it's not been triggered when the file changed.

https://github.com/apache/opendal/actions/runs/12332075431/job/34419665126

Fix the CI first