### PR TITLE
refactor(layers/logging): Don't trigger logigng in heavy IO path

### DIFF
--- a/core/benches/vs_fs/src/main.rs
+++ b/core/benches/vs_fs/src/main.rs
@@ -76,7 +76,7 @@ fn prepare() -> String {
     rng.fill_bytes(&mut content);
 
     let name = uuid::Uuid::new_v4();
-    let path = format!("/tmp/opendal/{}", name);
+    let path = format!("/tmp/opendal/{name}");
     let _ = std::fs::write(path, content);
 
     name.to_string()

--- a/core/examples/basic/src/main.rs
+++ b/core/examples/basic/src/main.rs
@@ -29,7 +29,7 @@ async fn example(op: Operator) -> Result<()> {
 
     // Fetch metadata of s3.
     let meta = op.stat("test.txt").await?;
-    println!("stat: {:?}", meta);
+    println!("stat: {meta:?}");
 
     // Delete data from s3.
     op.delete("test.txt").await?;


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

Users reported that logging layer can result in heavy CPU usage in profile:

![image](https://github.com/user-attachments/assets/c74059e1-d9f8-4c26-9f1b-df2b0f80ae58)


# What changes are included in this PR?

It's not a good idea to trigger log even while it's a cheap operations (like `length.to_string()`)

# Are there any user-facing changes?

Logs are smaller.
