### PR TITLE
feat(bindings/nodejs): Add ReadOptions and ReaderOptions support for new options API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "rust-analyzer.cargo.allTargets": true,
   "rust-analyzer.cargo.features": "all",
+  "rust-analyzer.procMacro.ignored": { "napi-derive": ["napi"] },
   "rust-analyzer.linkedProjects": [
     "${workspaceFolder}/core/Cargo.toml",
     "${workspaceFolder}/bindings/python/Cargo.toml",

--- a/bindings/nodejs/src/capability.rs
+++ b/bindings/nodejs/src/capability.rs
@@ -96,6 +96,24 @@ impl Capability {
         self.0.read
     }
 
+    /// If operator supports read with version.
+    #[napi(getter)]
+    pub fn read_with_version(&self) -> bool {
+        self.0.read_with_version
+    }
+
+    /// If operator supports read with range.
+    #[napi(getter)]
+    pub fn read_with_if_modified_since(&self) -> bool {
+        self.0.read_with_if_modified_since
+    }
+
+    /// If operator supports read with if unmodified since.
+    #[napi(getter)]
+    pub fn read_with_if_unmodified_since(&self) -> bool {
+        self.0.read_with_if_unmodified_since
+    }
+
     /// If operator supports read with if matched.
     #[napi(getter)]
     pub fn read_with_if_match(&self) -> bool {

--- a/bindings/nodejs/src/options.rs
+++ b/bindings/nodejs/src/options.rs
@@ -15,7 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use napi::bindgen_prelude::BigInt;
 use opendal::raw::parse_datetime_from_rfc3339;
+use std::ops::Bound as RangeBound;
 
 #[napi(object)]
 #[derive(Debug)]
@@ -91,6 +93,255 @@ impl From<StatOptions> for opendal::options::StatOptions {
             override_content_type: value.override_content_type,
             override_cache_control: value.override_cache_control,
             override_content_disposition: value.override_content_disposition,
+        }
+    }
+}
+
+#[napi(object)]
+#[derive(Default, Debug)]
+pub struct ReadOptions {
+    /**
+     * Set `version` for this operation.
+     *
+     * This option can be used to retrieve the data of a specified version of the given path.
+     */
+    pub version: Option<String>,
+
+    /**
+     * Set `concurrent` for the operation.
+     *
+     * OpenDAL by default to read file without concurrent. This is not efficient for cases when users
+     * read large chunks of data. By setting `concurrent`, opendal will reading files concurrently
+     * on support storage services.
+     *
+     * By setting `concurrent`, opendal will fetch chunks concurrently with
+     * the give chunk size.
+     */
+    pub concurrent: Option<u32>,
+
+    /**
+     * Sets the chunk size for this operation.
+     *
+     * OpenDAL will use services' preferred chunk size by default. Users can set chunk based on their own needs.
+     */
+    pub chunk: Option<u32>,
+
+    /**
+     * Controls the optimization strategy for range reads in [`Reader::fetch`].
+     *
+     * When performing range reads, if the gap between two requested ranges is smaller than
+     * the configured `gap` size, OpenDAL will merge these ranges into a single read request
+     * and discard the unrequested data in between. This helps reduce the number of API calls
+     * to remote storage services.
+     *
+     * This optimization is particularly useful when performing multiple small range reads
+     * that are close to each other, as it reduces the overhead of multiple network requests
+     * at the cost of transferring some additional data.
+     */
+    pub gap: Option<BigInt>,
+
+    /**
+     * Sets the offset (starting position) for range read operations.
+     * The read will start from this position in the file.
+     */
+    pub offset: Option<BigInt>,
+
+    /**
+     * Sets the size (length) for range read operations.
+     * The read will continue for this many bytes after the offset.
+     */
+    pub size: Option<BigInt>,
+
+    /**
+     * Sets if-match condition for this operation.
+     * If file exists and its etag doesn't match, an error will be returned.
+     */
+    pub if_match: Option<String>,
+
+    /**
+     * Sets if-none-match condition for this operation.
+     * If file exists and its etag matches, an error will be returned.
+     */
+    pub if_none_match: Option<String>,
+
+    /**
+     * Sets if-modified-since condition for this operation.
+     * If file exists and hasn't been modified since the specified time, an error will be returned.
+     * ISO 8601 formatted date string
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+     */
+    pub if_modified_since: Option<String>,
+
+    /**
+     * Sets if-unmodified-since condition for this operation.
+     * If file exists and has been modified since the specified time, an error will be returned.
+     * ISO 8601 formatted date string
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+     */
+    pub if_unmodified_since: Option<String>,
+
+    /**
+     * Specify the `content-type` header that should be sent back by the operation.
+     *
+     * This option is only meaningful when used along with presign.
+     */
+    pub content_type: Option<String>,
+
+    /**
+     * Specify the `cache-control` header that should be sent back by the operation.
+     *
+     * This option is only meaningful when used along with presign.
+     */
+    pub cache_control: Option<String>,
+
+    /**
+     * Specify the `content-disposition` header that should be sent back by the operation.
+     *
+     * This option is only meaningful when used along with presign.
+     */
+    pub content_disposition: Option<String>,
+}
+
+impl ReadOptions {
+    pub fn make_range(&self) -> (RangeBound<u64>, RangeBound<u64>) {
+        match (self.offset.clone(), self.size.clone()) {
+            (Some(offset), Some(size)) => {
+                let start = offset.get_u64().1;
+                let len = size.get_u64().1;
+                // prevent overflow
+                let end = start.checked_add(len).expect("offset + size overflow");
+                (RangeBound::Included(start), RangeBound::Excluded(end))
+            }
+            (Some(offset), None) => {
+                let start = offset.get_u64().1;
+                (RangeBound::Included(start), RangeBound::Unbounded)
+            }
+            (None, Some(size)) => {
+                let len = size.get_u64().1;
+                (RangeBound::Included(0), RangeBound::Excluded(len))
+            }
+            (None, None) => (RangeBound::Unbounded, RangeBound::Unbounded),
+        }
+    }
+}
+
+impl From<ReadOptions> for opendal::options::ReadOptions {
+    fn from(value: ReadOptions) -> Self {
+        let r = value.make_range();
+        let if_modified_since = value
+            .if_modified_since
+            .and_then(|v| parse_datetime_from_rfc3339(&v).ok());
+        let if_unmodified_since = value
+            .if_unmodified_since
+            .and_then(|v| parse_datetime_from_rfc3339(&v).ok());
+
+        Self {
+            version: value.version,
+            concurrent: value.concurrent.unwrap_or_default() as usize,
+            chunk: value.chunk.map(|chunk| chunk as usize),
+            gap: value.gap.map(|gap| gap.get_u64().1 as usize),
+            range: r.into(),
+            if_match: value.if_match,
+            if_none_match: value.if_none_match,
+            if_modified_since,
+            if_unmodified_since,
+            override_content_type: value.content_type,
+            override_cache_control: value.cache_control,
+            override_content_disposition: value.content_disposition,
+        }
+    }
+}
+
+#[napi(object)]
+#[derive(Default)]
+pub struct ReaderOptions {
+    /**
+     * Set `version` for this operation.
+     *
+     * This option can be used to retrieve the data of a specified version of the given path.
+     */
+    pub version: Option<String>,
+
+    /**
+     * Set `concurrent` for the operation.
+     *
+     * OpenDAL by default to read file without concurrent. This is not efficient for cases when users
+     * read large chunks of data. By setting `concurrent`, opendal will reading files concurrently
+     * on support storage services.
+     *
+     * By setting `concurrent`, opendal will fetch chunks concurrently with
+     * the give chunk size.
+     */
+    pub concurrent: Option<u32>,
+
+    /**
+     * Sets the chunk size for this operation.
+     *
+     * OpenDAL will use services' preferred chunk size by default. Users can set chunk based on their own needs.
+     */
+    pub chunk: Option<u32>,
+
+    /**
+     * Controls the optimization strategy for range reads in [`Reader::fetch`].
+     *
+     * When performing range reads, if the gap between two requested ranges is smaller than
+     * the configured `gap` size, OpenDAL will merge these ranges into a single read request
+     * and discard the unrequested data in between. This helps reduce the number of API calls
+     * to remote storage services.
+     *
+     * This optimization is particularly useful when performing multiple small range reads
+     * that are close to each other, as it reduces the overhead of multiple network requests
+     * at the cost of transferring some additional data.
+     */
+    pub gap: Option<BigInt>,
+
+    /**
+     * Sets if-match condition for this operation.
+     * If file exists and its etag doesn't match, an error will be returned.
+     */
+    pub if_match: Option<String>,
+
+    /**
+     * Sets if-none-match condition for this operation.
+     * If file exists and its etag matches, an error will be returned.
+     */
+    pub if_none_match: Option<String>,
+
+    /**
+     * Sets if-modified-since condition for this operation.
+     * If file exists and hasn't been modified since the specified time, an error will be returned.
+     * ISO 8601 formatted date string
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+     */
+    pub if_modified_since: Option<String>,
+
+    /**
+     * Sets if-unmodified-since condition for this operation.
+     * If file exists and has been modified since the specified time, an error will be returned.
+     * ISO 8601 formatted date string
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+     */
+    pub if_unmodified_since: Option<String>,
+}
+
+impl From<ReaderOptions> for opendal::options::ReaderOptions {
+    fn from(value: ReaderOptions) -> Self {
+        let if_modified_since = value
+            .if_modified_since
+            .and_then(|v| parse_datetime_from_rfc3339(&v).ok());
+        let if_unmodified_since = value
+            .if_unmodified_since
+            .and_then(|v| parse_datetime_from_rfc3339(&v).ok());
+
+        Self {
+            version: value.version,
+            concurrent: value.concurrent.unwrap_or_default() as usize,
+            chunk: value.chunk.map(|chunk| chunk as usize),
+            gap: value.gap.map(|gap| gap.get_u64().1 as usize),
+            if_match: value.if_match,
+            if_none_match: value.if_none_match,
+            if_modified_since,
+            if_unmodified_since,
         }
     }
 }

--- a/bindings/nodejs/tests/suites/asyncReadOptions.suite.mjs
+++ b/bindings/nodejs/tests/suites/asyncReadOptions.suite.mjs
@@ -32,7 +32,7 @@ export function run(op) {
 
   describe.runIf(capability.read && capability.write)('async read options', () => {
     test('read with range', async () => {
-      const size = 5 * 1024 * 1024
+      const size = 3 * 1024 * 1024
       const filename = `random_file_${randomUUID()}`
       const content = generateFixedBytes(size)
       const offset = Math.floor(Math.random() * (size - 1))
@@ -96,7 +96,7 @@ export function run(op) {
     })
 
     test.runIf(capability.readWithIfModifiedSince)('read with if modified since', async () => {
-      const size = 5 * 1024 * 1024
+      const size = 3 * 1024 * 1024
       const filename = `random_file_${randomUUID()}`
       const content = generateBytes(size)
 
@@ -120,7 +120,7 @@ export function run(op) {
     })
 
     test.runIf(capability.readWithIfUnmodifiedSince)('read with if unmodified since', async () => {
-      const size = 5 * 1024 * 1024
+      const size = 3 * 1024 * 1024
       const filename = `random_file_${randomUUID()}`
       const content = generateBytes(size)
 

--- a/bindings/nodejs/tests/suites/asyncReadOptions.suite.mjs
+++ b/bindings/nodejs/tests/suites/asyncReadOptions.suite.mjs
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { test, describe, expect, assert } from 'vitest'
+import { Writable } from 'node:stream'
+import { finished, pipeline } from 'node:stream/promises'
+
+import { generateBytes, generateFixedBytes, sleep } from '../utils.mjs'
+
+/**
+ * @param {import("../../index").Operator} op
+ */
+export function run(op) {
+  const capability = op.capability()
+
+  describe.runIf(capability.read && capability.write)('async read options', () => {
+    test('read with range', async () => {
+      const size = 5 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateFixedBytes(size)
+      const offset = Math.floor(Math.random() * (size - 1))
+      const maxLen = size - offset
+      const length = Math.floor(Math.random() * (maxLen - 1)) + 1
+
+      await op.write(filename, content)
+
+      const bs = await op.read(filename, {
+        offset: BigInt(offset),
+        size: BigInt(length),
+      })
+      expect(bs.length).toBe(length)
+      assert.equal(Buffer.compare(bs, content.subarray(offset, offset + length)), 0)
+
+      await op.delete(filename)
+    })
+
+    test.runIf(capability.readWithIfMatch)('read with if match', async () => {
+      const filename = `random_file_${randomUUID()}`
+      const content = generateBytes()
+
+      await op.write(filename, content)
+      const meta = await op.stat(filename)
+
+      const invalidOptions = {
+        ifMatch: '"invalid_etag"',
+      }
+
+      await expect(op.read(filename, invalidOptions)).rejects.toThrowError('ConditionNotMatch')
+
+      const bs = await op.read(filename, {
+        ifMatch: meta.etag,
+      })
+
+      assert.equal(Buffer.compare(bs, content), 0)
+
+      await op.delete(filename)
+    })
+
+    test.runIf(capability.readWithIfNoneMatch)('read with if none match', async () => {
+      const filename = `random_file_${randomUUID()}`
+      const content = generateBytes()
+
+      await op.write(filename, content)
+      const meta = await op.stat(filename)
+
+      const invalidOptions = {
+        ifNoneMatch: meta.etag,
+      }
+
+      await expect(op.read(filename, invalidOptions)).rejects.toThrowError('ConditionNotMatch')
+
+      const bs = await op.read(filename, {
+        ifNoneMatch: '"invalid_etag"',
+      })
+
+      assert.equal(Buffer.compare(bs, content), 0)
+
+      await op.delete(filename)
+    })
+
+    test.runIf(capability.readWithIfModifiedSince)('read with if modified since', async () => {
+      const size = 5 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateBytes(size)
+
+      await op.write(filename, content)
+      const meta = await op.stat(filename)
+
+      const sinceMinus = new Date(meta.lastModified)
+      sinceMinus.setSeconds(sinceMinus.getSeconds() - 1)
+      const bs = await op.read(filename, { ifModifiedSince: sinceMinus.toISOString() })
+      assert.equal(Buffer.compare(bs, content), 0)
+
+      await sleep(1000)
+
+      const sinceAdd = new Date(meta.lastModified)
+      sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)
+
+      await expect(op.read(filename, { ifModifiedSince: sinceAdd.toISOString() })).rejects.toThrowError(
+        'ConditionNotMatch',
+      )
+      await op.delete(filename)
+    })
+
+    test.runIf(capability.readWithIfUnmodifiedSince)('read with if unmodified since', async () => {
+      const size = 5 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateBytes(size)
+
+      await op.write(filename, content)
+      const meta = await op.stat(filename)
+
+      const sinceMinus = new Date(meta.lastModified)
+      sinceMinus.setSeconds(sinceMinus.getSeconds() - 3600)
+      await expect(op.read(filename, { ifUnmodifiedSince: sinceMinus.toISOString() })).rejects.toThrowError(
+        'ConditionNotMatch',
+      )
+
+      await sleep(1000)
+
+      const sinceAdd = new Date(meta.lastModified)
+      sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)
+
+      const bs = await op.read(filename, { ifUnmodifiedSince: sinceAdd.toISOString() })
+      assert.equal(Buffer.compare(bs, content), 0)
+
+      await op.delete(filename)
+    })
+
+    test.runIf(capability.readWithVersion)('read with version', async () => {
+      const filename = `random_file_${randomUUID()}`
+      const content = generateBytes()
+
+      await op.write(filename, content)
+      const meta = await op.stat(filename)
+      const data = await op.read(filename, { version: meta.version })
+      assert.equal(Buffer.compare(data, content), 0)
+
+      await op.write(filename, Buffer.from('1'))
+      // After writing new data, we can still read the first version data
+      const secondData = await op.read(filename, { version: meta.version })
+      assert.equal(Buffer.compare(secondData, content), 0)
+
+      await op.delete(filename)
+    })
+
+    test.runIf(capability.readWithVersion)('read with not existing version', async () => {
+      const filename = `random_file_${randomUUID()}`
+      const content = generateBytes()
+
+      await op.write(filename, content)
+      const meta = await op.stat(filename)
+
+      const filename2 = `random_file_${randomUUID()}`
+      const content2 = generateBytes()
+      await op.write(filename2, content2)
+
+      await expect(op.read(filename2, { version: meta.version })).rejects.toThrowError('NotFound')
+
+      await op.delete(filename)
+      await op.delete(filename2)
+    })
+  })
+
+  describe.runIf(capability.read && capability.write)('async reader options', () => {
+    test.runIf(capability.readWithIfMatch)('reader with if match', async () => {
+      const size = 3 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateFixedBytes(size)
+
+      await op.write(filename, content)
+      const meta = await op.stat(filename)
+
+      const invalidOptions = {
+        ifMatch: '"invalid_etag"',
+      }
+
+      const reader = await op.reader(filename, invalidOptions)
+      const buf = Buffer.alloc(content.length)
+      await expect(reader.read(buf)).rejects.toThrowError('ConditionNotMatch')
+
+      const r = await op.reader(filename, { ifMatch: meta.etag })
+      const rs = r.createReadStream()
+      let chunks = []
+      await pipeline(
+        rs,
+        new Writable({
+          write(chunk, encoding, callback) {
+            chunks.push(chunk)
+            callback()
+          },
+        }),
+      )
+
+      await finished(rs)
+      const bs = Buffer.concat(chunks)
+
+      assert.equal(Buffer.compare(bs, content), 0)
+      await op.delete(filename)
+    })
+
+    test.runIf(capability.readWithIfNoneMatch)('reader with if none match', async () => {
+      const size = 3 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateFixedBytes(size)
+
+      await op.write(filename, content)
+      const meta = await op.stat(filename)
+
+      const reader = await op.reader(filename, { ifNoneMatch: meta.etag })
+      const buf = Buffer.alloc(content.length)
+      await expect(reader.read(buf)).rejects.toThrowError('ConditionNotMatch')
+
+      const r = await op.reader(filename, { ifNoneMatch: '"invalid_etag"' })
+      const rs = r.createReadStream()
+      let chunks = []
+      await pipeline(
+        rs,
+        new Writable({
+          write(chunk, encoding, callback) {
+            chunks.push(chunk)
+            callback()
+          },
+        }),
+      )
+
+      await finished(rs)
+      const bs = Buffer.concat(chunks)
+
+      assert.equal(Buffer.compare(bs, content), 0)
+      await op.delete(filename)
+    })
+
+    test.runIf(capability.readWithIfModifiedSince)('reader with if modified since', async () => {
+      const size = 3 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateFixedBytes(size)
+
+      await op.write(filename, content)
+      const meta = await op.stat(filename)
+
+      const sinceMinus = new Date(meta.lastModified)
+      sinceMinus.setSeconds(sinceMinus.getSeconds() - 1)
+      const reader = await op.reader(filename, { ifModifiedSince: sinceMinus.toISOString() })
+      const rs = reader.createReadStream()
+      let chunks = []
+      await pipeline(
+        rs,
+        new Writable({
+          write(chunk, encoding, callback) {
+            chunks.push(chunk)
+            callback()
+          },
+        }),
+      )
+
+      await finished(rs)
+      const buf = Buffer.concat(chunks)
+      assert.equal(Buffer.compare(buf, content), 0)
+
+      await sleep(1000)
+
+      const sinceAdd = new Date(meta.lastModified)
+      sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)
+      const r = await op.reader(filename, { ifModifiedSince: sinceAdd.toISOString() })
+      const bs2 = Buffer.alloc(content.length)
+      await expect(r.read(bs2)).rejects.toThrowError('ConditionNotMatch')
+
+      await op.delete(filename)
+    })
+
+    test.runIf(capability.readWithIfUnmodifiedSince)('reader with if unmodified since', async () => {
+      const size = 3 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateFixedBytes(size)
+
+      await op.write(filename, content)
+      const meta = await op.stat(filename)
+
+      const sinceMinus = new Date(meta.lastModified)
+      sinceMinus.setSeconds(sinceMinus.getSeconds() - 1)
+
+      const r = await op.reader(filename, { ifUnmodifiedSince: sinceMinus.toISOString() })
+      const bs = Buffer.alloc(content.length)
+      await expect(r.read(bs)).rejects.toThrowError('ConditionNotMatch')
+
+      await sleep(1000)
+
+      const sinceAdd = new Date(meta.lastModified)
+      sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)
+
+      const reader = await op.reader(filename, { ifUnmodifiedSince: sinceAdd.toISOString() })
+      const rs = reader.createReadStream()
+      let chunks = []
+      await pipeline(
+        rs,
+        new Writable({
+          write(chunk, encoding, callback) {
+            chunks.push(chunk)
+            callback()
+          },
+        }),
+      )
+
+      await finished(rs)
+      const bs2 = Buffer.concat(chunks)
+      assert.equal(Buffer.compare(bs2, content), 0)
+
+      await op.delete(filename)
+    })
+  })
+}

--- a/bindings/nodejs/tests/suites/index.mjs
+++ b/bindings/nodejs/tests/suites/index.mjs
@@ -26,6 +26,8 @@ import { run as ServicesTestRun } from './services.suite.mjs'
 import { run as SyncIOTestRun } from './sync.suite.mjs'
 import { run as AsyncStatOptionsTestRun } from './asyncStatOptions.suite.mjs'
 import { run as SyncStatOptionsTestRun } from './syncStatOptions.suite.mjs'
+import { run as AsyncReadOptionsTestRun } from './asyncReadOptions.suite.mjs'
+import { run as SyncReadOptionsTestRun } from './syncReadOptions.suite.mjs'
 
 export function runner(testName, scheme) {
   if (!scheme) {
@@ -57,5 +59,7 @@ export function runner(testName, scheme) {
     SyncIOTestRun(operator)
     AsyncStatOptionsTestRun(operator)
     SyncStatOptionsTestRun(operator)
+    AsyncReadOptionsTestRun(operator)
+    SyncReadOptionsTestRun(operator)
   })
 }

--- a/bindings/nodejs/tests/suites/syncReadOptions.suite.mjs
+++ b/bindings/nodejs/tests/suites/syncReadOptions.suite.mjs
@@ -30,7 +30,7 @@ export function run(op) {
 
   describe.runIf(capability.read && capability.write)('sync read options', () => {
     test('read with range', () => {
-      const size = 5 * 1024 * 1024
+      const size = 3 * 1024 * 1024
       const filename = `random_file_${randomUUID()}`
       const content = generateFixedBytes(size)
       const offset = Math.floor(Math.random() * (size - 1))
@@ -94,7 +94,7 @@ export function run(op) {
     })
 
     test.runIf(capability.readWithIfModifiedSince)('read with if modified since', () => {
-      const size = 5 * 1024 * 1024
+      const size = 3 * 1024 * 1024
       const filename = `random_file_${randomUUID()}`
       const content = generateBytes(size)
 
@@ -118,7 +118,7 @@ export function run(op) {
     })
 
     test.runIf(capability.readWithIfUnmodifiedSince)('read with if unmodified since', () => {
-      const size = 5 * 1024 * 1024
+      const size = 3 * 1024 * 1024
       const filename = `random_file_${randomUUID()}`
       const content = generateBytes(size)
 

--- a/bindings/nodejs/tests/suites/syncReadOptions.suite.mjs
+++ b/bindings/nodejs/tests/suites/syncReadOptions.suite.mjs
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { test, describe, expect, assert } from 'vitest'
+
+import { generateFixedBytes, generateBytes } from '../utils.mjs'
+
+/**
+ * @param {import("../../index").Operator} op
+ */
+export function run(op) {
+  const capability = op.capability()
+
+  describe.runIf(capability.read && capability.write)('sync read options', () => {
+    test('read with range', () => {
+      const size = 5 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateFixedBytes(size)
+      const offset = Math.floor(Math.random() * (size - 1))
+      const maxLen = size - offset
+      const length = Math.floor(Math.random() * (maxLen - 1)) + 1
+
+      op.writeSync(filename, content)
+
+      const bs = op.readSync(filename, {
+        offset: BigInt(offset),
+        size: BigInt(length),
+      })
+      expect(bs.length).toBe(length)
+      assert.equal(Buffer.compare(bs, content.subarray(offset, offset + length)), 0)
+
+      op.deleteSync(filename)
+    })
+
+    test.runIf(capability.readWithIfMatch)('read with if match', () => {
+      const filename = `random_file_${randomUUID()}`
+      const content = generateBytes()
+
+      op.writeSync(filename, content)
+      const meta = op.statSync(filename)
+
+      const invalidOptions = {
+        ifMatch: '"invalid_etag"',
+      }
+
+      expect(() => op.readSync(filename, invalidOptions)).toThrowError('ConditionNotMatch')
+
+      const bs = op.readSync(filename, {
+        ifMatch: meta.etag,
+      })
+
+      assert.equal(Buffer.compare(bs, content), 0)
+
+      op.deleteSync(filename)
+    })
+
+    test.runIf(capability.readWithIfNoneMatch)('read with if none match', () => {
+      const filename = `random_file_${randomUUID()}`
+      const content = generateBytes()
+
+      op.writeSync(filename, content)
+      const meta = op.statSync(filename)
+
+      const invalidOptions = {
+        ifNoneMatch: meta.etag,
+      }
+
+      expect(() => op.readSync(filename, invalidOptions)).toThrowError('ConditionNotMatch')
+
+      const bs = op.readSync(filename, {
+        ifNoneMatch: '"invalid_etag"',
+      })
+
+      assert.equal(Buffer.compare(bs, content), 0)
+
+      op.deleteSync(filename)
+    })
+
+    test.runIf(capability.readWithIfModifiedSince)('read with if modified since', () => {
+      const size = 5 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateBytes(size)
+
+      op.writeSync(filename, content)
+      const meta = op.statSync(filename)
+
+      const sinceMinus = new Date(meta.lastModified)
+      sinceMinus.setSeconds(sinceMinus.getSeconds() - 1)
+      const bs = op.readSync(filename, { ifModifiedSince: sinceMinus.toISOString() })
+      assert.equal(Buffer.compare(bs, content), 0)
+
+      setTimeout(() => {
+        const sinceAdd = new Date(meta.lastModified)
+        sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)
+
+        expect(() => op.readSync(filename, { ifModifiedSince: sinceAdd.toISOString() })).toThrowError(
+          'ConditionNotMatch',
+        )
+        op.deleteSync(filename)
+      }, 1000)
+    })
+
+    test.runIf(capability.readWithIfUnmodifiedSince)('read with if unmodified since', () => {
+      const size = 5 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateBytes(size)
+
+      op.writeSync(filename, content)
+      const meta = op.statSync(filename)
+
+      const sinceMinus = new Date(meta.lastModified)
+      sinceMinus.setSeconds(sinceMinus.getSeconds() - 3600)
+      expect(() => op.readSync(filename, { ifUnmodifiedSince: sinceMinus.toISOString() })).toThrowError(
+        'ConditionNotMatch',
+      )
+
+      setTimeout(() => {
+        const sinceAdd = new Date(meta.lastModified)
+        sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)
+
+        const bs = op.readSync(filename, { ifUnmodifiedSince: sinceAdd.toISOString() })
+        assert.equal(Buffer.compare(bs, content), 0)
+
+        op.deleteSync(filename)
+      }, 1000)
+    })
+
+    test.runIf(capability.readWithVersion)('read with version', () => {
+      const filename = `random_file_${randomUUID()}`
+      const content = generateBytes()
+
+      op.writeSync(filename, content)
+      const meta = op.statSync(filename)
+      const data = op.readSync(filename, { version: meta.version })
+      assert.equal(Buffer.compare(data, content), 0)
+
+      op.writeSync(filename, Buffer.from('1'))
+      // After writing new data, we can still read the first version data
+      const secondData = op.readSync(filename, { version: meta.version })
+      assert.equal(Buffer.compare(secondData, content), 0)
+
+      op.deleteSync(filename)
+    })
+
+    test.runIf(capability.readWithVersion)('read with not existing version', () => {
+      const filename = `random_file_${randomUUID()}`
+      const content = generateBytes()
+
+      op.writeSync(filename, content)
+      const meta = op.statSync(filename)
+
+      const filename2 = `random_file_${randomUUID()}`
+      const content2 = generateBytes()
+      op.writeSync(filename2, content2)
+
+      expect(() => op.readSync(filename2, { version: meta.version })).toThrowError('NotFound')
+
+      op.deleteSync(filename)
+      op.deleteSync(filename2)
+    })
+  })
+
+  describe.runIf(capability.read && capability.write)('sync reader options', () => {
+    test.runIf(capability.readWithIfMatch)('reader with if match', () => {
+      const size = 3 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateFixedBytes(size)
+
+      op.writeSync(filename, content)
+      const meta = op.statSync(filename)
+
+      const invalidOptions = {
+        ifMatch: '"invalid_etag"',
+      }
+
+      const reader = op.readerSync(filename, invalidOptions)
+      const buf = Buffer.alloc(content.length)
+      expect(() => reader.read(buf)).toThrowError('ConditionNotMatch')
+
+      const r = op.readerSync(filename, { ifMatch: meta.etag })
+      const rs = r.createReadStream()
+
+      let chunks = []
+      rs.on('data', (chunk) => {
+        chunks.push(chunk)
+      })
+
+      rs.on('end', () => {
+        const buf = Buffer.concat(chunks)
+        assert.equal(Buffer.compare(buf, content), 0)
+
+        op.deleteSync(filename)
+      })
+    })
+
+    test.runIf(capability.readWithIfNoneMatch)('reader with if none match', () => {
+      const size = 3 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateFixedBytes(size)
+
+      op.writeSync(filename, content)
+      const meta = op.statSync(filename)
+
+      const reader = op.readerSync(filename, { ifNoneMatch: meta.etag })
+      const buf = Buffer.alloc(content.length)
+      expect(() => reader.read(buf)).toThrowError('ConditionNotMatch')
+
+      const r = op.readerSync(filename, { ifNoneMatch: '"invalid_etag"' })
+      const rs = r.createReadStream()
+
+      let chunks = []
+      rs.on('data', (chunk) => {
+        chunks.push(chunk)
+      })
+
+      rs.on('end', () => {
+        const buf = Buffer.concat(chunks)
+        assert.equal(Buffer.compare(buf, content), 0)
+
+        op.deleteSync(filename)
+      })
+    })
+
+    test.runIf(capability.readWithIfModifiedSince)('reader with if modified since', () => {
+      const size = 3 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateFixedBytes(size)
+
+      op.writeSync(filename, content)
+      const meta = op.statSync(filename)
+
+      const sinceMinus = new Date(meta.lastModified)
+      sinceMinus.setSeconds(sinceMinus.getSeconds() - 1)
+      const reader = op.readerSync(filename, { ifModifiedSince: sinceMinus.toISOString() })
+      const rs = reader.createReadStream()
+
+      let chunks = []
+      rs.on('data', (chunk) => {
+        chunks.push(chunk)
+      })
+
+      rs.on('end', () => {
+        const buf = Buffer.concat(chunks)
+        assert.equal(Buffer.compare(buf, content), 0)
+      })
+
+      setTimeout(() => {
+        const sinceAdd = new Date(meta.lastModified)
+        sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)
+        const r = op.readerSync(filename, { ifModifiedSince: sinceAdd.toISOString() })
+        const bs2 = Buffer.alloc(content.length)
+        expect(() => r.read(bs2)).toThrowError('ConditionNotMatch')
+
+        op.deleteSync(filename)
+      }, 1000)
+    })
+
+    test.runIf(capability.readWithIfUnmodifiedSince)('reader with if unmodified since', () => {
+      const size = 3 * 1024 * 1024
+      const filename = `random_file_${randomUUID()}`
+      const content = generateFixedBytes(size)
+
+      op.writeSync(filename, content)
+      const meta = op.statSync(filename)
+
+      const sinceMinus = new Date(meta.lastModified)
+      sinceMinus.setSeconds(sinceMinus.getSeconds() - 1)
+
+      const r = op.readerSync(filename, { ifUnmodifiedSince: sinceMinus.toISOString() })
+      const bs = Buffer.alloc(content.length)
+      expect(() => r.read(bs)).toThrowError('ConditionNotMatch')
+
+      setTimeout(() => {
+        const sinceAdd = new Date(meta.lastModified)
+        sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)
+
+        const reader = op.readerSync(filename, { ifUnmodifiedSince: sinceAdd.toISOString() })
+        const rs = reader.createReadStream()
+
+        let chunks = []
+        rs.on('data', (chunk) => {
+          chunks.push(chunk)
+        })
+
+        rs.on('end', () => {
+          const buf = Buffer.concat(chunks)
+          assert.equal(Buffer.compare(buf, content), 0)
+          op.deleteSync(filename)
+        })
+      }, 1000)
+    })
+  })
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/opendal/issues/6281.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
This PR adds support for opendal::options::ReadOptions and opendal::options::ReaderOptions conversion in the nodejs bindings. This is part of the migration to the new options API outlined in RFC-6213 (https://github.com/apache/opendal/pull/6213).
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Added a complete mapping and conversion of opendal::options::ReadOptions and opendal::options::ReaderOptions
- behavior tests mirroring Rust's async_read.rs test suite
- Added the capabilities to support the options

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
Yes, users can now add options to their read and reader requests
