### PR TITLE
fix(ci): Correctly upgrade upload-artifact to v4

### DIFF
--- a/.github/workflows/ci_bindings_nodejs.yml
+++ b/.github/workflows/ci_bindings_nodejs.yml
@@ -257,7 +257,7 @@ jobs:
       - name: Build
         run: ${{ matrix.settings.build }}
         shell: bash
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: bindings-macos-${{ matrix.settings.target }}
           path: bindings/nodejs/*.node


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

Our recent nodejs binding failed to release for macOS platform because the version of `@actions/upload-artifact` is wrong.

# What changes are included in this PR?

Upgrade it correctly.

# Are there any user-facing changes?

No.
