### PR TITLE
fix: better ocaml binding and happy clippy

### DIFF
--- a/.github/actions/setup-ocaml/action.yaml
+++ b/.github/actions/setup-ocaml/action.yaml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup OCaml
-      uses: ocaml/setup-ocaml@v2
+      uses: ocaml/setup-ocaml@v3
       with:
         ocaml-compiler: 4.14
         opam-depext: ${{inputs.need-depext == true}}

--- a/.github/actions/setup-ocaml/action.yaml
+++ b/.github/actions/setup-ocaml/action.yaml
@@ -27,7 +27,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup OCaml
-      uses: ocaml/setup-ocaml@v3
+      uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: 4.14
         opam-depext: ${{inputs.need-depext == true}}

--- a/.github/actions/setup-ocaml/action.yaml
+++ b/.github/actions/setup-ocaml/action.yaml
@@ -27,9 +27,11 @@ runs:
   using: "composite"
   steps:
     - name: Setup OCaml
-      uses: ocaml/setup-ocaml@v3
+      uses: ocaml/setup-ocaml@v2
       with:
         ocaml-compiler: 4.14
+        opam-depext: ${{inputs.need-depext == true}}
+        opam-pin: ${{inputs.need-pin == true}}
 
     - name: Set Opam env
       shell: bash

--- a/.github/actions/setup-ocaml/action.yaml
+++ b/.github/actions/setup-ocaml/action.yaml
@@ -30,8 +30,6 @@ runs:
       uses: ocaml/setup-ocaml@v3
       with:
         ocaml-compiler: 4.14
-        opam-depext: ${{inputs.need-depext == true}}
-        opam-pin: ${{inputs.need-pin == true}}
 
     - name: Set Opam env
       shell: bash

--- a/.github/workflows/ci_bindings_ocaml.yml
+++ b/.github/workflows/ci_bindings_ocaml.yml
@@ -34,7 +34,8 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Wait for https://github.com/ocaml/setup-ocaml/issues/872 fixes
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout PR
@@ -60,6 +61,9 @@ jobs:
 
       - name: Setup OCaml toolchain
         uses: ./.github/actions/setup-ocaml
+        with:
+          need-depext: true
+          need-pin: true
 
       - name: Clippy Check
         working-directory: "bindings/ocaml"

--- a/.github/workflows/ci_bindings_ocaml.yml
+++ b/.github/workflows/ci_bindings_ocaml.yml
@@ -34,8 +34,7 @@ on:
 
 jobs:
   test:
-    # Wait for https://github.com/ocaml/setup-ocaml/issues/872 fixes
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout PR
@@ -64,6 +63,11 @@ jobs:
         with:
           need-depext: true
           need-pin: true
+
+      - name: Clippy Check
+        working-directory: "bindings/ocaml"
+        run: |
+          cargo clippy -- -D warnings
 
       - name: Checks
         run: |

--- a/.github/workflows/ci_bindings_ocaml.yml
+++ b/.github/workflows/ci_bindings_ocaml.yml
@@ -60,9 +60,6 @@ jobs:
 
       - name: Setup OCaml toolchain
         uses: ./.github/actions/setup-ocaml
-        with:
-          need-depext: true
-          need-pin: true
 
       - name: Clippy Check
         working-directory: "bindings/ocaml"

--- a/bindings/ocaml/.cargo/config.toml
+++ b/bindings/ocaml/.cargo/config.toml
@@ -15,27 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Setup OCaml
-description: 'Prepare OCaml Build Environment'
-inputs:
-  need-depext:
-    description: "Enable the automation feature for opam depext."
-  need-pin:
-    description: "Enable the automation feature for opam pin."
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]
 
-runs:
-  using: "composite"
-  steps:
-    - name: Setup OCaml
-      uses: ocaml/setup-ocaml@v3
-      with:
-        ocaml-compiler: 4.14
-        opam-depext: ${{inputs.need-depext == true}}
-        opam-pin: ${{inputs.need-pin == true}}
-
-    - name: Set Opam env
-      shell: bash
-      run: opam env | tr '\n' ' ' >> $GITHUB_ENV
-    - name: Add Opam switch to PATH
-      shell: bash
-      run: opam var bin >> $GITHUB_PATH
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]

--- a/bindings/ocaml/Cargo.toml
+++ b/bindings/ocaml/Cargo.toml
@@ -31,7 +31,7 @@ crate-type = ["staticlib", "cdylib"]
 doc = false
 
 [dependencies]
-ocaml = { version = "^1.0.0-beta" }
+ocaml = { version = "1.2.0" }
 # this crate won't be published, we always use the local version
 opendal = { version = ">=0", path = "../../core", features = [
   # These are default features before v0.46. TODO: change to optional features
@@ -53,4 +53,4 @@ opendal = { version = ">=0", path = "../../core", features = [
 ] }
 
 [build-dependencies]
-ocaml-build = { version = "^1.0.0-beta" }
+ocaml-build = { version = "1.0.0" }

--- a/bindings/ocaml/README.md
+++ b/bindings/ocaml/README.md
@@ -6,64 +6,80 @@
 
 * OCaml version > 4.03 and < 5.0.0
 
-
 ## Contributing
 
-
 ### Setup
+
 We recommend using `OPAM the OCaml Package Manager` to install and manage the OCaml environment.
 
 #### Install OPAM
 
 The quickest way to get the latest opam up and working is to run this script:
+
 ```bash
 bash -c "sh <(curl -fsSL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)"
 ```
+
 Similarly, you can also use your distribution's package manager to install
 
 ##### Arch
+
 ```bash
 pacman -S opam
 ```
+
 ##### Debian | Ubuntu
+
 ```bash
 apt-get install opam
 ```
 
+#### macOS
+
+```bash
+brew install opam
+```
+
 #### Init OPAM
+
 *Do not put sudo in front of any opam commands. That would break your OCaml installation.*
 
 After Installing OPAM, we need to initialize it
 
 For the general case, we can execute
+
 ```bash
 opam init --bare -a -y
 ```
+
 If you are using WSL1 on windows, run:
+
 ```bash
 opam init --bare -a -y --disable-sandboxing
 ```
 
-
-
 #### Create OPAM Switch
+
 Using opam, we can have multiple versions of ocaml at the same time; this is called switch.
 
 Due to the upstream `ocaml-rs`, we currently do not support OCaml5, and recommend using the latest version of OCaml4
 We can create use this command:
 
-```
+```bash
 opam switch create opendal-ocaml4.14 ocaml-base-compiler.4.14.0
 
 eval $(opam env)
 ```
+
 #### Install OPAM Package
 
 OpenDAL does not depend on opam package except `ounit2` for testing.
 However, to facilitate development in an IDE such as vscode, it is usually necessary to install the following content
+
 ```bash
 opam install -y utop odoc ounit2 ocaml-lsp-server ocamlformat ocamlformat-rpc
 ```
+
 ### Build
 
 ```bash
@@ -72,7 +88,9 @@ dune build
 ```
 
 ### Test
+
 To execute unit tests, we can simply use the following command:
+
 ```bash
 cd bindings/ocaml
 dune test

--- a/bindings/ocaml/src/operator/mod.rs
+++ b/bindings/ocaml/src/operator/mod.rs
@@ -115,7 +115,7 @@ pub fn blocking_delete(operator: &mut Operator, path: String) -> Result<(), Stri
 #[ocaml::func]
 #[ocaml::sig("operator -> string array -> (unit, string) Result.t ")]
 pub fn blocking_remove(operator: &mut Operator, path: Vec<String>) -> Result<(), String> {
-    map_res_error(operator.0.remove(path))
+    map_res_error(operator.0.delete_iter(path))
 }
 
 #[ocaml::func]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

This patch aim to make ocaml binding a litter happier and do these things

- add clippy to ocaml binding
- add macos support from doc https://github.com/zshipko/ocaml-rs(cargo config)
- chore the ocaml and build rust version from beta to stable
- format some doc

--- error

Error: Bad request - ocaml/setup-ocaml@v3 is not allowed to be used in apache/opendal. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, verified in the GitHub Marketplace, or matching the following: */*@[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]+, AdoptOpenJDK/install-jdk@*, TobKed/label-when-approved-action@*, actions-cool/issues-helper@*, actions-rs/*, al-cheb/configure-pagefile-action@*, amannn/action-semantic-pull-request@*, apache/*, burrunan/gradle-cache-action@*, bytedeco/javacpp-presets/.github/actions/*, chromaui/action@*, codecov/codecov-action@*, container-tools/kind-action@*, container-tools/microshift-action@*, dawidd6/action-download-artifact@*, delaguardo/setup-graalvm@*, docker://jekyll/jekyll:*, docker://pandoc/core:2.9, eps1lon/actions-label-merge-conflict@*, gaurav-nelson/github-action-markdown-link-check@*, golangci/*, gr2m/twitter-together@*, gradle/wrapper-validation-action@*, julia-actions/julia-buildpk...
