### PR TITLE
refactor(core): Improve Error Message with Defective Value

### DIFF
--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -162,7 +162,7 @@ impl HttpFetch for reqwest::Client {
         let (parts, body) = req.into_parts();
         
         let url = reqwest::Url::from_str(&uri.to_string())
-            .map_err(|err| Error::new("request url is invalid")
+            .map_err(|err| Error::new(ErrorKind::InvalidInput, "request url is invalid")
                      .context("uri", uri).source(err))?;
 
         let mut req_builder = self.request(parts.method, url).headers(parts.headers);

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -163,7 +163,7 @@ impl HttpFetch for reqwest::Client {
 
         let url = reqwest::Url::from_str(&uri.to_string()).map_err(|err| {
             Error::new(ErrorKind::Unexpected, "request url is invalid")
-                .with_operation("http_util::Client::Url::from_str")
+                .with_operation("http_util::Client::fetch")
                 .with_context("url", uri.to_string())
                 .set_source(err)
         })?;

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -164,8 +164,7 @@ impl HttpFetch for reqwest::Client {
         let url = reqwest::Url::from_str(&uri.to_string())
             .expect(&format!("input request url must be valid {}", uri));
 
-        let mut req_builder = self.request(parts.method, url,)
-            .headers(parts.headers);
+        let mut req_builder = self.request(parts.method, url).headers(parts.headers);
 
         // Client under wasm doesn't support set version.
         #[cfg(not(target_arch = "wasm32"))]

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -164,7 +164,7 @@ impl HttpFetch for reqwest::Client {
         let mut req_builder = self
             .request(
                 parts.method,
-                reqwest::Url::from_str(&uri.to_string()).expect(format!("input request url must be valid {}", uri)),
+                reqwest::Url::from_str(&uri.to_string()).expect(&format!("input request url must be valid {}", uri)),
             )
             .headers(parts.headers);
 

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -161,9 +161,11 @@ impl HttpFetch for reqwest::Client {
 
         let (parts, body) = req.into_parts();
         
-        let url = reqwest::Url::from_str(&uri.to_string())
-            .map_err(|err| Error::new(ErrorKind::InvalidInput, "request url is invalid")
-                     .context("uri", uri).source(err))?;
+        let url = reqwest::Url::from_str(&uri.to_string()).map_err(|err| {
+            Error::new(ErrorKind::InvalidInput, "request url is invalid")
+                .context("uri", uri)
+                .source(err)
+        })?;
 
         let mut req_builder = self.request(parts.method, url).headers(parts.headers);
 

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -162,7 +162,7 @@ impl HttpFetch for reqwest::Client {
         let (parts, body) = req.into_parts();
 
         let url = reqwest::Url::from_str(&uri.to_string())
-            .expect(&format!("input request url must be valid {}", uri));
+            .unwrap_or_else(|_| panic!("input request url must be valid {}", uri));
 
         let mut req_builder = self.request(parts.method, url).headers(parts.headers);
 

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -161,11 +161,13 @@ impl HttpFetch for reqwest::Client {
 
         let (parts, body) = req.into_parts();
 
+        let url = reqwest::Url::from_str(&uri.to_string())
+            .expect(&format!("input request url must be valid {}", uri)); 
+
         let mut req_builder = self
             .request(
                 parts.method,
-                reqwest::Url::from_str(&uri.to_string())
-                    .expect(&format!("input request url must be valid {}", uri)),
+                url,
             )
             .headers(parts.headers);
 

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -165,7 +165,7 @@ impl HttpFetch for reqwest::Client {
             .request(
                 parts.method,
                 reqwest::Url::from_str(&uri.to_string())
-                      .expect(&format!("input request url must be valid {}", uri)),
+                    .expect(&format!("input request url must be valid {}", uri)),
             )
             .headers(parts.headers);
 

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -160,7 +160,7 @@ impl HttpFetch for reqwest::Client {
         let is_head = req.method() == http::Method::HEAD;
 
         let (parts, body) = req.into_parts();
-        
+
         let url = reqwest::Url::from_str(&uri.to_string()).map_err(|err| {
             Error::new(ErrorKind::InvalidInput, "request url is invalid")
                 .context("uri", uri)

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -162,9 +162,10 @@ impl HttpFetch for reqwest::Client {
         let (parts, body) = req.into_parts();
 
         let url = reqwest::Url::from_str(&uri.to_string()).map_err(|err| {
-            Error::new(ErrorKind::InvalidInput, "request url is invalid")
-                .context("uri", uri)
-                .source(err)
+            Error::new(ErrorKind::Unexpected, "request url is invalid")
+                .with_operation("http_util::Client::Url::from_str")
+                .with_context("url", uri.to_string())
+                .set_source(err)
         })?;
 
         let mut req_builder = self.request(parts.method, url).headers(parts.headers);

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -162,13 +162,9 @@ impl HttpFetch for reqwest::Client {
         let (parts, body) = req.into_parts();
 
         let url = reqwest::Url::from_str(&uri.to_string())
-            .expect(&format!("input request url must be valid {}", uri)); 
+            .expect(&format!("input request url must be valid {}", uri));
 
-        let mut req_builder = self
-            .request(
-                parts.method,
-                url,
-            )
+        let mut req_builder = self.request(parts.method, url,)
             .headers(parts.headers);
 
         // Client under wasm doesn't support set version.

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -164,7 +164,7 @@ impl HttpFetch for reqwest::Client {
         let mut req_builder = self
             .request(
                 parts.method,
-                reqwest::Url::from_str(&uri.to_string()).expect("input request url must be valid"),
+                reqwest::Url::from_str(&uri.to_string()).expect(format!("input request url must be valid {}", uri)),
             )
             .headers(parts.headers);
 

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -163,7 +163,7 @@ impl HttpFetch for reqwest::Client {
 
         let url = reqwest::Url::from_str(&uri.to_string()).map_err(|err| {
             Error::new(ErrorKind::Unexpected, "request url is invalid")
-                .with_operation("http_util::Client::fetch")
+                .with_operation("http_util::Client::send::fetch")
                 .with_context("url", uri.to_string())
                 .set_source(err)
         })?;

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -164,7 +164,8 @@ impl HttpFetch for reqwest::Client {
         let mut req_builder = self
             .request(
                 parts.method,
-                reqwest::Url::from_str(&uri.to_string()).expect(&format!("input request url must be valid {}", uri)),
+                reqwest::Url::from_str(&uri.to_string())
+                      .expect(&format!("input request url must be valid {}", uri)),
             )
             .headers(parts.headers);
 

--- a/core/src/raw/http_util/client.rs
+++ b/core/src/raw/http_util/client.rs
@@ -160,9 +160,10 @@ impl HttpFetch for reqwest::Client {
         let is_head = req.method() == http::Method::HEAD;
 
         let (parts, body) = req.into_parts();
-
+        
         let url = reqwest::Url::from_str(&uri.to_string())
-            .unwrap_or_else(|_| panic!("input request url must be valid {}", uri));
+            .map_err(|err| Error::new("request url is invalid")
+                     .context("uri", uri).source(err))?;
 
         let mut req_builder = self.request(parts.method, url).headers(parts.headers);
 


### PR DESCRIPTION
[The expect message produced by this fragment is not ideal](https://github.com/apache/opendal/blob/v0.53.1/core/src/raw/http_util/client.rs#L164-L169).

Here is an example of its presentation.
"input request url must be valid: InvalidIpv4Address"

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6123

# Rationale for this change
It is difficult to correct a defective value if the value is unknown.
This change prints the defective value.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Update to an error message to make correcting the error more tractable.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

The message contains information about a defective uri.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->