### PR TITLE
refacrtor: Reduce usage of scheme inside raw

### DIFF
--- a/core/src/docs/internals/accessor.rs
+++ b/core/src/docs/internals/accessor.rs
@@ -251,7 +251,6 @@
 //! }
 //!
 //! impl Builder for DuckBuilder {
-//!     const SCHEME: Scheme = Scheme::Duck;
 //!     type Accessor = DuckBackend;
 //!     type Config = DuckConfig;
 //!
@@ -298,7 +297,7 @@
 //!
 //!     fn metadata(&self) -> AccessorInfo {
 //!         let am = AccessorInfo::default();
-//!         am.set_scheme(Scheme::Duck)
+//!         am.set_scheme("duck")
 //!             .set_root(&self.root)
 //!             .set_capability(
 //!                 Capability {

--- a/core/src/layers/correctness_check.rs
+++ b/core/src/layers/correctness_check.rs
@@ -271,6 +271,7 @@ mod tests {
 
         fn info(&self) -> Arc<AccessorInfo> {
             let info = AccessorInfo::default();
+            info.set_scheme("memory");
             info.set_native_capability(self.capability);
 
             info.into()

--- a/core/src/layers/error_context.rs
+++ b/core/src/layers/error_context.rs
@@ -188,7 +188,7 @@ impl<A: Access> LayeredAccess for ErrorContextAccessor<A> {
 }
 
 pub struct ErrorContextWrapper<T> {
-    scheme: Scheme,
+    scheme: &'static str,
     path: String,
     inner: T,
     range: BytesRange,
@@ -196,7 +196,7 @@ pub struct ErrorContextWrapper<T> {
 }
 
 impl<T> ErrorContextWrapper<T> {
-    fn new(scheme: Scheme, path: String, inner: T) -> Self {
+    fn new(scheme: &'static str, path: String, inner: T) -> Self {
         Self {
             scheme,
             path,

--- a/core/src/layers/fastmetrics.rs
+++ b/core/src/layers/fastmetrics.rs
@@ -508,7 +508,7 @@ struct OperationLabels {
 
 impl EncodeLabelSet for OperationLabels {
     fn encode(&self, encoder: &mut dyn LabelSetEncoder) -> fmt::Result {
-        encoder.encode(&(observe::LABEL_SCHEME, self.labels.scheme.into_static()))?;
+        encoder.encode(&(observe::LABEL_SCHEME, self.labels.scheme))?;
         encoder.encode(&(observe::LABEL_NAMESPACE, self.labels.namespace.as_ref()))?;
         if !self.disable_label_root {
             encoder.encode(&(observe::LABEL_ROOT, self.labels.root.as_ref()))?;

--- a/core/src/layers/metrics.rs
+++ b/core/src/layers/metrics.rs
@@ -160,7 +160,7 @@ impl OperationLabels {
         let mut labels = Vec::with_capacity(6);
 
         labels.extend([
-            Label::new(observe::LABEL_SCHEME, self.0.scheme.into_static()),
+            Label::new(observe::LABEL_SCHEME, self.0.scheme),
             Label::new(observe::LABEL_NAMESPACE, self.0.namespace),
             Label::new(observe::LABEL_ROOT, self.0.root),
             Label::new(observe::LABEL_OPERATION, self.0.operation),

--- a/core/src/layers/observe/metrics.rs
+++ b/core/src/layers/observe/metrics.rs
@@ -151,7 +151,7 @@ pub static LABEL_STATUS_CODE: &str = "status_code";
 pub struct MetricLabels {
     /// The storage scheme identifier (e.g., "s3", "gcs", "azblob", "fs").
     /// Used to differentiate between different storage backends.
-    pub scheme: Scheme,
+    pub scheme: &'static str,
     /// The storage namespace (e.g., bucket name, container name).
     /// Identifies the specific storage container being accessed.
     pub namespace: Arc<str>,

--- a/core/src/layers/otelmetrics.rs
+++ b/core/src/layers/otelmetrics.rs
@@ -432,7 +432,7 @@ impl OtelMetricsInterceptor {
         let mut attributes = Vec::with_capacity(6);
 
         attributes.extend([
-            KeyValue::new(observe::LABEL_SCHEME, attrs.scheme.into_static()),
+            KeyValue::new(observe::LABEL_SCHEME, attrs.scheme),
             KeyValue::new(observe::LABEL_NAMESPACE, attrs.namespace),
             KeyValue::new(observe::LABEL_ROOT, attrs.root),
             KeyValue::new(observe::LABEL_OPERATION, attrs.operation),

--- a/core/src/layers/prometheus.rs
+++ b/core/src/layers/prometheus.rs
@@ -667,7 +667,7 @@ impl OperationLabels {
         let mut labels = Vec::with_capacity(6);
 
         labels.extend([
-            self.0.scheme.into_static(),
+            self.0.scheme,
             self.0.namespace.as_ref(),
             self.0.root.as_ref(),
             self.0.operation,

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -490,7 +490,7 @@ struct OperationLabels {
 
 impl EncodeLabelSet for OperationLabels {
     fn encode(&self, mut encoder: LabelSetEncoder) -> Result<(), fmt::Error> {
-        (observe::LABEL_SCHEME, self.labels.scheme.into_static()).encode(encoder.encode_label())?;
+        (observe::LABEL_SCHEME, self.labels.scheme).encode(encoder.encode_label())?;
         (observe::LABEL_NAMESPACE, self.labels.namespace.as_ref())
             .encode(encoder.encode_label())?;
         if !self.disable_label_root {

--- a/core/src/layers/retry.rs
+++ b/core/src/layers/retry.rs
@@ -619,7 +619,6 @@ mod tests {
     }
 
     impl Builder for MockBuilder {
-        const SCHEME: Scheme = Scheme::Custom("mock");
         type Config = ();
 
         fn build(self) -> Result<impl Access> {
@@ -642,18 +641,17 @@ mod tests {
 
         fn info(&self) -> Arc<AccessorInfo> {
             let am = AccessorInfo::default();
-            am.set_scheme(Scheme::Custom("mock"))
-                .set_native_capability(Capability {
-                    read: true,
-                    write: true,
-                    write_can_multi: true,
-                    delete: true,
-                    delete_max_size: Some(10),
-                    stat: true,
-                    list: true,
-                    list_with_recursive: true,
-                    ..Default::default()
-                });
+            am.set_scheme("mock").set_native_capability(Capability {
+                read: true,
+                write: true,
+                write_can_multi: true,
+                delete: true,
+                delete_max_size: Some(10),
+                stat: true,
+                list: true,
+                list_with_recursive: true,
+                ..Default::default()
+            });
 
             am.into()
         }

--- a/core/src/raw/adapters/kv/backend.rs
+++ b/core/src/raw/adapters/kv/backend.rs
@@ -51,7 +51,7 @@ where
             info: {
                 let am: AccessorInfo = AccessorInfo::default();
                 am.set_root("/");
-                am.set_scheme(kv_info.scheme());
+                am.set_scheme(kv_info.scheme().into_static());
                 am.set_name(kv_info.name());
 
                 let mut cap = kv_info.capabilities();

--- a/core/src/raw/adapters/typed_kv/backend.rs
+++ b/core/src/raw/adapters/typed_kv/backend.rs
@@ -46,7 +46,7 @@ where
             info: {
                 let am: AccessorInfo = AccessorInfo::default();
                 am.set_root("/");
-                am.set_scheme(kv_info.scheme());
+                am.set_scheme(kv_info.scheme().into_static());
                 am.set_name(kv_info.name());
 
                 let kv_cap = kv_info.capabilities();

--- a/core/src/raw/layer.rs
+++ b/core/src/raw/layer.rs
@@ -261,7 +261,7 @@ mod tests {
 
         fn info(&self) -> Arc<AccessorInfo> {
             let am = AccessorInfo::default();
-            am.set_scheme(Scheme::Custom("test"));
+            am.set_scheme("test");
             am.into()
         }
 

--- a/core/src/services/aliyun_drive/backend.rs
+++ b/core/src/services/aliyun_drive/backend.rs
@@ -130,7 +130,6 @@ impl AliyunDriveBuilder {
 }
 
 impl Builder for AliyunDriveBuilder {
-    const SCHEME: Scheme = Scheme::AliyunDrive;
     type Config = AliyunDriveConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -177,7 +176,7 @@ impl Builder for AliyunDriveBuilder {
             core: Arc::new(AliyunDriveCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::AliyunDrive)
+                    am.set_scheme("aliyun_drive")
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/aliyun_drive/backend.rs
+++ b/core/src/services/aliyun_drive/backend.rs
@@ -32,11 +32,10 @@ use super::error::parse_error;
 use super::lister::AliyunDriveLister;
 use super::lister::AliyunDriveParent;
 use super::writer::AliyunDriveWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::AliyunDriveConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "aliyun_drive";
-
 impl Configurator for AliyunDriveConfig {
     type Builder = AliyunDriveBuilder;
 

--- a/core/src/services/aliyun_drive/backend.rs
+++ b/core/src/services/aliyun_drive/backend.rs
@@ -35,6 +35,7 @@ use super::writer::AliyunDriveWriter;
 use crate::raw::*;
 use crate::services::AliyunDriveConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "aliyun_drive";
 
 impl Configurator for AliyunDriveConfig {
     type Builder = AliyunDriveBuilder;
@@ -176,7 +177,7 @@ impl Builder for AliyunDriveBuilder {
             core: Arc::new(AliyunDriveCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("aliyun_drive")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/aliyun_drive/mod.rs
+++ b/core/src/services/aliyun_drive/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for aliyun_drive service.
+#[cfg(feature = "services-aliyun-drive")]
+pub(super) const DEFAULT_SCHEME: &str = "aliyun_drive";
 #[cfg(feature = "services-aliyun-drive")]
 mod core;
 

--- a/core/src/services/alluxio/backend.rs
+++ b/core/src/services/alluxio/backend.rs
@@ -28,11 +28,10 @@ use super::error::parse_error;
 use super::lister::AlluxioLister;
 use super::writer::AlluxioWriter;
 use super::writer::AlluxioWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::AlluxioConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "alluxio";
-
 impl Configurator for AlluxioConfig {
     type Builder = AlluxioBuilder;
 

--- a/core/src/services/alluxio/backend.rs
+++ b/core/src/services/alluxio/backend.rs
@@ -31,6 +31,7 @@ use super::writer::AlluxioWriters;
 use crate::raw::*;
 use crate::services::AlluxioConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "alluxio";
 
 impl Configurator for AlluxioConfig {
     type Builder = AlluxioBuilder;
@@ -125,7 +126,7 @@ impl Builder for AlluxioBuilder {
             core: Arc::new(AlluxioCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("alluxio")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/alluxio/backend.rs
+++ b/core/src/services/alluxio/backend.rs
@@ -104,7 +104,6 @@ impl AlluxioBuilder {
 }
 
 impl Builder for AlluxioBuilder {
-    const SCHEME: Scheme = Scheme::Alluxio;
     type Config = AlluxioConfig;
 
     /// Builds the backend and returns the result of AlluxioBackend.
@@ -126,7 +125,7 @@ impl Builder for AlluxioBuilder {
             core: Arc::new(AlluxioCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Alluxio)
+                    am.set_scheme("alluxio")
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/alluxio/mod.rs
+++ b/core/src/services/alluxio/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for alluxio service.
+#[cfg(feature = "services-alluxio")]
+pub(super) const DEFAULT_SCHEME: &str = "alluxio";
 #[cfg(feature = "services-alluxio")]
 mod core;
 #[cfg(feature = "services-alluxio")]

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -301,7 +301,6 @@ impl AzblobBuilder {
 }
 
 impl Builder for AzblobBuilder {
-    const SCHEME: Scheme = Scheme::Azblob;
     type Config = AzblobConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -385,7 +384,7 @@ impl Builder for AzblobBuilder {
             core: Arc::new(AzblobCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Azblob)
+                    am.set_scheme("azblob")
                         .set_root(&root)
                         .set_name(container)
                         .set_native_capability(Capability {

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -38,11 +38,10 @@ use super::error::parse_error;
 use super::lister::AzblobLister;
 use super::writer::AzblobWriter;
 use super::writer::AzblobWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::AzblobConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "azblob";
-
 const AZBLOB_BATCH_LIMIT: usize = 256;
 
 impl From<AzureStorageConfig> for AzblobConfig {

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -41,6 +41,7 @@ use super::writer::AzblobWriters;
 use crate::raw::*;
 use crate::services::AzblobConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "azblob";
 
 const AZBLOB_BATCH_LIMIT: usize = 256;
 
@@ -384,7 +385,7 @@ impl Builder for AzblobBuilder {
             core: Arc::new(AzblobCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("azblob")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_name(container)
                         .set_native_capability(Capability {

--- a/core/src/services/azblob/mod.rs
+++ b/core/src/services/azblob/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for azblob service.
+#[cfg(feature = "services-azblob")]
+pub(super) const DEFAULT_SCHEME: &str = "azblob";
 #[cfg(feature = "services-azblob")]
 pub(crate) mod core;
 #[cfg(feature = "services-azblob")]

--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -249,7 +249,6 @@ impl AzdlsBuilder {
 }
 
 impl Builder for AzdlsBuilder {
-    const SCHEME: Scheme = Scheme::Azdls;
     type Config = AzdlsConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -296,7 +295,7 @@ impl Builder for AzdlsBuilder {
             core: Arc::new(AzdlsCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Azdls)
+                    am.set_scheme("azdls")
                         .set_root(&root)
                         .set_name(filesystem)
                         .set_native_capability(Capability {

--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -33,11 +33,10 @@ use super::error::parse_error;
 use super::lister::AzdlsLister;
 use super::writer::AzdlsWriter;
 use super::writer::AzdlsWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::AzdlsConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "azdls";
-
 impl From<AzureStorageConfig> for AzdlsConfig {
     fn from(config: AzureStorageConfig) -> Self {
         AzdlsConfig {

--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -36,6 +36,7 @@ use super::writer::AzdlsWriters;
 use crate::raw::*;
 use crate::services::AzdlsConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "azdls";
 
 impl From<AzureStorageConfig> for AzdlsConfig {
     fn from(config: AzureStorageConfig) -> Self {
@@ -295,7 +296,7 @@ impl Builder for AzdlsBuilder {
             core: Arc::new(AzdlsCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("azdls")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_name(filesystem)
                         .set_native_capability(Capability {

--- a/core/src/services/azdls/mod.rs
+++ b/core/src/services/azdls/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for azdls service.
+#[cfg(feature = "services-azdls")]
+pub(super) const DEFAULT_SCHEME: &str = "azdls";
 #[cfg(feature = "services-azdls")]
 mod backend;
 #[cfg(feature = "services-azdls")]

--- a/core/src/services/azfile/backend.rs
+++ b/core/src/services/azfile/backend.rs
@@ -32,11 +32,10 @@ use super::error::parse_error;
 use super::lister::AzfileLister;
 use super::writer::AzfileWriter;
 use super::writer::AzfileWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::AzfileConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "azfile";
-
 impl From<AzureStorageConfig> for AzfileConfig {
     fn from(config: AzureStorageConfig) -> Self {
         AzfileConfig {

--- a/core/src/services/azfile/backend.rs
+++ b/core/src/services/azfile/backend.rs
@@ -181,7 +181,6 @@ impl AzfileBuilder {
 }
 
 impl Builder for AzfileBuilder {
-    const SCHEME: Scheme = Scheme::Azfile;
     type Config = AzfileConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -226,7 +225,7 @@ impl Builder for AzfileBuilder {
             core: Arc::new(AzfileCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Azfile)
+                    am.set_scheme("azfile")
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/azfile/backend.rs
+++ b/core/src/services/azfile/backend.rs
@@ -35,6 +35,7 @@ use super::writer::AzfileWriters;
 use crate::raw::*;
 use crate::services::AzfileConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "azfile";
 
 impl From<AzureStorageConfig> for AzfileConfig {
     fn from(config: AzureStorageConfig) -> Self {
@@ -225,7 +226,7 @@ impl Builder for AzfileBuilder {
             core: Arc::new(AzfileCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("azfile")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/azfile/mod.rs
+++ b/core/src/services/azfile/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for azfile service.
+#[cfg(feature = "services-azfile")]
+pub(super) const DEFAULT_SCHEME: &str = "azfile";
 #[cfg(feature = "services-azfile")]
 mod core;
 #[cfg(feature = "services-azfile")]

--- a/core/src/services/b2/backend.rs
+++ b/core/src/services/b2/backend.rs
@@ -34,11 +34,10 @@ use super::error::parse_error;
 use super::lister::B2Lister;
 use super::writer::B2Writer;
 use super::writer::B2Writers;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::B2Config;
 use crate::*;
-const DEFAULT_SCHEME: &str = "b2";
-
 impl Configurator for B2Config {
     type Builder = B2Builder;
 

--- a/core/src/services/b2/backend.rs
+++ b/core/src/services/b2/backend.rs
@@ -37,6 +37,7 @@ use super::writer::B2Writers;
 use crate::raw::*;
 use crate::services::B2Config;
 use crate::*;
+const DEFAULT_SCHEME: &str = "b2";
 
 impl Configurator for B2Config {
     type Builder = B2Builder;
@@ -191,7 +192,7 @@ impl Builder for B2Builder {
             core: Arc::new(B2Core {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("b2")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/b2/backend.rs
+++ b/core/src/services/b2/backend.rs
@@ -136,7 +136,6 @@ impl B2Builder {
 }
 
 impl Builder for B2Builder {
-    const SCHEME: Scheme = Scheme::B2;
     type Config = B2Config;
 
     /// Builds the backend and returns the result of B2Backend.
@@ -192,7 +191,7 @@ impl Builder for B2Builder {
             core: Arc::new(B2Core {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::B2)
+                    am.set_scheme("b2")
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/b2/mod.rs
+++ b/core/src/services/b2/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for b2 service.
+#[cfg(feature = "services-b2")]
+pub(super) const DEFAULT_SCHEME: &str = "b2";
 #[cfg(feature = "services-b2")]
 mod core;
 #[cfg(feature = "services-b2")]

--- a/core/src/services/cacache/backend.rs
+++ b/core/src/services/cacache/backend.rs
@@ -27,8 +27,7 @@ use crate::*;
 use super::core::CacacheCore;
 use super::delete::CacacheDeleter;
 use super::writer::CacacheWriter;
-const DEFAULT_SCHEME: &str = "cacache";
-
+use super::DEFAULT_SCHEME;
 impl Configurator for CacacheConfig {
     type Builder = CacacheBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/cacache/backend.rs
+++ b/core/src/services/cacache/backend.rs
@@ -27,6 +27,7 @@ use crate::*;
 use super::core::CacacheCore;
 use super::delete::CacacheDeleter;
 use super::writer::CacacheWriter;
+const DEFAULT_SCHEME: &str = "cacache";
 
 impl Configurator for CacacheConfig {
     type Builder = CacacheBuilder;
@@ -64,7 +65,7 @@ impl Builder for CacacheBuilder {
         };
 
         let info = AccessorInfo::default();
-        info.set_scheme("cacache");
+        info.set_scheme(DEFAULT_SCHEME);
         info.set_name(&datadir_path);
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/cacache/backend.rs
+++ b/core/src/services/cacache/backend.rs
@@ -51,7 +51,6 @@ impl CacacheBuilder {
 }
 
 impl Builder for CacacheBuilder {
-    const SCHEME: Scheme = Scheme::Cacache;
     type Config = CacacheConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -65,7 +64,7 @@ impl Builder for CacacheBuilder {
         };
 
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Cacache);
+        info.set_scheme("cacache");
         info.set_name(&datadir_path);
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/cacache/mod.rs
+++ b/core/src/services/cacache/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for cacache service.
+#[cfg(feature = "services-cacache")]
+pub(super) const DEFAULT_SCHEME: &str = "cacache";
 #[cfg(feature = "services-cacache")]
 mod backend;
 #[cfg(feature = "services-cacache")]

--- a/core/src/services/cloudflare_kv/backend.rs
+++ b/core/src/services/cloudflare_kv/backend.rs
@@ -96,7 +96,6 @@ impl CloudflareKvBuilder {
 }
 
 impl Builder for CloudflareKvBuilder {
-    const SCHEME: Scheme = Scheme::CloudflareKv;
     type Config = CloudflareKvConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/compfs/backend.rs
+++ b/core/src/services/compfs/backend.rs
@@ -30,6 +30,7 @@ use crate::raw::oio::OneShotDeleter;
 use crate::raw::*;
 use crate::services::CompfsConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "compfs";
 
 impl Configurator for CompfsConfig {
     type Builder = CompfsBuilder;
@@ -90,7 +91,7 @@ impl Builder for CompfsBuilder {
         let core = CompfsCore {
             info: {
                 let am = AccessorInfo::default();
-                am.set_scheme("compfs")
+                am.set_scheme(DEFAULT_SCHEME)
                     .set_root(&root)
                     .set_native_capability(Capability {
                         stat: true,

--- a/core/src/services/compfs/backend.rs
+++ b/core/src/services/compfs/backend.rs
@@ -58,7 +58,6 @@ impl CompfsBuilder {
 }
 
 impl Builder for CompfsBuilder {
-    const SCHEME: Scheme = Scheme::Compfs;
     type Config = CompfsConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -91,7 +90,7 @@ impl Builder for CompfsBuilder {
         let core = CompfsCore {
             info: {
                 let am = AccessorInfo::default();
-                am.set_scheme(Scheme::Compfs)
+                am.set_scheme("compfs")
                     .set_root(&root)
                     .set_native_capability(Capability {
                         stat: true,

--- a/core/src/services/compfs/backend.rs
+++ b/core/src/services/compfs/backend.rs
@@ -26,12 +26,11 @@ use super::delete::CompfsDeleter;
 use super::lister::CompfsLister;
 use super::reader::CompfsReader;
 use super::writer::CompfsWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::oio::OneShotDeleter;
 use crate::raw::*;
 use crate::services::CompfsConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "compfs";
-
 impl Configurator for CompfsConfig {
     type Builder = CompfsBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/compfs/mod.rs
+++ b/core/src/services/compfs/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for compfs service.
+#[cfg(feature = "services-compfs")]
+pub(super) const DEFAULT_SCHEME: &str = "compfs";
 #[cfg(feature = "services-compfs")]
 mod core;
 #[cfg(feature = "services-compfs")]

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -34,12 +34,11 @@ use super::lister::CosListers;
 use super::lister::CosObjectVersionsLister;
 use super::writer::CosWriter;
 use super::writer::CosWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::oio::PageLister;
 use crate::raw::*;
 use crate::services::CosConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "cos";
-
 impl Configurator for CosConfig {
     type Builder = CosBuilder;
 

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -164,7 +164,6 @@ impl CosBuilder {
 }
 
 impl Builder for CosBuilder {
-    const SCHEME: Scheme = Scheme::Cos;
     type Config = CosConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -222,7 +221,7 @@ impl Builder for CosBuilder {
             core: Arc::new(CosCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Cos)
+                    am.set_scheme("cos")
                         .set_root(&root)
                         .set_name(&bucket)
                         .set_native_capability(Capability {

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -38,6 +38,7 @@ use crate::raw::oio::PageLister;
 use crate::raw::*;
 use crate::services::CosConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "cos";
 
 impl Configurator for CosConfig {
     type Builder = CosBuilder;
@@ -221,7 +222,7 @@ impl Builder for CosBuilder {
             core: Arc::new(CosCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("cos")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_name(&bucket)
                         .set_native_capability(Capability {

--- a/core/src/services/cos/mod.rs
+++ b/core/src/services/cos/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for cos service.
+#[cfg(feature = "services-cos")]
+pub(super) const DEFAULT_SCHEME: &str = "cos";
 #[cfg(feature = "services-cos")]
 mod core;
 #[cfg(feature = "services-cos")]

--- a/core/src/services/d1/backend.rs
+++ b/core/src/services/d1/backend.rs
@@ -135,7 +135,6 @@ impl D1Builder {
 }
 
 impl Builder for D1Builder {
-    const SCHEME: Scheme = Scheme::D1;
     type Config = D1Config;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/dashmap/backend.rs
+++ b/core/src/services/dashmap/backend.rs
@@ -26,12 +26,11 @@ use super::core::DashmapCore;
 use super::delete::DashmapDeleter;
 use super::lister::DashmapLister;
 use super::writer::DashmapWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::oio;
 use crate::raw::*;
 use crate::services::DashmapConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "dashmap";
-
 impl Configurator for DashmapConfig {
     type Builder = DashmapBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/dashmap/backend.rs
+++ b/core/src/services/dashmap/backend.rs
@@ -67,7 +67,6 @@ impl DashmapBuilder {
 }
 
 impl Builder for DashmapBuilder {
-    const SCHEME: Scheme = Scheme::Dashmap;
     type Config = DashmapConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -101,7 +100,7 @@ pub struct DashmapAccessor {
 impl DashmapAccessor {
     fn new(core: DashmapCore, root: String) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Dashmap);
+        info.set_scheme("dashmap");
         info.set_name("dashmap");
         info.set_root(&root);
         info.set_native_capability(Capability {

--- a/core/src/services/dashmap/backend.rs
+++ b/core/src/services/dashmap/backend.rs
@@ -30,6 +30,7 @@ use crate::raw::oio;
 use crate::raw::*;
 use crate::services::DashmapConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "dashmap";
 
 impl Configurator for DashmapConfig {
     type Builder = DashmapBuilder;
@@ -100,7 +101,7 @@ pub struct DashmapAccessor {
 impl DashmapAccessor {
     fn new(core: DashmapCore, root: String) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme("dashmap");
+        info.set_scheme(DEFAULT_SCHEME);
         info.set_name("dashmap");
         info.set_root(&root);
         info.set_native_capability(Capability {

--- a/core/src/services/dashmap/mod.rs
+++ b/core/src/services/dashmap/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for dashmap service.
+#[cfg(feature = "services-dashmap")]
+pub(super) const DEFAULT_SCHEME: &str = "dashmap";
 #[cfg(feature = "services-dashmap")]
 mod backend;
 #[cfg(feature = "services-dashmap")]

--- a/core/src/services/dbfs/backend.rs
+++ b/core/src/services/dbfs/backend.rs
@@ -29,11 +29,10 @@ use super::delete::DbfsDeleter;
 use super::error::parse_error;
 use super::lister::DbfsLister;
 use super::writer::DbfsWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::DbfsConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "dbfs";
-
 impl Configurator for DbfsConfig {
     type Builder = DbfsBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/dbfs/backend.rs
+++ b/core/src/services/dbfs/backend.rs
@@ -32,6 +32,7 @@ use super::writer::DbfsWriter;
 use crate::raw::*;
 use crate::services::DbfsConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "dbfs";
 
 impl Configurator for DbfsConfig {
     type Builder = DbfsBuilder;
@@ -149,7 +150,7 @@ impl Access for DbfsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         let am = AccessorInfo::default();
-        am.set_scheme("dbfs")
+        am.set_scheme(DEFAULT_SCHEME)
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/dbfs/backend.rs
+++ b/core/src/services/dbfs/backend.rs
@@ -96,7 +96,6 @@ impl DbfsBuilder {
 }
 
 impl Builder for DbfsBuilder {
-    const SCHEME: Scheme = Scheme::Dbfs;
     type Config = DbfsConfig;
 
     /// Build a DbfsBackend.
@@ -150,7 +149,7 @@ impl Access for DbfsBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         let am = AccessorInfo::default();
-        am.set_scheme(Scheme::Dbfs)
+        am.set_scheme("dbfs")
             .set_root(&self.core.root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/dbfs/mod.rs
+++ b/core/src/services/dbfs/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for dbfs service.
+#[cfg(feature = "services-dbfs")]
+pub(super) const DEFAULT_SCHEME: &str = "dbfs";
 #[cfg(feature = "services-dbfs")]
 mod core;
 #[cfg(feature = "services-dbfs")]

--- a/core/src/services/dropbox/builder.rs
+++ b/core/src/services/dropbox/builder.rs
@@ -126,7 +126,6 @@ impl DropboxBuilder {
 }
 
 impl Builder for DropboxBuilder {
-    const SCHEME: Scheme = Scheme::Dropbox;
     type Config = DropboxConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -182,7 +181,7 @@ impl Builder for DropboxBuilder {
             core: Arc::new(DropboxCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Dropbox)
+                    am.set_scheme("dropbox")
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/dropbox/builder.rs
+++ b/core/src/services/dropbox/builder.rs
@@ -26,11 +26,10 @@ use tokio::sync::Mutex;
 use super::backend::DropboxBackend;
 use super::core::DropboxCore;
 use super::core::DropboxSigner;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::DropboxConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "dropbox";
-
 impl Configurator for DropboxConfig {
     type Builder = DropboxBuilder;
 

--- a/core/src/services/dropbox/builder.rs
+++ b/core/src/services/dropbox/builder.rs
@@ -29,6 +29,7 @@ use super::core::DropboxSigner;
 use crate::raw::*;
 use crate::services::DropboxConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "dropbox";
 
 impl Configurator for DropboxConfig {
     type Builder = DropboxBuilder;
@@ -181,7 +182,7 @@ impl Builder for DropboxBuilder {
             core: Arc::new(DropboxCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("dropbox")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/dropbox/mod.rs
+++ b/core/src/services/dropbox/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for dropbox service.
+#[cfg(feature = "services-dropbox")]
+pub(super) const DEFAULT_SCHEME: &str = "dropbox";
 #[cfg(feature = "services-dropbox")]
 mod backend;
 #[cfg(feature = "services-dropbox")]

--- a/core/src/services/etcd/backend.rs
+++ b/core/src/services/etcd/backend.rs
@@ -136,7 +136,6 @@ impl EtcdBuilder {
 }
 
 impl Builder for EtcdBuilder {
-    const SCHEME: Scheme = Scheme::Etcd;
     type Config = EtcdConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/foundationdb/backend.rs
+++ b/core/src/services/foundationdb/backend.rs
@@ -59,7 +59,6 @@ impl FoundationdbBuilder {
 }
 
 impl Builder for FoundationdbBuilder {
-    const SCHEME: Scheme = Scheme::Foundationdb;
     type Config = FoundationdbConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -26,11 +26,10 @@ use super::lister::FsLister;
 use super::reader::FsReader;
 use super::writer::FsWriter;
 use super::writer::FsWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::FsConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "fs";
-
 impl Configurator for FsConfig {
     type Builder = FsBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -29,6 +29,7 @@ use super::writer::FsWriters;
 use crate::raw::*;
 use crate::services::FsConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "fs";
 
 impl Configurator for FsConfig {
     type Builder = FsBuilder;
@@ -144,7 +145,7 @@ impl Builder for FsBuilder {
             core: Arc::new(FsCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("fs")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root.to_string_lossy())
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -72,7 +72,6 @@ impl FsBuilder {
 }
 
 impl Builder for FsBuilder {
-    const SCHEME: Scheme = Scheme::Fs;
     type Config = FsConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -145,7 +144,7 @@ impl Builder for FsBuilder {
             core: Arc::new(FsCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Fs)
+                    am.set_scheme("fs")
                         .set_root(&root.to_string_lossy())
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/fs/mod.rs
+++ b/core/src/services/fs/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for fs service.
+#[cfg(feature = "services-fs")]
+pub(super) const DEFAULT_SCHEME: &str = "fs";
 #[cfg(feature = "services-fs")]
 mod core;
 #[cfg(feature = "services-fs")]

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -109,7 +109,6 @@ impl FtpBuilder {
 }
 
 impl Builder for FtpBuilder {
-    const SCHEME: Scheme = Scheme::Ftp;
     type Config = FtpConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -162,7 +161,7 @@ impl Builder for FtpBuilder {
 
         let accessor_info = AccessorInfo::default();
         accessor_info
-            .set_scheme(Scheme::Ftp)
+            .set_scheme("ftp")
             .set_root(&root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -39,6 +39,7 @@ use super::writer::FtpWriter;
 use crate::raw::*;
 use crate::services::FtpConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "ftp";
 
 impl Configurator for FtpConfig {
     type Builder = FtpBuilder;
@@ -161,7 +162,7 @@ impl Builder for FtpBuilder {
 
         let accessor_info = AccessorInfo::default();
         accessor_info
-            .set_scheme("ftp")
+            .set_scheme(DEFAULT_SCHEME)
             .set_root(&root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -36,11 +36,10 @@ use super::err::parse_error;
 use super::lister::FtpLister;
 use super::reader::FtpReader;
 use super::writer::FtpWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::FtpConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "ftp";
-
 impl Configurator for FtpConfig {
     type Builder = FtpBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/ftp/mod.rs
+++ b/core/src/services/ftp/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for ftp service.
+#[cfg(feature = "services-ftp")]
+pub(super) const DEFAULT_SCHEME: &str = "ftp";
 #[cfg(feature = "services-ftp")]
 mod delete;
 #[cfg(feature = "services-ftp")]

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -37,6 +37,7 @@ use crate::raw::oio::BatchDeleter;
 use crate::raw::*;
 use crate::services::GcsConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "gcs";
 
 const DEFAULT_GCS_ENDPOINT: &str = "https://storage.googleapis.com";
 const DEFAULT_GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.read_write";
@@ -307,7 +308,7 @@ impl Builder for GcsBuilder {
             core: Arc::new(GcsCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("gcs")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_name(bucket)
                         .set_native_capability(Capability {

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -234,7 +234,6 @@ impl GcsBuilder {
 }
 
 impl Builder for GcsBuilder {
-    const SCHEME: Scheme = Scheme::Gcs;
     type Config = GcsConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -308,7 +307,7 @@ impl Builder for GcsBuilder {
             core: Arc::new(GcsCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Gcs)
+                    am.set_scheme("gcs")
                         .set_root(&root)
                         .set_name(bucket)
                         .set_native_capability(Capability {

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -33,12 +33,11 @@ use super::error::parse_error;
 use super::lister::GcsLister;
 use super::writer::GcsWriter;
 use super::writer::GcsWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::oio::BatchDeleter;
 use crate::raw::*;
 use crate::services::GcsConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "gcs";
-
 const DEFAULT_GCS_ENDPOINT: &str = "https://storage.googleapis.com";
 const DEFAULT_GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.read_write";
 

--- a/core/src/services/gcs/mod.rs
+++ b/core/src/services/gcs/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for gcs service.
+#[cfg(feature = "services-gcs")]
+pub(super) const DEFAULT_SCHEME: &str = "gcs";
 #[cfg(feature = "services-gcs")]
 mod core;
 #[cfg(feature = "services-gcs")]

--- a/core/src/services/gdrive/builder.rs
+++ b/core/src/services/gdrive/builder.rs
@@ -36,6 +36,7 @@ use crate::raw::PathCacher;
 use crate::services::GdriveConfig;
 use crate::Scheme;
 use crate::*;
+const DEFAULT_SCHEME: &str = "gdrive";
 
 impl Configurator for GdriveConfig {
     type Builder = GdriveBuilder;
@@ -142,7 +143,7 @@ impl Builder for GdriveBuilder {
         debug!("backend use root {root}");
 
         let info = AccessorInfo::default();
-        info.set_scheme("gdrive")
+        info.set_scheme(DEFAULT_SCHEME)
             .set_root(&root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/gdrive/builder.rs
+++ b/core/src/services/gdrive/builder.rs
@@ -135,7 +135,6 @@ impl GdriveBuilder {
 }
 
 impl Builder for GdriveBuilder {
-    const SCHEME: Scheme = Scheme::Gdrive;
     type Config = GdriveConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -143,7 +142,7 @@ impl Builder for GdriveBuilder {
         debug!("backend use root {root}");
 
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Gdrive)
+        info.set_scheme("gdrive")
             .set_root(&root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/gdrive/builder.rs
+++ b/core/src/services/gdrive/builder.rs
@@ -28,6 +28,7 @@ use super::backend::GdriveBackend;
 use super::core::GdriveCore;
 use super::core::GdrivePathQuery;
 use super::core::GdriveSigner;
+use super::DEFAULT_SCHEME;
 use crate::raw::normalize_root;
 use crate::raw::Access;
 use crate::raw::AccessorInfo;
@@ -36,8 +37,6 @@ use crate::raw::PathCacher;
 use crate::services::GdriveConfig;
 use crate::Scheme;
 use crate::*;
-const DEFAULT_SCHEME: &str = "gdrive";
-
 impl Configurator for GdriveConfig {
     type Builder = GdriveBuilder;
 

--- a/core/src/services/gdrive/mod.rs
+++ b/core/src/services/gdrive/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for gdrive service.
+#[cfg(feature = "services-gdrive")]
+pub(super) const DEFAULT_SCHEME: &str = "gdrive";
 #[cfg(feature = "services-gdrive")]
 mod backend;
 #[cfg(feature = "services-gdrive")]

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -26,12 +26,11 @@ use sha2::Digest;
 use super::core::*;
 use super::error::parse_error;
 use super::writer::GhacWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::ghac::core::GhacCore;
 use crate::services::GhacConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "ghac";
-
 fn value_or_env(
     explicit_value: Option<String>,
     env_var_name: &str,

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -136,7 +136,6 @@ impl GhacBuilder {
 }
 
 impl Builder for GhacBuilder {
-    const SCHEME: Scheme = Scheme::Ghac;
     type Config = GhacConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -174,7 +173,7 @@ impl Builder for GhacBuilder {
         let core = GhacCore {
             info: {
                 let am = AccessorInfo::default();
-                am.set_scheme(Scheme::Ghac)
+                am.set_scheme("ghac")
                     .set_root(&root)
                     .set_name(&version)
                     .set_native_capability(Capability {

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -30,6 +30,7 @@ use crate::raw::*;
 use crate::services::ghac::core::GhacCore;
 use crate::services::GhacConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "ghac";
 
 fn value_or_env(
     explicit_value: Option<String>,
@@ -173,7 +174,7 @@ impl Builder for GhacBuilder {
         let core = GhacCore {
             info: {
                 let am = AccessorInfo::default();
-                am.set_scheme("ghac")
+                am.set_scheme(DEFAULT_SCHEME)
                     .set_root(&root)
                     .set_name(&version)
                     .set_native_capability(Capability {

--- a/core/src/services/ghac/mod.rs
+++ b/core/src/services/ghac/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for ghac service.
+#[cfg(feature = "services-ghac")]
+pub(super) const DEFAULT_SCHEME: &str = "ghac";
 #[cfg(feature = "services-ghac")]
 mod error;
 #[cfg(feature = "services-ghac")]

--- a/core/src/services/ghac/writer.rs
+++ b/core/src/services/ghac/writer.rs
@@ -68,7 +68,7 @@ impl GhacWriter {
                 let azure_core = Arc::new(AzblobCore {
                     info: {
                         let am = AccessorInfo::default();
-                        am.set_scheme(Scheme::Azblob)
+                        am.set_scheme("azblob")
                             .set_root("/")
                             .set_name(container)
                             .set_native_capability(Capability {

--- a/core/src/services/github/backend.rs
+++ b/core/src/services/github/backend.rs
@@ -34,6 +34,7 @@ use super::writer::GithubWriters;
 use crate::raw::*;
 use crate::services::GithubConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "github";
 
 impl Configurator for GithubConfig {
     type Builder = GithubBuilder;
@@ -150,7 +151,7 @@ impl Builder for GithubBuilder {
             core: Arc::new(GithubCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("github")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/github/backend.rs
+++ b/core/src/services/github/backend.rs
@@ -119,7 +119,6 @@ impl GithubBuilder {
 }
 
 impl Builder for GithubBuilder {
-    const SCHEME: Scheme = Scheme::Github;
     type Config = GithubConfig;
 
     /// Builds the backend and returns the result of GithubBackend.
@@ -151,7 +150,7 @@ impl Builder for GithubBuilder {
             core: Arc::new(GithubCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Github)
+                    am.set_scheme("github")
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/github/backend.rs
+++ b/core/src/services/github/backend.rs
@@ -31,11 +31,10 @@ use super::error::parse_error;
 use super::lister::GithubLister;
 use super::writer::GithubWriter;
 use super::writer::GithubWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::GithubConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "github";
-
 impl Configurator for GithubConfig {
     type Builder = GithubBuilder;
 

--- a/core/src/services/github/mod.rs
+++ b/core/src/services/github/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for github service.
+#[cfg(feature = "services-github")]
+pub(super) const DEFAULT_SCHEME: &str = "github";
 #[cfg(feature = "services-github")]
 mod core;
 #[cfg(feature = "services-github")]

--- a/core/src/services/gridfs/backend.rs
+++ b/core/src/services/gridfs/backend.rs
@@ -119,7 +119,6 @@ impl GridfsBuilder {
 }
 
 impl Builder for GridfsBuilder {
-    const SCHEME: Scheme = Scheme::Gridfs;
     type Config = GridfsConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -125,7 +125,6 @@ impl HdfsBuilder {
 }
 
 impl Builder for HdfsBuilder {
-    const SCHEME: Scheme = Scheme::Hdfs;
     type Config = HdfsConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -175,7 +174,7 @@ impl Builder for HdfsBuilder {
         Ok(HdfsBackend {
             info: {
                 let am = AccessorInfo::default();
-                am.set_scheme(Scheme::Hdfs)
+                am.set_scheme("hdfs")
                     .set_root(&root)
                     .set_native_capability(Capability {
                         stat: true,

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -28,11 +28,10 @@ use super::delete::HdfsDeleter;
 use super::lister::HdfsLister;
 use super::reader::HdfsReader;
 use super::writer::HdfsWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::HdfsConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "hdfs";
-
 impl Configurator for HdfsConfig {
     type Builder = HdfsBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -31,6 +31,7 @@ use super::writer::HdfsWriter;
 use crate::raw::*;
 use crate::services::HdfsConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "hdfs";
 
 impl Configurator for HdfsConfig {
     type Builder = HdfsBuilder;
@@ -174,7 +175,7 @@ impl Builder for HdfsBuilder {
         Ok(HdfsBackend {
             info: {
                 let am = AccessorInfo::default();
-                am.set_scheme("hdfs")
+                am.set_scheme(DEFAULT_SCHEME)
                     .set_root(&root)
                     .set_native_capability(Capability {
                         stat: true,

--- a/core/src/services/hdfs/mod.rs
+++ b/core/src/services/hdfs/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for hdfs service.
+#[cfg(feature = "services-hdfs")]
+pub(super) const DEFAULT_SCHEME: &str = "hdfs";
 #[cfg(feature = "services-hdfs")]
 mod delete;
 #[cfg(feature = "services-hdfs")]

--- a/core/src/services/hdfs_native/backend.rs
+++ b/core/src/services/hdfs_native/backend.rs
@@ -28,11 +28,10 @@ use super::error::parse_hdfs_error;
 use super::lister::HdfsNativeLister;
 use super::reader::HdfsNativeReader;
 use super::writer::HdfsNativeWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::HdfsNativeConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "hdfs_native";
-
 /// [Hadoop Distributed File System (HDFS™)](https://hadoop.apache.org/) support.
 /// Using [Native Rust HDFS client](https://github.com/Kimahriman/hdfs-native).
 impl Configurator for HdfsNativeConfig {

--- a/core/src/services/hdfs_native/backend.rs
+++ b/core/src/services/hdfs_native/backend.rs
@@ -31,6 +31,7 @@ use super::writer::HdfsNativeWriter;
 use crate::raw::*;
 use crate::services::HdfsNativeConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "hdfs_native";
 
 /// [Hadoop Distributed File System (HDFS™)](https://hadoop.apache.org/) support.
 /// Using [Native Rust HDFS client](https://github.com/Kimahriman/hdfs-native).
@@ -149,7 +150,7 @@ impl Access for HdfsNativeBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         let am = AccessorInfo::default();
-        am.set_scheme("hdfs_native")
+        am.set_scheme(DEFAULT_SCHEME)
             .set_root(&self.root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/hdfs_native/backend.rs
+++ b/core/src/services/hdfs_native/backend.rs
@@ -94,7 +94,6 @@ impl HdfsNativeBuilder {
 }
 
 impl Builder for HdfsNativeBuilder {
-    const SCHEME: Scheme = Scheme::HdfsNative;
     type Config = HdfsNativeConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -150,7 +149,7 @@ impl Access for HdfsNativeBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         let am = AccessorInfo::default();
-        am.set_scheme(Scheme::HdfsNative)
+        am.set_scheme("hdfs_native")
             .set_root(&self.root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/hdfs_native/mod.rs
+++ b/core/src/services/hdfs_native/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for hdfs_native service.
+#[cfg(feature = "services-hdfs-native")]
+pub(super) const DEFAULT_SCHEME: &str = "hdfs_native";
 #[cfg(feature = "services-hdfs-native")]
 mod delete;
 #[cfg(feature = "services-hdfs-native")]

--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -28,6 +28,7 @@ use super::error::parse_error;
 use crate::raw::*;
 use crate::services::HttpConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "http";
 
 impl Configurator for HttpConfig {
     type Builder = HttpBuilder;
@@ -157,7 +158,7 @@ impl Builder for HttpBuilder {
         }
 
         let info = AccessorInfo::default();
-        info.set_scheme("http")
+        info.set_scheme(DEFAULT_SCHEME)
             .set_root(&root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -129,7 +129,6 @@ impl HttpBuilder {
 }
 
 impl Builder for HttpBuilder {
-    const SCHEME: Scheme = Scheme::Http;
     type Config = HttpConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -158,7 +157,7 @@ impl Builder for HttpBuilder {
         }
 
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Http)
+        info.set_scheme("http")
             .set_root(&root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -25,11 +25,10 @@ use log::debug;
 
 use super::core::HttpCore;
 use super::error::parse_error;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::HttpConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "http";
-
 impl Configurator for HttpConfig {
     type Builder = HttpBuilder;
 

--- a/core/src/services/http/mod.rs
+++ b/core/src/services/http/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for http service.
+#[cfg(feature = "services-http")]
+pub(super) const DEFAULT_SCHEME: &str = "http";
 #[cfg(feature = "services-http")]
 mod error;
 

--- a/core/src/services/huggingface/backend.rs
+++ b/core/src/services/huggingface/backend.rs
@@ -28,11 +28,10 @@ use super::core::HuggingfaceCore;
 use super::core::HuggingfaceStatus;
 use super::error::parse_error;
 use super::lister::HuggingfaceLister;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::HuggingfaceConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "huggingface";
-
 impl Configurator for HuggingfaceConfig {
     type Builder = HuggingfaceBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/huggingface/backend.rs
+++ b/core/src/services/huggingface/backend.rs
@@ -126,7 +126,6 @@ impl HuggingfaceBuilder {
 }
 
 impl Builder for HuggingfaceBuilder {
-    const SCHEME: Scheme = Scheme::Huggingface;
     type Config = HuggingfaceConfig;
 
     /// Build a HuggingfaceBackend.
@@ -173,7 +172,7 @@ impl Builder for HuggingfaceBuilder {
             core: Arc::new(HuggingfaceCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Huggingface)
+                    am.set_scheme("huggingface")
                         .set_native_capability(Capability {
                             stat: true,
 

--- a/core/src/services/huggingface/backend.rs
+++ b/core/src/services/huggingface/backend.rs
@@ -31,6 +31,7 @@ use super::lister::HuggingfaceLister;
 use crate::raw::*;
 use crate::services::HuggingfaceConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "huggingface";
 
 impl Configurator for HuggingfaceConfig {
     type Builder = HuggingfaceBuilder;
@@ -172,7 +173,7 @@ impl Builder for HuggingfaceBuilder {
             core: Arc::new(HuggingfaceCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("huggingface")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_native_capability(Capability {
                             stat: true,
 

--- a/core/src/services/huggingface/mod.rs
+++ b/core/src/services/huggingface/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for huggingface service.
+#[cfg(feature = "services-huggingface")]
+pub(super) const DEFAULT_SCHEME: &str = "huggingface";
 #[cfg(feature = "services-huggingface")]
 mod core;
 #[cfg(feature = "services-huggingface")]

--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -106,7 +106,6 @@ impl IpfsBuilder {
 }
 
 impl Builder for IpfsBuilder {
-    const SCHEME: Scheme = Scheme::Ipfs;
     type Config = IpfsConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -132,7 +131,7 @@ impl Builder for IpfsBuilder {
         debug!("backend use endpoint {}", &endpoint);
 
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Ipfs)
+        info.set_scheme("ipfs")
             .set_root(&root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -30,6 +30,7 @@ use super::ipld::PBNode;
 use crate::raw::*;
 use crate::services::IpfsConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "ipfs";
 
 impl Configurator for IpfsConfig {
     type Builder = IpfsBuilder;
@@ -131,7 +132,7 @@ impl Builder for IpfsBuilder {
         debug!("backend use endpoint {}", &endpoint);
 
         let info = AccessorInfo::default();
-        info.set_scheme("ipfs")
+        info.set_scheme(DEFAULT_SCHEME)
             .set_root(&root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -27,11 +27,10 @@ use prost::Message;
 use super::core::IpfsCore;
 use super::error::parse_error;
 use super::ipld::PBNode;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::IpfsConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "ipfs";
-
 impl Configurator for IpfsConfig {
     type Builder = IpfsBuilder;
 

--- a/core/src/services/ipfs/mod.rs
+++ b/core/src/services/ipfs/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for ipfs service.
+#[cfg(feature = "services-ipfs")]
+pub(super) const DEFAULT_SCHEME: &str = "ipfs";
 #[cfg(feature = "services-ipfs")]
 mod error;
 #[cfg(feature = "services-ipfs")]

--- a/core/src/services/ipmfs/builder.rs
+++ b/core/src/services/ipmfs/builder.rs
@@ -124,7 +124,6 @@ impl IpmfsBuilder {
 }
 
 impl Builder for IpmfsBuilder {
-    const SCHEME: Scheme = Scheme::Ipmfs;
     type Config = IpmfsConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -138,7 +137,7 @@ impl Builder for IpmfsBuilder {
             .unwrap_or_else(|| "http://localhost:5001".to_string());
 
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Ipmfs)
+        info.set_scheme("ipmfs")
             .set_root(&root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/ipmfs/builder.rs
+++ b/core/src/services/ipmfs/builder.rs
@@ -24,6 +24,7 @@ use super::core::IpmfsCore;
 use crate::raw::*;
 use crate::services::IpmfsConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "ipmfs";
 
 impl Configurator for IpmfsConfig {
     type Builder = IpmfsBuilder;
@@ -137,7 +138,7 @@ impl Builder for IpmfsBuilder {
             .unwrap_or_else(|| "http://localhost:5001".to_string());
 
         let info = AccessorInfo::default();
-        info.set_scheme("ipmfs")
+        info.set_scheme(DEFAULT_SCHEME)
             .set_root(&root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/ipmfs/builder.rs
+++ b/core/src/services/ipmfs/builder.rs
@@ -21,11 +21,10 @@ use log::debug;
 
 use super::backend::IpmfsBackend;
 use super::core::IpmfsCore;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::IpmfsConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "ipmfs";
-
 impl Configurator for IpmfsConfig {
     type Builder = IpmfsBuilder;
 

--- a/core/src/services/ipmfs/mod.rs
+++ b/core/src/services/ipmfs/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for ipmfs service.
+#[cfg(feature = "services-ipmfs")]
+pub(super) const DEFAULT_SCHEME: &str = "ipmfs";
 #[cfg(feature = "services-ipmfs")]
 mod backend;
 #[cfg(feature = "services-ipmfs")]

--- a/core/src/services/koofr/backend.rs
+++ b/core/src/services/koofr/backend.rs
@@ -37,6 +37,7 @@ use super::writer::KoofrWriters;
 use crate::raw::*;
 use crate::services::KoofrConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "koofr";
 
 impl Configurator for KoofrConfig {
     type Builder = KoofrBuilder;
@@ -174,7 +175,7 @@ impl Builder for KoofrBuilder {
             core: Arc::new(KoofrCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("koofr")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/koofr/backend.rs
+++ b/core/src/services/koofr/backend.rs
@@ -34,11 +34,10 @@ use super::error::parse_error;
 use super::lister::KoofrLister;
 use super::writer::KoofrWriter;
 use super::writer::KoofrWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::KoofrConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "koofr";
-
 impl Configurator for KoofrConfig {
     type Builder = KoofrBuilder;
 

--- a/core/src/services/koofr/backend.rs
+++ b/core/src/services/koofr/backend.rs
@@ -136,7 +136,6 @@ impl KoofrBuilder {
 }
 
 impl Builder for KoofrBuilder {
-    const SCHEME: Scheme = Scheme::Koofr;
     type Config = KoofrConfig;
 
     /// Builds the backend and returns the result of KoofrBackend.
@@ -175,7 +174,7 @@ impl Builder for KoofrBuilder {
             core: Arc::new(KoofrCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Koofr)
+                    am.set_scheme("koofr")
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/koofr/mod.rs
+++ b/core/src/services/koofr/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for koofr service.
+#[cfg(feature = "services-koofr")]
+pub(super) const DEFAULT_SCHEME: &str = "koofr";
 #[cfg(feature = "services-koofr")]
 mod core;
 #[cfg(feature = "services-koofr")]

--- a/core/src/services/lakefs/backend.rs
+++ b/core/src/services/lakefs/backend.rs
@@ -32,11 +32,10 @@ use super::delete::LakefsDeleter;
 use super::error::parse_error;
 use super::lister::LakefsLister;
 use super::writer::LakefsWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::LakefsConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "lakefs";
-
 impl Configurator for LakefsConfig {
     type Builder = LakefsBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/lakefs/backend.rs
+++ b/core/src/services/lakefs/backend.rs
@@ -126,7 +126,6 @@ impl LakefsBuilder {
 }
 
 impl Builder for LakefsBuilder {
-    const SCHEME: Scheme = Scheme::Lakefs;
     type Config = LakefsConfig;
 
     /// Build a LakefsBackend.
@@ -176,19 +175,18 @@ impl Builder for LakefsBuilder {
             core: Arc::new(LakefsCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Lakefs)
-                        .set_native_capability(Capability {
-                            stat: true,
+                    am.set_scheme("lakefs").set_native_capability(Capability {
+                        stat: true,
 
-                            list: true,
+                        list: true,
 
-                            read: true,
-                            write: true,
-                            delete: true,
-                            copy: true,
-                            shared: true,
-                            ..Default::default()
-                        });
+                        read: true,
+                        write: true,
+                        delete: true,
+                        copy: true,
+                        shared: true,
+                        ..Default::default()
+                    });
                     am.into()
                 },
                 endpoint,

--- a/core/src/services/lakefs/backend.rs
+++ b/core/src/services/lakefs/backend.rs
@@ -35,6 +35,7 @@ use super::writer::LakefsWriter;
 use crate::raw::*;
 use crate::services::LakefsConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "lakefs";
 
 impl Configurator for LakefsConfig {
     type Builder = LakefsBuilder;
@@ -175,18 +176,19 @@ impl Builder for LakefsBuilder {
             core: Arc::new(LakefsCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("lakefs").set_native_capability(Capability {
-                        stat: true,
+                    am.set_scheme(DEFAULT_SCHEME)
+                        .set_native_capability(Capability {
+                            stat: true,
 
-                        list: true,
+                            list: true,
 
-                        read: true,
-                        write: true,
-                        delete: true,
-                        copy: true,
-                        shared: true,
-                        ..Default::default()
-                    });
+                            read: true,
+                            write: true,
+                            delete: true,
+                            copy: true,
+                            shared: true,
+                            ..Default::default()
+                        });
                     am.into()
                 },
                 endpoint,

--- a/core/src/services/lakefs/mod.rs
+++ b/core/src/services/lakefs/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for lakefs service.
+#[cfg(feature = "services-lakefs")]
+pub(super) const DEFAULT_SCHEME: &str = "lakefs";
 #[cfg(feature = "services-lakefs")]
 mod core;
 #[cfg(feature = "services-lakefs")]

--- a/core/src/services/memcached/backend.rs
+++ b/core/src/services/memcached/backend.rs
@@ -85,7 +85,6 @@ impl MemcachedBuilder {
 }
 
 impl Builder for MemcachedBuilder {
-    const SCHEME: Scheme = Scheme::Memcached;
     type Config = MemcachedConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/memory/backend.rs
+++ b/core/src/services/memory/backend.rs
@@ -50,7 +50,6 @@ impl MemoryBuilder {
 }
 
 impl Builder for MemoryBuilder {
-    const SCHEME: Scheme = Scheme::Memory;
     type Config = MemoryConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -72,7 +71,7 @@ pub struct MemoryAccessor {
 impl MemoryAccessor {
     fn new(core: MemoryCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Memory);
+        info.set_scheme("memory");
         info.set_name(&format!("{:p}", Arc::as_ptr(&core.data)));
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/memory/backend.rs
+++ b/core/src/services/memory/backend.rs
@@ -22,12 +22,11 @@ use super::core::*;
 use super::delete::MemoryDeleter;
 use super::lister::MemoryLister;
 use super::writer::MemoryWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::oio;
 use crate::raw::*;
 use crate::services::MemoryConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "memory";
-
 impl Configurator for MemoryConfig {
     type Builder = MemoryBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/memory/backend.rs
+++ b/core/src/services/memory/backend.rs
@@ -26,6 +26,7 @@ use crate::raw::oio;
 use crate::raw::*;
 use crate::services::MemoryConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "memory";
 
 impl Configurator for MemoryConfig {
     type Builder = MemoryBuilder;
@@ -71,7 +72,7 @@ pub struct MemoryAccessor {
 impl MemoryAccessor {
     fn new(core: MemoryCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme("memory");
+        info.set_scheme(DEFAULT_SCHEME);
         info.set_name(&format!("{:p}", Arc::as_ptr(&core.data)));
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/memory/mod.rs
+++ b/core/src/services/memory/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for memory service.
+#[cfg(feature = "services-memory")]
+pub(super) const DEFAULT_SCHEME: &str = "memory";
 #[cfg(feature = "services-memory")]
 mod backend;
 #[cfg(feature = "services-memory")]

--- a/core/src/services/mini_moka/backend.rs
+++ b/core/src/services/mini_moka/backend.rs
@@ -26,13 +26,12 @@ use super::core::*;
 use super::delete::MiniMokaDeleter;
 use super::lister::MiniMokaLister;
 use super::writer::MiniMokaWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::oio;
 use crate::raw::oio::HierarchyLister;
 use crate::raw::*;
 use crate::services::MiniMokaConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "mini_moka";
-
 impl Configurator for MiniMokaConfig {
     type Builder = MiniMokaBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/mini_moka/backend.rs
+++ b/core/src/services/mini_moka/backend.rs
@@ -103,7 +103,6 @@ impl MiniMokaBuilder {
 }
 
 impl Builder for MiniMokaBuilder {
-    const SCHEME: Scheme = Scheme::MiniMoka;
     type Config = MiniMokaConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -156,7 +155,7 @@ impl Access for MiniMokaBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::MiniMoka)
+        info.set_scheme("mini_moka")
             .set_root(&self.root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/mini_moka/backend.rs
+++ b/core/src/services/mini_moka/backend.rs
@@ -31,6 +31,7 @@ use crate::raw::oio::HierarchyLister;
 use crate::raw::*;
 use crate::services::MiniMokaConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "mini_moka";
 
 impl Configurator for MiniMokaConfig {
     type Builder = MiniMokaBuilder;
@@ -155,7 +156,7 @@ impl Access for MiniMokaBackend {
 
     fn info(&self) -> Arc<AccessorInfo> {
         let info = AccessorInfo::default();
-        info.set_scheme("mini_moka")
+        info.set_scheme(DEFAULT_SCHEME)
             .set_root(&self.root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/mini_moka/mod.rs
+++ b/core/src/services/mini_moka/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for mini_moka service.
+#[cfg(feature = "services-mini-moka")]
+pub(super) const DEFAULT_SCHEME: &str = "mini_moka";
 #[cfg(feature = "services-mini-moka")]
 mod backend;
 #[cfg(feature = "services-mini-moka")]

--- a/core/src/services/moka/backend.rs
+++ b/core/src/services/moka/backend.rs
@@ -30,6 +30,7 @@ use crate::raw::oio;
 use crate::raw::*;
 use crate::services::MokaConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "moka";
 
 impl Configurator for MokaConfig {
     type Builder = MokaBuilder;
@@ -202,7 +203,7 @@ pub struct MokaAccessor {
 impl MokaAccessor {
     fn new(core: MokaCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme("moka");
+        info.set_scheme(DEFAULT_SCHEME);
         info.set_name(core.cache.name().unwrap_or("moka"));
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/moka/backend.rs
+++ b/core/src/services/moka/backend.rs
@@ -151,7 +151,6 @@ impl MokaBuilder {
 }
 
 impl Builder for MokaBuilder {
-    const SCHEME: Scheme = Scheme::Moka;
     type Config = MokaConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -203,7 +202,7 @@ pub struct MokaAccessor {
 impl MokaAccessor {
     fn new(core: MokaCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Moka);
+        info.set_scheme("moka");
         info.set_name(core.cache.name().unwrap_or("moka"));
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/moka/backend.rs
+++ b/core/src/services/moka/backend.rs
@@ -26,12 +26,11 @@ use super::core::*;
 use super::delete::MokaDeleter;
 use super::lister::MokaLister;
 use super::writer::MokaWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::oio;
 use crate::raw::*;
 use crate::services::MokaConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "moka";
-
 impl Configurator for MokaConfig {
     type Builder = MokaBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/moka/mod.rs
+++ b/core/src/services/moka/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for moka service.
+#[cfg(feature = "services-moka")]
+pub(super) const DEFAULT_SCHEME: &str = "moka";
 #[cfg(feature = "services-moka")]
 mod backend;
 #[cfg(feature = "services-moka")]

--- a/core/src/services/mongodb/backend.rs
+++ b/core/src/services/mongodb/backend.rs
@@ -128,7 +128,6 @@ impl MongodbBuilder {
 }
 
 impl Builder for MongodbBuilder {
-    const SCHEME: Scheme = Scheme::Mongodb;
     type Config = MongodbConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/monoiofs/backend.rs
+++ b/core/src/services/monoiofs/backend.rs
@@ -61,7 +61,6 @@ impl MonoiofsBuilder {
 }
 
 impl Builder for MonoiofsBuilder {
-    const SCHEME: Scheme = Scheme::Monoiofs;
     type Config = MonoiofsConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/monoiofs/core.rs
+++ b/core/src/services/monoiofs/core.rs
@@ -69,7 +69,7 @@ impl MonoiofsCore {
         Self {
             info: {
                 let am = AccessorInfo::default();
-                am.set_scheme(Scheme::Monoiofs)
+                am.set_scheme("monoiofs")
                     .set_root(&root.to_string_lossy())
                     .set_native_capability(Capability {
                         stat: true,

--- a/core/src/services/monoiofs/core.rs
+++ b/core/src/services/monoiofs/core.rs
@@ -28,10 +28,9 @@ use futures::Future;
 use monoio::FusionDriver;
 use monoio::RuntimeBuilder;
 
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::*;
-const DEFAULT_SCHEME: &str = "monoiofs";
-
 pub const BUFFER_SIZE: usize = 2 * 1024 * 1024; // 2 MiB
 
 /// a boxed function that spawns task in current monoio runtime

--- a/core/src/services/monoiofs/core.rs
+++ b/core/src/services/monoiofs/core.rs
@@ -30,6 +30,7 @@ use monoio::RuntimeBuilder;
 
 use crate::raw::*;
 use crate::*;
+const DEFAULT_SCHEME: &str = "monoiofs";
 
 pub const BUFFER_SIZE: usize = 2 * 1024 * 1024; // 2 MiB
 
@@ -69,7 +70,7 @@ impl MonoiofsCore {
         Self {
             info: {
                 let am = AccessorInfo::default();
-                am.set_scheme("monoiofs")
+                am.set_scheme(DEFAULT_SCHEME)
                     .set_root(&root.to_string_lossy())
                     .set_native_capability(Capability {
                         stat: true,

--- a/core/src/services/monoiofs/mod.rs
+++ b/core/src/services/monoiofs/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for monoiofs service.
+#[cfg(feature = "services-monoiofs")]
+pub(super) const DEFAULT_SCHEME: &str = "monoiofs";
 #[cfg(feature = "services-monoiofs")]
 mod core;
 #[cfg(feature = "services-monoiofs")]

--- a/core/src/services/mysql/backend.rs
+++ b/core/src/services/mysql/backend.rs
@@ -113,7 +113,6 @@ impl MysqlBuilder {
 }
 
 impl Builder for MysqlBuilder {
-    const SCHEME: Scheme = Scheme::Mysql;
     type Config = MysqlConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -38,6 +38,7 @@ use super::writer::ObsWriters;
 use crate::raw::*;
 use crate::services::ObsConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "obs";
 
 impl Configurator for ObsConfig {
     type Builder = ObsBuilder;
@@ -232,7 +233,7 @@ impl Builder for ObsBuilder {
             core: Arc::new(ObsCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("obs")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_name(&bucket)
                         .set_native_capability(Capability {

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -35,11 +35,10 @@ use super::error::parse_error;
 use super::lister::ObsLister;
 use super::writer::ObsWriter;
 use super::writer::ObsWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::ObsConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "obs";
-
 impl Configurator for ObsConfig {
     type Builder = ObsBuilder;
 

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -154,7 +154,6 @@ impl ObsBuilder {
 }
 
 impl Builder for ObsBuilder {
-    const SCHEME: Scheme = Scheme::Obs;
     type Config = ObsConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -233,7 +232,7 @@ impl Builder for ObsBuilder {
             core: Arc::new(ObsCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Obs)
+                    am.set_scheme("obs")
                         .set_root(&root)
                         .set_name(&bucket)
                         .set_native_capability(Capability {

--- a/core/src/services/obs/mod.rs
+++ b/core/src/services/obs/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for obs service.
+#[cfg(feature = "services-obs")]
+pub(super) const DEFAULT_SCHEME: &str = "obs";
 #[cfg(feature = "services-obs")]
 mod core;
 #[cfg(feature = "services-obs")]

--- a/core/src/services/onedrive/builder.rs
+++ b/core/src/services/onedrive/builder.rs
@@ -137,7 +137,6 @@ impl OnedriveBuilder {
 }
 
 impl Builder for OnedriveBuilder {
-    const SCHEME: Scheme = Scheme::Onedrive;
     type Config = OnedriveConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -145,7 +144,7 @@ impl Builder for OnedriveBuilder {
         debug!("backend use root {root}");
 
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Onedrive)
+        info.set_scheme("onedrive")
             .set_root(&root)
             .set_native_capability(Capability {
                 read: true,

--- a/core/src/services/onedrive/builder.rs
+++ b/core/src/services/onedrive/builder.rs
@@ -27,6 +27,7 @@ use services::onedrive::core::OneDriveSigner;
 use tokio::sync::Mutex;
 
 use super::backend::OnedriveBackend;
+use super::DEFAULT_SCHEME;
 use crate::raw::normalize_root;
 use crate::raw::Access;
 use crate::raw::AccessorInfo;
@@ -34,8 +35,6 @@ use crate::raw::HttpClient;
 use crate::services::OnedriveConfig;
 use crate::Scheme;
 use crate::*;
-const DEFAULT_SCHEME: &str = "onedrive";
-
 impl Configurator for OnedriveConfig {
     type Builder = OnedriveBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/onedrive/builder.rs
+++ b/core/src/services/onedrive/builder.rs
@@ -34,6 +34,7 @@ use crate::raw::HttpClient;
 use crate::services::OnedriveConfig;
 use crate::Scheme;
 use crate::*;
+const DEFAULT_SCHEME: &str = "onedrive";
 
 impl Configurator for OnedriveConfig {
     type Builder = OnedriveBuilder;
@@ -144,7 +145,7 @@ impl Builder for OnedriveBuilder {
         debug!("backend use root {root}");
 
         let info = AccessorInfo::default();
-        info.set_scheme("onedrive")
+        info.set_scheme(DEFAULT_SCHEME)
             .set_root(&root)
             .set_native_capability(Capability {
                 read: true,

--- a/core/src/services/onedrive/mod.rs
+++ b/core/src/services/onedrive/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for onedrive service.
+#[cfg(feature = "services-onedrive")]
+pub(super) const DEFAULT_SCHEME: &str = "onedrive";
 #[cfg(feature = "services-onedrive")]
 mod backend;
 #[cfg(feature = "services-onedrive")]

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -318,7 +318,6 @@ impl OssBuilder {
 }
 
 impl Builder for OssBuilder {
-    const SCHEME: Scheme = Scheme::Oss;
     type Config = OssConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -411,7 +410,7 @@ impl Builder for OssBuilder {
             core: Arc::new(OssCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Oss)
+                    am.set_scheme("oss")
                         .set_root(&root)
                         .set_name(bucket)
                         .set_native_capability(Capability {

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -38,6 +38,7 @@ use super::writer::OssWriters;
 use crate::raw::*;
 use crate::services::OssConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "oss";
 
 const DEFAULT_BATCH_MAX_OPERATIONS: usize = 1000;
 
@@ -410,7 +411,7 @@ impl Builder for OssBuilder {
             core: Arc::new(OssCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("oss")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_name(bucket)
                         .set_native_capability(Capability {

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -35,11 +35,10 @@ use super::lister::OssListers;
 use super::lister::OssObjectVersionsLister;
 use super::writer::OssWriter;
 use super::writer::OssWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::OssConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "oss";
-
 const DEFAULT_BATCH_MAX_OPERATIONS: usize = 1000;
 
 impl Configurator for OssConfig {

--- a/core/src/services/oss/mod.rs
+++ b/core/src/services/oss/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for oss service.
+#[cfg(feature = "services-oss")]
+pub(super) const DEFAULT_SCHEME: &str = "oss";
 #[cfg(feature = "services-oss")]
 mod core;
 #[cfg(feature = "services-oss")]

--- a/core/src/services/pcloud/backend.rs
+++ b/core/src/services/pcloud/backend.rs
@@ -34,6 +34,7 @@ use super::writer::PcloudWriters;
 use crate::raw::*;
 use crate::services::PcloudConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "pcloud";
 
 impl Configurator for PcloudConfig {
     type Builder = PcloudBuilder;
@@ -168,7 +169,7 @@ impl Builder for PcloudBuilder {
             core: Arc::new(PcloudCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("pcloud")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/pcloud/backend.rs
+++ b/core/src/services/pcloud/backend.rs
@@ -132,7 +132,6 @@ impl PcloudBuilder {
 }
 
 impl Builder for PcloudBuilder {
-    const SCHEME: Scheme = Scheme::Pcloud;
     type Config = PcloudConfig;
 
     /// Builds the backend and returns the result of PcloudBackend.
@@ -169,7 +168,7 @@ impl Builder for PcloudBuilder {
             core: Arc::new(PcloudCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Pcloud)
+                    am.set_scheme("pcloud")
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/pcloud/backend.rs
+++ b/core/src/services/pcloud/backend.rs
@@ -31,11 +31,10 @@ use super::error::PcloudError;
 use super::lister::PcloudLister;
 use super::writer::PcloudWriter;
 use super::writer::PcloudWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::PcloudConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "pcloud";
-
 impl Configurator for PcloudConfig {
     type Builder = PcloudBuilder;
 

--- a/core/src/services/pcloud/mod.rs
+++ b/core/src/services/pcloud/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for pcloud service.
+#[cfg(feature = "services-pcloud")]
+pub(super) const DEFAULT_SCHEME: &str = "pcloud";
 #[cfg(feature = "services-pcloud")]
 mod core;
 #[cfg(feature = "services-pcloud")]

--- a/core/src/services/persy/backend.rs
+++ b/core/src/services/persy/backend.rs
@@ -65,7 +65,6 @@ impl PersyBuilder {
 }
 
 impl Builder for PersyBuilder {
-    const SCHEME: Scheme = Scheme::Persy;
     type Config = PersyConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/postgresql/backend.rs
+++ b/core/src/services/postgresql/backend.rs
@@ -112,7 +112,6 @@ impl PostgresqlBuilder {
 }
 
 impl Builder for PostgresqlBuilder {
-    const SCHEME: Scheme = Scheme::Postgresql;
     type Config = PostgresqlConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/redb/backend.rs
+++ b/core/src/services/redb/backend.rs
@@ -97,7 +97,6 @@ impl RedbBuilder {
 }
 
 impl Builder for RedbBuilder {
-    const SCHEME: Scheme = Scheme::Redb;
     type Config = RedbConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/redis/backend.rs
+++ b/core/src/services/redis/backend.rs
@@ -32,12 +32,11 @@ use tokio::sync::OnceCell;
 use super::core::*;
 use super::delete::RedisDeleter;
 use super::writer::RedisWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::oio;
 use crate::raw::*;
 use crate::services::RedisConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "redis";
-
 const DEFAULT_REDIS_ENDPOINT: &str = "tcp://127.0.0.1:6379";
 const DEFAULT_REDIS_PORT: u16 = 6379;
 

--- a/core/src/services/redis/backend.rs
+++ b/core/src/services/redis/backend.rs
@@ -144,7 +144,6 @@ impl RedisBuilder {
 }
 
 impl Builder for RedisBuilder {
-    const SCHEME: Scheme = Scheme::Redis;
     type Config = RedisConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -278,7 +277,7 @@ pub struct RedisAccessor {
 impl RedisAccessor {
     fn new(core: RedisCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Redis);
+        info.set_scheme("redis");
         info.set_name(&core.addr);
         info.set_root("/");
         info.set_native_capability(Capability {
@@ -396,7 +395,7 @@ mod tests {
 
         // Verify basic properties
         assert_eq!(accessor.root, "/");
-        assert_eq!(accessor.info.scheme(), Scheme::Redis);
+        assert_eq!(accessor.info.scheme(), "redis");
         assert!(accessor.info.native_capability().read);
         assert!(accessor.info.native_capability().write);
         assert!(accessor.info.native_capability().delete);

--- a/core/src/services/redis/backend.rs
+++ b/core/src/services/redis/backend.rs
@@ -36,6 +36,7 @@ use crate::raw::oio;
 use crate::raw::*;
 use crate::services::RedisConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "redis";
 
 const DEFAULT_REDIS_ENDPOINT: &str = "tcp://127.0.0.1:6379";
 const DEFAULT_REDIS_PORT: u16 = 6379;
@@ -277,7 +278,7 @@ pub struct RedisAccessor {
 impl RedisAccessor {
     fn new(core: RedisCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme("redis");
+        info.set_scheme(DEFAULT_SCHEME);
         info.set_name(&core.addr);
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/redis/mod.rs
+++ b/core/src/services/redis/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for redis service.
+#[cfg(feature = "services-redis")]
+pub(super) const DEFAULT_SCHEME: &str = "redis";
 #[cfg(feature = "services-redis")]
 mod backend;
 #[cfg(feature = "services-redis")]

--- a/core/src/services/rocksdb/backend.rs
+++ b/core/src/services/rocksdb/backend.rs
@@ -63,7 +63,6 @@ impl RocksdbBuilder {
 }
 
 impl Builder for RocksdbBuilder {
-    const SCHEME: Scheme = Scheme::Rocksdb;
     type Config = RocksdbConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -66,6 +66,7 @@ static ENDPOINT_TEMPLATES: LazyLock<HashMap<&'static str, &'static str>> = LazyL
     m
 });
 
+const DEFAULT_SCHEME: &str = "s3";
 const DEFAULT_BATCH_MAX_OPERATIONS: usize = 1000;
 
 impl Configurator for S3Config {
@@ -903,7 +904,7 @@ impl Builder for S3Builder {
             core: Arc::new(S3Core {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("s3")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_name(bucket)
                         .set_native_capability(Capability {

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -716,7 +716,6 @@ impl S3Builder {
 }
 
 impl Builder for S3Builder {
-    const SCHEME: Scheme = Scheme::S3;
     type Config = S3Config;
 
     fn build(mut self) -> Result<impl Access> {
@@ -904,7 +903,7 @@ impl Builder for S3Builder {
             core: Arc::new(S3Core {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::S3)
+                    am.set_scheme("s3")
                         .set_root(&root)
                         .set_name(bucket)
                         .set_native_capability(Capability {

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -50,6 +50,7 @@ use super::lister::S3Listers;
 use super::lister::S3ObjectVersionsLister;
 use super::writer::S3Writer;
 use super::writer::S3Writers;
+use super::DEFAULT_SCHEME;
 use crate::raw::oio::PageLister;
 use crate::raw::*;
 use crate::services::S3Config;
@@ -66,7 +67,6 @@ static ENDPOINT_TEMPLATES: LazyLock<HashMap<&'static str, &'static str>> = LazyL
     m
 });
 
-const DEFAULT_SCHEME: &str = "s3";
 const DEFAULT_BATCH_MAX_OPERATIONS: usize = 1000;
 
 impl Configurator for S3Config {

--- a/core/src/services/s3/mod.rs
+++ b/core/src/services/s3/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for s3 service.
+#[cfg(feature = "services-s3")]
+pub(super) const DEFAULT_SCHEME: &str = "s3";
 #[cfg(feature = "services-s3")]
 mod core;
 #[cfg(feature = "services-s3")]

--- a/core/src/services/seafile/backend.rs
+++ b/core/src/services/seafile/backend.rs
@@ -145,7 +145,6 @@ impl SeafileBuilder {
 }
 
 impl Builder for SeafileBuilder {
-    const SCHEME: Scheme = Scheme::Seafile;
     type Config = SeafileConfig;
 
     /// Builds the backend and returns the result of SeafileBackend.
@@ -189,7 +188,7 @@ impl Builder for SeafileBuilder {
             core: Arc::new(SeafileCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Seafile)
+                    am.set_scheme("seafile")
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/seafile/backend.rs
+++ b/core/src/services/seafile/backend.rs
@@ -36,6 +36,7 @@ use super::writer::SeafileWriters;
 use crate::raw::*;
 use crate::services::SeafileConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "seafile";
 
 impl Configurator for SeafileConfig {
     type Builder = SeafileBuilder;
@@ -188,7 +189,7 @@ impl Builder for SeafileBuilder {
             core: Arc::new(SeafileCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("seafile")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/seafile/backend.rs
+++ b/core/src/services/seafile/backend.rs
@@ -33,11 +33,10 @@ use super::error::parse_error;
 use super::lister::SeafileLister;
 use super::writer::SeafileWriter;
 use super::writer::SeafileWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::SeafileConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "seafile";
-
 impl Configurator for SeafileConfig {
     type Builder = SeafileBuilder;
 

--- a/core/src/services/seafile/mod.rs
+++ b/core/src/services/seafile/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for seafile service.
+#[cfg(feature = "services-seafile")]
+pub(super) const DEFAULT_SCHEME: &str = "seafile";
 #[cfg(feature = "services-seafile")]
 mod core;
 #[cfg(feature = "services-seafile")]

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -35,11 +35,10 @@ use super::error::parse_sftp_error;
 use super::lister::SftpLister;
 use super::reader::SftpReader;
 use super::writer::SftpWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::SftpConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "sftp";
-
 impl Configurator for SftpConfig {
     type Builder = SftpBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -38,6 +38,7 @@ use super::writer::SftpWriter;
 use crate::raw::*;
 use crate::services::SftpConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "sftp";
 
 impl Configurator for SftpConfig {
     type Builder = SftpBuilder;
@@ -180,7 +181,7 @@ impl Builder for SftpBuilder {
 
         let info = AccessorInfo::default();
         info.set_root(root.as_str())
-            .set_scheme("sftp")
+            .set_scheme(DEFAULT_SCHEME)
             .set_native_capability(Capability {
                 stat: true,
 

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -141,7 +141,6 @@ impl SftpBuilder {
 }
 
 impl Builder for SftpBuilder {
-    const SCHEME: Scheme = Scheme::Sftp;
     type Config = SftpConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -181,7 +180,7 @@ impl Builder for SftpBuilder {
 
         let info = AccessorInfo::default();
         info.set_root(root.as_str())
-            .set_scheme(Scheme::Sftp)
+            .set_scheme("sftp")
             .set_native_capability(Capability {
                 stat: true,
 

--- a/core/src/services/sftp/mod.rs
+++ b/core/src/services/sftp/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for sftp service.
+#[cfg(feature = "services-sftp")]
+pub(super) const DEFAULT_SCHEME: &str = "sftp";
 #[cfg(feature = "services-sftp")]
 mod delete;
 #[cfg(feature = "services-sftp")]

--- a/core/src/services/sled/backend.rs
+++ b/core/src/services/sled/backend.rs
@@ -79,7 +79,6 @@ impl SledBuilder {
 }
 
 impl Builder for SledBuilder {
-    const SCHEME: Scheme = Scheme::Sled;
     type Config = SledConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/sqlite/backend.rs
+++ b/core/src/services/sqlite/backend.rs
@@ -121,7 +121,6 @@ impl SqliteBuilder {
 }
 
 impl Builder for SqliteBuilder {
-    const SCHEME: Scheme = Scheme::Sqlite;
     type Config = SqliteConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/surrealdb/backend.rs
+++ b/core/src/services/surrealdb/backend.rs
@@ -144,7 +144,6 @@ impl SurrealdbBuilder {
 }
 
 impl Builder for SurrealdbBuilder {
-    const SCHEME: Scheme = Scheme::Surrealdb;
     type Config = SurrealdbConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/swift/backend.rs
+++ b/core/src/services/swift/backend.rs
@@ -31,6 +31,7 @@ use super::writer::SwiftWriter;
 use crate::raw::*;
 use crate::services::SwiftConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "swift";
 
 impl Configurator for SwiftConfig {
     type Builder = SwiftBuilder;
@@ -155,7 +156,7 @@ impl Builder for SwiftBuilder {
             core: Arc::new(SwiftCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("swift")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/swift/backend.rs
+++ b/core/src/services/swift/backend.rs
@@ -28,11 +28,10 @@ use super::delete::SwfitDeleter;
 use super::error::parse_error;
 use super::lister::SwiftLister;
 use super::writer::SwiftWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::SwiftConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "swift";
-
 impl Configurator for SwiftConfig {
     type Builder = SwiftBuilder;
     fn into_builder(self) -> Self::Builder {

--- a/core/src/services/swift/backend.rs
+++ b/core/src/services/swift/backend.rs
@@ -113,7 +113,6 @@ impl SwiftBuilder {
 }
 
 impl Builder for SwiftBuilder {
-    const SCHEME: Scheme = Scheme::Swift;
     type Config = SwiftConfig;
 
     /// Build a SwiftBackend.
@@ -156,7 +155,7 @@ impl Builder for SwiftBuilder {
             core: Arc::new(SwiftCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Swift)
+                    am.set_scheme("swift")
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/swift/mod.rs
+++ b/core/src/services/swift/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for swift service.
+#[cfg(feature = "services-swift")]
+pub(super) const DEFAULT_SCHEME: &str = "swift";
 #[cfg(feature = "services-swift")]
 mod core;
 #[cfg(feature = "services-swift")]

--- a/core/src/services/tikv/backend.rs
+++ b/core/src/services/tikv/backend.rs
@@ -96,7 +96,6 @@ impl TikvBuilder {
 }
 
 impl Builder for TikvBuilder {
-    const SCHEME: Scheme = Scheme::Tikv;
     type Config = TikvConfig;
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/services/upyun/backend.rs
+++ b/core/src/services/upyun/backend.rs
@@ -128,7 +128,6 @@ impl UpyunBuilder {
 }
 
 impl Builder for UpyunBuilder {
-    const SCHEME: Scheme = Scheme::Upyun;
     type Config = UpyunConfig;
 
     /// Builds the backend and returns the result of UpyunBackend.
@@ -170,7 +169,7 @@ impl Builder for UpyunBuilder {
             core: Arc::new(UpyunCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::Upyun)
+                    am.set_scheme("upyun")
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/upyun/backend.rs
+++ b/core/src/services/upyun/backend.rs
@@ -29,11 +29,10 @@ use super::error::parse_error;
 use super::lister::UpyunLister;
 use super::writer::UpyunWriter;
 use super::writer::UpyunWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::UpyunConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "upyun";
-
 impl Configurator for UpyunConfig {
     type Builder = UpyunBuilder;
 

--- a/core/src/services/upyun/backend.rs
+++ b/core/src/services/upyun/backend.rs
@@ -32,6 +32,7 @@ use super::writer::UpyunWriters;
 use crate::raw::*;
 use crate::services::UpyunConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "upyun";
 
 impl Configurator for UpyunConfig {
     type Builder = UpyunBuilder;
@@ -169,7 +170,7 @@ impl Builder for UpyunBuilder {
             core: Arc::new(UpyunCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("upyun")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/upyun/mod.rs
+++ b/core/src/services/upyun/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for upyun service.
+#[cfg(feature = "services-upyun")]
+pub(super) const DEFAULT_SCHEME: &str = "upyun";
 #[cfg(feature = "services-upyun")]
 mod core;
 #[cfg(feature = "services-upyun")]

--- a/core/src/services/vercel_artifacts/builder.rs
+++ b/core/src/services/vercel_artifacts/builder.rs
@@ -21,13 +21,12 @@ use std::sync::Arc;
 
 use super::backend::VercelArtifactsBackend;
 use super::core::VercelArtifactsCore;
+use super::DEFAULT_SCHEME;
 use crate::raw::Access;
 use crate::raw::AccessorInfo;
 use crate::raw::HttpClient;
 use crate::services::VercelArtifactsConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "vercel_artifacts";
-
 impl Configurator for VercelArtifactsConfig {
     type Builder = VercelArtifactsBuilder;
 

--- a/core/src/services/vercel_artifacts/builder.rs
+++ b/core/src/services/vercel_artifacts/builder.rs
@@ -26,6 +26,7 @@ use crate::raw::AccessorInfo;
 use crate::raw::HttpClient;
 use crate::services::VercelArtifactsConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "vercel_artifacts";
 
 impl Configurator for VercelArtifactsConfig {
     type Builder = VercelArtifactsBuilder;
@@ -85,7 +86,7 @@ impl Builder for VercelArtifactsBuilder {
 
     fn build(self) -> Result<impl Access> {
         let info = AccessorInfo::default();
-        info.set_scheme("vercel_artifacts")
+        info.set_scheme(DEFAULT_SCHEME)
             .set_native_capability(Capability {
                 stat: true,
 

--- a/core/src/services/vercel_artifacts/builder.rs
+++ b/core/src/services/vercel_artifacts/builder.rs
@@ -25,7 +25,6 @@ use crate::raw::Access;
 use crate::raw::AccessorInfo;
 use crate::raw::HttpClient;
 use crate::services::VercelArtifactsConfig;
-use crate::Scheme;
 use crate::*;
 
 impl Configurator for VercelArtifactsConfig {
@@ -82,12 +81,11 @@ impl VercelArtifactsBuilder {
 }
 
 impl Builder for VercelArtifactsBuilder {
-    const SCHEME: Scheme = Scheme::VercelArtifacts;
     type Config = VercelArtifactsConfig;
 
     fn build(self) -> Result<impl Access> {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::VercelArtifacts)
+        info.set_scheme("vercel_artifacts")
             .set_native_capability(Capability {
                 stat: true,
 

--- a/core/src/services/vercel_artifacts/mod.rs
+++ b/core/src/services/vercel_artifacts/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for vercel_artifacts service.
+#[cfg(feature = "services-vercel-artifacts")]
+pub(super) const DEFAULT_SCHEME: &str = "vercel_artifacts";
 #[cfg(feature = "services-vercel-artifacts")]
 mod backend;
 #[cfg(feature = "services-vercel-artifacts")]

--- a/core/src/services/vercel_blob/backend.rs
+++ b/core/src/services/vercel_blob/backend.rs
@@ -107,7 +107,6 @@ impl VercelBlobBuilder {
 }
 
 impl Builder for VercelBlobBuilder {
-    const SCHEME: Scheme = Scheme::VercelBlob;
     type Config = VercelBlobConfig;
 
     /// Builds the backend and returns the result of VercelBlobBackend.
@@ -128,7 +127,7 @@ impl Builder for VercelBlobBuilder {
             core: Arc::new(VercelBlobCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::VercelBlob)
+                    am.set_scheme("vercel_blob")
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/vercel_blob/backend.rs
+++ b/core/src/services/vercel_blob/backend.rs
@@ -35,6 +35,7 @@ use super::writer::VercelBlobWriters;
 use crate::raw::*;
 use crate::services::VercelBlobConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "vercel_blob";
 
 impl Configurator for VercelBlobConfig {
     type Builder = VercelBlobBuilder;
@@ -127,7 +128,7 @@ impl Builder for VercelBlobBuilder {
             core: Arc::new(VercelBlobCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("vercel_blob")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/vercel_blob/backend.rs
+++ b/core/src/services/vercel_blob/backend.rs
@@ -32,11 +32,10 @@ use super::error::parse_error;
 use super::lister::VercelBlobLister;
 use super::writer::VercelBlobWriter;
 use super::writer::VercelBlobWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::VercelBlobConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "vercel_blob";
-
 impl Configurator for VercelBlobConfig {
     type Builder = VercelBlobBuilder;
 

--- a/core/src/services/vercel_blob/mod.rs
+++ b/core/src/services/vercel_blob/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for vercel_blob service.
+#[cfg(feature = "services-vercel-blob")]
+pub(super) const DEFAULT_SCHEME: &str = "vercel_blob";
 #[cfg(feature = "services-vercel-blob")]
 mod core;
 #[cfg(feature = "services-vercel-blob")]

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -29,11 +29,10 @@ use super::delete::WebdavDeleter;
 use super::error::parse_error;
 use super::lister::WebdavLister;
 use super::writer::WebdavWriter;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::WebdavConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "webdav";
-
 impl Configurator for WebdavConfig {
     type Builder = WebdavBuilder;
 

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -135,7 +135,6 @@ impl WebdavBuilder {
 }
 
 impl Builder for WebdavBuilder {
-    const SCHEME: Scheme = Scheme::Webdav;
     type Config = WebdavConfig;
 
     fn build(self) -> Result<impl Access> {
@@ -176,7 +175,7 @@ impl Builder for WebdavBuilder {
         let core = Arc::new(WebdavCore {
             info: {
                 let am = AccessorInfo::default();
-                am.set_scheme(Scheme::Webdav)
+                am.set_scheme("webdav")
                     .set_root(&root)
                     .set_native_capability(Capability {
                         stat: true,

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -32,6 +32,7 @@ use super::writer::WebdavWriter;
 use crate::raw::*;
 use crate::services::WebdavConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "webdav";
 
 impl Configurator for WebdavConfig {
     type Builder = WebdavBuilder;
@@ -175,7 +176,7 @@ impl Builder for WebdavBuilder {
         let core = Arc::new(WebdavCore {
             info: {
                 let am = AccessorInfo::default();
-                am.set_scheme("webdav")
+                am.set_scheme(DEFAULT_SCHEME)
                     .set_root(&root)
                     .set_native_capability(Capability {
                         stat: true,

--- a/core/src/services/webdav/mod.rs
+++ b/core/src/services/webdav/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for webdav service.
+#[cfg(feature = "services-webdav")]
+pub(super) const DEFAULT_SCHEME: &str = "webdav";
 #[cfg(feature = "services-webdav")]
 mod core;
 #[cfg(feature = "services-webdav")]

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -147,7 +147,6 @@ impl WebhdfsBuilder {
 }
 
 impl Builder for WebhdfsBuilder {
-    const SCHEME: Scheme = Scheme::Webhdfs;
     type Config = WebhdfsConfig;
 
     /// build the backend
@@ -181,7 +180,7 @@ impl Builder for WebhdfsBuilder {
         let auth = self.config.delegation.map(|dt| format!("delegation={dt}"));
 
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Webhdfs)
+        info.set_scheme("webhdfs")
             .set_root(&root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -37,6 +37,7 @@ use super::writer::WebhdfsWriters;
 use crate::raw::*;
 use crate::services::WebhdfsConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "webhdfs";
 
 const WEBHDFS_DEFAULT_ENDPOINT: &str = "http://127.0.0.1:9870";
 
@@ -180,7 +181,7 @@ impl Builder for WebhdfsBuilder {
         let auth = self.config.delegation.map(|dt| format!("delegation={dt}"));
 
         let info = AccessorInfo::default();
-        info.set_scheme("webhdfs")
+        info.set_scheme(DEFAULT_SCHEME)
             .set_root(&root)
             .set_native_capability(Capability {
                 stat: true,

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -34,11 +34,10 @@ use super::message::FileStatusType;
 use super::message::FileStatusWrapper;
 use super::writer::WebhdfsWriter;
 use super::writer::WebhdfsWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::WebhdfsConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "webhdfs";
-
 const WEBHDFS_DEFAULT_ENDPOINT: &str = "http://127.0.0.1:9870";
 
 impl Configurator for WebhdfsConfig {

--- a/core/src/services/webhdfs/mod.rs
+++ b/core/src/services/webhdfs/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for webhdfs service.
+#[cfg(feature = "services-webhdfs")]
+pub(super) const DEFAULT_SCHEME: &str = "webhdfs";
 #[cfg(feature = "services-webhdfs")]
 mod delete;
 #[cfg(feature = "services-webhdfs")]

--- a/core/src/services/yandex_disk/backend.rs
+++ b/core/src/services/yandex_disk/backend.rs
@@ -33,6 +33,7 @@ use super::writer::YandexDiskWriters;
 use crate::raw::*;
 use crate::services::YandexDiskConfig;
 use crate::*;
+const DEFAULT_SCHEME: &str = "yandex_disk";
 
 impl Configurator for YandexDiskConfig {
     type Builder = YandexDiskBuilder;
@@ -126,7 +127,7 @@ impl Builder for YandexDiskBuilder {
             core: Arc::new(YandexDiskCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme("yandex_disk")
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/yandex_disk/backend.rs
+++ b/core/src/services/yandex_disk/backend.rs
@@ -30,11 +30,10 @@ use super::error::parse_error;
 use super::lister::YandexDiskLister;
 use super::writer::YandexDiskWriter;
 use super::writer::YandexDiskWriters;
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::YandexDiskConfig;
 use crate::*;
-const DEFAULT_SCHEME: &str = "yandex_disk";
-
 impl Configurator for YandexDiskConfig {
     type Builder = YandexDiskBuilder;
 

--- a/core/src/services/yandex_disk/backend.rs
+++ b/core/src/services/yandex_disk/backend.rs
@@ -104,7 +104,6 @@ impl YandexDiskBuilder {
 }
 
 impl Builder for YandexDiskBuilder {
-    const SCHEME: Scheme = Scheme::YandexDisk;
     type Config = YandexDiskConfig;
 
     /// Builds the backend and returns the result of YandexDiskBackend.
@@ -127,7 +126,7 @@ impl Builder for YandexDiskBuilder {
             core: Arc::new(YandexDiskCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::YandexDisk)
+                    am.set_scheme("yandex_disk")
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/yandex_disk/mod.rs
+++ b/core/src/services/yandex_disk/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for yandex_disk service.
+#[cfg(feature = "services-yandex-disk")]
+pub(super) const DEFAULT_SCHEME: &str = "yandex_disk";
 #[cfg(feature = "services-yandex-disk")]
 mod core;
 #[cfg(feature = "services-yandex-disk")]

--- a/core/src/types/builder.rs
+++ b/core/src/types/builder.rs
@@ -49,8 +49,6 @@ use crate::*;
 /// }
 /// ```
 pub trait Builder: Default + 'static {
-    /// Associated scheme for this builder. It indicates what underlying service is.
-    const SCHEME: Scheme;
     /// Associated configuration for this builder.
     type Config: Configurator;
 
@@ -60,7 +58,6 @@ pub trait Builder: Default + 'static {
 
 /// Dummy implementation of builder
 impl Builder for () {
-    const SCHEME: Scheme = Scheme::Custom("dummy");
     type Config = ();
 
     fn build(self) -> Result<impl Access> {

--- a/core/src/types/operator/info.rs
+++ b/core/src/types/operator/info.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::str::FromStr;
 use std::sync::Arc;
 
 use crate::raw::*;
@@ -31,7 +32,8 @@ impl OperatorInfo {
 
     /// [`Scheme`] of operator.
     pub fn scheme(&self) -> Scheme {
-        self.0.scheme()
+        let scheme_str = self.0.scheme();
+        Scheme::from_str(scheme_str).unwrap_or(Scheme::Custom(scheme_str))
     }
 
     /// Root of operator, will be in format like `/path/to/dir/`

--- a/core/src/types/operator/operator.rs
+++ b/core/src/types/operator/operator.rs
@@ -1004,7 +1004,7 @@ impl Operator {
             return Err(
                 Error::new(ErrorKind::IsADirectory, "write path is a directory")
                     .with_operation("Operator::writer")
-                    .with_context("service", acc.info().scheme().into_static())
+                    .with_context("service", acc.info().scheme())
                     .with_context("path", &path),
             );
         }


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/opendal/issues/5445

# Rationale for this change

Remove the internal usage of scheme from raw and services to get ready for our crates split and  from_uri suspport.

# What changes are included in this PR?

Try our best to not use `Scheme`.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
