### PR TITLE
refactor: remove uuid dependency when creating a temp path

### DIFF
--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -275,23 +275,3 @@ impl Access for FsBackend {
         Ok(RpRename::default())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_tmp_file_of() {
-        let cases = vec![
-            ("hello.txt", "hello.txt"),
-            ("/tmp/opendal.log", "opendal.log"),
-            ("/abc/def/hello.parquet", "hello.parquet"),
-        ];
-
-        for (path, expected_prefix) in cases {
-            let tmp_file = tmp_file_of(path);
-            assert!(tmp_file.len() > expected_prefix.len());
-            assert!(tmp_file.starts_with(expected_prefix));
-        }
-    }
-}

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -29,7 +29,6 @@ use suppaftp::types::Response;
 use suppaftp::FtpError;
 use suppaftp::Status;
 use tokio::sync::OnceCell;
-use uuid::Uuid;
 
 use super::core::FtpCore;
 use super::delete::FtpDeleter;
@@ -300,13 +299,7 @@ impl Access for FtpBackend {
             }
         }
 
-        let tmp_path = if op.append() {
-            None
-        } else {
-            let uuid = Uuid::new_v4().to_string();
-            Some(format!("{}.{}", path, uuid))
-        };
-
+        let tmp_path = op.append().then_some(build_tmp_path_of(path));
         let w = FtpWriter::new(ftp_stream, path.to_string(), tmp_path);
 
         Ok((RpWrite::new(), w))


### PR DESCRIPTION
# Which issue does this PR close?

The follow-up for a dependency question from #6317.

# Rationale for this change

1. Removes `uuid` dependency for:
  * fs
  * ftp
  * hdfs
2. Uses std when possible compared to using a crate. e.g., fastrand, getrandom.

# What changes are included in this PR?

* refactor `build_tmp_path_of`
* add tests
* minor code cleanup


# Are there any user-facing changes?

no.