### PR TITLE
doc: py binding version is wrong for now

### DIFF
--- a/bindings/python/CONTRIBUTING.md
+++ b/bindings/python/CONTRIBUTING.md
@@ -39,14 +39,14 @@ sudo apt install -y python3-dev python3-pip python3-venv
 
 All operations were performed within a Python virtual environment (venv) to prevent conflicts with the system's Python environment or other project venvs.
 
-OpenDAL specify the `requires-python` in `pyproject.toml` as `>= 3.7`. You can use `python -m venv venv` to setup virtualenv to start development.
+OpenDAL specify the `requires-python` in `pyproject.toml` as `>= 3.10`. You can use `python -m venv venv` to setup virtualenv to start development.
 
 After `venv` has been prepared, you can activate it by `source venv/bin/activate`.
 
 To simplify our work, we will utilize the tool [`maturin`](https://github.com/PyO3/maturin). Kindly install it beforehand.
 
 ```shell
-pip install 'maturin[patchelf]'
+pip install maturin
 ```
 
 ## Build


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


This patch fix python version is wrong in `bindings/python/CONTRIBUTING.md`

and seems use `pip install maturin` is better than `pip install 'maturin[patchelf]'` for now
cause pip install 'maturin[patchelf]'  needs Ninja which is not so kindly for user install
