### PR TITLE
fix(service/fs): handle if_not_exists flag to raise ConditionNotMatch error

### DIFF
--- a/core/src/services/fs/core.rs
+++ b/core/src/services/fs/core.rs
@@ -119,20 +119,14 @@ impl FsCore {
     ) -> Result<(PathBuf, Option<PathBuf>)> {
         if let Some(atomic_write_dir) = &self.atomic_write_dir {
             let target_path = self.ensure_write_abs_path(&self.root, path).await?;
+            let path = if op.if_not_exists() {
+                target_path.to_string_lossy().to_string()
+            } else {
+                build_tmp_path_of(path)
+            };
             let tmp_path = self
-                .ensure_write_abs_path(atomic_write_dir, &build_tmp_path_of(path))
+                .ensure_write_abs_path(atomic_write_dir, &path)
                 .await?;
-
-            if op.if_not_exists()
-                && tokio::fs::try_exists(&target_path)
-                    .await
-                    .map_err(new_std_io_error)?
-            {
-                return Err(parse_error(std::io::Error::new(
-                    std::io::ErrorKind::AlreadyExists,
-                    "file already exists",
-                )));
-            }
 
             // If the target file exists, we should append to the end of it directly.
             let should_append = op.append()

--- a/core/src/services/fs/core.rs
+++ b/core/src/services/fs/core.rs
@@ -124,9 +124,7 @@ impl FsCore {
             } else {
                 build_tmp_path_of(path)
             };
-            let tmp_path = self
-                .ensure_write_abs_path(atomic_write_dir, &path)
-                .await?;
+            let tmp_path = self.ensure_write_abs_path(atomic_write_dir, &path).await?;
 
             // If the target file exists, we should append to the end of it directly.
             let should_append = op.append()

--- a/core/src/services/fs/core.rs
+++ b/core/src/services/fs/core.rs
@@ -123,6 +123,17 @@ impl FsCore {
                 .ensure_write_abs_path(atomic_write_dir, &build_tmp_path_of(path))
                 .await?;
 
+            if op.if_not_exists()
+                && tokio::fs::try_exists(&target_path)
+                    .await
+                    .map_err(new_std_io_error)?
+            {
+                return Err(parse_error(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    "file already exists",
+                )));
+            }
+
             // If the target file exists, we should append to the end of it directly.
             let should_append = op.append()
                 && tokio::fs::try_exists(&target_path)

--- a/core/src/services/fs/writer.rs
+++ b/core/src/services/fs/writer.rs
@@ -18,45 +18,64 @@
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use bytes::Buf;
 use tokio::io::AsyncWriteExt;
 
 use crate::raw::*;
+use crate::services::fs::core::FsCore;
 use crate::*;
 
-pub type FsWriters =
-    TwoWays<FsWriter<tokio::fs::File>, oio::PositionWriter<FsWriter<tokio::fs::File>>>;
+pub type FsWriters = TwoWays<FsWriter, oio::PositionWriter<FsWriter>>;
 
-pub struct FsWriter<F> {
+pub struct FsWriter {
     target_path: PathBuf,
-    tmp_path: Option<PathBuf>,
-
-    f: Option<F>,
+    /// The temp_path is used to specify whether we should move to target_path after the file has been closed.
+    temp_path: Option<PathBuf>,
+    f: tokio::fs::File,
 }
 
-impl<F> FsWriter<F> {
-    pub fn new(target_path: PathBuf, tmp_path: Option<PathBuf>, f: F) -> Self {
-        Self {
-            target_path,
-            tmp_path,
+impl FsWriter {
+    pub async fn create(core: Arc<FsCore>, path: &str, op: OpWrite) -> Result<Self> {
+        let target_path = core.ensure_write_abs_path(&core.root, path).await?;
 
-            f: Some(f),
+        // Create a target file using our OpWrite to check for permissions and existence.
+        //
+        // If target check passed, we can go decide which path we should go for writing.
+        let target_file = core.fs_write(&target_path, &op).await?;
+
+        // file is created success with append.
+        let is_append = op.append();
+        // file is created success with if_not_exists.
+        let is_exist = !op.if_not_exists();
+
+        let (mut f, mut temp_path) = (target_file, None);
+        if core.atomic_write_dir.is_some() {
+            // The only case we allow write in place is the file
+            // exists and users request for append writing.
+            if !(is_append && is_exist) {
+                (f, temp_path) = core.fs_tempfile_write(path).await?;
+            }
         }
+
+        Ok(Self {
+            target_path,
+            temp_path,
+            f,
+        })
     }
 }
 
 /// # Safety
 ///
 /// We will only take `&mut Self` reference for FsWriter.
-unsafe impl<F> Sync for FsWriter<F> {}
+unsafe impl Sync for FsWriter {}
 
-impl oio::Write for FsWriter<tokio::fs::File> {
+impl oio::Write for FsWriter {
     async fn write(&mut self, mut bs: Buffer) -> Result<()> {
-        let f = self.f.as_mut().expect("FsWriter must be initialized");
-
         while bs.has_remaining() {
-            let n = f.write(bs.chunk()).await.map_err(new_std_io_error)?;
+            let n = self.f.write(bs.chunk()).await.map_err(new_std_io_error)?;
             bs.advance(n);
         }
 
@@ -64,33 +83,25 @@ impl oio::Write for FsWriter<tokio::fs::File> {
     }
 
     async fn close(&mut self) -> Result<Metadata> {
-        let f = self.f.as_mut().expect("FsWriter must be initialized");
-        f.flush().await.map_err(new_std_io_error)?;
-        f.sync_all().await.map_err(new_std_io_error)?;
+        self.f.flush().await.map_err(new_std_io_error)?;
+        self.f.sync_all().await.map_err(new_std_io_error)?;
 
-        if let Some(tmp_path) = &self.tmp_path {
-            tokio::fs::rename(tmp_path, &self.target_path)
+        if let Some(temp_path) = &self.temp_path {
+            tokio::fs::rename(temp_path, &self.target_path)
                 .await
                 .map_err(new_std_io_error)?;
         }
 
-        let file_meta = f.metadata().await.map_err(new_std_io_error)?;
-        let mode = if file_meta.is_file() {
-            EntryMode::FILE
-        } else if file_meta.is_dir() {
-            EntryMode::DIR
-        } else {
-            EntryMode::Unknown
-        };
-        let meta = Metadata::new(mode)
+        let file_meta = self.f.metadata().await.map_err(new_std_io_error)?;
+        let meta = Metadata::new(EntryMode::FILE)
             .with_content_length(file_meta.len())
             .with_last_modified(file_meta.modified().map_err(new_std_io_error)?.into());
         Ok(meta)
     }
 
     async fn abort(&mut self) -> Result<()> {
-        if let Some(tmp_path) = &self.tmp_path {
-            tokio::fs::remove_file(tmp_path)
+        if let Some(temp_path) = &self.temp_path {
+            tokio::fs::remove_file(temp_path)
                 .await
                 .map_err(new_std_io_error)
         } else {
@@ -102,11 +113,10 @@ impl oio::Write for FsWriter<tokio::fs::File> {
     }
 }
 
-impl oio::PositionWrite for FsWriter<tokio::fs::File> {
+impl oio::PositionWrite for FsWriter {
     async fn write_all_at(&self, offset: u64, buf: Buffer) -> Result<()> {
-        let f = self.f.as_ref().expect("FsWriter must be initialized");
-
-        let f = f
+        let f = self
+            .f
             .try_clone()
             .await
             .map_err(new_std_io_error)?
@@ -132,9 +142,8 @@ impl oio::PositionWrite for FsWriter<tokio::fs::File> {
     }
 
     async fn close(&self) -> Result<Metadata> {
-        let f = self.f.as_ref().expect("FsWriter must be initialized");
-
-        let mut f = f
+        let mut f = self
+            .f
             .try_clone()
             .await
             .map_err(new_std_io_error)?
@@ -144,8 +153,8 @@ impl oio::PositionWrite for FsWriter<tokio::fs::File> {
         f.flush().map_err(new_std_io_error)?;
         f.sync_all().map_err(new_std_io_error)?;
 
-        if let Some(tmp_path) = &self.tmp_path {
-            tokio::fs::rename(tmp_path, &self.target_path)
+        if let Some(temp_path) = &self.temp_path {
+            tokio::fs::rename(temp_path, &self.target_path)
                 .await
                 .map_err(new_std_io_error)?;
         }
@@ -165,8 +174,8 @@ impl oio::PositionWrite for FsWriter<tokio::fs::File> {
     }
 
     async fn abort(&self) -> Result<()> {
-        if let Some(tmp_path) = &self.tmp_path {
-            tokio::fs::remove_file(tmp_path)
+        if let Some(temp_path) = &self.temp_path {
+            tokio::fs::remove_file(temp_path)
                 .await
                 .map_err(new_std_io_error)
         } else {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

While implementing the `WriteOptions`#6322 in Node.js, I found that the `if_not_exists` property test fails without throwing the `ConditionNotMatch` exception.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

When `if_not_exists` is true, if the file already exists, a `ConditionNotMatch` exception should be thrown.

https://github.com/apache/opendal/blob/23f01dd545ebd2a7445f08cc5e7de8a19e70fb25/core/tests/behavior/async_write.rs#L773-L778

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
