### PR TITLE
feat(bindings/cpp) remove lib.rs.h from opendal.hpp

### DIFF
--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -97,7 +97,15 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 else()
     set(RUST_LIB ${CARGO_TARGET_DIR}/release/${CMAKE_STATIC_LIBRARY_PREFIX}opendal_cpp${CMAKE_STATIC_LIBRARY_SUFFIX})
 endif()
-set(CPP_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include ${CARGO_TARGET_DIR}/cxxbridge/opendal-cpp/src)
+
+set(CPP_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include
+                    ${PROJECT_SOURCE_DIR}/src
+                    ${CARGO_TARGET_DIR}/cxxbridge
+                    ${CARGO_TARGET_DIR}/cxxbridge/opendal-cpp/src)
+
+file(GLOB CPP_SOURCE_FILE "src/details/*.cpp")
+file(GLOB CPP_HEADER_FILE "src/details/*.hpp")
+
 list(APPEND CPP_SOURCE_FILE src/opendal.cpp)
 list(APPEND CPP_HEADER_FILE include/opendal.hpp)
 if (OPENDAL_ENABLE_ASYNC)

--- a/bindings/cpp/src/details/common.hpp
+++ b/bindings/cpp/src/details/common.hpp
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #pragma once
 
 #include "rust/cxx.h"

--- a/bindings/cpp/src/details/common.hpp
+++ b/bindings/cpp/src/details/common.hpp
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include "rust/cxx.h"
+
+namespace opendal::details {
+
+template <typename T>
+auto rust_str(T &&s) -> decltype(s.data(), s.size(), rust::Str()) {
+  return rust::Str(s.data(), s.size());
+}
+
+template <typename T>
+auto rust_string(T &&s) -> decltype(s.data(), s.size(), rust::String()) {
+  return rust::String(s.data(), s.size());
+}
+
+template <typename T, typename Container>
+auto rust_slice(Container &&s)
+    -> decltype(s.data(), s.size(), rust::Slice<T>()) {
+  using Elem = std::remove_pointer_t<decltype(s.data())>;
+  static_assert(std::is_convertible_v<Elem, T>,
+                "Container element type must be convertible to T");
+
+  return rust::Slice<T>(reinterpret_cast<T *>(s.data()), s.size());
+}
+
+}  // namespace opendal::details

--- a/bindings/cpp/src/details/lister.hpp
+++ b/bindings/cpp/src/details/lister.hpp
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "lib.rs.h"
+
+/**
+ * @class Lister
+ * @brief Lister is designed to list the entries of a directory.
+ * @details It provides next operation to get the next entry. You can also use
+ * it like an iterator.
+ * @code{.cpp}
+ * auto lister = operator.lister("dir/");
+ * for (const auto &entry : lister) {
+ *   // Do something with entry
+ * }
+ * @endcode
+ */
+namespace opendal::details {
+
+class Lister {
+ public:
+  Lister(rust::Box<opendal::ffi::Lister> &&lister)
+      : raw_lister_{std::move(lister)} {}
+
+  Lister(Lister &&) = default;
+
+  ~Lister() = default;
+
+  /**
+   * @brief Get the next entry of the lister
+   *
+   * @return The next entry of the lister
+   */
+  ffi::OptionalEntry next() { return raw_lister_->next(); }
+
+ private:
+  rust::Box<opendal::ffi::Lister> raw_lister_;
+};
+
+}  // namespace opendal::details

--- a/bindings/cpp/src/details/operator.cpp
+++ b/bindings/cpp/src/details/operator.cpp
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 #include "details/operator.hpp"
 
 #include "details/common.hpp"

--- a/bindings/cpp/src/details/operator.cpp
+++ b/bindings/cpp/src/details/operator.cpp
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "details/operator.hpp"
+
+#include "details/common.hpp"
+#include "lib.rs.h"
+
+namespace opendal::details {
+
+rust::Box<opendal::ffi::Operator> Operator::create_by_config(
+    std::string_view scheme,
+    const std::unordered_map<std::string, std::string> &config) {
+  auto rust_map = rust::Vec<ffi::HashMapValue>();
+  rust_map.reserve(config.size());
+  for (auto &[k, v] : config) {
+    rust_map.push_back({rust_string(k), rust_string(v)});
+  }
+
+  return opendal::ffi::new_operator(rust_str(scheme), rust_map);
+}
+
+std::string Operator::read(std::string_view path) {
+  auto rust_vec = operator_->read(rust_str(path));
+  return {rust_vec.data(), rust_vec.data() + rust_vec.size()};
+}
+
+void Operator::write(std::string_view path, std::string_view data) {
+  operator_->write(rust_str(path), rust_slice<const uint8_t>(data));
+}
+
+rust::Box<ffi::Reader> Operator::reader(std::string_view path) {
+  return operator_->reader(rust_str(path));
+}
+
+bool Operator::exists(std::string_view path) {
+  return operator_->exists(rust_str(path));
+}
+
+void Operator::create_dir(std::string_view path) {
+  operator_->create_dir(rust_str(path));
+}
+
+void Operator::copy(std::string_view src, std::string_view dst) {
+  operator_->copy(rust_str(src), rust_str(dst));
+}
+
+void Operator::rename(std::string_view src, std::string_view dst) {
+  operator_->rename(rust_str(src), rust_str(dst));
+}
+
+void Operator::remove(std::string_view path) {
+  operator_->remove(rust_str(path));
+}
+
+ffi::Metadata Operator::stat(std::string_view path) {
+  return operator_->stat(rust_str(path));
+}
+
+rust::Vec<ffi::Entry> Operator::list(std::string_view path) {
+  return operator_->list(rust_str(path));
+}
+
+rust::Box<ffi::Lister> Operator::lister(std::string_view path) {
+  return operator_->lister(rust_str(path));
+}
+
+}  // namespace opendal::details

--- a/bindings/cpp/src/details/operator.hpp
+++ b/bindings/cpp/src/details/operator.hpp
@@ -19,6 +19,10 @@
 
 #pragma once
 
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
 #include "lib.rs.h"
 
 namespace opendal::details {

--- a/bindings/cpp/src/details/operator.hpp
+++ b/bindings/cpp/src/details/operator.hpp
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "lib.rs.h"
+
+namespace opendal::details {
+
+class Operator {
+ public:
+  Operator(std::string_view scheme,
+           const std::unordered_map<std::string, std::string> &config = {})
+      : operator_(create_by_config(scheme, config)) {}
+
+  Operator(const Operator &) = delete;
+  Operator &operator=(const Operator &) = delete;
+
+  Operator(Operator &&) = default;
+  Operator &operator=(Operator &&) = default;
+  ~Operator() = default;
+
+  std::string read(std::string_view path);
+
+  void write(std::string_view path, std::string_view data);
+
+  rust::Box<ffi::Reader> reader(std::string_view path);
+
+  bool exists(std::string_view path);
+
+  void create_dir(std::string_view path);
+
+  void copy(std::string_view src, std::string_view dst);
+
+  void rename(std::string_view src, std::string_view dst);
+
+  void remove(std::string_view path);
+
+  ffi::Metadata stat(std::string_view path);
+
+  rust::Vec<ffi::Entry> list(std::string_view path);
+
+  rust::Box<ffi::Lister> lister(std::string_view path);
+
+ private:
+  using OperatorBox = rust::Box<opendal::ffi::Operator>;
+  using ConfigMap = std::unordered_map<std::string, std::string>;
+
+  OperatorBox create_by_config(std::string_view scheme,
+                               const ConfigMap &config);
+
+  OperatorBox operator_;
+};
+
+}  // namespace opendal::details

--- a/bindings/cpp/src/details/reader.cpp
+++ b/bindings/cpp/src/details/reader.cpp
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "details/reader.hpp"
+
+namespace opendal::details {
+
+ffi::SeekDir rust_seek_dir(std::ios_base::seekdir dir) {
+  switch (dir) {
+    case std::ios_base::beg:
+      return ffi::SeekDir::Start;
+
+    case std::ios_base::cur:
+      return ffi::SeekDir::Current;
+
+    case std::ios_base::end:
+      return ffi::SeekDir::End;
+
+    default:
+      throw std::runtime_error("invalid seekdir");
+  }
+}
+
+std::size_t Reader::read(void *s, std::size_t n) {
+  return reader_->read(rust::Slice<uint8_t>(static_cast<uint8_t *>(s), n));
+}
+
+std::uint64_t Reader::seek(std::uint64_t off, std::ios_base::seekdir dir) {
+  return reader_->seek(off, rust_seek_dir(dir));
+}
+
+}  // namespace opendal::details

--- a/bindings/cpp/src/details/reader.hpp
+++ b/bindings/cpp/src/details/reader.hpp
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "lib.rs.h"
+
+namespace opendal::details {
+/**
+ * @class Reader
+ * @brief Reader is designed to read data from the operator.
+ * @details It provides basic read and seek operations. If you want to use it
+ * like a stream, you can use `ReaderStream` instead.
+ * @code{.cpp}
+ * opendal::ReaderStream stream(operator.reader("path"));
+ * @endcode
+ */
+class Reader {
+ public:
+  Reader(rust::Box<opendal::ffi::Reader> &&reader)
+      : reader_(std::move(reader)) {}
+
+  Reader(Reader &&) = default;
+
+  ~Reader() = default;
+
+  std::size_t read(void *s, std::size_t n);
+
+  std::uint64_t seek(std::uint64_t off, std::ios_base::seekdir dir);
+
+ private:
+  rust::Box<opendal::ffi::Reader> reader_;
+};
+
+}  // namespace opendal::details

--- a/bindings/cpp/src/opendal.cpp
+++ b/bindings/cpp/src/opendal.cpp
@@ -19,137 +19,14 @@
 
 #include "opendal.hpp"
 
-using namespace opendal;
+#include <memory>
 
-#define RUST_STR(s) rust::Str(s.data(), s.size())
-#define RUST_STRING(s) rust::String(s.data(), s.size())
+#include "boost/date_time/posix_time/time_parsers.hpp"
+#include "details/lister.hpp"
+#include "details/operator.hpp"
+#include "details/reader.hpp"
 
-// Operator
-
-Operator::Operator(std::string_view scheme,
-                   const std::unordered_map<std::string, std::string> &config) {
-  auto rust_map = rust::Vec<ffi::HashMapValue>();
-  rust_map.reserve(config.size());
-  for (auto &[k, v] : config) {
-    rust_map.push_back({RUST_STRING(k), RUST_STRING(v)});
-  }
-
-  operator_ = opendal::ffi::new_operator(RUST_STR(scheme), rust_map);
-}
-
-bool Operator::available() const { return operator_.has_value(); }
-
-// We can't avoid copy, because std::vector hides the internal structure.
-// std::vector doesn't support init from a pointer without copy.
-std::vector<uint8_t> Operator::read(std::string_view path) {
-  auto rust_vec = operator_.value()->read(RUST_STR(path));
-
-  return {rust_vec.data(), rust_vec.data() + rust_vec.size()};
-}
-
-void Operator::write(std::string_view path, const std::vector<uint8_t> &data) {
-  operator_.value()->write(
-      RUST_STR(path), rust::Slice<const uint8_t>(data.data(), data.size()));
-}
-
-bool Operator::exists(std::string_view path) {
-  return operator_.value()->exists(RUST_STR(path));
-}
-
-bool Operator::is_exist(std::string_view path) {
-  return exists(path);
-}
-
-void Operator::create_dir(std::string_view path) {
-  operator_.value()->create_dir(RUST_STR(path));
-}
-
-void Operator::copy(std::string_view src, std::string_view dst) {
-  operator_.value()->copy(RUST_STR(src), RUST_STR(dst));
-}
-
-void Operator::rename(std::string_view src, std::string_view dst) {
-  operator_.value()->rename(RUST_STR(src), RUST_STR(dst));
-}
-
-void Operator::remove(std::string_view path) {
-  operator_.value()->remove(RUST_STR(path));
-}
-
-Metadata Operator::stat(std::string_view path) {
-  return {operator_.value()->stat(RUST_STR(path))};
-}
-
-std::vector<Entry> Operator::list(std::string_view path) {
-  auto rust_vec = operator_.value()->list(RUST_STR(path));
-
-  std::vector<Entry> entries;
-  entries.reserve(rust_vec.size());
-  for (auto &&entry : rust_vec) {
-    entries.push_back(std::move(entry));
-  }
-  return entries;
-}
-
-Lister Operator::lister(std::string_view path) {
-  return operator_.value()->lister(RUST_STR(path));
-}
-
-Reader Operator::reader(std::string_view path) {
-  return operator_.value()->reader(RUST_STR(path));
-}
-
-// Reader
-
-std::streamsize Reader::read(void *s, std::streamsize n) {
-  auto rust_slice = rust::Slice<uint8_t>(reinterpret_cast<uint8_t *>(s), n);
-  auto read_size = raw_reader_->read(rust_slice);
-  return read_size;
-}
-
-ffi::SeekDir to_rust_seek_dir(std::ios_base::seekdir dir);
-
-std::streampos Reader::seek(std::streamoff off, std::ios_base::seekdir dir) {
-  return raw_reader_->seek(off, to_rust_seek_dir(dir));
-}
-
-// Lister
-
-std::optional<Entry> Lister::next() {
-  auto entry = raw_lister_->next();
-  if (entry.has_value) {
-    return std::move(entry.value);
-  } else {
-    return std::nullopt;
-  }
-}
-
-// Metadata
-
-std::optional<std::string> parse_optional_string(ffi::OptionalString &&s);
-
-Metadata::Metadata(ffi::Metadata &&other) {
-  type = static_cast<EntryMode>(other.mode);
-  content_length = other.content_length;
-  cache_control = parse_optional_string(std::move(other.cache_control));
-  content_disposition =
-      parse_optional_string(std::move(other.content_disposition));
-  content_type = parse_optional_string(std::move(other.content_type));
-  content_md5 = parse_optional_string(std::move(other.content_md5));
-  etag = parse_optional_string(std::move(other.etag));
-  auto last_modified_str =
-      parse_optional_string(std::move(other.last_modified));
-  if (last_modified_str.has_value()) {
-    last_modified =
-        boost::posix_time::from_iso_string(last_modified_str.value());
-  }
-}
-
-// Entry
-
-Entry::Entry(ffi::Entry &&other) : path(std::move(other.path)) {}
-
-// helper functions
+namespace opendal {
 
 std::optional<std::string> parse_optional_string(ffi::OptionalString &&s) {
   if (s.has_value) {
@@ -159,15 +36,129 @@ std::optional<std::string> parse_optional_string(ffi::OptionalString &&s) {
   }
 }
 
-ffi::SeekDir to_rust_seek_dir(std::ios_base::seekdir dir) {
-  switch (dir) {
-    case std::ios_base::beg:
-      return ffi::SeekDir::Start;
-    case std::ios_base::cur:
-      return ffi::SeekDir::Current;
-    case std::ios_base::end:
-      return ffi::SeekDir::End;
-    default:
-      throw std::runtime_error("invalid seekdir");
-  }
+Entry parse_entry(ffi::Entry &&other) {
+  return Entry{
+      .path = std::string(std::move(other.path)),
+  };
 }
+
+Metadata parse_meta_data(ffi::Metadata &&meta) {
+  Metadata metadata{
+      .type = static_cast<EntryMode>(meta.mode),
+      .content_length = meta.content_length,
+      .cache_control = parse_optional_string(std::move(meta.cache_control)),
+      .content_disposition =
+          parse_optional_string(std::move(meta.content_disposition)),
+      .content_md5 = parse_optional_string(std::move(meta.content_md5)),
+      .content_type = parse_optional_string(std::move(meta.content_type)),
+      .etag = parse_optional_string(std::move(meta.etag)),
+  };
+
+  auto last_modified_str = parse_optional_string(std::move(meta.last_modified));
+  if (last_modified_str.has_value()) {
+    metadata.last_modified =
+        boost::posix_time::from_iso_string(last_modified_str.value());
+  }
+
+  return metadata;
+}
+
+Operator::Operator() = default;
+
+Operator::Operator(std::string_view scheme,
+                   const std::unordered_map<std::string, std::string> &config) {
+  operator_ = std::make_unique<details::Operator>(scheme, config);
+}
+
+Operator::~Operator() = default;
+
+Operator::Operator(Operator &&) = default;
+Operator &Operator::operator=(Operator &&) = default;
+
+bool Operator::available() const { return operator_ != nullptr; }
+
+// We can't avoid copy, because std::vector hides the internal structure.
+// std::vector doesn't support init from a pointer without copy.
+std::string Operator::read(std::string_view path) {
+  return operator_->read(path);
+}
+
+void Operator::write(std::string_view path, std::string_view data) {
+  operator_->write(path, data);
+}
+
+bool Operator::exists(std::string_view path) { return operator_->exists(path); }
+
+bool Operator::is_exist(std::string_view path) { return exists(path); }
+
+void Operator::create_dir(std::string_view path) {
+  operator_->create_dir(path);
+}
+
+void Operator::copy(std::string_view src, std::string_view dst) {
+  operator_->copy(src, dst);
+}
+
+void Operator::rename(std::string_view src, std::string_view dst) {
+  operator_->rename(src, dst);
+}
+
+void Operator::remove(std::string_view path) { operator_->remove(path); }
+
+Metadata Operator::stat(std::string_view path) {
+  return parse_meta_data(operator_->stat(path));
+}
+
+std::vector<Entry> Operator::list(std::string_view path) {
+  auto rust_vec = operator_->list(path);
+
+  std::vector<Entry> entries;
+  entries.reserve(rust_vec.size());
+  for (auto &&entry : rust_vec) {
+    entries.emplace_back(parse_entry(std::move(entry)));
+  }
+
+  return entries;
+}
+
+Lister Operator::lister(std::string_view path) {
+  return std::make_unique<details::Lister>(operator_->lister(path));
+}
+
+Reader Operator::reader(std::string_view path) {
+  return std::make_unique<details::Reader>(operator_->reader(path));
+}
+
+Lister::Lister(std::unique_ptr<details::Lister> lister)
+    : raw_lister_{std::move(lister)} {};
+
+Lister::Lister(Lister &&) = default;
+
+Lister::~Lister() = default;
+
+std::optional<Entry> Lister::next() {
+  auto entry = raw_lister_->next();
+  
+  if (!entry.has_value) {
+    return std::nullopt;
+  }
+
+  return parse_entry(std::move(entry.value));
+}
+
+Reader::Reader(std::unique_ptr<details::Reader> &&reader)
+      : raw_reader_{std::move(reader)} {}
+
+Reader::Reader(Reader &&) = default;
+
+Reader::~Reader() = default;
+
+std::streamsize Reader::read(void *s, std::streamsize n) {
+  return raw_reader_->read(s, n);
+}
+
+std::streampos Reader::seek(std::streamoff off, std::ios_base::seekdir dir) {
+  return raw_reader_->seek(off, dir);
+}
+
+}  // namespace opendal

--- a/bindings/cpp/src/opendal.cpp
+++ b/bindings/cpp/src/opendal.cpp
@@ -138,7 +138,7 @@ Lister::~Lister() = default;
 
 std::optional<Entry> Lister::next() {
   auto entry = raw_lister_->next();
-  
+
   if (!entry.has_value) {
     return std::nullopt;
   }
@@ -147,7 +147,7 @@ std::optional<Entry> Lister::next() {
 }
 
 Reader::Reader(std::unique_ptr<details::Reader> &&reader)
-      : raw_reader_{std::move(reader)} {}
+    : raw_reader_{std::move(reader)} {}
 
 Reader::Reader(Reader &&) = default;
 

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -3,14 +3,8 @@ project(opendal-cpp-examples)
 
 set(CMAKE_CXX_STANDARD 17)
 
-include(FetchContent)
-FetchContent_Declare(
-  opendal-cpp
-  GIT_REPOSITORY https://github.com/apache/opendal.git
-  GIT_TAG        v0.52.0
-  SOURCE_SUBDIR  bindings/cpp
-)
-FetchContent_MakeAvailable(opendal-cpp)
+# use local bindings/cpp directory
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../bindings/cpp opendal_cpp_build)
 
 add_executable(basic-example basic.cpp)
 target_link_libraries(basic-example opendal_cpp)

--- a/examples/cpp/basic.cpp
+++ b/examples/cpp/basic.cpp
@@ -1,11 +1,10 @@
 #include "opendal.hpp"
 
 #include <string>
-#include <vector>
 #include <iostream>
 
 int main() {
-  std::vector<uint8_t> data = {'a', 'b', 'c'};
+  std::string_view data = "abc";
 
   // Init operator
   opendal::Operator op = opendal::Operator("memory");
@@ -15,11 +14,17 @@ int main() {
 
   // Read data from operator
   auto res = op.read("test"); // res == data
+  std::cout << res << std::endl;
 
   // Using reader
   auto reader = op.reader("test");
-  opendal::ReaderStream stream(std::move(reader));
-  std::string res2;
-  stream >> res2; // res2 == "abc"
+  std::string res2(3, 0);
+  reader.read(res2.data(), data.size()); // res2 == "abc"
   std::cout << res2 << std::endl;
+
+  // Using reader stream
+  opendal::ReaderStream stream(op.reader("test"));
+  std::string res3;
+  stream >> res3; // res3 == "abc"
+  std::cout << res3 << std::endl;
 }


### PR DESCRIPTION
# Which issue does this PR close?

nop, but inspired by the discussion https://github.com/apache/opendal/discussions/6035

# Rationale for this change

Remove lib.rs.h from opendal.hpp to make the included source files cleaner for users.

# What changes are included in this PR?

- Using type erasure to remove lib.rs.h from opendal.hpp, but note that this will introduce an additional pointer access overhead, we will fix this in the future.
- Replace macro definitions with template functions to convert C++ containers into Rust containers.
- Change the return type of operator::read from vector<uint8_t> to string.
- Rename Lister::ListerIterator to Lister::Iterator to eliminate naming redundancy.

# Are there any user-facing changes?
- Change the return type of operator::read from vector<uint8_t> to string. Since the C++ binding hasn't been officially released yet, I think this change should be acceptable.
- This helps minimize the code expansion when users include opendal.hpp during preprocessing.


cc @JackDrogon 
