### PR TITLE
fix(fs/ftp/hdfs): correct tmp_path generation for append operations

### DIFF
--- a/core/src/services/fs/core.rs
+++ b/core/src/services/fs/core.rs
@@ -128,7 +128,7 @@ impl FsCore {
                 && tokio::fs::try_exists(&target_path)
                     .await
                     .map_err(new_std_io_error)?;
-            let tmp_path = should_append.then_some(tmp_path);
+            let tmp_path = (!should_append).then_some(tmp_path);
 
             Ok((target_path, tmp_path))
         } else {

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -299,7 +299,7 @@ impl Access for FtpBackend {
             }
         }
 
-        let tmp_path = op.append().then_some(build_tmp_path_of(path));
+        let tmp_path = (!op.append()).then_some(build_tmp_path_of(path));
         let w = FtpWriter::new(ftp_stream, path.to_string(), tmp_path);
 
         Ok((RpWrite::new(), w))

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -300,7 +300,7 @@ impl Access for HdfsBackend {
         let should_append = op.append() && target_exists;
         let tmp_path = self.atomic_write_dir.as_ref().and_then(|atomic_write_dir| {
             // If the target file exists, we should append to the end of it directly.
-            should_append.then_some(build_rooted_abs_path(
+            (!should_append).then_some(build_rooted_abs_path(
                 atomic_write_dir,
                 &build_tmp_path_of(path),
             ))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
#6324 modified the tmp_path value during append, but the value was inverted.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
