### PR TITLE
fix: java bug in list with delete option test 

### DIFF
--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncListTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncListTest.java
@@ -325,8 +325,8 @@ class AsyncListTest extends BehaviorTestBase {
         ListOptions options = ListOptions.builder().deleted(true).build();
         List<Entry> entries = asyncOp().list(dir, options).join();
 
-        assertThat(entries.size()).isEqualTo(1);
-        assertThat(entries.get(0).getPath()).isEqualTo(path);
+        List<String> actual = entries.stream().map(Entry::getPath).sorted().collect(Collectors.toList());
+        assertThat(actual).contains(path);
 
         asyncOp().removeAll(dir).join();
     }

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingListTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingListTest.java
@@ -205,8 +205,8 @@ public class BlockingListTest extends BehaviorTestBase {
         ListOptions options = ListOptions.builder().deleted(true).build();
         List<Entry> entries = op().list(dir, options);
 
-        assertThat(entries.size()).isEqualTo(1);
-        assertThat(entries.get(0).getPath()).isEqualTo(path);
+        List<String> actual = entries.stream().map(Entry::getPath).sorted().collect(Collectors.toList());
+        assertThat(actual).contains(path);
 
         op().removeAll(dir);
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6256.

# Rationale for this change

Fix the Java listWithDeleted test that incorrectly expected 1 deleted entry. The actual count is 2 because it includes both the deleted file and the directory entry. Now it will stream the paths and ensure the deleted file is included in the output.

# What changes are included in this PR?

* repaired unit tests

# Are there any user-facing changes?
No

### Testing 

s3 with bucket versioning

cc: @Xuanwo 
