### PR TITLE
ci: remove docker-compose version top-level elements

### DIFF
--- a/fixtures/alluxio/docker-compose-alluxio.yml
+++ b/fixtures/alluxio/docker-compose-alluxio.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: "3.8"
 services:
   alluxio-master:
     image: alluxio/alluxio:2.9.3

--- a/fixtures/azblob/docker-compose-azurite.yml
+++ b/fixtures/azblob/docker-compose-azurite.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   azurite:
     image: mcr.microsoft.com/azure-storage/azurite

--- a/fixtures/etcd/docker-compose-cluster.yml
+++ b/fixtures/etcd/docker-compose-cluster.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
 services:
   etcd1:
     image: bitnami/etcd:latest

--- a/fixtures/etcd/docker-compose-standalone-tls.yml
+++ b/fixtures/etcd/docker-compose-standalone-tls.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
 services:
   etcd:
     image: bitnami/etcd:latest

--- a/fixtures/etcd/docker-compose-standalone.yml
+++ b/fixtures/etcd/docker-compose-standalone.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
 services:
   etcd:
     image: bitnami/etcd:latest

--- a/fixtures/ftp/docker-compose-vsftpd.yml
+++ b/fixtures/ftp/docker-compose-vsftpd.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: "3.8"
 services:
   vsftpd:
     image: fauria/vsftpd

--- a/fixtures/hdfs/docker-compose-hdfs-cluster.yml
+++ b/fixtures/hdfs/docker-compose-hdfs-cluster.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   namenode:
     image: bde2020/hadoop-namenode:2.0.0-hadoop3.2.1-java8

--- a/fixtures/http/docker-compose-caddy.yml
+++ b/fixtures/http/docker-compose-caddy.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
 services:
   caddy:
     image: caddy:latest

--- a/fixtures/http/docker-compose-nginx.yml
+++ b/fixtures/http/docker-compose-nginx.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
 services:
   nginx:
     image: nginx:latest

--- a/fixtures/libsql/docker-compose-auth.yml
+++ b/fixtures/libsql/docker-compose-auth.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   libsql:
     image: ghcr.io/libsql/sqld:v0.21.9

--- a/fixtures/libsql/docker-compose.yml
+++ b/fixtures/libsql/docker-compose.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   libsql:
     image: ghcr.io/libsql/sqld:v0.21.9

--- a/fixtures/memcached/docker-compose-memcached-with-auth.yml
+++ b/fixtures/memcached/docker-compose-memcached-with-auth.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   memcached:
     image: bitnami/memcached
@@ -29,4 +27,4 @@ services:
       MEMCACHED_USERNAME: "test"
       MEMCACHED_PASSWORD: "test"
     ports:
-      - '11211:11211'
+      - "11211:11211"

--- a/fixtures/memcached/docker-compose-memcached.yml
+++ b/fixtures/memcached/docker-compose-memcached.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   memcached:
     image: bitnami/memcached

--- a/fixtures/mongodb/docker-compose-basic-auth.yml
+++ b/fixtures/mongodb/docker-compose-basic-auth.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.1'
-
 services:
 
   mongo:

--- a/fixtures/mongodb/docker-compose-no-auth.yml
+++ b/fixtures/mongodb/docker-compose-no-auth.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.1'
-
 services:
 
   mongo:

--- a/fixtures/mysql/docker-compose.yml
+++ b/fixtures/mysql/docker-compose.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   mysql-db:
     image: mysql:8.1.0

--- a/fixtures/postgresql/docker-compose.yml
+++ b/fixtures/postgresql/docker-compose.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   postgres-db:
     image: postgres:13

--- a/fixtures/redis/docker-compose-dragonfly.yml
+++ b/fixtures/redis/docker-compose-dragonfly.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   redis:
     image: docker.dragonflydb.io/dragonflydb/dragonfly

--- a/fixtures/redis/docker-compose-kvrocks.yml
+++ b/fixtures/redis/docker-compose-kvrocks.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   redis:
     image: apache/kvrocks:2.5.1

--- a/fixtures/redis/docker-compose-redis-cluster-tls.yml
+++ b/fixtures/redis/docker-compose-redis-cluster-tls.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   redis-node-0:
     image: docker.io/bitnami/redis-cluster:7.0

--- a/fixtures/redis/docker-compose-redis-cluster.yml
+++ b/fixtures/redis/docker-compose-redis-cluster.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   redis-node-0:
     image: docker.io/bitnami/redis-cluster:7.0

--- a/fixtures/redis/docker-compose-redis-tls.yml
+++ b/fixtures/redis/docker-compose-redis-tls.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   redis:
     image: docker.io/bitnami/redis:7.0

--- a/fixtures/redis/docker-compose-redis.yml
+++ b/fixtures/redis/docker-compose-redis.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   redis:
     image: docker.io/bitnami/redis:7.0

--- a/fixtures/s3/docker-compose-ceph-rados.yml
+++ b/fixtures/s3/docker-compose-ceph-rados.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: "3.8"
-
 services:
   ceph-demo:
     image: quay.io/ceph/demo

--- a/fixtures/s3/docker-compose-minio.yml
+++ b/fixtures/s3/docker-compose-minio.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   minio:
     image: quay.io/minio/minio:RELEASE.2024-09-22T00-33-43Z

--- a/fixtures/seafile/docker-compose-seafile.yml
+++ b/fixtures/seafile/docker-compose-seafile.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: "3.8"
 services:
   db:
     image: mariadb:10.11

--- a/fixtures/sftp/docker-compose-sftp-with-default-root.yml
+++ b/fixtures/sftp/docker-compose-sftp-with-default-root.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   sftp-with-default-root:
     image: atmoz/sftp:debian

--- a/fixtures/sftp/docker-compose-sftp.yml
+++ b/fixtures/sftp/docker-compose-sftp.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   sftp:
     image: atmoz/sftp:debian

--- a/fixtures/swift/docker-compose-ceph-rados.yml
+++ b/fixtures/swift/docker-compose-ceph-rados.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: "3.8"
-
 services:
   ceph-demo:
     image: quay.io/ceph/demo

--- a/fixtures/swift/docker-compose-swift.yml
+++ b/fixtures/swift/docker-compose-swift.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   swift:
     image: openstackswift/saio:py3

--- a/fixtures/webdav/docker-compose-webdav-jfrog.yml
+++ b/fixtures/webdav/docker-compose-webdav-jfrog.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   jfrog:
     image: releases-docker.jfrog.io/jfrog/artifactory-oss:latest

--- a/fixtures/webdav/docker-compose-webdav-nextcloud.yml
+++ b/fixtures/webdav/docker-compose-webdav-nextcloud.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   nextcloud:
     image: nextcloud

--- a/fixtures/webdav/docker-compose-webdav-owncloud.yml
+++ b/fixtures/webdav/docker-compose-webdav-owncloud.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   owncloud:
     image: owncloud/server

--- a/fixtures/webdav/docker-compose-webdav-with-auth.yml
+++ b/fixtures/webdav/docker-compose-webdav-with-auth.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   webdav:
     image: dgraziotin/nginx-webdav-nononsense

--- a/fixtures/webdav/docker-compose-webdav-with-empty-passwd.yml
+++ b/fixtures/webdav/docker-compose-webdav-with-empty-passwd.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   webdav:
     image: dgraziotin/nginx-webdav-nononsense

--- a/fixtures/webdav/docker-compose-webdav.yml
+++ b/fixtures/webdav/docker-compose-webdav.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   webdav:
     image: dgraziotin/nginx-webdav-nononsense

--- a/fixtures/webhdfs/docker-compose-webhdfs.yml
+++ b/fixtures/webhdfs/docker-compose-webhdfs.yml
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '3.8'
-
 services:
   namenode:
     image: bde2020/hadoop-namenode:2.0.0-hadoop3.1.3-java8


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
According to the [Compose Specification](https://github.com/compose-spec/compose-spec/blob/main/04-version-and-name.md), the top-level `version` field in docker-compose files is obsolete and only kept for backward compatibility. Compose no longer relies on the `version` field to select a schema and will always use the most recent specification. Keeping the `version` field results in a warning message. Therefore, removing it aligns with the latest Compose specification.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Removed the top-level ‎`version` field from all docker-compose YAML files.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
