### PR TITLE
refactor: Introduce SftpCore for improved service structure

### DIFF
--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -22,21 +22,16 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use bb8::PooledConnection;
-use bb8::RunError;
 use log::debug;
 use openssh::KnownHosts;
-use openssh::SessionBuilder;
-use openssh_sftp_client::Sftp;
-use openssh_sftp_client::SftpOptions;
 use tokio::io::AsyncSeekExt;
 use tokio::sync::OnceCell;
 
+use super::core::SftpCore;
 use super::delete::SftpDeleter;
 use super::error::is_not_found;
 use super::error::is_sftp_protocol_error;
 use super::error::parse_sftp_error;
-use super::error::parse_ssh_error;
 use super::lister::SftpLister;
 use super::reader::SftpReader;
 use super::writer::SftpWriter;
@@ -184,41 +179,38 @@ impl Builder for SftpBuilder {
             None => KnownHosts::Strict,
         };
 
-        debug!("sftp backend finished: {:?}", &self);
+        let info = AccessorInfo::default();
+        info.set_root(root.as_str())
+            .set_scheme(Scheme::Sftp)
+            .set_native_capability(Capability {
+                stat: true,
+                stat_has_content_length: true,
+                stat_has_last_modified: true,
 
-        Ok(SftpBackend {
-            info: {
-                let am = AccessorInfo::default();
-                am.set_root(root.as_str())
-                    .set_scheme(Scheme::Sftp)
-                    .set_native_capability(Capability {
-                        stat: true,
-                        stat_has_content_length: true,
-                        stat_has_last_modified: true,
+                read: true,
 
-                        read: true,
+                write: true,
+                write_can_multi: true,
 
-                        write: true,
-                        write_can_multi: true,
+                create_dir: true,
+                delete: true,
 
-                        create_dir: true,
-                        delete: true,
+                list: true,
+                list_with_limit: true,
+                list_has_content_length: true,
+                list_has_last_modified: true,
 
-                        list: true,
-                        list_with_limit: true,
-                        list_has_content_length: true,
-                        list_has_last_modified: true,
+                copy: self.config.enable_copy,
+                rename: true,
 
-                        copy: self.config.enable_copy,
-                        rename: true,
+                shared: true,
 
-                        shared: true,
+                ..Default::default()
+            });
 
-                        ..Default::default()
-                    });
-
-                am.into()
-            },
+        let accessor_info = Arc::new(info);
+        let core = Arc::new(SftpCore {
+            info: accessor_info,
             endpoint,
             root,
             user,
@@ -226,124 +218,24 @@ impl Builder for SftpBuilder {
             known_hosts_strategy,
 
             client: OnceCell::new(),
-        })
+        });
+
+        debug!("sftp backend finished: {:?}", &self);
+        Ok(SftpBackend { core })
     }
 }
 
 /// Backend is used to serve `Accessor` support for sftp.
 #[derive(Clone)]
 pub struct SftpBackend {
-    info: Arc<AccessorInfo>,
-    endpoint: String,
-    pub root: String,
-    user: Option<String>,
-    key: Option<String>,
-    known_hosts_strategy: KnownHosts,
-
-    pub client: OnceCell<bb8::Pool<Manager>>,
-}
-
-pub struct Manager {
-    endpoint: String,
-    root: String,
-    user: Option<String>,
-    key: Option<String>,
-    known_hosts_strategy: KnownHosts,
-}
-
-#[async_trait::async_trait]
-impl bb8::ManageConnection for Manager {
-    type Connection = Sftp;
-    type Error = Error;
-
-    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        let mut session = SessionBuilder::default();
-
-        if let Some(user) = &self.user {
-            session.user(user.clone());
-        }
-
-        if let Some(key) = &self.key {
-            session.keyfile(key);
-        }
-
-        session.known_hosts_check(self.known_hosts_strategy.clone());
-
-        let session = session
-            .connect(&self.endpoint)
-            .await
-            .map_err(parse_ssh_error)?;
-
-        let sftp = Sftp::from_session(session, SftpOptions::default())
-            .await
-            .map_err(parse_sftp_error)?;
-
-        if !self.root.is_empty() {
-            let mut fs = sftp.fs();
-
-            let paths = Path::new(&self.root).components();
-            let mut current = PathBuf::new();
-            for p in paths {
-                current.push(p);
-                let res = fs.create_dir(p).await;
-
-                if let Err(e) = res {
-                    // ignore error if dir already exists
-                    if !is_sftp_protocol_error(&e) {
-                        return Err(parse_sftp_error(e));
-                    }
-                }
-                fs.set_cwd(&current);
-            }
-        }
-
-        debug!("sftp connection created at {}", self.root);
-        Ok(sftp)
-    }
-
-    // Check if connect valid by checking the root path.
-    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
-        let _ = conn.fs().metadata("./").await.map_err(parse_sftp_error)?;
-
-        Ok(())
-    }
-
-    /// Always allow reuse conn.
-    fn has_broken(&self, _: &mut Self::Connection) -> bool {
-        false
-    }
+    pub core: Arc<SftpCore>,
 }
 
 impl Debug for SftpBackend {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend").finish()
-    }
-}
-
-impl SftpBackend {
-    pub async fn connect(&self) -> Result<PooledConnection<'static, Manager>> {
-        let client = self
-            .client
-            .get_or_try_init(|| async {
-                bb8::Pool::builder()
-                    .max_size(64)
-                    .build(Manager {
-                        endpoint: self.endpoint.clone(),
-                        root: self.root.clone(),
-                        user: self.user.clone(),
-                        key: self.key.clone(),
-                        known_hosts_strategy: self.known_hosts_strategy.clone(),
-                    })
-                    .await
-            })
-            .await?;
-
-        client.get_owned().await.map_err(|err| match err {
-            RunError::User(err) => err,
-            RunError::TimedOut => {
-                Error::new(ErrorKind::Unexpected, "connection request: timeout").set_temporary()
-            }
-        })
+        f.debug_struct("SftpBackend")
+            .field("core", &self.core)
+            .finish()
     }
 }
 
@@ -358,16 +250,16 @@ impl Access for SftpBackend {
     type BlockingDeleter = ();
 
     fn info(&self) -> Arc<AccessorInfo> {
-        self.info.clone()
+        self.core.info.clone()
     }
 
     async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
-        let client = self.connect().await?;
+        let client = self.core.connect().await?;
         let mut fs = client.fs();
-        fs.set_cwd(&self.root);
+        fs.set_cwd(&self.core.root);
 
         let paths = Path::new(&path).components();
-        let mut current = PathBuf::from(&self.root);
+        let mut current = PathBuf::from(&self.core.root);
         for p in paths {
             current = current.join(p);
             let res = fs.create_dir(p).await;
@@ -385,9 +277,9 @@ impl Access for SftpBackend {
     }
 
     async fn stat(&self, path: &str, _: OpStat) -> Result<RpStat> {
-        let client = self.connect().await?;
+        let client = self.core.connect().await?;
         let mut fs = client.fs();
-        fs.set_cwd(&self.root);
+        fs.set_cwd(&self.core.root);
 
         let meta: Metadata = fs.metadata(path).await.map_err(parse_sftp_error)?.into();
 
@@ -395,10 +287,10 @@ impl Access for SftpBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let client = self.connect().await?;
+        let client = self.core.connect().await?;
 
         let mut fs = client.fs();
-        fs.set_cwd(&self.root);
+        fs.set_cwd(&self.core.root);
 
         let path = fs.canonicalize(path).await.map_err(parse_sftp_error)?;
 
@@ -424,10 +316,10 @@ impl Access for SftpBackend {
             self.create_dir(dir, OpCreateDir::default()).await?;
         }
 
-        let client = self.connect().await?;
+        let client = self.core.connect().await?;
 
         let mut fs = client.fs();
-        fs.set_cwd(&self.root);
+        fs.set_cwd(&self.core.root);
         let path = fs.canonicalize(path).await.map_err(parse_sftp_error)?;
 
         let mut option = client.options();
@@ -446,14 +338,14 @@ impl Access for SftpBackend {
     async fn delete(&self) -> Result<(RpDelete, Self::Deleter)> {
         Ok((
             RpDelete::default(),
-            oio::OneShotDeleter::new(SftpDeleter::new(Arc::new(self.clone()))),
+            oio::OneShotDeleter::new(SftpDeleter::new(self.core.clone())),
         ))
     }
 
     async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let client = self.connect().await?;
+        let client = self.core.connect().await?;
         let mut fs = client.fs();
-        fs.set_cwd(&self.root);
+        fs.set_cwd(&self.core.root);
 
         let file_path = format!("./{}", path);
 
@@ -476,10 +368,10 @@ impl Access for SftpBackend {
     }
 
     async fn copy(&self, from: &str, to: &str, _: OpCopy) -> Result<RpCopy> {
-        let client = self.connect().await?;
+        let client = self.core.connect().await?;
 
         let mut fs = client.fs();
-        fs.set_cwd(&self.root);
+        fs.set_cwd(&self.core.root);
 
         if let Some((dir, _)) = to.rsplit_once('/') {
             self.create_dir(dir, OpCreateDir::default()).await?;
@@ -499,10 +391,10 @@ impl Access for SftpBackend {
     }
 
     async fn rename(&self, from: &str, to: &str, _: OpRename) -> Result<RpRename> {
-        let client = self.connect().await?;
+        let client = self.core.connect().await?;
 
         let mut fs = client.fs();
-        fs.set_cwd(&self.root);
+        fs.set_cwd(&self.core.root);
 
         if let Some((dir, _)) = to.rsplit_once('/') {
             self.create_dir(dir, OpCreateDir::default()).await?;

--- a/core/src/services/sftp/core.rs
+++ b/core/src/services/sftp/core.rs
@@ -1,0 +1,155 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use bb8::PooledConnection;
+use bb8::RunError;
+use log::debug;
+use openssh::KnownHosts;
+use openssh::SessionBuilder;
+use openssh_sftp_client::Sftp;
+use openssh_sftp_client::SftpOptions;
+use tokio::sync::OnceCell;
+
+use super::error::is_sftp_protocol_error;
+use super::error::parse_sftp_error;
+use super::error::parse_ssh_error;
+use crate::raw::*;
+use crate::*;
+
+pub struct SftpCore {
+    pub info: Arc<AccessorInfo>,
+    pub endpoint: String,
+    pub root: String,
+    pub user: Option<String>,
+    pub key: Option<String>,
+    pub known_hosts_strategy: KnownHosts,
+
+    pub client: OnceCell<bb8::Pool<Manager>>,
+}
+
+impl Debug for SftpCore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SftpCore")
+            .field("endpoint", &self.endpoint)
+            .field("root", &self.root)
+            .finish()
+    }
+}
+
+impl SftpCore {
+    pub async fn connect(&self) -> Result<PooledConnection<'static, Manager>> {
+        let client = self
+            .client
+            .get_or_try_init(|| async {
+                bb8::Pool::builder()
+                    .max_size(64)
+                    .build(Manager {
+                        endpoint: self.endpoint.clone(),
+                        root: self.root.clone(),
+                        user: self.user.clone(),
+                        key: self.key.clone(),
+                        known_hosts_strategy: self.known_hosts_strategy.clone(),
+                    })
+                    .await
+            })
+            .await?;
+
+        client.get_owned().await.map_err(|err| match err {
+            RunError::User(err) => err,
+            RunError::TimedOut => {
+                Error::new(ErrorKind::Unexpected, "connection request: timeout").set_temporary()
+            }
+        })
+    }
+}
+
+pub struct Manager {
+    endpoint: String,
+    root: String,
+    user: Option<String>,
+    key: Option<String>,
+    known_hosts_strategy: KnownHosts,
+}
+
+#[async_trait::async_trait]
+impl bb8::ManageConnection for Manager {
+    type Connection = Sftp;
+    type Error = Error;
+
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        let mut session = SessionBuilder::default();
+
+        if let Some(user) = &self.user {
+            session.user(user.clone());
+        }
+
+        if let Some(key) = &self.key {
+            session.keyfile(key);
+        }
+
+        session.known_hosts_check(self.known_hosts_strategy.clone());
+
+        let session = session
+            .connect(&self.endpoint)
+            .await
+            .map_err(parse_ssh_error)?;
+
+        let sftp = Sftp::from_session(session, SftpOptions::default())
+            .await
+            .map_err(parse_sftp_error)?;
+
+        if !self.root.is_empty() {
+            let mut fs = sftp.fs();
+
+            let paths = Path::new(&self.root).components();
+            let mut current = PathBuf::new();
+            for p in paths {
+                current.push(p);
+                let res = fs.create_dir(p).await;
+
+                if let Err(e) = res {
+                    // ignore error if dir already exists
+                    if !is_sftp_protocol_error(&e) {
+                        return Err(parse_sftp_error(e));
+                    }
+                }
+                fs.set_cwd(&current);
+            }
+        }
+
+        debug!("sftp connection created at {}", self.root);
+        Ok(sftp)
+    }
+
+    // Check if connect valid by checking the root path.
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        let _ = conn.fs().metadata("./").await.map_err(parse_sftp_error)?;
+
+        Ok(())
+    }
+
+    /// Always allow reuse conn.
+    fn has_broken(&self, _: &mut Self::Connection) -> bool {
+        false
+    }
+}

--- a/core/src/services/sftp/delete.rs
+++ b/core/src/services/sftp/delete.rs
@@ -15,18 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::backend::SftpBackend;
+use super::core::SftpCore;
 use super::error::{is_not_found, parse_sftp_error};
 use crate::raw::*;
 use crate::*;
 use std::sync::Arc;
 
 pub struct SftpDeleter {
-    core: Arc<SftpBackend>,
+    core: Arc<SftpCore>,
 }
 
 impl SftpDeleter {
-    pub fn new(core: Arc<SftpBackend>) -> Self {
+    pub fn new(core: Arc<SftpCore>) -> Self {
         Self { core }
     }
 }

--- a/core/src/services/sftp/mod.rs
+++ b/core/src/services/sftp/mod.rs
@@ -32,6 +32,8 @@ mod writer;
 mod backend;
 #[cfg(feature = "services-sftp")]
 pub use backend::SftpBuilder as Sftp;
+#[cfg(feature = "services-sftp")]
+mod core;
 
 mod config;
 pub use config::SftpConfig;

--- a/core/src/services/sftp/reader.rs
+++ b/core/src/services/sftp/reader.rs
@@ -19,7 +19,7 @@ use bb8::PooledConnection;
 use bytes::BytesMut;
 use openssh_sftp_client::file::File;
 
-use super::backend::Manager;
+use super::core::Manager;
 use super::error::parse_sftp_error;
 use crate::raw::*;
 use crate::*;


### PR DESCRIPTION
# Which issue does this PR close?
Part of https://github.com/apache/opendal/issues/5702

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
This pull request refactors the `SftpBackend` by introducing a new `SftpCore` struct to encapsulate the core functionality and state. The changes aim to improve code organization and maintainability. 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
