### PR TITLE
refactor(core): Put Backtrace in a box to reduce error size

### DIFF
--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -529,10 +529,7 @@ fn infer_storage_name_from_endpoint(endpoint: &str) -> Option<String> {
         .trim_end_matches('/')
         .to_lowercase();
 
-    if KNOWN_AZBLOB_ENDPOINT_SUFFIX
-        .iter()
-        .any(|s| *s == endpoint_suffix.as_str())
-    {
+    if KNOWN_AZBLOB_ENDPOINT_SUFFIX.contains(&endpoint_suffix.as_str()) {
         storage_name.map(|s| s.to_string())
     } else {
         None

--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -366,10 +366,7 @@ fn infer_storage_name_from_endpoint(endpoint: &str) -> Option<String> {
         .trim_end_matches('/')
         .to_lowercase();
 
-    if KNOWN_AZDLS_ENDPOINT_SUFFIX
-        .iter()
-        .any(|s| *s == endpoint_suffix.as_str())
-    {
+    if KNOWN_AZDLS_ENDPOINT_SUFFIX.contains(&endpoint_suffix.as_str()) {
         storage_name.map(|s| s.to_string())
     } else {
         None

--- a/core/src/types/blocking_write/std_writer.rs
+++ b/core/src/types/blocking_write/std_writer.rs
@@ -49,14 +49,10 @@ impl StdWriter {
         self.flush()?;
 
         let Some(w) = &mut self.w else {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "writer has been closed",
-            ));
+            return Err(std::io::Error::other("writer has been closed"));
         };
 
-        w.close()
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+        w.close().map_err(std::io::Error::other)?;
 
         // Drop writer after close succeed;
         self.w = None;
@@ -68,10 +64,7 @@ impl StdWriter {
 impl Write for StdWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         let Some(w) = &mut self.w else {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "writer has been closed",
-            ));
+            return Err(std::io::Error::other("writer has been closed"));
         };
 
         loop {
@@ -81,19 +74,14 @@ impl Write for StdWriter {
             }
 
             let bs = self.buf.get().expect("frozen buffer must be valid");
-            let n = w
-                .write(Buffer::from(bs))
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            let n = w.write(Buffer::from(bs)).map_err(std::io::Error::other)?;
             self.buf.advance(n);
         }
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
         let Some(w) = &mut self.w else {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "writer has been closed",
-            ));
+            return Err(std::io::Error::other("writer has been closed"));
         };
 
         loop {
@@ -103,8 +91,7 @@ impl Write for StdWriter {
                 return Ok(());
             };
 
-            w.write(Buffer::from(bs))
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err))?;
+            w.write(Buffer::from(bs)).map_err(std::io::Error::other)?;
             self.buf.clean();
         }
     }

--- a/integrations/virtiofs/src/error.rs
+++ b/integrations/virtiofs/src/error.rs
@@ -61,21 +61,15 @@ impl From<Error> for io::Error {
             Error::VhostUserFsError { message, source } => {
                 let message = format!("Vhost user fs error: {}", message);
                 match source {
-                    Some(source) => io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("{}, source: {:?}", message, source),
-                    ),
-                    None => io::Error::new(io::ErrorKind::Other, message),
+                    Some(source) => io::Error::other(format!("{}, source: {:?}", message, source)),
+                    None => io::Error::other(message),
                 }
             }
             Error::Unexpected { message, source } => {
                 let message = format!("Unexpected error: {}", message);
                 match source {
-                    Some(source) => io::Error::new(
-                        io::ErrorKind::Other,
-                        format!("{}, source: {:?}", message, source),
-                    ),
-                    None => io::Error::new(io::ErrorKind::Other, message),
+                    Some(source) => io::Error::other(format!("{}, source: {:?}", message, source)),
+                    None => io::Error::other(message),
                 }
             }
         }


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

This PR will address clippy issues around:

```rust
error: the `Err`-variant returned from this function is very large
   --> src/services/oss/core.rs:176:10
    |
176 |     ) -> Result<http::request::Builder> {
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the `Err`-variant is at least 128 bytes
    |
    = help: try reducing the size of `types::error::Error`, for example by boxing large elements or replacing it with `Box<types::error::Error>`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
```

# What changes are included in this PR?

This PR also fixed other clippy issues at the same time to make CI happy.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
