### PR TITLE
ci: Disable zigbuild to workaround undefined symbol

### DIFF
--- a/.github/workflows/release_java.yml
+++ b/.github/workflows/release_java.yml
@@ -31,6 +31,10 @@ on:
       - "bindings/java/tools/build.py"
   workflow_dispatch:
 
+env:
+  # Refer to https://github.com/apache/opendal/issues/5935
+  CARGO_BUILD_ENABLE_ZIGBUILD: "false"
+
 jobs:
   stage-snapshot:
     runs-on: ${{ matrix.os }}
@@ -90,8 +94,7 @@ jobs:
             -Djni.classifier=${{ matrix.classifier }} \
             -Dcargo-build.profile=release \
             -Dcargo-build.features=services-all \
-            # Refer to https://github.com/apache/opendal/issues/5935
-            # -Dcargo-build.enableZigbuild=true \
+            -Dcargo-build.enableZigbuild=${{ env.CARGO_BUILD_ENABLE_ZIGBUILD }} \
             -DaltStagingDirectory=local-staging \
             -DskipRemoteStaging=true \
             -DserverId=apache.releases.https \


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Workaround for https://github.com/apache/opendal/issues/5935

# Rationale for this change

I'm guessing this related to zigbuild since our java binding's CI works correctly.

# What changes are included in this PR?

Disable zigbuild for now.

# Are there any user-facing changes?

Users are not affected directly.