### PR TITLE
feat(!): Bump arrow version of parquet_opendal to 54.x

### DIFF
--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.86"
-datafusion = "44.0.0"
+datafusion = "45.0.0"
 libtest-mimic = "0.8.1"
 opendal = { version = "0.52.0", path = "../../core", features = [
   "services-memory",

--- a/integrations/parquet/Cargo.toml
+++ b/integrations/parquet/Cargo.toml
@@ -32,13 +32,13 @@ async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
 opendal = { version = "0.52.0", path = "../../core" }
-parquet = { version = "53.1", default-features = false, features = [
+parquet = { version = "54.2", default-features = false, features = [
   "async",
   "arrow",
 ] }
 
 [dev-dependencies]
-arrow = { version = "53.1" }
+arrow = { version = "54.2" }
 opendal = { version = "0.52.0", path = "../../core", features = [
   "services-memory",
   "services-s3",


### PR DESCRIPTION
Fixes failing tests in CI
