### PR TITLE
refactor: Migrate http service to context based http client

### DIFF
--- a/core/src/services/http/core.rs
+++ b/core/src/services/http/core.rs
@@ -1,0 +1,123 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+use http::header;
+use http::header::IF_MATCH;
+use http::header::IF_NONE_MATCH;
+use http::Request;
+use http::Response;
+
+use crate::raw::*;
+use crate::*;
+
+pub struct HttpCore {
+    pub info: Arc<AccessorInfo>,
+
+    pub endpoint: String,
+    pub root: String,
+    pub client: HttpClient,
+
+    pub authorization: Option<String>,
+}
+
+impl Debug for HttpCore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpCore")
+            .field("endpoint", &self.endpoint)
+            .field("root", &self.root)
+            .field("client", &self.client)
+            .finish()
+    }
+}
+
+impl HttpCore {
+    pub fn has_authorization(&self) -> bool {
+        self.authorization.is_some()
+    }
+
+    pub fn http_get_request(
+        &self,
+        path: &str,
+        range: BytesRange,
+        args: &OpRead,
+    ) -> Result<Request<Buffer>> {
+        let p = build_rooted_abs_path(&self.root, path);
+
+        let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
+
+        let mut req = Request::get(&url);
+
+        if let Some(if_match) = args.if_match() {
+            req = req.header(IF_MATCH, if_match);
+        }
+
+        if let Some(if_none_match) = args.if_none_match() {
+            req = req.header(IF_NONE_MATCH, if_none_match);
+        }
+
+        if let Some(auth) = &self.authorization {
+            req = req.header(header::AUTHORIZATION, auth.clone())
+        }
+
+        if !range.is_full() {
+            req = req.header(header::RANGE, range.to_header());
+        }
+
+        req.body(Buffer::new()).map_err(new_request_build_error)
+    }
+
+    pub async fn http_get(
+        &self,
+        path: &str,
+        range: BytesRange,
+        args: &OpRead,
+    ) -> Result<Response<HttpBody>> {
+        let req = self.http_get_request(path, range, args)?;
+        self.client.fetch(req).await
+    }
+
+    pub fn http_head_request(&self, path: &str, args: &OpStat) -> Result<Request<Buffer>> {
+        let p = build_rooted_abs_path(&self.root, path);
+
+        let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
+
+        let mut req = Request::head(&url);
+
+        if let Some(if_match) = args.if_match() {
+            req = req.header(IF_MATCH, if_match);
+        }
+
+        if let Some(if_none_match) = args.if_none_match() {
+            req = req.header(IF_NONE_MATCH, if_none_match);
+        }
+
+        if let Some(auth) = &self.authorization {
+            req = req.header(header::AUTHORIZATION, auth.clone())
+        }
+
+        req.body(Buffer::new()).map_err(new_request_build_error)
+    }
+
+    pub async fn http_head(&self, path: &str, args: &OpStat) -> Result<Response<Buffer>> {
+        let req = self.http_head_request(path, args)?;
+        self.client.send(req).await
+    }
+}

--- a/core/src/services/http/core.rs
+++ b/core/src/services/http/core.rs
@@ -33,7 +33,6 @@ pub struct HttpCore {
 
     pub endpoint: String,
     pub root: String,
-    pub client: HttpClient,
 
     pub authorization: Option<String>,
 }
@@ -43,7 +42,6 @@ impl Debug for HttpCore {
         f.debug_struct("HttpCore")
             .field("endpoint", &self.endpoint)
             .field("root", &self.root)
-            .field("client", &self.client)
             .finish()
     }
 }
@@ -91,7 +89,7 @@ impl HttpCore {
         args: &OpRead,
     ) -> Result<Response<HttpBody>> {
         let req = self.http_get_request(path, range, args)?;
-        self.client.fetch(req).await
+        self.info.http_client().fetch(req).await
     }
 
     pub fn http_head_request(&self, path: &str, args: &OpStat) -> Result<Request<Buffer>> {
@@ -118,6 +116,6 @@ impl HttpCore {
 
     pub async fn http_head(&self, path: &str, args: &OpStat) -> Result<Response<Buffer>> {
         let req = self.http_head_request(path, args)?;
-        self.client.send(req).await
+        self.info.http_client().send(req).await
     }
 }

--- a/core/src/services/http/mod.rs
+++ b/core/src/services/http/mod.rs
@@ -21,6 +21,8 @@ mod error;
 #[cfg(feature = "services-http")]
 mod backend;
 #[cfg(feature = "services-http")]
+mod core;
+#[cfg(feature = "services-http")]
 pub use backend::HttpBuilder as Http;
 
 mod config;


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/opendal/issues/5677
Part of https://github.com/apache/opendal/issues/5702
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- This pull request refactors the `HttpBackend` by introducing a new `HttpCore` struct to encapsulate the core functionality and state. The changes aim to improve code organization and maintainability.
- Use the `http_client` from AccessorInfo, instead of directly accessing the backend, to migrate the service to a context-based http client.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
