### PR TITLE
feat(core): support sharing one redb database between different Operators

### DIFF
--- a/core/src/services/redb/backend.rs
+++ b/core/src/services/redb/backend.rs
@@ -98,6 +98,18 @@ impl Builder for RedbBuilder {
                 .into()
         };
 
+        {
+            let write_txn = db.begin_write().map_err(parse_transaction_error)?;
+
+            let table_define: redb::TableDefinition<&str, &[u8]> =
+                redb::TableDefinition::new(&table_name);
+
+            write_txn
+                .open_table(table_define)
+                .map_err(parse_table_error)?;
+            write_txn.commit().map_err(parse_commit_error)?;
+        }
+
         Ok(RedbBackend::new(Adapter {
             datadir: datadir_path,
             table: table_name,

--- a/core/src/services/redb/backend.rs
+++ b/core/src/services/redb/backend.rs
@@ -50,6 +50,18 @@ pub struct RedbBuilder {
 }
 
 impl RedbBuilder {
+    /// Set the database for Redb.
+    ///
+    /// This method should be called when you want to
+    /// use multiple tables of one database because
+    /// Redb doesn't allow opening a database that have been opened.
+    ///
+    /// Don't forget to set Builder's `datadir` to the origin datadir of `db`.
+    pub fn database(mut self, db: Arc<redb::Database>) -> Self {
+        self.database = Some(db);
+        self
+    }
+
     /// Set the path to the redb data directory. Will create if not exists.
     pub fn datadir(mut self, path: &str) -> Self {
         self.config.datadir = Some(path.into());
@@ -65,12 +77,6 @@ impl RedbBuilder {
     /// Set the root for Redb.
     pub fn root(mut self, path: &str) -> Self {
         self.config.root = Some(path.into());
-        self
-    }
-
-    /// Set the database for Redb
-    pub fn database(mut self, db: &Arc<redb::Database>) -> Self {
-        self.database = Some(db.clone());
         self
     }
 }

--- a/core/src/services/redb/backend.rs
+++ b/core/src/services/redb/backend.rs
@@ -275,7 +275,7 @@ fn create_table(db: &redb::Database, table: &str) -> Result<()> {
 
         match read_txn.open_table(table_define) {
             Ok(_) => return Ok(()),
-            Err(e) if matches!(e, redb::TableError::TableDoesNotExist(_)) => (),
+            Err(redb::TableError::TableDoesNotExist(_)) => (),
             Err(e) => return Err(parse_table_error(e)),
         }
     }

--- a/core/src/services/redb/backend.rs
+++ b/core/src/services/redb/backend.rs
@@ -56,19 +56,36 @@ impl RedbBuilder {
     /// use multiple tables of one database because
     /// Redb doesn't allow opening a database that have been opened.
     ///
-    /// Don't forget to set Builder's `datadir` to the origin datadir of `db`.
+    /// <div class="warning">
+    ///
+    /// `datadir` and `database` should not be set simultaneously.
+    /// If both are set, `database` will take precedence.
+    ///
+    /// </div>
     pub fn database(mut self, db: Arc<redb::Database>) -> Self {
         self.database = Some(db);
         self
     }
 
     /// Set the path to the redb data directory. Will create if not exists.
+    ///
+    ///
+    /// <div class="warning">
+    ///
+    /// Opening redb database via `datadir` takes away the ability to access multiple redb tables.
+    /// If you need to access multiple redb tables, the correct solution is to
+    /// create an `Arc<redb::database>` beforehand and then share it via [`database`]
+    /// with multiple builders where every builder will open one redb table.
+    ///
+    /// </div>
+    ///
+    /// [`database`]: RedbBuilder::database
     pub fn datadir(mut self, path: &str) -> Self {
         self.config.datadir = Some(path.into());
         self
     }
 
-    /// Set the table name for Redb.
+    /// Set the table name for Redb. Will create if not exists.
     pub fn table(mut self, table: &str) -> Self {
         self.config.table = Some(table.into());
         self
@@ -86,28 +103,30 @@ impl Builder for RedbBuilder {
     type Config = RedbConfig;
 
     fn build(self) -> Result<impl Access> {
-        let datadir_path = self.config.datadir.ok_or_else(|| {
-            Error::new(ErrorKind::ConfigInvalid, "datadir is required but not set")
-                .with_context("service", Scheme::Redb)
-        })?;
-
         let table_name = self.config.table.ok_or_else(|| {
             Error::new(ErrorKind::ConfigInvalid, "table is required but not set")
                 .with_context("service", Scheme::Redb)
         })?;
 
-        let db = if let Some(db) = self.database {
-            db
+        let (datadir, db) = if let Some(db) = self.database {
+            (None, db)
         } else {
-            redb::Database::create(&datadir_path)
+            let datadir = self.config.datadir.ok_or_else(|| {
+                Error::new(ErrorKind::ConfigInvalid, "datadir is required but not set")
+                    .with_context("service", Scheme::Redb)
+            })?;
+
+            let db = redb::Database::create(&datadir)
                 .map_err(parse_database_error)?
-                .into()
+                .into();
+
+            (Some(datadir), db)
         };
 
         create_table(&db, &table_name)?;
 
         Ok(RedbBackend::new(Adapter {
-            datadir: datadir_path,
+            datadir,
             table: table_name,
             db,
         })
@@ -120,7 +139,7 @@ pub type RedbBackend = kv::Backend<Adapter>;
 
 #[derive(Clone)]
 pub struct Adapter {
-    datadir: String,
+    datadir: Option<String>,
     table: String,
     db: Arc<redb::Database>,
 }
@@ -139,7 +158,7 @@ impl kv::Adapter for Adapter {
     fn info(&self) -> kv::Info {
         kv::Info::new(
             Scheme::Redb,
-            &self.datadir,
+            &self.table,
             Capability {
                 read: true,
                 write: true,

--- a/core/src/services/redb/docs.md
+++ b/core/src/services/redb/docs.md
@@ -15,9 +15,10 @@ This service can be used to:
 
 ## Configuration
 
-- `datadir`: Set the path to the redb data directory
+- `datadir`: Set the path to the redb data directory.
+- `table`: Set the table name for Redb.
 
-You can refer to [`RedbBuilder`]'s docs for more information
+You can refer to [`RedbBuilder`]'s docs for more information.
 
 ## Example
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6172 .

# What changes are included in this PR?

- [x] `RedbBuilder::database(self, db: &Arc<redb::Database>) -> Self`
- [x] Creating the specified table at build stage if it doesn't exist (It's really important because trying to get something in table is a common need, but errors will occur when the table doesn't exist)

# Are there any user-facing changes?

- Users got a new method: `opendal::services::Redb::database(self, db: &Arc<redb::Database>) -> Self`
- (breaking change) `OperatorInfo::name` for redb become table name instead of datadir.