### PR TITLE
chore(github-actions): revert 1password action update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,20 @@ updates:
       third-party-actions:
         patterns:
           - "*"
+    ignore:
+      # Ignore 1Password v2 actions until 1Password resolves these problems:
+      # 1. Windows support https://github.com/1Password/load-secrets-action/issues/46
+      # 2. `1password/load-secrets-action/configure@v2` doesn't export environment variables into
+      #    service composite actions. e.g., `.github/services/s3/aws_s3/action.yml`.
+      #    The dynamic composite actions call a service action can't utilize connect tokens.
+      #    A proper fix (untested) might not need 1Password's support but it's also not urgent.
+      #    Moreover, we will expose the least amount of permission if we refactor CI.
+      #    We can perhaps utilize a config file, e.g., `.github/services/1password.json`,
+      #    where we:
+      #    a. load secrets in shared workflows, e.g., `.github/workflows/test_behavior_core.yml`
+      #    b. pass secrets to composite actions, e.g., `.github/actions/test_behavior_core` via environment variables
+      - dependency-name: 1password/load-secrets-action/configure
+      - dependency-name: 1password/load-secrets-action
 
   # Core dependencies - semiannual updates with groups
   - package-ecosystem: "cargo"

--- a/.github/services/azblob/azure_azblob/action.yml
+++ b/.github/services/azblob/azure_azblob/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/azdls/azdls/action.yml
+++ b/.github/services/azdls/azdls/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/azfile/azfile/action.yml
+++ b/.github/services/azfile/azfile/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/b2/b2/action.yml
+++ b/.github/services/b2/b2/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/cos/cos/action.yml
+++ b/.github/services/cos/cos/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/dropbox/dropbox/disable_action.yml
+++ b/.github/services/dropbox/dropbox/disable_action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup credentials
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/gcs/gcs/action.yml
+++ b/.github/services/gcs/gcs/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/gcs/gcs_with_default_storage_class/action.yml
+++ b/.github/services/gcs/gcs_with_default_storage_class/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/gdrive/gdrive/action.yml
+++ b/.github/services/gdrive/gdrive/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/hdfs/hdfs_default_gcs/action.yml
+++ b/.github/services/hdfs/hdfs_default_gcs/action.yml
@@ -27,7 +27,7 @@ runs:
         distribution: temurin
         java-version: "11"
     - name: Load secrets
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/koofr/koofr/disable_action.yml
+++ b/.github/services/koofr/koofr/disable_action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/oss/oss/action.yml
+++ b/.github/services/oss/oss/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/oss/oss_with_versioning/action.yml
+++ b/.github/services/oss/oss_with_versioning/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3/action.yml
+++ b/.github/services/s3/aws_s3/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3_with_list_objects_v1/action.yml
+++ b/.github/services/s3/aws_s3_with_list_objects_v1/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3_with_sse_c/action.yml
+++ b/.github/services/s3/aws_s3_with_sse_c/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3_with_versioning/action.yml
+++ b/.github/services/s3/aws_s3_with_versioning/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3_with_virtual_host/action.yml
+++ b/.github/services/s3/aws_s3_with_virtual_host/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/services/s3/r2/disabled_action.yml
+++ b/.github/services/s3/r2/disabled_action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@v1
       with:
         export-env: true
       env:

--- a/.github/workflows/ci_bindings_haskell.yml
+++ b/.github/workflows/ci_bindings_haskell.yml
@@ -122,7 +122,7 @@ jobs:
 #          name: bindings-haskell-sdist
 #      - name: Load secret
 #        id: op-load-secret
-#        uses: 1password/load-secrets-action@v2
+#        uses: 1password/load-secrets-action@v1
 #        with:
 #          export-env: true
 #        env:

--- a/.github/workflows/ci_weekly_update.yml
+++ b/.github/workflows/ci_weekly_update.yml
@@ -52,13 +52,13 @@ jobs:
 
       - name: Setup 1Password Connect
         if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v1
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}
 
       - name: Setup
-        uses: 1password/load-secrets-action@v2
+        uses: 1password/load-secrets-action@v1
         with:
           export-env: true
         env:

--- a/.github/workflows/test_behavior_bin_ofs.yml
+++ b/.github/workflows/test_behavior_bin_ofs.yml
@@ -50,11 +50,11 @@ jobs:
       # Waiting for https://github.com/1Password/load-secrets-action/issues/46
       - name: Setup 1Password Connect
         if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v1
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}
-    
+
       - name: Test Bin Ofs
         uses: ./.github/actions/test_behavior_bin_ofs
         with:

--- a/.github/workflows/test_behavior_binding_c.yml
+++ b/.github/workflows/test_behavior_binding_c.yml
@@ -50,7 +50,7 @@ jobs:
       # Waiting for https://github.com/1Password/load-secrets-action/issues/46
       - name: Setup 1Password Connect
         if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v1
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/test_behavior_binding_go.yml
+++ b/.github/workflows/test_behavior_binding_go.yml
@@ -57,7 +57,7 @@ jobs:
       # Waiting for https://github.com/1Password/load-secrets-action/issues/46
       - name: Setup 1Password Connect
         if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v1
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/test_behavior_binding_java.yml
+++ b/.github/workflows/test_behavior_binding_java.yml
@@ -50,7 +50,7 @@ jobs:
       # Waiting for https://github.com/1Password/load-secrets-action/issues/46
       - name: Setup 1Password Connect
         if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v1
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/test_behavior_binding_nodejs.yml
+++ b/.github/workflows/test_behavior_binding_nodejs.yml
@@ -50,7 +50,7 @@ jobs:
       # Waiting for https://github.com/1Password/load-secrets-action/issues/46
       - name: Setup 1Password Connect
         if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v1
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/test_behavior_binding_python.yml
+++ b/.github/workflows/test_behavior_binding_python.yml
@@ -50,7 +50,7 @@ jobs:
       # Waiting for https://github.com/1Password/load-secrets-action/issues/46
       - name: Setup 1Password Connect
         if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v1
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/test_behavior_core.yml
+++ b/.github/workflows/test_behavior_core.yml
@@ -49,7 +49,7 @@ jobs:
       # Waiting for https://github.com/1Password/load-secrets-action/issues/46
       - name: Setup 1Password Connect
         if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v1
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/test_behavior_integration_object_store.yml
+++ b/.github/workflows/test_behavior_integration_object_store.yml
@@ -50,7 +50,7 @@ jobs:
       # Waiting for https://github.com/1Password/load-secrets-action/issues/46
       - name: Setup 1Password Connect
         if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v1
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}


### PR DESCRIPTION
# Which issue does this PR close?

Found `1password/load-secrets-action@v2` is blocking CI.

# Rationale for this change

I made an investigation about what CI is complaining as well as 1Password actions. I have an idea for the fix (including as an inline-comment). However, this is not urgent. In the meantime, I will not block CI for your incoming release.

Since this PR touches Dependabot config, we will get auto updates again. We can prioritize merging this PR firstly to rerun CI in other PRs automatically.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
