### PR TITLE
fix(integrations/object_store): fix double percent encoding

### DIFF
--- a/integrations/object_store/src/store.rs
+++ b/integrations/object_store/src/store.rs
@@ -38,6 +38,7 @@ use object_store::PutResult;
 use object_store::{GetOptions, UploadPart};
 use object_store::{GetRange, GetResultPayload};
 use object_store::{GetResult, PutMode};
+use opendal::raw::percent_decode_path;
 use opendal::Buffer;
 use opendal::Writer;
 use opendal::{Operator, OperatorInfo};
@@ -148,9 +149,10 @@ impl ObjectStore for OpendalStore {
         bytes: PutPayload,
         opts: PutOptions,
     ) -> object_store::Result<PutResult> {
-        let mut future_write = self
-            .inner
-            .write_with(location.as_ref(), Buffer::from_iter(bytes.into_iter()));
+        let mut future_write = self.inner.write_with(
+            &percent_decode_path(location.as_ref()),
+            Buffer::from_iter(bytes.into_iter()),
+        );
         let opts_mode = opts.mode.clone();
         match opts.mode {
             PutMode::Overwrite => {}
@@ -192,7 +194,7 @@ impl ObjectStore for OpendalStore {
     ) -> object_store::Result<Box<dyn MultipartUpload>> {
         let writer = self
             .inner
-            .writer_with(location.as_ref())
+            .writer_with(&percent_decode_path(location.as_ref()))
             .concurrent(8)
             .into_send()
             .await
@@ -220,8 +222,9 @@ impl ObjectStore for OpendalStore {
         location: &Path,
         options: GetOptions,
     ) -> object_store::Result<GetResult> {
+        let raw_location = percent_decode_path(location.as_ref());
         let meta = {
-            let mut s = self.inner.stat_with(location.as_ref());
+            let mut s = self.inner.stat_with(&raw_location);
             if let Some(version) = &options.version {
                 s = s.version(version.as_str())
             }
@@ -260,7 +263,7 @@ impl ObjectStore for OpendalStore {
         }
 
         let reader = {
-            let mut r = self.inner.reader_with(location.as_ref());
+            let mut r = self.inner.reader_with(raw_location.as_ref());
             if let Some(version) = options.version {
                 r = r.version(version.as_str());
             }
@@ -322,7 +325,7 @@ impl ObjectStore for OpendalStore {
 
     async fn delete(&self, location: &Path) -> object_store::Result<()> {
         self.inner
-            .delete(location.as_ref())
+            .delete(&percent_decode_path(location.as_ref()))
             .into_send()
             .await
             .map_err(|err| format_object_store_error(err, location.as_ref()))?;
@@ -333,7 +336,9 @@ impl ObjectStore for OpendalStore {
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
         // object_store `Path` always removes trailing slash
         // need to add it back
-        let path = prefix.map_or("".into(), |x| format!("{}/", x));
+        let path = prefix.map_or("".into(), |x| {
+            format!("{}/", percent_decode_path(x.as_ref()))
+        });
 
         let lister_fut = self.inner.lister_with(&path).recursive(true);
         let fut = async move {
@@ -358,7 +363,9 @@ impl ObjectStore for OpendalStore {
         prefix: Option<&Path>,
         offset: &Path,
     ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
-        let path = prefix.map_or("".into(), |x| format!("{}/", x));
+        let path = prefix.map_or("".into(), |x| {
+            format!("{}/", percent_decode_path(x.as_ref()))
+        });
         let offset = offset.clone();
 
         // clone self for 'static lifetime
@@ -418,7 +425,9 @@ impl ObjectStore for OpendalStore {
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
-        let path = prefix.map_or("".into(), |x| format!("{}/", x));
+        let path = prefix.map_or("".into(), |x| {
+            format!("{}/", percent_decode_path(x.as_ref()))
+        });
         let mut stream = self
             .inner
             .lister_with(&path)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6129.

# What changes are included in this PR?

Performing `percent_decode_path` in `object-store-opendal` before invoking inner operations

# Are there any user-facing changes?

No