### PR TITLE
fix: exception name in python

### DIFF
--- a/bindings/python/src/errors.rs
+++ b/bindings/python/src/errors.rs
@@ -20,36 +20,35 @@ use pyo3::exceptions::PyException;
 
 use crate::*;
 
-create_exception!(opendal, Error, PyException, "OpenDAL Base Exception");
-create_exception!(opendal, UnexpectedError, Error, "Unexpected errors");
-create_exception!(opendal, UnsupportedError, Error, "Unsupported operation");
-create_exception!(opendal, ConfigInvalidError, Error, "Config is invalid");
-create_exception!(opendal, NotFoundError, Error, "Not found");
-create_exception!(opendal, PermissionDeniedError, Error, "Permission denied");
-create_exception!(opendal, IsADirectoryError, Error, "Is a directory");
-create_exception!(opendal, NotADirectoryError, Error, "Not a directory");
-create_exception!(opendal, AlreadyExistsError, Error, "Already exists");
-create_exception!(opendal, IsSameFileError, Error, "Is same file");
+create_exception!(opendal.exceptions, Error, PyException, "OpenDAL Base Exception");
+create_exception!(opendal.exceptions, Unexpected, Error, "Unexpected errors");
+create_exception!(opendal.exceptions, Unsupported, Error, "Unsupported operation");
+create_exception!(opendal.exceptions, ConfigInvalid, Error, "Config is invalid");
+create_exception!(opendal.exceptions, NotFound, Error, "Not found");
+create_exception!(opendal.exceptions, PermissionDenied, Error, "Permission denied");
+create_exception!(opendal.exceptions, IsADirectory, Error, "Is a directory");
+create_exception!(opendal.exceptions, NotADirectory, Error, "Not a directory");
+create_exception!(opendal.exceptions, AlreadyExists, Error, "Already exists");
+create_exception!(opendal.exceptions, IsSameFile, Error, "Is same file");
 create_exception!(
-    opendal,
-    ConditionNotMatchError,
+    opendal.exceptions,
+    ConditionNotMatch,
     Error,
     "Condition not match"
 );
 
 pub fn format_pyerr(err: ocore::Error) -> PyErr {
-    use ocore::ErrorKind::*;
     match err.kind() {
-        Unexpected => UnexpectedError::new_err(err.to_string()),
-        Unsupported => UnsupportedError::new_err(err.to_string()),
-        ConfigInvalid => ConfigInvalidError::new_err(err.to_string()),
-        NotFound => NotFoundError::new_err(err.to_string()),
-        PermissionDenied => PermissionDeniedError::new_err(err.to_string()),
-        IsADirectory => IsADirectoryError::new_err(err.to_string()),
-        NotADirectory => NotADirectoryError::new_err(err.to_string()),
-        AlreadyExists => AlreadyExistsError::new_err(err.to_string()),
-        IsSameFile => IsSameFileError::new_err(err.to_string()),
-        ConditionNotMatch => ConditionNotMatchError::new_err(err.to_string()),
-        _ => UnexpectedError::new_err(err.to_string()),
+        ocore::ErrorKind::Unexpected => Unexpected::new_err(err.to_string()),
+        ocore::ErrorKind::Unsupported => Unsupported::new_err(err.to_string()),
+        ocore::ErrorKind::ConfigInvalid => ConfigInvalid::new_err(err.to_string()),
+        ocore::ErrorKind::NotFound => NotFound::new_err(err.to_string()),
+        ocore::ErrorKind::PermissionDenied => PermissionDenied::new_err(err.to_string()),
+        ocore::ErrorKind::IsADirectory => IsADirectory::new_err(err.to_string()),
+        ocore::ErrorKind::NotADirectory => NotADirectory::new_err(err.to_string()),
+        ocore::ErrorKind::AlreadyExists => AlreadyExists::new_err(err.to_string()),
+        ocore::ErrorKind::IsSameFile => IsSameFile::new_err(err.to_string()),
+        ocore::ErrorKind::ConditionNotMatch => ConditionNotMatch::new_err(err.to_string()),
+        _ => Unexpected::new_err(err.to_string()),
     }
 }

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -98,16 +98,16 @@ fn _opendal(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     let exception_module = PyModule::new(py, "exceptions")?;
     exception_module.add("Error", py.get_type::<Error>())?;
-    exception_module.add("Unexpected", py.get_type::<UnexpectedError>())?;
-    exception_module.add("Unsupported", py.get_type::<UnsupportedError>())?;
-    exception_module.add("ConfigInvalid", py.get_type::<ConfigInvalidError>())?;
-    exception_module.add("NotFound", py.get_type::<NotFoundError>())?;
-    exception_module.add("PermissionDenied", py.get_type::<PermissionDeniedError>())?;
-    exception_module.add("IsADirectory", py.get_type::<IsADirectoryError>())?;
-    exception_module.add("NotADirectory", py.get_type::<NotADirectoryError>())?;
-    exception_module.add("AlreadyExists", py.get_type::<AlreadyExistsError>())?;
-    exception_module.add("IsSameFile", py.get_type::<IsSameFileError>())?;
-    exception_module.add("ConditionNotMatch", py.get_type::<ConditionNotMatchError>())?;
+    exception_module.add("Unexpected", py.get_type::<Unexpected>())?;
+    exception_module.add("Unsupported", py.get_type::<Unsupported>())?;
+    exception_module.add("ConfigInvalid", py.get_type::<ConfigInvalid>())?;
+    exception_module.add("NotFound", py.get_type::<NotFound>())?;
+    exception_module.add("PermissionDenied", py.get_type::<PermissionDenied>())?;
+    exception_module.add("IsADirectory", py.get_type::<IsADirectory>())?;
+    exception_module.add("NotADirectory", py.get_type::<NotADirectory>())?;
+    exception_module.add("AlreadyExists", py.get_type::<AlreadyExists>())?;
+    exception_module.add("IsSameFile", py.get_type::<IsSameFile>())?;
+    exception_module.add("ConditionNotMatch", py.get_type::<ConditionNotMatch>())?;
     m.add_submodule(&exception_module)?;
     py.import("sys")?
         .getattr("modules")?

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -102,7 +102,7 @@ impl Operator {
             let w = this.writer(&path).map_err(format_pyerr)?;
             Ok(File::new_writer(w))
         } else {
-            Err(UnsupportedError::new_err(format!(
+            Err(Unsupported::new_err(format!(
                 "OpenDAL doesn't support mode: {mode}"
             )))
         }
@@ -304,7 +304,7 @@ impl AsyncOperator {
                 let w = this.writer(&path).await.map_err(format_pyerr)?;
                 Ok(AsyncFile::new_writer(w))
             } else {
-                Err(UnsupportedError::new_err(format!(
+                Err(Unsupported::new_err(format!(
                     "OpenDAL doesn't support mode: {mode}"
                 )))
             }
@@ -578,9 +578,9 @@ impl PresignedRequest {
             let k = k.as_str();
             let v = v
                 .to_str()
-                .map_err(|err| UnexpectedError::new_err(err.to_string()))?;
+                .map_err(|err| Unexpected::new_err(err.to_string()))?;
             if headers.insert(k, v).is_some() {
-                return Err(UnexpectedError::new_err("duplicate header"));
+                return Err(Unexpected::new_err("duplicate header"));
             }
         }
         Ok(headers)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/opendal/issues/5452

# Rationale for this change


after this patch:

```python
Traceback (most recent call last):
  File "C:\Users\Trim21\proj\test\f.py", line 14, in <module>
    op.read("non-exists-path")
opendal.exceptions.NotFound: NotFound (permanent) at stat, context: { service: redis, path: non-exists-path } => kv doesn't have this path
```

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Yes, name in user exception message

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
