### PR TITLE
build: fix Cargo.lock and pass --locked in CI

### DIFF
--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -108,7 +108,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         working-directory: core
-        run: cargo build
+        run: cargo build --locked
 
   build_all_features:
     runs-on: ubuntu-latest
@@ -133,7 +133,7 @@ jobs:
 
       - name: Build
         working-directory: core
-        run: cargo build --all-features
+        run: cargo build --all-features --locked
 
   build_all_platforms:
     runs-on: ${{ matrix.os }}
@@ -213,7 +213,7 @@ jobs:
             services-webdav
             services-webhdfs
           )
-          cargo build --features "${FEATURES[*]}"
+          cargo build --features "${FEATURES[*]}" --locked
 
   # We only support some services(see `available_services` below) for now.
   build_under_wasm:
@@ -233,7 +233,7 @@ jobs:
             services-s3
           )
           rustup target add wasm32-unknown-unknown
-          cargo build --target wasm32-unknown-unknown --no-default-features --features="${FEATURES[*]}"
+          cargo build --target wasm32-unknown-unknown --no-default-features --features="${FEATURES[*]}" --locked
 
   unit:
     runs-on: ubuntu-latest

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -5118,6 +5118,7 @@ dependencies = [
  "mini-moka",
  "moka",
  "mongodb",
+ "mongodb-internal-macros",
  "monoio",
  "once_cell",
  "openssh",


### PR DESCRIPTION

# Which issue does this PR close?

```
> cargo build --locked
error: the lock file /Users/xxchan/Projects/opendal/core/Cargo.lock needs to be updated but --locked was passed to prevent this If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
```

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
