### PR TITLE
fix(bindings/python): Fix Writer doesn't throw correct error code

### DIFF
--- a/bindings/python/src/file.rs
+++ b/bindings/python/src/file.rs
@@ -268,8 +268,7 @@ impl File {
 
     fn close(&mut self) -> PyResult<()> {
         if let FileState::Writer(w) = &mut self.0 {
-            w.close()
-                .map_err(|err| PyIOError::new_err(err.to_string()))?;
+            w.close().map_err(format_pyerr_from_io_error)?;
         };
         self.0 = FileState::Closed;
         Ok(())
@@ -514,9 +513,7 @@ impl AsyncFile {
         future_into_py(py, async move {
             let mut state = state.lock().await;
             if let AsyncFileState::Writer(w) = &mut *state {
-                w.close()
-                    .await
-                    .map_err(|err| PyIOError::new_err(err.to_string()))?;
+                w.close().await.map_err(format_pyerr_from_io_error)?;
             }
             *state = AsyncFileState::Closed;
             Ok(())


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6235

# Rationale for this change

python bindings users `FuturesWriter` directly which returns rust IO error. This can lead to we return different exceptions compared to `write`.

# What changes are included in this PR?

This PR fixed this by downcast them to the correct error.

# Are there any user-facing changes?

No.
