### PR TITLE
feat(bindings/java): Add ListOptions support for new options API

### DIFF
--- a/bindings/java/src/async_operator.rs
+++ b/bindings/java/src/async_operator.rs
@@ -34,9 +34,9 @@ use opendal::Operator;
 use opendal::Scheme;
 
 use crate::convert::{
-    bytes_to_jbytearray, jmap_to_hashmap, offset_length_to_range, read_int64_field,
+    bytes_to_jbytearray, jmap_to_hashmap, jstring_to_string, offset_length_to_range,
+    read_int64_field,
 };
-use crate::convert::{jstring_to_string, read_bool_field};
 use crate::executor::executor_or_default;
 use crate::executor::get_current_env;
 use crate::executor::Executor;
@@ -44,7 +44,7 @@ use crate::make_metadata;
 use crate::make_operator_info;
 use crate::make_presigned_request;
 use crate::Result;
-use crate::{make_entry, make_write_options};
+use crate::{make_entry, make_list_options, make_write_options};
 
 #[no_mangle]
 pub extern "system" fn Java_org_apache_opendal_AsyncOperator_constructor(
@@ -504,13 +504,9 @@ fn intern_list(
     let id = request_id(env)?;
 
     let path = jstring_to_string(env, &path)?;
-    let recursive = read_bool_field(env, &options, "recursive")?;
-
-    let mut list_op = op.list_with(&path);
-    list_op = list_op.recursive(recursive);
-
+    let list_opts = make_list_options(env, &options)?;
     executor_or_default(env, executor)?.spawn(async move {
-        let entries = list_op.await.map_err(Into::into);
+        let entries = op.list_options(&path, list_opts).await.map_err(Into::into);
         let result = make_entries(entries);
         complete_future(id, result.map(JValueOwned::Object))
     });

--- a/bindings/java/src/convert.rs
+++ b/bindings/java/src/convert.rs
@@ -106,6 +106,22 @@ pub(crate) fn read_map_field(
     }
 }
 
+pub(crate) fn read_jlong_field_to_usize(
+    env: &mut JNIEnv,
+    options: &JObject,
+    field_name: &str,
+) -> Result<Option<usize>> {
+    match read_int64_field(env, options, field_name)? {
+        -1 => Ok(None),
+        v if v > 0 => Ok(Some(v as usize)),
+        v => Err(Error::new(
+            ErrorKind::Unexpected,
+            format!("{} must be positive, instead got: {}", field_name, v),
+        )
+        .into()),
+    }
+}
+
 pub(crate) fn offset_length_to_range(offset: i64, length: i64) -> Result<(Bound<u64>, Bound<u64>)> {
     let offset = u64::try_from(offset)
         .map_err(|_| Error::new(ErrorKind::RangeNotSatisfied, "offset must be non-negative"))?;

--- a/bindings/java/src/main/java/org/apache/opendal/Capability.java
+++ b/bindings/java/src/main/java/org/apache/opendal/Capability.java
@@ -173,6 +173,16 @@ public class Capability {
     public final boolean listWithRecursive;
 
     /**
+     * If backend support list with versions.
+     */
+    public final boolean listWithVersions;
+
+    /**
+     * If backend support list with deleted.
+     */
+    public final boolean listWithDeleted;
+
+    /**
      * If operator supports presign.
      */
     public final boolean presign;
@@ -227,6 +237,8 @@ public class Capability {
             boolean listWithLimit,
             boolean listWithStartAfter,
             boolean listWithRecursive,
+            boolean listWithVersions,
+            boolean listWithDeleted,
             boolean presign,
             boolean presignRead,
             boolean presignStat,
@@ -261,6 +273,8 @@ public class Capability {
         this.listWithLimit = listWithLimit;
         this.listWithStartAfter = listWithStartAfter;
         this.listWithRecursive = listWithRecursive;
+        this.listWithVersions = listWithVersions;
+        this.listWithDeleted = listWithDeleted;
         this.presign = presign;
         this.presignRead = presignRead;
         this.presignStat = presignStat;

--- a/bindings/java/src/main/java/org/apache/opendal/ListOptions.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ListOptions.java
@@ -28,4 +28,27 @@ public class ListOptions {
      * Return files in subdirectory as well.
      */
     public final boolean recursive;
+
+    /**
+     * The limit passed to underlying service to specify the max results
+     * that could return per-request.
+     */
+    @Builder.Default
+    public final long limit = -1;
+
+    /**
+     * The startAfter option passes to underlying service to specify the
+     * specified key to start listing from.
+     */
+    public final String startAfter;
+
+    /**
+     * The versions option is used to control whether the object versions should be returned.
+     */
+    public final boolean versions;
+
+    /**
+     * The deleted is used to control whether the deleted objects should be returned.
+     */
+    public final boolean deleted;
 }

--- a/bindings/java/src/operator.rs
+++ b/bindings/java/src/operator.rs
@@ -29,12 +29,11 @@ use opendal::blocking;
 use opendal::options;
 
 use crate::convert::{
-    bytes_to_jbytearray, jstring_to_string, offset_length_to_range, read_bool_field,
-    read_int64_field,
+    bytes_to_jbytearray, jstring_to_string, offset_length_to_range, read_int64_field,
 };
 use crate::make_metadata;
 use crate::Result;
-use crate::{make_entry, make_write_options};
+use crate::{make_entry, make_list_options, make_write_options};
 
 /// # Safety
 ///
@@ -296,15 +295,8 @@ fn intern_list(
     options: JObject,
 ) -> Result<jobjectArray> {
     let path = jstring_to_string(env, &path)?;
-    let recursive = read_bool_field(env, &options, "recursive")?;
-
-    let entries = op.list_options(
-        &path,
-        options::ListOptions {
-            recursive,
-            ..Default::default()
-        },
-    )?;
+    let list_opts = make_list_options(env, &options)?;
+    let entries = op.list_options(&path, list_opts)?;
 
     let jarray = env.new_object_array(
         entries.len() as jsize,

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncListTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncListTest.java
@@ -256,7 +256,7 @@ class AsyncListTest extends BehaviorTestBase {
     void testListWithLimitCollectsAllPages() {
         assumeTrue(asyncOp().info.fullCapability.listWithLimit);
 
-        final String dir = String.format("%s/", UUID.randomUUID());
+        String dir = String.format("%s/", UUID.randomUUID());
         asyncOp().createDir(dir).join();
         for (int i = 0; i < 5; i++) {
             String file = dir + "file-" + i;
@@ -316,7 +316,7 @@ class AsyncListTest extends BehaviorTestBase {
         assumeTrue(asyncOp().info.fullCapability.listWithDeleted);
 
         String dir = String.format("%s/", UUID.randomUUID());
-        final String path = dir + "file";
+        String path = dir + "file";
         asyncOp().createDir(dir).join();
 
         asyncOp().write(path, "data").join();

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncListTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncListTest.java
@@ -251,4 +251,83 @@ class AsyncListTest extends BehaviorTestBase {
                 .join();
         assertThat(noRecursiveEntries).hasSize(3);
     }
+
+    @Test
+    void testListWithLimitCollectsAllPages() {
+        assumeTrue(asyncOp().info.fullCapability.listWithLimit);
+
+        final String dir = String.format("%s/", UUID.randomUUID());
+        asyncOp().createDir(dir).join();
+        for (int i = 0; i < 5; i++) {
+            String file = dir + "file-" + i;
+            asyncOp().write(file, "data").join();
+        }
+
+        ListOptions options = ListOptions.builder().limit(3).build();
+        List<Entry> entries = asyncOp().list(dir, options).join();
+        assertThat(entries.size()).isEqualTo(6);
+
+        asyncOp().removeAll(dir).join();
+    }
+
+    @Test
+    void testListWithStartAfter() {
+        assumeTrue(asyncOp().info.fullCapability.listWithStartAfter);
+
+        String dir = String.format("%s/", UUID.randomUUID());
+        asyncOp().createDir(dir).join();
+
+        List<String> filesToCreate = Lists.newArrayList();
+        for (int i = 0; i < 5; i++) {
+            String file = dir + "file-" + i;
+            asyncOp().write(file, "data").join();
+            filesToCreate.add(file);
+        }
+
+        ListOptions options =
+                ListOptions.builder().startAfter(filesToCreate.get(2)).build();
+        List<Entry> entries = asyncOp().list(dir, options).join();
+        List<String> actual = entries.stream().map(Entry::getPath).sorted().collect(Collectors.toList());
+
+        assertThat(actual).containsAnyElementsOf(filesToCreate.subList(3, 5));
+        asyncOp().removeAll(dir).join();
+    }
+
+    @Test
+    void testListWithVersions() {
+        assumeTrue(asyncOp().info.fullCapability.listWithVersions);
+
+        String dir = String.format("%s/", UUID.randomUUID());
+        String path = dir + "versioned-file";
+
+        asyncOp().createDir(dir).join();
+        asyncOp().write(path, "data-1").join();
+        asyncOp().write(path, "data-2").join();
+
+        ListOptions options = ListOptions.builder().versions(true).build();
+        List<Entry> entries = asyncOp().list(dir, options).join();
+
+        assertThat(entries).isNotEmpty();
+        asyncOp().removeAll(dir).join();
+    }
+
+    @Test
+    void testListWithDeleted() {
+        assumeTrue(asyncOp().info.fullCapability.listWithDeleted);
+
+        String dir = String.format("%s/", UUID.randomUUID());
+        final String path = dir + "file";
+        asyncOp().createDir(dir).join();
+
+        asyncOp().write(path, "data").join();
+        asyncOp().delete(path).join();
+
+        ListOptions options = ListOptions.builder().deleted(true).build();
+        List<Entry> entries = asyncOp().list(dir, options).join();
+
+        assertThat(entries.size()).isEqualTo(1);
+        assertThat(entries.get(0).getPath()).isEqualTo(path);
+
+        asyncOp().removeAll(dir).join();
+    }
 }

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingListTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingListTest.java
@@ -196,9 +196,9 @@ public class BlockingListTest extends BehaviorTestBase {
         assumeTrue(op().info.fullCapability.listWithDeleted);
 
         String dir = String.format("%s/", UUID.randomUUID());
-        final String path = dir + "file";
-        op().createDir(dir);
+        String path = dir + "file";
 
+        op().createDir(dir);
         op().write(path, "data");
         op().delete(path);
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingListTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingListTest.java
@@ -25,12 +25,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.apache.opendal.Capability;
 import org.apache.opendal.Entry;
 import org.apache.opendal.ListOptions;
 import org.apache.opendal.Metadata;
 import org.apache.opendal.OpenDALException;
 import org.apache.opendal.test.condition.OpenDALExceptionCondition;
+import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -128,5 +130,84 @@ public class BlockingListTest extends BehaviorTestBase {
         final List<Entry> noRecursiveEntries =
                 op().list(dir, ListOptions.builder().recursive(false).build());
         assertThat(noRecursiveEntries).hasSize(3);
+    }
+
+    @Test
+    void testListWithLimitCollectsAllPages() {
+        assumeTrue(op().info.fullCapability.listWithLimit);
+
+        String dir = String.format("%s/", UUID.randomUUID());
+        op().createDir(dir);
+        for (int i = 0; i < 5; i++) {
+            String file = dir + "file-" + i;
+            op().write(file, "data");
+        }
+
+        ListOptions options = ListOptions.builder().limit(3).build();
+        List<Entry> entries = op().list(dir, options);
+        assertThat(entries.size()).isEqualTo(6);
+
+        op().removeAll(dir);
+    }
+
+    @Test
+    void testListWithStartAfter() {
+        assumeTrue(op().info.fullCapability.listWithStartAfter);
+
+        String dir = String.format("%s/", UUID.randomUUID());
+        op().createDir(dir);
+
+        List<String> filesToCreate = Lists.newArrayList();
+        for (int i = 0; i < 5; i++) {
+            String file = dir + "file-" + i;
+            op().write(file, "data");
+            filesToCreate.add(file);
+        }
+
+        ListOptions options =
+                ListOptions.builder().startAfter(filesToCreate.get(2)).build();
+        List<Entry> entries = op().list(dir, options);
+        List<String> actual = entries.stream().map(Entry::getPath).sorted().collect(Collectors.toList());
+
+        assertThat(actual).containsAnyElementsOf(filesToCreate.subList(3, 5));
+        op().removeAll(dir);
+    }
+
+    @Test
+    void testListWithVersions() {
+        assumeTrue(op().info.fullCapability.listWithVersions);
+
+        String dir = String.format("%s/", UUID.randomUUID());
+        String path = dir + "versioned-file";
+
+        op().createDir(dir);
+        op().write(path, "data-1");
+        op().write(path, "data-2");
+
+        ListOptions options = ListOptions.builder().versions(true).build();
+        List<Entry> entries = op().list(dir, options);
+
+        assertThat(entries).isNotEmpty();
+        op().removeAll(dir);
+    }
+
+    @Test
+    void testListWithDeleted() {
+        assumeTrue(op().info.fullCapability.listWithDeleted);
+
+        String dir = String.format("%s/", UUID.randomUUID());
+        final String path = dir + "file";
+        op().createDir(dir);
+
+        op().write(path, "data");
+        op().delete(path);
+
+        ListOptions options = ListOptions.builder().deleted(true).build();
+        List<Entry> entries = op().list(dir, options);
+
+        assertThat(entries.size()).isEqualTo(1);
+        assertThat(entries.get(0).getPath()).isEqualTo(path);
+
+        op().removeAll(dir);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Related to #6226.

# Rationale for this change

This PR adds support for the rest of the ListOptions and migrates the rest of them to use the new options API support in Java bindings as part of the migration to the new options API outlined in RFC-6213 (#6213). 

# What changes are included in this PR?

* Extended the java capabilities to include the required listing capabilities for the rest of the list options
* Added a complete mapping and conversion of theopendal::options::ListOptions and the Java ListOptions class. 

# Are there any user-facing changes?
Yes, added the rest of ListOptions: `limit, startAfter, versions, deleted`

