### PR TITLE
fix(integrations/cloud_filter): use explicit `stat` instead of `Entry::metadata` in `fetch_placeholders`

### DIFF
--- a/integrations/cloud_filter/src/lib.rs
+++ b/integrations/cloud_filter/src/lib.rs
@@ -216,7 +216,7 @@ impl Filter for CloudFilter {
             })?
             .filter_map(|e| async {
                 let entry = e.ok()?;
-                let metadata = self.op.stat(&entry.path()).await.ok()?;
+                let metadata = self.op.stat(entry.path()).await.ok()?;
                 let entry_remote_path = PathBuf::from(entry.path());
                 let relative_path = entry_remote_path
                     .strip_prefix(&remote_path)

--- a/integrations/cloud_filter/src/lib.rs
+++ b/integrations/cloud_filter/src/lib.rs
@@ -216,7 +216,7 @@ impl Filter for CloudFilter {
             })?
             .filter_map(|e| async {
                 let entry = e.ok()?;
-                let metadata = entry.metadata();
+                let metadata = self.op.stat(&entry.path()).await.ok()?;
                 let entry_remote_path = PathBuf::from(entry.path());
                 let relative_path = entry_remote_path
                     .strip_prefix(&remote_path)

--- a/integrations/cloud_filter/tests/behavior/fetch_data.rs
+++ b/integrations/cloud_filter/tests/behavior/fetch_data.rs
@@ -43,8 +43,8 @@ pub fn test_fetch_data() -> Result<(), Failed> {
 
         assert_eq!(
             expected_content,
-            file_content(&path).expect("file hash"),
-            "file hash",
+            file_content(&path).expect("file content"),
+            "file content",
         )
     }
     Ok(())

--- a/integrations/cloud_filter/tests/behavior/utils.rs
+++ b/integrations/cloud_filter/tests/behavior/utils.rs
@@ -35,7 +35,8 @@ pub fn file_content(path: impl Display) -> anyhow::Result<String> {
     let content = powershell_script::run(&format!("Get-Content \"{path}\""))
         .context("run powershell")?
         .stdout()
-        .unwrap_or_default();
+        .unwrap_or_default()
+        .replace("\r\n", "\n"); // powershell returns CRLF, but the fixtures use LF
     Ok(content)
 }
 


### PR DESCRIPTION
# Rationale for this change

The `Operator::lister` will not fetch `Metadata::content_length` implicitly, and the zero `Metadata::content_length` causes `CloudFiler::fetch_data` won't be called.

Related #5414 

# What changes are included in this PR?

Call `Operator:stat` explicitly in `CloudFiler::fetch_placeholders`.
