### PR TITLE
ci(bindings/nodejs): Don't upload gh release

### DIFF
--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -73,7 +73,7 @@
     "test": "vitest",
     "bench": "node -r dotenv/config ./benchmark/node.js dotenv_config_path=./.env",
     "bench:deno": "deno bench ./benchmark/deno.ts --reload=npm:opendal --allow-read --allow-ffi --allow-net --allow-env",
-    "prepublishOnly": "napi prepublish -t npm"
+    "prepublishOnly": "napi prepublish -t npm --skip-gh-release"
   },
   "prettier": {
     "overrides": [


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

OpenDAL is a monorepo, and bindings-nodejs uses a different version than the Rust core. Uploading a GitHub release for both can be confusing for users.

It also makes our release CI always fail.

# What changes are included in this PR?

Skip gh release upload for nodejs release.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
