### PR TITLE
refactor(metrics): simplify the registration of `PrometheusClientLayer`

### DIFF
--- a/core/src/layers/fastmetrics.rs
+++ b/core/src/layers/fastmetrics.rs
@@ -90,7 +90,7 @@ impl FastmetricsLayer {
         GLOBAL.get_or_init(|| {
             Self::builder()
                 .register_global()
-                .expect("Failed to register to global registry")
+                .expect("Failed to register metrics into the global registry")
         })
     }
 }
@@ -189,7 +189,6 @@ impl FastmetricsLayerBuilder {
     /// # Example
     ///
     /// ```no_run
-    /// # use log::debug;
     /// # use opendal::layers::FastmetricsLayer;
     /// # use opendal::services;
     /// # use opendal::Operator;

--- a/core/src/layers/fastmetrics.rs
+++ b/core/src/layers/fastmetrics.rs
@@ -66,6 +66,24 @@ impl FastmetricsLayer {
 
     /// Return a shared global [`FastmetricsLayer`] instance that registers metrics into the
     /// fastmetrics global registry.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use opendal::layers::FastmetricsLayer;
+    /// # use opendal::services;
+    /// # use opendal::Operator;
+    /// # use opendal::Result;
+    ///
+    /// # fn main() -> Result<()> {
+    /// // Pick a builder and configure it.
+    /// let builder = services::Memory::default();
+    /// let _ = Operator::new(builder)?
+    ///     .layer(FastmetricsLayer::global().clone())
+    ///     .finish();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn global() -> &'static Self {
         static GLOBAL: OnceLock<FastmetricsLayer> = OnceLock::new();
 
@@ -168,7 +186,7 @@ impl FastmetricsLayerBuilder {
 
     /// Register the metrics into the registry and return a [`FastmetricsLayer`].
     ///
-    /// # Examples
+    /// # Example
     ///
     /// ```no_run
     /// # use log::debug;
@@ -264,7 +282,7 @@ impl FastmetricsLayerBuilder {
 
     /// Register the metrics into the global registry and return a [`FastmetricsLayer`].
     ///
-    /// # Examples
+    /// # Example
     ///
     /// ```no_run
     /// # use opendal::layers::FastmetricsLayer;

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -94,7 +94,6 @@ impl PrometheusLayer {
     /// # Example
     ///
     /// ```no_run
-    /// # use log::debug;
     /// # use opendal::layers::PrometheusLayer;
     /// # use opendal::services;
     /// # use opendal::Operator;
@@ -108,7 +107,7 @@ impl PrometheusLayer {
     ///
     /// let duration_seconds_buckets = prometheus::exponential_buckets(0.01, 2.0, 16).unwrap();
     /// let bytes_buckets = prometheus::exponential_buckets(1.0, 2.0, 16).unwrap();
-    /// let op = Operator::new(builder)?
+    /// let _ = Operator::new(builder)?
     ///     .layer(
     ///         PrometheusLayer::builder()
     ///             .duration_seconds_buckets(duration_seconds_buckets)
@@ -117,9 +116,7 @@ impl PrometheusLayer {
     ///             .expect("register metrics successfully"),
     ///     )
     ///     .finish();
-    /// debug!("operator: {op:?}");
-    ///
-    /// Ok(())
+    /// # Ok(())
     /// # }
     /// ```
     pub fn builder() -> PrometheusLayerBuilder {
@@ -132,7 +129,6 @@ impl PrometheusLayer {
     /// # Example
     ///
     /// ```no_run
-    /// # use log::debug;
     /// # use opendal::layers::PrometheusLayer;
     /// # use opendal::services;
     /// # use opendal::Operator;
@@ -154,7 +150,7 @@ impl PrometheusLayer {
         GLOBAL.get_or_init(|| {
             Self::builder()
                 .register_default()
-                .expect("Failed to register to global registry")
+                .expect("Failed to register metrics into the global registry")
         })
     }
 }
@@ -244,7 +240,6 @@ impl PrometheusLayerBuilder {
     /// # Example
     ///
     /// ```no_run
-    /// # use log::debug;
     /// # use opendal::layers::PrometheusLayer;
     /// # use opendal::services;
     /// # use opendal::Operator;
@@ -483,7 +478,6 @@ impl PrometheusLayerBuilder {
     /// # Example
     ///
     /// ```no_run
-    /// # use log::debug;
     /// # use opendal::layers::PrometheusLayer;
     /// # use opendal::services;
     /// # use opendal::Operator;

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use prometheus::core::AtomicI64;
@@ -124,6 +125,18 @@ impl PrometheusLayer {
     /// ```
     pub fn builder() -> PrometheusLayerBuilder {
         PrometheusLayerBuilder::default()
+    }
+
+    /// Return a shared global [`PrometheusLayer`] instance that registers metrics into the
+    /// prometheus default (global) registry.
+    pub fn global() -> &'static Self {
+        static GLOBAL: OnceLock<PrometheusLayer> = OnceLock::new();
+
+        GLOBAL.get_or_init(|| {
+            Self::builder()
+                .register_default()
+                .expect("Failed to register to global registry")
+        })
     }
 }
 

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -80,8 +80,7 @@ use crate::*;
 /// encoder.encode(&prometheus::gather(), &mut buffer).unwrap();
 /// println!("## Prometheus Metrics");
 /// println!("{}", String::from_utf8(buffer.clone()).unwrap());
-///
-/// Ok(())
+/// # Ok(())
 /// # }
 /// ```
 #[derive(Clone, Debug)]
@@ -129,6 +128,26 @@ impl PrometheusLayer {
 
     /// Return a shared global [`PrometheusLayer`] instance that registers metrics into the
     /// prometheus default (global) registry.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use log::debug;
+    /// # use opendal::layers::PrometheusLayer;
+    /// # use opendal::services;
+    /// # use opendal::Operator;
+    /// # use opendal::Result;
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<()> {
+    /// // Pick a builder and configure it.
+    /// let builder = services::Memory::default();
+    /// let _ = Operator::new(builder)?
+    ///     .layer(PrometheusLayer::global().clone())
+    ///     .finish();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn global() -> &'static Self {
         static GLOBAL: OnceLock<PrometheusLayer> = OnceLock::new();
 
@@ -235,18 +254,14 @@ impl PrometheusLayerBuilder {
     /// # async fn main() -> Result<()> {
     /// // Pick a builder and configure it.
     /// let builder = services::Memory::default();
-    /// let registry = prometheus::default_registry();
-    ///
-    /// let op = Operator::new(builder)?
+    /// let _ = Operator::new(builder)?
     ///     .layer(
     ///         PrometheusLayer::builder()
-    ///             .register(registry)
+    ///             .register(prometheus::default_registry())
     ///             .expect("register metrics successfully"),
     ///     )
     ///     .finish();
-    /// debug!("operator: {op:?}");
-    ///
-    /// Ok(())
+    /// # Ok(())
     /// # }
     /// ```
     pub fn register(self, registry: &Registry) -> Result<PrometheusLayer> {
@@ -478,17 +493,14 @@ impl PrometheusLayerBuilder {
     /// # async fn main() -> Result<()> {
     /// // Pick a builder and configure it.
     /// let builder = services::Memory::default();
-    ///
-    /// let op = Operator::new(builder)?
+    /// let _ = Operator::new(builder)?
     ///     .layer(
     ///         PrometheusLayer::builder()
     ///             .register_default()
     ///             .expect("register metrics successfully"),
     ///     )
     ///     .finish();
-    /// debug!("operator: {op:?}");
-    ///
-    /// Ok(())
+    /// # Ok(())
     /// # }
     /// ```
     pub fn register_default(self) -> Result<PrometheusLayer> {

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -183,7 +183,6 @@ impl PrometheusClientLayerBuilder {
     /// # Example
     ///
     /// ```no_run
-    /// # use log::debug;
     /// # use opendal::layers::PrometheusClientLayer;
     /// # use opendal::services;
     /// # use opendal::Operator;

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -74,8 +74,7 @@ use crate::*;
 /// prometheus_client::encoding::text::encode(&mut buf, &registry).unwrap();
 /// println!("## Prometheus Metrics");
 /// println!("{}", buf);
-///
-/// Ok(())
+/// # Ok(())
 /// # }
 /// ```
 #[derive(Clone, Debug)]
@@ -181,7 +180,7 @@ impl PrometheusClientLayerBuilder {
 
     /// Register the metrics into the registry and return a [`PrometheusClientLayer`].
     ///
-    /// # Examples
+    /// # Example
     ///
     /// ```no_run
     /// # use log::debug;
@@ -196,12 +195,10 @@ impl PrometheusClientLayerBuilder {
     /// let builder = services::Memory::default();
     /// let mut registry = prometheus_client::registry::Registry::default();
     ///
-    /// let op = Operator::new(builder)?
+    /// let _ = Operator::new(builder)?
     ///     .layer(PrometheusClientLayer::builder().register(&mut registry))
     ///     .finish();
-    /// debug!("operator: {op:?}");
-    ///
-    /// Ok(())
+    /// # Ok(())
     /// # }
     /// ```
     pub fn register(self, registry: &mut Registry) -> PrometheusClientLayer {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

`PrometheusLayer` / `FastmetricsLayer` / `PrometheusClientLayer` need to be registered before instantiation.

Taking the `FastmetricsLayer` as an example, if there are multiple operators in an application that need the `FastmetricsLayer`,  you may need to instantiate it once and pass it to multiple operators, like `.layer(fastmetrics_layer.clone())`.
We cannot directly call `.layer(FastmetricsLayer::default().register(registry))` for different services, because registering the same metrics multiple times will cause register errors (at least for `prometheus`/`fastmetrics` crates, but `prometheus_client` won't report errors when registering metrics).

Therefore, we can provide a global instance for the `PrometheusLayer` and `FastmetricsLayer` for users to use directly without having to construct it by themselves.

# What changes are included in this PR?

- ~~add `global` method for `PrometheusLayer`~~ add global instance doc for `PrometheusLayer`
- ~~add `global` method for `FastmetricsLayer`~~ add global instance doc for `FastmetricsLayer`
- simplify the registration code of `PrometheusClientLayer`

# Are there any user-facing changes?

