### PR TITLE
chore(bindings/go): update Go dependencies

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -22,7 +22,7 @@ go 1.22.4
 toolchain go1.22.5
 
 require (
-	github.com/ebitengine/purego v0.8.3
-	github.com/jupiterrider/ffi v0.4.1
+	github.com/ebitengine/purego v0.8.4
+	github.com/jupiterrider/ffi v0.5.0
 	golang.org/x/sys v0.24.0
 )

--- a/bindings/go/go.sum
+++ b/bindings/go/go.sum
@@ -1,6 +1,6 @@
-github.com/ebitengine/purego v0.8.3 h1:K+0AjQp63JEZTEMZiwsI9g0+hAMNohwUOtY0RPGexmc=
-github.com/ebitengine/purego v0.8.3/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
-github.com/jupiterrider/ffi v0.4.1 h1:Obg+xpuA+rRkRTEN7xu3IagjNDMO8fRUhOPpLEztPYI=
-github.com/jupiterrider/ffi v0.4.1/go.mod h1:Ba3hjU7Sz2+TO8HupjZwGssVnzo7RG3xF77byUBueB4=
+github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0omw=
+github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/jupiterrider/ffi v0.5.0 h1:j2nSgpabbV1JOwgP4Kn449sJUHq3cVLAZVBoOYn44V8=
+github.com/jupiterrider/ffi v0.5.0/go.mod h1:x7xdNKo8h0AmLuXfswDUBxUsd2OqUP4ekC8sCnsmbvo=
 golang.org/x/sys v0.24.0 h1:Twjiwq9dn6R1fQcyiK+wQyHWfaz/BJB+YIpzU/Cv3Xg=
 golang.org/x/sys v0.24.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
- Update github.com/ebitengine/purego from v0.8.3 to v0.8.4

- Update github.com/jupiterrider/ffi from v0.4.1 to v0.5.0

The v0.5.0 of ffi introduces embed libffi.

Make life easier for Windows and macOS developers :) https://github.com/apache/opendal/issues/6279#issuecomment-2960719317