### PR TITLE
fix(core): Only run size tests on 64bit platforms

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -154,6 +154,7 @@ mod tests {
     ///
     /// We assert our public structs here to make sure we don't introduce
     /// unexpected struct/enum size change.
+    #[cfg(target_pointer_width = "64")]
     #[test]
     fn assert_size() {
         assert_eq!(16, size_of::<Operator>());


### PR DESCRIPTION
# Which issue does this PR close?
Closes #6077.

# Rationale for this change
This only runs the assert_size tests on 64bit platforms. They have hardcoded values for that platform only.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
Nope

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
