### PR TITLE
chore: update typos version

### DIFF
--- a/.github/workflows/ci_check.yml
+++ b/.github/workflows/ci_check.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check typos
-        uses: crate-ci/typos@v1.28.4
+        uses: crate-ci/typos@v1.31.1
 
   licenses:
     runs-on: ubuntu-latest

--- a/.typos.toml
+++ b/.typos.toml
@@ -27,6 +27,7 @@
 "hsa" = "hsa"
 # Tech words
 "WRONLY" = "WRONLY"
+"typ" = "typ"
 
 [files]
 extend-exclude = [


### PR DESCRIPTION
# Which issue does this PR close?

This patch chore typos-cli version