### PR TITLE
feat(services-fs): Support write-if-not-exists in fs backend

### DIFF
--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -513,7 +513,7 @@ impl Access for FsBackend {
                         // Map io AlreadyExists to opendal ConditionNotMatch
                         Error::new(
                             ErrorKind::ConditionNotMatch,
-                            ErrorKind::ConditionNotMatch.to_string(),
+                            "The file already exists in the filesystem",
                         )
                         .set_source(e)
                     }

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -187,6 +187,7 @@ impl Access for FsBackend {
                 write_can_empty: true,
                 write_can_append: true,
                 write_can_multi: true,
+                write_with_if_not_exists: true,
                 create_dir: true,
                 delete: true,
 
@@ -470,7 +471,14 @@ impl Access for FsBackend {
         };
 
         let mut f = std::fs::OpenOptions::new();
-        f.create(true).write(true);
+
+        if op.if_not_exists() {
+            f.create_new(true);
+        } else {
+            f.create(true);
+        }
+
+        f.write(true);
 
         if op.append() {
             f.append(true);

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -320,7 +320,19 @@ impl Access for FsBackend {
         let f = open_options
             .open(tmp_path.as_ref().unwrap_or(&target_path))
             .await
-            .map_err(new_std_io_error)?;
+            .map_err(|e| {
+                match e.kind() {
+                    std::io::ErrorKind::AlreadyExists => {
+                        // Map io AlreadyExists to opendal ConditionNotMatch
+                        Error::new(
+                            ErrorKind::ConditionNotMatch,
+                            ErrorKind::ConditionNotMatch.to_string(),
+                        )
+                        .set_source(e)
+                    }
+                    _ => new_std_io_error(e),
+                }
+            })?;
 
         let w = FsWriter::new(target_path, tmp_path, f);
 
@@ -495,7 +507,19 @@ impl Access for FsBackend {
 
         let f = f
             .open(tmp_path.as_ref().unwrap_or(&target_path))
-            .map_err(new_std_io_error)?;
+            .map_err(|e| {
+                match e.kind() {
+                    std::io::ErrorKind::AlreadyExists => {
+                        // Map io AlreadyExists to opendal ConditionNotMatch
+                        Error::new(
+                            ErrorKind::ConditionNotMatch,
+                            ErrorKind::ConditionNotMatch.to_string(),
+                        )
+                        .set_source(e)
+                    }
+                    _ => new_std_io_error(e),
+                }
+            })?;
 
         Ok((RpWrite::new(), FsWriter::new(target_path, tmp_path, f)))
     }

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -303,7 +303,14 @@ impl Access for FsBackend {
         };
 
         let mut open_options = tokio::fs::OpenOptions::new();
-        open_options.create(true).write(true);
+        if op.if_not_exists() {
+            open_options.create_new(true);
+        } else {
+            open_options.create(true);
+        }
+
+        open_options.write(true);
+
         if op.append() {
             open_options.append(true);
         } else {

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -326,7 +326,7 @@ impl Access for FsBackend {
                         // Map io AlreadyExists to opendal ConditionNotMatch
                         Error::new(
                             ErrorKind::ConditionNotMatch,
-                            ErrorKind::ConditionNotMatch.to_string(),
+                            "The file already exists in the filesystem",
                         )
                         .set_source(e)
                     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5606.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Explained in issue

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Explained in issue

# Are there any user-facing changes?

No. Adds support of existing capability for existing backend

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
