### PR TITLE
fix: drop useless import and clippy happy for java binding

### DIFF
--- a/.github/workflows/ci_bindings_java.yml
+++ b/.github/workflows/ci_bindings_java.yml
@@ -57,6 +57,9 @@ jobs:
         run: |
           ./mvnw clean compile spotless:check
 
+      - name: Check Clippy
+        run: cargo clippy -- -D warnings
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci_bindings_java.yml
+++ b/.github/workflows/ci_bindings_java.yml
@@ -58,6 +58,7 @@ jobs:
           ./mvnw clean compile spotless:check
 
       - name: Check Clippy
+        working-directory: bindings/java
         run: cargo clippy -- -D warnings
 
   test:

--- a/bindings/java/src/async_operator.rs
+++ b/bindings/java/src/async_operator.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::future::Future;
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -30,10 +29,9 @@ use jni::sys::jobject;
 use jni::sys::jsize;
 use jni::JNIEnv;
 use opendal::layers::BlockingLayer;
-use opendal::operator_futures::FutureWrite;
 use opendal::raw::PresignedRequest;
+use opendal::Operator;
 use opendal::Scheme;
-use opendal::{Metadata, Operator};
 
 use crate::convert::jstring_to_string;
 use crate::convert::{

--- a/bindings/java/src/convert.rs
+++ b/bindings/java/src/convert.rs
@@ -69,8 +69,8 @@ pub(crate) fn string_to_jstring<'a>(
     )
 }
 
-pub(crate) fn get_optional_string_from_object<'a>(
-    env: &mut JNIEnv<'a>,
+pub(crate) fn get_optional_string_from_object(
+    env: &mut JNIEnv<'_>,
     obj: &JObject,
     method: &str,
 ) -> crate::Result<Option<String>> {
@@ -84,8 +84,8 @@ pub(crate) fn get_optional_string_from_object<'a>(
     }
 }
 
-pub(crate) fn get_optional_map_from_object<'a>(
-    env: &mut JNIEnv<'a>,
+pub(crate) fn get_optional_map_from_object(
+    env: &mut JNIEnv<'_>,
     obj: &JObject,
     method: &str,
 ) -> crate::Result<Option<HashMap<String, String>>> {

--- a/bindings/java/src/executor.rs
+++ b/bindings/java/src/executor.rs
@@ -20,6 +20,7 @@ use std::ffi::c_void;
 use std::future::Future;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::OnceLock;
 use std::thread::available_parallelism;
 
 use jni::objects::JClass;
@@ -28,12 +29,11 @@ use jni::objects::JValue;
 use jni::sys::jlong;
 use jni::JNIEnv;
 use jni::JavaVM;
-use once_cell::sync::OnceCell;
 use tokio::task::JoinHandle;
 
 use crate::Result;
 
-static mut RUNTIME: OnceCell<Executor> = OnceCell::new();
+static RUNTIME: OnceLock<Executor> = OnceLock::new();
 thread_local! {
     static ENV: RefCell<Option<*mut jni::sys::JNIEnv>> = const { RefCell::new(None) };
 }
@@ -43,7 +43,9 @@ thread_local! {
 /// This function could be only called by java vm when unload this lib.
 #[no_mangle]
 pub unsafe extern "system" fn JNI_OnUnload(_: JavaVM, _: *mut c_void) {
-    let _ = RUNTIME.take();
+    // Since OnceLock doesn't have a take() method, we can't remove the runtime
+    // This is fine as the JVM is shutting down anyway
+    // The runtime will be dropped when the process exits
 }
 
 /// # Safety
@@ -186,10 +188,11 @@ pub(crate) fn executor_or_default<'a>(
 ///
 /// This function could be only when the lib is loaded.
 unsafe fn default_executor<'a>(env: &mut JNIEnv<'a>) -> Result<&'a Executor> {
-    RUNTIME.get_or_try_init(|| {
+    Ok(RUNTIME.get_or_init(|| {
         make_tokio_executor(
             env,
             available_parallelism().map(NonZeroUsize::get).unwrap_or(1),
         )
-    })
+        .expect("Failed to initialize default executor")
+    }))
 }

--- a/bindings/java/src/executor.rs
+++ b/bindings/java/src/executor.rs
@@ -195,14 +195,5 @@ unsafe fn default_executor<'a>(env: &mut JNIEnv<'a>) -> Result<&'a Executor> {
         available_parallelism().map(NonZeroUsize::get).unwrap_or(1),
     )?;
 
-    // It's okay if another thread initialized it first
-    let _ = RUNTIME.set(executor);
-
-    // Now RUNTIME should be initialized
-    Ok(RUNTIME.get().ok_or_else(|| {
-        opendal::Error::new(
-            opendal::ErrorKind::Unexpected,
-            "Failed to initialize default executor",
-        )
-    })?)
+    Ok(RUNTIME.get_or_init(|| executor))
 }

--- a/bindings/java/src/executor.rs
+++ b/bindings/java/src/executor.rs
@@ -42,10 +42,7 @@ thread_local! {
 ///
 /// This function could be only called by java vm when unload this lib.
 #[no_mangle]
-pub unsafe extern "system" fn JNI_OnUnload(_: JavaVM, _: *mut c_void) {
-    // This is fine as the JVM is shutting down anyway
-    // The runtime will be dropped when the process exits
-}
+pub unsafe extern "system" fn JNI_OnUnload(_: JavaVM, _: *mut c_void) {}
 
 /// # Safety
 ///

--- a/bindings/java/src/executor.rs
+++ b/bindings/java/src/executor.rs
@@ -43,7 +43,6 @@ thread_local! {
 /// This function could be only called by java vm when unload this lib.
 #[no_mangle]
 pub unsafe extern "system" fn JNI_OnUnload(_: JavaVM, _: *mut c_void) {
-    // Since OnceLock doesn't have a take() method, we can't remove the runtime
     // This is fine as the JVM is shutting down anyway
     // The runtime will be dropped when the process exits
 }

--- a/bindings/java/src/executor.rs
+++ b/bindings/java/src/executor.rs
@@ -197,10 +197,10 @@ unsafe fn default_executor<'a>(env: &mut JNIEnv<'a>) -> Result<&'a Executor> {
         env,
         available_parallelism().map(NonZeroUsize::get).unwrap_or(1),
     )?;
-    
+
     // It's okay if another thread initialized it first
     let _ = RUNTIME.set(executor);
-    
+
     // Now RUNTIME should be initialized
     Ok(RUNTIME.get().ok_or_else(|| {
         opendal::Error::new(


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5745 

This patch do these things for java binding:

- drop useless import
- use latest stable api to the warning -> `Replace once_cell::sync::OnceCell with the standard library's std::sync::OnceLock (available since Rust 1.70)`
- make clippy happy
- add clippy ci for java binding