### PR TITLE
feat(bindings/nodejs): Add ListOptions support for new options API

### DIFF
--- a/bindings/nodejs/src/capability.rs
+++ b/bindings/nodejs/src/capability.rs
@@ -257,6 +257,18 @@ impl Capability {
         self.0.list_with_recursive
     }
 
+    /// If backend supports list with versions.
+    #[napi(getter)]
+    pub fn list_with_versions(&self) -> bool {
+        self.0.list_with_versions
+    }
+
+    /// If backend supports list with deleted.
+    #[napi(getter)]
+    pub fn list_with_deleted(&self) -> bool {
+        self.0.list_with_deleted
+    }
+
     /// If operator supports presign.
     #[napi(getter)]
     pub fn presign(&self) -> bool {

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -27,7 +27,7 @@ use std::time::Duration;
 use futures::AsyncReadExt;
 use futures::TryStreamExt;
 use napi::bindgen_prelude::*;
-use opendal::options::{ReadOptions, ReaderOptions, StatOptions};
+use opendal::options::{ListOptions, ReadOptions, ReaderOptions, StatOptions};
 
 mod capability;
 mod options;
@@ -490,6 +490,22 @@ impl Operator {
             .map_err(format_napi_error)
     }
 
+    /// Remove given paths.
+    ///
+    /// ### Notes
+    /// If underlying services support delete in batch, we will use batch delete instead.
+    ///
+    /// ### Examples
+    /// ```javascript
+    /// op.removeSync(["abc", "def"]);
+    /// ```
+    #[napi]
+    pub fn remove_sync(&self, paths: Vec<String>) -> Result<()> {
+        self.blocking_op
+            .delete_iter(paths)
+            .map_err(format_napi_error)
+    }
+
     /// Remove the path and all nested dirs and files recursively.
     ///
     /// ### Notes
@@ -504,6 +520,22 @@ impl Operator {
         self.async_op
             .remove_all(&path)
             .await
+            .map_err(format_napi_error)
+    }
+
+    /// Remove the path and all nested dirs and files recursively.
+    ///
+    /// ### Notes
+    /// If underlying services support delete in batch, we will use batch delete instead.
+    ///
+    /// ### Examples
+    /// ```javascript
+    /// op.removeAllSync("path/to/dir/");
+    /// ```
+    #[napi]
+    pub fn remove_all_sync(&self, path: String) -> Result<()> {
+        self.blocking_op
+            .remove_all(&path)
             .map_err(format_napi_error)
     }
 
@@ -539,22 +571,19 @@ impl Operator {
     /// }
     /// ```
     #[napi]
-    pub async fn list(&self, path: String, options: Option<ListOptions>) -> Result<Vec<Entry>> {
-        let mut l = self.async_op.list_with(&path);
-        if let Some(options) = options {
-            if let Some(limit) = options.limit {
-                l = l.limit(limit as usize);
-            }
-            if let Some(recursive) = options.recursive {
-                l = l.recursive(recursive);
-            }
-        }
+    pub async fn list(
+        &self,
+        path: String,
+        options: Option<options::ListOptions>,
+    ) -> Result<Vec<Entry>> {
+        let options = options.map_or(ListOptions::default(), ListOptions::from);
+        let l = self
+            .async_op
+            .list_options(&path, options)
+            .await
+            .map_err(format_napi_error)?;
 
-        Ok(l.await
-            .map_err(format_napi_error)?
-            .iter()
-            .map(|e| Entry(e.to_owned()))
-            .collect())
+        Ok(l.into_iter().map(Entry).collect())
     }
 
     /// List the given path synchronously.
@@ -582,18 +611,23 @@ impl Operator {
     /// ```javascript
     /// const list = op.listSync("path/to/dir/", { recursive: true });
     /// for (let entry of list) {
-    ///   let meta = op.statSync(entry.path);
+    ///   let path = entry.path();
+    ///   let meta = entry.metadata();
     ///   if (meta.isFile) {
     ///     // do something
     ///   }
     /// }
     /// ```
     #[napi]
-    pub fn list_sync(&self, path: String, options: Option<ListOptions>) -> Result<Vec<Entry>> {
-        let options = options.unwrap_or_default();
+    pub fn list_sync(
+        &self,
+        path: String,
+        options: Option<options::ListOptions>,
+    ) -> Result<Vec<Entry>> {
+        let options = options.map_or(ListOptions::default(), ListOptions::from);
         let l = self
             .blocking_op
-            .list_options(&path, options.into())
+            .list_options(&path, options)
             .map_err(format_napi_error)?;
 
         Ok(l.into_iter().map(Entry).collect())
@@ -680,6 +714,12 @@ impl Entry {
     pub fn path(&self) -> String {
         self.0.path().to_string()
     }
+
+    /// Return the metadata of this entry.
+    #[napi]
+    pub fn metadata(&self) -> Metadata {
+        Metadata(self.0.metadata().clone())
+    }
 }
 
 #[napi]
@@ -718,6 +758,13 @@ impl Metadata {
     #[napi]
     pub fn is_file(&self) -> bool {
         self.0.is_file()
+    }
+
+    /// This function returns `true` if the file represented by this metadata has been marked for
+    /// deletion or has been permanently deleted.
+    #[napi]
+    pub fn is_deleted(&self) -> bool {
+        self.0.is_deleted()
     }
 
     /// Content-Disposition of this object
@@ -768,23 +815,6 @@ impl Metadata {
     #[napi(getter)]
     pub fn version(&self) -> Option<String> {
         self.0.version().map(|v| v.to_string())
-    }
-}
-
-#[napi(object)]
-#[derive(Default)]
-pub struct ListOptions {
-    pub limit: Option<u32>,
-    pub recursive: Option<bool>,
-}
-
-impl From<ListOptions> for opendal::options::ListOptions {
-    fn from(value: ListOptions) -> Self {
-        Self {
-            limit: value.limit.map(|v| v as usize),
-            recursive: value.recursive.unwrap_or_default(),
-            ..Default::default()
-        }
     }
 }
 

--- a/bindings/nodejs/src/options.rs
+++ b/bindings/nodejs/src/options.rs
@@ -329,3 +329,65 @@ impl From<ReaderOptions> for opendal::options::ReaderOptions {
         }
     }
 }
+
+#[napi(object)]
+#[derive(Debug, Default)]
+pub struct ListOptions {
+    /**
+     * The limit passed to underlying service to specify the max results
+     * that could return per-request.
+     *
+     * Users could use this to control the memory usage of list operation.
+     */
+    pub limit: Option<u32>,
+
+    /**
+     * The start_after passed to underlying service to specify the specified key
+     * to start listing from.
+     */
+    pub start_after: Option<String>,
+
+    /**
+     * The recursive is used to control whether the list operation is recursive.
+     *
+     * - If `false`, list operation will only list the entries under the given path.
+     * - If `true`, list operation will list all entries that starts with given path.
+     *
+     * Default to `false`.
+     */
+    pub recursive: Option<bool>,
+
+    /**
+     * The versions is used to control whether the object versions should be returned.
+     *
+     * - If `false`, list operation will not return with object versions
+     * - If `true`, list operation will return with object versions if object versioning is supported
+     *   by the underlying service
+     *
+     * Default to `false`
+     */
+    pub versions: Option<bool>,
+
+    /**
+     * The deleted is used to control whether the deleted objects should be returned.
+     *
+     * - If `false`, list operation will not return with deleted objects
+     * - If `true`, list operation will return with deleted objects if object versioning is supported
+     *   by the underlying service
+     *
+     * Default to `false`
+     */
+    pub deleted: Option<bool>,
+}
+
+impl From<ListOptions> for opendal::options::ListOptions {
+    fn from(value: ListOptions) -> Self {
+        Self {
+            limit: value.limit.map(|v| v as usize),
+            start_after: value.start_after,
+            recursive: value.recursive.unwrap_or_default(),
+            versions: value.versions.unwrap_or_default(),
+            deleted: value.deleted.unwrap_or_default(),
+        }
+    }
+}

--- a/bindings/nodejs/tests/suites/asyncListOptions.suite.mjs
+++ b/bindings/nodejs/tests/suites/asyncListOptions.suite.mjs
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { randomUUID } from 'node:crypto'
+import path from 'node:path'
+import { test, describe, expect, assert } from 'vitest'
+import { EntryMode } from '../../index.mjs'
+
+/**
+ * @param {import("../../index").Operator} op
+ */
+export function run(op) {
+  const capability = op.capability()
+
+  describe.runIf(capability.write && capability.read && capability.list)('async listOptions tests', () => {
+    test('test remove all', async () => {
+      const parent = `random_remove_${randomUUID()}/`
+      await op.createDir(parent)
+
+      const expected = ['x/', 'x/y', 'x/x/', 'x/x/y', 'x/x/x/', 'x/x/x/y', 'x/x/x/x/']
+
+      for await (const entry of expected) {
+        if (entry.endsWith('/')) {
+          await op.createDir(path.join(parent, entry))
+        } else {
+          await op.write(path.join(parent, entry), 'test_scan')
+        }
+      }
+
+      await op.removeAll(path.join(parent, 'x/'))
+
+      for await (const entry of expected) {
+        if (entry.endsWith('/')) {
+          continue
+        }
+
+        assert.isNotTrue(await op.exists(path.join(parent, entry)))
+      }
+
+      await op.removeAll(parent)
+    })
+
+    test.runIf(capability.listWithRecursive)('list with recursive', async () => {
+      const dirname = `random_dir_${randomUUID()}/`
+      await op.createDir(dirname)
+
+      const expected = ['x/', 'x/y', 'x/x/', 'x/x/y', 'x/x/x/', 'x/x/x/y', 'x/x/x/x/']
+      for await (const entry of expected) {
+        if (entry.endsWith('/')) {
+          await op.createDir(path.join(dirname, entry))
+        } else {
+          await op.write(path.join(dirname, entry), 'test_scan')
+        }
+      }
+
+      const lists = await op.list(dirname, { recursive: true })
+      const actual = lists.filter((item) => item.metadata().isFile()).map((item) => item.path().slice(dirname.length))
+      expect(actual.length).toEqual(3)
+
+      expect(actual.sort()).toEqual(['x/x/x/y', 'x/x/y', 'x/y'])
+
+      await op.removeAll(dirname)
+    })
+
+    test.runIf(capability.listWithStartAfter)('list with start after', async () => {
+      const dirname = `random_dir_${randomUUID()}/`
+
+      await op.createDir(dirname)
+
+      const given = Array.from({ length: 6 }, (_, i) => path.join(dirname, `file_${i}_${randomUUID()}`))
+      for await (const entry of given) {
+        await op.write(entry, 'content')
+      }
+
+      const lists = await op.list(dirname, { startAfter: given[2] })
+      const actual = lists.filter((item) => item.path() !== dirname).map((item) => item.path())
+      const expected = given.slice(3)
+      expect(actual).toEqual(expected)
+
+      await op.removeAll(dirname)
+    })
+
+    test.runIf(capability.listWithVersions)('list with versions', async () => {
+      const dirname = `random_dir_${randomUUID()}/`
+
+      await op.createDir(dirname)
+
+      const filePath = path.join(dirname, `random_file_${randomUUID()}`)
+      await op.write(filePath, '1')
+      await op.write(filePath, '2')
+      const lists = await op.list(dirname, { versions: true })
+      const actual = lists.filter((item) => item.path() !== dirname)
+      expect(actual.length).toBe(2)
+      expect(actual[0].metadata().version).not.toBe(actual[1].metadata().version)
+
+      for await (const entry of actual) {
+        expect(entry.path()).toBe(filePath)
+        const meta = entry.metadata()
+        expect(meta.mode).toBe(EntryMode.FILE)
+      }
+
+      await op.removeAll(dirname)
+    })
+
+    test.runIf(capability.listWithLimit)('list with limit', async () => {
+      const dirname = `random_dir_${randomUUID()}/`
+      await op.createDir(dirname)
+
+      const given = Array.from({ length: 5 }, (_, i) => path.join(dirname, `file_${i}_${randomUUID()}`))
+      for await (const entry of given) {
+        await op.write(entry, 'data')
+      }
+
+      const lists = await op.list(dirname, { limit: 3 })
+      expect(lists.length).toBe(6)
+
+      await op.removeAll(dirname)
+    })
+
+    test.runIf(capability.listWithVersions && capability.listWithStartAfter)(
+      'list with versions and start after',
+      async () => {
+        const dirname = `random_dir_${randomUUID()}/`
+        await op.createDir(dirname)
+        const given = Array.from({ length: 6 }, (_, i) => path.join(dirname, `file_${i}_${randomUUID()}`))
+        for await (const entry of given) {
+          await op.write(entry, '1')
+          await op.write(entry, '2')
+        }
+        const lists = await op.list(dirname, { versions: true, startAfter: given[2] })
+        const actual = lists.filter((item) => item.path() !== dirname)
+        const expected = given.slice(3)
+        expect(actual).toEqual(expected)
+
+        await op.removeAll(dirname)
+      },
+    )
+
+    test.runIf(capability.listWithDeleted)('list with deleted', async () => {
+      const dirname = `random_dir_${randomUUID()}/`
+      await op.createDir(dirname)
+      const filePath = path.join(dirname, `random_file_${randomUUID()}`)
+      await op.write(filePath, '1')
+
+      const lists = await op.list(dirname, { deleted: true })
+      expect(lists.length).toBe(1)
+
+      await op.write(filePath, '2')
+      await op.remove(filePath)
+
+      const actual = lists.filter((item) => item.path() === filePath && item.metadata().isDeleted())
+      expect(actual.length).toBe(1)
+
+      await op.removeAll(dirname)
+    })
+  })
+}

--- a/bindings/nodejs/tests/suites/index.mjs
+++ b/bindings/nodejs/tests/suites/index.mjs
@@ -28,6 +28,8 @@ import { run as AsyncStatOptionsTestRun } from './asyncStatOptions.suite.mjs'
 import { run as SyncStatOptionsTestRun } from './syncStatOptions.suite.mjs'
 import { run as AsyncReadOptionsTestRun } from './asyncReadOptions.suite.mjs'
 import { run as SyncReadOptionsTestRun } from './syncReadOptions.suite.mjs'
+import { run as AsyncListOptionsTestRun } from './asyncListOptions.suite.mjs'
+import { run as SyncListOptionsTestRun } from './syncListOptions.suite.mjs'
 
 export function runner(testName, scheme) {
   if (!scheme) {
@@ -61,5 +63,7 @@ export function runner(testName, scheme) {
     SyncStatOptionsTestRun(operator)
     AsyncReadOptionsTestRun(operator)
     SyncReadOptionsTestRun(operator)
+    AsyncListOptionsTestRun(operator)
+    SyncListOptionsTestRun(operator)
   })
 }

--- a/bindings/nodejs/tests/suites/syncListOptions.suite.mjs
+++ b/bindings/nodejs/tests/suites/syncListOptions.suite.mjs
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { randomUUID } from 'node:crypto'
+import path from 'node:path'
+import { test, describe, expect, assert } from 'vitest'
+import { EntryMode } from '../../index.mjs'
+
+/**
+ * @param {import("../../index").Operator} op
+ */
+export function run(op) {
+  const capability = op.capability()
+
+  describe.runIf(capability.write && capability.read && capability.list)('sync listOptions tests', () => {
+    test('test remove all', () => {
+      const parent = `random_remove_${randomUUID()}/`
+      op.createDirSync(parent)
+
+      const expected = ['x/', 'x/y', 'x/x/', 'x/x/y', 'x/x/x/', 'x/x/x/y', 'x/x/x/x/']
+
+      for (const entry of expected) {
+        if (entry.endsWith('/')) {
+          op.createDirSync(path.join(parent, entry))
+        } else {
+          op.writeSync(path.join(parent, entry), 'test_scan')
+        }
+      }
+
+      op.removeAllSync(path.join(parent, 'x/'))
+
+      for (const entry of expected) {
+        if (entry.endsWith('/')) {
+          continue
+        }
+
+        assert.isNotTrue(op.existsSync(path.join(parent, entry)))
+      }
+
+      op.removeAllSync(parent)
+    })
+
+    test.runIf(capability.listWithRecursive)('list with recursive', () => {
+      const dirname = `random_dir_${randomUUID()}/`
+      op.createDirSync(dirname)
+
+      const expected = ['x/', 'x/y', 'x/x/', 'x/x/y', 'x/x/x/', 'x/x/x/y', 'x/x/x/x/']
+      for (const entry of expected) {
+        if (entry.endsWith('/')) {
+          op.createDirSync(path.join(dirname, entry))
+        } else {
+          op.writeSync(path.join(dirname, entry), 'test_scan')
+        }
+      }
+
+      const lists = op.listSync(dirname, { recursive: true })
+      const actual = lists.filter((item) => item.metadata().isFile()).map((item) => item.path().slice(dirname.length))
+      expect(actual.length).toEqual(3)
+
+      expect(actual.sort()).toEqual(['x/x/x/y', 'x/x/y', 'x/y'])
+
+      op.removeAllSync(dirname)
+    })
+
+    test.runIf(capability.listWithStartAfter)('list with start after', () => {
+      const dirname = `random_dir_${randomUUID()}/`
+
+      op.createDirSync(dirname)
+
+      const given = Array.from({ length: 6 }, (_, i) => path.join(dirname, `file_${i}_${randomUUID()}`))
+      for (const entry of given) {
+        op.writeSync(entry, 'content')
+      }
+
+      const lists = op.listSync(dirname, { startAfter: given[2] })
+      const actual = lists.filter((item) => item.path() !== dirname).map((item) => item.path())
+      const expected = given.slice(3)
+      expect(actual).toEqual(expected)
+
+      op.removeAllSync(dirname)
+    })
+
+    test.runIf(capability.listWithVersions)('list with versions', () => {
+      const dirname = `random_dir_${randomUUID()}/`
+
+      op.createDirSync(dirname)
+
+      const filePath = path.join(dirname, `random_file_${randomUUID()}`)
+      op.writeSync(filePath, '1')
+      op.writeSync(filePath, '2')
+      const lists = op.listSync(dirname, { versions: true })
+      const actual = lists.filter((item) => item.path() !== dirname)
+      expect(actual.length).toBe(2)
+      expect(actual[0].metadata().version).not.toBe(actual[1].metadata().version)
+
+      for (const entry of actual) {
+        expect(entry.path()).toBe(filePath)
+        const meta = entry.metadata()
+        expect(meta.mode).toBe(EntryMode.FILE)
+      }
+
+      op.removeAllSync(dirname)
+    })
+
+    test.runIf(capability.listWithLimit)('list with limit', () => {
+      const dirname = `random_dir_${randomUUID()}/`
+      op.createDirSync(dirname)
+
+      const given = Array.from({ length: 5 }, (_, i) => path.join(dirname, `file_${i}_${randomUUID()}`))
+      for (const entry of given) {
+        op.writeSync(entry, 'data')
+      }
+
+      const lists = op.listSync(dirname, { limit: 3 })
+      expect(lists.length).toBe(6)
+
+      op.removeAllSync(dirname)
+    })
+
+    test.runIf(capability.listWithVersions && capability.listWithStartAfter)(
+      'list with versions and start after',
+      () => {
+        const dirname = `random_dir_${randomUUID()}/`
+        op.createDirSync(dirname)
+        const given = Array.from({ length: 6 }, (_, i) => path.join(dirname, `file_${i}_${randomUUID()}`))
+        for (const entry of given) {
+          op.writeSync(entry, '1')
+          op.writeSync(entry, '2')
+        }
+        const lists = op.listSync(dirname, { versions: true, startAfter: given[2] })
+        const actual = lists.filter((item) => item.path() !== dirname)
+        const expected = given.slice(3)
+        expect(actual).toEqual(expected)
+
+        op.removeAllSync(dirname)
+      },
+    )
+
+    test.runIf(capability.listWithDeleted)('list with deleted', () => {
+      const dirname = `random_dir_${randomUUID()}/`
+      op.createDirSync(dirname)
+      const filePath = path.join(dirname, `random_file_${randomUUID()}`)
+      op.writeSync(filePath, '1')
+
+      const lists = op.listSync(dirname, { deleted: true })
+      expect(lists.length).toBe(1)
+
+      op.writeSync(filePath, '2')
+      op.removeSync(filePath)
+
+      const actual = lists.filter((item) => item.path() === filePath && item.metadata().isDeleted())
+      expect(actual.length).toBe(1)
+
+      op.removeAllSync(dirname)
+    })
+  })
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to https://github.com/apache/opendal/issues/6281.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
This PR adds support for opendal::options::ListOptions conversion in the nodejs bindings. This is part of the migration to the new options API outlined in RFC-6213 (https://github.com/apache/opendal/pull/6213).
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Added a complete mapping and conversion of opendal::options::ListOptions
- behavior tests mirroring Rust's async_list.rs test suite
- Added the capabilities to support the options

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
Yes, users can now add options to their list requests
