### PR TITLE
s3: user metadata: parse any valid utf8

### DIFF
--- a/core/src/raw/http_util/header.rs
+++ b/core/src/raw/http_util/header.rs
@@ -206,8 +206,7 @@ pub fn parse_prefixed_headers(headers: &HeaderMap, prefix: &str) -> HashMap<Stri
         .iter()
         .filter_map(|(name, value)| {
             name.as_str().strip_prefix(prefix).and_then(|stripped_key| {
-                value
-                    .to_str()
+                String::from_utf8(value.as_bytes().to_vec())
                     .ok()
                     .map(|parsed_value| (stripped_key.to_string(), parsed_value.to_string()))
             })


### PR DESCRIPTION
error still not handled

# Which issue does this PR close?

It mitigates, but does not close #6131 

# Are there any user-facing changes?
More values can be successfully parsed - which can have security implications. But I'm not aware of the skipping being intentional.