### PR TITLE
Add support to partial read using offset and length to Java client

### DIFF
--- a/bindings/java/src/async_operator.rs
+++ b/bindings/java/src/async_operator.rs
@@ -305,11 +305,58 @@ fn intern_read(
     Ok(id)
 }
 
+#[no_mangle]
+pub unsafe extern "system" fn Java_org_apache_opendal_AsyncOperator_read_with_offset(
+    mut env: JNIEnv,
+    _: JClass,
+    op: *mut Operator,
+    executor: *const Executor,
+    offset: jlong,
+    len: jlong,
+    path: JString,
+) -> jlong {
+    intern_read_with_offset(&mut env, op, executor, offset, len, path).unwrap_or_else(|e| {
+        e.throw(&mut env);
+        0
+    })
+}
+
+fn intern_read_with_offset(
+    env: &mut JNIEnv,
+    op: *mut Operator,
+    executor: *const Executor,
+    offset: jlong,
+    len: jlong,
+    path: JString,
+) -> Result<jlong> {
+    let op = unsafe { &mut *op };
+    let id = request_id(env)?;
+
+    let path = jstring_to_string(env, &path)?;
+
+    executor_or_default(env, executor)?.spawn(async move {
+        let result = do_read_with_offset(op, offset, len, path).await;
+        complete_future(id, result.map(JValueOwned::Object))
+    });
+
+    Ok(id)
+}
+
 async fn do_read<'local>(op: &mut Operator, path: String) -> Result<JObject<'local>> {
     let content = op.read(&path).await?.to_bytes();
 
     let env = unsafe { get_current_env() };
     let result = env.byte_array_from_slice(&content)?;
+    Ok(result.into())
+}
+
+async fn do_read_with_offset<'local>(op: &mut Operator, offset: jlong, len: jlong, path: String) -> Result<JObject<'local>> {
+    let offset = offset as u64;
+    let len = len as u64;
+
+    let buffer = op.read_with(&path).range(offset..(offset + len)).await?.to_bytes();
+    let env = unsafe { get_current_env() };
+    let result = env.byte_array_from_slice(&buffer)?;
     Ok(result.into())
 }
 

--- a/bindings/java/src/main/java/org/apache/opendal/AsyncOperator.java
+++ b/bindings/java/src/main/java/org/apache/opendal/AsyncOperator.java
@@ -228,6 +228,11 @@ public class AsyncOperator extends NativeObject {
         return AsyncRegistry.take(requestId);
     }
 
+    public CompletableFuture<byte[]> read(String path, long offset, long len) {
+        final long requestId = read_with_offset(nativeHandle, executorHandle, offset, len, path);
+        return AsyncRegistry.take(requestId);
+    }
+
     public CompletableFuture<PresignedRequest> presignRead(String path, Duration duration) {
         final long requestId = presignRead(nativeHandle, executorHandle, path, duration.toNanos());
         return AsyncRegistry.take(requestId);
@@ -286,6 +291,8 @@ public class AsyncOperator extends NativeObject {
     private static native long constructor(long executorHandle, String scheme, Map<String, String> map);
 
     private static native long read(long nativeHandle, long executorHandle, String path);
+
+    private static native long read_with_offset(long nativeHandle, long executorHandle, long offset, long len, String path);
 
     private static native long write(
             long nativeHandle, long executorHandle, String path, byte[] content, WriteOptions options);

--- a/bindings/java/src/main/java/org/apache/opendal/Operator.java
+++ b/bindings/java/src/main/java/org/apache/opendal/Operator.java
@@ -99,6 +99,10 @@ public class Operator extends NativeObject {
         return read(nativeHandle, path);
     }
 
+    public byte[] read(String path, long offset, long len) {
+        return read_with_offset(nativeHandle, offset, len, path);
+    }
+
     public OperatorInputStream createInputStream(String path) {
         return new OperatorInputStream(this, path);
     }
@@ -143,6 +147,8 @@ public class Operator extends NativeObject {
     private static native void write(long op, String path, byte[] content, WriteOptions options);
 
     private static native byte[] read(long op, String path);
+
+    private static native byte[] read_with_offset(long op, long offset, long len, String path);
 
     private static native void delete(long op, String path);
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncReadOnlyTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncReadOnlyTest.java
@@ -119,6 +119,14 @@ public class AsyncReadOnlyTest extends BehaviorTestBase {
         assertEquals(FILE_SHA256_DIGEST, sha256Digest(content));
     }
 
+    @Test
+    public void testReadOnlyReadOffset() throws NoSuchAlgorithmException {
+        final byte[] content = asyncOp().read(NORMAL_FILE_NAME, 0, FILE_LENGTH).join();
+        assertEquals(FILE_LENGTH, content.length);
+
+        assertEquals(FILE_SHA256_DIGEST, sha256Digest(content));
+    }
+
     /**
      * Read full content should match.
      */

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingReadOnlyTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingReadOnlyTest.java
@@ -94,6 +94,13 @@ public class BlockingReadOnlyTest extends BehaviorTestBase {
         assertEquals(FILE_SHA256_DIGEST, sha256Digest(content));
     }
 
+    @Test
+    public void testBlockingReadonlyReadOffset() throws NoSuchAlgorithmException {
+        final byte[] content = op().read(NORMAL_FILE_NAME, 0, FILE_LENGTH);
+        assertEquals(FILE_LENGTH, content.length);
+        assertEquals(FILE_SHA256_DIGEST, sha256Digest(content));
+    }
+
     /**
      * Read not exist file should return NotFound
      */


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5825 

# Rationale for this change

Exposes reading part of a file using offset and length in the Java API.

# What changes are included in this PR?

1. Added API in Java and native binding
2. Added implementation in native binding to expose offset reading

# Are there any user-facing changes?

Operator.java:

```java
byte[] read(String path, long offset, long len)
```

AsyncOperator.java:
```java
public CompletableFuture<byte[]> read(String path, long offset, long len)
```
