### PR TITLE
fix(website): Handling badges click behavior correctly

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -255,7 +255,7 @@ const config = {
         additionalLanguages: ["rust", "java", "groovy"],
       },
       zoom: {
-        selector: ".markdown img",
+        selector: "img:not(a img)",
         background: "rgba(255, 255, 255, 0.8)",
         config: {},
       },


### PR DESCRIPTION
# Rationale for this change
Images inside links (such as badges in the README) were being captured by the image zoom plugin ( `docusaurus-plugin-image-zoom` ), which interfered with their expected click behavior.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Updated the image zoom plugin configuration to exclude images inside anchor tags by modifying the CSS selector to `img:not(a img)`. 
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->


https://github.com/user-attachments/assets/f6881de4-bdea-40c6-9c45-5978249e455f

