### PR TITLE
chore(dependabot): exclude rand and getrandom crates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,8 +52,6 @@ updates:
           - "base64"
           - "bytes"
           - "chrono"
-          - "rand"
-          - "getrandom"
           - "http*"
           - "percent-encoding"
           - "prometheus*"
@@ -84,6 +82,10 @@ updates:
       others:
         patterns:
           - "*"
+        exclude-patterns:
+          # Please upgrade to new APIs when updating "rand"
+          - "rand"
+          - "getrandom"
 
   - package-ecosystem: "cargo"
     directory: "/bin/oay"


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Address comment. https://github.com/apache/opendal/pull/6389#issuecomment-3066615483
I didn't know the API changes. Sorry.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Exclude rand, getrandom crates from the dependabot group.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
