### PR TITLE
ci(website): avoid including rc when calculate the latest version

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -56,7 +56,7 @@ const config = {
       }
 
       const refName = exec(
-        "git describe --tags --abbrev=0 --match 'v*'",
+        "git describe --tags --abbrev=0 --match 'v*' --exclude '*rc*'",
       ).toString();
       const version = semver.parse(refName, {}, true);
       return `${version.major}.${version.minor}.${version.patch}`;


### PR DESCRIPTION
This follows up https://github.com/apache/opendal/commit/e15d3147e0d660cda19ec88e5495e5676cd590fc.

Otherwise, when we're under a voting release, the version calculate is wrong. For example,

* When we have `v0.51.3-rc.1` and `v0.51.2`
* The current `git describe --tags --abbrev=0 --match 'v*'` gives `v0.51.3-rc.1`