### PR TITLE
feat(layers/prometheus_client): Add disable_label_root to allow skip root label in metrics

### DIFF
--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -107,7 +107,7 @@ pub struct PrometheusClientLayerBuilder {
     entries_rate_buckets: Vec<f64>,
     duration_seconds_buckets: Vec<f64>,
     ttfb_buckets: Vec<f64>,
-    enable_label_root: bool,
+    disable_label_root: bool,
 }
 
 impl Default for PrometheusClientLayerBuilder {
@@ -119,7 +119,7 @@ impl Default for PrometheusClientLayerBuilder {
             entries_rate_buckets: observe::DEFAULT_ENTRIES_RATE_BUCKETS.to_vec(),
             duration_seconds_buckets: observe::DEFAULT_DURATION_SECONDS_BUCKETS.to_vec(),
             ttfb_buckets: observe::DEFAULT_TTFB_BUCKETS.to_vec(),
-            enable_label_root: true,
+            disable_label_root: false,
         }
     }
 }
@@ -173,9 +173,10 @@ impl PrometheusClientLayerBuilder {
         self
     }
 
-    /// Set enable high cardinality labels. The high cardinality labels might have risks of cardinality explosion, so we can disable it by default.
-    pub fn enable_high_cardinality_labels(mut self, enable: bool) -> Self {
-        self.enable_label_root = enable;
+    /// The 'root' label might have risks of being high cardinality, users can choose to disable it
+    /// when they found it's not useful for their metrics.
+    pub fn disable_label_root(mut self, disable: bool) -> Self {
+        self.disable_label_root = disable;
         self
     }
 
@@ -368,7 +369,7 @@ impl PrometheusClientLayerBuilder {
                 http_connection_errors_total,
                 http_status_errors_total,
 
-                enable_label_root: self.enable_label_root,
+                disable_label_root: self.disable_label_root,
             },
         }
     }
@@ -406,14 +407,14 @@ pub struct PrometheusClientInterceptor {
     http_connection_errors_total: Family<OperationLabels, Counter>,
     http_status_errors_total: Family<OperationLabels, Counter>,
 
-    enable_label_root: bool,
+    disable_label_root: bool,
 }
 
 impl observe::MetricsIntercept for PrometheusClientInterceptor {
     fn observe(&self, labels: observe::MetricLabels, value: observe::MetricValue) {
         let labels = OperationLabels {
             labels,
-            enable_label_root: self.enable_label_root,
+            disable_label_root: self.disable_label_root,
         };
         match value {
             observe::MetricValue::OperationBytes(v) => self
@@ -490,7 +491,7 @@ impl observe::MetricsIntercept for PrometheusClientInterceptor {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct OperationLabels {
     labels: observe::MetricLabels,
-    enable_label_root: bool,
+    disable_label_root: bool,
 }
 
 impl EncodeLabelSet for OperationLabels {
@@ -498,7 +499,7 @@ impl EncodeLabelSet for OperationLabels {
         (observe::LABEL_SCHEME, self.labels.scheme.into_static()).encode(encoder.encode_label())?;
         (observe::LABEL_NAMESPACE, self.labels.namespace.as_ref())
             .encode(encoder.encode_label())?;
-        if self.enable_label_root {
+        if !self.disable_label_root {
             (observe::LABEL_ROOT, self.labels.root.as_ref()).encode(encoder.encode_label())?;
         }
         (observe::LABEL_OPERATION, self.labels.operation).encode(encoder.encode_label())?;


### PR DESCRIPTION
# Which issue does this PR close?

none

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

currently the `root` label might have high cardinality in certain systems, like users may have thousands of different `root` values for something like `stage`s.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

this pr addes a `enable_high_cardinality_labels` method to `PrometheusClientLayerBuilder`, if this method set as `false`, the `root` label will not be rendered in the labels encoding.

# Are there any user-facing changes?


adds a `enable_high_cardinality_labels` in `PrometheusClientLayerBuilder`. the default behaviour is not changed

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
