### PR TITLE
ci: disable windows free-thread build

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -85,6 +85,9 @@ jobs:
           sccache: true
           manylinux: auto
       - name: Build free-threaded wheels
+        # windows free-threading building doesn't work on windows
+        # https://github.com/apache/opendal/pull/5449#issuecomment-2560469190
+        if: ${{ runner.os != 'Windows' }}
         uses: PyO3/maturin-action@v1
         with:
           working-directory: "bindings/python"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


# Rationale for this change

free threading build is currently broken on windows

https://github.com/apache/opendal/actions/runs/12470186276
