### PR TITLE
fix: python binding kwargs parsing

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -158,6 +158,7 @@ doc = false
 
 [dependencies]
 bytes = "1.5.0"
+dict_derive = "0.6.0"
 futures = "0.3.28"
 # this crate won't be published, we always use the local version
 opendal = { version = ">=0", path = "../../core", features = [

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -118,7 +118,10 @@ impl Operator {
     #[pyo3(signature = (path, bs, **kwargs))]
     pub fn write(&self, path: &str, bs: Vec<u8>, kwargs: Option<WriteOptions>) -> PyResult<()> {
         let kwargs = kwargs.unwrap_or_default();
-        let mut write = self.core.write_with(path, bs).append(kwargs.append);
+        let mut write = self
+            .core
+            .write_with(path, bs)
+            .append(kwargs.append.unwrap_or(false));
         if let Some(chunk) = kwargs.chunk {
             write = write.chunk(chunk);
         }
@@ -333,7 +336,9 @@ impl AsyncOperator {
         let this = self.core.clone();
         let bs = bs.as_bytes().to_vec();
         future_into_py(py, async move {
-            let mut write = this.write_with(&path, bs).append(kwargs.append);
+            let mut write = this
+                .write_with(&path, bs)
+                .append(kwargs.append.unwrap_or(false));
             if let Some(buffer) = kwargs.chunk {
                 write = write.chunk(buffer);
             }

--- a/bindings/python/src/options.rs
+++ b/bindings/python/src/options.rs
@@ -15,12 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use pyo3::{pyclass, FromPyObject};
+use dict_derive::FromPyObject;
+use pyo3::pyclass;
 
 #[pyclass(module = "opendal")]
 #[derive(FromPyObject, Default)]
 pub struct WriteOptions {
-    pub append: bool,
+    pub append: Option<bool>,
     pub chunk: Option<usize>,
     pub content_type: Option<String>,
     pub content_disposition: Option<String>,

--- a/bindings/python/tests/test_write.py
+++ b/bindings/python/tests/test_write.py
@@ -29,7 +29,7 @@ def test_sync_write(service_name, operator, async_operator):
     filename = f"test_file_{str(uuid4())}.txt"
     content = os.urandom(size)
     size = len(content)
-    operator.write(filename, content)
+    operator.write(filename, content, content_type="text/plain")
     metadata = operator.stat(filename)
     assert metadata is not None
     assert metadata.mode.is_file()


### PR DESCRIPTION
# Which issue does this PR close?



<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

kwargs parsing is not correct with default pyo3 derive, it will try to parse from attribute instead of `dict.__getitem__`

```text
Traceback (most recent call last):
  File "C:\Users\Trim21\proj\test\f.py", line 15, in <module>
    print(s3.write("test", b"tc", content_type="text/html"))
AttributeError: 'dict' object has no attribute 'append'
```
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Use `dict_derive` to parse struct from kwargs dict. Didn't find this in pyo3.



another option is to remove `#[pyclass]` from `WriteOptions` and remove `m.add_class::<WriteOptions>()?` which may cause a breaking change and pyo3 doesn't support optional with `#[pyo3(item)]`



<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Yes, `op.write()` not support kwargs.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
