### PR TITLE
feat(bindings/java): Add WriteOptions support for new options API

### DIFF
--- a/bindings/java/src/convert.rs
+++ b/bindings/java/src/convert.rs
@@ -76,6 +76,10 @@ pub(crate) fn read_int64_field(env: &mut JNIEnv<'_>, obj: &JObject, field: &str)
     Ok(env.get_field(obj, field, "J")?.j()?)
 }
 
+pub(crate) fn read_int_field(env: &mut JNIEnv<'_>, obj: &JObject, field: &str) -> Result<i32> {
+    Ok(env.get_field(obj, field, "I")?.i()?)
+}
+
 pub(crate) fn read_string_field(
     env: &mut JNIEnv<'_>,
     obj: &JObject,

--- a/bindings/java/src/main/java/org/apache/opendal/WriteOptions.java
+++ b/bindings/java/src/main/java/org/apache/opendal/WriteOptions.java
@@ -79,4 +79,16 @@ public class WriteOptions {
      * Requires capability: writeWithIfNotExists
      */
     public final boolean ifNotExists;
+
+    /**
+     * Sets concurrent write operations for this writer.
+     */
+    @Builder.Default
+    public final int concurrent = 1;
+
+    /**
+     * Sets chunk size for buffered writes.
+     */
+    @Builder.Default
+    public final long chunk = -1L;
 }

--- a/bindings/java/src/operator.rs
+++ b/bindings/java/src/operator.rs
@@ -30,11 +30,11 @@ use opendal::options;
 
 use crate::convert::{
     bytes_to_jbytearray, jstring_to_string, offset_length_to_range, read_bool_field,
-    read_int64_field, read_map_field, read_string_field,
+    read_int64_field,
 };
-use crate::make_entry;
 use crate::make_metadata;
 use crate::Result;
+use crate::{make_entry, make_write_options};
 
 /// # Safety
 ///
@@ -127,25 +127,9 @@ fn intern_write(
 ) -> Result<()> {
     let path = jstring_to_string(env, &path)?;
     let content = env.convert_byte_array(content)?;
+    let write_opts = make_write_options(env, &options)?;
 
-    let append = read_bool_field(env, &options, "append")?;
-    let content_type = read_string_field(env, &options, "contentType")?;
-    let content_disposition = read_string_field(env, &options, "contentDisposition")?;
-    let cache_control = read_string_field(env, &options, "cacheControl")?;
-    let user_metadata = read_map_field(env, &options, "userMetadata")?;
-
-    let _ = op.write_options(
-        &path,
-        content,
-        options::WriteOptions {
-            append,
-            content_type,
-            content_disposition,
-            cache_control,
-            user_metadata,
-            ..Default::default()
-        },
-    )?;
+    let _ = op.write_options(&path, content, write_opts)?;
     Ok(())
 }
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncWriteOptionsTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncWriteOptionsTest.java
@@ -43,6 +43,37 @@ public class AsyncWriteOptionsTest extends BehaviorTestBase {
     }
 
     @Test
+    void testWriteWithChunk() {
+        assumeTrue(asyncOp().info.fullCapability.writeCanMulti);
+
+        final String path = UUID.randomUUID().toString();
+        final byte[] content = generateBytes(5 * 1024 * 1024);
+
+        WriteOptions options = WriteOptions.builder().chunk(1024 * 1024L).build();
+
+        asyncOp().write(path, content, options).join();
+
+        byte[] result = asyncOp().read(path).join();
+        assertThat(result).isEqualTo(content);
+    }
+
+    @Test
+    void testWriteWithConcurrentChunk() {
+        assumeTrue(asyncOp().info.fullCapability.writeCanMulti);
+
+        final String path = UUID.randomUUID().toString();
+        final byte[] content = generateBytes(5 * 1024 * 1024);
+
+        WriteOptions options =
+                WriteOptions.builder().chunk(1024 * 1024L).concurrent(4).build();
+
+        asyncOp().write(path, content, options).join();
+
+        byte[] result = asyncOp().read(path).join();
+        assertThat(result).isEqualTo(content);
+    }
+
+    @Test
     void testWriteWithCacheControl() {
         assumeTrue(asyncOp().info.fullCapability.writeWithCacheControl);
         final String path = UUID.randomUUID().toString();

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingWriteOptionTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingWriteOptionTest.java
@@ -89,4 +89,35 @@ public class BlockingWriteOptionTest extends BehaviorTestBase {
         assertThat(result.length).isEqualTo(contentOne.length + contentTwo.length);
         assertThat(result).isEqualTo("Test Data".getBytes());
     }
+
+    @Test
+    void testWriteWithChunk() {
+        assumeTrue(op().info.fullCapability.writeCanMulti);
+
+        final String path = UUID.randomUUID().toString();
+        final byte[] content = generateBytes(5 * 1024 * 1024);
+
+        WriteOptions options = WriteOptions.builder().chunk(1024 * 1024L).build();
+
+        op().write(path, content, options);
+
+        byte[] result = op().read(path);
+        assertThat(result).isEqualTo(content);
+    }
+
+    @Test
+    void testWriteWithConcurrentChunk() {
+        assumeTrue(op().info.fullCapability.writeCanMulti);
+
+        final String path = UUID.randomUUID().toString();
+        final byte[] content = generateBytes(5 * 1024 * 1024);
+
+        WriteOptions options =
+                WriteOptions.builder().chunk(1024 * 1024L).concurrent(4).build();
+
+        op().write(path, content, options);
+
+        byte[] result = op().read(path);
+        assertThat(result).isEqualTo(content);
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Related to #6214.

# Rationale for this change

This PR implements WriteOptions support in Java bindings as part of the migration to the new options API outlined in RFC-6213 (#6213). This is the first step in migrating Java bindings to use the new options APIs, starting with write operations. Although if you rather have all options migrated in one go we can close.

# What changes are included in this PR?

Added a complete mapping and conversion of the`opendal::options::WriteOptions` and the Java WriteOptions class. 

# Are there any user-facing changes?

no, but I added the ability to handle chunking, and concurrency options to match opt api.

Let me know if this is the right direction!

