### PR TITLE
feat(services/s3): Add ListObjectsV1 support for better support old storage services 

### DIFF
--- a/.github/services/s3/aws_s3_with_list_objects_v1/action.yml
+++ b/.github/services/s3/aws_s3_with_list_objects_v1/action.yml
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: aws_s3
+description: "Behavior test for AWS S3. This service is sponsored by @datafuse_labs."
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup
+      uses: 1password/load-secrets-action@v1
+      with:
+        export-env: true
+      env:
+        OPENDAL_S3_ROOT: op://services/s3/root
+        OPENDAL_S3_BUCKET: op://services/s3/bucket
+        OPENDAL_S3_ENDPOINT: op://services/s3/endpoint
+        OPENDAL_S3_ACCESS_KEY_ID: op://services/s3/access_key_id
+        OPENDAL_S3_SECRET_ACCESS_KEY: op://services/s3/secret_access_key
+        OPENDAL_S3_REGION: op://services/s3/region
+
+    - name: Add extra settings
+      shell: bash
+      run: |
+        echo "OPENDAL_S3_DISABLE_LIST_OBJECTS_V2=true" >> $GITHUB_ENV

--- a/.github/services/s3/minio_s3_with_list_objects_v1/action.yml
+++ b/.github/services/s3/minio_s3_with_list_objects_v1/action.yml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: minio_s3_with_versioning
+description: "Behavior test for Minio S3 with bucket versioning enabled"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup MinIO Server
+      shell: bash
+      working-directory: fixtures/s3
+      run: docker compose -f docker-compose-minio.yml up -d --wait
+    - name: Setup test bucket
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: "minioadmin"
+        AWS_SECRET_ACCESS_KEY: "minioadmin"
+        AWS_EC2_METADATA_DISABLED: "true"
+      run: |
+        aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test
+
+    - name: Setup
+      shell: bash
+      run: |
+        cat << EOF >> $GITHUB_ENV
+        OPENDAL_S3_BUCKET=test
+        OPENDAL_S3_ENDPOINT=http://127.0.0.1:9000
+        OPENDAL_S3_ACCESS_KEY_ID=minioadmin
+        OPENDAL_S3_SECRET_ACCESS_KEY=minioadmin
+        OPENDAL_S3_REGION=us-east-1
+        OPENDAL_S3_DISABLE_LIST_OBJECTS_V2=true
+        EOF

--- a/core/src/raw/enum_utils.rs
+++ b/core/src/raw/enum_utils.rs
@@ -163,6 +163,16 @@ impl<ONE: oio::Write, TWO: oio::Write, THREE: oio::Write> oio::Write
     }
 }
 
+impl<ONE: oio::List, TWO: oio::List, THREE: oio::List> oio::List for ThreeWays<ONE, TWO, THREE> {
+    async fn next(&mut self) -> Result<Option<oio::Entry>> {
+        match self {
+            Self::One(v) => v.next().await,
+            Self::Two(v) => v.next().await,
+            Self::Three(v) => v.next().await,
+        }
+    }
+}
+
 /// FourWays is used to implement traits that based on four ways.
 ///
 /// Users can wrap four different trait types together.

--- a/core/src/raw/http_util/mod.rs
+++ b/core/src/raw/http_util/mod.rs
@@ -57,6 +57,7 @@ mod uri;
 pub use uri::new_http_uri_invalid_error;
 pub use uri::percent_decode_path;
 pub use uri::percent_encode_path;
+pub use uri::QueryPairsWriter;
 
 mod error;
 pub use error::new_request_build_error;

--- a/core/src/raw/http_util/uri.rs
+++ b/core/src/raw/http_util/uri.rs
@@ -64,6 +64,55 @@ pub fn percent_decode_path(path: &str) -> String {
     }
 }
 
+/// QueryPairsWriter is used to write query pairs to a url.
+pub struct QueryPairsWriter {
+    base: String,
+    has_query: bool,
+}
+
+impl QueryPairsWriter {
+    /// Create a new QueryPairsWriter with the given base.
+    pub fn new(s: &str) -> Self {
+        // 256 is the average size we observed of a url
+        // in production.
+        //
+        // We eargely allocate the string to avoid multiple
+        // allocations.
+        let mut base = String::with_capacity(256);
+        base.push_str(s);
+
+        Self {
+            base,
+            has_query: false,
+        }
+    }
+
+    /// Push a new pair of key and value to the url.
+    ///
+    /// The input key and value must already been percent
+    /// encoded correcrtly.
+    pub fn push(mut self, key: &str, value: &str) -> Self {
+        if self.has_query {
+            self.base.push('&');
+        } else {
+            self.base.push('?');
+            self.has_query = true;
+        }
+
+        // Append the key and value to the base string
+        self.base.push_str(key);
+        self.base.push('=');
+        self.base.push_str(value);
+
+        self
+    }
+
+    /// Finish the url and return it.
+    pub fn finish(self) -> String {
+        self.base
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -43,7 +43,7 @@ use std::sync::LazyLock;
 use super::core::*;
 use super::delete::S3Deleter;
 use super::error::parse_error;
-use super::lister::{S3Lister, S3Listers, S3ObjectVersionsLister};
+use super::lister::{S3ListerV2, S3Listers, S3ObjectVersionsLister};
 use super::writer::S3Writer;
 use super::writer::S3Writers;
 use crate::raw::oio::PageLister;
@@ -1095,7 +1095,7 @@ impl Access for S3Backend {
                 args,
             )))
         } else {
-            TwoWays::One(PageLister::new(S3Lister::new(
+            TwoWays::One(PageLister::new(S3ListerV2::new(
                 self.core.clone(),
                 path,
                 args,

--- a/core/src/services/s3/config.rs
+++ b/core/src/services/s3/config.rs
@@ -188,6 +188,11 @@ pub struct S3Config {
 
     /// Enable write with append so that opendal will send write request with append headers.
     pub enable_write_with_append: bool,
+
+    /// OpenDAL uses List Objects V2 by default to list objects.
+    /// However, some legacy services do not yet support V2.
+    /// This option allows users to switch back to the older List Objects V1.
+    pub disable_list_objects_v2: bool,
 }
 
 impl Debug for S3Config {

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -676,7 +676,7 @@ impl S3Core {
         self.send(req).await
     }
 
-    pub async fn s3_list_objects(
+    pub async fn s3_list_objects_v2(
         &self,
         path: &str,
         continuation_token: &str,
@@ -1070,7 +1070,7 @@ pub struct DeleteObjectsResultError {
     pub version_id: Option<String>,
 }
 
-/// Output of ListBucket/ListObjects.
+/// Output of ListBucketV2/ListObjectsV2.
 ///
 /// ## Note
 ///
@@ -1081,7 +1081,7 @@ pub struct DeleteObjectsResultError {
 /// is not exist.
 #[derive(Default, Debug, Deserialize)]
 #[serde(default, rename_all = "PascalCase")]
-pub struct ListObjectsOutput {
+pub struct ListObjectsOutputV2 {
     pub is_truncated: Option<bool>,
     pub next_continuation_token: Option<String>,
     pub common_prefixes: Vec<OutputCommonPrefix>,
@@ -1407,7 +1407,8 @@ mod tests {
 </ListBucketResult>"#,
         );
 
-        let out: ListObjectsOutput = quick_xml::de::from_reader(bs.reader()).expect("must success");
+        let out: ListObjectsOutputV2 =
+            quick_xml::de::from_reader(bs.reader()).expect("must success");
 
         assert!(!out.is_truncated.unwrap());
         assert!(out.next_continuation_token.is_none());

--- a/core/src/services/s3/lister.rs
+++ b/core/src/services/s3/lister.rs
@@ -17,8 +17,7 @@
 
 use std::sync::Arc;
 
-use super::core::S3Core;
-use super::core::{ListObjectVersionsOutput, ListObjectsOutputV2};
+use super::core::*;
 use super::error::parse_error;
 use crate::raw::oio::PageContext;
 use crate::raw::*;
@@ -29,7 +28,134 @@ use crate::Result;
 use bytes::Buf;
 use quick_xml::de;
 
-pub type S3Listers = TwoWays<oio::PageLister<S3ListerV2>, oio::PageLister<S3ObjectVersionsLister>>;
+pub type S3Listers = ThreeWays<
+    oio::PageLister<S3ListerV1>,
+    oio::PageLister<S3ListerV2>,
+    oio::PageLister<S3ObjectVersionsLister>,
+>;
+
+/// S3ListerV1 implements ListObjectV1 for s3 backend.
+pub struct S3ListerV1 {
+    core: Arc<S3Core>,
+
+    path: String,
+    args: OpList,
+
+    delimiter: &'static str,
+    /// marker can also be used as `start-after` for list objects v1.
+    /// We will use it as `start-after` for the first page and then ignore
+    /// it in the following pages.
+    first_marker: String,
+}
+
+impl S3ListerV1 {
+    pub fn new(core: Arc<S3Core>, path: &str, args: OpList) -> Self {
+        let delimiter = if args.recursive() { "" } else { "/" };
+        let first_marker = args
+            .start_after()
+            .map(|start_after| build_abs_path(&core.root, start_after))
+            .unwrap_or_default();
+
+        Self {
+            core,
+
+            path: path.to_string(),
+            args,
+            delimiter,
+            first_marker,
+        }
+    }
+}
+
+impl oio::PageList for S3ListerV1 {
+    async fn next_page(&self, ctx: &mut oio::PageContext) -> Result<()> {
+        let resp = self
+            .core
+            .s3_list_objects_v1(
+                &self.path,
+                // `marker` is used as `start-after` for the first page.
+                if !ctx.token.is_empty() {
+                    &ctx.token
+                } else {
+                    &self.first_marker
+                },
+                self.delimiter,
+                self.args.limit(),
+            )
+            .await?;
+
+        if resp.status() != http::StatusCode::OK {
+            return Err(parse_error(resp));
+        }
+        let bs = resp.into_body();
+
+        let output: ListObjectsOutputV1 = de::from_reader(bs.reader())
+            .map_err(new_xml_deserialize_error)
+            // Allow S3 list to retry on XML deserialization errors.
+            //
+            // This is because the S3 list API may return incomplete XML data under high load.
+            // We are confident that our XML decoding logic is correct. When this error occurs,
+            // we allow retries to obtain the correct data.
+            .map_err(Error::set_temporary)?;
+
+        // Try our best to check whether this list is done.
+        //
+        // - Check `is_truncated`
+        // - Check the length of `common_prefixes` and `contents` (very rare case)
+        ctx.done = if let Some(is_truncated) = output.is_truncated {
+            !is_truncated
+        } else {
+            output.common_prefixes.is_empty() && output.contents.is_empty()
+        };
+        // Try out best to find the next marker.
+        //
+        // - Check `next-marker`
+        // - Check the last object key
+        // - Check the last common prefix
+        ctx.token = if let Some(next_marker) = &output.next_marker {
+            next_marker.clone()
+        } else if let Some(content) = output.contents.last() {
+            content.key.clone()
+        } else if let Some(prefix) = output.common_prefixes.last() {
+            prefix.prefix.clone()
+        } else {
+            "".to_string()
+        };
+
+        for prefix in output.common_prefixes {
+            let de = oio::Entry::new(
+                &build_rel_path(&self.core.root, &prefix.prefix),
+                Metadata::new(EntryMode::DIR),
+            );
+
+            ctx.entries.push_back(de);
+        }
+
+        for object in output.contents {
+            let mut path = build_rel_path(&self.core.root, &object.key);
+            if path.is_empty() {
+                path = "/".to_string();
+            }
+
+            let mut meta = Metadata::new(EntryMode::from_path(&path));
+            meta.set_is_current(true);
+            if let Some(etag) = &object.etag {
+                meta.set_etag(etag);
+                meta.set_content_md5(etag.trim_matches('"'));
+            }
+            meta.set_content_length(object.size);
+
+            // object.last_modified provides more precise time that contains
+            // nanosecond, let's trim them.
+            meta.set_last_modified(parse_datetime_from_rfc3339(object.last_modified.as_str())?);
+
+            let de = oio::Entry::with(path, meta);
+            ctx.entries.push_back(de);
+        }
+
+        Ok(())
+    }
+}
 
 /// S3ListerV2 implements ListObjectV2 for s3 backend.
 pub struct S3ListerV2 {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes https://github.com/apache/opendal/issues/5974

# Rationale for this change

As explained in https://github.com/apache/opendal/issues/5974

# What changes are included in this PR?

- Add ListObjectsV1 support
- A new config `disable_list_objects_v2`.
- Related tests.

# Are there any user-facing changes?

A new config `disable_list_objects_v2`.