### PR TITLE
fix: mac can not build lua binding

### DIFF
--- a/bindings/lua/.cargo/config.toml
+++ b/bindings/lua/.cargo/config.toml
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

This path fix macOS can not build lua binding by adding config(which is like other binding))

refer doc: for mlua https://github.com/mlua-rs/mlua
> On macOS, you need to set additional linker arguments. One option is to compile with cargo rustc --release -- -C link-arg=-undefined -C link-arg=dynamic_lookup, the other is to create a .cargo/config.toml with the following content:

```
[target.x86_64-apple-darwin]
rustflags = [
  "-C", "link-arg=-undefined",
  "-C", "link-arg=dynamic_lookup",
]

[target.aarch64-apple-darwin]
rustflags = [
  "-C", "link-arg=-undefined",
  "-C", "link-arg=dynamic_lookup",
]
```

if without this patch build on macOS error:


```cli
rror: linking with `cc` failed: exit status: 1
  |
  = note: env -u IPHONEOS_DEPLOYMENT_TARGET -u TVOS_DEPLOYMENT_TARGET -u XROS_DEPLOYMENT_TARGET LC_ALL="C" PATH="/Users/hyi/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin:/Users/hyi/.codeium/windsurf/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/libpq/bin:/opt/homebrew/Cellar/llvm/19.1.7_1/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/hyi/.nvm/versions/node/v18.20.5/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/hyi/.codeium/windsurf/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/libpq/bin:/opt/homebrew/Cellar/llvm/19.1.7_1/bin:/Users/hyi/.atuin/bin:/Users/hyi/.local/bin:/Users/hyi/.cargo/bin:/Applications/kitty.app/Contents/MacOS:/Users/hyi/.orbstack/bin:/Users/hyi/Library/Application Support/Code/User/globalStorage/github.copilot-chat/debugCommand:/Users/hyi/.orbstack/bin" VSLANG="1033" ZERO_AR_DATE="1" "cc" "-Wl,-exported_symbols_list" "-Wl,/var/folders/c3/51t_3cqj7bx98dq1ptyy0v700000gn/T/rustcPztnQX/list" "/var/folders/c3/51t_3cqj7bx98dq1ptyy0v700000gn/T/rustcPztnQX/symbols.o" "/Users/hyi/prs/opendal/bindings/lua/target/release/deps/opendal_lua.opendal_lua.4662ef7d9bed56-cgu.00.rcgu.o" "/Users/hyi/prs/opendal/bindings/lua/target/release/deps/opendal_lua.opendal_lua.4662ef7d9bed56-cgu.01.rcgu.o" "/Users/hyi/prs/opendal/bindings/lua/target/release/deps/opendal_lua.opendal_lua.4662ef7d9bed56-cgu.02.rcgu.o" "/Users/hyi/prs/opendal/bindings/lua/target/release/deps/opendal_lua.opendal_lua.4662ef7d9bed56-cgu.03.rcgu.o" "/Users/hyi/prs/opendal/bindings/lua/target/release/deps/opendal_lua.opendal_lua.4662ef7d9bed56-cgu.04.rcgu.o" "/Users/hyi/prs/opendal/bindings/lua/target/release/deps/opendal_lua.opendal_lua.4662ef7d9bed56-cgu.05.rcgu.o" "/Users/hyi/prs/opendal/bindings/lua/target/release/deps/opendal_lua.opendal_lua.4662ef7d9bed56-cgu.06.rcgu.o"
.....
```
