### PR TITLE
feat(bindings/go): support for offset-based read operation.

### DIFF
--- a/bindings/c/README.md
+++ b/bindings/c/README.md
@@ -84,6 +84,23 @@ sudo apt-get install cmake
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
+For Fedora:
+
+```shell
+# install C/C++ toolchain
+sudo dnf groupinstall "Development Tools" "Development Libraries"
+sudo dnf install gcc-c++
+
+# install clang-format
+sudo dnf install clang-tools-extra
+
+# install and build GTest library
+sudo dnf install gtest-devel
+
+# install CMake 
+sudo dnf install cmake
+```
+
 ## Makefile
 
 - To **build the library and header file**.

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -866,13 +866,13 @@ struct opendal_result_read opendal_operator_read(const struct opendal_operator *
 /**
  * \brief Blocking read a range of data from `path`.
  *
- * Read a range of data from `path` blocking by operator. The range starts from `offset`
- * with size of `size`.
+ * Read a range of data from `path` blocking by operator. The range starts from `start`
+ * to `end`.
  *
  * @param op The opendal_operator created previously
  * @param path The path you want to read the data out
- * @param offset The start position of the range to read
- * @param size The size of the range to read
+ * @param start The start position of the range to read. 0 means the start of the file.
+ * @param end The end position of the range to read. 0 means the end of the file.
  * @see opendal_operator
  * @see opendal_result_read
  * @see opendal_error
@@ -889,7 +889,7 @@ struct opendal_result_read opendal_operator_read(const struct opendal_operator *
  * ```C
  * // ... you have write "Hello, World!" to path "/testpath"
  *
- * // Read 5 bytes starting from offset 0
+ * // Read bytes starting from 0 to 5
  * opendal_result_read r = opendal_operator_read_range(op, "/testpath", 0, 5);
  * assert(r.error == NULL);
  *
@@ -910,8 +910,8 @@ struct opendal_result_read opendal_operator_read(const struct opendal_operator *
  */
 struct opendal_result_read opendal_operator_read_range(const struct opendal_operator *op,
                                                        const char *path,
-                                                       uint64_t offset,
-                                                       uint64_t size);
+                                                       uint64_t start,
+                                                       uint64_t end);
 
 /**
  * \brief Blocking read the data from `path`.

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -864,6 +864,56 @@ struct opendal_result_read opendal_operator_read(const struct opendal_operator *
                                                  const char *path);
 
 /**
+ * \brief Blocking read a range of data from `path`.
+ *
+ * Read a range of data from `path` blocking by operator. The range starts from `offset`
+ * with size of `size`.
+ *
+ * @param op The opendal_operator created previously
+ * @param path The path you want to read the data out
+ * @param offset The start position of the range to read
+ * @param size The size of the range to read
+ * @see opendal_operator
+ * @see opendal_result_read
+ * @see opendal_error
+ * @return Returns opendal_result_read, the `data` field is a pointer to a newly allocated
+ * opendal_bytes containing the range of data, the `error` field contains the error. If the
+ * `error` is not NULL, then the operation failed and the `data` field contains empty bytes.
+ *
+ * \note If the read operation succeeds, the returned opendal_bytes is newly allocated on heap.
+ * After your usage of that, please call opendal_bytes_free() to free the space.
+ *
+ * # Example
+ *
+ * Following is an example
+ * ```C
+ * // ... you have write "Hello, World!" to path "/testpath"
+ *
+ * // Read 5 bytes starting from offset 0
+ * opendal_result_read r = opendal_operator_read_range(op, "/testpath", 0, 5);
+ * assert(r.error == NULL);
+ *
+ * opendal_bytes bytes = r.data;
+ * assert(bytes.len == 5);
+ * opendal_bytes_free(&bytes);
+ * ```
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_result_read opendal_operator_read_range(const struct opendal_operator *op,
+                                                       const char *path,
+                                                       uint64_t offset,
+                                                       uint64_t size);
+
+/**
  * \brief Blocking read the data from `path`.
  *
  * Read the data out from `path` blocking by operator, returns

--- a/bindings/c/src/operator.rs
+++ b/bindings/c/src/operator.rs
@@ -295,6 +295,77 @@ pub unsafe extern "C" fn opendal_operator_read(
     }
 }
 
+/// \brief Blocking read a range of data from `path`.
+///
+/// Read a range of data from `path` blocking by operator. The range starts from `offset` 
+/// with size of `size`.
+///
+/// @param op The opendal_operator created previously
+/// @param path The path you want to read the data out
+/// @param offset The start position of the range to read
+/// @param size The size of the range to read
+/// @see opendal_operator
+/// @see opendal_result_read
+/// @see opendal_error
+/// @return Returns opendal_result_read, the `data` field is a pointer to a newly allocated
+/// opendal_bytes containing the range of data, the `error` field contains the error. If the
+/// `error` is not NULL, then the operation failed and the `data` field contains empty bytes.
+///
+/// \note If the read operation succeeds, the returned opendal_bytes is newly allocated on heap.
+/// After your usage of that, please call opendal_bytes_free() to free the space.
+///
+/// # Example
+///
+/// Following is an example
+/// ```C
+/// // ... you have write "Hello, World!" to path "/testpath"
+///
+/// // Read 5 bytes starting from offset 0
+/// opendal_result_read r = opendal_operator_read_range(op, "/testpath", 0, 5);
+/// assert(r.error == NULL);
+///
+/// opendal_bytes bytes = r.data;
+/// assert(bytes.len == 5);
+/// opendal_bytes_free(&bytes);
+/// ```
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_read_range(
+    op: &opendal_operator,
+    path: *const c_char,
+    offset: u64,
+    size: u64,
+) -> opendal_result_read {
+    assert!(!path.is_null());
+    let path = std::ffi::CStr::from_ptr(path)
+        .to_str()
+        .expect("malformed path");
+    match op
+        .deref()
+        .read_with(path)
+        .range(offset..offset + size)
+        .call()
+    {
+        Ok(b) => opendal_result_read {
+            data: opendal_bytes::new(b),
+            error: std::ptr::null_mut(),
+        },
+        Err(e) => opendal_result_read {
+            data: opendal_bytes::empty(),
+            error: opendal_error::new(e),
+        },
+    }
+}
+
 /// \brief Blocking read the data from `path`.
 ///
 /// Read the data out from `path` blocking by operator, returns

--- a/bindings/c/src/operator.rs
+++ b/bindings/c/src/operator.rs
@@ -297,13 +297,13 @@ pub unsafe extern "C" fn opendal_operator_read(
 
 /// \brief Blocking read a range of data from `path`.
 ///
-/// Read a range of data from `path` blocking by operator. The range starts from `offset` 
-/// with size of `size`.
+/// Read a range of data from `path` blocking by operator. The range starts from `start`
+/// to `end`.
 ///
 /// @param op The opendal_operator created previously
 /// @param path The path you want to read the data out
-/// @param offset The start position of the range to read
-/// @param size The size of the range to read
+/// @param start The start position of the range to read. 0 means the start of the file.
+/// @param end The end position of the range to read. 0 means the end of the file.
 /// @see opendal_operator
 /// @see opendal_result_read
 /// @see opendal_error
@@ -320,7 +320,7 @@ pub unsafe extern "C" fn opendal_operator_read(
 /// ```C
 /// // ... you have write "Hello, World!" to path "/testpath"
 ///
-/// // Read 5 bytes starting from offset 0
+/// // Read bytes starting from 0 to 5
 /// opendal_result_read r = opendal_operator_read_range(op, "/testpath", 0, 5);
 /// assert(r.error == NULL);
 ///
@@ -342,19 +342,14 @@ pub unsafe extern "C" fn opendal_operator_read(
 pub unsafe extern "C" fn opendal_operator_read_range(
     op: &opendal_operator,
     path: *const c_char,
-    offset: u64,
-    size: u64,
+    start: u64,
+    end: u64,
 ) -> opendal_result_read {
     assert!(!path.is_null());
     let path = std::ffi::CStr::from_ptr(path)
         .to_str()
         .expect("malformed path");
-    match op
-        .deref()
-        .read_with(path)
-        .range(offset..offset + size)
-        .call()
-    {
+    match op.deref().read_with(path).range(start..end).call() {
         Ok(b) => opendal_result_read {
             data: opendal_bytes::new(b),
             error: std::ptr::null_mut(),

--- a/bindings/c/tests/bdd.cpp
+++ b/bindings/c/tests/bdd.cpp
@@ -132,6 +132,7 @@ TEST_F(OpendalBddTest, FeatureTest)
     EXPECT_EQ(error, nullptr);
 
     opendal_bytes_free(&r.data);
+    opendal_bytes_free(&r2.data);
 
     // The directory "tmpdir/" should exist and should be a directory
     error = opendal_operator_create_dir(this->p, "tmpdir/");

--- a/bindings/c/tests/bdd.cpp
+++ b/bindings/c/tests/bdd.cpp
@@ -93,6 +93,14 @@ TEST_F(OpendalBddTest, FeatureTest)
         EXPECT_EQ(this->content[i], (char)(r.data.data[i]));
     }
 
+    // The blocking file "test" must have content "Hello"
+    struct opendal_result_read r2 = opendal_operator_read_range(this->p, this->path.c_str(), 0, 5);
+    EXPECT_EQ(r2.error, nullptr);
+    EXPECT_EQ(r2.data.len, 5);
+    for (int i = 0; i < r2.data.len; i++) {
+        EXPECT_EQ(this->content[i], (char)(r2.data.data[i]));
+    }
+
     // The blocking file should be deleted
     error = opendal_operator_delete(this->p, this->path.c_str());
     EXPECT_EQ(error, nullptr);

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -256,7 +256,7 @@ export SERVICE="\$OPENDAL_TEST"
 # Get architecture
 architecture=\$(uname -m)
 if [ "\$architecture" = "x86_64" ]; then
-    ARCH="x86_64"
+    ARCH="amd64"
     GOARCH="amd64"
 elif [ "\$architecture" = "aarch64" ] || [ "\$architecture" = "arm64" ]; then
     ARCH="arm64"
@@ -274,14 +274,17 @@ cd -
 export GITHUB_WORKSPACE="\$PWD/opendal-go-services"
 export VERSION="latest"
 export TARGET="linux"
-export DIR="\$GITHUB_WORKSPACE/libopendal_c_\$VERSION_\$SERVICE_\$TARGET"
+export DIR="\$GITHUB_WORKSPACE/libopendal_c_\${VERSION}_\${SERVICE}_\${TARGET}"
 
 # Create directory if not exists
 mkdir -p "\$DIR"
 
-export OUTPUT="\$DIR/libopendal_c_\$VERSION_\$SERVICE_\$TARGET.so"
+export OUTPUT="\$DIR/libopendal_c.\$TARGET.so.zst"
 # Compress with zstd
 zstd -19 opendal/bindings/c/target/debug/libopendal_c.so -o \$OUTPUT
+
+# Set environment variables for test
+export MATRIX='{"build": [{"target":"linux", "goos":"linux", "goarch": "'\$GOARCH'"}], "service": ["fs"]}'
 
 # Generate code
 cd opendal-go-services/internal/generate
@@ -290,9 +293,6 @@ cd -
 
 # Delete unnecessary files
 rm -rf \$DIR
-
-# Set environment variables for test
-export MATRIX='{"build": [{"target":"linux", "goos":"linux", "goarch": "'\$GOARCH'"}], "service": ["fs"]}'
 
 # Run tests
 go test ./opendal/bindings/go/tests/behavior_tests -v -run TestBehavior

--- a/bindings/go/ffi.go
+++ b/bindings/go/ffi.go
@@ -116,6 +116,7 @@ var withFFIs = []contextWithFFI{
 
 	withOperatorCreateDir,
 	withOperatorRead,
+	withOperatorReadRange,
 	withOperatorWrite,
 	withOperatorDelete,
 	withOperatorStat,

--- a/bindings/go/range.go
+++ b/bindings/go/range.go
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package opendal
+
+type BoundType int
+
+const (
+	Included BoundType = iota
+	Excluded
+	Unbounded
+)
+
+type Bound struct {
+	Type  BoundType
+	Value uint64
+}
+
+func (b Bound) GetValue() uint64 {
+	switch b.Type {
+	case Included, Excluded:
+		return b.Value
+	default:
+		return 0
+	}
+}
+
+type Range struct {
+	start Bound
+	end   Bound
+}
+
+func (r Range) Start() uint64 {
+	return r.start.GetValue()
+}
+
+func (r Range) End() uint64 {
+	return r.end.GetValue()
+}
+
+func rangeFrom(value uint64) *Range {
+	return &Range{
+		start: Bound{Type: Included, Value: value},
+		end:   Bound{Type: Unbounded},
+	}
+}
+
+func rangeUntil(value uint64) *Range {
+	return &Range{
+		start: Bound{Type: Unbounded},
+		end:   Bound{Type: Excluded, Value: value},
+	}
+}
+
+func rangeBetween(start, end uint64) *Range {
+	return &Range{
+		start: Bound{Type: Included, Value: start},
+		end:   Bound{Type: Excluded, Value: end},
+	}
+}

--- a/bindings/go/tests/behavior_tests/opendal_test.go
+++ b/bindings/go/tests/behavior_tests/opendal_test.go
@@ -163,6 +163,15 @@ func genFixedBytes(size uint) []byte {
 	return content
 }
 
+func genOffsetLength(size uint) (uint64, uint64) {
+	n, _ := rand.Int(rand.Reader, big.NewInt(int64(size-1)))
+	offset := uint64(n.Int64())
+	n, _ = rand.Int(rand.Reader, big.NewInt(int64(uint64(size)-offset)))
+	length := uint64(n.Int64()) + 1
+
+	return offset, length
+}
+
 type fixture struct {
 	op   *opendal.Operator
 	lock *sync.Mutex

--- a/bindings/go/tests/behavior_tests/read_test.go
+++ b/bindings/go/tests/behavior_tests/read_test.go
@@ -31,6 +31,7 @@ func testsRead(cap *opendal.Capability) []behaviorTest {
 	}
 	return []behaviorTest{
 		testReadFull,
+		testReadRange,
 		testReader,
 		testReadNotExist,
 		testReadWithDirPath,
@@ -47,6 +48,18 @@ func testReadFull(assert *require.Assertions, op *opendal.Operator, fixture *fix
 	assert.Nil(err)
 	assert.Equal(size, uint(len(bs)), "read size")
 	assert.Equal(content, bs, "read content")
+}
+
+func testReadRange(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, size := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+	offset, length := genOffsetLength(size)
+
+	bs, err := op.Read(path, opendal.ReadBetween(offset, offset+length))
+	assert.Nil(err)
+	assert.Equal(length, uint64(len(bs)), "read size")
+	assert.Equal(content[offset:offset+length], bs, "read content")
 }
 
 func testReader(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {


### PR DESCRIPTION
Part of #4892.

This PR aims to support the offset-based read operation requested in #5326.

I'm unsure if this is an appropriate method signature (`func (op *Operator) Read(path string, opts ...withReadOption) ([]byte, error)`). **Please actively share your thoughts**.

```go
func testReadRange(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
	path, content, size := fixture.NewFile()

	assert.Nil(op.Write(path, content), "write must succeed")
	offset, length := genOffsetLength(size)

	bs, err := op.Read(path, opendal.ReadBetween(offset, offset+length))
	assert.Nil(err)
	assert.Equal(length, uint64(len(bs)), "read size")
	assert.Equal(content[offset:offset+length], bs, "read content")
}
```