### PR TITLE
refactor(core)!: Migrate to context based executor

### DIFF
--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -169,6 +169,11 @@ impl<A: Access> Layer<A> for TimeoutLayer {
     type LayeredAccess = TimeoutAccessor<A>;
 
     fn layer(&self, inner: A) -> Self::LayeredAccess {
+        let info = inner.info();
+        info.update_executor(|exec| {
+            Executor::with(TimeoutExecutor::new(exec.into_inner(), self.io_timeout))
+        });
+
         TimeoutAccessor {
             inner,
 
@@ -232,27 +237,13 @@ impl<A: Access> LayeredAccess for TimeoutAccessor<A> {
             .await
     }
 
-    async fn read(&self, path: &str, mut args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        if let Some(exec) = args.executor().cloned() {
-            args = args.with_executor(Executor::with(TimeoutExecutor::new(
-                exec.into_inner(),
-                self.io_timeout,
-            )));
-        }
-
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         self.io_timeout(Operation::ReaderStart, self.inner.read(path, args))
             .await
             .map(|(rp, r)| (rp, TimeoutWrapper::new(r, self.io_timeout)))
     }
 
-    async fn write(&self, path: &str, mut args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        if let Some(exec) = args.executor().cloned() {
-            args = args.with_executor(Executor::with(TimeoutExecutor::new(
-                exec.into_inner(),
-                self.io_timeout,
-            )));
-        }
-
+    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
         self.io_timeout(Operation::WriterStart, self.inner.write(path, args))
             .await
             .map(|(rp, r)| (rp, TimeoutWrapper::new(r, self.io_timeout)))

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -150,7 +150,7 @@ mod tests {
     /// unexpected struct/enum size change.
     #[test]
     fn assert_size() {
-        assert_eq!(32, size_of::<Operator>());
+        assert_eq!(16, size_of::<Operator>());
         assert_eq!(320, size_of::<Entry>());
         assert_eq!(296, size_of::<Metadata>());
         assert_eq!(1, size_of::<EntryMode>());

--- a/core/src/raw/accessor.rs
+++ b/core/src/raw/accessor.rs
@@ -1093,7 +1093,7 @@ impl AccessorInfo {
         }
     }
 
-    /// Set executor for the context.
+    /// Update executor for the context.
     ///
     /// # Note
     ///

--- a/core/src/raw/ops.rs
+++ b/core/src/raw/ops.rs
@@ -20,7 +20,6 @@
 //! By using ops, users can add more context for operation.
 
 use crate::raw::*;
-use crate::*;
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -313,7 +312,6 @@ pub struct OpRead {
     override_cache_control: Option<String>,
     override_content_disposition: Option<String>,
     version: Option<String>,
-    executor: Option<Executor>,
 }
 
 impl OpRead {
@@ -425,31 +423,6 @@ impl OpRead {
     /// Get version from option
     pub fn version(&self) -> Option<&str> {
         self.version.as_deref()
-    }
-
-    /// Set the executor of the option
-    pub fn with_executor(mut self, executor: Executor) -> Self {
-        self.executor = Some(executor);
-        self
-    }
-
-    /// Merge given executor into option.
-    ///
-    /// If executor has already been set, this will do nothing.
-    /// Otherwise, this will set the given executor.
-    pub(crate) fn merge_executor(self, executor: Option<Executor>) -> Self {
-        if self.executor.is_some() {
-            return self;
-        }
-        if let Some(exec) = executor {
-            return self.with_executor(exec);
-        }
-        self
-    }
-
-    /// Get executor from option
-    pub fn executor(&self) -> Option<&Executor> {
-        self.executor.as_ref()
     }
 }
 
@@ -632,7 +605,6 @@ pub struct OpWrite {
     content_disposition: Option<String>,
     content_encoding: Option<String>,
     cache_control: Option<String>,
-    executor: Option<Executor>,
     if_match: Option<String>,
     if_none_match: Option<String>,
     if_not_exists: bool,
@@ -721,17 +693,6 @@ impl OpWrite {
         self
     }
 
-    /// Get the executor from option
-    pub fn executor(&self) -> Option<&Executor> {
-        self.executor.as_ref()
-    }
-
-    /// Set the executor of the option
-    pub fn with_executor(mut self, executor: Executor) -> Self {
-        self.executor = Some(executor);
-        self
-    }
-
     /// Set the If-Match of the option
     pub fn with_if_match(mut self, s: &str) -> Self {
         self.if_match = Some(s.to_string());
@@ -763,20 +724,6 @@ impl OpWrite {
     /// Get If-Not-Exist from option
     pub fn if_not_exists(&self) -> bool {
         self.if_not_exists
-    }
-
-    /// Merge given executor into option.
-    ///
-    /// If executor has already been set, this will do nothing.
-    /// Otherwise, this will set the given executor.
-    pub(crate) fn merge_executor(self, executor: Option<Executor>) -> Self {
-        if self.executor.is_some() {
-            return self;
-        }
-        if let Some(exec) = executor {
-            return self.with_executor(exec);
-        }
-        self
     }
 
     /// Set the user defined metadata of the op

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -586,10 +586,7 @@ impl Operator {
         OperatorFuture::new(
             self.inner().clone(),
             path,
-            (
-                OpRead::default().merge_executor(self.default_executor.clone()),
-                OpReader::default(),
-            ),
+            (OpRead::default(), OpReader::default()),
             |inner, path, (args, options)| async move {
                 if !validate_path(&path, EntryMode::FILE) {
                     return Err(
@@ -673,10 +670,7 @@ impl Operator {
         OperatorFuture::new(
             self.inner().clone(),
             path,
-            (
-                OpRead::default().merge_executor(self.default_executor.clone()),
-                OpReader::default(),
-            ),
+            (OpRead::default(), OpReader::default()),
             |inner, path, (args, options)| async move {
                 if !validate_path(&path, EntryMode::FILE) {
                     return Err(
@@ -937,10 +931,7 @@ impl Operator {
         OperatorFuture::new(
             self.inner().clone(),
             path,
-            (
-                OpWrite::default().merge_executor(self.default_executor.clone()),
-                OpWriter::default(),
-            ),
+            (OpWrite::default(), OpWriter::default()),
             |inner, path, (args, options)| async move {
                 if !validate_path(&path, EntryMode::FILE) {
                     return Err(
@@ -1014,11 +1005,7 @@ impl Operator {
         OperatorFuture::new(
             self.inner().clone(),
             path,
-            (
-                OpWrite::default().merge_executor(self.default_executor.clone()),
-                OpWriter::default(),
-                bs,
-            ),
+            (OpWrite::default(), OpWriter::default(), bs),
             |inner, path, (args, options, bs)| async move {
                 if !validate_path(&path, EntryMode::FILE) {
                     return Err(

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -112,9 +112,6 @@ use crate::*;
 pub struct Operator {
     // accessor is what Operator delegates for
     accessor: Accessor,
-
-    /// The default executor that used to run futures in background.
-    default_executor: Option<Executor>,
 }
 
 /// # Operator basic API.
@@ -126,10 +123,7 @@ impl Operator {
 
     /// Convert inner accessor into operator.
     pub fn from_inner(accessor: Accessor) -> Self {
-        Self {
-            accessor,
-            default_executor: None,
-        }
+        Self { accessor }
     }
 
     /// Convert operator into inner accessor.
@@ -153,15 +147,15 @@ impl Operator {
     }
 
     /// Get the default executor.
+    #[deprecated(note = "use Operator::executor instead", since = "0.53.0")]
     pub fn default_executor(&self) -> Option<Executor> {
-        self.default_executor.clone()
+        None
     }
 
     /// Specify the default executor.
-    pub fn with_default_executor(&self, executor: Executor) -> Self {
-        let mut op = self.clone();
-        op.default_executor = Some(executor);
-        op
+    #[deprecated(note = "use Operator::update_executor instead", since = "0.53.0")]
+    pub fn with_default_executor(&self, _: Executor) -> Self {
+        self.clone()
     }
 
     /// Get information of underlying accessor.
@@ -180,6 +174,20 @@ impl Operator {
     /// ```
     pub fn info(&self) -> OperatorInfo {
         OperatorInfo::new(self.accessor.info())
+    }
+
+    /// Get the executor used by current operator.
+    pub fn executor(&self) -> Executor {
+        self.accessor.info().executor()
+    }
+
+    /// Update executor for the context.
+    ///
+    /// # Note
+    ///
+    /// Tasks must be forwarded to the old executor after the update. Otherwise, features such as retry, timeout, and metrics may not function properly.
+    pub fn update_executor(&self, f: impl FnOnce(Executor) -> Executor) {
+        self.accessor.info().update_executor(f);
     }
 
     /// Create a new blocking operator.

--- a/core/src/types/operator/operator_futures.rs
+++ b/core/src/types/operator/operator_futures.rs
@@ -224,11 +224,6 @@ impl<F: Future<Output = Result<PresignedRequest>>> FuturePresignWrite<F> {
 pub type FutureRead<F> = OperatorFuture<(OpRead, OpReader), Buffer, F>;
 
 impl<F: Future<Output = Result<Buffer>>> FutureRead<F> {
-    /// Set the executor for this operation.
-    pub fn executor(self, executor: Executor) -> Self {
-        self.map(|(args, op_reader)| (args.with_executor(executor), op_reader))
-    }
-
     /// Set `range` for this `read` request.
     ///
     /// If we have a file with size `n`.
@@ -580,11 +575,6 @@ impl<F: Future<Output = Result<Reader>>> FutureReader<F> {
 pub type FutureWrite<F> = OperatorFuture<(OpWrite, OpWriter, Buffer), Metadata, F>;
 
 impl<F: Future<Output = Result<Metadata>>> FutureWrite<F> {
-    /// Set the executor for this operation.
-    pub fn executor(self, executor: Executor) -> Self {
-        self.map(|(args, options, bs)| (args.with_executor(executor), options, bs))
-    }
-
     /// Sets append mode for this write request.
     ///
     /// ### Capability
@@ -1049,11 +1039,6 @@ impl<F: Future<Output = Result<Metadata>>> FutureWrite<F> {
 pub type FutureWriter<F> = OperatorFuture<(OpWrite, OpWriter), Writer, F>;
 
 impl<F: Future<Output = Result<Writer>>> FutureWriter<F> {
-    /// Set the executor for this operation.
-    pub fn executor(self, executor: Executor) -> Self {
-        self.map(|(args, options)| (args.with_executor(executor), options))
-    }
-
     /// Sets append mode for this write request.
     ///
     /// ### Capability

--- a/core/src/types/read/buffer_stream.rs
+++ b/core/src/types/read/buffer_stream.rs
@@ -88,7 +88,7 @@ impl ChunkedReader {
     /// We don't need to handle `Executor::timeout` since we are outside the layer.
     fn new(ctx: Arc<ReadContext>, range: BytesRange) -> Self {
         let tasks = ConcurrentTasks::new(
-            ctx.args().executor().cloned().unwrap_or_default(),
+            ctx.accessor().info().executor(),
             ctx.options().concurrent(),
             |mut r: oio::Reader| {
                 Box::pin(async {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/opendal/issues/5808

# Rationale for this change

As part work of https://github.com/apache/opendal/issues/5480

# What changes are included in this PR?

- Migrate TimeoutLayer to context based.
- Remove `executor` from `OpRead` and `OpWrite`
- Change public API of `Operator`

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
