### PR TITLE
feat(java): add WriteOptions for write methods

### DIFF
--- a/bindings/java/src/convert.rs
+++ b/bindings/java/src/convert.rs
@@ -69,6 +69,24 @@ pub(crate) fn string_to_jstring<'a>(
     )
 }
 
+pub(crate) fn get_optional_string_from_object<'a>(env: &mut JNIEnv<'a>, obj: &JObject, method: &str) -> crate::Result<Option<String>> {
+    let result = env.call_method(obj, method, "()Ljava/lang/String;", &[])?.l()?;
+    if result.is_null() {
+        Ok(None)
+    } else {
+        Ok(Some(jstring_to_string(env, &JString::from(result))?))
+    }
+}
+
+pub(crate) fn get_optional_map_from_object<'a>(env: &mut JNIEnv<'a>, obj: &JObject, method: &str) -> crate::Result<Option<HashMap<String, String>>> {
+    let result = env.call_method(obj, method, "()Ljava/util/Map;", &[])?.l()?;
+    if result.is_null() {
+        Ok(None)
+    } else {
+        Ok(Some(jmap_to_hashmap(env, &result)?))
+    }
+}
+
 /// # Safety
 ///
 /// The caller must guarantee that the Object passed in is an instance

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -94,7 +94,7 @@ fn make_operator_info<'a>(env: &mut JNIEnv<'a>, info: OperatorInfo) -> Result<JO
 fn make_capability<'a>(env: &mut JNIEnv<'a>, cap: Capability) -> Result<JObject<'a>> {
     let capability = env.new_object(
         "org/apache/opendal/Capability",
-        "(ZZZZZZZZZZZZZZZJJZZZZZZZZZZZZZZ)V",
+        "(ZZZZZZZZZZZZZZZZZZZJJZZZZZZZZZZZZZZ)V",
         &[
             JValue::Bool(cap.stat as jboolean),
             JValue::Bool(cap.stat_with_if_match as jboolean),
@@ -111,6 +111,10 @@ fn make_capability<'a>(env: &mut JNIEnv<'a>, cap: Capability) -> Result<JObject<
             JValue::Bool(cap.write_with_content_type as jboolean),
             JValue::Bool(cap.write_with_content_disposition as jboolean),
             JValue::Bool(cap.write_with_cache_control as jboolean),
+            JValue::Bool(cap.write_with_if_match as jboolean),
+            JValue::Bool(cap.write_with_if_none_match as jboolean),
+            JValue::Bool(cap.write_with_if_not_exists as jboolean),
+            JValue::Bool(cap.write_with_user_metadata as jboolean),
             JValue::Long(convert::usize_to_jlong(cap.write_multi_max_size)),
             JValue::Long(convert::usize_to_jlong(cap.write_multi_min_size)),
             JValue::Bool(cap.create_dir as jboolean),

--- a/bindings/java/src/main/java/org/apache/opendal/AsyncOperator.java
+++ b/bindings/java/src/main/java/org/apache/opendal/AsyncOperator.java
@@ -190,11 +190,22 @@ public class AsyncOperator extends NativeObject {
     }
 
     public CompletableFuture<Void> write(String path, String content) {
-        return write(path, content.getBytes(StandardCharsets.UTF_8));
+        return write(
+                path,
+                content.getBytes(StandardCharsets.UTF_8),
+                WriteOptions.builder().build());
     }
 
     public CompletableFuture<Void> write(String path, byte[] content) {
-        final long requestId = write(nativeHandle, executorHandle, path, content);
+        return write(path, content, WriteOptions.builder().build());
+    }
+
+    public CompletableFuture<Void> write(String path, String content, WriteOptions options) {
+        return write(path, content.getBytes(StandardCharsets.UTF_8), options);
+    }
+
+    public CompletableFuture<Void> write(String path, byte[] content, WriteOptions options) {
+        final long requestId = write(nativeHandle, executorHandle, path, content, options);
         return AsyncRegistry.take(requestId);
     }
 
@@ -272,7 +283,8 @@ public class AsyncOperator extends NativeObject {
 
     private static native long read(long nativeHandle, long executorHandle, String path);
 
-    private static native long write(long nativeHandle, long executorHandle, String path, byte[] content);
+    private static native long write(
+            long nativeHandle, long executorHandle, String path, byte[] content, WriteOptions options);
 
     private static native long append(long nativeHandle, long executorHandle, String path, byte[] content);
 

--- a/bindings/java/src/main/java/org/apache/opendal/Capability.java
+++ b/bindings/java/src/main/java/org/apache/opendal/Capability.java
@@ -99,6 +99,27 @@ public class Capability {
     public final boolean writeWithCacheControl;
 
     /**
+     * If operator supports write with if match.
+     */
+    public final boolean writeWithIfMatch;
+
+    /**
+     * If operator supports write with if none match.
+     *
+     */
+    public final boolean writeWithIfNoneMatch;
+
+    /**
+     * If operator supports write with if not exists.
+     */
+    public final boolean writeWithIfNotExists;
+
+    /**
+     * If operator supports write with user metadata.
+     */
+    public final boolean writeWithUserMetadata;
+
+    /**
      * write_multi_max_size is the max size that services support in write_multi.
      * For example, AWS S3 supports 5GiB as max in write_multi.
      */
@@ -196,6 +217,10 @@ public class Capability {
             boolean writeWithContentType,
             boolean writeWithContentDisposition,
             boolean writeWithCacheControl,
+            boolean writeWithIfMatch,
+            boolean writeWithIfNoneMatch,
+            boolean writeWithIfNotExists,
+            boolean writeWithUserMetadata,
             long writeMultiMaxSize,
             long writeMultiMinSize,
             boolean createDir,
@@ -227,6 +252,10 @@ public class Capability {
         this.writeWithContentType = writeWithContentType;
         this.writeWithContentDisposition = writeWithContentDisposition;
         this.writeWithCacheControl = writeWithCacheControl;
+        this.writeWithIfMatch = writeWithIfMatch;
+        this.writeWithIfNoneMatch = writeWithIfNoneMatch;
+        this.writeWithIfNotExists = writeWithIfNotExists;
+        this.writeWithUserMetadata = writeWithUserMetadata;
         this.writeMultiMaxSize = writeMultiMaxSize;
         this.writeMultiMinSize = writeMultiMinSize;
         this.createDir = createDir;

--- a/bindings/java/src/main/java/org/apache/opendal/Operator.java
+++ b/bindings/java/src/main/java/org/apache/opendal/Operator.java
@@ -76,7 +76,15 @@ public class Operator extends NativeObject {
     }
 
     public void write(String path, byte[] content) {
-        write(nativeHandle, path, content);
+        write(nativeHandle, path, content, WriteOptions.builder().build());
+    }
+
+    public void write(String path, String content, WriteOptions options) {
+        write(path, content.getBytes(StandardCharsets.UTF_8), options);
+    }
+
+    public void write(String path, byte[] content, WriteOptions options) {
+        write(nativeHandle, path, content, options);
     }
 
     public OperatorOutputStream createOutputStream(String path) {
@@ -128,7 +136,7 @@ public class Operator extends NativeObject {
 
     private static native long duplicate(long op);
 
-    private static native void write(long op, String path, byte[] content);
+    private static native void write(long op, String path, byte[] content, WriteOptions options);
 
     private static native byte[] read(long op, String path);
 

--- a/bindings/java/src/main/java/org/apache/opendal/WriteOptions.java
+++ b/bindings/java/src/main/java/org/apache/opendal/WriteOptions.java
@@ -1,0 +1,69 @@
+package org.apache.opendal;
+
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class WriteOptions {
+
+    /**
+     * Sets the Content-Type header for the object.
+     * Requires capability: writeWithContentType
+     */
+    private String contentType;
+
+    /**
+     * Sets the Content-Disposition header for the object
+     * Requires capability: writeWithContentDisposition
+     */
+    private String contentDisposition;
+
+    /**
+     * Sets the Cache-Control header for the object
+     * Requires capability: writeWithCacheControl
+     */
+    private String cacheControl;
+
+    /**
+     * Sets the Content-Encoding header for the object
+     */
+    private String contentEncoding;
+
+    /**
+     * Sets the If-Match header for conditional writes
+     * Requires capability: writeWithIfMatch
+     */
+    private String ifMatch;
+
+    /**
+     * Sets the If-None-Match header for conditional writes
+     * Requires capability: writeWithIfNoneMatch
+     */
+    private String ifNoneMatch;
+
+    /**
+     * Sets custom metadata for the file.
+     * Requires capability: writeWithUserMetadata
+     */
+    private Map<String, String> userMetadata;
+
+    /**
+     * Enables append mode for writing.
+     * When true, data will be appended to the end of existing file.
+     * Requires capability: writeCanAppend
+     */
+    private boolean append;
+
+    /**
+     * Write only if the file does not exist.
+     * Operation will fail if the file at the designated path already exists.
+     * Requires capability: writeWithIfNotExists
+     */
+    private boolean ifNotExists;
+}

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncWriteOptionsTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncWriteOptionsTest.java
@@ -1,0 +1,97 @@
+package org.apache.opendal.test.behavior;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import java.util.UUID;
+import org.apache.opendal.OpenDALException.Code;
+import org.apache.opendal.WriteOptions;
+import org.apache.opendal.test.condition.OpenDALExceptionCondition;
+import org.junit.jupiter.api.Test;
+
+public class AsyncWriteOptionsTest extends BehaviorTestBase {
+
+    @Test
+    void testIfNotExists() {
+        assumeTrue(asyncOp().info.fullCapability.writeWithIfNotExists);
+        final String path = UUID.randomUUID().toString();
+        final byte[] content = generateBytes();
+        WriteOptions options = WriteOptions.builder().ifNotExists(true).build();
+        asyncOp().write(path, content, options).join();
+
+        assertThatThrownBy(() -> asyncOp().write(path, content, options).join())
+                .is(OpenDALExceptionCondition.ofAsync(Code.ConditionNotMatch));
+    }
+
+    @Test
+    void testWriteWithCacheControl() {
+        assumeTrue(asyncOp().info.fullCapability.writeWithCacheControl);
+        final String path = UUID.randomUUID().toString();
+        final byte[] content = generateBytes();
+        final String cacheControl = "max-age=3600";
+
+        WriteOptions options = WriteOptions.builder().cacheControl(cacheControl).build();
+
+        asyncOp().write(path, content, options).join();
+
+        String actualCacheControl = asyncOp().stat(path).join().getCacheControl();
+        assertThat(actualCacheControl).isEqualTo(cacheControl);
+    }
+
+    @Test
+    void testWriteWithIfNoneMatch() {
+        assumeTrue(asyncOp().info.fullCapability.writeWithIfNoneMatch);
+        final String path = UUID.randomUUID().toString();
+        final byte[] content = generateBytes();
+
+        asyncOp().write(path, content).join();
+        String etag = asyncOp().stat(path).join().getEtag();
+
+        WriteOptions options = WriteOptions.builder().ifNoneMatch(etag).build();
+
+        assertThatThrownBy(() -> asyncOp().write(path, content, options).join())
+                .is(OpenDALExceptionCondition.ofAsync(Code.ConditionNotMatch));
+    }
+
+    @Test
+    void testWriteWithIfMatch() {
+        assumeTrue(asyncOp().info.fullCapability.writeWithIfMatch);
+
+        final String pathA = UUID.randomUUID().toString();
+        final String pathB = UUID.randomUUID().toString();
+        final byte[] contentA = generateBytes();
+        final byte[] contentB = generateBytes();
+
+        asyncOp().write(pathA, contentA).join();
+        asyncOp().write(pathB, contentB).join();
+
+        String etagA = asyncOp().stat(pathA).join().getEtag();
+        String etagB = asyncOp().stat(pathB).join().getEtag();
+
+        WriteOptions optionsA = WriteOptions.builder().ifMatch(etagA).build();
+
+        asyncOp().write(pathA, contentA, optionsA).join();
+
+        WriteOptions optionsB = WriteOptions.builder().ifMatch(etagB).build();
+
+        assertThatThrownBy(() -> asyncOp().write(pathA, contentA, optionsB).join())
+                .is(OpenDALExceptionCondition.ofAsync(Code.ConditionNotMatch));
+    }
+
+    @Test
+    void testWriteWithAppend() {
+        assumeTrue(asyncOp().info.fullCapability.writeCanAppend);
+
+        final String path = UUID.randomUUID().toString();
+        final byte[] contentOne = "Test".getBytes();
+        final byte[] contentTwo = " Data".getBytes();
+        asyncOp().write(path, contentOne).join();
+
+        WriteOptions appendOptions = WriteOptions.builder().append(true).build();
+        asyncOp().write(path, contentTwo, appendOptions);
+
+        byte[] result = asyncOp().read(path).join();
+        assertThat(result.length).isEqualTo(contentOne.length + contentTwo.length);
+        assertThat(result).isEqualTo("Test Data".getBytes());
+    }
+}

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingWriteOptionTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingWriteOptionTest.java
@@ -1,0 +1,73 @@
+package org.apache.opendal.test.behavior;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import java.util.UUID;
+import org.apache.opendal.WriteOptions;
+import org.junit.jupiter.api.Test;
+
+public class BlockingWriteOptionTest extends BehaviorTestBase {
+
+    @Test
+    void testWriteWithCacheControl() {
+        assumeTrue(op().info.fullCapability.writeWithCacheControl);
+
+        final String path = UUID.randomUUID().toString();
+        final byte[] content = generateBytes();
+        final String cacheControl = "max-age=3600";
+
+        WriteOptions options = WriteOptions.builder().cacheControl(cacheControl).build();
+        op().write(path, content, options);
+
+        String actualCacheControl = op().stat(path).getCacheControl();
+        assertThat(actualCacheControl).isEqualTo(cacheControl);
+    }
+
+    @Test
+    void testWriteWithContentType() {
+        assumeTrue(op().info.fullCapability.writeWithContentType);
+
+        final String path = UUID.randomUUID().toString();
+        final byte[] content = generateBytes();
+        final String contentType = "application/json";
+
+        WriteOptions options = WriteOptions.builder().contentType(contentType).build();
+        op().write(path, content, options);
+
+        String actualContentType = op().stat(path).getContentType();
+        assertThat(actualContentType).isEqualTo(contentType);
+    }
+
+    @Test
+    void testWriteWithContentDisposition() {
+        assumeTrue(op().info.fullCapability.writeWithContentDisposition);
+
+        final String path = UUID.randomUUID().toString();
+        final byte[] content = generateBytes();
+        final String disposition = "attachment; filename=\"test.txt\"";
+
+        WriteOptions options =
+                WriteOptions.builder().contentDisposition(disposition).build();
+        op().write(path, content, options);
+
+        String actualDisposition = op().stat(path).getContentDisposition();
+        assertThat(actualDisposition).isEqualTo(disposition);
+    }
+
+    @Test
+    void testWriteWithAppend() {
+        assumeTrue(op().info.fullCapability.writeCanAppend);
+
+        final String path = UUID.randomUUID().toString();
+        final byte[] contentOne = "Test".getBytes();
+        final byte[] contentTwo = " Data".getBytes();
+
+        op().write(path, contentOne);
+        WriteOptions appendOptions = WriteOptions.builder().append(true).build();
+        op().write(path, contentTwo, appendOptions);
+
+        byte[] result = op().read(path);
+        assertThat(result.length).isEqualTo(contentOne.length + contentTwo.length);
+        assertThat(result).isEqualTo("Test Data".getBytes());
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

related to #5651 

Closes #.

# Rationale for this change

exposing write options to the java bindings for conditional writes

# What changes are included in this PR?

introduce write options to the exposed `write_with` method in rust

# Are there any user-facing changes?

yes
