### PR TITLE
docs: Try using new nightly rust to build ruby docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -182,6 +182,10 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
 
+      - name: Setup Rust Nightly
+        run: |
+          rustup toolchain install ${{ env.RUST_DOC_TOOLCHAIN }}
+
       - name: Build Docs
         working-directory: bindings/ruby
         run: bundle exec rake doc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -182,11 +182,6 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
 
-      - name: Setup Rust Nightly
-        # yard-rustdoc depends on a particular rust doc JSON format
-        run: |
-          rustup toolchain install nightly-2024-08-19
-
       - name: Build Docs
         working-directory: bindings/ruby
         run: bundle exec rake doc

--- a/bindings/ruby/Rakefile
+++ b/bindings/ruby/Rakefile
@@ -52,7 +52,7 @@ namespace :doc do
     target_dir = "tmp"
     ext_dir = "opendal-ruby"
     run(<<~CMD)
-      cargo +nightly-2024-08-19 rustdoc \
+      cargo rustdoc \
         --target-dir #{target_dir} \
         --package #{ext_dir} \
         -Zunstable-options \

--- a/bindings/ruby/Rakefile
+++ b/bindings/ruby/Rakefile
@@ -52,7 +52,7 @@ namespace :doc do
     target_dir = "tmp"
     ext_dir = "opendal-ruby"
     run(<<~CMD)
-      cargo rustdoc \
+      cargo +nightly-2025-03-18 rustdoc \
         --target-dir #{target_dir} \
         --package #{ext_dir} \
         -Zunstable-options \


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

Try to use new nightly rust to build ruby docs instead of an old nightly.

# What changes are included in this PR?

The current usage of old nightly breaks https://github.com/apache/opendal/pull/6154

# Are there any user-facing changes?

None
