### PR TITLE
feat(java): add ReadOptions for read methods

### DIFF
--- a/bindings/java/src/async_operator.rs
+++ b/bindings/java/src/async_operator.rs
@@ -29,14 +29,14 @@ use jni::sys::jobject;
 use jni::sys::jsize;
 use jni::JNIEnv;
 use opendal::layers::BlockingLayer;
-use opendal::raw::PresignedRequest;
 use opendal::Entry;
-use opendal::Error;
-use opendal::ErrorKind;
 use opendal::Operator;
 use opendal::Scheme;
 
-use crate::convert::{jmap_to_hashmap, read_int64_field, read_map_field, read_string_field};
+use crate::convert::{
+    bytes_to_jbytearray, jmap_to_hashmap, offset_length_to_range, read_int64_field, read_map_field,
+    read_string_field,
+};
 use crate::convert::{jstring_to_string, read_bool_field};
 use crate::executor::executor_or_default;
 use crate::executor::get_current_env;
@@ -253,17 +253,13 @@ fn intern_stat(
     let path = jstring_to_string(env, &path)?;
 
     executor_or_default(env, executor)?.spawn(async move {
-        let result = do_stat(op, path).await;
+        let metadata = op.stat(&path).await.map_err(Into::into);
+        let mut env = unsafe { get_current_env() };
+        let result = metadata.and_then(|metadata| make_metadata(&mut env, metadata));
         complete_future(id, result.map(JValueOwned::Object))
     });
 
     Ok(id)
-}
-
-async fn do_stat<'local>(op: &mut Operator, path: String) -> Result<JObject<'local>> {
-    let metadata = op.stat(&path).await?;
-    let mut env = unsafe { get_current_env() };
-    make_metadata(&mut env, metadata)
 }
 
 /// # Safety
@@ -299,37 +295,18 @@ fn intern_read(
     let offset = read_int64_field(env, &options, "offset")?;
     let length = read_int64_field(env, &options, "length")?;
 
+    let mut read_op = op.read_with(&path);
+    read_op = read_op.range(offset_length_to_range(offset, length)?);
+
     executor_or_default(env, executor)?.spawn(async move {
-        let result = do_read(op, path, offset, length).await;
-        complete_future(id, result.map(JValueOwned::Object))
+        let result = read_op.await.map_err(Into::into);
+
+        let mut env = unsafe { get_current_env() };
+        let result = result.and_then(|bs| bytes_to_jbytearray(&mut env, bs.to_bytes()));
+        complete_future(id, result.map(|bs| JValueOwned::Object(bs.into())))
     });
 
     Ok(id)
-}
-
-async fn do_read<'local>(
-    op: &mut Operator,
-    path: String,
-    offset: i64,
-    length: i64,
-) -> Result<JObject<'local>> {
-    let offset = u64::try_from(offset)
-        .map_err(|_| Error::new(ErrorKind::RangeNotSatisfied, "offset must be non-negative"))?;
-
-    let content = if length == -1 {
-        op.read_with(&path).range(offset..).await?.to_bytes()
-    } else {
-        let length = u64::try_from(length)
-            .map_err(|_| Error::new(ErrorKind::RangeNotSatisfied, "length must be non-negative"))?;
-        op.read_with(&path)
-            .range(offset..(offset + length))
-            .await?
-            .to_bytes()
-    };
-
-    let env = unsafe { get_current_env() };
-    let result = env.byte_array_from_slice(&content)?;
-    Ok(result.into())
 }
 
 /// # Safety
@@ -664,7 +641,7 @@ fn intern_presign_read(
     let expire = Duration::from_nanos(expire as u64);
 
     executor_or_default(env, executor)?.spawn(async move {
-        let result = do_presign_read(op, path, expire).await;
+        let result = op.presign_read(&path, expire).await.map_err(Into::into);
         let mut env = unsafe { get_current_env() };
         let result = result.and_then(|req| make_presigned_request(&mut env, req));
         complete_future(id, result.map(JValueOwned::Object))
@@ -672,15 +649,6 @@ fn intern_presign_read(
 
     Ok(id)
 }
-
-async fn do_presign_read(
-    op: &mut Operator,
-    path: String,
-    expire: Duration,
-) -> Result<PresignedRequest> {
-    Ok(op.presign_read(&path, expire).await?)
-}
-
 /// # Safety
 ///
 /// This function should not be called before the Operator is ready.
@@ -713,21 +681,13 @@ fn intern_presign_write(
     let expire = Duration::from_nanos(expire as u64);
 
     executor_or_default(env, executor)?.spawn(async move {
-        let result = do_presign_write(op, path, expire).await;
+        let result = op.presign_write(&path, expire).await.map_err(Into::into);
         let mut env = unsafe { get_current_env() };
         let result = result.and_then(|req| make_presigned_request(&mut env, req));
         complete_future(id, result.map(JValueOwned::Object))
     });
 
     Ok(id)
-}
-
-async fn do_presign_write(
-    op: &mut Operator,
-    path: String,
-    expire: Duration,
-) -> Result<PresignedRequest> {
-    Ok(op.presign_write(&path, expire).await?)
 }
 
 /// # Safety
@@ -762,21 +722,13 @@ fn intern_presign_stat(
     let expire = Duration::from_nanos(expire as u64);
 
     executor_or_default(env, executor)?.spawn(async move {
-        let result = do_presign_stat(op, path, expire).await;
+        let result = op.presign_stat(&path, expire).await.map_err(Into::into);
         let mut env = unsafe { get_current_env() };
         let result = result.and_then(|req| make_presigned_request(&mut env, req));
         complete_future(id, result.map(JValueOwned::Object))
     });
 
     Ok(id)
-}
-
-async fn do_presign_stat(
-    op: &mut Operator,
-    path: String,
-    expire: Duration,
-) -> Result<PresignedRequest> {
-    Ok(op.presign_stat(&path, expire).await?)
 }
 
 fn make_object<'local>(

--- a/bindings/java/src/convert.rs
+++ b/bindings/java/src/convert.rs
@@ -77,6 +77,14 @@ pub(crate) fn read_bool_field(
     Ok(env.get_field(obj, field, "Z")?.z()?)
 }
 
+pub(crate) fn read_int64_field(
+    env: &mut JNIEnv<'_>,
+    obj: &JObject,
+    field: &str,
+) -> crate::Result<i64> {
+    Ok(env.get_field(obj, field, "J")?.j()?)
+}
+
 pub(crate) fn read_string_field(
     env: &mut JNIEnv<'_>,
     obj: &JObject,

--- a/bindings/java/src/executor.rs
+++ b/bindings/java/src/executor.rs
@@ -118,7 +118,7 @@ pub(crate) fn make_tokio_executor(env: &mut JNIEnv, cores: usize) -> Result<Exec
         .worker_threads(cores)
         .thread_name_fn(move || {
             let id = counter.fetch_add(1, Ordering::SeqCst);
-            format!("opendal-tokio-worker-{}", id)
+            format!("opendal-tokio-worker-{id}")
         })
         .on_thread_start(move || {
             ENV.with(|cell| {

--- a/bindings/java/src/main/java/org/apache/opendal/AsyncOperator.java
+++ b/bindings/java/src/main/java/org/apache/opendal/AsyncOperator.java
@@ -242,7 +242,15 @@ public class AsyncOperator extends NativeObject {
     }
 
     public CompletableFuture<byte[]> read(String path) {
-        final long requestId = read(nativeHandle, executorHandle, path);
+        return read(path, ReadOptions.builder().build());
+    }
+
+    public CompletableFuture<byte[]> read(String path, long offset, long length) {
+        return read(path, ReadOptions.builder().offset(offset).length(length).build());
+    }
+
+    public CompletableFuture<byte[]> read(String path, ReadOptions options) {
+        final long requestId = read(nativeHandle, executorHandle, path, options);
         return AsyncRegistry.take(requestId);
     }
 
@@ -303,7 +311,7 @@ public class AsyncOperator extends NativeObject {
 
     private static native long constructor(long executorHandle, String scheme, Map<String, String> map);
 
-    private static native long read(long nativeHandle, long executorHandle, String path);
+    private static native long read(long nativeHandle, long executorHandle, String path, ReadOptions options);
 
     private static native long write(
             long nativeHandle, long executorHandle, String path, byte[] content, WriteOptions options);

--- a/bindings/java/src/main/java/org/apache/opendal/Operator.java
+++ b/bindings/java/src/main/java/org/apache/opendal/Operator.java
@@ -96,7 +96,15 @@ public class Operator extends NativeObject {
     }
 
     public byte[] read(String path) {
-        return read(nativeHandle, path);
+        return read(path, ReadOptions.builder().build());
+    }
+
+    public byte[] read(String path, long offset, long length) {
+        return read(path, ReadOptions.builder().offset(offset).length(length).build());
+    }
+
+    public byte[] read(String path, ReadOptions options) {
+        return read(nativeHandle, path, options);
     }
 
     public OperatorInputStream createInputStream(String path) {
@@ -142,7 +150,7 @@ public class Operator extends NativeObject {
 
     private static native void write(long op, String path, byte[] content, WriteOptions options);
 
-    private static native byte[] read(long op, String path);
+    private static native byte[] read(long op, String path, ReadOptions options);
 
     private static native void delete(long op, String path);
 

--- a/bindings/java/src/main/java/org/apache/opendal/ReadOptions.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ReadOptions.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.opendal;
+
+import lombok.Builder;
+
+@Builder
+public class ReadOptions {
+    /**
+     * Sets the offset of the read operation.
+     */
+    public final long offset;
+
+    /**
+     * Sets the length of the read operation.
+     */
+    @Builder.Default
+    public final long length = -1;
+}

--- a/core/src/types/operator/blocking_operator.rs
+++ b/core/src/types/operator/blocking_operator.rs
@@ -665,7 +665,7 @@ impl BlockingOperator {
         self.writer_with(path).call()
     }
 
-    /// Create a new reader with extra options
+    /// Create a new writer with extra options
     ///
     /// # Examples
     ///


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #5825.

## Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Mentioned in the above issue

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Support read options for both async and blocking read in java binding

## Are there any user-facing changes?

Yes

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
