### PR TITLE
feat(core): implement if_modified_since and if_unmodified_since for stat_with

### DIFF
--- a/core/src/raw/ops.rs
+++ b/core/src/raw/ops.rs
@@ -511,6 +511,8 @@ impl OpReader {
 pub struct OpStat {
     if_match: Option<String>,
     if_none_match: Option<String>,
+    if_modified_since: Option<DateTime<Utc>>,
+    if_unmodified_since: Option<DateTime<Utc>>,
     override_content_type: Option<String>,
     override_cache_control: Option<String>,
     override_content_disposition: Option<String>,
@@ -543,6 +545,28 @@ impl OpStat {
     /// Get If-None-Match from option
     pub fn if_none_match(&self) -> Option<&str> {
         self.if_none_match.as_deref()
+    }
+
+    /// Set the If-Modified-Since of the option
+    pub fn with_if_modified_since(mut self, v: DateTime<Utc>) -> Self {
+        self.if_modified_since = Some(v);
+        self
+    }
+
+    /// Get If-Modified-Since from option
+    pub fn if_modified_since(&self) -> Option<DateTime<Utc>> {
+        self.if_modified_since
+    }
+
+    /// Set the If-Unmodified-Since of the option
+    pub fn with_if_unmodified_since(mut self, v: DateTime<Utc>) -> Self {
+        self.if_unmodified_since = Some(v);
+        self
+    }
+
+    /// Get If-Unmodified-Since from option
+    pub fn if_unmodified_since(&self) -> Option<DateTime<Utc>> {
+        self.if_unmodified_since
     }
 
     /// Sets the content-disposition header that should be sent back by the remote read operation.

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -926,6 +926,8 @@ impl Access for S3Backend {
                 stat_has_content_encoding: true,
                 stat_with_if_match: true,
                 stat_with_if_none_match: true,
+                stat_with_if_modified_since: true,
+                stat_with_if_unmodified_since: true,
                 stat_with_override_cache_control: !self.core.disable_stat_with_override,
                 stat_with_override_content_disposition: !self.core.disable_stat_with_override,
                 stat_with_override_content_type: !self.core.disable_stat_with_override,

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -338,9 +338,21 @@ impl S3Core {
         if let Some(if_none_match) = args.if_none_match() {
             req = req.header(IF_NONE_MATCH, if_none_match);
         }
-
         if let Some(if_match) = args.if_match() {
             req = req.header(IF_MATCH, if_match);
+        }
+
+        if let Some(if_modified_since) = args.if_modified_since() {
+            req = req.header(
+                IF_MODIFIED_SINCE,
+                format_datetime_into_http_date(if_modified_since),
+            );
+        }
+        if let Some(if_unmodified_since) = args.if_unmodified_since() {
+            req = req.header(
+                IF_UNMODIFIED_SINCE,
+                format_datetime_into_http_date(if_unmodified_since),
+            );
         }
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;

--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -70,6 +70,10 @@ pub struct Capability {
     pub stat_with_if_match: bool,
     /// Indicates if conditional stat operations using If-None-Match are supported.
     pub stat_with_if_none_match: bool,
+    /// Indicates if conditional stat operations using If-Modified-Since are supported.
+    pub stat_with_if_modified_since: bool,
+    /// Indicates if conditional stat operations using If-Unmodified-Since are supported.
+    pub stat_with_if_unmodified_since: bool,
     /// Indicates if Cache-Control header override is supported during stat operations.
     pub stat_with_override_cache_control: bool,
     /// Indicates if Content-Disposition header override is supported during stat operations.

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -257,7 +257,7 @@ impl Operator {
     ///
     /// This feature can be used to check if the file's `ETag` matches the given `ETag`.
     ///
-    /// If file exists and it's etag doesn't match, an error with kind [`ErrorKind::ConditionNotMatch`]
+    /// If file exists, and it's etag doesn't match, an error with kind [`ErrorKind::ConditionNotMatch`]
     /// will be returned.
     ///
     /// ```
@@ -276,7 +276,7 @@ impl Operator {
     ///
     /// This feature can be used to check if the file's `ETag` doesn't match the given `ETag`.
     ///
-    /// If file exists and it's etag match, an error with kind [`ErrorKind::ConditionNotMatch`]
+    /// If file exists, and it's etag match, an error with kind [`ErrorKind::ConditionNotMatch`]
     /// will be returned.
     ///
     /// ```
@@ -285,6 +285,46 @@ impl Operator {
     ///
     /// # async fn test(op: Operator, etag: &str) -> Result<()> {
     /// let mut metadata = op.stat_with("path/to/file").if_none_match(etag).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ## `if_modified_since`
+    ///
+    /// set `if_modified_since` for this `stat` request.
+    ///
+    /// This feature can be used to check if the file has been modified since the given time.
+    ///
+    /// If file exists, and it's not modified after the given time, an error with kind [`ErrorKind::ConditionNotMatch`]
+    /// will be returned.
+    ///
+    /// ```
+    /// # use opendal::Result;
+    /// use opendal::Operator;
+    /// use chrono::Utc;
+    ///
+    /// # async fn test(op: Operator) -> Result<()> {
+    /// let mut metadata = op.stat_with("path/to/file").if_modified_since(Utc::now()).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// ## `if_unmodified_since`
+    ///
+    /// set `if_unmodified_since` for this `stat` request.
+    ///
+    /// This feature can be used to check if the file has NOT been modified since the given time.
+    ///
+    /// If file exists, and it's modified after the given time, an error with kind [`ErrorKind::ConditionNotMatch`]
+    /// will be returned.
+    ///
+    /// ```
+    /// # use opendal::Result;
+    /// use opendal::Operator;
+    /// use chrono::Utc;
+    ///
+    /// # async fn test(op: Operator) -> Result<()> {
+    /// let mut metadata = op.stat_with("path/to/file").if_unmodified_since(Utc::now()).await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/core/src/types/operator/operator_futures.rs
+++ b/core/src/types/operator/operator_futures.rs
@@ -104,6 +104,16 @@ impl<F: Future<Output = Result<Metadata>>> FutureStat<F> {
         self.map(|args| args.with_if_none_match(v))
     }
 
+    /// Set the If-Modified-Since for this operation.
+    pub fn if_modified_since(self, v: DateTime<Utc>) -> Self {
+        self.map(|args| args.with_if_modified_since(v))
+    }
+
+    /// Set the If-Unmodified-Since for this operation.
+    pub fn if_unmodified_since(self, v: DateTime<Utc>) -> Self {
+        self.map(|args| args.with_if_unmodified_since(v))
+    }
+
     /// Set the version for this operation.
     pub fn version(self, v: &str) -> Self {
         self.map(|args| args.with_version(v))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
support conditional stat based on modification time.


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes. we can use `stat_with().if_modified_since()` and `stat().if_unmodified_since()` now.


<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
