### PR TITLE
refactor: Migrate WebHDFS service to context based http client

### DIFF
--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -181,8 +181,6 @@ impl Builder for WebhdfsBuilder {
 
         let auth = self.config.delegation.map(|dt| format!("delegation={dt}"));
 
-        let client = HttpClient::new()?;
-
         let info = AccessorInfo::default();
         info.set_scheme(Scheme::Webhdfs)
             .set_root(&root)
@@ -216,7 +214,6 @@ impl Builder for WebhdfsBuilder {
             endpoint,
             user_name: self.config.user_name,
             auth,
-            client,
             root_checker: OnceCell::new(),
             atomic_write_dir,
             disable_list_batch: self.config.disable_list_batch,
@@ -277,7 +274,7 @@ impl Access for WebhdfsBackend {
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
         let req = self.core.webhdfs_create_dir_request(path)?;
 
-        let resp = self.core.client.send(req).await?;
+        let resp = self.info().http_client().send(req).await?;
 
         let status = resp.status();
 

--- a/core/src/services/webhdfs/core.rs
+++ b/core/src/services/webhdfs/core.rs
@@ -42,7 +42,6 @@ pub struct WebhdfsCore {
 
     pub atomic_write_dir: Option<String>,
     pub disable_list_batch: bool,
-    pub client: HttpClient,
 }
 
 impl Debug for WebhdfsCore {
@@ -101,7 +100,7 @@ impl WebhdfsCore {
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
-        let resp = self.client.send(req).await?;
+        let resp = self.info.http_client().send(req).await?;
 
         let status = resp.status();
 
@@ -146,7 +145,7 @@ impl WebhdfsCore {
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
-        let resp = self.client.send(req).await?;
+        let resp = self.info.http_client().send(req).await?;
 
         let status = resp.status();
 
@@ -183,7 +182,7 @@ impl WebhdfsCore {
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
-        self.client.send(req).await
+        self.info.http_client().send(req).await
     }
 
     pub fn webhdfs_append_request(
@@ -284,7 +283,7 @@ impl WebhdfsCore {
         let req = Request::get(&url)
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
-        self.client.send(req).await
+        self.info.http_client().send(req).await
     }
 
     pub async fn webhdfs_list_status_batch_request(
@@ -312,7 +311,7 @@ impl WebhdfsCore {
         let req = Request::get(&url)
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
-        self.client.send(req).await
+        self.info.http_client().send(req).await
     }
 
     pub async fn webhdfs_read_file(
@@ -321,7 +320,7 @@ impl WebhdfsCore {
         range: BytesRange,
     ) -> Result<Response<HttpBody>> {
         let req = self.webhdfs_open_request(path, &range)?;
-        self.client.fetch(req).await
+        self.info.http_client().fetch(req).await
     }
 
     pub(super) async fn webhdfs_get_file_status(&self, path: &str) -> Result<Response<Buffer>> {
@@ -342,7 +341,7 @@ impl WebhdfsCore {
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
-        self.client.send(req).await
+        self.info.http_client().send(req).await
     }
 
     pub async fn webhdfs_delete(&self, path: &str) -> Result<Response<Buffer>> {
@@ -363,7 +362,7 @@ impl WebhdfsCore {
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
-        self.client.send(req).await
+        self.info.http_client().send(req).await
     }
 }
 

--- a/core/src/services/webhdfs/core.rs
+++ b/core/src/services/webhdfs/core.rs
@@ -1,0 +1,374 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+use bytes::Buf;
+use http::header::CONTENT_LENGTH;
+use http::header::CONTENT_TYPE;
+use http::Request;
+use http::Response;
+use http::StatusCode;
+use serde::Deserialize;
+use tokio::sync::OnceCell;
+
+use super::error::parse_error;
+use crate::raw::*;
+use crate::*;
+
+pub struct WebhdfsCore {
+    pub info: Arc<AccessorInfo>,
+    pub root: String,
+    pub endpoint: String,
+    pub user_name: Option<String>,
+    pub auth: Option<String>,
+    pub root_checker: OnceCell<()>,
+
+    pub atomic_write_dir: Option<String>,
+    pub disable_list_batch: bool,
+    pub client: HttpClient,
+}
+
+impl Debug for WebhdfsCore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebhdfsCore")
+            .field("root", &self.root)
+            .field("endpoint", &self.endpoint)
+            .finish()
+    }
+}
+
+impl WebhdfsCore {
+    pub fn webhdfs_create_dir_request(&self, path: &str) -> Result<Request<Buffer>> {
+        let p = build_abs_path(&self.root, path);
+
+        let mut url = format!(
+            "{}/webhdfs/v1/{}?op=MKDIRS&overwrite=true&noredirect=true",
+            self.endpoint,
+            percent_encode_path(&p),
+        );
+        if let Some(user) = &self.user_name {
+            url += format!("&user.name={user}").as_str();
+        }
+        if let Some(auth) = &self.auth {
+            url += format!("&{auth}").as_str();
+        }
+
+        let req = Request::put(&url);
+
+        req.body(Buffer::new()).map_err(new_request_build_error)
+    }
+
+    /// create object
+    pub async fn webhdfs_create_object_request(
+        &self,
+        path: &str,
+        size: Option<u64>,
+        args: &OpWrite,
+        body: Buffer,
+    ) -> Result<Request<Buffer>> {
+        let p = build_abs_path(&self.root, path);
+
+        let mut url = format!(
+            "{}/webhdfs/v1/{}?op=CREATE&overwrite=true&noredirect=true",
+            self.endpoint,
+            percent_encode_path(&p),
+        );
+        if let Some(user) = &self.user_name {
+            url += format!("&user.name={user}").as_str();
+        }
+        if let Some(auth) = &self.auth {
+            url += format!("&{auth}").as_str();
+        }
+
+        let req = Request::put(&url);
+
+        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
+
+        let resp = self.client.send(req).await?;
+
+        let status = resp.status();
+
+        if status != StatusCode::CREATED && status != StatusCode::OK {
+            return Err(parse_error(resp));
+        }
+
+        let bs = resp.into_body();
+
+        let resp: LocationResponse =
+            serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
+
+        let mut req = Request::put(&resp.location);
+
+        if let Some(size) = size {
+            req = req.header(CONTENT_LENGTH, size);
+        };
+
+        if let Some(content_type) = args.content_type() {
+            req = req.header(CONTENT_TYPE, content_type);
+        };
+        let req = req.body(body).map_err(new_request_build_error)?;
+
+        Ok(req)
+    }
+
+    pub async fn webhdfs_init_append_request(&self, path: &str) -> Result<String> {
+        let p = build_abs_path(&self.root, path);
+        let mut url = format!(
+            "{}/webhdfs/v1/{}?op=APPEND&noredirect=true",
+            self.endpoint,
+            percent_encode_path(&p),
+        );
+        if let Some(user) = &self.user_name {
+            url += format!("&user.name={user}").as_str();
+        }
+        if let Some(auth) = &self.auth {
+            url += &format!("&{auth}");
+        }
+
+        let req = Request::post(url)
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+
+        let resp = self.client.send(req).await?;
+
+        let status = resp.status();
+
+        match status {
+            StatusCode::OK => {
+                let bs = resp.into_body();
+                let resp: LocationResponse =
+                    serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
+
+                Ok(resp.location)
+            }
+            _ => Err(parse_error(resp)),
+        }
+    }
+
+    pub async fn webhdfs_rename_object(&self, from: &str, to: &str) -> Result<Response<Buffer>> {
+        let from = build_abs_path(&self.root, from);
+        let to = build_rooted_abs_path(&self.root, to);
+
+        let mut url = format!(
+            "{}/webhdfs/v1/{}?op=RENAME&destination={}",
+            self.endpoint,
+            percent_encode_path(&from),
+            percent_encode_path(&to)
+        );
+        if let Some(user) = &self.user_name {
+            url += format!("&user.name={user}").as_str();
+        }
+        if let Some(auth) = &self.auth {
+            url += &format!("&{auth}");
+        }
+
+        let req = Request::put(&url)
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+
+        self.client.send(req).await
+    }
+
+    pub fn webhdfs_append_request(
+        &self,
+        location: &str,
+        size: u64,
+        body: Buffer,
+    ) -> Result<Request<Buffer>> {
+        let mut url = location.to_string();
+        if let Some(user) = &self.user_name {
+            url += format!("&user.name={user}").as_str();
+        }
+        if let Some(auth) = &self.auth {
+            url += &format!("&{auth}");
+        }
+
+        let mut req = Request::post(&url);
+
+        req = req.header(CONTENT_LENGTH, size.to_string());
+
+        req.body(body).map_err(new_request_build_error)
+    }
+
+    /// CONCAT will concat sources to the path
+    pub fn webhdfs_concat_request(
+        &self,
+        path: &str,
+        sources: Vec<String>,
+    ) -> Result<Request<Buffer>> {
+        let p = build_abs_path(&self.root, path);
+
+        let sources = sources
+            .iter()
+            .map(|p| build_rooted_abs_path(&self.root, p))
+            .collect::<Vec<String>>()
+            .join(",");
+
+        let mut url = format!(
+            "{}/webhdfs/v1/{}?op=CONCAT&sources={}",
+            self.endpoint,
+            percent_encode_path(&p),
+            percent_encode_path(&sources),
+        );
+        if let Some(user) = &self.user_name {
+            url += format!("&user.name={user}").as_str();
+        }
+        if let Some(auth) = &self.auth {
+            url += &format!("&{auth}");
+        }
+
+        let req = Request::post(url);
+
+        req.body(Buffer::new()).map_err(new_request_build_error)
+    }
+
+    fn webhdfs_open_request(&self, path: &str, range: &BytesRange) -> Result<Request<Buffer>> {
+        let p = build_abs_path(&self.root, path);
+        let mut url = format!(
+            "{}/webhdfs/v1/{}?op=OPEN",
+            self.endpoint,
+            percent_encode_path(&p),
+        );
+        if let Some(user) = &self.user_name {
+            url += format!("&user.name={user}").as_str();
+        }
+        if let Some(auth) = &self.auth {
+            url += &format!("&{auth}");
+        }
+
+        if !range.is_full() {
+            url += &format!("&offset={}", range.offset());
+            if let Some(size) = range.size() {
+                url += &format!("&length={size}")
+            }
+        }
+
+        let req = Request::get(&url)
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+
+        Ok(req)
+    }
+
+    pub async fn webhdfs_list_status_request(&self, path: &str) -> Result<Response<Buffer>> {
+        let p = build_abs_path(&self.root, path);
+        let mut url = format!(
+            "{}/webhdfs/v1/{}?op=LISTSTATUS",
+            self.endpoint,
+            percent_encode_path(&p),
+        );
+        if let Some(user) = &self.user_name {
+            url += format!("&user.name={user}").as_str();
+        }
+        if let Some(auth) = &self.auth {
+            url += format!("&{auth}").as_str();
+        }
+
+        let req = Request::get(&url)
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+        self.client.send(req).await
+    }
+
+    pub async fn webhdfs_list_status_batch_request(
+        &self,
+        path: &str,
+        start_after: &str,
+    ) -> Result<Response<Buffer>> {
+        let p = build_abs_path(&self.root, path);
+
+        let mut url = format!(
+            "{}/webhdfs/v1/{}?op=LISTSTATUS_BATCH",
+            self.endpoint,
+            percent_encode_path(&p),
+        );
+        if !start_after.is_empty() {
+            url += format!("&startAfter={}", start_after).as_str();
+        }
+        if let Some(user) = &self.user_name {
+            url += format!("&user.name={user}").as_str();
+        }
+        if let Some(auth) = &self.auth {
+            url += format!("&{auth}").as_str();
+        }
+
+        let req = Request::get(&url)
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+        self.client.send(req).await
+    }
+
+    pub async fn webhdfs_read_file(
+        &self,
+        path: &str,
+        range: BytesRange,
+    ) -> Result<Response<HttpBody>> {
+        let req = self.webhdfs_open_request(path, &range)?;
+        self.client.fetch(req).await
+    }
+
+    pub(super) async fn webhdfs_get_file_status(&self, path: &str) -> Result<Response<Buffer>> {
+        let p = build_abs_path(&self.root, path);
+        let mut url = format!(
+            "{}/webhdfs/v1/{}?op=GETFILESTATUS",
+            self.endpoint,
+            percent_encode_path(&p),
+        );
+        if let Some(user) = &self.user_name {
+            url += format!("&user.name={user}").as_str();
+        }
+        if let Some(auth) = &self.auth {
+            url += format!("&{auth}").as_str();
+        }
+
+        let req = Request::get(&url)
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+
+        self.client.send(req).await
+    }
+
+    pub async fn webhdfs_delete(&self, path: &str) -> Result<Response<Buffer>> {
+        let p = build_abs_path(&self.root, path);
+        let mut url = format!(
+            "{}/webhdfs/v1/{}?op=DELETE&recursive=false",
+            self.endpoint,
+            percent_encode_path(&p),
+        );
+        if let Some(user) = &self.user_name {
+            url += format!("&user.name={user}").as_str();
+        }
+        if let Some(auth) = &self.auth {
+            url += format!("&{auth}").as_str();
+        }
+
+        let req = Request::delete(&url)
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+
+        self.client.send(req).await
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub(super) struct LocationResponse {
+    pub location: String,
+}

--- a/core/src/services/webhdfs/delete.rs
+++ b/core/src/services/webhdfs/delete.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::backend::WebhdfsBackend;
+use super::core::WebhdfsCore;
 use super::error::parse_error;
 use crate::raw::*;
 use crate::*;
@@ -23,11 +23,11 @@ use http::StatusCode;
 use std::sync::Arc;
 
 pub struct WebhdfsDeleter {
-    core: Arc<WebhdfsBackend>,
+    core: Arc<WebhdfsCore>,
 }
 
 impl WebhdfsDeleter {
-    pub fn new(core: Arc<WebhdfsBackend>) -> Self {
+    pub fn new(core: Arc<WebhdfsCore>) -> Self {
         Self { core }
     }
 }

--- a/core/src/services/webhdfs/lister.rs
+++ b/core/src/services/webhdfs/lister.rs
@@ -15,24 +15,26 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use bytes::Buf;
 use http::StatusCode;
 
-use super::backend::WebhdfsBackend;
+use super::core::WebhdfsCore;
 use super::error::parse_error;
 use super::message::*;
 use crate::raw::*;
 use crate::*;
 
 pub struct WebhdfsLister {
-    backend: WebhdfsBackend,
+    core: Arc<WebhdfsCore>,
     path: String,
 }
 
 impl WebhdfsLister {
-    pub fn new(backend: WebhdfsBackend, path: &str) -> Self {
+    pub fn new(core: Arc<WebhdfsCore>, path: &str) -> Self {
         Self {
-            backend,
+            core,
             path: path.to_string(),
         }
     }
@@ -40,8 +42,8 @@ impl WebhdfsLister {
 
 impl oio::PageList for WebhdfsLister {
     async fn next_page(&self, ctx: &mut oio::PageContext) -> Result<()> {
-        let file_status = if self.backend.disable_list_batch {
-            let resp = self.backend.webhdfs_list_status_request(&self.path).await?;
+        let file_status = if self.core.disable_list_batch {
+            let resp = self.core.webhdfs_list_status_request(&self.path).await?;
             match resp.status() {
                 StatusCode::OK => {
                     ctx.done = true;
@@ -64,7 +66,7 @@ impl oio::PageList for WebhdfsLister {
             }
         } else {
             let resp = self
-                .backend
+                .core
                 .webhdfs_list_status_batch_request(&self.path, &ctx.token)
                 .await?;
             match resp.status() {

--- a/core/src/services/webhdfs/mod.rs
+++ b/core/src/services/webhdfs/mod.rs
@@ -31,5 +31,8 @@ mod backend;
 #[cfg(feature = "services-webhdfs")]
 pub use backend::WebhdfsBuilder as Webhdfs;
 
+#[cfg(feature = "services-webhdfs")]
+mod core;
+
 mod config;
 pub use config::WebhdfsConfig;

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -15,11 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use bytes::Buf;
 use http::StatusCode;
 use uuid::Uuid;
 
-use super::backend::WebhdfsBackend;
+use super::core::WebhdfsCore;
 use super::error::parse_error;
 use crate::raw::*;
 use crate::services::webhdfs::message::FileStatusWrapper;
@@ -29,26 +31,26 @@ pub type WebhdfsWriters =
     TwoWays<oio::BlockWriter<WebhdfsWriter>, oio::AppendWriter<WebhdfsWriter>>;
 
 pub struct WebhdfsWriter {
-    backend: WebhdfsBackend,
+    core: Arc<WebhdfsCore>,
 
     op: OpWrite,
     path: String,
 }
 
 impl WebhdfsWriter {
-    pub fn new(backend: WebhdfsBackend, op: OpWrite, path: String) -> Self {
-        WebhdfsWriter { backend, op, path }
+    pub fn new(core: Arc<WebhdfsCore>, op: OpWrite, path: String) -> Self {
+        WebhdfsWriter { core, op, path }
     }
 }
 
 impl oio::BlockWrite for WebhdfsWriter {
     async fn write_once(&self, size: u64, body: Buffer) -> Result<Metadata> {
         let req = self
-            .backend
+            .core
             .webhdfs_create_object_request(&self.path, Some(size), &self.op, body)
             .await?;
 
-        let resp = self.backend.client.send(req).await?;
+        let resp = self.core.client.send(req).await?;
 
         let status = resp.status();
         match status {
@@ -58,14 +60,14 @@ impl oio::BlockWrite for WebhdfsWriter {
     }
 
     async fn write_block(&self, block_id: Uuid, size: u64, body: Buffer) -> Result<()> {
-        let Some(ref atomic_write_dir) = self.backend.atomic_write_dir else {
+        let Some(ref atomic_write_dir) = self.core.atomic_write_dir else {
             return Err(Error::new(
                 ErrorKind::Unsupported,
                 "write multi is not supported when atomic is not set",
             ));
         };
         let req = self
-            .backend
+            .core
             .webhdfs_create_object_request(
                 &format!("{}{}", atomic_write_dir, block_id),
                 Some(size),
@@ -74,7 +76,7 @@ impl oio::BlockWrite for WebhdfsWriter {
             )
             .await?;
 
-        let resp = self.backend.client.send(req).await?;
+        let resp = self.core.client.send(req).await?;
 
         let status = resp.status();
         match status {
@@ -84,7 +86,7 @@ impl oio::BlockWrite for WebhdfsWriter {
     }
 
     async fn complete_block(&self, block_ids: Vec<Uuid>) -> Result<Metadata> {
-        let Some(ref atomic_write_dir) = self.backend.atomic_write_dir else {
+        let Some(ref atomic_write_dir) = self.core.atomic_write_dir else {
             return Err(Error::new(
                 ErrorKind::Unsupported,
                 "write multi is not supported when atomic is not set",
@@ -97,11 +99,9 @@ impl oio::BlockWrite for WebhdfsWriter {
                 .map(|s| format!("{}{}", atomic_write_dir, s))
                 .collect();
             // concat blocks
-            let req = self
-                .backend
-                .webhdfs_concat_request(&first_block_id, sources)?;
+            let req = self.core.webhdfs_concat_request(&first_block_id, sources)?;
 
-            let resp = self.backend.client.send(req).await?;
+            let resp = self.core.client.send(req).await?;
 
             let status = resp.status();
 
@@ -110,7 +110,7 @@ impl oio::BlockWrite for WebhdfsWriter {
             }
         }
         // delete the path file
-        let resp = self.backend.webhdfs_delete(&self.path).await?;
+        let resp = self.core.webhdfs_delete(&self.path).await?;
         let status = resp.status();
         if status != StatusCode::OK {
             return Err(parse_error(resp));
@@ -118,7 +118,7 @@ impl oio::BlockWrite for WebhdfsWriter {
 
         // rename concat file to path
         let resp = self
-            .backend
+            .core
             .webhdfs_rename_object(&first_block_id, &self.path)
             .await?;
 
@@ -132,7 +132,7 @@ impl oio::BlockWrite for WebhdfsWriter {
 
     async fn abort_block(&self, block_ids: Vec<Uuid>) -> Result<()> {
         for block_id in block_ids {
-            let resp = self.backend.webhdfs_delete(&block_id.to_string()).await?;
+            let resp = self.core.webhdfs_delete(&block_id.to_string()).await?;
             match resp.status() {
                 StatusCode::OK => {}
                 _ => return Err(parse_error(resp)),
@@ -144,7 +144,7 @@ impl oio::BlockWrite for WebhdfsWriter {
 
 impl oio::AppendWrite for WebhdfsWriter {
     async fn offset(&self) -> Result<u64> {
-        let resp = self.backend.webhdfs_get_file_status(&self.path).await?;
+        let resp = self.core.webhdfs_get_file_status(&self.path).await?;
         let status = resp.status();
         match status {
             StatusCode::OK => {
@@ -157,11 +157,11 @@ impl oio::AppendWrite for WebhdfsWriter {
             }
             StatusCode::NOT_FOUND => {
                 let req = self
-                    .backend
+                    .core
                     .webhdfs_create_object_request(&self.path, None, &self.op, Buffer::new())
                     .await?;
 
-                let resp = self.backend.client.send(req).await?;
+                let resp = self.core.client.send(req).await?;
                 let status = resp.status();
 
                 match status {
@@ -174,9 +174,9 @@ impl oio::AppendWrite for WebhdfsWriter {
     }
 
     async fn append(&self, _offset: u64, size: u64, body: Buffer) -> Result<Metadata> {
-        let location = self.backend.webhdfs_init_append_request(&self.path).await?;
-        let req = self.backend.webhdfs_append_request(&location, size, body)?;
-        let resp = self.backend.client.send(req).await?;
+        let location = self.core.webhdfs_init_append_request(&self.path).await?;
+        let req = self.core.webhdfs_append_request(&location, size, body)?;
+        let resp = self.core.client.send(req).await?;
 
         let status = resp.status();
         match status {

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -50,7 +50,7 @@ impl oio::BlockWrite for WebhdfsWriter {
             .webhdfs_create_object_request(&self.path, Some(size), &self.op, body)
             .await?;
 
-        let resp = self.core.client.send(req).await?;
+        let resp = self.core.info.http_client().send(req).await?;
 
         let status = resp.status();
         match status {
@@ -76,7 +76,7 @@ impl oio::BlockWrite for WebhdfsWriter {
             )
             .await?;
 
-        let resp = self.core.client.send(req).await?;
+        let resp = self.core.info.http_client().send(req).await?;
 
         let status = resp.status();
         match status {
@@ -101,7 +101,7 @@ impl oio::BlockWrite for WebhdfsWriter {
             // concat blocks
             let req = self.core.webhdfs_concat_request(&first_block_id, sources)?;
 
-            let resp = self.core.client.send(req).await?;
+            let resp = self.core.info.http_client().send(req).await?;
 
             let status = resp.status();
 
@@ -161,7 +161,7 @@ impl oio::AppendWrite for WebhdfsWriter {
                     .webhdfs_create_object_request(&self.path, None, &self.op, Buffer::new())
                     .await?;
 
-                let resp = self.core.client.send(req).await?;
+                let resp = self.core.info.http_client().send(req).await?;
                 let status = resp.status();
 
                 match status {
@@ -176,7 +176,7 @@ impl oio::AppendWrite for WebhdfsWriter {
     async fn append(&self, _offset: u64, size: u64, body: Buffer) -> Result<Metadata> {
         let location = self.core.webhdfs_init_append_request(&self.path).await?;
         let req = self.core.webhdfs_append_request(&location, size, body)?;
-        let resp = self.core.client.send(req).await?;
+        let resp = self.core.info.http_client().send(req).await?;
 
         let status = resp.status();
         match status {


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/5677
Part of https://github.com/apache/opendal/issues/5702
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- This pull request refactors the `WebhdfsBackend` by introducing a new `WebhdfsCore` struct to encapsulate the core functionality and state. The changes aim to improve code organization and maintainability.
- Updated methods to use `AccessorInfo` for HTTP requests.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
