### PR TITLE
docs(python): add documentation for local usage

### DIFF
--- a/bindings/python/docs/index.md
+++ b/bindings/python/docs/index.md
@@ -7,7 +7,7 @@ pip install opendal
 ```
 
 ## Local Usage
-There are two required arguments for working with files locally:
+Developer must set two required arguments to work with files locally:
 - `scheme`: which should be specified as `fs`
 - `root`: where OpenDAl considers the root of the directory for operations will be.
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6471 

# Rationale for this change

Adds some documentation on **local usage** to go over the `root` concept, as well as show some basic examples of reading and writing.

I think it makes sense to explicitly mark these docs as **local usage** as I was playing around with S3, and noticed that we do not need to specify a `root` like we do for local usage, which is why I added the documentation about the `root` argument/concept.  I am happy to write more docs for S3 usage in the future!

I believe these docs can be slightly cleaned up if/when https://github.com/apache/opendal/issues/6479 is implemented as it seems clunky to have to explicitly get the `Path` object as a string in the example code.

# What changes are included in this PR?

Just documentation changes.

# Are there any user-facing changes?
No code changes, but documentation is user-facing `:)`
