### PR TITLE
feat(core): Implement http related metrics support for prom client

### DIFF
--- a/core/src/layers/observe/mod.rs
+++ b/core/src/layers/observe/mod.rs
@@ -19,15 +19,17 @@
 //!
 //! This module offers essential components to facilitate the implementation of observability in OpenDAL.
 //!
-//! # Prometheus Metrics
+//! # Metrics
 //!
 //! These metrics are essential for understanding the behavior and performance of our applications.
 //!
-//! | Metric Name                  | Type      | Description                                                  | Labels                                          |
-//! |------------------------------|-----------|--------------------------------------------------------------|-------------------------------------------------|
-//! | operation_duration_seconds   | Histogram | Histogram of time spent during opendal operations            | scheme, namespace, root, operation, path        |
-//! | operation_bytes.             | Histogram | Histogram of the bytes transferred during opendal operations | scheme, operation, root, operation, path        |
-//! | operation_errors_total       | Counter   | Error counter during opendal operations                      | scheme, operation, root, operation, path, error |
+//! | Metric Name                   | Type      | Description                                                  | Labels                                          |
+//! |-------------------------------|-----------|--------------------------------------------------------------|-------------------------------------------------|
+//! | operation_duration_seconds    | Histogram | Histogram of time spent during opendal operations            | scheme, namespace, root, operation, path        |
+//! | operation_bytes.              | Histogram | Histogram of the bytes transferred during opendal operations | scheme, namespace, root, operation, path        |
+//! | operation_errors_total        | Counter   | Error counter during opendal operations                      | scheme, namespace, root, operation, path, error |
+//! | http_request_duration_seconds | Histogram | Histogram of time spent during http requests                 | scheme, namespace, root, operation              |
+//! | http_request_bytes.           | Histogram | Histogram of the bytes transferred during http requests      | scheme, namespace, root, operation              |
 
 mod metrics;
 
@@ -41,6 +43,8 @@ pub use metrics::LABEL_OPERATION;
 pub use metrics::LABEL_PATH;
 pub use metrics::LABEL_ROOT;
 pub use metrics::LABEL_SCHEME;
+pub use metrics::METRIC_HTTP_REQUEST_BYTES;
+pub use metrics::METRIC_HTTP_REQUEST_DURATION_SECONDS;
 pub use metrics::METRIC_OPERATION_BYTES;
 pub use metrics::METRIC_OPERATION_DURATION_SECONDS;
 pub use metrics::METRIC_OPERATION_ERRORS_TOTAL;

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -82,6 +82,11 @@ impl HttpClient {
         Self { fetcher }
     }
 
+    /// Get the inner http client.
+    pub(crate) fn into_inner(self) -> HttpFetcher {
+        self.fetcher
+    }
+
     /// Build a new http client in async context.
     #[deprecated]
     pub fn build(builder: reqwest::ClientBuilder) -> Result<Self> {

--- a/core/src/raw/http_util/mod.rs
+++ b/core/src/raw/http_util/mod.rs
@@ -25,6 +25,7 @@
 mod client;
 pub use client::HttpClient;
 pub use client::HttpFetch;
+pub use client::HttpFetcher;
 
 /// temporary client used by several features
 #[allow(unused_imports)]


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/opendal/issues/5794

# Rationale for this change

See https://github.com/apache/opendal/issues/5794

# What changes are included in this PR?

- Add http related metrics for `observe::MetricsLayer`
- Implement for `PrometheusClientLayer`

# Are there any user-facing changes?

New APIs for `PrometheusClientLayerBuilder` to configure http metrics.