### PR TITLE
docs(release): fix CI workflow links for bindings

### DIFF
--- a/website/community/release/release.md
+++ b/website/community/release/release.md
@@ -119,9 +119,9 @@ Pushing a Git tag to GitHub repo will trigger a GitHub Actions workflow that cre
 
 After pushing the tag, we need to check the GitHub action status to make sure the release candidate is created successfully.
 
-- Python: [Bindings Python CI](https://github.com/apache/opendal/actions/workflows/bindings_python.yml)
-- Java: [Bindings Java CI](https://github.com/apache/opendal/actions/workflows/bindings_java.yml) and [Bindings Java Release](https://github.com/apache/opendal/actions/workflows/release_java.yml)
-- Node.js: [Bindings Node.js CI](https://github.com/apache/opendal/actions/workflows/bindings_nodejs.yml)
+- Python: [Bindings Python CI](https://github.com/apache/opendal/actions/workflows/ci_bindings_python.yml)
+- Java: [Bindings Java CI](https://github.com/apache/opendal/actions/workflows/ci_bindings_java.yml) and [Bindings Java Release](https://github.com/apache/opendal/actions/workflows/release_java.yml)
+- Node.js: [Bindings Node.js CI](https://github.com/apache/opendal/actions/workflows/ci_bindings_nodejs.yml)
 
 In the most cases, it would be great to rerun the failed workflow directly when you find some failures. But if a new code patch is needed to fix the failure, you should create a new release candidate tag, increase the rc number and push it to GitHub.
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
Fix incorrect CI workflow links in the release documentation.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?
Updated the workflow links for Python, Java, and Node.js bindings to their correct CI URLs.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

No user-facing changes. Documentation links only.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
