### PR TITLE
chore(website): upgrade prism-react-renderer to v2.4.1

### DIFF
--- a/website/DEPENDENCIES.node.csv
+++ b/website/DEPENDENCIES.node.csv
@@ -6,7 +6,7 @@
 "docusaurus-lunr-search@3.6.0","MIT","https://github.com/lelouch77/docusaurus-lunr-search"
 "docusaurus-plugin-image-zoom@3.0.1","MIT","https://github.com/gabrielcsapo/docusaurus-plugin-image-zoom"
 "lunr@2.3.9","MIT","https://github.com/olivernn/lunr.js"
-"prism-react-renderer@1.3.5","MIT","https://github.com/FormidableLabs/prism-react-renderer"
+"prism-react-renderer@2.4.1","MIT","https://github.com/FormidableLabs/prism-react-renderer"
 "react-dom@19.1.0","MIT","https://github.com/facebook/react"
 "react@19.1.0","MIT","https://github.com/facebook/react"
 "semver@7.7.2","ISC","https://github.com/npm/node-semver"

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -25,8 +25,7 @@ const exec = require("child_process").execSync;
 const path = require("path");
 const crates_llms_txt = require("crates-llms-txt");
 
-const lightCodeTheme = require("prism-react-renderer/themes/github");
-const darkCodeTheme = require("prism-react-renderer/themes/dracula");
+const { themes } = require("prism-react-renderer");
 const repoAddress = "https://github.com/apache/opendal";
 
 const baseUrl = process.env.OPENDAL_WEBSITE_BASE_URL
@@ -373,8 +372,8 @@ const config = {
         copyright: `Copyright © 2022-${new Date().getFullYear()}, The Apache Software Foundation<br/>Apache OpenDAL, OpenDAL, Apache, the Apache feather and the Apache OpenDAL project logo are either registered trademarks or trademarks of the Apache Software Foundation.`,
       },
       prism: {
-        theme: lightCodeTheme,
-        darkTheme: darkCodeTheme,
+        theme: themes.github,
+        darkTheme: themes.dracula,
         additionalLanguages: ["rust", "java", "groovy"],
       },
       zoom: {

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,7 @@
     "docusaurus-lunr-search": "^3.6.0",
     "docusaurus-plugin-image-zoom": "^3.0.1",
     "lunr": "^2.3.9",
-    "prism-react-renderer": "^1.3.5",
+    "prism-react-renderer": "^2.4.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "semver": "^7.7.2"

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -27,8 +27,8 @@ dependencies:
     specifier: ^2.3.9
     version: 2.3.9
   prism-react-renderer:
-    specifier: ^1.3.5
-    version: 1.3.5(react@19.1.0)
+    specifier: ^2.4.1
+    version: 2.4.1(react@19.1.0)
   react:
     specifier: ^19.1.0
     version: 19.1.0
@@ -2562,7 +2562,7 @@ packages:
       lodash: 4.17.21
       nprogress: 0.2.0
       postcss: 8.5.6
-      prism-react-renderer: 2.4.0(react@19.1.0)
+      prism-react-renderer: 2.4.1(react@19.1.0)
       prismjs: 1.29.0
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -2608,7 +2608,7 @@ packages:
       '@types/react-router-config': 5.0.11
       clsx: 2.1.1
       parse-numeric-range: 1.3.0
-      prism-react-renderer: 2.4.0(react@19.1.0)
+      prism-react-renderer: 2.4.1(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       tslib: 2.8.1
@@ -8182,16 +8182,8 @@ packages:
     resolution: {integrity: sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==}
     engines: {node: '>=4'}
 
-  /prism-react-renderer@1.3.5(react@19.1.0):
-    resolution: {integrity: sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==}
-    peerDependencies:
-      react: '>=0.14.9'
-    dependencies:
-      react: 19.1.0
-    dev: false
-
-  /prism-react-renderer@2.4.0(react@19.1.0):
-    resolution: {integrity: sha512-327BsVCD/unU4CNLZTWVHyUHKnsqcvj2qbPlQ8MiBE2eq2rgctjigPA1Gp9HLF83kZ20zNN6jgizHJeEsyFYOw==}
+  /prism-react-renderer@2.4.1(react@19.1.0):
+    resolution: {integrity: sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==}
     peerDependencies:
       react: '>=16.0.0'
     dependencies:


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6417.

# Rationale for this change
Dependabot was unable to correctly upgrade ‎`prism-react-renderer`, so this dependency was updated manually from v1.3.5 to v2.4.1. This ensures we stay up to date with the latest features and bug fixes.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
- Manually upgraded ‎`prism-react-renderer` from v1.3.5 to v2.4.1
- Adjusted ‎`docusaurus.config.js` to match the new theme import method in the latest ‎`prism-react-renderer`
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
No user-facing changes; this PR only updates 

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
