### PR TITLE
refactor(core): Migrate BlockWriter to use executor from context

### DIFF
--- a/core/src/raw/oio/write/block_write.rs
+++ b/core/src/raw/oio/write/block_write.rs
@@ -114,8 +114,8 @@ pub struct BlockWriter<W: BlockWrite> {
 
 impl<W: BlockWrite> BlockWriter<W> {
     /// Create a new BlockWriter.
-    pub fn new(inner: W, executor: Option<Executor>, concurrent: usize) -> Self {
-        let executor = executor.unwrap_or_default();
+    pub fn new(info: Arc<AccessorInfo>, inner: W, concurrent: usize) -> Self {
+        let executor = info.executor();
 
         Self {
             w: Arc::new(inner),
@@ -328,7 +328,7 @@ mod tests {
     async fn test_block_writer_with_concurrent_errors() {
         let mut rng = thread_rng();
 
-        let mut w = BlockWriter::new(TestWrite::new(), Some(Executor::new()), 8);
+        let mut w = BlockWriter::new(Arc::default(), TestWrite::new(), 8);
         let mut total_size = 0u64;
         let mut expected_content = Vec::new();
 
@@ -372,7 +372,7 @@ mod tests {
         let mut rng = thread_rng();
 
         for _ in 1..100 {
-            let mut w = BlockWriter::new(TestWrite::new(), Some(Executor::new()), 8);
+            let mut w = BlockWriter::new(Arc::default(), TestWrite::new(), 8);
 
             let size = rng.gen_range(1..1024);
             let mut bs = vec![0; size];

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -596,8 +596,8 @@ impl Access for AzblobBackend {
             AzblobWriters::Two(oio::AppendWriter::new(w))
         } else {
             AzblobWriters::One(oio::BlockWriter::new(
+                self.core.info.clone(),
                 w,
-                args.executor().cloned(),
                 args.concurrent(),
             ))
         };

--- a/core/src/services/ghac/writer.rs
+++ b/core/src/services/ghac/writer.rs
@@ -138,7 +138,7 @@ impl GhacWriter {
                     signer: { reqsign::AzureStorageSigner::new() },
                 });
                 let w = AzblobWriter::new(azure_core, OpWrite::default(), path.to_string());
-                let writer = oio::BlockWriter::new(w, None, 4);
+                let writer = oio::BlockWriter::new(core.info.clone(), w, 4);
                 Ok(TwoWays::Two(GhacWriterV2 {
                     core,
                     writer,

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -684,8 +684,8 @@ impl Access for WebhdfsBackend {
             WebhdfsWriters::Two(oio::AppendWriter::new(w))
         } else {
             WebhdfsWriters::One(oio::BlockWriter::new(
+                self.info.clone(),
                 w,
-                args.executor().cloned(),
                 args.concurrent(),
             ))
         };


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/5831

# Rationale for this change

Migrate BlockWriter to use executor from context so that users can inject context in executor instead.

# What changes are included in this PR?

Migrate BlockWriter to use executor from context

# Are there any user-facing changes?

No.