### PR TITLE
Support parsing AzdlConfig from Azure Storage connection strings

### DIFF
--- a/core/src/services/azdls/config.rs
+++ b/core/src/services/azdls/config.rs
@@ -21,6 +21,10 @@ use std::fmt::Formatter;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::*;
+
+use super::endpoint::DfsEndpoint;
+
 /// Azure Data Lake Storage Gen2 Support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct AzdlsConfig {
@@ -58,6 +62,153 @@ pub struct AzdlsConfig {
     pub authority_host: Option<String>,
 }
 
+impl AzdlsConfig {
+    const AZURITE_DEFAULT_STORAGE_ACCOUNT_NAME: &str = "devstoreaccount1";
+    const AZURITE_DEFAULT_STORAGE_ACCOUNT_KEY: &str =
+        "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+    /// Create a new `AzdlsConfig` instance from an [Azure Storage connection string][1].
+    ///
+    /// [1]: https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string
+    ///
+    /// # Example
+    /// ```
+    /// use opendal::services::AzdlsConfig;
+    ///
+    /// let conn_str = "AccountName=example;DefaultEndpointsProtocol=https;EndpointSuffix=core.windows.net";
+    ///
+    /// let mut config = AzdlsConfig::try_from_connection_string(&conn_str).unwrap();
+    ///
+    /// // Set other parameters if needed
+    /// config.client_id = Some("myClientId".to_string());
+    /// config.client_secret = Some("myClientSecret".to_string());
+    /// config.tenant_id = Some("myTenantId".to_string());
+    /// ```
+    pub fn try_from_connection_string(conn_str: &str) -> Result<Self> {
+        let key_value_pairs = parse_connection_string(conn_str)?;
+
+        let mut config = Self::default();
+
+        // ADLS doesn't support a dedicated parameter like `BlobEndpoint`,
+        // `FileEndpoint`, etc.
+        // Instead, we need to build up the endpoint from its parts.
+        let mut endpoint = DfsEndpoint::default();
+
+        // Values used to parse and validate Azurite parameters.
+        let mut use_development_storage = false;
+        let mut development_storage_proxy_uri = None;
+
+        for (key, value) in key_value_pairs {
+            match key {
+                "AccountName" => {
+                    config.account_name = Some(value.to_string());
+                    endpoint.set_account_name(value)?;
+                }
+                "AccountKey" => {
+                    config.account_key = Some(value.to_string());
+                }
+                "DefaultEndpointsProtocol" => {
+                    endpoint.set_protocol(value)?;
+                }
+                "EndpointSuffix" => {
+                    endpoint.set_suffix(value)?;
+                }
+                "SharedAccessSignature" => {
+                    config.sas_token = Some(value.to_string());
+                }
+                "BlobEndpoint" | "FileEndpoint" | "QueueEndpoint" | "TableEndpoint" => {
+                    // ADLSv2 endpoints need to be built up explicitly from the
+                    // `AccountName`, `EndpointSuffix` and `DefaultEndpointsProtocol`
+                    // fields instead. There is currently no equivalent for DFS.
+                    return Err(Error::new(
+                        ErrorKind::ConfigInvalid,
+                        format!("{} is not supported with Azdls", key),
+                    ));
+                }
+                "UseDevelopmentStorage" => {
+                    if value == "true" {
+                        use_development_storage = true;
+                    }
+                }
+                "DevelopmentStorageProxyUri" => {
+                    development_storage_proxy_uri = Some(value.to_string());
+                }
+                _ => {
+                    return Err(Error::new(
+                        ErrorKind::ConfigInvalid,
+                        format!("Unexpected key in connection string: {}", key),
+                    ));
+                }
+            }
+        }
+
+        if use_development_storage {
+            apply_azurite_parameters(&mut config, development_storage_proxy_uri)?;
+        } else {
+            endpoint.validate()?;
+            config.endpoint = Some(endpoint.to_string());
+        }
+
+        Ok(config)
+    }
+}
+
+/// Takes a semicolon-delimited Azure Storage connection string and returns
+/// key-value pairs split from it.
+fn parse_connection_string(conn_str: &str) -> Result<Vec<(&str, &str)>> {
+    conn_str
+        .split(';')
+        .map(|field| {
+            field.split_once('=').ok_or(Error::new(
+                ErrorKind::ConfigInvalid,
+                format!(
+                    "Invalid connection string, expected '=' in field: {}",
+                    field
+                ),
+            ))
+        })
+        .collect()
+}
+
+/// Applies development storage-specific defaults.
+fn apply_azurite_parameters(
+    config: &mut AzdlsConfig,
+    development_storage_proxy_uri: Option<String>,
+) -> Result<()> {
+    if development_storage_proxy_uri.is_none() {
+        // `UseDevelopmentStorage` was set without `DevelopmentStorageProxyUri`.
+        //
+        // At time of this writing, Azurite doesn't yet support ADLS (see
+        // https://github.com/Azure/Azurite/issues/553 for tracking).
+        //
+        // This implementation tries to be forward-compatible for when
+        // Azurite starts to support ADLSv2.
+        // More specifically, we can re-use defaults for account name and key,
+        // but the endpoint is dependent on the storage implementation. So,
+        // when support arrives, users will need to pass
+        // `DevelopmentStorageProxyUri` explicitly.
+        return Err(Error::new(
+            ErrorKind::ConfigInvalid,
+            "AzdlsConfig: UseDevelopmentStorage isn't supported without DevelopmentStorageProxyUri",
+        ));
+    }
+
+    // `DevelopmentStorage` aka Azurite was enabled and we have proxy
+    // URI available. Let's set the passed URI and the corresponding defaults.
+    config.endpoint = development_storage_proxy_uri;
+
+    // We don't want to overwrite explicitly provided account values.
+    if config.account_name.is_none() {
+        config.account_name = Some(AzdlsConfig::AZURITE_DEFAULT_STORAGE_ACCOUNT_NAME.to_string());
+    }
+
+    if config.account_key.is_none() {
+        config.account_key = Some(AzdlsConfig::AZURITE_DEFAULT_STORAGE_ACCOUNT_KEY.to_string());
+    }
+
+    Ok(())
+}
+
 impl Debug for AzdlsConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut ds = f.debug_struct("AzdlsConfig");
@@ -85,5 +236,95 @@ impl Debug for AzdlsConfig {
             ds.field("sas_token", &"<redacted>");
         }
         ds.finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::services::AzdlsConfig;
+
+    #[test]
+    fn test_azdlsconfig_try_from_connection_string() {
+        let test_cases = vec![
+        (
+            "with minimal parameters",
+            "AccountName=example;EndpointSuffix=core.windows.net;DefaultEndpointsProtocol=https",
+            AzdlsConfig {
+                endpoint: Some("https://example.dfs.core.windows.net".to_string()),
+                account_name: Some("example".to_string()),
+                ..Default::default()
+            },
+        ),
+        (
+            "more parameters",
+            "AccountName=example;AccountKey=myKey;EndpointSuffix=core.windows.net;DefaultEndpointsProtocol=https;SharedAccessSignature=mySas",
+            AzdlsConfig {
+                endpoint: Some("https://example.dfs.core.windows.net".to_string()),
+                account_name: Some("example".to_string()),
+                account_key: Some("myKey".to_string()),
+                sas_token: Some("mySas".to_string()),
+                ..Default::default()
+            },
+        ),
+        (
+            "development storage",
+            "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://127.0.0.1:12345",
+            AzdlsConfig {
+                endpoint: Some("http://127.0.0.1:12345".to_string()),
+                account_name: Some(AzdlsConfig::AZURITE_DEFAULT_STORAGE_ACCOUNT_NAME.to_string()),
+                account_key: Some(AzdlsConfig::AZURITE_DEFAULT_STORAGE_ACCOUNT_KEY.to_string()),
+                ..Default::default()
+            },
+        ),
+        (
+            "development storage with custom account values",
+            "UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://127.0.0.1:12345;AccountName=myAccount;AccountKey=myKey",
+            AzdlsConfig {
+                endpoint: Some("http://127.0.0.1:12345".to_string()),
+                account_name: Some("myAccount".to_string()),
+                account_key: Some("myKey".to_string()),
+                ..Default::default()
+            },
+        )];
+
+        for (name, conn_str, expected) in test_cases {
+            let config = AzdlsConfig::try_from_connection_string(conn_str).unwrap();
+            assert_eq!(config, expected, "Test case: {}", name);
+        }
+    }
+
+    #[test]
+    fn test_azdlsconfig_try_from_connection_string_fails() {
+        let test_cases = vec![
+            (
+                "missing equals",
+                "AccountNameexample;AccountKey=example;EndpointSuffix=core.windows.net;DefaultEndpointsProtocol=https",
+            ),
+            (
+                "invalid key",
+                "InvalidKey=example;AccountName=example;EndpointSuffix=core.windows.net;DefaultEndpointsProtocol=https",
+            ),
+            (
+                "with endpoint key",
+                "BlobEndpoint=https://example.blob.core.windows.net;AccountName=example",
+            ),
+            (
+                "with unknown endpoint suffix",
+                "AccountName=example;EndpointSuffix=some.where.unknown.com;DefaultEndpointsProtocol=https",
+            ),
+            (
+                "with invalid protocol",
+                "AccountName=example;EndpointSuffix=some.where.unknown.com;DefaultEndpointsProtocol=ftp",
+            ),
+            (
+                "with unspecified use of development storage",
+                "UseDevelopmentStorage=true"
+            ),
+        ];
+
+        for (name, conn_str) in test_cases {
+            let result = AzdlsConfig::try_from_connection_string(conn_str);
+            assert!(result.is_err(), "Test case: {}", name);
+        }
     }
 }

--- a/core/src/services/azdls/config.rs
+++ b/core/src/services/azdls/config.rs
@@ -240,7 +240,7 @@ impl Debug for AzdlsConfig {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::services::AzdlsConfig;
 
     #[test]

--- a/core/src/services/azdls/endpoint.rs
+++ b/core/src/services/azdls/endpoint.rs
@@ -59,6 +59,9 @@ impl DfsEndpoint {
         Ok(())
     }
 
+    // We only call account_name() _indirectly_ through `TryFrom`. The compiler
+    // doesn't recognize this and marks the method as dead code.
+    #[allow(dead_code)]
     pub(crate) fn account_name(&self) -> &str {
         &self.account_name
     }
@@ -199,7 +202,7 @@ impl TryFrom<&str> for DfsEndpoint {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::DfsEndpoint;
 
     #[test]

--- a/core/src/services/azdls/endpoint.rs
+++ b/core/src/services/azdls/endpoint.rs
@@ -1,0 +1,149 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::{Display, Formatter};
+
+use crate::*;
+
+/// DFS Endpoints are the endpoints used to access Azure Data Lake Storage Gen2.
+///
+/// This struct is used to build, parse and validate endpoint strings.
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct DfsEndpoint {
+    // Should be either "http" or "https".
+    protocol: String,
+
+    account_name: String,
+
+    // This is the suffix for the endpoint, e.g. "core.windows.net".
+    suffix: String,
+}
+
+impl DfsEndpoint {
+    /// Known endpoint suffix Azure Data Lake Storage Gen2 URI syntax.
+    ///
+    /// Azure public cloud: https://accountname.dfs.core.windows.net
+    /// Azure US Government: https://accountname.dfs.core.usgovcloudapi.net
+    /// Azure China: https://accountname.dfs.core.chinacloudapi.cn
+    const KNOWN_SUFFIXES: &[&str] = &[
+        "core.windows.net",
+        "core.usgovcloudapi.net",
+        "core.chinacloudapi.cn",
+    ];
+
+    const STORAGE: &str = "dfs";
+
+    pub(crate) fn set_protocol(&mut self, protocol: &str) -> Result<()> {
+        if protocol != "http" && protocol != "https" {
+            return Err(Error::new(
+                ErrorKind::ConfigInvalid,
+                format!("Invalid protocol: {} should be http or https", protocol),
+            ));
+        }
+
+        self.protocol = protocol.to_string();
+        Ok(())
+    }
+
+    pub(crate) fn account_name(&self) -> &str {
+        &self.account_name
+    }
+
+    pub(crate) fn set_account_name(&mut self, account_name: &str) -> Result<()> {
+        if account_name.is_empty() {
+            return Err(Error::new(
+                ErrorKind::ConfigInvalid,
+                "Account name cannot be empty".to_string(),
+            ));
+        }
+
+        self.account_name = account_name.to_string();
+        Ok(())
+    }
+
+    pub(crate) fn set_suffix(&mut self, suffix: &str) -> Result<()> {
+        if !Self::KNOWN_SUFFIXES.contains(&suffix) {
+            return Err(Error::new(
+                ErrorKind::ConfigInvalid,
+                format!("Unexpected endpoint suffix: {}", suffix),
+            ));
+        }
+
+        self.suffix = suffix.to_string();
+        Ok(())
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        if self.protocol.is_empty() {
+            return Err(Error::new(
+                ErrorKind::ConfigInvalid,
+                "DfsEndpoint: protocol cannot be empty".to_string(),
+            ));
+        }
+
+        if self.account_name.is_empty() {
+            return Err(Error::new(
+                ErrorKind::ConfigInvalid,
+                "DfsEndpoint: account name cannot be empty".to_string(),
+            ));
+        }
+
+        if self.suffix.is_empty() {
+            return Err(Error::new(
+                ErrorKind::ConfigInvalid,
+                "DfsEndpoint suffix cannot be empty".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl Display for DfsEndpoint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.validate().is_err() {
+            return Err(std::fmt::Error);
+        }
+
+        write!(
+            f,
+            "{}://{}.{}.{}",
+            self.protocol,
+            self.account_name,
+            Self::STORAGE,
+            self.suffix
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::DfsEndpoint;
+
+    #[test]
+    fn test_dfsendpoint_to_string() {
+        let endpoint = DfsEndpoint {
+            protocol: "https".to_string(),
+            account_name: "accountname".to_string(),
+            suffix: "core.windows.net".to_string(),
+        };
+
+        let expected = "https://accountname.dfs.core.windows.net";
+        let result = endpoint.to_string();
+        assert_eq!(result, expected);
+    }
+}

--- a/core/src/services/azdls/mod.rs
+++ b/core/src/services/azdls/mod.rs
@@ -16,6 +16,8 @@
 // under the License.
 
 #[cfg(feature = "services-azdls")]
+mod backend;
+#[cfg(feature = "services-azdls")]
 mod core;
 #[cfg(feature = "services-azdls")]
 mod delete;
@@ -27,9 +29,8 @@ mod lister;
 mod writer;
 
 #[cfg(feature = "services-azdls")]
-mod backend;
-#[cfg(feature = "services-azdls")]
 pub use backend::AzdlsBuilder as Azdls;
 
 mod config;
+mod endpoint;
 pub use config::AzdlsConfig;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6211.

# Rationale for this change

As mentioned in the issue description. Azure SDKs tend to allow users to pass a connection string. This PR parsing functionality to populate an `AzdlsConfig` struct with fields from a connection string.

# What changes are included in this PR?

The primary change is the addition of a public `AzdlsConfig::try_from_connection_string(conn_str: &str) -> Result<Self>`.

There are some minor internal changes that come along with it:
 - I introduced a `DfsEndpoint` struct which helps to build up endpoints from individually parsed connection string fields
 - I refactored some code in `backend.rs` to reuse the `DfsEndpoint`, IMO it now nicely groups some utility functionality

# Are there any user-facing changes?
Yes, users will now be able pass Azure Storage connection strings to `AzdfsConfig::try_from_connection_string()`. Nothing user-facing is changed or removed.
