### PR TITLE
website: ASF infra doesn't allow us to load images from github

### DIFF
--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -18,8 +18,6 @@
 xuanwo:
   name: Xuanwo
   url: https://github.com/Xuanwo
-  image_url: https://github.com/Xuanwo.png
 psiace:
   name: PsiACE
   url: https://github.com/PsiACE
-  image_url: https://github.com/PsiACE.png


### PR DESCRIPTION
# Which issue does this PR close?

ASF infra doesn't allow us to load images from github

![image](https://github.com/user-attachments/assets/7835aa2b-1b39-4f45-81ef-2be30cc9148e)

# Rationale for this change

No idea on how to fix it, remove the image first.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
