### PR TITLE
fix: always contains path label if configured

### DIFF
--- a/core/src/layers/observe/mod.rs
+++ b/core/src/layers/observe/mod.rs
@@ -51,11 +51,11 @@ pub use metrics::METRIC_OPERATION_ERRORS_TOTAL;
 /// - level > 0: the path label will be the path split by "/" and get the last n level,
 ///   if n=1 and input path is "abc/def/ghi", and then we'll use "abc/" as the path label.
 pub fn path_label_value(path: &str, level: usize) -> Option<&str> {
-    if path.is_empty() {
-        return None;
-    }
-
     if level > 0 {
+        if path.is_empty() {
+            return Some("");
+        }
+
         let label_value = path
             .char_indices()
             .filter(|&(_, c)| c == '/')
@@ -80,6 +80,7 @@ mod tests {
         assert_eq!(path_label_value(path, 3), Some("abc/def/ghi"));
         assert_eq!(path_label_value(path, usize::MAX), Some("abc/def/ghi"));
 
-        assert_eq!(path_label_value("", 1), None);
+        assert_eq!(path_label_value("", 0), None);
+        assert_eq!(path_label_value("", 1), Some(""));
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Grand unstoppable panic after switching to the built-in PrometheusLayer 🥲

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

At least for Prometheus client, we should always provide a label set with the same length. Current implementation will ignore the "path" label if path is empty.

# Are there any user-facing changes?


bugfix

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
