### PR TITLE
chore: fix clippy warnings when using rust 1.88

### DIFF
--- a/bin/oay/src/services/s3/service.rs
+++ b/bin/oay/src/services/s3/service.rs
@@ -80,7 +80,7 @@ async fn handle_list_objects(
     state: State<S3State>,
     params: Query<ListObjectsV2Params>,
 ) -> Result<OkResponse, ErrorResponse> {
-    log::debug!("got params: {:?}", params);
+    log::debug!("got params: {params:?}");
 
     if !state.op.info().full_capability().list_with_start_after {
         return Err(ErrorResponse {

--- a/bin/oli/src/commands/bench/suite.rs
+++ b/bin/oli/src/commands/bench/suite.rs
@@ -143,7 +143,7 @@ impl BenchSuite {
             rt.block_on(async {
                 println!("Deleting object at path: {path}");
                 if let Err(err) = op.delete(&path).await {
-                    eprintln!("failed to delete object: {}", err);
+                    eprintln!("failed to delete object: {err}");
                 }
             });
         }

--- a/bin/oli/src/commands/cp.rs
+++ b/bin/oli/src/commands/cp.rs
@@ -163,8 +163,7 @@ impl CopyCmd {
             let entry_path = Path::new(depath);
             let relative_path = entry_path.strip_prefix(src_root_path).with_context(|| {
                 format!(
-                    "Internal error: Lister path '{}' does not start with source path '{}'",
-                    depath, src_path
+                    "Internal error: Lister path '{depath}' does not start with source path '{src_path}'"
                 )
             })?; // relative_path is a &Path
 
@@ -182,10 +181,7 @@ impl CopyCmd {
 
             // Explicitly stat the source file to get fresh metadata
             let fresh_meta = src_op.stat(depath).await.with_context(|| {
-                format!(
-                    "Failed to stat source file '{}' before recursive copy",
-                    depath
-                )
+                format!("Failed to stat source file '{depath}' before recursive copy")
             })?;
 
             // Use the Path object `current_dst_path_path` to check parent

--- a/bin/oli/src/commands/edit.rs
+++ b/bin/oli/src/commands/edit.rs
@@ -118,12 +118,12 @@ impl EditCmd {
             // Try to upload the modified content
             match op.write(&path, new_content_vec.clone()).await {
                 Ok(_) => {
-                    println!("File uploaded successfully to {}", path);
+                    println!("File uploaded successfully to {path}");
                     // Successfully uploaded, temp_file_persister can be dropped, deleting the temp file.
                 }
                 Err(e) => {
                     // Upload failed, offer to save temp file
-                    eprintln!("Error uploading file: {}", e);
+                    eprintln!("Error uploading file: {e}");
                     let kept_path = temp_file_persister
                         .keep()
                         .context("Failed to preserve temporary file after upload error")?;

--- a/bin/oli/src/commands/ls.rs
+++ b/bin/oli/src/commands/ls.rs
@@ -147,11 +147,11 @@ fn print_tree(node: &TreeNode, prefix: &str) {
             TREE_MIDDLE_ITEM
         };
         let display_name = if child_node.is_dir {
-            format!("{}/", name)
+            format!("{name}/")
         } else {
             name.to_string()
         };
-        println!("{}{}{}", prefix, connector, display_name);
+        println!("{prefix}{connector}{display_name}");
 
         if !child_node.children.is_empty() {
             let new_prefix = if is_last {
@@ -159,7 +159,7 @@ fn print_tree(node: &TreeNode, prefix: &str) {
             } else {
                 TREE_VERTICAL_LINE
             };
-            print_tree(child_node, &format!("{}{}", prefix, new_prefix));
+            print_tree(child_node, &format!("{prefix}{new_prefix}"));
         }
     }
 }

--- a/bin/oli/src/commands/mv.rs
+++ b/bin/oli/src/commands/mv.rs
@@ -65,7 +65,7 @@ impl MoveCmd {
                 actual_dst_path.push_str(file_name);
             }
 
-            println!("Moving: {}", src_path);
+            println!("Moving: {src_path}");
             self.cp_file(
                 &src_op,
                 &src_path,
@@ -91,7 +91,7 @@ impl MoveCmd {
             let suffix = path.strip_prefix(prefix).expect("invalid path");
             let depath = dst_root.join(suffix);
 
-            println!("Moving: {}", path);
+            println!("Moving: {path}");
             let meta = entry.metadata();
             if meta.is_dir() {
                 dst_op.create_dir(&depath.to_string_lossy()).await?;

--- a/bin/oli/tests/integration/edit.rs
+++ b/bin/oli/tests/integration/edit.rs
@@ -48,8 +48,7 @@ fn create_modifying_editor(
 ) -> Result<std::path::PathBuf> {
     let editor_path = dir.join("modifying_editor.sh");
     let script_content = format!(
-        "#!/bin/bash\n# Mock editor that adds content to the file\necho '{}' >> \"$1\"\nexit 0\n",
-        content_to_add
+        "#!/bin/bash\n# Mock editor that adds content to the file\necho '{content_to_add}' >> \"$1\"\nexit 0\n"
     );
     fs::write(&editor_path, script_content)?;
 
@@ -69,8 +68,7 @@ fn create_modifying_editor(
 fn create_replacing_editor(dir: &std::path::Path, new_content: &str) -> Result<std::path::PathBuf> {
     let editor_path = dir.join("replacing_editor.sh");
     let script_content = format!(
-        "#!/bin/bash\n# Mock editor that replaces file content\necho '{}' > \"$1\"\nexit 0\n",
-        new_content
+        "#!/bin/bash\n# Mock editor that replaces file content\necho '{new_content}' > \"$1\"\nexit 0\n"
     );
     fs::write(&editor_path, script_content)?;
 

--- a/bin/oli/tests/integration/test_utils.rs
+++ b/bin/oli/tests/integration/test_utils.rs
@@ -117,7 +117,7 @@ impl std::fmt::Display for DirectorySnapshot {
             }
             table.add_row(row);
         }
-        write!(f, "{}", table)
+        write!(f, "{table}")
     }
 }
 

--- a/core/src/layers/immutable_index.rs
+++ b/core/src/layers/immutable_index.rs
@@ -296,7 +296,7 @@ mod tests {
             map.insert(entry.path().to_string(), entry.metadata().mode());
         }
 
-        debug!("current files: {:?}", map);
+        debug!("current files: {map:?}");
 
         assert_eq!(map["file"], EntryMode::FILE);
         assert_eq!(map["dir/"], EntryMode::DIR);
@@ -398,7 +398,7 @@ mod tests {
             map.insert(entry.path().to_string(), entry.metadata().mode());
         }
 
-        debug!("current files: {:?}", map);
+        debug!("current files: {map:?}");
 
         assert_eq!(map["dataset/stateful/ontime_2007_200.csv"], EntryMode::FILE);
         assert_eq!(map["dataset/stateful/ontime_2008_200.csv"], EntryMode::FILE);

--- a/core/src/layers/logging.rs
+++ b/core/src/layers/logging.rs
@@ -226,7 +226,7 @@ struct LoggingContext<'a>(&'a [(&'a str, &'a str)]);
 impl Display for LoggingContext<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (k, v) in self.0.iter() {
-            write!(f, " {}={}", k, v)?;
+            write!(f, " {k}={v}")?;
         }
         Ok(())
     }

--- a/core/src/layers/oteltrace.rs
+++ b/core/src/layers/oteltrace.rs
@@ -84,7 +84,7 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         let tracer = global::tracer("opendal");
         let mut span = tracer.start("create");
         span.set_attribute(KeyValue::new("path", path.to_string()));
-        span.set_attribute(KeyValue::new("args", format!("{:?}", args)));
+        span.set_attribute(KeyValue::new("args", format!("{args:?}")));
         let cx = TraceContext::current_with_span(span);
         self.inner.create_dir(path, args).with_context(cx).await
     }
@@ -93,7 +93,7 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         let tracer = global::tracer("opendal");
         let mut span = tracer.start("read");
         span.set_attribute(KeyValue::new("path", path.to_string()));
-        span.set_attribute(KeyValue::new("args", format!("{:?}", args)));
+        span.set_attribute(KeyValue::new("args", format!("{args:?}")));
         self.inner
             .read(path, args)
             .await
@@ -104,7 +104,7 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         let tracer = global::tracer("opendal");
         let mut span = tracer.start("write");
         span.set_attribute(KeyValue::new("path", path.to_string()));
-        span.set_attribute(KeyValue::new("args", format!("{:?}", args)));
+        span.set_attribute(KeyValue::new("args", format!("{args:?}")));
         self.inner
             .write(path, args)
             .await
@@ -116,7 +116,7 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         let mut span = tracer.start("copy");
         span.set_attribute(KeyValue::new("from", from.to_string()));
         span.set_attribute(KeyValue::new("to", to.to_string()));
-        span.set_attribute(KeyValue::new("args", format!("{:?}", args)));
+        span.set_attribute(KeyValue::new("args", format!("{args:?}")));
         let cx = TraceContext::current_with_span(span);
         self.inner().copy(from, to, args).with_context(cx).await
     }
@@ -126,7 +126,7 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         let mut span = tracer.start("rename");
         span.set_attribute(KeyValue::new("from", from.to_string()));
         span.set_attribute(KeyValue::new("to", to.to_string()));
-        span.set_attribute(KeyValue::new("args", format!("{:?}", args)));
+        span.set_attribute(KeyValue::new("args", format!("{args:?}")));
         let cx = TraceContext::current_with_span(span);
         self.inner().rename(from, to, args).with_context(cx).await
     }
@@ -135,7 +135,7 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         let tracer = global::tracer("opendal");
         let mut span = tracer.start("stat");
         span.set_attribute(KeyValue::new("path", path.to_string()));
-        span.set_attribute(KeyValue::new("args", format!("{:?}", args)));
+        span.set_attribute(KeyValue::new("args", format!("{args:?}")));
         let cx = TraceContext::current_with_span(span);
         self.inner().stat(path, args).with_context(cx).await
     }
@@ -148,7 +148,7 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         let tracer = global::tracer("opendal");
         let mut span = tracer.start("list");
         span.set_attribute(KeyValue::new("path", path.to_string()));
-        span.set_attribute(KeyValue::new("args", format!("{:?}", args)));
+        span.set_attribute(KeyValue::new("args", format!("{args:?}")));
         self.inner
             .list(path, args)
             .await
@@ -159,7 +159,7 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         let tracer = global::tracer("opendal");
         let mut span = tracer.start("presign");
         span.set_attribute(KeyValue::new("path", path.to_string()));
-        span.set_attribute(KeyValue::new("args", format!("{:?}", args)));
+        span.set_attribute(KeyValue::new("args", format!("{args:?}")));
         let cx = TraceContext::current_with_span(span);
         self.inner().presign(path, args).with_context(cx).await
     }

--- a/core/src/raw/azure.rs
+++ b/core/src/raw/azure.rs
@@ -116,10 +116,7 @@ fn parse_connection_string(conn_str: &str) -> Result<HashMap<String, String>> {
         .map(|field| {
             let (key, value) = field.trim().split_once('=').ok_or(Error::new(
                 ErrorKind::ConfigInvalid,
-                format!(
-                    "Invalid connection string, expected '=' in field: {}",
-                    field
-                ),
+                format!("Invalid connection string, expected '=' in field: {field}"),
             ))?;
             Ok((key.to_string(), value.to_string()))
         })
@@ -265,7 +262,7 @@ fn collect_endpoint_from_parts(
     if protocol != "http" && protocol != "https" {
         return Err(Error::new(
             ErrorKind::ConfigInvalid,
-            format!("Invalid DefaultEndpointsProtocol: {}", protocol),
+            format!("Invalid DefaultEndpointsProtocol: {protocol}"),
         ));
     }
 
@@ -430,7 +427,7 @@ mod tests {
             if let Some(expected) = expected {
                 assert_azure_storage_config_eq(&actual.expect(name), &expected, name);
             } else {
-                assert!(actual.is_err(), "Expected error for case: {}", name);
+                assert!(actual.is_err(), "Expected error for case: {name}");
             }
         }
     }
@@ -457,8 +454,7 @@ mod tests {
             assert_eq!(
                 account_name,
                 expected_account_name.map(|s| s.to_string()),
-                "Endpoint: {}",
-                endpoint
+                "Endpoint: {endpoint}"
             );
         }
     }
@@ -471,23 +467,19 @@ mod tests {
     ) {
         assert_eq!(
             actual.account_name, expected.account_name,
-            "account_name mismatch: {}",
-            name
+            "account_name mismatch: {name}"
         );
         assert_eq!(
             actual.account_key, expected.account_key,
-            "account_key mismatch: {}",
-            name
+            "account_key mismatch: {name}"
         );
         assert_eq!(
             actual.endpoint, expected.endpoint,
-            "endpoint mismatch: {}",
-            name
+            "endpoint mismatch: {name}"
         );
         assert_eq!(
             actual.sas_token, expected.sas_token,
-            "sas_token mismatch: {}",
-            name
+            "sas_token mismatch: {name}"
         );
     }
 }

--- a/core/src/raw/http_util/multipart.rs
+++ b/core/src/raw/http_util/multipart.rs
@@ -182,7 +182,7 @@ impl FormDataPart {
         let mut headers = HeaderMap::new();
         headers.insert(
             CONTENT_DISPOSITION,
-            format!("form-data; name=\"{}\"", name).parse().unwrap(),
+            format!("form-data; name=\"{name}\"").parse().unwrap(),
         );
 
         Self {

--- a/core/src/raw/oio/write/position_write.rs
+++ b/core/src/raw/oio/write/position_write.rs
@@ -254,7 +254,7 @@ mod tests {
                 match w.write(bs.clone().into()).await {
                     Ok(_) => break,
                     Err(e) => {
-                        println!("write error: {:?}", e);
+                        println!("write error: {e:?}");
                         continue;
                     }
                 }
@@ -264,11 +264,11 @@ mod tests {
         loop {
             match w.close().await {
                 Ok(n) => {
-                    println!("close: {:?}", n);
+                    println!("close: {n:?}");
                     break;
                 }
                 Err(e) => {
-                    println!("close error: {:?}", e);
+                    println!("close error: {e:?}");
                     continue;
                 }
             }

--- a/core/src/raw/path_cache.rs
+++ b/core/src/raw/path_cache.rs
@@ -238,7 +238,7 @@ mod tests {
             let cache = PathCacher::new(TestQuery {});
 
             let actual = cache.get(input).await.unwrap();
-            assert_eq!(actual.as_deref(), expect, "{}", name)
+            assert_eq!(actual.as_deref(), expect, "{name}")
         }
     }
 }

--- a/core/src/services/aliyun_drive/backend.rs
+++ b/core/src/services/aliyun_drive/backend.rs
@@ -171,7 +171,7 @@ impl Builder for AliyunDriveBuilder {
                 ))
             }
         };
-        debug!("backend use drive_type {:?}", drive_type);
+        debug!("backend use drive_type {drive_type:?}");
 
         Ok(AliyunDriveBackend {
             core: Arc::new(AliyunDriveCore {

--- a/core/src/services/aliyun_drive/core.rs
+++ b/core/src/services/aliyun_drive/core.rs
@@ -85,7 +85,7 @@ impl AliyunDriveCore {
         // AliyunDrive raise NullPointerException if you haven't set a user-agent.
         req.headers_mut().insert(
             header::USER_AGENT,
-            HeaderValue::from_str(&format!("opendal/{}", VERSION))
+            HeaderValue::from_str(&format!("opendal/{VERSION}"))
                 .expect("user agent must be valid header value"),
         );
         if req.method() == Method::POST {

--- a/core/src/services/alluxio/lister.rs
+++ b/core/src/services/alluxio/lister.rs
@@ -49,7 +49,7 @@ impl oio::PageList for AlluxioLister {
                 for file_info in file_infos {
                     let path: String = file_info.path.clone();
                     let path = if file_info.folder {
-                        format!("{}/", path)
+                        format!("{path}/")
                     } else {
                         path
                     };

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -308,7 +308,7 @@ impl Builder for AzblobBuilder {
         debug!("backend build started: {:?}", &self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         // Handle endpoint, region and container name.
         let container = match self.config.container.is_empty() {

--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -256,7 +256,7 @@ impl Builder for AzdlsBuilder {
         debug!("backend build started: {:?}", &self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         // Handle endpoint, region and container name.
         let filesystem = match self.config.filesystem.is_empty() {

--- a/core/src/services/azfile/backend.rs
+++ b/core/src/services/azfile/backend.rs
@@ -188,7 +188,7 @@ impl Builder for AzfileBuilder {
         debug!("backend build started: {:?}", &self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let endpoint = match &self.config.endpoint {
             Some(endpoint) => Ok(endpoint.clone()),

--- a/core/src/services/cloudflare_kv/backend.rs
+++ b/core/src/services/cloudflare_kv/backend.rs
@@ -137,8 +137,7 @@ impl Builder for CloudflareKvBuilder {
         );
 
         let url_prefix = format!(
-            r"https://api.cloudflare.com/client/v4/accounts/{}/storage/kv/namespaces/{}",
-            account_id, namespace_id
+            r"https://api.cloudflare.com/client/v4/accounts/{account_id}/storage/kv/namespaces/{namespace_id}"
         );
 
         Ok(CloudflareKvBackend::new(Adapter {
@@ -246,7 +245,7 @@ impl kv::Adapter for Adapter {
     async fn scan(&self, path: &str) -> Result<Self::Scanner> {
         let mut url = format!("{}/keys", self.url_prefix);
         if !path.is_empty() {
-            url = format!("{}?prefix={}", url, path);
+            url = format!("{url}?prefix={path}");
         }
         let mut req = Request::get(&url);
         req = req.header(header::CONTENT_TYPE, "application/json");
@@ -261,7 +260,7 @@ impl kv::Adapter for Adapter {
                     serde_json::from_reader(body.reader()).map_err(|e| {
                         Error::new(
                             ErrorKind::Unexpected,
-                            format!("failed to parse error response: {}", e),
+                            format!("failed to parse error response: {e}"),
                         )
                     })?;
                 Ok(Box::new(kv::ScanStdIter::new(

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -171,7 +171,7 @@ impl Builder for CosBuilder {
         debug!("backend build started: {:?}", &self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let bucket = match &self.config.bucket {
             Some(bucket) => Ok(bucket.to_string()),

--- a/core/src/services/d1/model.rs
+++ b/core/src/services/d1/model.rs
@@ -39,7 +39,7 @@ impl D1Response {
         let response: D1Response = serde_json::from_slice(bs).map_err(|e| {
             Error::new(
                 crate::ErrorKind::Unexpected,
-                format!("failed to parse error response: {}", e),
+                format!("failed to parse error response: {e}"),
             )
         })?;
 

--- a/core/src/services/dbfs/backend.rs
+++ b/core/src/services/dbfs/backend.rs
@@ -104,7 +104,7 @@ impl Builder for DbfsBuilder {
         debug!("backend build started: {:?}", &self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let endpoint = match &self.config.endpoint {
             Some(endpoint) => Ok(endpoint.clone()),

--- a/core/src/services/dropbox/backend.rs
+++ b/core/src/services/dropbox/backend.rs
@@ -58,7 +58,7 @@ impl Access for DropboxBackend {
             if "file" == decoded_response.tag {
                 return Err(Error::new(
                     ErrorKind::NotADirectory,
-                    format!("it's not a directory {}", path),
+                    format!("it's not a directory {path}"),
                 ));
             }
         }
@@ -95,7 +95,7 @@ impl Access for DropboxBackend {
                     } else {
                         return Err(Error::new(
                             ErrorKind::Unexpected,
-                            format!("no size found for file {}", path),
+                            format!("no size found for file {path}"),
                         ));
                     }
                 }

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -238,10 +238,10 @@ impl Builder for GcsBuilder {
     type Config = GcsConfig;
 
     fn build(self) -> Result<impl Access> {
-        debug!("backend build started: {:?}", self);
+        debug!("backend build started: {self:?}");
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         // Handle endpoint and bucket name
         let bucket = match self.config.bucket.is_empty() {

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -293,7 +293,7 @@ impl GcsCore {
         );
 
         if let Some(acl) = &self.predefined_acl {
-            write!(&mut url, "&predefinedAcl={}", acl).unwrap();
+            write!(&mut url, "&predefinedAcl={acl}").unwrap();
         }
 
         // Makes the operation conditional on whether the object's current generation

--- a/core/src/services/gdrive/builder.rs
+++ b/core/src/services/gdrive/builder.rs
@@ -140,7 +140,7 @@ impl Builder for GdriveBuilder {
 
     fn build(self) -> Result<impl Access> {
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let info = AccessorInfo::default();
         info.set_scheme(Scheme::Gdrive)

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -41,10 +41,7 @@ fn value_or_env(
     }
 
     env::var(env_var_name).map_err(|err| {
-        let text = format!(
-            "{} not found, maybe not in github action environment?",
-            env_var_name
-        );
+        let text = format!("{env_var_name} not found, maybe not in github action environment?");
         Error::new(ErrorKind::ConfigInvalid, text)
             .with_operation(operation)
             .set_source(err)
@@ -143,13 +140,13 @@ impl Builder for GhacBuilder {
     type Config = GhacConfig;
 
     fn build(self) -> Result<impl Access> {
-        debug!("backend build started: {:?}", self);
+        debug!("backend build started: {self:?}");
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let service_version = get_cache_service_version();
-        debug!("backend use service version {:?}", service_version);
+        debug!("backend use service version {service_version:?}");
 
         let mut version = self
             .config
@@ -160,7 +157,7 @@ impl Builder for GhacBuilder {
         // ghac requires to use hex digest of Sha256 as version.
         if matches!(service_version, GhacVersion::V2) {
             let hash = sha2::Sha256::digest(&version);
-            version = format!("{:x}", hash);
+            version = format!("{hash:x}");
         }
 
         let cache_url = self

--- a/core/src/services/ghac/core.rs
+++ b/core/src/services/ghac/core.rs
@@ -280,7 +280,7 @@ impl GhacCore {
                             ErrorKind::Unexpected,
                             "create cache entry returns non-ok",
                         )
-                        .with_context("parts", format!("{:?}", parts)));
+                        .with_context("parts", format!("{parts:?}")));
                     }
                     query_resp.signed_upload_url
                 } else {

--- a/core/src/services/github/backend.rs
+++ b/core/src/services/github/backend.rs
@@ -211,7 +211,7 @@ impl Access for GithubBackend {
 
         let resp = self
             .core
-            .upload(&format!("{}.gitkeep", path), empty_bytes)
+            .upload(&format!("{path}.gitkeep"), empty_bytes)
             .await?;
 
         let status = resp.status();

--- a/core/src/services/github/core.rs
+++ b/core/src/services/github/core.rs
@@ -66,7 +66,7 @@ impl GithubCore {
 
     pub fn sign(&self, req: request::Builder) -> Result<request::Builder> {
         let mut req = req
-            .header(header::USER_AGENT, format!("opendal-{}", VERSION))
+            .header(header::USER_AGENT, format!("opendal-{VERSION}"))
             .header("X-GitHub-Api-Version", "2022-11-28");
 
         // Github access_token is optional.
@@ -195,7 +195,7 @@ impl GithubCore {
 
     pub async fn delete(&self, path: &str) -> Result<()> {
         // If path is a directory, we should delete path/.gitkeep
-        let formatted_path = format!("{}.gitkeep", path);
+        let formatted_path = format!("{path}.gitkeep");
         let p = if path.ends_with('/') {
             formatted_path.as_str()
         } else {
@@ -280,7 +280,7 @@ impl GithubCore {
 
     /// We use git_url to call github's Tree based API.
     pub async fn list_with_recursive(&self, git_url: &str) -> Result<Vec<Tree>> {
-        let url = format!("{}?recursive=true", git_url);
+        let url = format!("{git_url}?recursive=true");
 
         let req = Request::get(url);
 

--- a/core/src/services/github/lister.rs
+++ b/core/src/services/github/lister.rs
@@ -53,7 +53,7 @@ impl oio::PageList for GithubLister {
             for entry in resp.entries {
                 let path = build_rel_path(&self.core.root, &entry.path);
                 let entry = if entry.type_field == "dir" {
-                    let path = format!("{}/", path);
+                    let path = format!("{path}/");
                     Entry::new(&path, Metadata::new(EntryMode::DIR))
                 } else {
                     if path.ends_with(".gitkeep") {
@@ -85,7 +85,7 @@ impl oio::PageList for GithubLister {
                 format!("{}/{}", self.path, t.path)
             };
             let entry = if t.type_field == "tree" {
-                let path = format!("{}/", path);
+                let path = format!("{path}/");
                 Entry::new(&path, Metadata::new(EntryMode::DIR))
             } else {
                 if path.ends_with(".gitkeep") {

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -140,7 +140,7 @@ impl Builder for HdfsBuilder {
         };
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let mut builder = hdrs::ClientBuilder::new(name_node);
         if let Some(ticket_cache_path) = &self.config.kerberos_ticket_cache_path {
@@ -155,7 +155,7 @@ impl Builder for HdfsBuilder {
         // Create root dir if not exist.
         if let Err(e) = client.metadata(&root) {
             if e.kind() == io::ErrorKind::NotFound {
-                debug!("root {} is not exist, creating now", root);
+                debug!("root {root} is not exist, creating now");
 
                 client.create_dir(&root).map_err(new_std_io_error)?
             }

--- a/core/src/services/hdfs_native/backend.rs
+++ b/core/src/services/hdfs_native/backend.rs
@@ -109,7 +109,7 @@ impl Builder for HdfsNativeBuilder {
         };
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let client = hdfs_native::Client::new(name_node).map_err(parse_hdfs_error)?;
 

--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -144,7 +144,7 @@ impl Builder for HttpBuilder {
         };
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let mut auth = None;
         if let Some(username) = &self.config.username {

--- a/core/src/services/huggingface/backend.rs
+++ b/core/src/services/huggingface/backend.rs
@@ -142,7 +142,7 @@ impl Builder for HuggingfaceBuilder {
             )),
             Some(repo_type) => Err(Error::new(
                 ErrorKind::ConfigInvalid,
-                format!("unknown repo_type: {}", repo_type).as_str(),
+                format!("unknown repo_type: {repo_type}").as_str(),
             )
             .with_operation("Builder::build")
             .with_context("service", Scheme::Huggingface)),

--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -121,7 +121,7 @@ impl Builder for IpfsBuilder {
             .with_context("service", Scheme::Ipfs)
             .with_context("root", &root));
         }
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let endpoint = match &self.config.endpoint {
             Some(endpoint) => Ok(endpoint.clone()),

--- a/core/src/services/ipmfs/builder.rs
+++ b/core/src/services/ipmfs/builder.rs
@@ -129,7 +129,7 @@ impl Builder for IpmfsBuilder {
 
     fn build(self) -> Result<impl Access> {
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let endpoint = self
             .config

--- a/core/src/services/koofr/lister.rs
+++ b/core/src/services/koofr/lister.rs
@@ -68,7 +68,7 @@ impl oio::PageList for KoofrLister {
             let path = build_abs_path(&normalize_root(&self.path), &file.name);
 
             let entry = if file.ty == "dir" {
-                let path = format!("{}/", path);
+                let path = format!("{path}/");
                 Entry::new(&path, Metadata::new(EntryMode::DIR))
             } else {
                 let m = Metadata::new(EntryMode::FILE)

--- a/core/src/services/lakefs/core.rs
+++ b/core/src/services/lakefs/core.rs
@@ -127,15 +127,15 @@ impl LakefsCore {
         }
 
         if !delimiter.is_empty() {
-            url.push_str(&format!("&delimiter={}", delimiter));
+            url.push_str(&format!("&delimiter={delimiter}"));
         }
 
         if let Some(amount) = amount {
-            url.push_str(&format!("&amount={}", amount));
+            url.push_str(&format!("&amount={amount}"));
         }
 
         if let Some(after) = after {
-            url.push_str(&format!("&after={}", after));
+            url.push_str(&format!("&after={after}"));
         }
 
         let mut req = Request::get(&url);

--- a/core/src/services/memcached/binary.rs
+++ b/core/src/services/memcached/binary.rs
@@ -127,7 +127,7 @@ impl Connection {
             .await
             .map_err(new_std_io_error)?;
         writer
-            .write_all(format!("\x00{}\x00{}", username, password).as_bytes())
+            .write_all(format!("\x00{username}\x00{password}").as_bytes())
             .await
             .map_err(new_std_io_error)?;
         writer.flush().await.map_err(new_std_io_error)?;

--- a/core/src/services/mini_moka/backend.rs
+++ b/core/src/services/mini_moka/backend.rs
@@ -131,7 +131,7 @@ impl Builder for MiniMokaBuilder {
 
         let core = Arc::new(MiniMokaCore { cache });
 
-        debug!("backend build finished: {}", root);
+        debug!("backend build finished: {root}");
         Ok(MiniMokaBackend::new(core, root))
     }
 }

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -161,7 +161,7 @@ impl Builder for ObsBuilder {
         debug!("backend build started: {:?}", &self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let bucket = match &self.config.bucket {
             Some(bucket) => Ok(bucket.to_string()),

--- a/core/src/services/onedrive/builder.rs
+++ b/core/src/services/onedrive/builder.rs
@@ -142,7 +142,7 @@ impl Builder for OnedriveBuilder {
 
     fn build(self) -> Result<impl Access> {
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let info = AccessorInfo::default();
         info.set_scheme(Scheme::Onedrive)

--- a/core/src/services/onedrive/core.rs
+++ b/core/src/services/onedrive/core.rs
@@ -354,7 +354,7 @@ impl OneDriveCore {
     ) -> Result<Response<Buffer>> {
         let mut request = Request::put(url);
 
-        let range = format!("bytes {}-{}/{}", offset, chunk_end, total_len);
+        let range = format!("bytes {offset}-{chunk_end}/{total_len}");
         request = request.header(header::CONTENT_RANGE, range);
 
         let size = chunk_end - offset + 1;

--- a/core/src/services/onedrive/lister.rs
+++ b/core/src/services/onedrive/lister.rs
@@ -55,7 +55,7 @@ impl oio::PageList for OneDriveLister {
                 GENERAL_SELECT_PARAM
             );
             if let Some(limit) = self.op.limit() {
-                base + &format!("&$top={}", limit)
+                base + &format!("&$top={limit}")
             } else {
                 base
             }
@@ -111,7 +111,7 @@ impl oio::PageList for OneDriveLister {
                 .strip_prefix(Self::DRIVE_ROOT_PREFIX)
                 .unwrap_or("");
 
-            let path = format!("{}/{}", parent_path, name);
+            let path = format!("{parent_path}/{name}");
             let mut normalized_path = build_rel_path(self.core.root.as_str(), path.as_str());
             let entry_mode = match drive_item.item_type {
                 ItemType::Folder { .. } => EntryMode::DIR,

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -643,7 +643,7 @@ impl S3Builder {
             endpoint.to_string()
         } else {
             // Prefix https if endpoint doesn't start with scheme.
-            format!("https://{}", endpoint)
+            format!("https://{endpoint}")
         };
 
         // Remove bucket name from endpoint.
@@ -789,7 +789,7 @@ impl Builder for S3Builder {
             v => {
                 return Err(Error::new(
                     ErrorKind::ConfigInvalid,
-                    format!("{:?} is not a supported checksum_algorithm.", v),
+                    format!("{v:?} is not a supported checksum_algorithm."),
                 ))
             }
         };
@@ -1261,7 +1261,7 @@ mod tests {
 
         for (name, endpoint, bucket, expected) in cases {
             let region = S3Builder::detect_region(endpoint, bucket).await;
-            assert_eq!(region.as_deref(), expected, "{}", name);
+            assert_eq!(region.as_deref(), expected, "{name}");
         }
     }
 }

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -1033,11 +1033,11 @@ impl S3Core {
                 .expect("write into string must succeed");
         }
         if !delimiter.is_empty() {
-            write!(url, "&delimiter={}", delimiter).expect("write into string must succeed");
+            write!(url, "&delimiter={delimiter}").expect("write into string must succeed");
         }
 
         if let Some(limit) = limit {
-            write!(url, "&max-keys={}", limit).expect("write into string must succeed");
+            write!(url, "&max-keys={limit}").expect("write into string must succeed");
         }
         if !key_marker.is_empty() {
             write!(url, "&key-marker={}", percent_encode_path(key_marker))

--- a/core/src/services/seafile/lister.rs
+++ b/core/src/services/seafile/lister.rs
@@ -61,7 +61,7 @@ impl oio::PageList for SeafileLister {
                                 .with_content_length(info.size.unwrap_or(0));
                             Entry::new(&rel_path, meta)
                         } else {
-                            let path = format!("{}/", rel_path);
+                            let path = format!("{rel_path}/");
                             Entry::new(&path, Metadata::new(EntryMode::DIR))
                         };
 

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -172,7 +172,7 @@ impl Builder for SftpBuilder {
                 } else {
                     return Err(Error::new(
                         ErrorKind::ConfigInvalid,
-                        format!("unknown known_hosts strategy: {}", v).as_str(),
+                        format!("unknown known_hosts strategy: {v}").as_str(),
                     ));
                 }
             }
@@ -339,7 +339,7 @@ impl Access for SftpBackend {
         let mut fs = client.fs();
         fs.set_cwd(&self.core.root);
 
-        let file_path = format!("./{}", path);
+        let file_path = format!("./{path}");
 
         let dir = match fs.open_dir(&file_path).await {
             Ok(dir) => dir,

--- a/core/src/services/swift/backend.rs
+++ b/core/src/services/swift/backend.rs
@@ -121,7 +121,7 @@ impl Builder for SwiftBuilder {
         debug!("backend build started: {:?}", &self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let endpoint = match self.config.endpoint {
             Some(endpoint) => {

--- a/core/src/services/swift/core.rs
+++ b/core/src/services/swift/core.rs
@@ -124,7 +124,7 @@ impl SwiftCore {
         // Set user metadata headers.
         if let Some(user_metadata) = args.user_metadata() {
             for (k, v) in user_metadata {
-                req = req.header(format!("X-Object-Meta-{}", k), v);
+                req = req.header(format!("X-Object-Meta-{k}"), v);
             }
         }
 

--- a/core/src/services/tikv/backend.rs
+++ b/core/src/services/tikv/backend.rs
@@ -116,7 +116,7 @@ impl Builder for TikvBuilder {
             return Err(
                 Error::new(ErrorKind::ConfigInvalid, "invalid tls configuration")
                     .with_context("service", Scheme::Tikv)
-                    .with_context("endpoints", format!("{:?}", endpoints)),
+                    .with_context("endpoints", format!("{endpoints:?}")),
             )?;
         }
 

--- a/core/src/services/upyun/lister.rs
+++ b/core/src/services/upyun/lister.rs
@@ -83,7 +83,7 @@ impl oio::PageList for UpyunLister {
             let path = build_abs_path(&normalize_root(&self.path), &file.name);
 
             let entry = if file.type_field == "folder" {
-                let path = format!("{}/", path);
+                let path = format!("{path}/");
                 Entry::new(&path, Metadata::new(EntryMode::DIR))
             } else {
                 let m = Metadata::new(EntryMode::FILE)

--- a/core/src/services/upyun/writer.rs
+++ b/core/src/services/upyun/writer.rs
@@ -66,7 +66,7 @@ impl oio::MultipartWrite for UpyunWriter {
                 let id =
                     parse_header_to_str(resp.headers(), X_UPYUN_MULTI_UUID)?.ok_or(Error::new(
                         ErrorKind::Unexpected,
-                        format!("{} header is missing", X_UPYUN_MULTI_UUID),
+                        format!("{X_UPYUN_MULTI_UUID} header is missing"),
                     ))?;
 
                 Ok(id.to_string())

--- a/core/src/services/vercel_blob/core.rs
+++ b/core/src/services/vercel_blob/core.rs
@@ -220,7 +220,7 @@ impl VercelBlobCore {
         );
 
         if let Some(limit) = limit {
-            url.push_str(&format!("&limit={}", limit))
+            url.push_str(&format!("&limit={limit}"))
         }
 
         let req = Request::get(&url);

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -160,7 +160,7 @@ impl Builder for WebdavBuilder {
             .to_string();
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
-        debug!("backend use root {}", root);
+        debug!("backend use root {root}");
 
         let mut authorization = None;
         if let Some(username) = &self.config.username {

--- a/core/src/services/webdav/core.rs
+++ b/core/src/services/webdav/core.rs
@@ -403,7 +403,7 @@ pub fn parse_propstat(propstat: &Propstat) -> Result<Metadata> {
         if code >= 400 {
             return Err(Error::new(
                 ErrorKind::Unexpected,
-                format!("propfind response is unexpected: {} {}", code, text),
+                format!("propfind response is unexpected: {code} {text}"),
             ));
         }
     }

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -158,7 +158,7 @@ impl Builder for WebhdfsBuilder {
     /// exits.
     /// if the directory does not exit, the directory will be automatically created
     fn build(self) -> Result<impl Access> {
-        debug!("start building backend: {:?}", self);
+        debug!("start building backend: {self:?}");
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
         debug!("backend use root {root}");
@@ -174,7 +174,7 @@ impl Builder for WebhdfsBuilder {
             }
             None => WEBHDFS_DEFAULT_ENDPOINT.to_string(),
         };
-        debug!("backend use endpoint {}", endpoint);
+        debug!("backend use endpoint {endpoint}");
 
         let atomic_write_dir = self.config.atomic_write_dir;
 

--- a/core/src/services/webhdfs/core.rs
+++ b/core/src/services/webhdfs/core.rs
@@ -293,7 +293,7 @@ impl WebhdfsCore {
             percent_encode_path(&p),
         );
         if !start_after.is_empty() {
-            url += format!("&startAfter={}", start_after).as_str();
+            url += format!("&startAfter={start_after}").as_str();
         }
         if let Some(user) = &self.user_name {
             url += format!("&user.name={user}").as_str();

--- a/core/src/services/webhdfs/writer.rs
+++ b/core/src/services/webhdfs/writer.rs
@@ -67,7 +67,7 @@ impl oio::BlockWrite for WebhdfsWriter {
         let resp = self
             .core
             .webhdfs_create_object(
-                &format!("{}{}", atomic_write_dir, block_id),
+                &format!("{atomic_write_dir}{block_id}"),
                 Some(size),
                 &self.op,
                 body,
@@ -92,7 +92,7 @@ impl oio::BlockWrite for WebhdfsWriter {
         if block_ids.len() >= 2 {
             let sources: Vec<String> = block_ids[1..]
                 .iter()
-                .map(|s| format!("{}{}", atomic_write_dir, s))
+                .map(|s| format!("{atomic_write_dir}{s}"))
                 .collect();
             // concat blocks
             let resp = self.core.webhdfs_concat(&first_block_id, sources).await?;

--- a/core/src/services/yandex_disk/core.rs
+++ b/core/src/services/yandex_disk/core.rs
@@ -269,11 +269,11 @@ impl YandexDiskCore {
         );
 
         if let Some(limit) = limit {
-            url = format!("{}&limit={}", url, limit);
+            url = format!("{url}&limit={limit}");
         }
 
         if let Some(offset) = offset {
-            url = format!("{}&offset={}", url, offset);
+            url = format!("{url}&offset={offset}");
         }
 
         let req = Request::get(url);

--- a/core/src/services/yandex_disk/lister.rs
+++ b/core/src/services/yandex_disk/lister.rs
@@ -81,7 +81,7 @@ impl oio::PageList for YandexDiskLister {
                             let md = parse_info(mf)?;
 
                             if md.mode().is_dir() {
-                                path = format!("{}/", path);
+                                path = format!("{path}/");
                             }
 
                             ctx.entries.push_back(Entry::new(&path, md));

--- a/core/src/types/buffer.rs
+++ b/core/src/types/buffer.rs
@@ -263,16 +263,9 @@ impl Buffer {
 
         assert!(
             begin <= end,
-            "range start must not be greater than end: {:?} <= {:?}",
-            begin,
-            end,
+            "range start must not be greater than end: {begin:?} <= {end:?}",
         );
-        assert!(
-            end <= len,
-            "range end out of bounds: {:?} <= {:?}",
-            end,
-            len,
-        );
+        assert!(end <= len, "range end out of bounds: {end:?} <= {len:?}",);
 
         if end == begin {
             return Buffer::new();

--- a/core/src/types/delete/deleter.rs
+++ b/core/src/types/delete/deleter.rs
@@ -162,7 +162,7 @@ impl Deleter {
     /// - [`Deleter::delete_iter`]: delete an infallible iterator of paths.
     /// - [`Deleter::delete_try_iter`]: delete a fallible iterator of paths.
     /// - [`Deleter::delete_try_stream`]: delete a fallible stream of paths.
-    pub async fn delete_stream<S, D>(&mut self, mut stream: S) -> Result<()>
+    pub async fn delete_stream<S, D>(&mut self, stream: S) -> Result<()>
     where
         S: Stream<Item = D>,
         D: IntoDeleteInput,
@@ -182,7 +182,7 @@ impl Deleter {
     /// - [`Deleter::delete_iter`]: delete an infallible iterator of paths.
     /// - [`Deleter::delete_try_iter`]: delete a fallible iterator of paths.
     /// - [`Deleter::delete_stream`]: delete an infallible stream of paths.
-    pub async fn delete_try_stream<S, D>(&mut self, mut try_stream: S) -> Result<()>
+    pub async fn delete_try_stream<S, D>(&mut self, try_stream: S) -> Result<()>
     where
         S: Stream<Item = Result<D>>,
         D: IntoDeleteInput,

--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -298,7 +298,7 @@ impl Debug for Error {
         if let Some(backtrace) = &self.backtrace {
             writeln!(f)?;
             writeln!(f, "Backtrace:")?;
-            writeln!(f, "{}", backtrace)?;
+            writeln!(f, "{backtrace}")?;
         }
 
         Ok(())

--- a/core/src/types/list.rs
+++ b/core/src/types/list.rs
@@ -127,7 +127,7 @@ mod tests {
                 future::ready(entry.ok())
             })
             .for_each(|entry| {
-                println!("{:?}", entry);
+                println!("{entry:?}");
                 future::ready(())
             })
             .await;

--- a/core/tests/behavior/async_list.rs
+++ b/core/tests/behavior/async_list.rs
@@ -229,7 +229,7 @@ pub async fn test_list_non_exist_dir(op: Operator) -> Result<()> {
     while let Some(de) = obs.try_next().await? {
         objects.insert(de.path().to_string(), de);
     }
-    debug!("got objects: {:?}", objects);
+    debug!("got objects: {objects:?}");
 
     assert_eq!(objects.len(), 0, "dir should only return empty");
     Ok(())
@@ -256,8 +256,7 @@ pub async fn test_list_sub_dir(op: Operator) -> Result<()> {
     }
     assert!(
         found,
-        "dir should be found in list, but only got: {:?}",
-        entries
+        "dir should be found in list, but only got: {entries:?}"
     );
 
     op.delete(&path).await.expect("delete must succeed");
@@ -310,7 +309,7 @@ pub async fn test_list_nested_dir(op: Operator) -> Result<()> {
     while let Some(de) = obs.try_next().await? {
         objects.insert(de.path().to_string(), de);
     }
-    debug!("got objects: {:?}", objects);
+    debug!("got objects: {objects:?}");
 
     assert_eq!(objects.len(), 3, "dir should only got 3 objects");
 
@@ -412,7 +411,7 @@ pub async fn test_list_non_exist_dir_with_recursive(op: Operator) -> Result<()> 
     while let Some(de) = obs.try_next().await? {
         objects.insert(de.path().to_string(), de);
     }
-    debug!("got objects: {:?}", objects);
+    debug!("got objects: {objects:?}");
 
     assert_eq!(objects.len(), 0, "dir should only return empty");
     Ok(())
@@ -598,7 +597,7 @@ pub async fn test_list_files_with_versions(op: Operator) -> Result<()> {
 
     let parent = TEST_FIXTURE.new_dir_path();
     let file_name = TEST_FIXTURE.new_file_path();
-    let file_path = format!("{}{}", parent, file_name);
+    let file_path = format!("{parent}{file_name}");
     op.write(file_path.as_str(), "1").await?;
     op.write(file_path.as_str(), "2").await?;
 
@@ -623,7 +622,7 @@ pub async fn test_list_files_with_deleted(op: Operator) -> Result<()> {
 
     let parent = TEST_FIXTURE.new_dir_path();
     let file_name = TEST_FIXTURE.new_file_path();
-    let file_path = format!("{}{}", parent, file_name);
+    let file_path = format!("{parent}{file_name}");
     op.write(file_path.as_str(), "1").await?;
 
     // List with deleted should include self too.


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Fix clippy warnings when using rust 1.88

# What changes are included in this PR?

```
cargo clippy --all-features --all-targets --fix
```

# Are there any user-facing changes?

