### PR TITLE
fix(bindings/python): wrong filename used when reading CSV in pandas exemple

### DIFF
--- a/bindings/python/docs/examples/pandas.ipynb
+++ b/bindings/python/docs/examples/pandas.ipynb
@@ -27,7 +27,7 @@
     "op.write(\"test.csv\", b\"name,age\\nAlice,25\\nBob,30\\nCharlie,35\")\n",
     "\n",
     "# Open and read the DataFrame from the file.\n",
-    "with op.open(\"test123.csv\", mode=\"rb\") as file:\n",
+    "with op.open(\"test.csv\", mode=\"rb\") as file:\n",
     "    read_df = pd.read_csv(file)\n",
     "    print(f\"read_df: {read_df}\")"
    ]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6056

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The example code currently attempts to read a file named test123.csv, which was never written.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
- Fixed the filename in the file : `bindings/python/docs/examples/pandas.ipynb`  from test123.csv to test.csv to match the file that is written.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
