### PR TITLE
fix(dav-server): Fix create_dir to create nested directories

### DIFF
--- a/integrations/dav-server/src/fs.rs
+++ b/integrations/dav-server/src/fs.rs
@@ -125,7 +125,11 @@ impl DavFileSystem for OpendalFs {
             // During MKCOL processing, a server MUST make the Request-URI a member of its parent collection, unless the Request-URI is "/".  If no such ancestor exists, the method MUST fail.
             // refer to https://datatracker.ietf.org/doc/html/rfc2518#section-8.3.1
             let parent = Path::new(&path).parent().unwrap();
-            match self.op.exists(parent.to_str().unwrap()).await {
+            match self
+                .op
+                .exists(format!("{}/", parent.display()).as_str())
+                .await
+            {
                 Ok(exist) => {
                     if !exist && parent != Path::new("/") {
                         return Err(FsError::NotFound);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

MKCOL method fails to create folder under nested path in webdav.

for example:
MKCOL /a/
MKCOL /a/b/

I found out it was because of the exists function, adding “/” to the end of the path makes exists think it's a folder instead of a file.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

One line of code
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

hasn't

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
