### PR TITLE
ci: enable trust publishing for rust crates

### DIFF
--- a/.github/workflows/release_rust.yml
+++ b/.github/workflows/release_rust.yml
@@ -33,6 +33,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       # Publish package one by one instead of flooding the registry
       max-parallel: 1
@@ -76,6 +78,8 @@ jobs:
         env:
           LD_LIBRARY_PATH: ${{ env.JAVA_HOME }}/lib/server:${{ env.LD_LIBRARY_PATH }}
 
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Publish ${{ matrix.package }}
         working-directory: ${{ matrix.package }}
         # Only publish if it's a tag and the tag is not a pre-release
@@ -83,4 +87,4 @@ jobs:
         run: cargo publish --no-verify
         env:
           LD_LIBRARY_PATH: ${{ env.JAVA_HOME }}/lib/server:${{ env.LD_LIBRARY_PATH }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6439.

# Rationale for this change
Crates.io now supports trust publishing for crate releases. 
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
