### PR TITLE
ci: GHAC v1 has been shutdown entirely

### DIFF
--- a/.github/workflows/service_test_ghac.yml
+++ b/.github/workflows/service_test_ghac.yml
@@ -37,34 +37,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ghac_v1:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork
-    permissions:
-      actions: write
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Rust toolchain
-        uses: ./.github/actions/setup
-        with:
-          need-nextest: true
-
-      - name: Configure Cache Env
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-            core.exportVariable('ACTIONS_CACHE_SERVICE_V2', '');
-
-      - name: Test
-        shell: bash
-        working-directory: core
-        run: cargo test behavior --features tests,services-ghac
-        env:
-          OPENDAL_TEST: ghac
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   ghac_v2:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || !github.event.pull_request.head.repo.fork


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None.

# Rationale for this change

GHAC v1 has been shutdown entirely.

```
error: test failed, to rerun pass `--test behavior`
test panicked: write must succeed: Unexpected (persistent) at write => {"$id":"1","innerException":null,"message":"This legacy service is shutting down, effective April 15, 2025. Migrate to the new service ASAP. For more information: https://gh.io/gha-cache-sunset","typeName":"Microsoft.Azure.DevOps.ArtifactCache.WebApi.ArtifactCacheServiceDecommissionedException, Microsoft.Azure.DevOps.ArtifactCache.WebApi","typeKey":"ArtifactCacheServiceDecommissionedException","errorCode":0,"eventId":3000}

Context:
   uri: https://acghubeus2.actions.githubusercontent.com/5JidZSUIbXpO2kk5tNBS56uxOnK9OaX8tLwVV8MTgXiDZI5Q5G/_apis/artifactcache/caches
   response: Parts { status: 422, version: HTTP/1.1, headers: {"content-length": "426", "content-type": "application/json; charset=utf-8", "date": "Wed, 16 Apr 2025 02:53:57 GMT", "server": "Kestrel", "cache-control": "no-store,no-cache", "pragma": "no-cache", "strict-transport-security": "max-age=2592000", "x-tfs-processid": "92826509-6045-40df-b02b-bcf993e4364c", "activityid": "fe943d43-c920-4195-95d8-7f053d1450da", "x-tfs-session": "fe943d43-c920-4195-95d8-7f053d1450da", "x-vss-e2eid": "fe943d43-c920-4195-95d8-7f053d1450da", "x-vss-senderdeploymentid": "5f814983-29e7-4f0f-d4b8-8016a66b281b", "x-frame-options": "SAMEORIGIN"} }
   called: Backend::ghac_reserve
   service: ghac
   path: 1ade3adb-5301-4e15-b98b-4908107f0a8e
```

# What changes are included in this PR?

Remove the ghac v1 tests.

We don't remove the ghac v1 code directly since GHES still depends on it. We will remove them once github team confirmed that GHES is also upgraded.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
