### PR TITLE
refactor: Migrate redis from adapter::kv to Access instead

### DIFF
--- a/core/src/services/redis/core.rs
+++ b/core/src/services/redis/core.rs
@@ -172,6 +172,15 @@ impl RedisCore {
         Ok(result.map(Buffer::from))
     }
 
+    pub async fn get_range(&self, key: &str, start: isize, end: isize) -> Result<Option<Buffer>> {
+        let mut conn = self.conn().await?;
+        let result: Option<Bytes> = conn
+            .getrange(key, start, end)
+            .await
+            .map_err(format_redis_error)?;
+        Ok(result.map(Buffer::from))
+    }
+
     pub async fn set(&self, key: &str, value: Buffer) -> Result<()> {
         let mut conn = self.conn().await?;
         let value = value.to_vec();

--- a/core/src/services/redis/core.rs
+++ b/core/src/services/redis/core.rs
@@ -15,6 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::time::Duration;
+
+use bb8::RunError;
+use bytes::Bytes;
 use redis::aio::ConnectionLike;
 use redis::aio::ConnectionManager;
 use redis::cluster::ClusterClient;
@@ -26,9 +32,9 @@ use redis::Pipeline;
 use redis::RedisError;
 use redis::RedisFuture;
 use redis::Value;
+use tokio::sync::OnceCell;
 
-use crate::Error;
-use crate::ErrorKind;
+use crate::*;
 
 #[derive(Clone)]
 pub enum RedisConnection {
@@ -103,6 +109,87 @@ impl bb8::ManageConnection for RedisConnectionManager {
 
     fn has_broken(&self, _: &mut Self::Connection) -> bool {
         false
+    }
+}
+
+/// RedisCore holds the Redis connection and configuration
+#[derive(Clone)]
+pub struct RedisCore {
+    pub addr: String,
+    pub client: Option<Client>,
+    pub cluster_client: Option<ClusterClient>,
+    pub conn: OnceCell<bb8::Pool<RedisConnectionManager>>,
+    pub default_ttl: Option<Duration>,
+}
+
+impl Debug for RedisCore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut ds = f.debug_struct("RedisCore");
+        ds.field("addr", &self.addr);
+        ds.finish()
+    }
+}
+
+impl RedisCore {
+    pub async fn conn(&self) -> Result<bb8::PooledConnection<'_, RedisConnectionManager>> {
+        let pool = self
+            .conn
+            .get_or_try_init(|| async {
+                bb8::Pool::builder()
+                    .build(self.get_redis_connection_manager())
+                    .await
+                    .map_err(|err| {
+                        Error::new(ErrorKind::ConfigInvalid, "connect to redis failed")
+                            .set_source(err)
+                    })
+            })
+            .await?;
+        pool.get().await.map_err(|err| match err {
+            RunError::TimedOut => {
+                Error::new(ErrorKind::Unexpected, "get connection from pool failed").set_temporary()
+            }
+            RunError::User(err) => err,
+        })
+    }
+
+    pub fn get_redis_connection_manager(&self) -> RedisConnectionManager {
+        if let Some(_client) = self.client.clone() {
+            RedisConnectionManager {
+                client: self.client.clone(),
+                cluster_client: None,
+            }
+        } else {
+            RedisConnectionManager {
+                client: None,
+                cluster_client: self.cluster_client.clone(),
+            }
+        }
+    }
+
+    pub async fn get(&self, key: &str) -> Result<Option<Buffer>> {
+        let mut conn = self.conn().await?;
+        let result: Option<Bytes> = conn.get(key).await.map_err(format_redis_error)?;
+        Ok(result.map(Buffer::from))
+    }
+
+    pub async fn set(&self, key: &str, value: Buffer) -> Result<()> {
+        let mut conn = self.conn().await?;
+        let value = value.to_vec();
+        if let Some(dur) = self.default_ttl {
+            let _: () = conn
+                .set_ex(key, value, dur.as_secs())
+                .await
+                .map_err(format_redis_error)?;
+        } else {
+            let _: () = conn.set(key, value).await.map_err(format_redis_error)?;
+        }
+        Ok(())
+    }
+
+    pub async fn delete(&self, key: &str) -> Result<()> {
+        let mut conn = self.conn().await?;
+        let _: () = conn.del(key).await.map_err(format_redis_error)?;
+        Ok(())
     }
 }
 

--- a/core/src/services/redis/docs.md
+++ b/core/src/services/redis/docs.md
@@ -5,13 +5,12 @@ This service can be used to:
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
-- [x] copy
-- [x] rename
+- [ ] ~~create_dir~~
+- [ ] ~~copy~~
+- [ ] ~~rename~~
 - [ ] ~~list~~
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/redis/writer.rs
+++ b/core/src/services/redis/writer.rs
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use super::core::RedisCore;
+use crate::raw::oio;
+use crate::*;
+
+pub struct RedisWriter {
+    core: std::sync::Arc<RedisCore>,
+    path: String,
+    buffer: oio::QueueBuf,
+}
+
+impl RedisWriter {
+    pub fn new(core: std::sync::Arc<RedisCore>, path: String) -> Self {
+        Self {
+            core,
+            path,
+            buffer: oio::QueueBuf::new(),
+        }
+    }
+}
+
+impl oio::Write for RedisWriter {
+    async fn write(&mut self, bs: Buffer) -> Result<()> {
+        self.buffer.push(bs);
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<Metadata> {
+        let buf = self.buffer.clone().collect();
+        let length = buf.len() as u64;
+        self.core.set(&self.path, buf).await?;
+
+        let meta = Metadata::new(EntryMode::from_path(&self.path)).with_content_length(length);
+        Ok(meta)
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        self.buffer.clear();
+        Ok(())
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Part https://github.com/apache/opendal/issues/5739

# Rationale for this change

See https://github.com/apache/opendal/issues/5739

# What changes are included in this PR?

Migrate redis from adapter::kv to Access instead

# Are there any user-facing changes?

No.
