### PR TITLE
refactor!: Bump OpenDAL MSRV to 1.80

### DIFF
--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -80,8 +80,8 @@ jobs:
   check_msrv:
     runs-on: ubuntu-latest
     env:
-      # OpenDAL's MSRV is 1.75.
-      OPENDAL_MSRV: "1.75"
+      # OpenDAL's MSRV is 1.80.
+      OPENDAL_MSRV: "1.80"
     steps:
       - uses: actions/checkout@v4
       - name: Setup msrv of rust

--- a/bin/oay/Cargo.lock
+++ b/bin/oay/Cargo.lock
@@ -1047,7 +1047,6 @@ dependencies = [
  "http",
  "log",
  "md-5",
- "once_cell",
  "percent-encoding",
  "quick-xml",
  "reqwest",

--- a/bin/oay/Cargo.toml
+++ b/bin/oay/Cargo.toml
@@ -26,7 +26,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.41.17"
 
 [features]

--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -1211,7 +1211,6 @@ dependencies = [
  "http",
  "log",
  "md-5",
- "once_cell",
  "percent-encoding",
  "quick-xml 0.36.2",
  "rand",

--- a/bin/ofs/Cargo.toml
+++ b/bin/ofs/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [dependencies]
 anyhow = { version = "1" }

--- a/bin/oli/Cargo.lock
+++ b/bin/oli/Cargo.lock
@@ -1316,7 +1316,6 @@ dependencies = [
  "http",
  "log",
  "md-5",
- "once_cell",
  "percent-encoding",
  "prost",
  "quick-xml 0.36.2",

--- a/bin/oli/Cargo.toml
+++ b/bin/oli/Cargo.toml
@@ -26,7 +26,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.41.17"
 
 [dependencies]

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/bindings/c/Cargo.toml
+++ b/bindings/c/Cargo.toml
@@ -35,7 +35,6 @@ cbindgen = "0.26.0"
 
 [dependencies]
 bytes = "1.4.0"
-once_cell = "1.17.1"
 # this crate won't be published, we always use the local version
 opendal = { version = ">=0", path = "../../core", features = [
   "layers-blocking",

--- a/bindings/c/src/operator.rs
+++ b/bindings/c/src/operator.rs
@@ -19,13 +19,13 @@ use std::collections::HashMap;
 use std::ffi::c_void;
 use std::os::raw::c_char;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 use ::opendal as core;
-use once_cell::sync::Lazy;
 
 use super::*;
 
-static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/bindings/cpp/Cargo.toml
+++ b/bindings/cpp/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [lib]
 crate-type = ["staticlib"]

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/haskell/Cargo.toml
+++ b/bindings/haskell/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -151,7 +151,6 @@ services-yandex-disk = ["opendal/services-yandex-disk"]
 [dependencies]
 anyhow = "1.0.71"
 jni = "0.21.1"
-once_cell = "1.19.0"
 # this crate won't be published, we always use the local version
 opendal = { version = ">=0", path = "../../core", features = [
   "layers-blocking",

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/lua/Cargo.toml
+++ b/bindings/lua/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [features]
 default = ["mlua/lua52"]

--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [features]
 default = [

--- a/bindings/ocaml/Cargo.toml
+++ b/bindings/ocaml/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [lib]
 crate-type = ["staticlib", "cdylib"]

--- a/bindings/php/Cargo.toml
+++ b/bindings/php/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.45.16"
 
 [features]

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/ruby/opendal.gemspec
+++ b/bindings/ruby/opendal.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |spec|
 
   spec.extensions = ["./extconf.rb"]
 
-  spec.requirements = ["Rust >= 1.75"]
+  spec.requirements = ["Rust >= 1.80"]
   # use a Ruby version which:
   # - supports Rubygems with the ability of compilation of Rust gem
   # - not end of life

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -5291,7 +5291,6 @@ dependencies = [
  "mongodb",
  "mongodb-internal-macros",
  "monoio",
- "once_cell",
  "openssh",
  "openssh-sftp-client",
  "opentelemetry",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -247,12 +247,10 @@ futures = { version = "0.3", default-features = false, features = [
   "std",
   "async-await",
 ] }
+ghac = { version = "0.2.0", optional = true }
 http = "1.1"
 log = "0.4"
 md-5 = "0.10"
-# TODO: remove once_cell when lazy_lock is stable: https://doc.rust-lang.org/std/cell/struct.LazyCell.html
-ghac = { version = "0.2.0", optional = true }
-once_cell = "1"
 percent-encoding = "2"
 quick-xml = { version = "0.36", features = ["serialize", "overlapped-lists"] }
 reqwest = { version = "0.12.2", features = [

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.52.0"
 
 [lints.clippy]
@@ -43,7 +43,7 @@ members = [".", "examples/*", "fuzz", "edge/*", "benches/vs_*"]
 [workspace.package]
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.51.1"
 
 [features]
@@ -173,6 +173,12 @@ services-obs = [
   "reqsign?/reqwest_request",
 ]
 services-onedrive = []
+services-opfs = [
+  "dep:js-sys",
+  "dep:wasm-bindgen",
+  "dep:wasm-bindgen-futures",
+  "dep:web-sys",
+]
 services-oss = [
   "dep:reqsign",
   "reqsign?/services-aliyun",
@@ -204,7 +210,6 @@ services-vercel-blob = []
 services-webdav = []
 services-webhdfs = []
 services-yandex-disk = []
-services-opfs = ["dep:js-sys", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:web-sys"]
 
 [lib]
 bench = false
@@ -360,8 +365,9 @@ monoio = { version = "0.2.4", optional = true, features = [
   "renameat",
 ] }
 # for service-opfs
+js-sys = { version = "0.3.77", optional = true }
 wasm-bindgen = { version = "0.2.100", optional = true }
-wasm-bindgen-futures = { version = "0.4.50", optional = true}
+wasm-bindgen-futures = { version = "0.4.50", optional = true }
 web-sys = { version = "0.3.77", optional = true, features = [
   "Window",
   "File",
@@ -373,8 +379,6 @@ web-sys = { version = "0.3.77", optional = true, features = [
   "StorageManager",
   "FileSystemGetFileOptions",
 ] }
-js-sys = { version = "0.3.77", optional = true}
-
 
 # Layers
 # for layers-async-backtrace

--- a/core/benches/types/concurrent_tasks.rs
+++ b/core/benches/types/concurrent_tasks.rs
@@ -19,12 +19,12 @@ use std::time::Duration;
 
 use criterion::BatchSize;
 use criterion::Criterion;
-use once_cell::sync::Lazy;
 use opendal::raw::ConcurrentTasks;
 use opendal::Executor;
+use std::sync::LazyLock;
 
-pub static TOKIO: Lazy<tokio::runtime::Runtime> =
-    Lazy::new(|| tokio::runtime::Runtime::new().expect("build tokio runtime"));
+pub static TOKIO: LazyLock<tokio::runtime::Runtime> =
+    LazyLock::new(|| tokio::runtime::Runtime::new().expect("build tokio runtime"));
 
 pub fn bench_concurrent_tasks(c: &mut Criterion) {
     let mut group = c.benchmark_group("bench_concurrent_tasks");

--- a/core/benches/vs_fs/Cargo.toml
+++ b/core/benches/vs_fs/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "opendal-benchmark-vs-fs"
 publish = false
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.0.0"
 
 [dependencies]

--- a/core/benches/vs_s3/Cargo.toml
+++ b/core/benches/vs_s3/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "opendal-benchmark-vs-s3"
 publish = false
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.0.0"
 
 [dependencies]

--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "opendal-fuzz"
 publish = false
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.0.0"
 
 [package.metadata]

--- a/core/src/layers/blocking.rs
+++ b/core/src/layers/blocking.rs
@@ -96,14 +96,14 @@ use crate::*;
 /// > runtime on demand.
 ///
 /// ```rust,no_run
-/// # use once_cell::sync::Lazy;
+/// # use std::sync::LazyLock;
 /// # use opendal::layers::BlockingLayer;
 /// # use opendal::services;
 /// # use opendal::BlockingOperator;
 /// # use opendal::Operator;
 /// # use opendal::Result;
 ///
-/// static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+/// static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
 ///     tokio::runtime::Builder::new_multi_thread()
 ///         .enable_all()
 ///         .build()
@@ -310,12 +310,12 @@ impl<I: oio::Delete + 'static> oio::BlockingDelete for BlockingWrapper<I> {
 
 #[cfg(test)]
 mod tests {
-    use once_cell::sync::Lazy;
+    use std::sync::LazyLock;
 
     use super::*;
     use crate::types::Result;
 
-    static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+    static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
         tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()

--- a/core/src/layers/dtrace.rs
+++ b/core/src/layers/dtrace.rs
@@ -335,18 +335,16 @@ impl<R: oio::BlockingRead> oio::BlockingRead for DtraceLayerWrapper<R> {
         probe_lazy!(opendal, blocking_reader_read_start, c_path.as_ptr());
         self.inner
             .read()
-            .map(|bs| {
+            .inspect(|bs| {
                 probe_lazy!(
                     opendal,
                     blocking_reader_read_ok,
                     c_path.as_ptr(),
                     bs.remaining()
                 );
-                bs
             })
-            .map_err(|e| {
+            .inspect_err(|_| {
                 probe_lazy!(opendal, blocking_reader_read_error, c_path.as_ptr());
-                e
             })
     }
 }
@@ -361,9 +359,8 @@ impl<R: oio::Write> oio::Write for DtraceLayerWrapper<R> {
             .map(|_| {
                 probe_lazy!(opendal, writer_write_ok, c_path.as_ptr());
             })
-            .map_err(|err| {
+            .inspect_err(|_| {
                 probe_lazy!(opendal, writer_write_error, c_path.as_ptr());
-                err
             })
     }
 
@@ -376,9 +373,8 @@ impl<R: oio::Write> oio::Write for DtraceLayerWrapper<R> {
             .map(|_| {
                 probe_lazy!(opendal, writer_poll_abort_ok, c_path.as_ptr());
             })
-            .map_err(|err| {
+            .inspect_err(|_| {
                 probe_lazy!(opendal, writer_poll_abort_error, c_path.as_ptr());
-                err
             })
     }
 
@@ -388,13 +384,11 @@ impl<R: oio::Write> oio::Write for DtraceLayerWrapper<R> {
         self.inner
             .close()
             .await
-            .map(|meta| {
+            .inspect(|_| {
                 probe_lazy!(opendal, writer_close_ok, c_path.as_ptr());
-                meta
             })
-            .map_err(|err| {
+            .inspect_err(|_| {
                 probe_lazy!(opendal, writer_close_error, c_path.as_ptr());
-                err
             })
     }
 }
@@ -408,9 +402,8 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for DtraceLayerWrapper<R> {
             .map(|_| {
                 probe_lazy!(opendal, blocking_writer_write_ok, c_path.as_ptr());
             })
-            .map_err(|err| {
+            .inspect_err(|_| {
                 probe_lazy!(opendal, blocking_writer_write_error, c_path.as_ptr());
-                err
             })
     }
 
@@ -419,13 +412,11 @@ impl<R: oio::BlockingWrite> oio::BlockingWrite for DtraceLayerWrapper<R> {
         probe_lazy!(opendal, blocking_writer_close_start, c_path.as_ptr());
         self.inner
             .close()
-            .map(|meta| {
+            .inspect(|_| {
                 probe_lazy!(opendal, blocking_writer_close_ok, c_path.as_ptr());
-                meta
             })
-            .map_err(|err| {
+            .inspect_err(|_| {
                 probe_lazy!(opendal, blocking_writer_close_error, c_path.as_ptr());
-                err
             })
     }
 }

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -321,9 +321,8 @@ impl<T: oio::Read> oio::Read for ErrorContextWrapper<T> {
         self.inner
             .read()
             .await
-            .map(|bs| {
+            .inspect(|bs| {
                 self.processed += bs.len() as u64;
-                bs
             })
             .map_err(|err| {
                 err.with_operation(Operation::ReaderRead)
@@ -339,9 +338,8 @@ impl<T: oio::BlockingRead> oio::BlockingRead for ErrorContextWrapper<T> {
     fn read(&mut self) -> Result<Buffer> {
         self.inner
             .read()
-            .map(|bs| {
+            .inspect(|bs| {
                 self.processed += bs.len() as u64;
-                bs
             })
             .map_err(|err| {
                 err.with_operation(Operation::ReaderRead)
@@ -422,9 +420,8 @@ impl<T: oio::List> oio::List for ErrorContextWrapper<T> {
         self.inner
             .next()
             .await
-            .map(|bs| {
+            .inspect(|bs| {
                 self.processed += bs.is_some() as u64;
-                bs
             })
             .map_err(|err| {
                 err.with_operation(Operation::ListerNext)
@@ -439,9 +436,8 @@ impl<T: oio::BlockingList> oio::BlockingList for ErrorContextWrapper<T> {
     fn next(&mut self) -> Result<Option<oio::Entry>> {
         self.inner
             .next()
-            .map(|bs| {
+            .inspect(|bs| {
                 self.processed += bs.is_some() as u64;
-                bs
             })
             .map_err(|err| {
                 err.with_operation(Operation::ListerNext)
@@ -466,9 +462,8 @@ impl<T: oio::Delete> oio::Delete for ErrorContextWrapper<T> {
         self.inner
             .flush()
             .await
-            .map(|n| {
+            .inspect(|&n| {
                 self.processed += n as u64;
-                n
             })
             .map_err(|err| {
                 err.with_operation(Operation::DeleterFlush)
@@ -491,9 +486,8 @@ impl<T: oio::BlockingDelete> oio::BlockingDelete for ErrorContextWrapper<T> {
     fn flush(&mut self) -> Result<usize> {
         self.inner
             .flush()
-            .map(|n| {
+            .inspect(|&n| {
                 self.processed += n as u64;
-                n
             })
             .map_err(|err| {
                 err.with_operation(Operation::DeleterFlush)

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -288,7 +288,7 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
         self.inner
             .create_dir(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.logger.log(
                     &self.info,
                     Operation::CreateDir,
@@ -296,17 +296,15 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                     "finished",
                     None,
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::CreateDir,
                     &[("path", path)],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -335,15 +333,14 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                     LoggingReader::new(self.info.clone(), self.logger.clone(), path, r),
                 )
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::ReaderStart,
                     &[("path", path)],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -370,15 +367,14 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                 let w = LoggingWriter::new(self.info.clone(), self.logger.clone(), path, w);
                 (rp, w)
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::WriterStart,
                     &[("path", path)],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -394,7 +390,7 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
         self.inner
             .copy(from, to, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.logger.log(
                     &self.info,
                     Operation::Copy,
@@ -402,17 +398,15 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                     "finished",
                     None,
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::Copy,
                     &[("from", from), ("to", to)],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -428,7 +422,7 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
         self.inner
             .rename(from, to, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.logger.log(
                     &self.info,
                     Operation::Rename,
@@ -436,17 +430,15 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                     "finished",
                     None,
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::Rename,
                     &[("from", from), ("to", to)],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -462,7 +454,7 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
         self.inner
             .stat(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.logger.log(
                     &self.info,
                     Operation::Stat,
@@ -470,17 +462,15 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                     "finished",
                     None,
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::Stat,
                     &[("path", path)],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -497,15 +487,14 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                 let d = LoggingDeleter::new(self.info.clone(), self.logger.clone(), d);
                 (rp, d)
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::DeleterStart,
                     &[],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -532,15 +521,14 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                 let streamer = LoggingLister::new(self.info.clone(), self.logger.clone(), path, v);
                 (rp, streamer)
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::ListerStart,
                     &[("path", path)],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -556,7 +544,7 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
         self.inner
             .presign(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.logger.log(
                     &self.info,
                     Operation::Presign,
@@ -564,17 +552,15 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                     "finished",
                     None,
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::Presign,
                     &[("path", path)],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -589,7 +575,7 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
 
         self.inner
             .blocking_create_dir(path, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.logger.log(
                     &self.info,
                     Operation::CreateDir,
@@ -597,17 +583,15 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                     "finished",
                     None,
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::CreateDir,
                     &[("path", path)],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -633,15 +617,14 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                 let r = LoggingReader::new(self.info.clone(), self.logger.clone(), path, r);
                 (rp, r)
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::ReaderStart,
                     &[("path", path)],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -667,15 +650,14 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                 let w = LoggingWriter::new(self.info.clone(), self.logger.clone(), path, w);
                 (rp, w)
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::WriterStart,
                     &[("path", path)],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -690,7 +672,7 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
 
         self.inner
             .blocking_copy(from, to, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.logger.log(
                     &self.info,
                     Operation::Copy,
@@ -698,17 +680,15 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                     "finished",
                     None,
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::Copy,
                     &[("from", from), ("to", to)],
                     "",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -723,7 +703,7 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
 
         self.inner
             .blocking_rename(from, to, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.logger.log(
                     &self.info,
                     Operation::Rename,
@@ -731,17 +711,15 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                     "finished",
                     None,
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::Rename,
                     &[("from", from), ("to", to)],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -756,7 +734,7 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
 
         self.inner
             .blocking_stat(path, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.logger.log(
                     &self.info,
                     Operation::Stat,
@@ -764,17 +742,15 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                     "finished",
                     None,
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::Stat,
                     &[("path", path)],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -790,15 +766,14 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                 let d = LoggingDeleter::new(self.info.clone(), self.logger.clone(), d);
                 (rp, d)
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::DeleterStart,
                     &[],
                     "failed",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 
@@ -824,15 +799,14 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
                 let li = LoggingLister::new(self.info.clone(), self.logger.clone(), path, v);
                 (rp, li)
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.logger.log(
                     &self.info,
                     Operation::ListerStart,
                     &[("path", path)],
                     "",
-                    Some(&err),
+                    Some(err),
                 );
-                err
             })
     }
 }

--- a/core/src/layers/observe/metrics.rs
+++ b/core/src/layers/observe/metrics.rs
@@ -245,23 +245,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         self.inner()
             .create_dir(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     path,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(move |err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     path,
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -273,23 +271,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
             .inner
             .read(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     path,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     path,
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((
@@ -311,23 +307,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
             .inner
             .write(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     path,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     path,
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((
@@ -348,23 +342,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         self.inner()
             .copy(from, to, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     from,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(move |err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     from,
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -375,23 +367,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         self.inner()
             .rename(from, to, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     from,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(move |err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     from,
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -402,23 +392,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         self.inner()
             .stat(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     path,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(move |err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     path,
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -430,23 +418,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
             .inner
             .delete()
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     "",
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     "",
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((
@@ -468,23 +454,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
             .inner
             .list(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     path,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     path,
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((
@@ -505,23 +489,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         self.inner()
             .presign(path, args)
             .await
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     path,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(move |err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     path,
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -531,23 +513,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let start = Instant::now();
         self.inner()
             .blocking_create_dir(path, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     path,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(move |err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     path,
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -558,23 +538,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let (rp, reader) = self
             .inner
             .blocking_read(path, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     path,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     path,
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((
@@ -595,23 +573,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let (rp, writer) = self
             .inner
             .blocking_write(path, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     path,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     path,
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((
@@ -631,23 +607,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let start = Instant::now();
         self.inner()
             .blocking_copy(from, to, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     from,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(move |err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     from,
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -657,23 +631,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let start = Instant::now();
         self.inner()
             .blocking_rename(from, to, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     from,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     from,
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -683,23 +655,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let start = Instant::now();
         self.inner()
             .blocking_stat(path, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     path,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(move |err| {
+            .inspect_err(move |err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     path,
                     op,
                     err.kind(),
                 );
-                err
             })
     }
 
@@ -710,23 +680,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let (rp, writer) = self
             .inner
             .blocking_delete()
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     "",
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     "",
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((
@@ -747,23 +715,21 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let (rp, lister) = self
             .inner
             .blocking_list(path, args)
-            .map(|v| {
+            .inspect(|_| {
                 self.interceptor.observe_operation_duration_seconds(
                     self.info.clone(),
                     path,
                     op,
                     start.elapsed(),
                 );
-                v
             })
-            .map_err(|err| {
+            .inspect_err(|err| {
                 self.interceptor.observe_operation_errors_total(
                     self.info.clone(),
                     path,
                     op,
                     err.kind(),
                 );
-                err
             })?;
 
         Ok((

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -27,8 +27,8 @@ use futures::Future;
 use futures::TryStreamExt;
 use http::Request;
 use http::Response;
-use once_cell::sync::Lazy;
 use raw::oio::Read;
+use std::sync::LazyLock;
 
 use super::parse_content_encoding;
 use super::parse_content_length;
@@ -40,7 +40,8 @@ use crate::*;
 /// This is merely a temporary solution because reqsign requires a reqwest client to be passed.
 /// We will remove it after the next major version of reqsign, which will enable users to provide their own client.
 #[allow(dead_code)]
-pub(crate) static GLOBAL_REQWEST_CLIENT: Lazy<reqwest::Client> = Lazy::new(reqwest::Client::new);
+pub(crate) static GLOBAL_REQWEST_CLIENT: LazyLock<reqwest::Client> =
+    LazyLock::new(reqwest::Client::new);
 
 /// HttpFetcher is a type erased [`HttpFetch`].
 pub type HttpFetcher = Arc<dyn HttpFetchDyn>;

--- a/core/src/raw/tests/utils.rs
+++ b/core/src/raw/tests/utils.rs
@@ -19,12 +19,12 @@ use std::collections::HashMap;
 use std::env;
 use std::str::FromStr;
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 use crate::*;
 
 /// TEST_RUNTIME is the runtime used for running tests.
-pub static TEST_RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
+pub static TEST_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -35,7 +35,6 @@ use http::header::IF_NONE_MATCH;
 use http::header::IF_UNMODIFIED_SINCE;
 use http::Request;
 use http::Response;
-use once_cell::sync::Lazy;
 use reqsign::GoogleCredential;
 use reqsign::GoogleCredentialLoader;
 use reqsign::GoogleSigner;
@@ -43,6 +42,7 @@ use reqsign::GoogleToken;
 use reqsign::GoogleTokenLoader;
 use serde::Deserialize;
 use serde::Serialize;
+use std::sync::LazyLock;
 
 use super::uri::percent_encode_path;
 use crate::raw::*;
@@ -83,8 +83,8 @@ impl Debug for GcsCore {
     }
 }
 
-static BACKOFF: Lazy<ExponentialBuilder> =
-    Lazy::new(|| ExponentialBuilder::default().with_jitter());
+static BACKOFF: LazyLock<ExponentialBuilder> =
+    LazyLock::new(|| ExponentialBuilder::default().with_jitter());
 
 impl GcsCore {
     async fn load_token(&self) -> Result<Option<GoogleToken>> {

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -32,13 +32,13 @@ use log::debug;
 use log::warn;
 use md5::Digest;
 use md5::Md5;
-use once_cell::sync::Lazy;
 use reqsign::AwsAssumeRoleLoader;
 use reqsign::AwsConfig;
 use reqsign::AwsCredentialLoad;
 use reqsign::AwsDefaultLoader;
 use reqsign::AwsV4Signer;
 use reqwest::Url;
+use std::sync::LazyLock;
 
 use super::core::*;
 use super::delete::S3Deleter;
@@ -53,7 +53,7 @@ use crate::*;
 use constants::X_AMZ_VERSION_ID;
 
 /// Allow constructing correct region endpoint if user gives a global endpoint.
-static ENDPOINT_TEMPLATES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
+static ENDPOINT_TEMPLATES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
     let mut m = HashMap::new();
     // AWS S3 Service.
     m.insert(

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -429,12 +429,12 @@ impl From<Error> for io::Error {
 #[cfg(test)]
 mod tests {
     use anyhow::anyhow;
-    use once_cell::sync::Lazy;
     use pretty_assertions::assert_eq;
+    use std::sync::LazyLock;
 
     use super::*;
 
-    static TEST_ERROR: Lazy<Error> = Lazy::new(|| Error {
+    static TEST_ERROR: LazyLock<Error> = LazyLock::new(|| Error {
         kind: ErrorKind::Unexpected,
         message: "something wrong happened".to_string(),
         status: ErrorStatus::Permanent,
@@ -449,17 +449,17 @@ mod tests {
 
     #[test]
     fn test_error_display() {
-        let s = format!("{}", Lazy::force(&TEST_ERROR));
+        let s = format!("{}", LazyLock::force(&TEST_ERROR));
         assert_eq!(
             s,
             r#"Unexpected (permanent) at Read, context: { path: /path/to/file, called: send_async } => something wrong happened, source: networking error"#
         );
-        println!("{:#?}", Lazy::force(&TEST_ERROR));
+        println!("{:#?}", LazyLock::force(&TEST_ERROR));
     }
 
     #[test]
     fn test_error_debug() {
-        let s = format!("{:?}", Lazy::force(&TEST_ERROR));
+        let s = format!("{:?}", LazyLock::force(&TEST_ERROR));
         assert_eq!(
             s,
             r#"Unexpected (permanent) at Read => something wrong happened

--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.0.1"
 
 [dependencies]

--- a/integrations/cloud_filter/Cargo.toml
+++ b/integrations/cloud_filter/Cargo.toml
@@ -23,7 +23,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 name = "cloud_filter_opendal"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.0.6"
 
 [package.metadata.docs.rs]

--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -25,7 +25,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 
 [dependencies]
 anyhow = "1"

--- a/integrations/fuse3/Cargo.toml
+++ b/integrations/fuse3/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.0.13"
 
 [dependencies]

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.50.0"
 
 [features]

--- a/integrations/parquet/Cargo.toml
+++ b/integrations/parquet/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.4.0"
 
 [dependencies]

--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -23,7 +23,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 name = "unftp-sbe-opendal"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.0.13"
 
 [dependencies]

--- a/integrations/virtiofs/Cargo.toml
+++ b/integrations/virtiofs/Cargo.toml
@@ -24,7 +24,7 @@ edition = "2021"
 homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
-rust-version = "1.75"
+rust-version = "1.80"
 version = "0.0.0"
 
 [dependencies]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

As discussed in https://github.com/apache/opendal/discussions/5864

# Rationale for this change

Bump opendal to 1.80 to allow we use new features from std. Also, get opendal community ready for the comming 1.85 changes.

# What changes are included in this PR?

- Bump OpenDAL MSRV to 1.80
- Use `inspect{_err}` to replace manully `map{_err}`
- Use std LazyLock to replace once_cell 

# Are there any user-facing changes?

- Rust core users will now requires rust 1.80 to build opendal.
- Bindings like java/nodejs/python are not affected.
