### PR TITLE
fix: drop todo use std instead of once_cell as todo comments

### DIFF
--- a/bin/oay/Cargo.lock
+++ b/bin/oay/Cargo.lock
@@ -1047,7 +1047,6 @@ dependencies = [
  "http",
  "log",
  "md-5",
- "once_cell",
  "percent-encoding",
  "quick-xml",
  "reqwest",

--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -1211,7 +1211,6 @@ dependencies = [
  "http",
  "log",
  "md-5",
- "once_cell",
  "percent-encoding",
  "quick-xml 0.36.2",
  "rand",

--- a/bin/oli/Cargo.lock
+++ b/bin/oli/Cargo.lock
@@ -1316,7 +1316,6 @@ dependencies = [
  "http",
  "log",
  "md-5",
- "once_cell",
  "percent-encoding",
  "prost",
  "quick-xml 0.36.2",

--- a/bindings/c/src/operator.rs
+++ b/bindings/c/src/operator.rs
@@ -21,7 +21,7 @@ use std::os::raw::c_char;
 use std::str::FromStr;
 
 use ::opendal as core;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 use super::*;
 

--- a/bindings/c/src/operator.rs
+++ b/bindings/c/src/operator.rs
@@ -21,7 +21,7 @@ use std::os::raw::c_char;
 use std::str::FromStr;
 
 use ::opendal as core;
-use std::sync::LazyLock;
+use once_cell::sync::Lazy;
 
 use super::*;
 

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -5291,7 +5291,6 @@ dependencies = [
  "mongodb",
  "mongodb-internal-macros",
  "monoio",
- "once_cell",
  "openssh",
  "openssh-sftp-client",
  "opentelemetry",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -245,9 +245,7 @@ futures = { version = "0.3", default-features = false, features = [
 http = "1.1"
 log = "0.4"
 md-5 = "0.10"
-# TODO: remove once_cell when lazy_lock is stable: https://doc.rust-lang.org/std/cell/struct.LazyCell.html
 ghac = { version = "0.2.0", optional = true }
-once_cell = "1"
 percent-encoding = "2"
 quick-xml = { version = "0.36", features = ["serialize", "overlapped-lists"] }
 reqwest = { version = "0.12.2", features = [

--- a/core/benches/types/concurrent_tasks.rs
+++ b/core/benches/types/concurrent_tasks.rs
@@ -19,9 +19,9 @@ use std::time::Duration;
 
 use criterion::BatchSize;
 use criterion::Criterion;
-use std::sync::LazyLock as Lazy;
 use opendal::raw::ConcurrentTasks;
 use opendal::Executor;
+use std::sync::LazyLock as Lazy;
 
 pub static TOKIO: Lazy<tokio::runtime::Runtime> =
     Lazy::new(|| tokio::runtime::Runtime::new().expect("build tokio runtime"));

--- a/core/benches/types/concurrent_tasks.rs
+++ b/core/benches/types/concurrent_tasks.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use criterion::BatchSize;
 use criterion::Criterion;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock as Lazy;
 use opendal::raw::ConcurrentTasks;
 use opendal::Executor;
 

--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -96,7 +96,7 @@ use crate::*;
 /// > runtime on demand.
 ///
 /// ```rust,no_run
-/// # use once_cell::sync::Lazy;
+/// # use std::sync::LazyLock as Lazy;
 /// # use opendal::layers::BlockingLayer;
 /// # use opendal::services;
 /// # use opendal::BlockingOperator;
@@ -310,7 +310,7 @@ impl<I: oio::Delete + 'static> oio::BlockingDelete for BlockingWrapper<I> {
 
 #[cfg(test)]
 mod tests {
-    use once_cell::sync::Lazy;
+    use std::sync::LazyLock as Lazy;
 
     use super::*;
     use crate::types::Result;

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -27,8 +27,8 @@ use futures::Future;
 use futures::TryStreamExt;
 use http::Request;
 use http::Response;
-use std::sync::LazyLock as Lazy;
 use raw::oio::Read;
+use std::sync::LazyLock as Lazy;
 
 use super::parse_content_encoding;
 use super::parse_content_length;

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -27,7 +27,7 @@ use futures::Future;
 use futures::TryStreamExt;
 use http::Request;
 use http::Response;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock as Lazy;
 use raw::oio::Read;
 
 use super::parse_content_encoding;

--- a/core/src/raw/tests/utils.rs
+++ b/core/src/raw/tests/utils.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::env;
 use std::str::FromStr;
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock as Lazy;
 
 use crate::*;
 

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -35,7 +35,7 @@ use http::header::IF_NONE_MATCH;
 use http::header::IF_UNMODIFIED_SINCE;
 use http::Request;
 use http::Response;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock as Lazy;
 use reqsign::GoogleCredential;
 use reqsign::GoogleCredentialLoader;
 use reqsign::GoogleSigner;

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -35,7 +35,6 @@ use http::header::IF_NONE_MATCH;
 use http::header::IF_UNMODIFIED_SINCE;
 use http::Request;
 use http::Response;
-use std::sync::LazyLock as Lazy;
 use reqsign::GoogleCredential;
 use reqsign::GoogleCredentialLoader;
 use reqsign::GoogleSigner;
@@ -43,6 +42,7 @@ use reqsign::GoogleToken;
 use reqsign::GoogleTokenLoader;
 use serde::Deserialize;
 use serde::Serialize;
+use std::sync::LazyLock as Lazy;
 
 use super::uri::percent_encode_path;
 use crate::raw::*;

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -32,13 +32,13 @@ use log::debug;
 use log::warn;
 use md5::Digest;
 use md5::Md5;
-use std::sync::LazyLock as Lazy;
 use reqsign::AwsAssumeRoleLoader;
 use reqsign::AwsConfig;
 use reqsign::AwsCredentialLoad;
 use reqsign::AwsDefaultLoader;
 use reqsign::AwsV4Signer;
 use reqwest::Url;
+use std::sync::LazyLock as Lazy;
 
 use super::core::*;
 use super::delete::S3Deleter;

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -32,7 +32,7 @@ use log::debug;
 use log::warn;
 use md5::Digest;
 use md5::Md5;
-use once_cell::sync::Lazy;
+use std::sync::LazyLock as Lazy;
 use reqsign::AwsAssumeRoleLoader;
 use reqsign::AwsConfig;
 use reqsign::AwsCredentialLoad;

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -429,7 +429,7 @@ impl From<Error> for io::Error {
 #[cfg(test)]
 mod tests {
     use anyhow::anyhow;
-    use once_cell::sync::Lazy;
+    use std::sync::LazyLock as Lazy;
     use pretty_assertions::assert_eq;
 
     use super::*;

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -429,8 +429,8 @@ impl From<Error> for io::Error {
 #[cfg(test)]
 mod tests {
     use anyhow::anyhow;
-    use std::sync::LazyLock as Lazy;
     use pretty_assertions::assert_eq;
+    use std::sync::LazyLock as Lazy;
 
     use super::*;
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

This patch is not finish(need better import) to check if ci can pass.
if passed will better replace all `Lazy` to `LazyLock`

learned from this(Chinese)
https://zjp-cn.github.io/rust-note/learn-from-pr-issue/LazyLock.html
