### PR TITLE
feat(bindings/ruby): add operator info

### DIFF
--- a/bindings/ruby/src/lib.rs
+++ b/bindings/ruby/src/lib.rs
@@ -29,6 +29,7 @@ mod io;
 mod lister;
 mod metadata;
 mod operator;
+mod operator_info;
 
 pub fn format_magnus_error(err: ocore::Error) -> Error {
     Error::new(exception::runtime_error(), err.to_string())
@@ -43,6 +44,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     let _ = capability::include(&gem_module);
     let _ = io::include(&gem_module);
     let _ = lister::include(&ruby, &gem_module);
+    let _ = operator_info::include(&gem_module);
 
     Ok(())
 }

--- a/bindings/ruby/src/operator.rs
+++ b/bindings/ruby/src/operator.rs
@@ -40,6 +40,7 @@ use crate::capability::Capability;
 use crate::io::Io;
 use crate::lister::Lister;
 use crate::metadata::Metadata;
+use crate::operator_info::OperatorInfo;
 use crate::*;
 
 /// @yard
@@ -241,6 +242,11 @@ impl Operator {
 
         Ok(Lister::new(lister))
     }
+
+    /// Gets meta information of the underlying accessor.
+    fn info(&self) -> Result<OperatorInfo, Error> {
+        Ok(OperatorInfo(self.0.info()))
+    }
 }
 
 pub fn include(gem_module: &RModule) -> Result<(), Error> {
@@ -258,6 +264,7 @@ pub fn include(gem_module: &RModule) -> Result<(), Error> {
     class.define_method("copy", method!(Operator::copy, 2))?;
     class.define_method("open", method!(Operator::open, 2))?;
     class.define_method("list", method!(Operator::list, -1))?;
+    class.define_method("info", method!(Operator::info, 0))?;
 
     Ok(())
 }

--- a/bindings/ruby/src/operator_info.rs
+++ b/bindings/ruby/src/operator_info.rs
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![allow(
+    rustdoc::broken_intra_doc_links,
+    reason = "YARD's syntax for documentation"
+)]
+
+use magnus::class;
+use magnus::method;
+use magnus::prelude::*;
+use magnus::Error;
+use magnus::RModule;
+
+use crate::capability::Capability;
+use crate::*;
+
+/// Metadata for operator, users can use this metadata to get information of operator.
+#[magnus::wrap(class = "OpenDAL::OperatorInfo", free_immediately, size)]
+pub struct OperatorInfo(pub ocore::OperatorInfo);
+
+impl OperatorInfo {
+    /// @yard
+    /// @def scheme
+    /// Returns the scheme string of the operator.
+    /// @return [String]
+    pub fn scheme(&self) -> &str {
+        self.0.scheme().into()
+    }
+
+    /// @yard
+    /// @def root
+    /// Returns the root path of the operator, will be in format like `/path/to/dir/`
+    /// @return [String]
+    pub fn root(&self) -> String {
+        self.0.root()
+    }
+
+    /// @yard
+    /// @def name
+    /// Returns the name of backend, could be empty if underlying backend doesn't have namespace concept.
+    ///
+    /// For example:
+    ///
+    /// - name for `s3` => bucket name
+    /// - name for `azblob` => container name
+    ///
+    /// @return [String]
+    pub fn name(&self) -> String {
+        self.0.name()
+    }
+
+    /// @yard
+    /// @def capability
+    /// Returns the [`Full Capability`] of the operator.
+    /// @return [Capability]
+    pub fn capability(&self) -> Capability {
+        Capability::new(self.0.full_capability())
+    }
+}
+
+pub fn include(gem_module: &RModule) -> Result<(), Error> {
+    let class = gem_module.define_class("OperatorInfo", class::object())?;
+    class.define_method("scheme", method!(OperatorInfo::scheme, 0))?;
+    class.define_method("root", method!(OperatorInfo::root, 0))?;
+    class.define_method("name", method!(OperatorInfo::name, 0))?;
+    class.define_method("capability", method!(OperatorInfo::capability, 0))?;
+
+    Ok(())
+}

--- a/bindings/ruby/test/operator_info_test.rb
+++ b/bindings/ruby/test/operator_info_test.rb
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# frozen_string_literal: true
+
+require "test_helper"
+
+class OperatorInfoTest < ActiveSupport::TestCase
+  setup do
+    @op = OpenDAL::Operator.new("memory", {})
+  end
+
+  test "returns meta information" do
+    info = @op.info
+
+    assert_equal "memory", info.scheme
+    assert_equal "/", info.root
+    assert info.name.length > 0
+    assert info.capability.stat
+  end
+end


### PR DESCRIPTION
# Which issue does this PR close?

Part of #5227

# What changes are included in this PR?

Add `OperatorInfo`.

# Are there any user-facing changes?

No

# Question

I want to expose what configured layers are in an operator. Is there an API or issue about it? This is not useful in Rust core but is convenient for Python/Ruby users.