### PR TITLE
feat(services/gcs): Impl content-encoding support for GCS stat, write and presign

### DIFF
--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -563,7 +563,6 @@ struct GetObjectJsonResponse {
     /// Content encoding of this object
     ///
     /// For example: "contentEncoding": "br"
-    #[serde(default)]
     content_encoding: String,
     /// Custom metadata of this object.
     ///

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -362,6 +362,7 @@ impl Access for GcsBackend {
                 stat_has_content_md5: true,
                 stat_has_content_length: true,
                 stat_has_content_type: true,
+                stat_has_content_encoding: true,
                 stat_has_last_modified: true,
                 stat_has_user_metadata: true,
 
@@ -374,6 +375,7 @@ impl Access for GcsBackend {
                 write_can_empty: true,
                 write_can_multi: true,
                 write_with_content_type: true,
+                write_with_content_encoding: true,
                 write_with_user_metadata: true,
                 write_with_if_not_exists: true,
 
@@ -440,6 +442,12 @@ impl Access for GcsBackend {
         m.set_content_length(size);
         if !meta.content_type.is_empty() {
             m.set_content_type(&meta.content_type);
+        }
+
+        if let Some(content_encoding) = meta.content_encoding.as_ref() {
+            if !content_encoding.is_empty() {
+                m.set_content_encoding(content_encoding);
+            }
         }
 
         m.set_last_modified(parse_datetime_from_rfc3339(&meta.updated)?);
@@ -554,6 +562,10 @@ struct GetObjectJsonResponse {
     ///
     /// For example: `"contentType": "image/png",`
     content_type: String,
+    /// Content encoding of this object
+    ///
+    /// For example: "contentEncoding": "br"
+    content_encoding: Option<String>,
     /// Custom metadata of this object.
     ///
     /// For example: `"metadata" : { "my-key": "my-value" }`

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -444,10 +444,8 @@ impl Access for GcsBackend {
             m.set_content_type(&meta.content_type);
         }
 
-        if let Some(content_encoding) = meta.content_encoding.as_ref() {
-            if !content_encoding.is_empty() {
-                m.set_content_encoding(content_encoding);
-            }
+        if !meta.content_encoding.is_empty() {
+            m.set_content_encoding(&meta.content_encoding);
         }
 
         m.set_last_modified(parse_datetime_from_rfc3339(&meta.updated)?);
@@ -565,7 +563,8 @@ struct GetObjectJsonResponse {
     /// Content encoding of this object
     ///
     /// For example: "contentEncoding": "br"
-    content_encoding: Option<String>,
+    #[serde(default)]
+    content_encoding: String,
     /// Custom metadata of this object.
     ///
     /// For example: `"metadata" : { "my-key": "my-value" }`
@@ -610,7 +609,7 @@ mod tests {
         assert_eq!(meta.md5_hash, "fHcEH1vPwA6eTPqxuasXcg==");
         assert_eq!(meta.etag, "CKWasoTgyPkCEAE=");
         assert_eq!(meta.content_type, "image/png");
-        assert_eq!(meta.content_encoding, Some("br".to_string()));
+        assert_eq!(meta.content_encoding, "br".to_string());
         assert_eq!(
             meta.metadata,
             HashMap::from_iter([("location".to_string(), "everywhere".to_string())])

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -588,6 +588,7 @@ mod tests {
   "generation": "1660563214863653",
   "metageneration": "1",
   "contentType": "image/png",
+  "contentEncoding": "br",
   "storageClass": "STANDARD",
   "size": "56535",
   "md5Hash": "fHcEH1vPwA6eTPqxuasXcg==",
@@ -609,6 +610,7 @@ mod tests {
         assert_eq!(meta.md5_hash, "fHcEH1vPwA6eTPqxuasXcg==");
         assert_eq!(meta.etag, "CKWasoTgyPkCEAE=");
         assert_eq!(meta.content_type, "image/png");
+        assert_eq!(meta.content_encoding, Some("br".to_string()));
         assert_eq!(
             meta.metadata,
             HashMap::from_iter([("location".to_string(), "everywhere".to_string())])

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -24,6 +24,7 @@ use std::time::Duration;
 use backon::ExponentialBuilder;
 use backon::Retryable;
 use bytes::Bytes;
+use http::header::CONTENT_ENCODING;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
 use http::header::HOST;
@@ -267,6 +268,7 @@ impl GcsCore {
             storage_class: self.default_storage_class.as_deref(),
             cache_control: op.cache_control(),
             content_type: op.content_type(),
+            content_encoding: op.content_encoding(),
             metadata: op.user_metadata(),
         };
 
@@ -345,6 +347,11 @@ impl GcsCore {
 
         if let Some(content_type) = args.content_type() {
             req = req.header(CONTENT_TYPE, content_type);
+        }
+
+        // Completely untested at this point
+        if let Some(content_encoding) = args.content_encoding() {
+            req = req.header(CONTENT_ENCODING, content_encoding);
         }
 
         if let Some(acl) = &self.predefined_acl {
@@ -638,6 +645,8 @@ impl GcsCore {
 pub struct InsertRequestMetadata<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     content_type: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content_encoding: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     storage_class: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -349,7 +349,6 @@ impl GcsCore {
             req = req.header(CONTENT_TYPE, content_type);
         }
 
-        // Completely untested at this point
         if let Some(content_encoding) = args.content_encoding() {
             req = req.header(CONTENT_ENCODING, content_encoding);
         }

--- a/core/src/types/operator/operator_futures.rs
+++ b/core/src/types/operator/operator_futures.rs
@@ -200,6 +200,11 @@ impl<F: Future<Output = Result<PresignedRequest>>> FuturePresignWrite<F> {
         self.map(|(args, dur)| (args.with_content_disposition(v), dur))
     }
 
+    /// Set the content encoding of the operation
+    pub fn content_encoding(self, v: &str) -> Self {
+        self.map(|(args, dur)| (args.with_content_encoding(v), dur))
+    }
+
     /// Set the content type of option
     pub fn cache_control(self, v: &str) -> Self {
         self.map(|(args, dur)| (args.with_cache_control(v), dur))


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/5607

# Rationale for this change

Explained in the issue

# What changes are included in this PR?

- Implements `content_encoding` support for Gcs for `stat`, `write` and `presign`.
- Adds `stat_has_content_encoding: true` and `write_with_content_encoding: true` to capabilities of `GcsBackend`
- Added `contentEncoding` check to `test_deserialize_get_object_json_response`

NOTE: I haven't tested `presign` yet with these changes yet, which is why I added `WIP`.

# Are there any user-facing changes?

If the users were relying on `Gcs` service to ignore `content_encoding`, then they might have to update their code.

