### PR TITLE
test(core): refactor capability checks using skip_if_no_capabilities macro

### DIFF
--- a/core/tests/behavior/async_copy.rs
+++ b/core/tests/behavior/async_copy.rs
@@ -109,9 +109,7 @@ pub async fn test_copy_non_existing_source(op: Operator) -> Result<()> {
 
 /// Copy a dir as source should return an error.
 pub async fn test_copy_source_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
 
     let source_path = format!("{}/", uuid::Uuid::new_v4());
     let target_path = uuid::Uuid::new_v4().to_string();
@@ -128,9 +126,7 @@ pub async fn test_copy_source_dir(op: Operator) -> Result<()> {
 
 /// Copy to a dir should return an error.
 pub async fn test_copy_target_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
 
     let source_path = uuid::Uuid::new_v4().to_string();
     let (content, _) = gen_bytes(op.info().full_capability());

--- a/core/tests/behavior/async_delete.rs
+++ b/core/tests/behavior/async_delete.rs
@@ -65,9 +65,7 @@ pub async fn test_delete_file(op: Operator) -> Result<()> {
 
 /// Delete empty dir should succeed.
 pub async fn test_delete_empty_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
 
     let path = TEST_FIXTURE.new_dir_path();
 
@@ -135,9 +133,7 @@ pub async fn test_remove_one_file(op: Operator) -> Result<()> {
 
 /// Delete via stream.
 pub async fn test_delete_stream(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
     // Gdrive think that this test is an abuse of their service and redirect us
     // to an infinite loop. Let's ignore this test for gdrive.
     if op.info().scheme() == Scheme::Gdrive {
@@ -216,9 +212,7 @@ pub async fn test_remove_all_with_prefix_exists(op: Operator) -> Result<()> {
 }
 
 pub async fn test_delete_with_version(op: Operator) -> Result<()> {
-    if !op.info().full_capability().delete_with_version {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, delete_with_version);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -252,9 +246,7 @@ pub async fn test_delete_with_version(op: Operator) -> Result<()> {
 }
 
 pub async fn test_delete_with_not_existing_version(op: Operator) -> Result<()> {
-    if !op.info().full_capability().delete_with_version {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, delete_with_version);
 
     // retrieve a valid version
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
@@ -314,10 +306,10 @@ pub async fn test_batch_delete(op: Operator) -> Result<()> {
 }
 
 pub async fn test_batch_delete_with_version(op: Operator) -> Result<()> {
+    skip_if_no_capabilities!(op, delete_with_version);
+
     let mut cap = op.info().full_capability();
-    if !cap.delete_with_version {
-        return Ok(());
-    }
+
     if cap.delete_max_size.unwrap_or(1) <= 1 {
         return Ok(());
     }

--- a/core/tests/behavior/async_list.rs
+++ b/core/tests/behavior/async_list.rs
@@ -113,6 +113,9 @@ pub async fn test_list_prefix(op: Operator) -> Result<()> {
 
 /// listing a directory, which contains more objects than a single page can take.
 pub async fn test_list_rich_dir(op: Operator) -> Result<()> {
+    if !op.info().full_capability().create_dir {
+        return Ok(());
+    }
     // Gdrive think that this test is an abuse of their service and redirect us
     // to an infinite loop. Let's ignore this test for gdrive.
     if op.info().scheme() == Scheme::Gdrive {
@@ -145,6 +148,10 @@ pub async fn test_list_rich_dir(op: Operator) -> Result<()> {
 
 /// List empty dir should return itself.
 pub async fn test_list_empty_dir(op: Operator) -> Result<()> {
+    if !op.info().full_capability().create_dir {
+        return Ok(());
+    }
+
     let dir = format!("{}/", uuid::Uuid::new_v4());
 
     op.create_dir(&dir).await.expect("write must succeed");
@@ -237,6 +244,10 @@ pub async fn test_list_non_exist_dir(op: Operator) -> Result<()> {
 
 /// List dir should return correct sub dir.
 pub async fn test_list_sub_dir(op: Operator) -> Result<()> {
+    if !op.info().full_capability().create_dir {
+        return Ok(());
+    }
+
     let path = format!("{}/", uuid::Uuid::new_v4());
 
     op.create_dir(&path).await.expect("create must succeed");
@@ -265,6 +276,10 @@ pub async fn test_list_sub_dir(op: Operator) -> Result<()> {
 
 /// List dir should also to list nested dir.
 pub async fn test_list_nested_dir(op: Operator) -> Result<()> {
+    if !op.info().full_capability().create_dir {
+        return Ok(());
+    }
+
     let parent = format!("{}/", uuid::Uuid::new_v4());
     op.create_dir(&parent)
         .await
@@ -362,6 +377,10 @@ pub async fn test_list_dir_with_file_path(op: Operator) -> Result<()> {
 
 /// List with start after should start listing after the specified key
 pub async fn test_list_with_start_after(op: Operator) -> Result<()> {
+    if !op.info().full_capability().create_dir {
+        return Ok(());
+    }
+
     if !op.info().full_capability().list_with_start_after {
         return Ok(());
     }
@@ -418,6 +437,10 @@ pub async fn test_list_non_exist_dir_with_recursive(op: Operator) -> Result<()> 
 }
 
 pub async fn test_list_root_with_recursive(op: Operator) -> Result<()> {
+    if !op.info().full_capability().create_dir {
+        return Ok(());
+    }
+
     op.create_dir("/").await?;
 
     let w = op.lister_with("").recursive(true).await?;
@@ -435,6 +458,10 @@ pub async fn test_list_root_with_recursive(op: Operator) -> Result<()> {
 
 // Walk top down should output as expected
 pub async fn test_list_dir_with_recursive(op: Operator) -> Result<()> {
+    if !op.info().full_capability().create_dir {
+        return Ok(());
+    }
+
     let parent = uuid::Uuid::new_v4().to_string();
 
     let paths = [
@@ -473,6 +500,10 @@ pub async fn test_list_dir_with_recursive(op: Operator) -> Result<()> {
 
 // same as test_list_dir_with_recursive except listing 'x' instead of 'x/'
 pub async fn test_list_dir_with_recursive_no_trailing_slash(op: Operator) -> Result<()> {
+    if !op.info().full_capability().create_dir {
+        return Ok(());
+    }
+
     let parent = uuid::Uuid::new_v4().to_string();
 
     let paths = [
@@ -508,6 +539,10 @@ pub async fn test_list_dir_with_recursive_no_trailing_slash(op: Operator) -> Res
 }
 
 pub async fn test_list_file_with_recursive(op: Operator) -> Result<()> {
+    if !op.info().full_capability().create_dir {
+        return Ok(());
+    }
+
     let parent = uuid::Uuid::new_v4().to_string();
 
     let paths = ["y", "yy"];
@@ -542,6 +577,10 @@ pub async fn test_list_file_with_recursive(op: Operator) -> Result<()> {
 
 // Remove all should remove all in this path.
 pub async fn test_remove_all(op: Operator) -> Result<()> {
+    if !op.info().full_capability().create_dir {
+        return Ok(());
+    }
+
     let parent = uuid::Uuid::new_v4().to_string();
 
     let expected = [
@@ -651,6 +690,10 @@ pub async fn test_list_files_with_deleted(op: Operator) -> Result<()> {
 
 // listing a directory with version, which contains more object versions than a page can take
 pub async fn test_list_with_versions_and_limit(op: Operator) -> Result<()> {
+    if !op.info().full_capability().create_dir {
+        return Ok(());
+    }
+
     // Gdrive think that this test is an abuse of their service and redirect us
     // to an infinite loop. Let's ignore this test for gdrive.
     if op.info().scheme() == Scheme::Gdrive {

--- a/core/tests/behavior/async_list.rs
+++ b/core/tests/behavior/async_list.rs
@@ -113,9 +113,7 @@ pub async fn test_list_prefix(op: Operator) -> Result<()> {
 
 /// listing a directory, which contains more objects than a single page can take.
 pub async fn test_list_rich_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
     // Gdrive think that this test is an abuse of their service and redirect us
     // to an infinite loop. Let's ignore this test for gdrive.
     if op.info().scheme() == Scheme::Gdrive {
@@ -148,9 +146,7 @@ pub async fn test_list_rich_dir(op: Operator) -> Result<()> {
 
 /// List empty dir should return itself.
 pub async fn test_list_empty_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
 
     let dir = format!("{}/", uuid::Uuid::new_v4());
 
@@ -244,9 +240,7 @@ pub async fn test_list_non_exist_dir(op: Operator) -> Result<()> {
 
 /// List dir should return correct sub dir.
 pub async fn test_list_sub_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
 
     let path = format!("{}/", uuid::Uuid::new_v4());
 
@@ -276,9 +270,7 @@ pub async fn test_list_sub_dir(op: Operator) -> Result<()> {
 
 /// List dir should also to list nested dir.
 pub async fn test_list_nested_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
 
     let parent = format!("{}/", uuid::Uuid::new_v4());
     op.create_dir(&parent)
@@ -377,13 +369,7 @@ pub async fn test_list_dir_with_file_path(op: Operator) -> Result<()> {
 
 /// List with start after should start listing after the specified key
 pub async fn test_list_with_start_after(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
-
-    if !op.info().full_capability().list_with_start_after {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir, list_with_start_after);
 
     let dir = &format!("{}/", uuid::Uuid::new_v4());
     op.create_dir(dir).await?;
@@ -437,9 +423,7 @@ pub async fn test_list_non_exist_dir_with_recursive(op: Operator) -> Result<()> 
 }
 
 pub async fn test_list_root_with_recursive(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
 
     op.create_dir("/").await?;
 

--- a/core/tests/behavior/async_presign.rs
+++ b/core/tests/behavior/async_presign.rs
@@ -142,10 +142,7 @@ pub async fn test_presign_read(op: Operator) -> Result<()> {
 
 /// Presign delete should succeed.
 pub async fn test_presign_delete(op: Operator) -> Result<()> {
-    let cap = op.info().full_capability();
-    if !cap.presign_delete {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, presign_delete);
 
     let path = uuid::Uuid::new_v4().to_string();
     debug!("Generate a random file: {}", &path);

--- a/core/tests/behavior/async_read.rs
+++ b/core/tests/behavior/async_read.rs
@@ -185,9 +185,7 @@ pub async fn test_read_not_exist(op: Operator) -> anyhow::Result<()> {
 
 /// Reader with if_match should match, else get a ConditionNotMatch error.
 pub async fn test_reader_with_if_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_if_match);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -215,9 +213,7 @@ pub async fn test_reader_with_if_match(op: Operator) -> anyhow::Result<()> {
 
 /// Read with if_match should match, else get a ConditionNotMatch error.
 pub async fn test_read_with_if_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_if_match);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -244,9 +240,7 @@ pub async fn test_read_with_if_match(op: Operator) -> anyhow::Result<()> {
 
 /// Reader with if_none_match should match, else get a ConditionNotMatch error.
 pub async fn test_reader_with_if_none_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_none_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_if_none_match);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -277,9 +271,7 @@ pub async fn test_reader_with_if_none_match(op: Operator) -> anyhow::Result<()> 
 
 /// Reader with if_modified_since should match, otherwise, a ConditionNotMatch error will be returned.
 pub async fn test_reader_with_if_modified_since(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_modified_since {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_if_modified_since);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -306,9 +298,7 @@ pub async fn test_reader_with_if_modified_since(op: Operator) -> anyhow::Result<
 
 /// Reader with if_unmodified_since should match, otherwise, a ConditionNotMatch error will be returned.
 pub async fn test_reader_with_if_unmodified_since(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_unmodified_since {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_if_unmodified_since);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -335,9 +325,7 @@ pub async fn test_reader_with_if_unmodified_since(op: Operator) -> anyhow::Resul
 
 /// Read with if_none_match should match, else get a ConditionNotMatch error.
 pub async fn test_read_with_if_none_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_none_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_if_none_match);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -367,9 +355,7 @@ pub async fn test_read_with_if_none_match(op: Operator) -> anyhow::Result<()> {
 
 /// Read with dir path should return an error.
 pub async fn test_read_with_dir_path(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
 
     let path = TEST_FIXTURE.new_dir_path();
 
@@ -410,11 +396,7 @@ pub async fn test_read_with_special_chars(op: Operator) -> anyhow::Result<()> {
 
 /// Read file with override-cache-control should succeed.
 pub async fn test_read_with_override_cache_control(op: Operator) -> anyhow::Result<()> {
-    if !(op.info().full_capability().read_with_override_cache_control
-        && op.info().full_capability().presign)
-    {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_override_cache_control, presign);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -455,14 +437,7 @@ pub async fn test_read_with_override_cache_control(op: Operator) -> anyhow::Resu
 
 /// Read file with override_content_disposition should succeed.
 pub async fn test_read_with_override_content_disposition(op: Operator) -> anyhow::Result<()> {
-    if !(op
-        .info()
-        .full_capability()
-        .read_with_override_content_disposition
-        && op.info().full_capability().presign)
-    {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_override_content_disposition, presign);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -505,11 +480,7 @@ pub async fn test_read_with_override_content_disposition(op: Operator) -> anyhow
 
 /// Read file with override_content_type should succeed.
 pub async fn test_read_with_override_content_type(op: Operator) -> anyhow::Result<()> {
-    if !(op.info().full_capability().read_with_override_content_type
-        && op.info().full_capability().presign)
-    {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_override_content_type, presign);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -552,9 +523,7 @@ pub async fn test_read_with_override_content_type(op: Operator) -> anyhow::Resul
 
 /// Read with if_modified_since should match, otherwise, a ConditionNotMatch error will be returned.
 pub async fn test_read_with_if_modified_since(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_modified_since {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_if_modified_since);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -583,9 +552,7 @@ pub async fn test_read_with_if_modified_since(op: Operator) -> anyhow::Result<()
 
 /// Read with if_unmodified_since should match, otherwise, a ConditionNotMatch error will be returned.
 pub async fn test_read_with_if_unmodified_since(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_unmodified_since {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_if_unmodified_since);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -682,9 +649,7 @@ pub async fn test_read_only_read_with_dir_path(op: Operator) -> anyhow::Result<(
 
 /// Reader with if_match should match, else get a ConditionNotMatch error.
 pub async fn test_reader_only_read_with_if_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_if_match);
 
     let path = "normal_file.txt";
 
@@ -714,9 +679,7 @@ pub async fn test_reader_only_read_with_if_match(op: Operator) -> anyhow::Result
 
 /// Read with if_match should match, else get a ConditionNotMatch error.
 pub async fn test_read_only_read_with_if_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_if_match);
 
     let path = "normal_file.txt";
 
@@ -744,9 +707,7 @@ pub async fn test_read_only_read_with_if_match(op: Operator) -> anyhow::Result<(
 
 /// Reader with if_none_match should match, else get a ConditionNotMatch error.
 pub async fn test_reader_only_read_with_if_none_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_none_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_if_none_match);
 
     let path = "normal_file.txt";
 
@@ -776,9 +737,7 @@ pub async fn test_reader_only_read_with_if_none_match(op: Operator) -> anyhow::R
 
 /// Read with if_none_match should match, else get a ConditionNotMatch error.
 pub async fn test_read_only_read_with_if_none_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_none_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_if_none_match);
 
     let path = "normal_file.txt";
 
@@ -808,9 +767,7 @@ pub async fn test_read_only_read_with_if_none_match(op: Operator) -> anyhow::Res
 }
 
 pub async fn test_read_with_version(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_version {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_version);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
     op.write(path.as_str(), content.clone())
@@ -842,9 +799,7 @@ pub async fn test_read_with_version(op: Operator) -> anyhow::Result<()> {
 }
 
 pub async fn test_read_with_not_existing_version(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_version {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, read_with_version);
 
     // retrieve a valid version
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());

--- a/core/tests/behavior/async_rename.rs
+++ b/core/tests/behavior/async_rename.rs
@@ -82,9 +82,7 @@ pub async fn test_rename_non_existing_source(op: Operator) -> Result<()> {
 
 /// Rename a dir as source should return an error.
 pub async fn test_rename_source_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
 
     let source_path = format!("{}/", uuid::Uuid::new_v4());
     let target_path = uuid::Uuid::new_v4().to_string();
@@ -101,9 +99,7 @@ pub async fn test_rename_source_dir(op: Operator) -> Result<()> {
 
 /// Rename to a dir should return an error.
 pub async fn test_rename_target_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
 
     let source_path = uuid::Uuid::new_v4().to_string();
     let (content, _) = gen_bytes(op.info().full_capability());

--- a/core/tests/behavior/async_stat.rs
+++ b/core/tests/behavior/async_stat.rs
@@ -87,9 +87,7 @@ pub async fn test_stat_file(op: Operator) -> Result<()> {
 
 /// Stat existing file should return metadata
 pub async fn test_stat_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
 
     let path = TEST_FIXTURE.new_dir_path();
 
@@ -110,9 +108,7 @@ pub async fn test_stat_dir(op: Operator) -> Result<()> {
 
 /// Stat the parent dir of existing dir should return metadata
 pub async fn test_stat_nested_parent_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, create_dir);
 
     let parent = format!("{}", uuid::Uuid::new_v4());
     let file = format!("{}", uuid::Uuid::new_v4());
@@ -183,9 +179,7 @@ pub async fn test_stat_not_exist(op: Operator) -> Result<()> {
 
 /// Stat with if_match should succeed, else get a ConditionNotMatch error.
 pub async fn test_stat_with_if_match(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_if_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, stat_with_if_match);
 
     let (path, content, size) = TEST_FIXTURE.new_file(op.clone());
 
@@ -212,9 +206,7 @@ pub async fn test_stat_with_if_match(op: Operator) -> Result<()> {
 
 /// Stat with if_none_match should succeed, else get a ConditionNotMatch.
 pub async fn test_stat_with_if_none_match(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_if_none_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, stat_with_if_none_match);
 
     let (path, content, size) = TEST_FIXTURE.new_file(op.clone());
 
@@ -245,9 +237,7 @@ pub async fn test_stat_with_if_none_match(op: Operator) -> Result<()> {
 
 /// Stat file with if_modified_since should succeed, otherwise get a ConditionNotMatch error.
 pub async fn test_stat_with_if_modified_since(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_if_modified_since {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, stat_with_if_modified_since);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -275,9 +265,7 @@ pub async fn test_stat_with_if_modified_since(op: Operator) -> Result<()> {
 
 /// Stat file with if_unmodified_since should succeed, otherwise get a ConditionNotMatch error.
 pub async fn test_stat_with_if_unmodified_since(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_if_unmodified_since {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, stat_with_if_unmodified_since);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -305,11 +293,7 @@ pub async fn test_stat_with_if_unmodified_since(op: Operator) -> Result<()> {
 
 /// Stat file with override-cache-control should succeed.
 pub async fn test_stat_with_override_cache_control(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().stat_with_override_cache_control
-        && op.info().full_capability().presign)
-    {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, stat_with_override_cache_control, presign);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -350,14 +334,7 @@ pub async fn test_stat_with_override_cache_control(op: Operator) -> Result<()> {
 
 /// Stat file with override_content_disposition should succeed.
 pub async fn test_stat_with_override_content_disposition(op: Operator) -> Result<()> {
-    if !(op
-        .info()
-        .full_capability()
-        .stat_with_override_content_disposition
-        && op.info().full_capability().presign)
-    {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, stat_with_override_content_disposition, presign);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -399,11 +376,7 @@ pub async fn test_stat_with_override_content_disposition(op: Operator) -> Result
 
 /// Stat file with override_content_type should succeed.
 pub async fn test_stat_with_override_content_type(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().stat_with_override_content_type
-        && op.info().full_capability().presign)
-    {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, stat_with_override_content_type, presign);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -500,9 +473,7 @@ pub async fn test_read_only_stat_not_exist(op: Operator) -> Result<()> {
 
 /// Stat with if_match should succeed, else get a ConditionNotMatch error.
 pub async fn test_read_only_stat_with_if_match(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_if_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, stat_with_if_match);
 
     let path = "normal_file.txt";
 
@@ -525,9 +496,7 @@ pub async fn test_read_only_stat_with_if_match(op: Operator) -> Result<()> {
 
 /// Stat with if_none_match should succeed, else get a ConditionNotMatch.
 pub async fn test_read_only_stat_with_if_none_match(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_if_none_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, stat_with_if_none_match);
 
     let path = "normal_file.txt";
 
@@ -561,9 +530,7 @@ pub async fn test_read_only_stat_root(op: Operator) -> Result<()> {
 }
 
 pub async fn test_stat_with_version(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_version {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, stat_with_version);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -599,9 +566,7 @@ pub async fn test_stat_with_version(op: Operator) -> Result<()> {
 }
 
 pub async fn stat_with_not_existing_version(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_version {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, stat_with_version);
 
     // retrieve a valid version
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());

--- a/core/tests/behavior/async_write.rs
+++ b/core/tests/behavior/async_write.rs
@@ -87,9 +87,7 @@ pub async fn test_write_only(op: Operator) -> Result<()> {
 
 /// Write a file with empty content.
 pub async fn test_write_with_empty_content(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_can_empty {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_can_empty);
 
     let path = TEST_FIXTURE.new_file_path();
 
@@ -138,9 +136,7 @@ pub async fn test_write_with_special_chars(op: Operator) -> Result<()> {
 
 /// Write a single file with cache control should succeed.
 pub async fn test_write_with_cache_control(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_cache_control {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_with_cache_control);
 
     let path = uuid::Uuid::new_v4().to_string();
     let (content, _) = gen_bytes(op.info().full_capability());
@@ -164,9 +160,7 @@ pub async fn test_write_with_cache_control(op: Operator) -> Result<()> {
 
 /// Write a single file with content type should succeed.
 pub async fn test_write_with_content_type(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_content_type {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_with_content_type);
 
     let (path, content, size) = TEST_FIXTURE.new_file(op.clone());
 
@@ -188,9 +182,7 @@ pub async fn test_write_with_content_type(op: Operator) -> Result<()> {
 
 /// Write a single file with content disposition should succeed.
 pub async fn test_write_with_content_disposition(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_content_disposition {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_with_content_disposition);
 
     let (path, content, size) = TEST_FIXTURE.new_file(op.clone());
 
@@ -212,9 +204,7 @@ pub async fn test_write_with_content_disposition(op: Operator) -> Result<()> {
 
 /// Write a single file with content encoding should succeed.
 pub async fn test_write_with_content_encoding(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_content_encoding {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_with_content_encoding);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -234,9 +224,7 @@ pub async fn test_write_with_content_encoding(op: Operator) -> Result<()> {
 
 /// write a single file with user defined metadata should succeed.
 pub async fn test_write_with_user_metadata(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_user_metadata {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_with_user_metadata);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
     let target_user_metadata = vec![("location".to_string(), "everywhere".to_string())];
@@ -322,9 +310,7 @@ pub async fn test_writer_abort_with_concurrent(op: Operator) -> Result<()> {
 
 /// Append data into writer
 pub async fn test_writer_write(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().write_can_multi) {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_can_multi);
 
     let path = TEST_FIXTURE.new_file_path();
     let size = 5 * 1024 * 1024; // write file with 5 MiB
@@ -357,9 +343,7 @@ pub async fn test_writer_write(op: Operator) -> Result<()> {
 
 /// Append data into writer
 pub async fn test_writer_write_with_concurrent(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().write_can_multi) {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_can_multi);
 
     let path = TEST_FIXTURE.new_file_path();
     // We need at least 3 part to make sure concurrent happened.
@@ -402,10 +386,7 @@ pub async fn test_writer_write_with_concurrent(op: Operator) -> Result<()> {
 
 /// Streaming data into writer
 pub async fn test_writer_sink(op: Operator) -> Result<()> {
-    let cap = op.info().full_capability();
-    if !(cap.write && cap.write_can_multi) {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write, write_can_multi);
 
     let path = TEST_FIXTURE.new_file_path();
     let size = 5 * 1024 * 1024; // write file with 5 MiB
@@ -446,10 +427,7 @@ pub async fn test_writer_sink(op: Operator) -> Result<()> {
 
 /// Streaming data into writer
 pub async fn test_writer_sink_with_concurrent(op: Operator) -> Result<()> {
-    let cap = op.info().full_capability();
-    if !(cap.write && cap.write_can_multi) {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write, write_can_multi);
 
     let path = TEST_FIXTURE.new_file_path();
     let size = 8 * 1024 * 1024; // write file with 8 MiB
@@ -491,9 +469,7 @@ pub async fn test_writer_sink_with_concurrent(op: Operator) -> Result<()> {
 
 /// Copy data from reader to writer
 pub async fn test_writer_futures_copy(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().write_can_multi) {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_can_multi);
 
     let path = TEST_FIXTURE.new_file_path();
     let (content, size): (Vec<u8>, usize) =
@@ -526,9 +502,7 @@ pub async fn test_writer_futures_copy(op: Operator) -> Result<()> {
 
 /// Copy data from reader to writer
 pub async fn test_writer_futures_copy_with_concurrent(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().write_can_multi) {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_can_multi);
 
     let path = TEST_FIXTURE.new_file_path();
     let (content, size): (Vec<u8>, usize) =
@@ -561,10 +535,7 @@ pub async fn test_writer_futures_copy_with_concurrent(op: Operator) -> Result<()
 }
 
 pub async fn test_writer_return_metadata(op: Operator) -> Result<()> {
-    let cap = op.info().full_capability();
-    if !cap.write_can_multi {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_can_multi);
 
     let path = TEST_FIXTURE.new_file_path();
     let size = 5 * 1024 * 1024; // write file with 5 MiB
@@ -734,9 +705,7 @@ pub async fn test_writer_write_with_overwrite(op: Operator) -> Result<()> {
 
 /// Write an exists file with if_none_match should match, else get a ConditionNotMatch error.
 pub async fn test_write_with_if_none_match(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_if_none_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_with_if_none_match);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -758,9 +727,7 @@ pub async fn test_write_with_if_none_match(op: Operator) -> Result<()> {
 
 /// Write an file with if_not_exists will get a ConditionNotMatch error if file exists.
 pub async fn test_write_with_if_not_exists(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_if_not_exists {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_with_if_not_exists);
 
     let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
 
@@ -782,9 +749,7 @@ pub async fn test_write_with_if_not_exists(op: Operator) -> Result<()> {
 
 /// Write an file with if_match will get a ConditionNotMatch error if file's etag does not match.
 pub async fn test_write_with_if_match(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_if_match {
-        return Ok(());
-    }
+    skip_if_no_capabilities!(op, write_with_if_match);
 
     // Create two different files with different content
     let (path_a, content_a, _) = TEST_FIXTURE.new_file(op.clone());

--- a/core/tests/behavior/utils.rs
+++ b/core/tests/behavior/utils.rs
@@ -185,3 +185,15 @@ impl Fixture {
         let _ = op.delete_iter(paths).await;
     }
 }
+
+#[macro_export]
+macro_rules! skip_if_no_capabilities {
+    ($op:expr, $($cap:ident),+ $(,)?) => {
+        {
+            let caps = $op.info().full_capability();
+            if false $(|| !caps.$cap)+ {
+                return Ok(());
+            }
+        }
+    };
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Currently, most behavior tests already check for the `create_dir` capability before running tests that require directory creation, but the `async_list.rs` tests were missing this check. This PR adds `create_dir` capability checks to the relevant `async_list.rs` behavior tests for consistency and to prevent unnecessary failures when the operator does not support directory creation.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
 adds explicit checks for the `create_dir` capability in relevant `async_list.rs` behavior tests to ensure that tests requiring directory creation are only executed when supported by the operator.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
