### PR TITLE
refactor(ftp): restructure FtpBackend and introduce FtpCore

### DIFF
--- a/core/src/services/ftp/core.rs
+++ b/core/src/services/ftp/core.rs
@@ -1,0 +1,114 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::raw::AccessorInfo;
+use crate::*;
+use bb8::Pool;
+use futures_rustls::TlsConnector;
+use std::sync::Arc;
+use suppaftp::rustls::ClientConfig;
+use suppaftp::types::FileType;
+use suppaftp::Status;
+use suppaftp::{AsyncRustlsConnector, AsyncRustlsFtpStream};
+use suppaftp::{FtpError, ImplAsyncFtpStream};
+use tokio::sync::OnceCell;
+
+pub struct FtpCore {
+    pub info: Arc<AccessorInfo>,
+    pub endpoint: String,
+    pub root: String,
+    pub user: String,
+    pub password: String,
+    pub enable_secure: bool,
+    pub pool: OnceCell<Pool<Manager>>,
+}
+
+impl FtpCore {
+    // pub fn
+}
+
+pub struct Manager {
+    pub endpoint: String,
+    pub root: String,
+    pub user: String,
+    pub password: String,
+    pub enable_secure: bool,
+}
+
+#[async_trait::async_trait]
+impl bb8::ManageConnection for Manager {
+    type Connection = AsyncRustlsFtpStream;
+    type Error = FtpError;
+
+    async fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        let stream = ImplAsyncFtpStream::connect(&self.endpoint).await?;
+        // switch to secure mode if ssl/tls is on.
+        let mut ftp_stream = if self.enable_secure {
+            let mut root_store = suppaftp::rustls::RootCertStore::empty();
+            for cert in
+                rustls_native_certs::load_native_certs().expect("could not load platform certs")
+            {
+                root_store.add(cert).unwrap();
+            }
+
+            let cfg = ClientConfig::builder()
+                .with_root_certificates(root_store)
+                .with_no_client_auth();
+            stream
+                .into_secure(
+                    AsyncRustlsConnector::from(TlsConnector::from(Arc::new(cfg))),
+                    &self.endpoint,
+                )
+                .await?
+        } else {
+            stream
+        };
+
+        // login if needed
+        if !self.user.is_empty() {
+            ftp_stream.login(&self.user, &self.password).await?;
+        }
+
+        // change to the root path
+        match ftp_stream.cwd(&self.root).await {
+            Err(FtpError::UnexpectedResponse(e)) if e.status == Status::FileUnavailable => {
+                ftp_stream.mkdir(&self.root).await?;
+                // Then change to root path
+                ftp_stream.cwd(&self.root).await?;
+            }
+            // Other errors, return.
+            Err(e) => return Err(e),
+            // Do nothing if success.
+            Ok(_) => (),
+        }
+
+        ftp_stream.transfer_type(FileType::Binary).await?;
+
+        Ok(ftp_stream)
+    }
+
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        conn.noop().await
+    }
+
+    /// Don't allow reuse conn.
+    ///
+    /// We need to investigate why reuse conn will cause error.
+    fn has_broken(&self, _: &mut Self::Connection) -> bool {
+        true
+    }
+}

--- a/core/src/services/ftp/delete.rs
+++ b/core/src/services/ftp/delete.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::backend::FtpBackend;
+use super::core::FtpCore;
 use super::err::parse_error;
 use crate::raw::*;
 use crate::*;
@@ -25,11 +25,11 @@ use suppaftp::FtpError;
 use suppaftp::Status;
 
 pub struct FtpDeleter {
-    core: Arc<FtpBackend>,
+    core: Arc<FtpCore>,
 }
 
 impl FtpDeleter {
-    pub fn new(core: Arc<FtpBackend>) -> Self {
+    pub fn new(core: Arc<FtpCore>) -> Self {
         Self { core }
     }
 }

--- a/core/src/services/ftp/mod.rs
+++ b/core/src/services/ftp/mod.rs
@@ -30,6 +30,9 @@ mod writer;
 mod backend;
 #[cfg(feature = "services-ftp")]
 pub use backend::FtpBuilder as Ftp;
+#[cfg(feature = "services-ftp")]
+mod core;
 
 mod config;
+
 pub use config::FtpConfig;

--- a/core/src/services/ftp/reader.rs
+++ b/core/src/services/ftp/reader.rs
@@ -20,7 +20,7 @@ use bytes::BytesMut;
 use futures::AsyncRead;
 use futures::AsyncReadExt;
 
-use super::backend::Manager;
+use super::core::Manager;
 use super::err::parse_error;
 use crate::raw::*;
 use crate::*;

--- a/core/src/services/ftp/writer.rs
+++ b/core/src/services/ftp/writer.rs
@@ -20,7 +20,7 @@ use bytes::Buf;
 use futures::AsyncWrite;
 use futures::AsyncWriteExt;
 
-use super::backend::Manager;
+use super::core::Manager;
 use super::err::parse_error;
 use crate::raw::*;
 use crate::*;


### PR DESCRIPTION
# Which issue does this PR close?

Addresses #5702: Split service logic to  `backend` and `core` modules

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This pull request refactors the `FtpBackend` by introducing a new `FtpCore` struct to hosting connection functionality and state.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
