### PR TITLE
refactor: refactor some unnecessary clone and use next_back to make clippy happy

### DIFF
--- a/core/benches/vs_s3/src/main.rs
+++ b/core/benches/vs_s3/src/main.rs
@@ -69,7 +69,7 @@ fn bench_read(c: &mut Criterion, op: Operator, s3_client: aws_sdk_s3::Client, bu
     let mut group = c.benchmark_group("read");
     group.throughput(criterion::Throughput::Bytes(16 * 1024 * 1024));
 
-    TEST_RUNTIME.block_on(prepare(op.clone()));
+    TEST_RUNTIME.block_on(prepare(&op));
 
     group.bench_function("opendal_s3_reader", |b| {
         b.to_async(&*TEST_RUNTIME).iter(|| async {
@@ -118,10 +118,10 @@ fn bench_read(c: &mut Criterion, op: Operator, s3_client: aws_sdk_s3::Client, bu
     group.finish()
 }
 
-async fn prepare(op: Operator) {
+async fn prepare(op: &Operator) {
     let mut rng = thread_rng();
     let mut content = vec![0; 16 * 1024 * 1024];
     rng.fill_bytes(&mut content);
 
-    op.write("file", content.clone()).await.unwrap();
+    op.write("file", content).await.unwrap();
 }

--- a/core/src/raw/http_util/header.rs
+++ b/core/src/raw/http_util/header.rs
@@ -129,7 +129,7 @@ where
         .with_operation("http_util::parse_header_to_str")
     })?;
 
-    let value = if let Some(v) = headers.get(name.clone()) {
+    let value = if let Some(v) = headers.get(&name) {
         v
     } else {
         return Ok(None);

--- a/core/src/raw/path.rs
+++ b/core/src/raw/path.rs
@@ -157,7 +157,7 @@ pub fn get_basename(path: &str) -> &str {
     if !path.ends_with('/') {
         return path
             .split('/')
-            .last()
+            .next_back()
             .expect("file path without name is invalid");
     }
 

--- a/core/src/services/azblob/error.rs
+++ b/core/src/services/azblob/error.rs
@@ -76,7 +76,8 @@ pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
         _ => (ErrorKind::Unexpected, false),
     };
 
-    let mut message = match de::from_reader::<_, AzblobError>(bs.clone().reader()) {
+    let bs_content = bs.chunk();
+    let mut message = match de::from_reader::<_, AzblobError>(bs_content.reader()) {
         Ok(azblob_err) => format!("{azblob_err:?}"),
         Err(_) => String::from_utf8_lossy(&bs).into_owned(),
     };

--- a/core/src/services/azblob/error.rs
+++ b/core/src/services/azblob/error.rs
@@ -60,8 +60,8 @@ impl Debug for AzblobError {
 
 /// Parse error response into Error.
 pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
-    let (parts, mut body) = resp.into_parts();
-    let bs = body.copy_to_bytes(body.remaining());
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
 
     let (kind, retryable) = match parts.status {
         StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),

--- a/core/src/services/s3/error.rs
+++ b/core/src/services/s3/error.rs
@@ -37,6 +37,7 @@ pub(crate) struct S3Error {
 /// Parse error response into Error.
 pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
 
     let (mut kind, mut retryable) = match parts.status.as_u16() {
         403 => (ErrorKind::PermissionDenied, false),
@@ -49,10 +50,10 @@ pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
         _ => (ErrorKind::Unexpected, false),
     };
 
-    let body_content = body.chunk();
+    let body_content = bs.chunk();
     let (message, s3_err) = de::from_reader::<_, S3Error>(body_content.reader())
         .map(|s3_err| (format!("{s3_err:?}"), Some(s3_err)))
-        .unwrap_or_else(|_| (String::from_utf8_lossy(body_content).into_owned(), None));
+        .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
 
     if let Some(s3_err) = s3_err {
         (kind, retryable) = parse_s3_error_code(s3_err.code.as_str()).unwrap_or((kind, retryable));


### PR DESCRIPTION
This patch do not close any issues, just drop some un necessary clone to make a little better performance

and only check the `core` for now, if it is useful will check all others dir in separate pull request

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.
 
This patch do not close anything

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

no Rationale for this change

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

using static check to understand if we can drop some clone, and found 4 of them,


# Are there any user-facing changes?

No


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
