### PR TITLE
fix: make php binding happy again

### DIFF
--- a/.github/workflows/ci_bindings_php.yml
+++ b/.github/workflows/ci_bindings_php.yml
@@ -20,17 +20,17 @@ name: Bindings PHP CI
 on:
   # Disable PHP build until https://github.com/apache/opendal/issues/3055 addressed
   #
-  #  push:
-  #    branches:
-  #      - main
-  #    tags:
-  #      - '*'
-  #  pull_request:
-  #    branches:
-  #      - main
-  #    paths:
-  #      - "bindings/php/**"
-  #      - ".github/workflows/bindings_php.yml"
+   push:
+     branches:
+       - main
+     tags:
+       - '*'
+   pull_request:
+     branches:
+       - main
+     paths:
+       - "bindings/php/**"
+       - ".github/workflows/bindings_php.yml"
   workflow_dispatch:
 
 concurrency:
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2]
+        php: [8.2, 8.4]
 
     steps:
       - name: Checkout code
@@ -67,6 +67,11 @@ jobs:
       - name: Build opendal-php extension
         working-directory: "bindings/php"
         run: cargo build
+
+      - name: Clippy Check
+        working-directory: "bindings/php"
+        run: |
+          cargo clippy -- -D warnings
 
       - name: Enable opendal-php extension in php.ini
         run: |

--- a/.github/workflows/ci_bindings_php.yml
+++ b/.github/workflows/ci_bindings_php.yml
@@ -62,14 +62,14 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
 
-      - name: Build opendal-php extension
-        working-directory: "bindings/php"
-        run: cargo build
-
       - name: Clippy Check
         working-directory: "bindings/php"
         run: |
           cargo clippy -- -D warnings
+
+      - name: Build opendal-php extension
+        working-directory: "bindings/php"
+        run: cargo build
 
       - name: Enable opendal-php extension in php.ini
         run: |

--- a/.github/workflows/ci_bindings_php.yml
+++ b/.github/workflows/ci_bindings_php.yml
@@ -18,19 +18,17 @@
 name: Bindings PHP CI
 
 on:
-  # Disable PHP build until https://github.com/apache/opendal/issues/3055 addressed
-  #
-   push:
-     branches:
-       - main
-     tags:
-       - '*'
-   pull_request:
-     branches:
-       - main
-     paths:
-       - "bindings/php/**"
-       - ".github/workflows/bindings_php.yml"
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "bindings/php/**"
+      - ".github/workflows/bindings_php.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_php.yml
+++ b/.github/workflows/ci_bindings_php.yml
@@ -72,6 +72,7 @@ jobs:
         run: cargo build
 
       - name: Enable opendal-php extension in php.ini
+        working-directory: "bindings/php"
         run: |
           # 1. Find the extension_dir
           extension_dir=$(php -r "echo ini_get('extension_dir');")

--- a/bindings/php/Cargo.toml
+++ b/bindings/php/Cargo.toml
@@ -30,7 +30,7 @@ rust-version = "1.75"
 crate-type = ["cdylib"]
 
 [dependencies]
-ext-php-rs = "0.11.2"
+ext-php-rs = "0.13.1"
 # this crate won't be published, we always use the local version
 opendal = { version = ">=0", path = "../../core", features = [
   # These are default features before v0.46. TODO: change to optional features

--- a/bindings/php/src/lib.rs
+++ b/bindings/php/src/lib.rs
@@ -40,17 +40,26 @@ impl Operator {
 
     /// Write string into given path.
     pub fn write(&self, path: &str, content: String) -> PhpResult<()> {
-        self.0.write(path, content).map(|_| ()).map_err(format_php_err)
+        self.0
+            .write(path, content)
+            .map(|_| ())
+            .map_err(format_php_err)
     }
 
     /// Write bytes into given path, binary safe.
     pub fn write_binary(&self, path: &str, content: Vec<u8>) -> PhpResult<()> {
-        self.0.write(path, content).map(|_| ()).map_err(format_php_err)
+        self.0
+            .write(path, content)
+            .map(|_| ())
+            .map_err(format_php_err)
     }
 
     /// Read the whole path into bytes, binary safe.
     pub fn read(&self, path: &str) -> PhpResult<Binary<u8>> {
-        self.0.read(path).map_err(format_php_err).map(|buf| Binary::from(buf.to_vec()))
+        self.0
+            .read(path)
+            .map_err(format_php_err)
+            .map(|buf| Binary::from(buf.to_vec()))
     }
 
     /// Check if this path exists or not, return 1 if exists, 0 otherwise.

--- a/bindings/php/src/lib.rs
+++ b/bindings/php/src/lib.rs
@@ -40,23 +40,23 @@ impl Operator {
 
     /// Write string into given path.
     pub fn write(&self, path: &str, content: String) -> PhpResult<()> {
-        self.0.write(path, content).map_err(format_php_err)
+        self.0.write(path, content).map(|_| ()).map_err(format_php_err)
     }
 
     /// Write bytes into given path, binary safe.
     pub fn write_binary(&self, path: &str, content: Vec<u8>) -> PhpResult<()> {
-        self.0.write(path, content).map_err(format_php_err)
+        self.0.write(path, content).map(|_| ()).map_err(format_php_err)
     }
 
     /// Read the whole path into bytes, binary safe.
     pub fn read(&self, path: &str) -> PhpResult<Binary<u8>> {
-        self.0.read(path).map_err(format_php_err).map(Binary::from)
+        self.0.read(path).map_err(format_php_err).map(|buf| Binary::from(buf.to_vec()))
     }
 
     /// Check if this path exists or not, return 1 if exists, 0 otherwise.
     pub fn is_exist(&self, path: &str) -> PhpResult<u8> {
         self.0
-            .is_exist(path)
+            .exists(path)
             .map_err(format_php_err)
             .map(|b| if b { 1 } else { 0 })
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #2813

This patch aim to make php binding work and happy and greate again
and do these things

- open php binding ci
- fix binding ci workdir problem
- update ext-php-rs to match latest system and php
- drop php 8.1 and bring php 8.4 for ci test
- add clippy to ci
- fix the compiler error and clippy error


happy ci: https://github.com/yihong0618/opendal/actions/runs/13837386813