### PR TITLE
fix(gcs): headers missing in XML multipart API and incorrect x-goog-acl header values in XML API

### DIFF
--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -28,6 +28,8 @@ use backon::Retryable;
 use bytes::Buf;
 use bytes::Bytes;
 use constants::*;
+use http::header::CACHE_CONTROL;
+use http::header::CONTENT_DISPOSITION;
 use http::header::CONTENT_ENCODING;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
@@ -561,14 +563,46 @@ impl GcsCore {
         self.send(req).await
     }
 
-    pub async fn gcs_initiate_multipart_upload(&self, path: &str) -> Result<Response<Buffer>> {
+    pub async fn gcs_initiate_multipart_upload(&self, path: &str, op: &OpWrite) -> Result<Response<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
         let url = format!("{}/{}/{}?uploads", self.endpoint, self.bucket, p);
 
-        let mut req = Request::post(&url)
+        let mut builder = Request::post(&url)
             .header(CONTENT_LENGTH, 0)
-            .extension(Operation::Write)
+            .extension(Operation::Write);
+
+        if let Some(header_val) = op.content_disposition() {
+            builder = builder.header(CONTENT_DISPOSITION, header_val);
+        }
+
+        if let Some(header_val) = op.content_encoding() {
+            builder = builder.header(CONTENT_ENCODING, header_val);
+        }
+
+        if let Some(header_val) = op.content_type() {
+            builder = builder.header(CONTENT_TYPE, header_val);
+        }
+
+        if let Some(header_val) = op.cache_control() {
+            builder = builder.header(CACHE_CONTROL, header_val);
+        }
+
+        if let Some(metadata) = op.user_metadata() {
+            for (k, v) in metadata {
+                builder = builder.header(&format!("x-goog-meta-{k}"), v);
+            }
+        }
+
+        if let Some(acl) = self.predefined_acl.as_ref() {
+            if let Some(predefined_acl_in_xml_spec) = predefined_acl_to_xml_header(acl) {
+                builder = builder.header(X_GOOG_ACL, predefined_acl_in_xml_spec);
+            } else {
+               eprintln!("Unrecognized predefined_acl. Ignoring"); 
+            }
+        }
+
+        let mut req = builder
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -706,6 +740,19 @@ impl GcsCore {
         }
 
         Ok(m)
+    }
+}
+
+// https://cloud.google.com/storage/docs/xml-api/reference-headers#xgoogacl
+fn predefined_acl_to_xml_header(predefined_acl: &str) -> Option<&'static str> {
+    match predefined_acl {
+        "projectPrivate" => Some("project-private"),
+        "private" => Some("private"),
+        "bucketOwnerRead" => Some("bucket-owner-read"),
+        "bucketOwnerFullControl" => Some("bucket-owner-full-control"),
+        "publicRead" => Some("public-read"),
+        "authenticatedRead" => Some("authenticated-read"),
+        _ => None
     }
 }
 

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -372,7 +372,11 @@ impl GcsCore {
         }
 
         if let Some(acl) = &self.predefined_acl {
-            req = req.header(X_GOOG_ACL, acl);
+            if let Some(predefined_acl_in_xml_spec) = predefined_acl_to_xml_header(acl) {
+                req = req.header(X_GOOG_ACL, predefined_acl_in_xml_spec);
+            } else {
+                eprintln!("Unrecognized predefined_acl. Ignoring"); 
+            }
         }
 
         if let Some(storage_class) = &self.default_storage_class {

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -375,7 +375,7 @@ impl GcsCore {
             if let Some(predefined_acl_in_xml_spec) = predefined_acl_to_xml_header(acl) {
                 req = req.header(X_GOOG_ACL, predefined_acl_in_xml_spec);
             } else {
-                eprintln!("Unrecognized predefined_acl. Ignoring"); 
+                eprintln!("Unrecognized predefined_acl. Ignoring");
             }
         }
 
@@ -567,7 +567,11 @@ impl GcsCore {
         self.send(req).await
     }
 
-    pub async fn gcs_initiate_multipart_upload(&self, path: &str, op: &OpWrite) -> Result<Response<Buffer>> {
+    pub async fn gcs_initiate_multipart_upload(
+        &self,
+        path: &str,
+        op: &OpWrite,
+    ) -> Result<Response<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
         let url = format!("{}/{}/{}?uploads", self.endpoint, self.bucket, p);
@@ -602,7 +606,7 @@ impl GcsCore {
             if let Some(predefined_acl_in_xml_spec) = predefined_acl_to_xml_header(acl) {
                 builder = builder.header(X_GOOG_ACL, predefined_acl_in_xml_spec);
             } else {
-               eprintln!("Unrecognized predefined_acl. Ignoring"); 
+                eprintln!("Unrecognized predefined_acl. Ignoring");
             }
         }
 
@@ -756,7 +760,7 @@ fn predefined_acl_to_xml_header(predefined_acl: &str) -> Option<&'static str> {
         "bucketOwnerFullControl" => Some("bucket-owner-full-control"),
         "publicRead" => Some("public-read"),
         "authenticatedRead" => Some("authenticated-read"),
-        _ => None
+        _ => None,
     }
 }
 

--- a/core/src/services/gcs/writer.rs
+++ b/core/src/services/gcs/writer.rs
@@ -74,7 +74,7 @@ impl oio::MultipartWrite for GcsWriter {
     async fn initiate_part(&self) -> Result<String> {
         let resp = self
             .core
-            .gcs_initiate_multipart_upload(&percent_encode_path(&self.path))
+            .gcs_initiate_multipart_upload(&percent_encode_path(&self.path), &self.op)
             .await?;
 
         if !resp.status().is_success() {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Primarily – fix the issue reported in:
https://discord.com/channels/1081052318650339399/1081052319342407715/1380046336434503780

Secondarily:
Closes https://github.com/apache/opendal/issues/5612.



# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
OpenDAL's Gcs service currently does not write headers when doing multipart XML uploads. It also does not handle predefined ACLs correctly in the XML API.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Adds headers and metadata to XML multipart upload requests
- Converts predefined ACL to the format used in XML API (e.g. "publicRead" -> "public-read") when necessary

# Are there any user-facing changes?

No user-facing changes (unless they depend on broken behavior)

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
