### PR TITLE
fix: make haskell binding happier

### DIFF
--- a/.github/workflows/ci_bindings_haskell.yml
+++ b/.github/workflows/ci_bindings_haskell.yml
@@ -52,6 +52,10 @@ jobs:
           cabal update
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
+      - name: Clippy Check
+        working-directory: "bindings/haskell"
+        run: |
+          cargo clippy -- -D warnings
       - name: Restore haskell cache
         uses: actions/cache/restore@v4
         with:

--- a/bindings/haskell/CONTRIBUTING.md
+++ b/bindings/haskell/CONTRIBUTING.md
@@ -34,11 +34,19 @@ For Windows:
 Set-ExecutionPolicy Bypass -Scope Process -Force;[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; try { Invoke-Command -ScriptBlock ([ScriptBlock]::Create((Invoke-WebRequest https://www.haskell.org/ghcup/sh/bootstrap-haskell.ps1 -UseBasicParsing))) -ArgumentList $true } catch { Write-Error $_ }
 ```
 
+Setup ghc version to 9.4.8
+
+```shell
+ghcup install ghc 9.4.8 --set
+ghcup install cabal --set
+cabal update
+```
+
 To verify that everything is working properly, run `ghc -V` and `cabal -V`:
 
 ```shell
 > ghc -V
-The Glorious Glasgow Haskell Compilation System, version 9.2.8
+The Glorious Glasgow Haskell Compilation System, version 9.4.8
 > cabal -V
 cabal-install version 3.6.2.0
 compiled using version 3.6.2.0 of the Cabal library

--- a/bindings/haskell/src/lib.rs
+++ b/bindings/haskell/src/lib.rs
@@ -247,7 +247,7 @@ pub unsafe extern "C" fn blocking_is_exist(
         }
     };
 
-    let res = match op.is_exist(path_str) {
+    let res = match op.exists(path_str) {
         Ok(exist) => FFIResult::ok(exist),
         Err(e) => FFIResult::err_with_source("Failed to check if path exists", e),
     };

--- a/bindings/haskell/test/BasicTest.hs
+++ b/bindings/haskell/test/BasicTest.hs
@@ -17,10 +17,7 @@
 
 module BasicTest (basicTests) where
 
-import Colog (LogAction (LogAction), Msg (msgText))
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Data.IORef
-import qualified Data.Text as T
 import OpenDAL
 import Test.Tasty
 import Test.Tasty.HUnit
@@ -105,11 +102,3 @@ testError = do
 
 (?=) :: (MonadIO m, Eq a, Show a) => m a -> a -> m ()
 result ?= except = result >>= liftIO . (@?= except)
-
-findLister :: Lister -> String -> IO Bool
-findLister lister key = do
-  res <- nextLister lister
-  case res of
-    Left _ -> return False
-    Right Nothing -> return False
-    Right (Just k) -> if k == key then return True else findLister lister key


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

This patch do these things

- add clippy to haskell binding ci
- fix warning for exists
- cabal test warning
- update contributing doc for haskell that lock the version, because upper to this can not compile for now


warning:

```
[1 of 2] Compiling BasicTest        ( test/BasicTest.hs, /Users/yihong/repos/opendal/bindings/haskell/dist-newstyle/build/aarch64-osx/ghc-9.4.8/opendal-0.1.0/build/opendal-test/opendal-test-tmp/BasicTest.o ) [Source file changed]

test/BasicTest.hs:20:1: warning: [-Wunused-imports]
    The import of ‘Colog’ is redundant
      except perhaps to import instances from ‘Colog’
    To import instances alone, use: import Colog()
   |
20 | import Colog (LogAction (LogAction), Msg (msgText))
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

test/BasicTest.hs:22:1: warning: [-Wunused-imports]
    The qualified import of ‘Data.Text’ is redundant
      except perhaps to import instances from ‘Data.Text’
    To import instances alone, use: import Data.Text()
   |
22 | import qualified Data.Text as T
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

test/BasicTest.hs:109:1: warning: [-Wunused-top-binds]
    Defined but not used: ‘findLister’
    |
109 | findLister lister key = do
    | ^^^^^^^^^^
```
