### PR TITLE
docs: Fix rustic users entry

### DIFF
--- a/core/users.md
+++ b/core/users.md
@@ -10,4 +10,4 @@
 - [QuestDB](https://github.com/questdb/questdb): An open-source time-series database for high throughput ingestion and fast SQL queries with operational simplicity.
 - [RisingWave](https://github.com/risingwavelabs/risingwave): A Distributed SQL Database for Stream Processing
 - [Vector](https://github.com/vectordotdev/vector): A high-performance observability data pipeline.
-- [rustic](https://github.com/rustic-rs/rustic): About rustic - fast, encrypted, and deduplicated backups powered by Rust
+- [rustic](https://github.com/rustic-rs/rustic): Fast, encrypted, and deduplicated backups powered by Rust


### PR DESCRIPTION
The "About" header was accidentally copied when copying the "About" section on the GitHub project page.

# Which issue does this PR close?

Fixes issue with rustic's entry in the users list

# Rationale for this change

It's obviously a mistake

# What changes are included in this PR?

Rustic's entry in the users list has been fixed

# Are there any user-facing changes?

No
