### PR TITLE
fix(core): fix list with recursive when the object doesn't exist

### DIFF
--- a/core/src/raw/oio/list/flat_list.rs
+++ b/core/src/raw/oio/list/flat_list.rs
@@ -105,8 +105,6 @@ where
                     } else {
                         return Ok(Some(v));
                     }
-                } else {
-                    return Ok(None);
                 }
             }
 
@@ -159,8 +157,6 @@ where
                     } else {
                         return Ok(Some(v));
                     }
-                } else {
-                    return Ok(None);
                 }
             }
 

--- a/core/src/services/webdav/lister.rs
+++ b/core/src/services/webdav/lister.rs
@@ -81,13 +81,11 @@ impl oio::PageList for WebdavLister {
             }
 
             let decoded_path = percent_decode_path(&path);
-
-            // Ignore the root path itself.
-            if self.core.root == decoded_path {
-                continue;
-            }
-
-            let normalized_path = build_rel_path(&self.core.root, &decoded_path);
+            let normalized_path = if self.core.root != decoded_path {
+                build_rel_path(&self.core.root, &decoded_path)
+            } else {
+                "/".to_owned()
+            };
 
             // HACKS! HACKS! HACKS!
             //

--- a/core/tests/behavior/async_list.rs
+++ b/core/tests/behavior/async_list.rs
@@ -42,6 +42,7 @@ pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
             test_list_nested_dir,
             test_list_dir_with_file_path,
             test_list_with_start_after,
+            test_list_non_exist_dir_with_recursive,
             test_list_dir_with_recursive,
             test_list_dir_with_recursive_no_trailing_slash,
             test_list_file_with_recursive,
@@ -400,6 +401,20 @@ pub async fn test_list_with_start_after(op: Operator) -> Result<()> {
 
     op.remove_all(dir).await?;
 
+    Ok(())
+}
+
+pub async fn test_list_non_exist_dir_with_recursive(op: Operator) -> Result<()> {
+    let dir = format!("{}/", uuid::Uuid::new_v4());
+
+    let mut obs = op.lister_with(&dir).recursive(true).await?;
+    let mut objects = HashMap::new();
+    while let Some(de) = obs.try_next().await? {
+        objects.insert(de.path().to_string(), de);
+    }
+    debug!("got objects: {:?}", objects);
+
+    assert_eq!(objects.len(), 0, "dir should only return empty");
     Ok(())
 }
 

--- a/core/tests/behavior/blocking_list.rs
+++ b/core/tests/behavior/blocking_list.rs
@@ -30,6 +30,7 @@ pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
             op,
             test_blocking_list_dir,
             test_blocking_list_non_exist_dir,
+            test_blocking_list_not_exist_dir_with_recursive,
             test_blocking_list_dir_with_recursive,
             test_blocking_list_dir_with_recursive_no_trailing_slash,
             test_blocking_list_file_with_recursive,
@@ -112,6 +113,21 @@ pub fn test_blocking_remove_all(op: BlockingOperator) -> Result<()> {
         )
     }
 
+    Ok(())
+}
+
+pub fn test_blocking_list_not_exist_dir_with_recursive(op: BlockingOperator) -> Result<()> {
+    let dir = TEST_FIXTURE.new_dir_path();
+
+    let obs = op.lister_with(&dir).recursive(true).call()?;
+    let mut objects = HashMap::new();
+    for de in obs {
+        let de = de?;
+        objects.insert(de.path().to_string(), de);
+    }
+    debug!("got objects: {:?}", objects);
+
+    assert_eq!(objects.len(), 0, "dir should only return empty");
     Ok(())
 }
 

--- a/core/tests/behavior/blocking_list.rs
+++ b/core/tests/behavior/blocking_list.rs
@@ -117,7 +117,7 @@ pub fn test_blocking_remove_all(op: BlockingOperator) -> Result<()> {
 }
 
 pub fn test_blocking_list_not_exist_dir_with_recursive(op: BlockingOperator) -> Result<()> {
-    let dir = TEST_FIXTURE.new_dir_path();
+    let dir = format!("{}/", uuid::Uuid::new_v4());
 
     let obs = op.lister_with(&dir).recursive(true).call()?;
     let mut objects = HashMap::new();


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

# Rationale for this change

when performing `list_with_recursive`, if the object doesn't exist and the underlying service does not support `list_with_recursive`, we may incorrectly return the non-existent object.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
