### PR TITLE
feat(services/hdfs): refactor HdfsBackend to use HdfsCore for client operations

### DIFF
--- a/core/src/services/hdfs/core.rs
+++ b/core/src/services/hdfs/core.rs
@@ -15,22 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#[cfg(feature = "services-hdfs")]
-mod delete;
-#[cfg(feature = "services-hdfs")]
-mod lister;
-#[cfg(feature = "services-hdfs")]
-mod reader;
-#[cfg(feature = "services-hdfs")]
-mod writer;
+use std::{io::Result, sync::Arc};
 
-#[cfg(feature = "services-hdfs")]
-mod backend;
-#[cfg(feature = "services-hdfs")]
-pub use backend::HdfsBuilder as Hdfs;
+use hdrs::Metadata;
 
-#[cfg(feature = "services-hdfs")]
-mod core;
+use crate::raw::AccessorInfo;
 
-mod config;
-pub use config::HdfsConfig;
+#[derive(Clone, Debug)]
+pub struct HdfsCore {
+    pub info: Arc<AccessorInfo>,
+    pub client: Arc<hdrs::Client>,
+}
+
+impl HdfsCore {
+    pub fn get_metadata(&self, path: &str) -> Result<Metadata> {
+        let metadata = self.client.metadata(path)?;
+
+        Ok(metadata)
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Addresses #5702: Split service logic to  `backend` and `core` modules

Part of #5702.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
This pull request refactors the `GridFsBackend` by introducing a new `GridFsBackendCore` struct to hosting connection functionality and state. `GridFsCore` implements the `kv::Adapters` trait, allowing the removal of the `Adapter` struct

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
