### PR TITLE
feat(services/onedrive): implement read_with_if_none_match

### DIFF
--- a/core/src/raw/http_util/body.rs
+++ b/core/src/raw/http_util/body.rs
@@ -24,10 +24,10 @@ use oio::Read;
 use crate::raw::*;
 use crate::*;
 
-/// HttpBody is the streaming body that opendal's HttpClient returned.
+/// The streaming body that OpenDAL's HttpClient returned.
 ///
-/// It implements the `oio::Read` trait, service implementors can return it as
-/// `Access::Read`.
+/// We implement [`oio::Read`] for the `HttpBody`. Services can use `HttpBody` as
+/// [`Access::Read`].
 pub struct HttpBody {
     #[cfg(not(target_arch = "wasm32"))]
     stream: Box<dyn Stream<Item = Result<Buffer>> + Send + Sync + Unpin + 'static>,

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -80,18 +80,12 @@ impl Access for OnedriveBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let response = self
-            .core
-            .onedrive_get_content(path, args.range(), args.if_none_match())
-            .await?;
+        let response = self.core.onedrive_get_content(path, &args).await?;
 
         let status = response.status();
         match status {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
                 Ok((RpRead::default(), response.into_body()))
-            }
-            StatusCode::NOT_MODIFIED => {
-                Err(Error::new(ErrorKind::ConditionNotMatch, "eTag matches"))
             }
             _ => {
                 let (part, mut body) = response.into_parts();

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -80,12 +80,18 @@ impl Access for OnedriveBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let response = self.core.onedrive_get_content(path, args.range()).await?;
+        let response = self
+            .core
+            .onedrive_get_content(path, args.range(), args.if_none_match())
+            .await?;
 
         let status = response.status();
         match status {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
                 Ok((RpRead::default(), response.into_body()))
+            }
+            StatusCode::NOT_MODIFIED => {
+                Err(Error::new(ErrorKind::ConditionNotMatch, "eTag matches"))
             }
             _ => {
                 let (part, mut body) = response.into_parts();

--- a/core/src/services/onedrive/builder.rs
+++ b/core/src/services/onedrive/builder.rs
@@ -144,6 +144,8 @@ impl Builder for OnedriveBuilder {
             .set_root(&root)
             .set_native_capability(Capability {
                 read: true,
+                read_with_if_none_match: true,
+
                 write: true,
 
                 stat: true,

--- a/core/src/services/onedrive/core.rs
+++ b/core/src/services/onedrive/core.rs
@@ -148,8 +148,7 @@ impl OneDriveCore {
     pub(crate) async fn onedrive_get_content(
         &self,
         path: &str,
-        range: BytesRange,
-        etag: Option<&str>,
+        args: &OpRead,
     ) -> Result<Response<HttpBody>> {
         let path = build_rooted_abs_path(&self.root, path);
         let url: String = format!(
@@ -158,8 +157,8 @@ impl OneDriveCore {
             percent_encode_path(&path),
         );
 
-        let mut request = Request::get(&url).header(header::RANGE, range.to_header());
-        if let Some(etag) = etag {
+        let mut request = Request::get(&url).header(header::RANGE, args.range().to_header());
+        if let Some(etag) = args.if_none_match() {
             request = request.header(header::IF_NONE_MATCH, etag);
         }
 

--- a/core/src/services/onedrive/error.rs
+++ b/core/src/services/onedrive/error.rs
@@ -34,6 +34,7 @@ pub(super) fn parse_error(response: Response<Buffer>) -> Error {
         | StatusCode::BAD_GATEWAY
         | StatusCode::SERVICE_UNAVAILABLE
         | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        StatusCode::NOT_MODIFIED => (ErrorKind::ConditionNotMatch, false),
         _ => (ErrorKind::Unexpected, false),
     };
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of #5486.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

I encountered an issue with the HTTP client when working with OneDrive. Specifically, OneDrive returns a 302 Location response when downloading an item. See `onedrive_get_content`. This has two implications:

1. OpenDAL cannot implement "presign" for OneDrive without controlling or requiring the HTTP client to handle retries. While this is not an urgent issue, it may be worth tracking in an issue to gather requirements for the HTTP client.
2. In my implementation, I must assume that the HTTP client will automatically follow 302 redirects. If redirection does not occur, the OneDrive backend will return an error, which is not ideal. This is also not a good position for developers building services where developers can't predict how http clients will perform with redirections.