### PR TITLE
feat: Return hinted error for S3 wildcard if-none-match

### DIFF
--- a/core/src/layers/correctness_check.rs
+++ b/core/src/layers/correctness_check.rs
@@ -123,14 +123,14 @@ impl<A: Access> LayeredAccess for CorrectnessAccessor<A> {
             ));
         }
         if let Some(if_none_match) = args.if_none_match() {
-            // AWS S3 supports only wildcard (every resource) matching
-            let is_s3_wildcard_match = self.info.scheme() == Scheme::S3 && if_none_match == "*";
-            if !is_s3_wildcard_match || !capability.write_with_if_none_match {
-                return Err(new_unsupported_error(
-                    self.info.as_ref(),
-                    Operation::Write,
-                    "if_none_match",
-                ));
+            if !capability.write_with_if_none_match {
+                let mut err =
+                    new_unsupported_error(self.info.as_ref(), Operation::Write, "if_none_match");
+                if if_none_match == "*" && capability.write_with_if_not_exists {
+                    err = err.with_context("hint", "use if_not_exists instead");
+                }
+
+                return Err(err);
             }
         }
 
@@ -308,7 +308,7 @@ mod tests {
         }
 
         async fn write(&self, _: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-            Ok((RpWrite::new(), Box::new(())))
+            Ok((RpWrite::new(), Box::new(MockWriter)))
         }
 
         async fn list(&self, _: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
@@ -317,6 +317,22 @@ mod tests {
 
         async fn delete(&self) -> Result<(RpDelete, Self::Deleter)> {
             Ok((RpDelete::default(), Box::new(MockDeleter)))
+        }
+    }
+
+    struct MockWriter;
+
+    impl oio::Write for MockWriter {
+        async fn write(&mut self, _: Buffer) -> Result<()> {
+            Ok(())
+        }
+
+        async fn close(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        async fn abort(&mut self) -> Result<()> {
+            Ok(())
         }
     }
 
@@ -380,6 +396,7 @@ mod tests {
     async fn test_write_with() {
         let op = new_test_operator(Capability {
             write: true,
+            write_with_if_not_exists: true,
             ..Default::default()
         });
         let res = op.write_with("path", "".as_bytes()).append(true).await;
@@ -388,17 +405,31 @@ mod tests {
 
         let res = op
             .write_with("path", "".as_bytes())
-            .if_not_exists(true)
-            .await;
-        assert!(res.is_err());
-        assert_eq!(res.unwrap_err().kind(), ErrorKind::Unsupported);
-
-        let res = op
-            .write_with("path", "".as_bytes())
             .if_none_match("etag")
             .await;
         assert!(res.is_err());
-        assert_eq!(res.unwrap_err().kind(), ErrorKind::Unsupported);
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            "Unsupported (permanent) at write => service memory doesn't support operation write with args if_none_match"
+        );
+
+        // Now try a wildcard if-none-match
+        let res = op
+            .write_with("path", "".as_bytes())
+            .if_none_match("*")
+            .await;
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            "Unsupported (permanent) at write, context: { hint: use if_not_exists instead } => \
+            service memory doesn't support operation write with args if_none_match"
+        );
+
+        let res = op
+            .write_with("path", "".as_bytes())
+            .if_not_exists(true)
+            .await;
+        assert!(res.is_ok());
 
         let op = new_test_operator(Capability {
             write: true,

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -465,7 +465,7 @@ impl S3Core {
             req = req.header(IF_MATCH, if_match);
         }
 
-        if args.if_not_exists() {
+        if args.if_not_exists() || args.if_none_match() == Some("*") {
             req = req.header(IF_NONE_MATCH, "*");
         }
 

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -465,7 +465,7 @@ impl S3Core {
             req = req.header(IF_MATCH, if_match);
         }
 
-        if args.if_not_exists() || args.if_none_match() == Some("*") {
+        if args.if_not_exists() {
             req = req.header(IF_NONE_MATCH, "*");
         }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5505.

# Rationale for this change

Work-around for S3 allowing only wildcard(`*`) if-none-match requests.

# What changes are included in this PR?

Don't error out if the if-none-match argument is a wildcard and the scheme is S3.

Also hook-up the corresponding client argument.

# Are there any user-facing changes?

`if_none_match("*")` and only that should work for S3.
