### PR TITLE
refactor: Migrate icloud service to context based http client

### DIFF
--- a/core/src/services/icloud/backend.rs
+++ b/core/src/services/icloud/backend.rs
@@ -30,6 +30,8 @@ use crate::*;
 
 impl Configurator for IcloudConfig {
     type Builder = IcloudBuilder;
+
+    #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
         IcloudBuilder {
             config: self,
@@ -50,6 +52,7 @@ pub struct IcloudBuilder {
     ///
     /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
     /// during minor updates.
+    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
     pub http_client: Option<HttpClient>,
 }
 
@@ -143,6 +146,8 @@ impl IcloudBuilder {
     ///
     /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
     /// during minor updates.
+    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
+    #[allow(deprecated)]
     pub fn http_client(mut self, client: HttpClient) -> Self {
         self.http_client = Some(client);
         self
@@ -186,19 +191,32 @@ impl Builder for IcloudBuilder {
                 .with_context("service", Scheme::Icloud)),
         }?;
 
-        let client = if let Some(client) = self.http_client {
-            client
-        } else {
-            HttpClient::new().map_err(|err| {
-                err.with_operation("Builder::build")
-                    .with_context("service", Scheme::Icloud)
-            })?
-        };
-
         let session_data = SessionData::new();
 
+        let info = AccessorInfo::default();
+        info.set_scheme(Scheme::Icloud)
+            .set_root(&root)
+            .set_native_capability(Capability {
+                stat: true,
+                stat_has_content_length: true,
+                stat_has_last_modified: true,
+
+                read: true,
+
+                shared: true,
+                ..Default::default()
+            });
+
+        // allow deprecated api here for compatibility
+        #[allow(deprecated)]
+        if let Some(client) = self.http_client {
+            info.update_http_client(|_| client);
+        }
+
+        let accessor_info = Arc::new(info);
+
         let signer = IcloudSigner {
-            client: client.clone(),
+            info: accessor_info.clone(),
             data: session_data,
             apple_id,
             password,
@@ -211,6 +229,7 @@ impl Builder for IcloudBuilder {
         let signer = Arc::new(Mutex::new(signer));
         Ok(IcloudBackend {
             core: Arc::new(IcloudCore {
+                info: accessor_info,
                 signer: signer.clone(),
                 root,
                 path_cache: PathCacher::new(IcloudPathQuery::new(signer.clone())),
@@ -235,20 +254,7 @@ impl Access for IcloudBackend {
     type BlockingDeleter = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        let ma = AccessorInfo::default();
-        ma.set_scheme(Scheme::Icloud)
-            .set_root(&self.core.root)
-            .set_native_capability(Capability {
-                stat: true,
-                stat_has_content_length: true,
-                stat_has_last_modified: true,
-
-                read: true,
-
-                shared: true,
-                ..Default::default()
-            });
-        ma.into()
+        self.core.info.clone()
     }
 
     async fn stat(&self, path: &str, _: OpStat) -> Result<RpStat> {

--- a/core/src/services/icloud/core.rs
+++ b/core/src/services/icloud/core.rs
@@ -101,7 +101,7 @@ impl SessionData {
 
 #[derive(Clone)]
 pub struct IcloudSigner {
-    pub client: HttpClient,
+    pub info: Arc<AccessorInfo>,
 
     pub apple_id: String,
     pub password: String,
@@ -162,7 +162,7 @@ impl IcloudSigner {
             .map_err(new_request_build_error)?;
         self.sign(&mut req)?;
 
-        let resp = self.client.send(req).await?;
+        let resp = self.info.http_client().send(req).await?;
         if resp.status() != StatusCode::OK {
             return Err(parse_error(resp));
         }
@@ -189,7 +189,7 @@ impl IcloudSigner {
             .map_err(new_request_build_error)?;
         self.sign(&mut req)?;
 
-        let resp = self.client.send(req).await?;
+        let resp = self.info.http_client().send(req).await?;
         if resp.status() != StatusCode::OK {
             return Err(parse_error(resp));
         }
@@ -313,13 +313,14 @@ impl IcloudSigner {
     /// - Update the session data if needed.
     pub async fn send(&mut self, mut req: Request<Buffer>) -> Result<Response<Buffer>> {
         self.sign(&mut req)?;
-        let resp = self.client.send(req).await?;
+        let resp = self.info.http_client().send(req).await?;
 
         Ok(resp)
     }
 }
 
 pub struct IcloudCore {
+    pub info: Arc<AccessorInfo>,
     pub signer: Arc<Mutex<IcloudSigner>>,
     pub root: String,
     pub path_cache: PathCacher<IcloudPathQuery>,
@@ -413,7 +414,7 @@ impl IcloudCore {
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
-        let resp = signer.client.fetch(req).await?;
+        let resp = self.info.http_client().fetch(req).await?;
 
         Ok(resp)
     }


### PR DESCRIPTION
# Which issue does this PR close?
Part of https://github.com/apache/opendal/issues/5677
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->



# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Added `info` field to  `IcloudSigner` and `IcloudCore` , updated methods to use `AccessorInfo` for HTTP requests.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
