### PR TITLE
refactor(core/raw)!: Use AccessorInfo instead of seperate fields

### DIFF
--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -105,17 +105,13 @@ pub struct MetricsInterceptor {
 impl observe::MetricsIntercept for MetricsInterceptor {
     fn observe_operation_duration_seconds(
         &self,
-        scheme: Scheme,
-        namespace: Arc<String>,
-        root: Arc<String>,
+        info: Arc<AccessorInfo>,
         path: &str,
         op: Operation,
         duration: Duration,
     ) {
         let labels = OperationLabels {
-            scheme,
-            namespace,
-            root,
+            info,
             path,
             operation: op,
             error: None,
@@ -126,17 +122,13 @@ impl observe::MetricsIntercept for MetricsInterceptor {
 
     fn observe_operation_bytes(
         &self,
-        scheme: Scheme,
-        namespace: Arc<String>,
-        root: Arc<String>,
+        info: Arc<AccessorInfo>,
         path: &str,
         op: Operation,
         bytes: usize,
     ) {
         let labels = OperationLabels {
-            scheme,
-            namespace,
-            root,
+            info,
             path,
             operation: op,
             error: None,
@@ -147,17 +139,13 @@ impl observe::MetricsIntercept for MetricsInterceptor {
 
     fn observe_operation_errors_total(
         &self,
-        scheme: Scheme,
-        namespace: Arc<String>,
-        root: Arc<String>,
+        info: Arc<AccessorInfo>,
         path: &str,
         op: Operation,
         error: ErrorKind,
     ) {
         let labels = OperationLabels {
-            scheme,
-            namespace,
-            root,
+            info,
             path,
             operation: op,
             error: Some(error),
@@ -168,9 +156,7 @@ impl observe::MetricsIntercept for MetricsInterceptor {
 }
 
 struct OperationLabels<'a> {
-    scheme: Scheme,
-    namespace: Arc<String>,
-    root: Arc<String>,
+    info: Arc<AccessorInfo>,
     path: &'a str,
     operation: Operation,
     error: Option<ErrorKind>,
@@ -187,9 +173,9 @@ impl OperationLabels<'_> {
         let mut labels = Vec::with_capacity(6);
 
         labels.extend([
-            Label::new(observe::LABEL_SCHEME, self.scheme.into_static()),
-            Label::new(observe::LABEL_NAMESPACE, (*self.namespace).clone()),
-            Label::new(observe::LABEL_ROOT, (*self.root).clone()),
+            Label::new(observe::LABEL_SCHEME, self.info.scheme().into_static()),
+            Label::new(observe::LABEL_NAMESPACE, self.info.name()),
+            Label::new(observe::LABEL_ROOT, self.info.root()),
             Label::new(observe::LABEL_OPERATION, self.operation.into_static()),
         ]);
 

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -802,7 +802,7 @@ impl<T: Access + ?Sized> Access for Arc<T> {
 /// Accessor is the type erased accessor with `Arc<dyn Accessor>`.
 pub type Accessor = Arc<dyn AccessDyn>;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct AccessorInfoInner {
     scheme: Scheme,
     root: Arc<str>,
@@ -813,6 +813,21 @@ struct AccessorInfoInner {
 
     http_client: HttpClient,
     executor: Executor,
+}
+
+/// TODO: we can remove this after MSRV is 1.80
+impl Default for AccessorInfoInner {
+    fn default() -> Self {
+        AccessorInfoInner {
+            scheme: Scheme::Memory,
+            root: "".into(),
+            name: "".into(),
+            native_capability: Capability::default(),
+            full_capability: Capability::default(),
+            http_client: HttpClient::default(),
+            executor: Executor::default(),
+        }
+    }
 }
 
 /// Info for the accessor. Users can use this struct to retrieve information about the underlying backend.

--- a/core/src/types/operator/info.rs
+++ b/core/src/types/operator/info.rs
@@ -36,7 +36,7 @@ impl OperatorInfo {
 
     /// Root of operator, will be in format like `/path/to/dir/`
     pub fn root(&self) -> String {
-        self.0.root()
+        self.0.root().to_string()
     }
 
     /// Name of backend, could be empty if underlying backend doesn't have namespace concept.
@@ -46,7 +46,7 @@ impl OperatorInfo {
     /// - name for `s3` => bucket name
     /// - name for `azblob` => container name
     pub fn name(&self) -> String {
-        self.0.name()
+        self.0.name().to_string()
     }
 
     /// Get [`Full Capability`] of operator.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/opendal/issues/5795

# Rationale for this change

See https://github.com/apache/opendal/issues/5795 for details.

# What changes are included in this PR?

- Use AccessorInfo instead of seperate fields
- Return `Arc<str>` instead of `String` for `name` and `root` to avoid copy.

# Are there any user-facing changes?

None. Only raw API been touched.
