### PR TITLE
fix(hdfs): fix infinite loop in write for HDFS failure

### DIFF
--- a/core/src/services/hdfs/writer.rs
+++ b/core/src/services/hdfs/writer.rs
@@ -65,6 +65,10 @@ impl oio::Write for HdfsWriter<hdrs::AsyncFile> {
         while bs.has_remaining() {
             let n = f.write(bs.chunk()).await.map_err(new_std_io_error)?;
             bs.advance(n);
+
+            if n == 0 {
+                f.flush().await.map_err(new_std_io_error)?;
+            }
         }
 
         self.size += len;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6288.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This change serves as a temporary workaround. Ideally, the root issue in the `blocking` crate should be addressed.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- call `flush` to detect status of file when `write` return 0.

# Are there any user-facing changes?

No user-facing changes.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
