### PR TITLE
feat(services/gcs): Implement multipart/related and use it with Gcs

### DIFF
--- a/core/src/raw/http_util/mod.rs
+++ b/core/src/raw/http_util/mod.rs
@@ -73,5 +73,5 @@ mod multipart;
 pub use multipart::FormDataPart;
 pub use multipart::MixedPart;
 pub use multipart::Multipart;
-pub use multipart::RelatedPart;
 pub use multipart::Part;
+pub use multipart::RelatedPart;

--- a/core/src/raw/http_util/mod.rs
+++ b/core/src/raw/http_util/mod.rs
@@ -73,4 +73,5 @@ mod multipart;
 pub use multipart::FormDataPart;
 pub use multipart::MixedPart;
 pub use multipart::Multipart;
+pub use multipart::RelatedPart;
 pub use multipart::Part;

--- a/core/src/raw/http_util/multipart.rs
+++ b/core/src/raw/http_util/multipart.rs
@@ -523,6 +523,105 @@ impl Part for MixedPart {
     }
 }
 
+/// RelatedPart is a builder for multipart/related part.
+pub struct RelatedPart {
+    /// Common
+    headers: HeaderMap,
+    content: Buffer,
+}
+
+impl RelatedPart {
+    /// Create a new related
+    pub fn new() -> Self {
+        Self {
+            headers: HeaderMap::new(),
+            content: Buffer::new(),
+        }
+    }
+
+    /// Build a mixed part from a request.
+    pub fn from_request(req: Request<Buffer>) -> Self {
+        let (parts, content) = req.into_parts();
+
+        Self {
+            headers: parts.headers,
+            content,
+        }
+    }
+
+    /// Consume a mixed part to build a response.
+    pub fn into_response(mut self) -> Response<Buffer> {
+        let mut builder = Response::builder();
+
+        // Swap headers directly instead of copy the entire map.
+        mem::swap(builder.headers_mut().unwrap(), &mut self.headers);
+
+        builder
+            .body(self.content)
+            .expect("a related part must be valid response")
+    }
+
+    /// Insert a header into part.
+    pub fn header(mut self, key: HeaderName, value: HeaderValue) -> Self {
+        self.headers.insert(key, value);
+        self
+    }
+
+    /// Set the content for this part.
+    pub fn content(mut self, content: impl Into<Buffer>) -> Self {
+        self.content = content.into();
+        self
+    }
+}
+
+impl Part for RelatedPart {
+    const TYPE: &'static str = "related";
+
+    fn format(self) -> Buffer {
+        // This is what multipart/related body might look for an insert in GCS
+        // https://cloud.google.com/storage/docs/uploading-objects
+        /*
+        --separator_string
+        Content-Type: application/json; charset=UTF-8
+
+        {"name":"my-document.txt"}
+
+        --separator_string
+        Content-Type: text/plain
+
+        This is a text file.
+        --separator_string--
+        */
+
+        let mut bufs = Vec::with_capacity(3);
+        let mut bs = BytesMut::new();
+
+        // Write request headers.
+        for (k, v) in self.headers.iter() {
+            bs.extend_from_slice(k.as_str().as_bytes());
+            bs.extend_from_slice(b": ");
+            bs.extend_from_slice(v.as_bytes());
+            bs.extend_from_slice(b"\r\n");
+        }
+        bs.extend_from_slice(b"\r\n");
+        bufs.push(Buffer::from(bs.freeze()));
+
+        if !self.content.is_empty() {
+            bufs.push(self.content);
+            bufs.push(Buffer::from("\r\n"))
+        }
+
+        bufs.into_iter().flatten().collect()
+    }
+
+    fn parse(_s: &str) -> Result<Self> {
+        Err(Error::new(
+            ErrorKind::Unsupported,
+            "parsing multipart/related is not supported",
+        ))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use http::header::CONTENT_TYPE;

--- a/core/src/raw/http_util/multipart.rs
+++ b/core/src/raw/http_util/multipart.rs
@@ -1152,12 +1152,22 @@ This is a text file.
 
         let multipart = Multipart::new()
             .with_boundary("separator_string")
-            .part(RelatedPart::new()
-                .header("Content-Type".parse().unwrap(), "application/json; charset=UTF-8".parse().unwrap())
-                .content(r#"{"name":"my-document.txt"}"#)
-            ).part(RelatedPart::new()
-                .header("Content-Type".parse().unwrap(), "text/plain".parse().unwrap())
-                .content("This is a text file."));
+            .part(
+                RelatedPart::new()
+                    .header(
+                        "Content-Type".parse().unwrap(),
+                        "application/json; charset=UTF-8".parse().unwrap(),
+                    )
+                    .content(r#"{"name":"my-document.txt"}"#),
+            )
+            .part(
+                RelatedPart::new()
+                    .header(
+                        "Content-Type".parse().unwrap(),
+                        "text/plain".parse().unwrap(),
+                    )
+                    .content("This is a text file."),
+            );
 
         let bs = multipart.build();
 

--- a/core/src/raw/http_util/multipart.rs
+++ b/core/src/raw/http_util/multipart.rs
@@ -530,6 +530,12 @@ pub struct RelatedPart {
     content: Buffer,
 }
 
+impl Default for RelatedPart {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RelatedPart {
     /// Create a new related
     pub fn new() -> Self {

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -319,7 +319,9 @@ impl GcsCore {
             multipart = multipart.part(metadata_part);
 
             // Content-Type must be set, even if it is set in the metadata part
-            let content_type = op.content_type().unwrap_or("application/octet-stream")
+            let content_type = op
+                .content_type()
+                .unwrap_or("application/octet-stream")
                 .parse()
                 .expect("Failed to parse content-type");
             let media_part = RelatedPart::new()

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -307,18 +307,24 @@ impl GcsCore {
             Ok(req)
         } else {
             let mut multipart = Multipart::new();
-            let metadata_part = FormDataPart::new("metadata")
+            let metadata_part = RelatedPart::new()
                 .header(
                     CONTENT_TYPE,
                     "application/json; charset=UTF-8".parse().unwrap(),
                 )
                 .content(
                     serde_json::to_vec(&request_metadata)
-                        .expect("metadata serialization should success"),
+                        .expect("metadata serialization should succeed"),
                 );
             multipart = multipart.part(metadata_part);
 
-            let media_part = FormDataPart::new("media").content(body);
+            // Content-Type must be set, even if it is set in the metadata part
+            let content_type = op.content_type().unwrap_or("application/octet-stream")
+                .parse()
+                .expect("Failed to parse content-type");
+            let media_part = RelatedPart::new()
+                .header(CONTENT_TYPE, content_type)
+                .content(body);
             multipart = multipart.part(media_part);
 
             let req = multipart.apply(Request::post(url))?;
@@ -660,6 +666,8 @@ impl InsertRequestMetadata<'_> {
             && self.content_encoding.is_none()
             && self.storage_class.is_none()
             && self.cache_control.is_none()
+            // We could also put content-encoding in the url parameters
+            && self.content_encoding.is_none()
             && self.metadata.is_none()
     }
 }


### PR DESCRIPTION
The status of this PR:
With this PR applied, I am able to set metadata such as `content_encoding` and `content_type` in write operations with `Gcs`. I have tested it with the official Storage emulator provided by `firebase-tools`.

What's missing:
- ~I haven't tested this with the actual GCS yet~ EDIT: Tested in our project
- ~Unit tests for `RelatedPart`~ EDIT: There's now a simple unit test

# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/5624

TL;DR: Improves GCS API compliance

# Rationale for this change

The rationale for the change is discussed in the issue.

# What changes are included in this PR?

- Implement support for `multipart/related` (`RelatedPart`)
- Use `RelatedPart` in `gcs_insert_object_request` instead of `FormDataPart`

# Are there any user-facing changes?

None