### PR TITLE
feat(services/ipfs): implement ipfs_stat

### DIFF
--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -189,155 +189,9 @@ impl Access for IpfsBackend {
         self.core.info.clone()
     }
 
-    /// IPFS's stat behavior highly depends on its implementation.
-    ///
-    /// Based on IPFS [Path Gateway Specification](https://github.com/ipfs/specs/blob/main/http-gateways/PATH_GATEWAY.md),
-    /// response payload could be:
-    ///
-    /// > - UnixFS (implicit default)
-    /// >   - File
-    /// >     - Bytes representing file contents
-    /// >   - Directory
-    /// >     - Generated HTML with directory index
-    /// >     - When `index.html` is present, gateway can skip generating directory index and return it instead
-    /// > - Raw block (not this case)
-    /// > - CAR (not this case)
-    ///
-    /// When we HEAD a given path, we could have the following responses:
-    ///
-    /// - File
-    ///
-    /// ```http
-    /// :) curl -I https://ipfs.io/ipfs/QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ/normal_file
-    /// HTTP/1.1 200 Connection established
-    ///
-    /// HTTP/2 200
-    /// server: openresty
-    /// date: Thu, 08 Sep 2022 00:48:50 GMT
-    /// content-type: application/octet-stream
-    /// content-length: 262144
-    /// access-control-allow-methods: GET
-    /// cache-control: public, max-age=29030400, immutable
-    /// etag: "QmdP6teFTLSNVhT4W5jkhEuUBsjQ3xkp1GmRvDU6937Me1"
-    /// x-ipfs-gateway-host: ipfs-bank11-fr2
-    /// x-ipfs-path: /ipfs/QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ/normal_file
-    /// x-ipfs-roots: QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ,QmdP6teFTLSNVhT4W5jkhEuUBsjQ3xkp1GmRvDU6937Me1
-    /// x-ipfs-pop: ipfs-bank11-fr2
-    /// timing-allow-origin: *
-    /// x-ipfs-datasize: 262144
-    /// access-control-allow-origin: *
-    /// access-control-allow-methods: GET, POST, OPTIONS
-    /// access-control-allow-headers: X-Requested-With, Range, Content-Range, X-Chunked-Output, X-Stream-Output
-    /// access-control-expose-headers: Content-Range, X-Chunked-Output, X-Stream-Output
-    /// x-ipfs-lb-pop: gateway-bank1-fr2
-    /// strict-transport-security: max-age=31536000; includeSubDomains; preload
-    /// x-proxy-cache: MISS
-    /// accept-ranges: bytes
-    /// ```
-    ///
-    /// - Dir with generated index
-    ///
-    /// ```http
-    /// :( curl -I https://ipfs.io/ipfs/QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ/normal_dir
-    /// HTTP/1.1 200 Connection established
-    ///
-    /// HTTP/2 200
-    /// server: openresty
-    /// date: Wed, 07 Sep 2022 08:46:13 GMT
-    /// content-type: text/html
-    /// vary: Accept-Encoding
-    /// access-control-allow-methods: GET
-    /// etag: "DirIndex-2b567f6r5vvdg_CID-QmY44DyCDymRN1Qy7sGbupz1ysMkXTWomAQku5vBg7fRQW"
-    /// x-ipfs-gateway-host: ipfs-bank6-sg1
-    /// x-ipfs-path: /ipfs/QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ/normal_dir
-    /// x-ipfs-roots: QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ,QmY44DyCDymRN1Qy7sGbupz1ysMkXTWomAQku5vBg7fRQW
-    /// x-ipfs-pop: ipfs-bank6-sg1
-    /// timing-allow-origin: *
-    /// access-control-allow-origin: *
-    /// access-control-allow-methods: GET, POST, OPTIONS
-    /// access-control-allow-headers: X-Requested-With, Range, Content-Range, X-Chunked-Output, X-Stream-Output
-    /// access-control-expose-headers: Content-Range, X-Chunked-Output, X-Stream-Output
-    /// x-ipfs-lb-pop: gateway-bank3-sg1
-    /// strict-transport-security: max-age=31536000; includeSubDomains; preload
-    /// x-proxy-cache: MISS
-    /// ```
-    ///
-    /// - Dir with index.html
-    ///
-    /// ```http
-    /// :) curl -I http://127.0.0.1:8080/ipfs/QmVturFGV3z4WsP7cRV8Ci4avCdGWYXk2qBKvtAwFUp5Az
-    /// HTTP/1.1 302 Found
-    /// Access-Control-Allow-Headers: Content-Type
-    /// Access-Control-Allow-Headers: Range
-    /// Access-Control-Allow-Headers: User-Agent
-    /// Access-Control-Allow-Headers: X-Requested-With
-    /// Access-Control-Allow-Methods: GET
-    /// Access-Control-Allow-Origin: *
-    /// Access-Control-Expose-Headers: Content-Length
-    /// Access-Control-Expose-Headers: Content-Range
-    /// Access-Control-Expose-Headers: X-Chunked-Output
-    /// Access-Control-Expose-Headers: X-Ipfs-Path
-    /// Access-Control-Expose-Headers: X-Ipfs-Roots
-    /// Access-Control-Expose-Headers: X-Stream-Output
-    /// Content-Type: text/html; charset=utf-8
-    /// Location: /ipfs/QmVturFGV3z4WsP7cRV8Ci4avCdGWYXk2qBKvtAwFUp5Az/
-    /// X-Ipfs-Path: /ipfs/QmVturFGV3z4WsP7cRV8Ci4avCdGWYXk2qBKvtAwFUp5Az
-    /// X-Ipfs-Roots: QmVturFGV3z4WsP7cRV8Ci4avCdGWYXk2qBKvtAwFUp5Az
-    /// Date: Thu, 08 Sep 2022 00:52:29 GMT
-    /// ```
-    ///
-    /// In conclusion:
-    ///
-    /// - HTTP Status Code == 302 => directory
-    /// - HTTP Status Code == 200 && ETag starts with `"DirIndex` => directory
-    /// - HTTP Status Code == 200 && ETag not starts with `"DirIndex` => file
     async fn stat(&self, path: &str, _: OpStat) -> Result<RpStat> {
-        // Stat root always returns a DIR.
-        if path == "/" {
-            return Ok(RpStat::new(Metadata::new(EntryMode::DIR)));
-        }
-
-        let resp = self.core.ipfs_head(path).await?;
-
-        let status = resp.status();
-
-        match status {
-            StatusCode::OK => {
-                let mut m = Metadata::new(EntryMode::Unknown);
-
-                if let Some(v) = parse_content_length(resp.headers())? {
-                    m.set_content_length(v);
-                }
-
-                if let Some(v) = parse_content_type(resp.headers())? {
-                    m.set_content_type(v);
-                }
-
-                if let Some(v) = parse_etag(resp.headers())? {
-                    m.set_etag(v);
-
-                    if v.starts_with("\"DirIndex") {
-                        m.set_mode(EntryMode::DIR);
-                    } else {
-                        m.set_mode(EntryMode::FILE);
-                    }
-                } else {
-                    // Some service will stream the output of DirIndex.
-                    // If we don't have an etag, it's highly to be a dir.
-                    m.set_mode(EntryMode::DIR);
-                }
-
-                if let Some(v) = parse_content_disposition(resp.headers())? {
-                    m.set_content_disposition(v);
-                }
-
-                Ok(RpStat::new(m))
-            }
-            StatusCode::FOUND | StatusCode::MOVED_PERMANENTLY => {
-                Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
-            }
-            _ => Err(parse_error(resp)),
-        }
+        let metadata = self.core.ipfs_stat(path).await?;
+        Ok(RpStat::new(metadata))
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
@@ -358,20 +212,20 @@ impl Access for IpfsBackend {
     }
 
     async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let l = DirStream::new(Arc::new(self.clone()), path);
+        let l = DirStream::new(self.core.clone(), path);
         Ok((RpList::default(), oio::PageLister::new(l)))
     }
 }
 
 pub struct DirStream {
-    backend: Arc<IpfsBackend>,
+    core: Arc<IpfsCore>,
     path: String,
 }
 
 impl DirStream {
-    fn new(backend: Arc<IpfsBackend>, path: &str) -> Self {
+    fn new(core: Arc<IpfsCore>, path: &str) -> Self {
         Self {
-            backend,
+            core,
             path: path.to_string(),
         }
     }
@@ -379,7 +233,7 @@ impl DirStream {
 
 impl oio::PageList for DirStream {
     async fn next_page(&self, ctx: &mut oio::PageContext) -> Result<()> {
-        let resp = self.backend.core.ipfs_list(&self.path).await?;
+        let resp = self.core.ipfs_list(&self.path).await?;
 
         if resp.status() != StatusCode::OK {
             return Err(parse_error(resp));
@@ -397,11 +251,7 @@ impl oio::PageList for DirStream {
             .collect::<Vec<String>>();
 
         for mut name in names {
-            let meta = self
-                .backend
-                .stat(&name, OpStat::new())
-                .await?
-                .into_metadata();
+            let meta = self.core.ipfs_stat(&name).await?;
 
             if meta.mode().is_dir() {
                 name += "/";

--- a/core/src/services/ipfs/core.rs
+++ b/core/src/services/ipfs/core.rs
@@ -21,7 +21,9 @@ use std::sync::Arc;
 
 use http::Request;
 use http::Response;
+use http::StatusCode;
 
+use super::error::parse_error;
 use crate::raw::*;
 use crate::*;
 
@@ -85,5 +87,153 @@ impl IpfsCore {
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
         self.info.http_client().send(req).await
+    }
+
+    /// IPFS's stat behavior highly depends on its implementation.
+    ///
+    /// Based on IPFS [Path Gateway Specification](https://github.com/ipfs/specs/blob/main/http-gateways/PATH_GATEWAY.md),
+    /// response payload could be:
+    ///
+    /// > - UnixFS (implicit default)
+    /// >   - File
+    /// >     - Bytes representing file contents
+    /// >   - Directory
+    /// >     - Generated HTML with directory index
+    /// >     - When `index.html` is present, gateway can skip generating directory index and return it instead
+    /// > - Raw block (not this case)
+    /// > - CAR (not this case)
+    ///
+    /// When we HEAD a given path, we could have the following responses:
+    ///
+    /// - File
+    ///
+    /// ```http
+    /// :) curl -I https://ipfs.io/ipfs/QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ/normal_file
+    /// HTTP/1.1 200 Connection established
+    ///
+    /// HTTP/2 200
+    /// server: openresty
+    /// date: Thu, 08 Sep 2022 00:48:50 GMT
+    /// content-type: application/octet-stream
+    /// content-length: 262144
+    /// access-control-allow-methods: GET
+    /// cache-control: public, max-age=29030400, immutable
+    /// etag: "QmdP6teFTLSNVhT4W5jkhEuUBsjQ3xkp1GmRvDU6937Me1"
+    /// x-ipfs-gateway-host: ipfs-bank11-fr2
+    /// x-ipfs-path: /ipfs/QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ/normal_file
+    /// x-ipfs-roots: QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ,QmdP6teFTLSNVhT4W5jkhEuUBsjQ3xkp1GmRvDU6937Me1
+    /// x-ipfs-pop: ipfs-bank11-fr2
+    /// timing-allow-origin: *
+    /// x-ipfs-datasize: 262144
+    /// access-control-allow-origin: *
+    /// access-control-allow-methods: GET, POST, OPTIONS
+    /// access-control-allow-headers: X-Requested-With, Range, Content-Range, X-Chunked-Output, X-Stream-Output
+    /// access-control-expose-headers: Content-Range, X-Chunked-Output, X-Stream-Output
+    /// x-ipfs-lb-pop: gateway-bank1-fr2
+    /// strict-transport-security: max-age=31536000; includeSubDomains; preload
+    /// x-proxy-cache: MISS
+    /// accept-ranges: bytes
+    /// ```
+    ///
+    /// - Dir with generated index
+    ///
+    /// ```http
+    /// :( curl -I https://ipfs.io/ipfs/QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ/normal_dir
+    /// HTTP/1.1 200 Connection established
+    ///
+    /// HTTP/2 200
+    /// server: openresty
+    /// date: Wed, 07 Sep 2022 08:46:13 GMT
+    /// content-type: text/html
+    /// vary: Accept-Encoding
+    /// access-control-allow-methods: GET
+    /// etag: "DirIndex-2b567f6r5vvdg_CID-QmY44DyCDymRN1Qy7sGbupz1ysMkXTWomAQku5vBg7fRQW"
+    /// x-ipfs-gateway-host: ipfs-bank6-sg1
+    /// x-ipfs-path: /ipfs/QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ/normal_dir
+    /// x-ipfs-roots: QmPpCt1aYGb9JWJRmXRUnmJtVgeFFTJGzWFYEEX7bo9zGJ,QmY44DyCDymRN1Qy7sGbupz1ysMkXTWomAQku5vBg7fRQW
+    /// x-ipfs-pop: ipfs-bank6-sg1
+    /// timing-allow-origin: *
+    /// access-control-allow-origin: *
+    /// access-control-allow-methods: GET, POST, OPTIONS
+    /// access-control-allow-headers: X-Requested-With, Range, Content-Range, X-Chunked-Output, X-Stream-Output
+    /// access-control-expose-headers: Content-Range, X-Chunked-Output, X-Stream-Output
+    /// x-ipfs-lb-pop: gateway-bank3-sg1
+    /// strict-transport-security: max-age=31536000; includeSubDomains; preload
+    /// x-proxy-cache: MISS
+    /// ```
+    ///
+    /// - Dir with index.html
+    ///
+    /// ```http
+    /// :) curl -I http://127.0.0.1:8080/ipfs/QmVturFGV3z4WsP7cRV8Ci4avCdGWYXk2qBKvtAwFUp5Az
+    /// HTTP/1.1 302 Found
+    /// Access-Control-Allow-Headers: Content-Type
+    /// Access-Control-Allow-Headers: Range
+    /// Access-Control-Allow-Headers: User-Agent
+    /// Access-Control-Allow-Headers: X-Requested-With
+    /// Access-Control-Allow-Methods: GET
+    /// Access-Control-Allow-Origin: *
+    /// Access-Control-Expose-Headers: Content-Length
+    /// Access-Control-Expose-Headers: Content-Range
+    /// Access-Control-Expose-Headers: X-Chunked-Output
+    /// Access-Control-Expose-Headers: X-Ipfs-Path
+    /// Access-Control-Expose-Headers: X-Ipfs-Roots
+    /// Access-Control-Expose-Headers: X-Stream-Output
+    /// Content-Type: text/html; charset=utf-8
+    /// Location: /ipfs/QmVturFGV3z4WsP7cRV8Ci4avCdGWYXk2qBKvtAwFUp5Az/
+    /// X-Ipfs-Path: /ipfs/QmVturFGV3z4WsP7cRV8Ci4avCdGWYXk2qBKvtAwFUp5Az
+    /// X-Ipfs-Roots: QmVturFGV3z4WsP7cRV8Ci4avCdGWYXk2qBKvtAwFUp5Az
+    /// Date: Thu, 08 Sep 2022 00:52:29 GMT
+    /// ```
+    ///
+    /// In conclusion:
+    ///
+    /// - HTTP Status Code == 302 => directory
+    /// - HTTP Status Code == 200 && ETag starts with `"DirIndex` => directory
+    /// - HTTP Status Code == 200 && ETag not starts with `"DirIndex` => file
+    pub async fn ipfs_stat(&self, path: &str) -> Result<Metadata> {
+        // Stat root always returns a DIR.
+        if path == "/" {
+            return Ok(Metadata::new(EntryMode::DIR));
+        }
+
+        let resp = self.ipfs_head(path).await?;
+        let status = resp.status();
+
+        match status {
+            StatusCode::OK => {
+                let mut m = Metadata::new(EntryMode::Unknown);
+
+                if let Some(v) = parse_content_length(resp.headers())? {
+                    m.set_content_length(v);
+                }
+
+                if let Some(v) = parse_content_type(resp.headers())? {
+                    m.set_content_type(v);
+                }
+
+                if let Some(v) = parse_etag(resp.headers())? {
+                    m.set_etag(v);
+
+                    if v.starts_with("\"DirIndex") {
+                        m.set_mode(EntryMode::DIR);
+                    } else {
+                        m.set_mode(EntryMode::FILE);
+                    }
+                } else {
+                    // Some service will stream the output of DirIndex.
+                    // If we don't have an etag, it's highly to be a dir.
+                    m.set_mode(EntryMode::DIR);
+                }
+
+                if let Some(v) = parse_content_disposition(resp.headers())? {
+                    m.set_content_disposition(v);
+                }
+
+                Ok(m)
+            }
+            StatusCode::FOUND | StatusCode::MOVED_PERMANENTLY => Ok(Metadata::new(EntryMode::DIR)),
+            _ => Err(parse_error(resp)),
+        }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Rationale for this change

> Could we take it a step further and build a function like `pub async fn IpfsCore::ipfs_stat(name: &str) -> Result<Metadata>`? This would allow you to retrieve metadata for each name directly via the core for `DirStream`.

_Originally posted by @erickguan in https://github.com/apache/opendal/pull/5950#discussion_r2029422349_

This pull request refactors the IPFS backend implementation to simplify the code and improve maintainability. 

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
The main changes involve moving the `stat` logic from `IpfsBackend` to `IpfsCore`, updating the `DirStream` structure
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# Behavior test log
<details>
<summary>cargo test behavior --features tests,services-ipfs -- --show-output</summary>

```
running 23 tests
test behavior::test_read_only_read_full                    ... ok
test behavior::test_read_only_read_full_with_special_chars ... ok
test behavior::test_read_only_read_with_dir_path           ... ok
test behavior::test_read_only_read_with_if_match           ... ok
test behavior::test_read_only_read_with_if_none_match      ... ok
test behavior::test_reader_only_read_with_if_match         ... ok
test behavior::test_reader_only_read_with_if_none_match    ... ok
test behavior::test_read_only_read_with_range              ... ok
test behavior::test_read_only_read_not_exist               ... ok
test behavior::test_read_only_stat_not_cleaned_path        ... ok
test behavior::test_read_only_stat_file_and_dir            ... ok
test behavior::test_read_only_stat_with_if_match           ... ok
test behavior::test_read_only_stat_with_if_none_match      ... ok
test behavior::test_read_only_stat_root                    ... ok
test behavior::test_read_only_stat_special_chars           ... ok
test behavior::test_read_only_stat_not_exist               ... ok
test behavior::test_blocking_read_only_stat_not_exist      ... ok
test behavior::test_blocking_read_only_stat_special_chars  ... ok
test behavior::test_blocking_read_only_stat_file_and_dir   ... ok
test behavior::test_blocking_read_only_read_not_exist      ... ok
test behavior::test_blocking_read_only_read_with_range     ... ok
test behavior::test_blocking_read_only_read_full           ... ok
test behavior::test_list_only                              ... ok

test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.50s
```

</details>
