### PR TITLE
feat(bindings/go): implement io.Seeker

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -604,6 +604,22 @@ typedef struct opendal_result_reader_read {
 } opendal_result_reader_read;
 
 /**
+ * \brief The result type returned by opendal_reader_seek().
+ * The result type contains a pos field, which is the new position after seek,
+ * which is zero on error. The error field is the error code and error message.
+ */
+typedef struct opendal_result_reader_seek {
+  /**
+   * New position after seek
+   */
+  uint64_t pos;
+  /**
+   * The error, if ok, it is null
+   */
+  struct opendal_error *error;
+} opendal_result_reader_seek;
+
+/**
  * \brief The result type returned by opendal_writer_write().
  * The result type contains a size field, which is the size of the data written,
  * which is zero on error. The error field is the error code and error message.
@@ -1443,9 +1459,9 @@ struct opendal_result_reader_read opendal_reader_read(struct opendal_reader *sel
 /**
  * \brief Seek to an offset, in bytes, in a stream.
  */
-struct opendal_error *opendal_reader_seek(struct opendal_reader *self,
-                                          int64_t offset,
-                                          int32_t whence);
+struct opendal_result_reader_seek opendal_reader_seek(struct opendal_reader *self,
+                                                      int64_t offset,
+                                                      int32_t whence);
 
 /**
  * \brief Frees the heap memory used by the opendal_reader.

--- a/bindings/c/src/result.rs
+++ b/bindings/c/src/result.rs
@@ -148,6 +148,17 @@ pub struct opendal_result_reader_read {
     pub error: *mut opendal_error,
 }
 
+/// \brief The result type returned by opendal_reader_seek().
+/// The result type contains a pos field, which is the new position after seek,
+/// which is zero on error. The error field is the error code and error message.
+#[repr(C)]
+pub struct opendal_result_reader_seek {
+    /// New position after seek
+    pub pos: u64,
+    /// The error, if ok, it is null
+    pub error: *mut opendal_error,
+}
+
 /// \brief The result type returned by opendal_operator_writer().
 /// The result type for opendal_operator_writer(), the field `writer` contains the writer
 /// of the path, which is an iterator of the objects under the path. the field `code` represents

--- a/bindings/c/tests/reader.cpp
+++ b/bindings/c/tests/reader.cpp
@@ -63,8 +63,9 @@ TEST_F(OpendalReaderTest, SeekTest)
     EXPECT_EQ(r.error, nullptr);
 
     //  Test seek set
-    err = opendal_reader_seek(r.reader, 6, OPENDAL_SEEK_SET);
-    EXPECT_EQ(err, nullptr);
+    opendal_result_reader_seek seek_result = opendal_reader_seek(r.reader, 6, OPENDAL_SEEK_SET);
+    EXPECT_EQ(seek_result.pos, 6);
+    EXPECT_EQ(seek_result.error, nullptr);
 
     char buf1[64] = {0};
     opendal_result_reader_read read_result = opendal_reader_read(r.reader, (uint8_t *)buf1, 7);
@@ -73,8 +74,9 @@ TEST_F(OpendalReaderTest, SeekTest)
     EXPECT_EQ(std::string(buf1), "Gabcdef");
 
     // Test seek cur, now we step on '3'
-    err = opendal_reader_seek(r.reader, 3, OPENDAL_SEEK_CUR);
-    EXPECT_EQ(err, nullptr);
+    seek_result = opendal_reader_seek(r.reader, 3, OPENDAL_SEEK_CUR);
+    EXPECT_EQ(seek_result.pos, 16);
+    EXPECT_EQ(seek_result.error, nullptr);
 
     char buf2[64] = {0};
     read_result = opendal_reader_read(r.reader, (uint8_t*)buf2, 32 /* no more 32 bytes*/);
@@ -83,8 +85,9 @@ TEST_F(OpendalReaderTest, SeekTest)
     EXPECT_EQ(std::string(buf2), "34567");
 
     // Test seek end, now we step on 'g'
-    err = opendal_reader_seek(r.reader, -8, OPENDAL_SEEK_END);
-    EXPECT_EQ(err, nullptr);
+    seek_result = opendal_reader_seek(r.reader, -8, OPENDAL_SEEK_END);
+    EXPECT_EQ(seek_result.pos, 13);
+    EXPECT_EQ(seek_result.error, nullptr);
 
     char buf3[64] = {0};
     read_result = opendal_reader_read(r.reader, (uint8_t*)buf3, 32 /* no more 32 bytes*/);

--- a/bindings/go/ffi.go
+++ b/bindings/go/ffi.go
@@ -138,6 +138,7 @@ var withFFIs = []contextWithFFI{
 
 	withOperatorReader,
 	withReaderRead,
+	withReaderSeek,
 	withReaderFree,
 
 	withOperatorWriter,

--- a/bindings/go/reader.go
+++ b/bindings/go/reader.go
@@ -352,7 +352,7 @@ type readerSeek func(r *opendalReader, offset int64, whence int) (int64, error)
 
 var withReaderSeek = withFFI(ffiOpts{
 	sym:    symReaderSeek,
-	rType:  &ffi.TypePointer,
+	rType:  &typeResultReaderSeek,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
 }, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) readerSeek {
 	return func(r *opendalReader, offset int64, whence int) (int64, error) {

--- a/bindings/go/reader.go
+++ b/bindings/go/reader.go
@@ -130,7 +130,7 @@ type Reader struct {
 	ctx   context.Context
 }
 
-var _ io.ReadCloser = (*Reader)(nil)
+var _ io.ReadSeekCloser = (*Reader)(nil)
 
 // Read reads data from the underlying storage into the provided buffer.
 //
@@ -194,6 +194,52 @@ func (r *Reader) Read(buf []byte) (int, error) {
 		err = io.EOF
 	}
 	return int(totalSize), err
+}
+
+// Seek sets the offset for the next Read operation on the reader.
+//
+// This method implements the io.Seeker interface for Reader.
+//
+// # Parameters
+//
+//   - offset: The offset from the origin (specified by whence).
+//   - whence: The reference point for offset. Can be:
+//   - io.SeekStart (0): Relative to the start of the file
+//   - io.SeekCurrent (1): Relative to the current position
+//   - io.SeekEnd (2): Relative to the end of the file
+//
+// # Returns
+//
+//   - int64: The new absolute position in the file after the seek operation.
+//   - error: An error if the seek operation fails, or nil if successful.
+//
+// # Example
+//
+//	reader, err := op.Reader("path/to/file")
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	defer reader.Close()
+//
+//	// Seek to the middle of the file
+//	pos, err := reader.Seek(1000, io.SeekStart)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	fmt.Printf("New position: %d\n", pos)
+//
+//	// Seek relative to current position
+//	pos, err = reader.Seek(100, io.SeekCurrent)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//	fmt.Printf("New position: %d\n", pos)
+//
+// Note: The actual new position may differ from the requested position
+// if the underlying storage system has restrictions on seeking.
+func (r *Reader) Seek(offset int64, whence int) (int64, error) {
+	seek := getFFI[readerSeek](r.ctx, symReaderSeek)
+	return seek(r.inner, offset, whence)
 }
 
 // Close releases resources associated with the OperatorReader.
@@ -297,5 +343,29 @@ var withReaderRead = withFFI(ffiOpts{
 			return 0, parseError(ctx, result.error)
 		}
 		return result.size, nil
+	}
+})
+
+const symReaderSeek = "opendal_reader_seek"
+
+type readerSeek func(r *opendalReader, offset int64, whence int) (int64, error)
+
+var withReaderSeek = withFFI(ffiOpts{
+	sym:    symReaderSeek,
+	rType:  &ffi.TypePointer,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
+}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) readerSeek {
+	return func(r *opendalReader, offset int64, whence int) (int64, error) {
+		var result resultReaderSeek
+		ffiCall(
+			unsafe.Pointer(&result),
+			unsafe.Pointer(&r),
+			unsafe.Pointer(&offset),
+			unsafe.Pointer(&whence),
+		)
+		if result.error != nil {
+			return 0, parseError(ctx, result.error)
+		}
+		return int64(result.pos), nil
 	}
 })

--- a/bindings/go/tests/behavior_tests/opendal_test.go
+++ b/bindings/go/tests/behavior_tests/opendal_test.go
@@ -163,6 +163,14 @@ func genFixedBytes(size uint) []byte {
 	return content
 }
 
+func genOffsetLength(size uint) (int64, int64) {
+	// Generate a random offset and length within the given size
+	offset, _ := rand.Int(rand.Reader, big.NewInt(int64(size-1)))
+	length, _ := rand.Int(rand.Reader, big.NewInt(int64(size)-offset.Int64()))
+
+	return offset.Int64(), length.Int64()
+}
+
 type fixture struct {
 	op   *opendal.Operator
 	lock *sync.Mutex

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -117,6 +117,15 @@ var (
 		}[0],
 	}
 
+	typeResultReaderSeek = ffi.Type{
+		Type: ffi.Struct,
+		Elements: &[]*ffi.Type{
+			&ffi.TypePointer,
+			&ffi.TypePointer,
+			nil,
+		}[0],
+	}
+
 	typeResultIsExist = ffi.Type{
 		Type: ffi.Struct,
 		Elements: &[]*ffi.Type{

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -239,6 +239,11 @@ type resultReaderRead struct {
 	error *opendalError
 }
 
+type resultReaderSeek struct {
+	pos uint64
+	error *opendalError
+}
+
 type resultIsExist struct {
 	is_exist uint8
 	error    *opendalError


### PR DESCRIPTION
Follow #6119.

Part of #4892.

This PR aims to implement the offset-based read operation requested in #5326 by supporting the `io.Seeker` interface.

FYI: https://pkg.go.dev/io#Seeker

In a previous closed PR, I attempted to implement `io.ReaderAt` without a proper design. Now, we can directly use `opendal_reader_seek` to support `io.Seeker`!

The difference between `io.Seeker` and `io.ReaderAt` is that `io.ReaderAt` allows for parallel offset-based reading.

> Clients of ReadAt can execute parallel ReadAt calls on the same input source.
>
> From https://pkg.go.dev/io#ReaderAt

**NOTICE**: I made some changes to the signature of the C seek function.