### PR TITLE
chore(integrations/unftp): Make compatible with latest libunftp

### DIFF
--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -27,8 +27,8 @@ rust-version = "1.80"
 version = "0.1.1"
 
 [dependencies]
-async-trait = "0.1.80"
-libunftp = "0.20.0"
+async-trait = "0.1.88"
+libunftp = "0.21.0"
 opendal = { version = "0.53.0", path = "../../core" }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.7.11", features = ["compat"] }

--- a/integrations/unftp-sbe/README.md
+++ b/integrations/unftp-sbe/README.md
@@ -12,7 +12,7 @@
 
 `unftp-sbe-opendal` is an [unftp](https://crates.io/crates/unftp) `StorageBackend` implementation using opendal.
 
-This crate can help you to access ANY storage services with the same ftp API.
+This crate can help you to access ANY storage services with the same FTP API.
 
 ## Useful Links
 


### PR DESCRIPTION
A new version of [libunftp](https://crates.io/crates/libunftp) is out and the integration here (unftp-sbe-opendal) isn't compatible anymore due to an upgrade to the `async-trait` crate.

This change simply bumps `async-trait` and `libunftp` to the latest versions, making it compatible again.

It will be really great if the [unftp-sbe-opendal](https://crates.io/crates/unftp-sbe-opendal) crate can be released after this merge. This is because the [unFTP](https://github.com/bolcom/unFTP) project uses it and currently cannot release with opendal functionality unless a new version of `uftp-sbe-opendal` with these changes are released.

cc @George-Miao 