### PR TITLE
fix(bindings/python): open python3.13t release for windows since upstream had fixed

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -82,9 +82,6 @@ jobs:
           sccache: true
           manylinux: ${{ matrix.manylinux || 'auto' }}
       - name: Build free-threaded wheels
-        # windows free-threading building doesn't work on windows
-        # https://github.com/apache/opendal/pull/5449#issuecomment-2560469190
-        if: ${{ runner.os != 'Windows' }}
         uses: PyO3/maturin-action@v1
         with:
           working-directory: "bindings/python"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

This patch open python3.13t release and drop the hint comments
since https://github.com/PyO3/pyo3/pull/4808 had been merged

ci: https://github.com/yihong0618/opendal/actions/runs/13961638383/job/39083903662
