### PR TITLE
fix: drop fixme in py binding since upstream fixed

### DIFF
--- a/bindings/python/src/file.rs
+++ b/bindings/python/src/file.rs
@@ -15,9 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Remove this `allow` after <https://github.com/rust-lang/rust-clippy/issues/12039> fixed.
-#![allow(clippy::unnecessary_fallible_conversions)]
-
 use std::io::BufRead;
 use std::io::Read;
 use std::io::Seek;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

As title
