### PR TITLE
fix(bin/oli): Fix tests when TMPDIR is not /tmp

### DIFF
--- a/bin/oli/tests/integration/edit.rs
+++ b/bin/oli/tests/integration/edit.rs
@@ -137,7 +137,7 @@ async fn test_edit_existing_file_with_changes() -> Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    File uploaded successfully to tmp[TEMP_DIR]/test_file.txt
+    File uploaded successfully to [TEMP_DIR]/test_file.txt
 
     ----- stderr -----
     "#);
@@ -172,7 +172,7 @@ async fn test_edit_new_file() -> Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    File uploaded successfully to tmp[TEMP_DIR]/new_file.txt
+    File uploaded successfully to [TEMP_DIR]/new_file.txt
 
     ----- stderr -----
     "#);
@@ -264,7 +264,7 @@ async fn test_edit_file_content_replacement() -> Result<()> {
     success: true
     exit_code: 0
     ----- stdout -----
-    File uploaded successfully to tmp[TEMP_DIR]/replace_test.txt
+    File uploaded successfully to [TEMP_DIR]/replace_test.txt
 
     ----- stderr -----
     "#);

--- a/bin/oli/tests/integration/test_utils.rs
+++ b/bin/oli/tests/integration/test_utils.rs
@@ -138,7 +138,7 @@ macro_rules! assert_snapshot {
 pub(crate) use assert_snapshot;
 
 pub const REPLACEMENTS: &[(&str, &str)] = &[
-    (r"/.*\.tmp[^/]+", "[TEMP_DIR]"), // New regex for specific /.tmpXXXX patterns
+    (r"(?:/|(\s))\S*\.tmp[^/]+", "$1[TEMP_DIR]"), // New regex for specific /.tmpXXXX patterns
     (
         r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{9} UTC)",
         "[TIMESTAMP]",


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6428.

# Are there any user-facing changes?

No.

