### PR TITLE
fix(services/oss): unnecessary header 'content-type' are included in the get_object request

### DIFF
--- a/core/src/services/oss/core.rs
+++ b/core/src/services/oss/core.rs
@@ -335,7 +335,6 @@ impl OssCore {
         }
 
         let mut req = Request::get(&url);
-        req = req.header(CONTENT_TYPE, "application/octet-stream");
 
         if !range.is_full() {
             req = req.header(RANGE, range.to_header());


### PR DESCRIPTION
# Rationale for this change

The current implementation incorrectly includes a 'Content-Type' header in get_object requests to OSS. According to the official SDK documentation and specifications, this header should not be included for get_object operations. This unnecessary header cause the pre-signed get object request URL can't directly usable in browsers.

# What changes are included in this PR?

Removed the 'Content-Type' header from the request builder for get_object operations in the OSS service implementation. This aligns the behavior with the official OSS SDK specifications.

# Are there any user-facing changes?

Yes, but they are internal improvements:
- OSS get_object requests will no longer send an unnecessary 'Content-Type' header
- Make the pre-signed get object request URL directly usable in browsers.
- Improved compatibility with OSS API specifications
- No breaking changes for end-users - this is a bug fix aligning with expected behavior