### PR TITLE
feat(services/onedrive): add signer to utilize the refresh token

### DIFF
--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -31,19 +31,19 @@ use crate::raw::*;
 use crate::*;
 
 #[derive(Clone)]
-pub struct OneDriveBackend {
+pub struct OnedriveBackend {
     pub core: Arc<OneDriveCore>,
 }
 
-impl Debug for OneDriveBackend {
+impl Debug for OnedriveBackend {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OneDriveBackend")
+        f.debug_struct("OnedriveBackend")
             .field("core", &self.core)
             .finish()
     }
 }
 
-impl Access for OneDriveBackend {
+impl Access for OnedriveBackend {
     type Reader = HttpBody;
     type Writer = oio::OneShotWriter<OneDriveWriter>;
     type Lister = oio::PageLister<OneDriveLister>;

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -16,111 +16,54 @@
 // under the License.
 
 use std::fmt::Debug;
+use std::fmt::Formatter;
 use std::sync::Arc;
 
-use bytes::Buf;
-use bytes::Bytes;
-use http::header;
-use http::Request;
 use http::Response;
 use http::StatusCode;
 
-use super::delete::OnedriveDeleter;
+use super::core::OneDriveCore;
+use super::delete::OneDriveDeleter;
 use super::error::parse_error;
-use super::graph_model::CreateDirPayload;
-use super::graph_model::ItemType;
-use super::graph_model::OneDriveUploadSessionCreationRequestBody;
-use super::graph_model::OnedriveGetItemBody;
-use super::lister::OnedriveLister;
+use super::lister::OneDriveLister;
 use super::writer::OneDriveWriter;
 use crate::raw::*;
 use crate::*;
 
 #[derive(Clone)]
-pub struct OnedriveBackend {
-    info: Arc<AccessorInfo>,
-    root: String,
-    access_token: String,
-    client: HttpClient,
+pub struct OneDriveBackend {
+    pub core: Arc<OneDriveCore>,
 }
 
-impl OnedriveBackend {
-    pub(crate) fn new(root: String, access_token: String, http_client: HttpClient) -> Self {
-        Self {
-            info: {
-                let ma = AccessorInfo::default();
-                ma.set_scheme(Scheme::Onedrive)
-                    .set_root(&root)
-                    .set_native_capability(Capability {
-                        read: true,
-                        write: true,
-                        stat: true,
-                        stat_has_etag: true,
-                        stat_has_last_modified: true,
-                        stat_has_content_length: true,
-                        delete: true,
-                        create_dir: true,
-                        list: true,
-                        list_has_content_length: true,
-                        list_has_etag: true,
-                        list_has_last_modified: true,
-                        shared: true,
-                        ..Default::default()
-                    });
-
-                ma.into()
-            },
-            root,
-            access_token,
-            client: http_client,
-        }
+impl Debug for OneDriveBackend {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OneDriveBackend")
+            .field("core", &self.core)
+            .finish()
     }
 }
 
-impl Debug for OnedriveBackend {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut de = f.debug_struct("OneDriveBackend");
-        de.field("root", &self.root);
-        de.field("access_token", &"<redacted>");
-        de.finish()
-    }
-}
-
-impl Access for OnedriveBackend {
+impl Access for OneDriveBackend {
     type Reader = HttpBody;
     type Writer = oio::OneShotWriter<OneDriveWriter>;
-    type Lister = oio::PageLister<OnedriveLister>;
-    type Deleter = oio::OneShotDeleter<OnedriveDeleter>;
+    type Lister = oio::PageLister<OneDriveLister>;
+    type Deleter = oio::OneShotDeleter<OneDriveDeleter>;
     type BlockingReader = ();
     type BlockingWriter = ();
     type BlockingLister = ();
     type BlockingDeleter = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        self.info.clone()
+        self.core.info.clone()
     }
 
-    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
+    async fn create_dir(&self, path: &str, _args: OpCreateDir) -> Result<RpCreateDir> {
         if path == "/" {
             // skip, the root path exists in the personal OneDrive.
             return Ok(RpCreateDir::default());
         }
 
-        let path = build_rooted_abs_path(&self.root, path);
-        let path_before_last_slash = get_parent(&path);
-        let encoded_path = percent_encode_path(path_before_last_slash);
-
-        let uri = format!(
-            "https://graph.microsoft.com/v1.0/me/drive/root:{}:/children",
-            encoded_path
-        );
-
-        let folder_name = get_basename(&path);
-        let folder_name = folder_name.strip_suffix('/').unwrap_or(folder_name);
-
-        let body = CreateDirPayload::new(folder_name.to_string());
-
-        let response = self.onedrive_create_dir(&uri, body).await?;
+        let response = self.core.onedrive_create_dir(path).await?;
 
         let status = response.status();
         match status {
@@ -129,51 +72,23 @@ impl Access for OnedriveBackend {
         }
     }
 
-    async fn stat(&self, path: &str, _: OpStat) -> Result<RpStat> {
-        // Stat root always returns a DIR.
-        if path == "/" {
-            return Ok(RpStat::new(Metadata::new(EntryMode::DIR)));
-        }
+    async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {
+        let path = build_rooted_abs_path(&self.core.root, path);
+        let meta = self.core.onedrive_stat(path.as_str()).await?;
 
-        let resp = self.onedrive_get_stat(path).await?;
-        let status = resp.status();
-
-        if status.is_success() {
-            let bytes = resp.into_body();
-            let decoded_response: OnedriveGetItemBody =
-                serde_json::from_reader(bytes.reader()).map_err(new_json_deserialize_error)?;
-
-            let entry_mode: EntryMode = match decoded_response.item_type {
-                ItemType::Folder { .. } => EntryMode::DIR,
-                ItemType::File { .. } => EntryMode::FILE,
-            };
-
-            let mut meta = Metadata::new(entry_mode);
-            meta.set_etag(&decoded_response.e_tag);
-
-            let last_modified = decoded_response.last_modified_date_time;
-            let date_utc_last_modified = parse_datetime_from_rfc3339(&last_modified)?;
-            meta.set_last_modified(date_utc_last_modified);
-
-            meta.set_content_length(decoded_response.size);
-
-            Ok(RpStat::new(meta))
-        } else {
-            Err(parse_error(resp))
-        }
+        Ok(RpStat::new(meta))
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let resp = self.onedrive_get_content(path, args.range()).await?;
+        let response = self.core.onedrive_get_content(path, args.range()).await?;
 
-        let status = resp.status();
-
+        let status = response.status();
         match status {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
+                Ok((RpRead::default(), response.into_body()))
             }
             _ => {
-                let (part, mut body) = resp.into_parts();
+                let (part, mut body) = response.into_parts();
                 let buf = body.to_buffer().await?;
                 Err(parse_error(Response::from_parts(part, buf)))
             }
@@ -181,192 +96,23 @@ impl Access for OnedriveBackend {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_abs_path(&self.core.root, path);
 
         Ok((
             RpWrite::default(),
-            oio::OneShotWriter::new(OneDriveWriter::new(self.clone(), args, path)),
+            oio::OneShotWriter::new(OneDriveWriter::new(self.core.clone(), args, path)),
         ))
     }
 
     async fn delete(&self) -> Result<(RpDelete, Self::Deleter)> {
         Ok((
             RpDelete::default(),
-            oio::OneShotDeleter::new(OnedriveDeleter::new(Arc::new(self.clone()))),
+            oio::OneShotDeleter::new(OneDriveDeleter::new(self.core.clone())),
         ))
     }
 
-    async fn list(&self, path: &str, _op_list: OpList) -> Result<(RpList, Self::Lister)> {
-        let l = OnedriveLister::new(self.root.clone(), path.into(), self.clone());
-
+    async fn list(&self, path: &str, _args: OpList) -> Result<(RpList, Self::Lister)> {
+        let l = OneDriveLister::new(path.to_string(), self.core.clone());
         Ok((RpList::default(), oio::PageLister::new(l)))
-    }
-}
-
-impl OnedriveBackend {
-    pub(crate) const BASE_URL: &'static str = "https://graph.microsoft.com/v1.0/me";
-
-    async fn onedrive_get_stat(&self, path: &str) -> Result<Response<Buffer>> {
-        let path = build_rooted_abs_path(&self.root, path);
-        let url: String = format!(
-            "https://graph.microsoft.com/v1.0/me/drive/root:{}{}",
-            percent_encode_path(&path),
-            ""
-        );
-
-        let mut req = Request::get(&url);
-
-        let auth_header_content = format!("Bearer {}", self.access_token);
-        req = req.header(header::AUTHORIZATION, auth_header_content);
-
-        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
-
-        self.client.send(req).await
-    }
-
-    pub(crate) async fn onedrive_get_next_list_page(&self, url: &str) -> Result<Response<Buffer>> {
-        let mut req = Request::get(url);
-
-        let auth_header_content = format!("Bearer {}", self.access_token);
-        req = req.header(header::AUTHORIZATION, auth_header_content);
-
-        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
-
-        self.client.send(req).await
-    }
-
-    pub async fn onedrive_get_content(
-        &self,
-        path: &str,
-        range: BytesRange,
-    ) -> Result<Response<HttpBody>> {
-        let path = build_rooted_abs_path(&self.root, path);
-        let url: String = format!(
-            "https://graph.microsoft.com/v1.0/me/drive/root:{}{}",
-            percent_encode_path(&path),
-            ":/content"
-        );
-
-        let mut req = Request::get(&url).header(header::RANGE, range.to_header());
-
-        let auth_header_content = format!("Bearer {}", self.access_token);
-        req = req.header(header::AUTHORIZATION, auth_header_content);
-
-        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
-
-        self.client.fetch(req).await
-    }
-
-    pub async fn onedrive_upload_simple(
-        &self,
-        path: &str,
-        size: Option<usize>,
-        args: &OpWrite,
-        body: Buffer,
-    ) -> Result<Response<Buffer>> {
-        let url = format!(
-            "https://graph.microsoft.com/v1.0/me/drive/root:{}:/content",
-            percent_encode_path(path)
-        );
-
-        let mut req = Request::put(&url);
-
-        let auth_header_content = format!("Bearer {}", self.access_token);
-        req = req.header(header::AUTHORIZATION, auth_header_content);
-
-        if let Some(size) = size {
-            req = req.header(header::CONTENT_LENGTH, size)
-        }
-
-        if let Some(mime) = args.content_type() {
-            req = req.header(header::CONTENT_TYPE, mime)
-        }
-
-        let req = req.body(body).map_err(new_request_build_error)?;
-
-        self.client.send(req).await
-    }
-
-    pub(crate) async fn onedrive_chunked_upload(
-        &self,
-        url: &str,
-        args: &OpWrite,
-        offset: usize,
-        chunk_end: usize,
-        total_len: usize,
-        body: Buffer,
-    ) -> Result<Response<Buffer>> {
-        let mut req = Request::put(url);
-
-        let auth_header_content = format!("Bearer {}", self.access_token);
-        req = req.header(header::AUTHORIZATION, auth_header_content);
-
-        let range = format!("bytes {}-{}/{}", offset, chunk_end, total_len);
-        req = req.header("Content-Range".to_string(), range);
-
-        let size = chunk_end - offset + 1;
-        req = req.header(header::CONTENT_LENGTH, size.to_string());
-
-        if let Some(mime) = args.content_type() {
-            req = req.header(header::CONTENT_TYPE, mime)
-        }
-
-        let req = req.body(body).map_err(new_request_build_error)?;
-
-        self.client.send(req).await
-    }
-
-    pub(crate) async fn onedrive_create_upload_session(
-        &self,
-        url: &str,
-        body: OneDriveUploadSessionCreationRequestBody,
-    ) -> Result<Response<Buffer>> {
-        let mut req = Request::post(url);
-
-        let auth_header_content = format!("Bearer {}", self.access_token);
-        req = req.header(header::AUTHORIZATION, auth_header_content);
-
-        req = req.header(header::CONTENT_TYPE, "application/json");
-
-        let body_bytes = serde_json::to_vec(&body).map_err(new_json_serialize_error)?;
-        let asyn_body = Buffer::from(Bytes::from(body_bytes));
-        let req = req.body(asyn_body).map_err(new_request_build_error)?;
-
-        self.client.send(req).await
-    }
-
-    async fn onedrive_create_dir(
-        &self,
-        url: &str,
-        body: CreateDirPayload,
-    ) -> Result<Response<Buffer>> {
-        let mut req = Request::post(url);
-
-        let auth_header_content = format!("Bearer {}", self.access_token);
-        req = req.header(header::AUTHORIZATION, auth_header_content);
-        req = req.header(header::CONTENT_TYPE, "application/json");
-
-        let body_bytes = serde_json::to_vec(&body).map_err(new_json_serialize_error)?;
-        let async_body = Buffer::from(bytes::Bytes::from(body_bytes));
-        let req = req.body(async_body).map_err(new_request_build_error)?;
-
-        self.client.send(req).await
-    }
-
-    pub(crate) async fn onedrive_delete(&self, path: &str) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
-        let url = format!(
-            "https://graph.microsoft.com/v1.0/me/drive/root:/{}",
-            percent_encode_path(&path)
-        );
-
-        let mut req = Request::delete(&url);
-
-        let auth_header_content = format!("Bearer {}", self.access_token);
-        req = req.header(header::AUTHORIZATION, auth_header_content);
-
-        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
-
-        self.client.send(req).await
     }
 }

--- a/core/src/services/onedrive/builder.rs
+++ b/core/src/services/onedrive/builder.rs
@@ -83,6 +83,8 @@ impl OnedriveBuilder {
     ///
     /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
     /// during minor updates.
+    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
+    #[allow(deprecated)]
     pub fn http_client(mut self, http_client: HttpClient) -> Self {
         self.http_client = Some(http_client);
         self
@@ -127,19 +129,16 @@ impl Builder for OnedriveBuilder {
                 ..Default::default()
             });
 
-        let client = if let Some(client) = self.http_client {
-            client
-        } else {
-            HttpClient::new().map_err(|err| {
-                err.with_operation("Builder::build")
-                    .with_context("service", Scheme::Onedrive)
-            })?
-        };
+        // allow deprecated api here for compatibility
+        #[allow(deprecated)]
+        if let Some(client) = self.http_client {
+            info.update_http_client(|_| client);
+        }
+
         let core = Arc::new(OneDriveCore {
             info: Arc::new(info),
             root,
             access_token,
-            client,
         });
 
         Ok(OneDriveBackend { core })

--- a/core/src/services/onedrive/builder.rs
+++ b/core/src/services/onedrive/builder.rs
@@ -27,7 +27,7 @@ use services::onedrive::core::OneDriveSigner;
 
 use tokio::sync::Mutex;
 
-use super::backend::OneDriveBackend;
+use super::backend::OnedriveBackend;
 use crate::raw::normalize_root;
 use crate::raw::Access;
 use crate::raw::AccessorInfo;
@@ -219,6 +219,6 @@ impl Builder for OnedriveBuilder {
             signer: Arc::new(Mutex::new(signer)),
         });
 
-        Ok(OneDriveBackend { core })
+        Ok(OnedriveBackend { core })
     }
 }

--- a/core/src/services/onedrive/config.rs
+++ b/core/src/services/onedrive/config.rs
@@ -26,10 +26,16 @@ use serde::Serialize;
 #[serde(default)]
 #[non_exhaustive]
 pub struct OnedriveConfig {
-    /// bearer access token for OneDrive
-    pub access_token: Option<String>,
-    /// root path of OneDrive folder.
+    /// The root path for the OneDrive service for the file access
     pub root: Option<String>,
+    /// Microsoft Graph API (also OneDrive API) access token
+    pub access_token: Option<String>,
+    ///  Microsoft Graph API (also OneDrive API) refresh token
+    pub refresh_token: Option<String>,
+    /// Microsoft Graph API Application (client) ID that is in the Azure's app registration portal
+    pub client_id: Option<String>,
+    /// Microsoft Graph API Application client secret that is in the Azure's app registration portal
+    pub client_secret: Option<String>,
 }
 
 impl Debug for OnedriveConfig {

--- a/core/src/services/onedrive/core.rs
+++ b/core/src/services/onedrive/core.rs
@@ -80,9 +80,9 @@ impl OneDriveCore {
             Self::DRIVE_ROOT_URL.to_string()
         } else {
             // OneDrive returns 400 when try to access a folder with a ending slash
-            let path = build_rooted_abs_path(&root, &path);
+            let path = build_rooted_abs_path(root, path);
             let path = path.strip_suffix('/').unwrap_or(path.as_str());
-            format!("{}:{}", Self::DRIVE_ROOT_URL, percent_encode_path(&path))
+            format!("{}:{}", Self::DRIVE_ROOT_URL, percent_encode_path(path))
         }
     }
 
@@ -115,7 +115,7 @@ impl OneDriveCore {
     }
 
     pub(crate) async fn onedrive_get_stat(&self, path: &str) -> Result<Response<Buffer>> {
-        let url: String = format!("{}:{}", Self::DRIVE_ROOT_URL, percent_encode_path(&path));
+        let url: String = format!("{}:{}", Self::DRIVE_ROOT_URL, percent_encode_path(path));
 
         let mut request = Request::get(&url)
             .body(Buffer::new())
@@ -243,7 +243,7 @@ impl OneDriveCore {
         let path_before_last_slash = get_parent(&path);
         let normalized = path_before_last_slash
             .strip_suffix('/')
-            .unwrap_or(&path_before_last_slash);
+            .unwrap_or(path_before_last_slash);
         let encoded_path = percent_encode_path(normalized);
 
         let url = format!("{}:{}:/children", Self::DRIVE_ROOT_URL, encoded_path);
@@ -348,7 +348,7 @@ impl OneDriveSigner {
                 Ok(())
             }
             _ => {
-                return Err(parse_error(response));
+                Err(parse_error(response))
             }
         }
     }

--- a/core/src/services/onedrive/core.rs
+++ b/core/src/services/onedrive/core.rs
@@ -39,8 +39,6 @@ pub struct OneDriveCore {
     pub root: String,
 
     pub access_token: String,
-
-    pub client: HttpClient,
 }
 
 impl Debug for OneDriveCore {
@@ -124,7 +122,7 @@ impl OneDriveCore {
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
-        self.client.send(request).await
+        self.info.http_client().send(request).await
     }
 
     pub(crate) async fn onedrive_get_next_list_page(&self, url: &str) -> Result<Response<Buffer>> {
@@ -137,7 +135,7 @@ impl OneDriveCore {
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
-        self.client.send(request).await
+        self.info.http_client().send(request).await
     }
 
     pub(crate) async fn onedrive_get_content(
@@ -161,7 +159,7 @@ impl OneDriveCore {
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
-        self.client.fetch(request).await
+        self.info.http_client().fetch(request).await
     }
 
     pub async fn onedrive_upload_simple(
@@ -192,7 +190,7 @@ impl OneDriveCore {
 
         let request = request.body(body).map_err(new_request_build_error)?;
 
-        self.client.send(request).await
+        self.info.http_client().send(request).await
     }
 
     pub(crate) async fn onedrive_chunked_upload(
@@ -221,7 +219,7 @@ impl OneDriveCore {
 
         let request = request.body(body).map_err(new_request_build_error)?;
 
-        self.client.send(request).await
+        self.info.http_client().send(request).await
     }
 
     pub(crate) async fn onedrive_create_upload_session(
@@ -240,7 +238,7 @@ impl OneDriveCore {
         let body = Buffer::from(Bytes::from(body_bytes));
         let request = request.body(body).map_err(new_request_build_error)?;
 
-        self.client.send(request).await
+        self.info.http_client().send(request).await
     }
 
     /// Create a directory
@@ -272,7 +270,7 @@ impl OneDriveCore {
         let body = Buffer::from(bytes::Bytes::from(body_bytes));
         let request = request.body(body).map_err(new_request_build_error)?;
 
-        self.client.send(request).await
+        self.info.http_client().send(request).await
     }
 
     pub(crate) async fn onedrive_delete(&self, path: &str) -> Result<Response<Buffer>> {
@@ -288,6 +286,6 @@ impl OneDriveCore {
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
-        self.client.send(request).await
+        self.info.http_client().send(request).await
     }
 }

--- a/core/src/services/onedrive/core.rs
+++ b/core/src/services/onedrive/core.rs
@@ -1,0 +1,293 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+use bytes::Buf;
+use bytes::Bytes;
+use http::header;
+use http::Request;
+use http::Response;
+
+use super::error::parse_error;
+use super::graph_model::CreateDirPayload;
+use super::graph_model::ItemType;
+use super::graph_model::OneDriveItem;
+use super::graph_model::OneDriveUploadSessionCreationRequestBody;
+use crate::raw::*;
+use crate::*;
+
+pub struct OneDriveCore {
+    pub info: Arc<AccessorInfo>,
+
+    pub root: String,
+
+    pub access_token: String,
+
+    pub client: HttpClient,
+}
+
+impl Debug for OneDriveCore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OneDriveCore")
+            .field("root", &self.root)
+            .finish_non_exhaustive()
+    }
+}
+
+// OneDrive returns 400 when try to access a dir with the POSIX special directory entries
+const SPECIAL_POSIX_ENTRIES: [&str; 3] = [".", "/", ""];
+
+// OneDrive API parameters allows using with a parameter of:
+//
+// - ID
+// - file path
+//
+// `services-onedrive` uses the file path based API for simplicity.
+// Read more at https://learn.microsoft.com/en-us/graph/onedrive-addressing-driveitems
+//
+// When debugging and running behavior tests against `services-onedrive`,
+// please try to keep the drive clean to reduce the likelihood of flaky results.
+impl OneDriveCore {
+    // OneDrive personal's base URL. `me` is an alias that represents the user's "Drive".
+    pub(crate) const DRIVE_ROOT_URL: &str = "https://graph.microsoft.com/v1.0/me/drive/root";
+
+    /// Get a URL to an OneDrive item
+    ///
+    /// This function is useful for get an item and listing where OneDrive requires a more precise file path.
+    pub(crate) fn onedrive_item_url(root: &str, path: &str) -> String {
+        // OneDrive requires the root to be the same as `DRIVE_ROOT_URL`.
+        // For files under the root, the URL pattern becomes `https://graph.microsoft.com/v1.0/me/drive/root:<path>:`
+        if root == "/" && SPECIAL_POSIX_ENTRIES.contains(&path) {
+            Self::DRIVE_ROOT_URL.to_string()
+        } else {
+            // OneDrive returns 400 when try to access a folder with a ending slash
+            let path = build_rooted_abs_path(&root, &path);
+            let path = path.strip_suffix('/').unwrap_or(path.as_str());
+            format!("{}:{}", Self::DRIVE_ROOT_URL, percent_encode_path(&path))
+        }
+    }
+
+    pub(crate) async fn onedrive_stat(&self, path: &str) -> Result<Metadata> {
+        let response = self.onedrive_get_stat(path).await?;
+        let status = response.status();
+
+        if !status.is_success() {
+            return Err(parse_error(response));
+        }
+
+        let bytes = response.into_body();
+        let decoded_response: OneDriveItem =
+            serde_json::from_reader(bytes.reader()).map_err(new_json_deserialize_error)?;
+
+        let entry_mode: EntryMode = match decoded_response.item_type {
+            ItemType::Folder { .. } => EntryMode::DIR,
+            ItemType::File { .. } => EntryMode::FILE,
+        };
+
+        let mut meta = Metadata::new(entry_mode)
+            .with_etag(decoded_response.e_tag)
+            .with_content_length(decoded_response.size.max(0) as u64);
+
+        let last_modified = decoded_response.last_modified_date_time;
+        let date_utc_last_modified = parse_datetime_from_rfc3339(&last_modified)?;
+        meta.set_last_modified(date_utc_last_modified);
+
+        Ok(meta)
+    }
+
+    pub(crate) async fn onedrive_get_stat(&self, path: &str) -> Result<Response<Buffer>> {
+        let url: String = format!("{}:{}", Self::DRIVE_ROOT_URL, percent_encode_path(&path));
+
+        let mut request = Request::get(&url);
+
+        let auth_header_content = format!("Bearer {}", self.access_token);
+        request = request.header(header::AUTHORIZATION, auth_header_content);
+
+        let request = request
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+
+        self.client.send(request).await
+    }
+
+    pub(crate) async fn onedrive_get_next_list_page(&self, url: &str) -> Result<Response<Buffer>> {
+        let mut request = Request::get(url);
+
+        let auth_header_content = format!("Bearer {}", self.access_token);
+        request = request.header(header::AUTHORIZATION, auth_header_content);
+
+        let request = request
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+
+        self.client.send(request).await
+    }
+
+    pub(crate) async fn onedrive_get_content(
+        &self,
+        path: &str,
+        range: BytesRange,
+    ) -> Result<Response<HttpBody>> {
+        let path = build_rooted_abs_path(&self.root, path);
+        let url: String = format!(
+            "{}:{}:/content",
+            Self::DRIVE_ROOT_URL,
+            percent_encode_path(&path),
+        );
+
+        let mut request = Request::get(&url).header(header::RANGE, range.to_header());
+
+        let auth_header_content = format!("Bearer {}", self.access_token);
+        request = request.header(header::AUTHORIZATION, auth_header_content);
+
+        let request = request
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+
+        self.client.fetch(request).await
+    }
+
+    pub async fn onedrive_upload_simple(
+        &self,
+        path: &str,
+        size: Option<usize>,
+        args: &OpWrite,
+        body: Buffer,
+    ) -> Result<Response<Buffer>> {
+        let url = format!(
+            "{}:{}:/content",
+            Self::DRIVE_ROOT_URL,
+            percent_encode_path(path)
+        );
+
+        let mut request = Request::put(&url);
+
+        let auth_header_content = format!("Bearer {}", self.access_token);
+        request = request.header(header::AUTHORIZATION, auth_header_content);
+
+        if let Some(size) = size {
+            request = request.header(header::CONTENT_LENGTH, size)
+        }
+
+        if let Some(mime) = args.content_type() {
+            request = request.header(header::CONTENT_TYPE, mime)
+        }
+
+        let request = request.body(body).map_err(new_request_build_error)?;
+
+        self.client.send(request).await
+    }
+
+    pub(crate) async fn onedrive_chunked_upload(
+        &self,
+        url: &str,
+        args: &OpWrite,
+        offset: usize,
+        chunk_end: usize,
+        total_len: usize,
+        body: Buffer,
+    ) -> Result<Response<Buffer>> {
+        let mut request = Request::put(url);
+
+        let auth_header_content = format!("Bearer {}", self.access_token);
+        request = request.header(header::AUTHORIZATION, auth_header_content);
+
+        let range = format!("bytes {}-{}/{}", offset, chunk_end, total_len);
+        request = request.header("Content-Range".to_string(), range);
+
+        let size = chunk_end - offset + 1;
+        request = request.header(header::CONTENT_LENGTH, size.to_string());
+
+        if let Some(mime) = args.content_type() {
+            request = request.header(header::CONTENT_TYPE, mime)
+        }
+
+        let request = request.body(body).map_err(new_request_build_error)?;
+
+        self.client.send(request).await
+    }
+
+    pub(crate) async fn onedrive_create_upload_session(
+        &self,
+        url: &str,
+        body: OneDriveUploadSessionCreationRequestBody,
+    ) -> Result<Response<Buffer>> {
+        let mut request = Request::post(url);
+
+        let auth_header_content = format!("Bearer {}", self.access_token);
+        request = request.header(header::AUTHORIZATION, auth_header_content);
+
+        request = request.header(header::CONTENT_TYPE, "application/json");
+
+        let body_bytes = serde_json::to_vec(&body).map_err(new_json_serialize_error)?;
+        let body = Buffer::from(Bytes::from(body_bytes));
+        let request = request.body(body).map_err(new_request_build_error)?;
+
+        self.client.send(request).await
+    }
+
+    /// Create a directory
+    ///
+    /// When creates a folder, OneDrive returns a status code with 201.
+    /// When using `microsoft.graph.conflictBehavior=replace` to replace a folder, OneDrive returns 200.
+    pub(crate) async fn onedrive_create_dir(&self, path: &str) -> Result<Response<Buffer>> {
+        let path = build_rooted_abs_path(&self.root, path);
+        let path_before_last_slash = get_parent(&path);
+        let normalized = path_before_last_slash
+            .strip_suffix('/')
+            .unwrap_or(&path_before_last_slash);
+        let encoded_path = percent_encode_path(normalized);
+
+        let url = format!("{}:{}:/children", Self::DRIVE_ROOT_URL, encoded_path);
+
+        let folder_name = get_basename(&path);
+        let folder_name = folder_name.strip_suffix('/').unwrap_or(folder_name);
+
+        let body = CreateDirPayload::new(folder_name.to_string());
+
+        let mut request = Request::post(url);
+
+        let auth_header_content = format!("Bearer {}", self.access_token);
+        request = request.header(header::AUTHORIZATION, auth_header_content);
+        request = request.header(header::CONTENT_TYPE, "application/json");
+
+        let body_bytes = serde_json::to_vec(&body).map_err(new_json_serialize_error)?;
+        let body = Buffer::from(bytes::Bytes::from(body_bytes));
+        let request = request.body(body).map_err(new_request_build_error)?;
+
+        self.client.send(request).await
+    }
+
+    pub(crate) async fn onedrive_delete(&self, path: &str) -> Result<Response<Buffer>> {
+        let path = build_abs_path(&self.root, path);
+        let url = format!("{}:/{}:", Self::DRIVE_ROOT_URL, percent_encode_path(&path));
+
+        let mut request = Request::delete(&url);
+
+        let auth_header_content = format!("Bearer {}", self.access_token);
+        request = request.header(header::AUTHORIZATION, auth_header_content);
+
+        let request = request
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+
+        self.client.send(request).await
+    }
+}

--- a/core/src/services/onedrive/core.rs
+++ b/core/src/services/onedrive/core.rs
@@ -347,9 +347,7 @@ impl OneDriveSigner {
                     - chrono::TimeDelta::minutes(2); // assumes 2 mins graceful transmission for implementation simplicity
                 Ok(())
             }
-            _ => {
-                Err(parse_error(response))
-            }
+            _ => Err(parse_error(response)),
         }
     }
 

--- a/core/src/services/onedrive/delete.rs
+++ b/core/src/services/onedrive/delete.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::backend::OnedriveBackend;
+use super::core::OneDriveCore;
 use super::error::parse_error;
 use crate::raw::*;
 use crate::*;
@@ -24,25 +24,25 @@ use std::sync::Arc;
 
 /// Delete operation
 /// Documentation: https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_delete?view=odsp-graph-online
-pub struct OnedriveDeleter {
-    core: Arc<OnedriveBackend>,
+pub struct OneDriveDeleter {
+    core: Arc<OneDriveCore>,
 }
 
-impl OnedriveDeleter {
-    pub fn new(core: Arc<OnedriveBackend>) -> Self {
+impl OneDriveDeleter {
+    pub fn new(core: Arc<OneDriveCore>) -> Self {
         Self { core }
     }
 }
 
-impl oio::OneShotDelete for OnedriveDeleter {
+impl oio::OneShotDelete for OneDriveDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let resp = self.core.onedrive_delete(&path).await?;
+        let response = self.core.onedrive_delete(&path).await?;
 
-        let status = resp.status();
+        let status = response.status();
 
         match status {
             StatusCode::NO_CONTENT | StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(response)),
         }
     }
 }

--- a/core/src/services/onedrive/docs.md
+++ b/core/src/services/onedrive/docs.md
@@ -12,14 +12,17 @@ This service can be used to:
 
 ## Notes
 
-Currently, only OneDrive Personal is supported.
+Currently, OpenDAL supports OneDrive Personal only.
 
 ## Configuration
 
-- `access_token`: set the access_token for Graph API
-- `root`: Set the work directory for backend
+- `access_token`: set a short-live access token for Microsoft Graph API (also, OneDrive API)
+- `refresh_token`: set a long term access token for Microsoft Graph API
+- `client_id`: set the client ID for a Microsoft Graph API application (available though Azure's registration portal)
+- `client_secret`: set the client secret for a Microsoft Graph API application
+- `root`: Set the work directory for OneDrive backend
 
-You can refer to [`OnedriveBuilder`]'s docs for more information
+Read more at [`OnedriveBuilder`].
 
 ## Example
 

--- a/core/src/services/onedrive/error.rs
+++ b/core/src/services/onedrive/error.rs
@@ -22,12 +22,13 @@ use crate::raw::*;
 use crate::*;
 
 /// Parse error response into Error.
-pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
-    let (parts, body) = resp.into_parts();
+pub(super) fn parse_error(response: Response<Buffer>) -> Error {
+    let (parts, body) = response.into_parts();
     let bs = body.to_bytes();
 
     let (kind, retryable) = match parts.status {
         StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::CONFLICT => (ErrorKind::AlreadyExists, false),
         StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
         StatusCode::INTERNAL_SERVER_ERROR
         | StatusCode::BAD_GATEWAY

--- a/core/src/services/onedrive/graph_model.rs
+++ b/core/src/services/onedrive/graph_model.rs
@@ -21,7 +21,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct GraphApiOnedriveListResponse {
+pub struct GraphApiOneDriveListResponse {
     #[serde(rename = "@odata.nextLink")]
     pub next_link: Option<String>,
     pub value: Vec<OneDriveItem>,
@@ -30,20 +30,13 @@ pub struct GraphApiOnedriveListResponse {
 /// mapping for a DriveItem representation
 /// read more at https://learn.microsoft.com/en-us/onedrive/developer/rest-api/resources/driveitem
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct OneDriveItem {
     pub name: String,
-
-    #[serde(rename = "lastModifiedDateTime")]
     pub last_modified_date_time: String,
-
-    #[serde(rename = "eTag")]
     pub e_tag: String,
-
     pub size: i64,
-
-    #[serde(rename = "parentReference")]
     pub parent_reference: ParentReference,
-
     #[serde(flatten)]
     pub item_type: ItemType,
 }
@@ -70,36 +63,24 @@ pub enum ItemType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct OnedriveGetItemBody {
-    #[serde(rename = "cTag")]
-    pub(crate) c_tag: String,
-    #[serde(rename = "eTag")]
-    pub(crate) e_tag: String,
-    id: String,
-    #[serde(rename = "lastModifiedDateTime")]
-    pub(crate) last_modified_date_time: String,
-    pub(crate) name: String,
-    pub(crate) size: u64,
-
-    #[serde(flatten)]
-    pub(crate) item_type: ItemType,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct File {
-    #[serde(rename = "mimeType")]
     mime_type: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct Folder {
-    #[serde(rename = "childCount")]
     child_count: i64,
 }
 
+// Microsoft's documentation wants developers to set this as URL parameters.
+// If we follow the documentation, we can't replace the directory (409 existed error).
+// Though, even with this declaration, behavior tests show **flaky behavior**.
+const REPLACE_EXISTING_ITEM_WHEN_CONFLICT: &str = "replace";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateDirPayload {
-    // folder: String,
     #[serde(rename = "@microsoft.graph.conflictBehavior")]
     conflict_behavior: String,
     name: String,
@@ -109,7 +90,7 @@ pub struct CreateDirPayload {
 impl CreateDirPayload {
     pub fn new(name: String) -> Self {
         Self {
-            conflict_behavior: "replace".to_string(),
+            conflict_behavior: REPLACE_EXISTING_ITEM_WHEN_CONFLICT.to_string(),
             name,
             folder: EmptyStruct {},
         }
@@ -122,15 +103,14 @@ struct EmptyStruct {}
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct FileUploadItem {
     #[serde(rename = "@microsoft.graph.conflictBehavior")]
-    microsoft_graph_conflict_behavior: String,
+    conflict_behavior: String,
     name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct OneDriveUploadSessionCreationResponseBody {
-    #[serde(rename = "uploadUrl")]
     pub upload_url: String,
-    #[serde(rename = "expirationDateTime")]
     pub expiration_date_time: String,
 }
 
@@ -143,7 +123,7 @@ impl OneDriveUploadSessionCreationRequestBody {
     pub fn new(path: String) -> Self {
         OneDriveUploadSessionCreationRequestBody {
             item: FileUploadItem {
-                microsoft_graph_conflict_behavior: "replace".to_string(),
+                conflict_behavior: REPLACE_EXISTING_ITEM_WHEN_CONFLICT.to_string(),
                 name: path,
             },
         }
@@ -224,7 +204,7 @@ fn test_parse_one_drive_json() {
         ]
     }"#;
 
-    let response: GraphApiOnedriveListResponse = serde_json::from_str(data).unwrap();
+    let response: GraphApiOneDriveListResponse = serde_json::from_str(data).unwrap();
     assert_eq!(response.value.len(), 2);
     let item = &response.value[0];
     assert_eq!(item.name, "name");
@@ -290,7 +270,7 @@ fn test_parse_folder_single() {
         ]
       }"#;
 
-    let response: GraphApiOnedriveListResponse = serde_json::from_str(response_json).unwrap();
+    let response: GraphApiOneDriveListResponse = serde_json::from_str(response_json).unwrap();
     assert_eq!(response.value.len(), 1);
     let item = &response.value[0];
     if let ItemType::Folder { folder, .. } = &item.item_type {

--- a/core/src/services/onedrive/graph_model.rs
+++ b/core/src/services/onedrive/graph_model.rs
@@ -20,6 +20,13 @@ use std::collections::HashMap;
 use serde::Deserialize;
 use serde::Serialize;
 
+#[derive(Debug, Deserialize)]
+pub struct GraphOAuthRefreshTokenResponseBody {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_in: i64, // in seconds
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GraphApiOneDriveListResponse {
     #[serde(rename = "@odata.nextLink")]

--- a/core/src/services/onedrive/lister.rs
+++ b/core/src/services/onedrive/lister.rs
@@ -15,76 +15,68 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use bytes::Buf;
 
-use super::backend::OnedriveBackend;
+use super::core::OneDriveCore;
 use super::error::parse_error;
-use super::graph_model::GraphApiOnedriveListResponse;
+use super::graph_model::GraphApiOneDriveListResponse;
 use super::graph_model::ItemType;
 use crate::raw::oio;
 use crate::raw::*;
 use crate::*;
 
-pub struct OnedriveLister {
-    root: String,
+pub struct OneDriveLister {
+    core: Arc<OneDriveCore>,
     path: String,
-    backend: OnedriveBackend,
 }
 
-impl OnedriveLister {
+impl OneDriveLister {
     const DRIVE_ROOT_PREFIX: &'static str = "/drive/root:";
 
-    pub(crate) fn new(root: String, path: String, backend: OnedriveBackend) -> Self {
-        Self {
-            root,
-            path,
-            backend,
-        }
+    pub(crate) fn new(path: String, core: Arc<OneDriveCore>) -> Self {
+        Self { core, path }
     }
 }
 
-impl oio::PageList for OnedriveLister {
+impl oio::PageList for OneDriveLister {
     async fn next_page(&self, ctx: &mut oio::PageContext) -> Result<()> {
         let request_url = if ctx.token.is_empty() {
-            let path = build_rooted_abs_path(&self.root, &self.path);
-            let url: String = if path == "." || path == "/" {
-                "https://graph.microsoft.com/v1.0/me/drive/root/children".to_string()
-            } else {
-                format!(
-                    "https://graph.microsoft.com/v1.0/me/drive/root:/{}:/children",
-                    percent_encode_path(&path),
-                )
-            };
-            url
+            format!(
+                "{}:/children",
+                OneDriveCore::onedrive_item_url(&self.core.root, &self.path)
+            )
         } else {
             ctx.token.clone()
         };
 
-        let resp = self
-            .backend
-            .onedrive_get_next_list_page(&request_url)
-            .await?;
+        let response = self.core.onedrive_get_next_list_page(&request_url).await?;
 
-        let status_code = resp.status();
+        let status_code = response.status();
         if !status_code.is_success() {
             if status_code == http::StatusCode::NOT_FOUND {
                 ctx.done = true;
                 return Ok(());
             }
-            let error = parse_error(resp);
+            let error = parse_error(response);
             return Err(error);
         }
 
-        let bytes = resp.into_body();
-        let decoded_response: GraphApiOnedriveListResponse =
+        let bytes = response.into_body();
+        let decoded_response: GraphApiOneDriveListResponse =
             serde_json::from_reader(bytes.reader()).map_err(new_json_deserialize_error)?;
 
         // Include the current directory itself when handling the first page of the listing.
         if ctx.token.is_empty() && !ctx.done {
-            let path = build_abs_path(&self.root, self.path.as_str());
-            let path = build_rel_path(&self.root, &path);
-            let e = oio::Entry::new(&path, Metadata::new(EntryMode::DIR));
-            ctx.entries.push_back(e);
+            let path = self.path.clone(); //build_rooted_abs_path(&self.core.root, &self.path);
+            let full_path = build_rooted_abs_path(&self.core.root, &self.path);
+            let trimmed_full_path = full_path.strip_suffix('/').unwrap_or(&full_path);
+            // TODO: when listing a directory directly, we could reuse the stat result,
+            // cache the result when listing nested directory
+            let meta = self.core.onedrive_stat(&trimmed_full_path).await?;
+            let entry = oio::Entry::new(&path, meta);
+            ctx.entries.push_back(entry);
         }
 
         if let Some(next_link) = decoded_response.next_link {
@@ -101,13 +93,13 @@ impl oio::PageList for OnedriveLister {
                 .unwrap_or("");
 
             let path = format!("{}/{}", parent_path, name);
-            let mut normalized_path = build_rel_path(&self.root, &path);
+            let mut normalized_path = build_rel_path(self.core.root.as_str(), path.as_str());
             let entry_mode = match drive_item.item_type {
                 ItemType::Folder { .. } => EntryMode::DIR,
                 ItemType::File { .. } => EntryMode::FILE,
             };
 
-            // OneDrive returns the folder without the trailing `/`
+            // Add the trailing `/` because OneDrive returns a directory with the name
             if entry_mode == EntryMode::DIR {
                 normalized_path.push('/');
             }

--- a/core/src/services/onedrive/lister.rs
+++ b/core/src/services/onedrive/lister.rs
@@ -74,7 +74,7 @@ impl oio::PageList for OneDriveLister {
             let trimmed_full_path = full_path.strip_suffix('/').unwrap_or(&full_path);
             // TODO: when listing a directory directly, we could reuse the stat result,
             // cache the result when listing nested directory
-            let meta = self.core.onedrive_stat(&trimmed_full_path).await?;
+            let meta = self.core.onedrive_stat(trimmed_full_path).await?;
             let entry = oio::Entry::new(&path, meta);
             ctx.entries.push_back(entry);
         }

--- a/core/src/services/onedrive/mod.rs
+++ b/core/src/services/onedrive/mod.rs
@@ -18,6 +18,8 @@
 #[cfg(feature = "services-onedrive")]
 mod backend;
 #[cfg(feature = "services-onedrive")]
+mod core;
+#[cfg(feature = "services-onedrive")]
 mod delete;
 #[cfg(feature = "services-onedrive")]
 mod error;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5653.
Part of #5677.
Part of #5702.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

This is a somewhat large PR. Reviewing it commit by commit is easier.

1. This PR extracts the OneDrive service into the "core" structure. Minor changes to names, how to stat, etc.
2. Uses context for an HTTP client.
3. Adds a signer. This mostly follows the Google Drive service signer implementation.

# Are there any user-facing changes?

I added a few more refresh token settings for the OneDrive service. I added the documentation.