### PR TITLE
fix(services/onedrive): remove @odata.type field

### DIFF
--- a/core/src/services/onedrive/graph_model.rs
+++ b/core/src/services/onedrive/graph_model.rs
@@ -121,8 +121,6 @@ struct EmptyStruct {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct FileUploadItem {
-    #[serde(rename = "@odata.type")]
-    odata_type: String,
     #[serde(rename = "@microsoft.graph.conflictBehavior")]
     microsoft_graph_conflict_behavior: String,
     name: String,
@@ -145,7 +143,6 @@ impl OneDriveUploadSessionCreationRequestBody {
     pub fn new(path: String) -> Self {
         OneDriveUploadSessionCreationRequestBody {
             item: FileUploadItem {
-                odata_type: "microsoft.graph.driveItemUploadableProperties".to_string(),
                 microsoft_graph_conflict_behavior: "replace".to_string(),
                 name: path,
             },


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5690.

# Rationale for this change

Fixes a 400 error.

# Are there any user-facing changes?

No

# Tests

Behavior tests ok.

<details>

<summary>» OPENDAL_TEST=onedrive cargo test behavior --features tests,services-onedrive -- --show-output</summary>

```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.27s
     Running unittests src/lib.rs (target/debug/deps/opendal-6a1470b1a6444062)

running 0 tests

successes:

successes:

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 135 filtered out; finished in 0.00s

     Running tests/behavior/main.rs (target/debug/deps/behavior-b979b2a41b98fab9)

running 104 tests
test behavior::test_delete_with_version                       ... ok
test behavior::test_batch_delete_with_version                 ... ok
test behavior::test_batch_delete                              ... ok
test behavior::test_delete_with_not_existing_version          ... ok
test behavior::test_list_with_start_after                     ... ok
test behavior::test_list_with_versions_and_limit              ... ok
test behavior::test_list_with_versions_and_start_after        ... ok
test behavior::test_list_files_with_deleted                   ... ok
test behavior::test_list_files_with_versions                  ... ok
test behavior::test_reader_with_if_none_match                 ... ok
test behavior::test_reader_with_if_modified_since             ... ok
test behavior::test_reader_with_if_unmodified_since           ... ok
test behavior::test_reader_with_if_match                      ... ok
test behavior::test_read_with_if_none_match                   ... ok
test behavior::test_read_with_if_modified_since               ... ok
test behavior::test_read_with_if_unmodified_since             ... ok
test behavior::test_read_with_if_match                        ... ok
test behavior::test_read_with_override_cache_control          ... ok
test behavior::test_read_with_override_content_disposition    ... ok
test behavior::test_read_with_not_existing_version            ... ok
test behavior::test_read_with_version                         ... ok
test behavior::test_read_with_override_content_type           ... ok
test behavior::test_read_not_exist                            ... ok
test behavior::test_delete_not_existing                       ... ok
test behavior::test_check                                     ... ok
test behavior::test_stat_with_if_match                        ... ok
test behavior::test_stat_with_if_none_match                   ... ok
test behavior::test_stat_with_if_modified_since               ... ok
test behavior::test_stat_with_if_unmodified_since             ... ok
test behavior::test_stat_with_override_cache_control          ... ok
test behavior::test_stat_with_override_content_disposition    ... ok
test behavior::test_stat_with_override_content_type           ... ok
test behavior::test_stat_root                                 ... ok
test behavior::test_stat_with_version                         ... ok
test behavior::stat_with_not_existing_version                 ... ok
test behavior::test_list_root_with_recursive                  ... ok
test behavior::test_write_with_empty_content                  ... ok
test behavior::test_write_with_dir_path                       ... ok
test behavior::test_list_non_exist_dir                        ... ok
test behavior::test_write_with_cache_control                  ... ok
test behavior::test_write_with_content_type                   ... ok
test behavior::test_write_with_content_disposition            ... ok
test behavior::test_write_with_content_encoding               ... ok
test behavior::test_write_with_if_none_match                  ... ok
test behavior::test_write_with_if_not_exists                  ... ok
test behavior::test_write_with_if_match                       ... ok
test behavior::test_write_with_user_metadata                  ... ok
test behavior::test_stat_not_exist                            ... ok
test behavior::test_writer_write                              ... ok
test behavior::test_read_with_dir_path                        ... ok
test behavior::test_writer_write_with_concurrent              ... ok
test behavior::test_writer_sink                               ... ok
test behavior::test_writer_sink_with_concurrent               ... ok
test behavior::test_stat_with_special_chars                   ... ok
test behavior::test_delete_empty_dir                          ... ok
test behavior::test_writer_futures_copy                       ... ok
test behavior::test_writer_futures_copy_with_concurrent       ... ok
test behavior::test_writer_return_metadata                    ... ok
test behavior::test_writer_abort_with_concurrent              ... ok
test behavior::test_writer_abort                              ... ok
test behavior::test_write_returns_metadata                    ... ok
test behavior::test_read_with_special_chars                   ... ok
test behavior::test_write_with_special_chars                  ... ok
test behavior::test_stat_nested_parent_dir                    ... ok
test behavior::test_stat_not_cleaned_path                     ... ok
test behavior::test_blocking_create_dir                       ... ok
test behavior::test_blocking_read_not_exist                   ... ok
test behavior::test_stat_dir                                  ... ok
test behavior::test_blocking_stat_not_exist                   ... ok
test behavior::test_create_dir                                ... ok
test behavior::test_stat_file                                 ... ok
test behavior::test_list_prefix                               ... ok
test behavior::test_delete_file                               ... ok
test behavior::test_list_sub_dir                              ... ok
test behavior::test_list_file_with_recursive                  ... ok
test behavior::test_blocking_write_with_dir_path              ... ok
test behavior::test_blocking_create_dir_existing              ... ok
test behavior::test_create_dir_existing                       ... ok
test behavior::test_delete_with_special_chars                 ... ok
test behavior::test_list_dir_with_file_path                   ... ok
test behavior::test_blocking_stat_dir                         ... ok
test behavior::test_read_full                                 ... ok
test behavior::test_write_only                                ... ok
test behavior::test_list_dir                                  ... ok
test behavior::test_blocking_read_range                       ... ok
test behavior::test_read_range                                ... ok
test behavior::test_blocking_delete_file                      ... ok
test behavior::test_blocking_read_full                        ... ok
test behavior::test_blocking_stat_file                        ... ok
test behavior::test_blocking_write_returns_metadata           ... ok
test behavior::test_blocking_remove_one_file                  ... ok
test behavior::test_blocking_write_file                       ... ok
test behavior::test_list_nested_dir                           ... ok
test behavior::test_blocking_stat_with_special_chars          ... ok
test behavior::test_reader                                    ... ok
test behavior::test_blocking_write_with_special_chars         ... ok
test behavior::test_remove_one_file                           ... ok
test behavior::test_list_dir_with_recursive_no_trailing_slash ... ok
test behavior::test_list_dir_with_recursive                   ... ok
test behavior::test_writer_write_with_overwrite               ... ok
test behavior::test_remove_all                                ... ok
test behavior::test_list_empty_dir                            ... ok
test behavior::test_list_rich_dir                             ... ok
test behavior::test_delete_stream                             ... ok

test result: ok. 104 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 41.37s
```

</details>