### PR TITLE
ci: Pin the nightly version to rust 1.84 for fuzz

### DIFF
--- a/.github/actions/fuzz_test/action.yaml
+++ b/.github/actions/fuzz_test/action.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 name: Fuzz Test
-description: 'Fuzz test given setup and service'
+description: "Fuzz test given setup and service"
 inputs:
   setup:
     description: "The setup action for test"
@@ -41,7 +41,7 @@ runs:
           - name: Run Fuzz Test
             shell: bash
             working-directory: core/fuzz
-            run: cargo +nightly fuzz run ${{ inputs.target }} --features services-${{ inputs.service }} -- -max_total_time=120
+            run: cargo +nightly-2024-11-22 fuzz run ${{ inputs.target }} --features services-${{ inputs.service }} -- -max_total_time=120
             env:
               OPENDAL_TEST: ${{ inputs.service }}
         EOF

--- a/.github/workflows/test_fuzz.yml
+++ b/.github/workflows/test_fuzz.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        target: [ "fuzz_reader", "fuzz_writer" ]
+        target: ["fuzz_reader", "fuzz_writer"]
         cases:
           - { service: "memory", setup: "memory" }
           - { service: "fs", setup: "local_fs" }
@@ -54,8 +54,8 @@ jobs:
         shell: bash
         run: |
           sudo apt-get install -y libfuzzer-14-dev
-          rustup install nightly
-          cargo +nightly install cargo-fuzz
+          rustup install nightly-2024-11-22
+          cargo +nightly-2024-11-22 install cargo-fuzz
       - name: Fuzz
         uses: ./.github/actions/fuzz_test
         env:


### PR DESCRIPTION
# Which issue does this PR close?

Workaround for https://github.com/rust-lang/rust/issues/135515

# Rationale for this change

The latest rustc failed to build.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
