### PR TITLE
refactor: Introduce IpfsCore for improved service structure

### DIFF
--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -33,6 +33,8 @@ use crate::*;
 
 impl Configurator for IpfsConfig {
     type Builder = IpfsBuilder;
+
+    #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
         IpfsBuilder {
             config: self,
@@ -46,6 +48,8 @@ impl Configurator for IpfsConfig {
 #[derive(Default, Clone, Debug)]
 pub struct IpfsBuilder {
     config: IpfsConfig,
+
+    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
     http_client: Option<HttpClient>,
 }
 
@@ -93,6 +97,8 @@ impl IpfsBuilder {
     ///
     /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
     /// during minor updates.
+    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
+    #[allow(deprecated)]
     pub fn http_client(mut self, client: HttpClient) -> Self {
         self.http_client = Some(client);
         self
@@ -125,15 +131,6 @@ impl Builder for IpfsBuilder {
         }?;
         debug!("backend use endpoint {}", &endpoint);
 
-        let client = if let Some(client) = self.http_client {
-            client
-        } else {
-            HttpClient::new().map_err(|err| {
-                err.with_operation("Builder::build")
-                    .with_context("service", Scheme::Ipfs)
-            })?
-        };
-
         let info = AccessorInfo::default();
         info.set_scheme(Scheme::Ipfs)
             .set_root(&root)
@@ -158,7 +155,6 @@ impl Builder for IpfsBuilder {
             info: accessor_info,
             root,
             endpoint,
-            client,
         });
 
         Ok(IpfsBackend { core })

--- a/core/src/services/ipfs/core.rs
+++ b/core/src/services/ipfs/core.rs
@@ -29,7 +29,6 @@ pub struct IpfsCore {
     pub info: Arc<AccessorInfo>,
     pub endpoint: String,
     pub root: String,
-    pub client: HttpClient,
 }
 
 impl Debug for IpfsCore {
@@ -37,7 +36,6 @@ impl Debug for IpfsCore {
         f.debug_struct("IpfsCore")
             .field("endpoint", &self.endpoint)
             .field("root", &self.root)
-            .field("client", &self.client)
             .finish()
     }
 }
@@ -56,7 +54,7 @@ impl IpfsCore {
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
-        self.client.fetch(req).await
+        self.info.http_client().fetch(req).await
     }
 
     pub async fn ipfs_head(&self, path: &str) -> Result<Response<Buffer>> {
@@ -68,7 +66,7 @@ impl IpfsCore {
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
-        self.client.send(req).await
+        self.info.http_client().send(req).await
     }
 
     pub async fn ipfs_list(&self, path: &str) -> Result<Response<Buffer>> {
@@ -86,6 +84,6 @@ impl IpfsCore {
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
-        self.client.send(req).await
+        self.info.http_client().send(req).await
     }
 }

--- a/core/src/services/ipfs/core.rs
+++ b/core/src/services/ipfs/core.rs
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+use http::Request;
+use http::Response;
+
+use crate::raw::*;
+use crate::*;
+
+pub struct IpfsCore {
+    pub info: Arc<AccessorInfo>,
+    pub endpoint: String,
+    pub root: String,
+    pub client: HttpClient,
+}
+
+impl Debug for IpfsCore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IpfsCore")
+            .field("endpoint", &self.endpoint)
+            .field("root", &self.root)
+            .field("client", &self.client)
+            .finish()
+    }
+}
+
+impl IpfsCore {
+    pub async fn ipfs_get(&self, path: &str, range: BytesRange) -> Result<Response<HttpBody>> {
+        let p = build_rooted_abs_path(&self.root, path);
+
+        let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
+
+        let mut req = Request::get(&url);
+
+        if !range.is_full() {
+            req = req.header(http::header::RANGE, range.to_header());
+        }
+
+        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
+
+        self.client.fetch(req).await
+    }
+
+    pub async fn ipfs_head(&self, path: &str) -> Result<Response<Buffer>> {
+        let p = build_rooted_abs_path(&self.root, path);
+
+        let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
+
+        let req = Request::head(&url);
+
+        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
+
+        self.client.send(req).await
+    }
+
+    pub async fn ipfs_list(&self, path: &str) -> Result<Response<Buffer>> {
+        let p = build_rooted_abs_path(&self.root, path);
+
+        let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
+
+        let mut req = Request::get(&url);
+
+        // Use "application/vnd.ipld.raw" to disable IPLD codec deserialization
+        // OpenDAL will parse ipld data directly.
+        //
+        // ref: https://github.com/ipfs/specs/blob/main/http-gateways/PATH_GATEWAY.md
+        req = req.header(http::header::ACCEPT, "application/vnd.ipld.raw");
+
+        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
+
+        self.client.send(req).await
+    }
+}

--- a/core/src/services/ipfs/mod.rs
+++ b/core/src/services/ipfs/mod.rs
@@ -24,6 +24,8 @@ mod ipld;
 mod backend;
 #[cfg(feature = "services-ipfs")]
 pub use backend::IpfsBuilder as Ipfs;
+#[cfg(feature = "services-ipfs")]
+mod core;
 
 mod config;
 pub use config::IpfsConfig;


### PR DESCRIPTION
# Which issue does this PR close?
Part of https://github.com/apache/opendal/issues/5702
Part of #5677 

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- This pull request refactors the `IpfsBackend` by introducing a new `IpfsCore` struct to encapsulate the core functionality and state. The changes aim to improve code organization and maintainability. 
- Use the http_client from AccessorInfo, instead of directly accessing the backend, to migrate the service to a context-based http client.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
