### PR TITLE
feat:add tls support fot memcached

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3814,9 +3814,9 @@ dependencies = [
  "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tower-service",
- "webpki-roots 0.26.6",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -5052,6 +5052,7 @@ dependencies = [
  "reqwest",
  "rocksdb",
  "rust-nebula",
+ "rustls 0.23.15",
  "serde",
  "serde_json",
  "sha1",
@@ -5064,10 +5065,12 @@ dependencies = [
  "surrealdb",
  "tikv-client",
  "tokio",
+ "tokio-rustls 0.26.1",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -6425,7 +6428,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-retry2",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tokio-util",
  "url",
 ]
@@ -6613,7 +6616,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -6621,7 +6624,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.6",
+ "webpki-roots 0.26.7",
  "windows-registry",
 ]
 
@@ -7615,7 +7618,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots 0.26.6",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -8413,12 +8416,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls 0.23.15",
- "rustls-pki-types",
  "tokio",
 ]
 
@@ -8444,9 +8446,9 @@ dependencies = [
  "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tungstenite",
- "webpki-roots 0.26.6",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -8534,7 +8536,7 @@ dependencies = [
  "rustls-pemfile 2.2.0",
  "socket2",
  "tokio",
- "tokio-rustls 0.26.0",
+ "tokio-rustls 0.26.1",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -8889,7 +8891,7 @@ dependencies = [
  "rustls 0.23.15",
  "rustls-pki-types",
  "url",
- "webpki-roots 0.26.6",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -9190,9 +9192,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.6"
+version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -159,7 +159,12 @@ services-ipmfs = []
 services-koofr = []
 services-lakefs = []
 services-libsql = ["dep:hrana-client-proto"]
-services-memcached = ["dep:bb8"]
+services-memcached = [
+    "dep:bb8",
+    "dep:tokio-rustls",
+    "dep:webpki-roots",
+    "dep:rustls",
+]
 services-memory = []
 services-mini-moka = ["dep:mini-moka"]
 services-moka = ["dep:moka"]
@@ -359,6 +364,12 @@ monoio = { version = "0.2.4", optional = true, features = [
     "unlinkat",
     "renameat",
 ] }
+# for services-memcached
+rustls = { version = "0.23.15", default-features = false, features = [
+    "std",
+],  optional = true }
+tokio-rustls = { version = "0.26.1", optional = true }
+webpki-roots = { version = "0.26.7", optional = true }
 
 # Layers
 # for layers-async-backtrace

--- a/core/src/services/memcached/config.rs
+++ b/core/src/services/memcached/config.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::fmt::Debug;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use serde::Deserialize;
@@ -40,4 +41,8 @@ pub struct MemcachedConfig {
     pub password: Option<String>,
     /// The default ttl for put operations.
     pub default_ttl: Option<Duration>,
+    /// default is false
+    pub tls: Option<bool>,
+    /// Path to the CA certificate for TLS verification.
+    pub cafile: Option<PathBuf>,
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5419.

# Rationale for this change
see #5419
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Modified the `opendal::services::Memcached` to support TLS connections.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Users can enable TLS using `.tls()` and provide the CA file using `.cafile().` 
example:
```Rust
let memcached = Memcached::default()
        .endpoint(r#"tcp://example.app.local:11211"#)
        .tls(true)
        .cafile(path);
```

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
