### PR TITLE
fix(services/onedrive): fix OneDrive behavior tests

### DIFF
--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -147,12 +147,7 @@ impl Access for OnedriveBackend {
 
             Ok(RpStat::new(meta))
         } else {
-            match status {
-                StatusCode::NOT_FOUND if path.ends_with('/') => {
-                    Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
-                }
-                _ => Err(parse_error(resp)),
-            }
+            Err(parse_error(resp))
         }
     }
 

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -94,6 +94,11 @@ impl Access for OnedriveBackend {
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
+        if path == "/" {
+            // skip, the root path exists in the personal OneDrive.
+            return Ok(RpCreateDir::default());
+        }
+
         let path = build_rooted_abs_path(&self.root, path);
         let path_before_last_slash = get_parent(&path);
         let encoded_path = percent_encode_path(path_before_last_slash);


### PR DESCRIPTION
# Which issue does this PR close?

Per the reviewer comment from #5632.

# Rationale for this change

OpenDAL's OneDrive service doesn't pass the behavior tests.

# What changes are included in this PR?

Bug fixes to conform with the behavior tests.

# Are there any user-facing changes?

No

# Logs

Before:

<details>

<summary>OPENDAL_TEST=onedrive cargo test behavior  --features tests,services-onedrive -- --show-output</summary>

```
   Compiling opendal v0.52.0 (/home/erickg/Dev/opendal/core)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 10.98s
     Running unittests src/lib.rs (target/debug/deps/opendal-9022af4dd162386a)

running 0 tests

successes:

successes:

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 134 filtered out; finished in 0.00s

     Running tests/behavior/main.rs (target/debug/deps/behavior-c8073076fdb6f2e9)

running 102 tests
test behavior::test_delete_with_not_existing_version          ... ok
test behavior::test_delete_with_version                       ... ok
test behavior::test_list_with_start_after                     ... ok
test behavior::test_list_with_versions_and_limit              ... ok
test behavior::test_list_with_versions_and_start_after        ... ok
test behavior::test_list_files_with_deleted                   ... ok
test behavior::test_list_files_with_versions                  ... ok
test behavior::test_reader_with_if_match                      ... ok
test behavior::test_reader_with_if_modified_since             ... ok
test behavior::test_reader_with_if_unmodified_since           ... ok
test behavior::test_read_with_if_match                        ... ok
test behavior::test_read_with_if_none_match                   ... ok
test behavior::test_read_with_if_modified_since               ... ok
test behavior::test_read_with_if_unmodified_since             ... ok
test behavior::test_reader_with_if_none_match                 ... ok
test behavior::test_read_with_override_content_disposition    ... ok
test behavior::test_read_with_override_content_type           ... ok
test behavior::test_read_with_version                         ... ok
test behavior::test_read_with_not_existing_version            ... ok
test behavior::test_read_with_override_cache_control          ... ok
  2025-02-22T22:36:16.349812Z ERROR opendal::services: service=onedrive name= path=/: create_dir failed Unexpected (permanent) at create_dir => {"error":{"code":"BadRequest","message":"Resource not found for the segment 'root:'.","innerError":{"date":"2025-02-22T22:36:16","request-id":"90b73b9f-9617-4d2f-a74e-be03f1dc9dbe","client-request-id":"90b73b9f-9617-4d2f-a74e-be03f1dc9dbe"}}}

Context:
   uri: https://graph.microsoft.com/v1.0/me/drive/root:/:/children
   response: Parts { status: 400, version: HTTP/1.1, headers: {"transfer-encoding": "chunked", "content-type": "application/json", "strict-transport-security": "max-age=31536000", "request-id": "90b73b9f-9617-4d2f-a74e-be03f1dc9dbe", "client-request-id": "90b73b9f-9617-4d2f-a74e-be03f1dc9dbe", "x-ms-ags-diagnostic": "{\"ServerInfo\":{\"DataCenter\":\"Sweden Central\",\"Slice\":\"E\",\"Ring\":\"3\",\"ScaleUnit\":\"000\",\"RoleInstance\":\"GVX0EPF00007A19\"}}", "date": "Sat, 22 Feb 2025 22:36:16 GMT"} }
   service: onedrive
   path: /

    at src/layers/logging.rs:194

test behavior::test_list_root_with_recursive                  ... FAILED
test behavior::test_list_non_exist_dir                        ... ok
test behavior::test_delete_not_existing                       ... ok
test behavior::test_stat_with_if_match                        ... ok
test behavior::test_stat_with_if_none_match                   ... ok
test behavior::test_stat_with_if_modified_since               ... ok
test behavior::test_stat_with_if_unmodified_since             ... ok
test behavior::test_stat_with_override_cache_control          ... ok
test behavior::test_stat_with_override_content_disposition    ... ok
test behavior::test_stat_with_override_content_type           ... ok
test behavior::test_stat_root                                 ... ok
test behavior::test_stat_with_version                         ... ok
test behavior::stat_with_not_existing_version                 ... ok
test behavior::test_check                                     ... ok
test behavior::test_write_with_empty_content                  ... ok
test behavior::test_write_with_dir_path                       ... ok
test behavior::test_read_not_exist                            ... ok
test behavior::test_write_with_cache_control                  ... ok
test behavior::test_write_with_content_type                   ... ok
test behavior::test_write_with_content_disposition            ... ok
test behavior::test_write_with_content_encoding               ... ok
test behavior::test_write_with_if_none_match                  ... ok
test behavior::test_write_with_if_not_exists                  ... ok
test behavior::test_write_with_if_match                       ... ok
test behavior::test_write_with_user_metadata                  ... ok
test behavior::test_read_with_dir_path                        ... ok
test behavior::test_writer_write                              ... ok
thread '<unnamed>' panicked at tests/behavior/async_stat.rs:181:9:
assertion failed: meta.is_err()
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test behavior::test_stat_not_exist                            ... FAILED
test behavior::test_writer_write_with_concurrent              ... ok
test behavior::test_writer_sink                               ... ok
test behavior::test_writer_sink_with_concurrent               ... ok
thread '<unnamed>' panicked at tests/behavior/async_list.rs:157:5:
assertion `left == right` failed: only return the dir itself, but found: {}
  left: 0
 right: 1
test behavior::test_list_empty_dir                            ... FAILED
test behavior::test_create_dir_existing                       ... ok
test behavior::test_writer_futures_copy                       ... ok
test behavior::test_writer_futures_copy_with_concurrent       ... ok
test behavior::test_writer_return_metadata                    ... ok
test behavior::test_writer_abort                              ... ok
test behavior::test_delete_empty_dir                          ... ok
test behavior::test_stat_not_cleaned_path                     ... ok
test behavior::test_writer_abort_with_concurrent              ... ok
test behavior::test_list_sub_dir                              ... ok
test behavior::test_create_dir                                ... ok
test behavior::test_blocking_read_not_exist                   ... ok
test behavior::test_read_full                                 ... ok
test behavior::test_stat_nested_parent_dir                    ... ok
test behavior::test_stat_dir                                  ... ok
test behavior::test_blocking_create_dir_existing              ... ok
test behavior::test_blocking_stat_not_exist                   ... ok
test behavior::test_blocking_write_with_dir_path              ... ok
test behavior::test_blocking_create_dir                       ... ok
test behavior::test_delete_file                               ... ok
test behavior::test_stat_file                                 ... ok
test behavior::test_write_returns_metadata                    ... ok
test behavior::test_stat_with_special_chars                   ... ok
test behavior::test_blocking_stat_dir                         ... ok
test behavior::test_delete_with_special_chars                 ... ok
test behavior::test_blocking_stat_file                        ... ok
test behavior::test_read_with_special_chars                   ... ok
test behavior::test_write_with_special_chars                  ... ok
test behavior::test_blocking_write_file                       ... ok
test behavior::test_reader                                    ... ok
test behavior::test_write_only                                ... ok
test behavior::test_list_file_with_recursive                  ... ok
test behavior::test_read_range                                ... ok
test behavior::test_list_dir                                  ... ok
test behavior::test_blocking_remove_one_file                  ... ok
thread '<unnamed>' panicked at tests/behavior/async_list.rs:287:5:
assertion `left == right` failed: parent should got 2 entry
  left: 1
 right: 2
test behavior::test_list_nested_dir                           ... FAILED
test behavior::test_blocking_delete_file                      ... ok
test behavior::test_list_prefix                               ... ok
test behavior::test_blocking_stat_with_special_chars          ... ok
test behavior::test_list_dir_with_file_path                   ... ok
test behavior::test_blocking_write_returns_metadata           ... ok
test behavior::test_blocking_write_with_special_chars         ... ok
test behavior::test_remove_one_file                           ... ok
test behavior::test_list_dir_with_recursive                   ... ok
test behavior::test_blocking_read_range                       ... ok
test behavior::test_blocking_read_full                        ... ok
test behavior::test_writer_write_with_overwrite               ... ok
test behavior::test_list_dir_with_recursive_no_trailing_slash ... ok
thread '<unnamed>' panicked at tests/behavior/async_list.rs:139:5:
assertion `left == right` failed
  left: ["test_list_rich_dir/file-0", "test_list_rich_dir/file-1", "test_list_rich_dir/file-10", "test_list_rich_dir/file-2", "test_list_rich_dir/file-3", "test_list_rich_dir/file-4", "test_list_rich_dir/file-5", "test_list_rich_dir/file-6", "test_list_rich_dir/file-7", "test_list_rich_dir/file-8", "test_list_rich_dir/file-9"]
 right: ["test_list_rich_dir/", "test_list_rich_dir/file-0", "test_list_rich_dir/file-1", "test_list_rich_dir/file-10", "test_list_rich_dir/file-2", "test_list_rich_dir/file-3", "test_list_rich_dir/file-4", "test_list_rich_dir/file-5", "test_list_rich_dir/file-6", "test_list_rich_dir/file-7", "test_list_rich_dir/file-8", "test_list_rich_dir/file-9"]
test behavior::test_list_rich_dir                             ... FAILED
test behavior::test_remove_all                                ... ok
test behavior::test_delete_stream                             ... ok

failures:

---- behavior::test_list_root_with_recursive ----
Unexpected (persistent) at create_dir, context: { uri: https://graph.microsoft.com/v1.0/me/drive/root:/:/children, response: Parts { status: 400, version: HTTP/1.1, headers: {"transfer-encoding": "chunked", "content-type": "application/json", "strict-transport-security": "max-age=31536000", "request-id": "90b73b9f-9617-4d2f-a74e-be03f1dc9dbe", "client-request-id": "90b73b9f-9617-4d2f-a74e-be03f1dc9dbe", "x-ms-ags-diagnostic": "{\"ServerInfo\":{\"DataCenter\":\"Sweden Central\",\"Slice\":\"E\",\"Ring\":\"3\",\"ScaleUnit\":\"000\",\"RoleInstance\":\"GVX0EPF00007A19\"}}", "date": "Sat, 22 Feb 2025 22:36:16 GMT"} }, service: onedrive, path: / } => {"error":{"code":"BadRequest","message":"Resource not found for the segment 'root:'.","innerError":{"date":"2025-02-22T22:36:16","request-id":"90b73b9f-9617-4d2f-a74e-be03f1dc9dbe","client-request-id":"90b73b9f-9617-4d2f-a74e-be03f1dc9dbe"}}}

---- behavior::test_stat_not_exist ----
test panicked: assertion failed: meta.is_err()

---- behavior::test_list_empty_dir ----
test panicked: assertion `left == right` failed: only return the dir itself, but found: {}
  left: 0
 right: 1

---- behavior::test_list_nested_dir ----
test panicked: assertion `left == right` failed: parent should got 2 entry
  left: 1
 right: 2

---- behavior::test_list_rich_dir ----
test panicked: assertion `left == right` failed
  left: ["test_list_rich_dir/file-0", "test_list_rich_dir/file-1", "test_list_rich_dir/file-10", "test_list_rich_dir/file-2", "test_list_rich_dir/file-3", "test_list_rich_dir/file-4", "test_list_rich_dir/file-5", "test_list_rich_dir/file-6", "test_list_rich_dir/file-7", "test_list_rich_dir/file-8", "test_list_rich_dir/file-9"]
 right: ["test_list_rich_dir/", "test_list_rich_dir/file-0", "test_list_rich_dir/file-1", "test_list_rich_dir/file-10", "test_list_rich_dir/file-2", "test_list_rich_dir/file-3", "test_list_rich_dir/file-4", "test_list_rich_dir/file-5", "test_list_rich_dir/file-6", "test_list_rich_dir/file-7", "test_list_rich_dir/file-8", "test_list_rich_dir/file-9"]


failures:
    behavior::test_list_root_with_recursive
    behavior::test_stat_not_exist
    behavior::test_list_empty_dir
    behavior::test_list_nested_dir
    behavior::test_list_rich_dir

test result: FAILED. 97 passed; 5 failed; 0 ignored; 0 measured; 0 filtered out; finished in 37.43s
```

</details>


After:

<details>

<summary>OPENDAL_TEST=onedrive cargo test behavior  --features tests,services-onedrive -- --show-output</summary>

```
   Compiling opendal v0.52.0 (/home/erickg/Dev/opendal/core)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 7.39s
     Running unittests src/lib.rs (target/debug/deps/opendal-9022af4dd162386a)

running 0 tests

successes:

successes:

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 134 filtered out; finished in 0.00s

     Running tests/behavior/main.rs (target/debug/deps/behavior-c8073076fdb6f2e9)

running 102 tests
test behavior::test_delete_with_not_existing_version          ... ok
test behavior::test_delete_with_version                       ... ok
test behavior::test_list_with_start_after                     ... ok
test behavior::test_list_files_with_versions                  ... ok
test behavior::test_list_with_versions_and_limit              ... ok
test behavior::test_list_with_versions_and_start_after        ... ok
test behavior::test_list_files_with_deleted                   ... ok
test behavior::test_reader_with_if_none_match                 ... ok
test behavior::test_reader_with_if_modified_since             ... ok
test behavior::test_reader_with_if_unmodified_since           ... ok
test behavior::test_reader_with_if_match                      ... ok
test behavior::test_read_with_if_modified_since               ... ok
test behavior::test_read_with_if_unmodified_since             ... ok
test behavior::test_read_with_override_content_disposition    ... ok
test behavior::test_read_with_override_content_type           ... ok
test behavior::test_read_with_if_match                        ... ok
test behavior::test_read_with_not_existing_version            ... ok
test behavior::test_read_with_version                         ... ok
test behavior::test_read_with_override_cache_control          ... ok
test behavior::test_read_with_if_none_match                   ... ok
test behavior::test_read_not_exist                            ... ok
test behavior::test_check                                     ... ok
test behavior::test_list_non_exist_dir                        ... ok
test behavior::test_stat_with_if_match                        ... ok
test behavior::test_stat_with_if_none_match                   ... ok
test behavior::test_stat_with_if_modified_since               ... ok
test behavior::test_stat_with_if_unmodified_since             ... ok
test behavior::test_stat_with_override_cache_control          ... ok
test behavior::test_stat_with_override_content_disposition    ... ok
test behavior::test_stat_with_override_content_type           ... ok
test behavior::test_stat_root                                 ... ok
test behavior::test_stat_with_version                         ... ok
test behavior::stat_with_not_existing_version                 ... ok
test behavior::test_delete_not_existing                       ... ok
test behavior::test_write_with_empty_content                  ... ok
test behavior::test_write_with_dir_path                       ... ok
test behavior::test_list_root_with_recursive                  ... ok
test behavior::test_write_with_cache_control                  ... ok
test behavior::test_write_with_content_type                   ... ok
test behavior::test_write_with_content_disposition            ... ok
test behavior::test_write_with_content_encoding               ... ok
test behavior::test_write_with_if_none_match                  ... ok
test behavior::test_write_with_if_not_exists                  ... ok
test behavior::test_write_with_if_match                       ... ok
test behavior::test_write_with_user_metadata                  ... ok
test behavior::test_stat_not_exist                            ... ok
test behavior::test_writer_write                              ... ok
test behavior::test_create_dir                                ... ok
test behavior::test_writer_write_with_concurrent              ... ok
test behavior::test_writer_sink                               ... ok
test behavior::test_writer_sink_with_concurrent               ... ok
test behavior::test_read_with_dir_path                        ... ok
test behavior::test_delete_empty_dir                          ... ok
test behavior::test_writer_futures_copy                       ... ok
test behavior::test_writer_futures_copy_with_concurrent       ... ok
test behavior::test_writer_return_metadata                    ... ok
test behavior::test_writer_abort                              ... ok
test behavior::test_writer_abort_with_concurrent              ... ok
test behavior::test_create_dir_existing                       ... ok
test behavior::test_stat_dir                                  ... ok
test behavior::test_blocking_create_dir                       ... ok
test behavior::test_list_sub_dir                              ... ok
test behavior::test_blocking_read_not_exist                   ... ok
test behavior::test_read_with_special_chars                   ... ok
test behavior::test_read_full                                 ... ok
test behavior::test_blocking_create_dir_existing              ... ok
test behavior::test_blocking_stat_not_exist                   ... ok
test behavior::test_stat_with_special_chars                   ... ok
test behavior::test_read_range                                ... ok
test behavior::test_stat_nested_parent_dir                    ... ok
test behavior::test_write_with_special_chars                  ... ok
test behavior::test_list_file_with_recursive                  ... ok
test behavior::test_write_only                                ... ok
test behavior::test_write_returns_metadata                    ... ok
test behavior::test_blocking_write_with_dir_path              ... ok
test behavior::test_blocking_stat_dir                         ... ok
test behavior::test_list_dir_with_file_path                   ... ok
test behavior::test_stat_file                                 ... ok
test behavior::test_remove_one_file                           ... ok
test behavior::test_delete_file                               ... ok
test behavior::test_list_dir                                  ... ok
test behavior::test_blocking_delete_file                      ... ok
test behavior::test_list_prefix                               ... ok
test behavior::test_delete_with_special_chars                 ... ok
test behavior::test_blocking_stat_file                        ... ok
test behavior::test_blocking_read_range                       ... ok
test behavior::test_blocking_stat_with_special_chars          ... ok
test behavior::test_blocking_write_returns_metadata           ... ok
test behavior::test_stat_not_cleaned_path                     ... ok
test behavior::test_blocking_write_file                       ... ok
test behavior::test_blocking_remove_one_file                  ... ok
test behavior::test_blocking_write_with_special_chars         ... ok
test behavior::test_list_nested_dir                           ... ok
test behavior::test_blocking_read_full                        ... ok
test behavior::test_list_dir_with_recursive_no_trailing_slash ... ok
test behavior::test_list_dir_with_recursive                   ... ok
test behavior::test_reader                                    ... ok
test behavior::test_writer_write_with_overwrite               ... ok
test behavior::test_list_empty_dir                            ... ok
test behavior::test_remove_all                                ... ok
test behavior::test_list_rich_dir                             ... ok
test behavior::test_delete_stream                             ... ok

test result: ok. 102 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 40.41s
```

</details>