### PR TITLE
refactor(bindings/go): add ffiCall type for FFI function signature

### DIFF
--- a/.github/scripts/test_behavior/plan.py
+++ b/.github/scripts/test_behavior/plan.py
@@ -147,6 +147,7 @@ def calculate_hint(changed_files: list[str]) -> Hint:
             hint.binding_java = True
             hint.binding_python = True
             hint.binding_nodejs = True
+            hint.binding_go = True
             hint.bin_ofs = True
             for integration in INTEGRATIONS:
                 setattr(hint, f"integration_{integration}", True)
@@ -270,10 +271,6 @@ def generate_language_binding_cases(
     # Remove hdfs cases for java and go.
     if language == "java":
         cases = [v for v in cases if v["service"] != "hdfs"]
-    elif language == "go":
-        # hdfs: has problem with ListEmptyDir
-        # oss: timed out with ListSubDir
-        cases = [v for v in cases if v["service"] not in ["hdfs", "oss"]]
 
     if os.getenv("GITHUB_IS_PUSH") == "true":
         return cases

--- a/bindings/go/delete.go
+++ b/bindings/go/delete.go
@@ -52,7 +52,7 @@ var withOperatorDelete = withFFI(ffiOpts{
 	sym:    symOperatorDelete,
 	rType:  &ffi.TypePointer,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorDelete {
+}, func(ctx context.Context, ffiCall ffiCall) operatorDelete {
 	return func(op *opendalOperator, path string) error {
 		bytePath, err := BytePtrFromString(path)
 		if err != nil {

--- a/bindings/go/error.go
+++ b/bindings/go/error.go
@@ -106,7 +106,7 @@ var withErrorFree = withFFI(ffiOpts{
 	sym:    symErrorFree,
 	rType:  &ffi.TypeVoid,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(_ context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) errorFree {
+}, func(_ context.Context, ffiCall ffiCall) errorFree {
 	return func(e *opendalError) {
 		ffiCall(
 			nil,

--- a/bindings/go/ffi.go
+++ b/bindings/go/ffi.go
@@ -64,11 +64,13 @@ type ffiOpts struct {
 	aTypes []*ffi.Type
 }
 
+type ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)
+
 func withFFI[T any](
 	opts ffiOpts,
 	withFunc func(
 		ctx context.Context,
-		ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer),
+		ffiCall ffiCall,
 	) T,
 ) func(ctx context.Context, libopendal uintptr) (context.Context, error) {
 	return func(ctx context.Context, libopendal uintptr) (context.Context, error) {

--- a/bindings/go/lister.go
+++ b/bindings/go/lister.go
@@ -309,7 +309,7 @@ var withOperatorList = withFFI(ffiOpts{
 	sym:    symOperatorList,
 	rType:  &typeResultList,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorList {
+}, func(ctx context.Context, ffiCall ffiCall) operatorList {
 	return func(op *opendalOperator, path string) (*opendalLister, error) {
 		bytePath, err := BytePtrFromString(path)
 		if err != nil {
@@ -336,7 +336,7 @@ var withListerFree = withFFI(ffiOpts{
 	sym:    symListerFree,
 	rType:  &ffi.TypeVoid,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) listerFree {
+}, func(ctx context.Context, ffiCall ffiCall) listerFree {
 	return func(l *opendalLister) {
 		ffiCall(
 			nil,
@@ -353,7 +353,7 @@ var withListerNext = withFFI(ffiOpts{
 	sym:    symListerNext,
 	rType:  &typeResultListerNext,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) listerNext {
+}, func(ctx context.Context, ffiCall ffiCall) listerNext {
 	return func(l *opendalLister) (*opendalEntry, error) {
 		var result opendalResultListerNext
 		ffiCall(
@@ -375,7 +375,7 @@ var withEntryFree = withFFI(ffiOpts{
 	sym:    symEntryFree,
 	rType:  &ffi.TypePointer,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) entryFree {
+}, func(ctx context.Context, ffiCall ffiCall) entryFree {
 	return func(e *opendalEntry) {
 		ffiCall(
 			nil,
@@ -392,7 +392,7 @@ var withEntryName = withFFI(ffiOpts{
 	sym:    symEntryName,
 	rType:  &ffi.TypePointer,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) entryName {
+}, func(ctx context.Context, ffiCall ffiCall) entryName {
 	return func(e *opendalEntry) string {
 		var bytePtr *byte
 		ffiCall(
@@ -411,7 +411,7 @@ var withEntryPath = withFFI(ffiOpts{
 	sym:    symEntryPath,
 	rType:  &ffi.TypePointer,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) entryPath {
+}, func(ctx context.Context, ffiCall ffiCall) entryPath {
 	return func(e *opendalEntry) string {
 		var bytePtr *byte
 		ffiCall(

--- a/bindings/go/metadata.go
+++ b/bindings/go/metadata.go
@@ -93,7 +93,7 @@ var withMetaContentLength = withFFI(ffiOpts{
 	sym:    symMetadataContentLength,
 	rType:  &ffi.TypeUint64,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) metaContentLength {
+}, func(ctx context.Context, ffiCall ffiCall) metaContentLength {
 	return func(m *opendalMetadata) uint64 {
 		var length uint64
 		ffiCall(
@@ -112,7 +112,7 @@ var withMetaIsFile = withFFI(ffiOpts{
 	sym:    symMetadataIsFile,
 	rType:  &ffi.TypeUint8,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) metaIsFile {
+}, func(ctx context.Context, ffiCall ffiCall) metaIsFile {
 	return func(m *opendalMetadata) bool {
 		var result uint8
 		ffiCall(
@@ -131,7 +131,7 @@ var withMetaIsDir = withFFI(ffiOpts{
 	sym:    symMetadataIsDir,
 	rType:  &ffi.TypeUint8,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) metaIsDir {
+}, func(ctx context.Context, ffiCall ffiCall) metaIsDir {
 	return func(m *opendalMetadata) bool {
 		var result uint8
 		ffiCall(
@@ -150,7 +150,7 @@ var withMetaLastModified = withFFI(ffiOpts{
 	sym:    symMetadataLastModified,
 	rType:  &ffi.TypeSint64,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) metaLastModified {
+}, func(ctx context.Context, ffiCall ffiCall) metaLastModified {
 	return func(m *opendalMetadata) int64 {
 		var result int64
 		ffiCall(
@@ -169,7 +169,7 @@ var withMetaFree = withFFI(ffiOpts{
 	sym:    symMetadataFree,
 	rType:  &ffi.TypeVoid,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) metaFree {
+}, func(ctx context.Context, ffiCall ffiCall) metaFree {
 	return func(m *opendalMetadata) {
 		ffiCall(
 			nil,

--- a/bindings/go/operator.go
+++ b/bindings/go/operator.go
@@ -107,7 +107,7 @@ var withOperatorNew = withFFI(ffiOpts{
 	sym:    symOperatorNew,
 	rType:  &typeResultOperatorNew,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorNew {
+}, func(ctx context.Context, ffiCall ffiCall) operatorNew {
 	return func(scheme Scheme, opts *operatorOptions) (op *opendalOperator, err error) {
 		var byteName *byte
 		byteName, err = BytePtrFromString(scheme.Name())
@@ -137,7 +137,7 @@ var withOperatorFree = withFFI(ffiOpts{
 	sym:    symOperatorFree,
 	rType:  &ffi.TypeVoid,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(_ context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorFree {
+}, func(_ context.Context, ffiCall ffiCall) operatorFree {
 	return func(op *opendalOperator) {
 		ffiCall(
 			nil,
@@ -155,7 +155,7 @@ type operatorOptionsNew func() (opts *operatorOptions)
 var withOperatorOptionsNew = withFFI(ffiOpts{
 	sym:   symOperatorOptionsNew,
 	rType: &ffi.TypePointer,
-}, func(_ context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorOptionsNew {
+}, func(_ context.Context, ffiCall ffiCall) operatorOptionsNew {
 	return func() (opts *operatorOptions) {
 		ffiCall(unsafe.Pointer(&opts))
 		return
@@ -170,7 +170,7 @@ var withOperatorOptionsSet = withFFI(ffiOpts{
 	sym:    symOperatorOptionSet,
 	rType:  &ffi.TypeVoid,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
-}, func(_ context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorOptionsSet {
+}, func(_ context.Context, ffiCall ffiCall) operatorOptionsSet {
 	return func(opts *operatorOptions, key, value string) (err error) {
 		var (
 			byteKey   *byte
@@ -202,7 +202,7 @@ var withOperatorOptionsFree = withFFI(ffiOpts{
 	sym:    symOperatorOptionsFree,
 	rType:  &ffi.TypeVoid,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(_ context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorOptionsFree {
+}, func(_ context.Context, ffiCall ffiCall) operatorOptionsFree {
 	return func(opts *operatorOptions) {
 		ffiCall(
 			nil,
@@ -219,7 +219,7 @@ var withOperatorCopy = withFFI(ffiOpts{
 	sym:    symOperatorCopy,
 	rType:  &ffi.TypePointer,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorCopy {
+}, func(ctx context.Context, ffiCall ffiCall) operatorCopy {
 	return func(op *opendalOperator, src, dest string) (err error) {
 		var (
 			byteSrc  *byte
@@ -252,7 +252,7 @@ var withOperatorRename = withFFI(ffiOpts{
 	sym:    symOperatorRename,
 	rType:  &ffi.TypePointer,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorRename {
+}, func(ctx context.Context, ffiCall ffiCall) operatorRename {
 	return func(op *opendalOperator, src, dest string) (err error) {
 		var (
 			byteSrc  *byte
@@ -285,7 +285,7 @@ var withBytesFree = withFFI(ffiOpts{
 	sym:    symBytesFree,
 	rType:  &ffi.TypeVoid,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(_ context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) bytesFree {
+}, func(_ context.Context, ffiCall ffiCall) bytesFree {
 	return func(b *opendalBytes) {
 		ffiCall(
 			nil,

--- a/bindings/go/operator_info.go
+++ b/bindings/go/operator_info.go
@@ -243,7 +243,7 @@ var withOperatorInfoNew = withFFI(ffiOpts{
 	sym:    symOperatorInfoNew,
 	rType:  &ffi.TypePointer,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorInfoNew {
+}, func(ctx context.Context, ffiCall ffiCall) operatorInfoNew {
 	return func(op *opendalOperator) *opendalOperatorInfo {
 		var result *opendalOperatorInfo
 		ffiCall(
@@ -262,7 +262,7 @@ var withOperatorInfoFree = withFFI(ffiOpts{
 	sym:    symOperatorInfoFree,
 	rType:  &ffi.TypeVoid,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorInfoFree {
+}, func(ctx context.Context, ffiCall ffiCall) operatorInfoFree {
 	return func(info *opendalOperatorInfo) {
 		ffiCall(
 			nil,
@@ -279,7 +279,7 @@ var withOperatorInfoGetFullCapability = withFFI(ffiOpts{
 	sym:    symOperatorInfoGetFullCapability,
 	rType:  &typeCapability,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorInfoGetFullCapability {
+}, func(ctx context.Context, ffiCall ffiCall) operatorInfoGetFullCapability {
 	return func(info *opendalOperatorInfo) *opendalCapability {
 		var cap opendalCapability
 		ffiCall(
@@ -298,7 +298,7 @@ var withOperatorInfoGetNativeCapability = withFFI(ffiOpts{
 	sym:    symOperatorInfoGetNativeCapability,
 	rType:  &typeCapability,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorInfoGetNativeCapability {
+}, func(ctx context.Context, ffiCall ffiCall) operatorInfoGetNativeCapability {
 	return func(info *opendalOperatorInfo) *opendalCapability {
 		var cap opendalCapability
 		ffiCall(
@@ -317,7 +317,7 @@ var withOperatorInfoGetScheme = withFFI(ffiOpts{
 	sym:    symOperatorInfoGetScheme,
 	rType:  &ffi.TypePointer,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorInfoGetScheme {
+}, func(ctx context.Context, ffiCall ffiCall) operatorInfoGetScheme {
 	return func(info *opendalOperatorInfo) string {
 		var bytePtr *byte
 		ffiCall(
@@ -336,7 +336,7 @@ var withOperatorInfoGetRoot = withFFI(ffiOpts{
 	sym:    symOperatorInfoGetRoot,
 	rType:  &ffi.TypePointer,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorInfoGetRoot {
+}, func(ctx context.Context, ffiCall ffiCall) operatorInfoGetRoot {
 	return func(info *opendalOperatorInfo) string {
 		var bytePtr *byte
 		ffiCall(
@@ -355,7 +355,7 @@ var withOperatorInfoGetName = withFFI(ffiOpts{
 	sym:    symOperatorInfoGetName,
 	rType:  &ffi.TypePointer,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorInfoGetName {
+}, func(ctx context.Context, ffiCall ffiCall) operatorInfoGetName {
 	return func(info *opendalOperatorInfo) string {
 		var bytePtr *byte
 		ffiCall(

--- a/bindings/go/reader.go
+++ b/bindings/go/reader.go
@@ -257,7 +257,7 @@ var withOperatorRead = withFFI(ffiOpts{
 	sym:    symOperatorRead,
 	rType:  &typeResultRead,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorRead {
+}, func(ctx context.Context, ffiCall ffiCall) operatorRead {
 	return func(op *opendalOperator, path string) (opendalBytes, error) {
 		bytePath, err := BytePtrFromString(path)
 		if err != nil {
@@ -281,7 +281,7 @@ var withOperatorReader = withFFI(ffiOpts{
 	sym:    symOperatorReader,
 	rType:  &typeResultOperatorReader,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorReader {
+}, func(ctx context.Context, ffiCall ffiCall) operatorReader {
 	return func(op *opendalOperator, path string) (*opendalReader, error) {
 		bytePath, err := BytePtrFromString(path)
 		if err != nil {
@@ -308,7 +308,7 @@ var withReaderFree = withFFI(ffiOpts{
 	sym:    symReaderFree,
 	rType:  &ffi.TypeVoid,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) readerFree {
+}, func(ctx context.Context, ffiCall ffiCall) readerFree {
 	return func(r *opendalReader) {
 		ffiCall(
 			nil,
@@ -325,7 +325,7 @@ var withReaderRead = withFFI(ffiOpts{
 	sym:    symReaderRead,
 	rType:  &typeResultReaderRead,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) readerRead {
+}, func(ctx context.Context, ffiCall ffiCall) readerRead {
 	return func(r *opendalReader, buf []byte) (size uint, err error) {
 		var length = len(buf)
 		if length == 0 {
@@ -354,7 +354,7 @@ var withReaderSeek = withFFI(ffiOpts{
 	sym:    symReaderSeek,
 	rType:  &typeResultReaderSeek,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) readerSeek {
+}, func(ctx context.Context, ffiCall ffiCall) readerSeek {
 	return func(r *opendalReader, offset int64, whence int) (int64, error) {
 		var result resultReaderSeek
 		ffiCall(

--- a/bindings/go/stat.go
+++ b/bindings/go/stat.go
@@ -108,7 +108,7 @@ var withOperatorStat = withFFI(ffiOpts{
 	sym:    symOperatorStat,
 	rType:  &typeResultStat,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorStat {
+}, func(ctx context.Context, ffiCall ffiCall) operatorStat {
 	return func(op *opendalOperator, path string) (*opendalMetadata, error) {
 		bytePath, err := BytePtrFromString(path)
 		if err != nil {
@@ -135,7 +135,7 @@ var withOperatorIsExists = withFFI(ffiOpts{
 	sym:    symOperatorIsExist,
 	rType:  &typeResultIsExist,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorIsExist {
+}, func(ctx context.Context, ffiCall ffiCall) operatorIsExist {
 	return func(op *opendalOperator, path string) (bool, error) {
 		bytePath, err := BytePtrFromString(path)
 		if err != nil {

--- a/bindings/go/write.go
+++ b/bindings/go/write.go
@@ -197,7 +197,7 @@ var withOperatorWrite = withFFI(ffiOpts{
 	sym:    symOperatorWrite,
 	rType:  &ffi.TypePointer,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorWrite {
+}, func(ctx context.Context, ffiCall ffiCall) operatorWrite {
 	return func(op *opendalOperator, path string, data []byte) error {
 		bytePath, err := BytePtrFromString(path)
 		if err != nil {
@@ -223,7 +223,7 @@ var withOperatorCreateDir = withFFI(ffiOpts{
 	sym:    symOperatorCreateDir,
 	rType:  &ffi.TypePointer,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorCreateDir {
+}, func(ctx context.Context, ffiCall ffiCall) operatorCreateDir {
 	return func(op *opendalOperator, path string) error {
 		bytePath, err := BytePtrFromString(path)
 		if err != nil {
@@ -247,7 +247,7 @@ var withOperatorWriter = withFFI(ffiOpts{
 	sym:    symOperatorWriter,
 	rType:  &typeResultOperatorWriter,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) operatorWriter {
+}, func(ctx context.Context, ffiCall ffiCall) operatorWriter {
 	return func(op *opendalOperator, path string) (*opendalWriter, error) {
 		bytePath, err := BytePtrFromString(path)
 		if err != nil {
@@ -274,7 +274,7 @@ var withWriterFree = withFFI(ffiOpts{
 	sym:    symWriterFree,
 	rType:  &ffi.TypeVoid,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) writerFree {
+}, func(ctx context.Context, ffiCall ffiCall) writerFree {
 	return func(r *opendalWriter) {
 		ffiCall(
 			nil,
@@ -291,7 +291,7 @@ var withWriterWrite = withFFI(ffiOpts{
 	sym:    symWriterWrite,
 	rType:  &typeResultWriterWrite,
 	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) writerWrite {
+}, func(ctx context.Context, ffiCall ffiCall) writerWrite {
 	return func(r *opendalWriter, data []byte) (size int, err error) {
 		bytes := toOpendalBytes(data)
 		var result resultWriterWrite
@@ -315,7 +315,7 @@ var withWriterClose = withFFI(ffiOpts{
 	sym:    symWriterClose,
 	rType:  &ffi.TypePointer,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall func(rValue unsafe.Pointer, aValues ...unsafe.Pointer)) writerClose {
+}, func(ctx context.Context, ffiCall ffiCall) writerClose {
 	return func(r *opendalWriter) error {
 		var e *opendalError
 		ffiCall(


### PR DESCRIPTION
Part of #4892.

This PR:

1. Introduces a new type definition for the FFI function signature to enhance code maintainability and readability. This change standardizes FFI call handling across the codebase by replacing inline function signatures with a named type.

2. Enables all service tests for Go binding, which I believe is the final step needed to close #5326, as all feature requests in this issue have been completed.