### PR TITLE
Bump version to v0.51.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 * fix: update document against target format check and add hints by @waynexia in https://github.com/apache/opendal/pull/5361
 * fix: oli clippy and CI file by @waynexia in https://github.com/apache/opendal/pull/5389
 * fix(services/obs): support huawei.com by @FayeSpica in https://github.com/apache/opendal/pull/5399
+* fix(integrations/cloud_filter): use explicit `stat` instead of `Entry::metadata` in `fetch_placeholders` by @ho-229 in https://github.com/apache/opendal/pull/5416
 ### Docs
 * docs: Enable force_orphan to reduce clone size by @Xuanwo in https://github.com/apache/opendal/pull/5289
 * docs: Establish VISION for "One Layer, All Storage" by @Xuanwo in https://github.com/apache/opendal/pull/5309
@@ -80,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 * chore(deps): bump anyhow from 1.0.90 to 1.0.93 in /bin/oay by @dependabot in https://github.com/apache/opendal/pull/5375
 * chore(deps): bump serde from 1.0.210 to 1.0.215 in /bin/oli by @dependabot in https://github.com/apache/opendal/pull/5376
 * chore(deps): bump openssh-sftp-client from 0.15.1 to 0.15.2 in /core by @dependabot in https://github.com/apache/opendal/pull/5377
+* chore(ci): fix invalid Behavior Test Integration Cloud Filter trigger by @Zheaoli in https://github.com/apache/opendal/pull/5414
 
 ## [v0.50.2] - 2024-11-04
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #5412 

# What changes are included in this PR?

| Name                      | Version | Next    |
| -                         | -       | -       |
| core                      | 0.50.2  | 0.51.0  |
| integrations/cloud_filter | 0.0.3   | 0.0.4   |
| integrations/compat       |1.0.1      | 1.0.2   |
| integrations/dav-server   | 0.2.2   | 0.2.3   |
| integrations/fuse3        | 0.0.9   | 0.0.10  |
| integrations/object_store | 0.48.2  | 0.48.3  |
| integrations/parquet      | 0.2.2   | 0.2.3   |
| integrations/spring       | -       | -       |
| integrations/unftp-sbe    | 0.0.9   | 0.0.10   |
| integrations/virtiofs     | -       | -       |
| bin/oay                   | 0.41.13 | 0.41.14 |
| bin/ofs                   | 0.0.14  | 0.0.15  |
| bin/oli                   | 0.41.13 | 0.41.14 |
| bindings/c                | 0.45.1 | 0.45.2 |
| bindings/cpp              | 0.45.13 | 0.45.14 |
| bindings/dotnet           | 0.1.11   | 0.1.12  |
| bindings/go               | 0.1.4   | 0.1.5   |
| bindings/haskell          | 0.44.13 | 0.44.14 |
| bindings/java             | 0.47.5  | 0.47.6  |
| bindings/lua              | 0.1.11   | 0.1.12  |
| bindings/nodejs           | 0.47.7  | 0.47.8  |
| bindings/ocaml            | -       | -       |
| bindings/php              | 0.1.11   | 0.1.12  |
| bindings/python           | 0.45.12 | 0.45.13 |
| bindings/ruby             | 0.1.11   | 0.1.12  |
| bindings/swift            | -       | -       |
| bindings/zig              | -       | -       |


