### PR TITLE
fix: make build_abs_path to build_rooted_abs_path for chainsafe

### DIFF
--- a/core/src/services/chainsafe/core.rs
+++ b/core/src/services/chainsafe/core.rs
@@ -166,7 +166,7 @@ impl ChainsafeCore {
     }
 
     pub async fn list_objects(&self, path: &str) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_rooted_abs_path(&self.root, path);
 
         let url = format!(
             "https://api.chainsafe.io/api/v1/bucket/{}/ls",


### PR DESCRIPTION
make path / work for it close #5705

# Which issue does this PR close?

#5705

make it to `build_rooted_abs_path`

note: this path only for #5705 other path maybe need more tests so did not touch them in this patch