### PR TITLE
feat(bindings/python): Add feature groups for selective service building

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -149,6 +149,31 @@ services-upyun = ["opendal/services-upyun"]
 services-vercel-artifacts = ["opendal/services-vercel-artifacts"]
 services-yandex-disk = ["opendal/services-yandex-disk"]
 services-compfs = ["opendal/services-compfs"]
+
+# Feature groups based on existing service classification
+# Reference: current default vs services-all distinction
+
+# Core subset - most fundamental services from default set
+core = ["services-fs", "services-memory", "services-s3", "services-http"]
+
+# Current default services - exact preservation of existing default
+stable = [
+  "services-azblob", "services-azdls", "services-cos", "services-fs",
+  "services-gcs", "services-ghac", "services-http", "services-ipmfs", 
+  "services-memory", "services-obs", "services-oss", "services-s3",
+  "services-webdav", "services-webhdfs"
+]
+
+# Database services from services-all (optional set)
+database = [
+  "core",
+  "services-mysql", "services-postgresql", "services-redis",
+  "services-mongodb", "services-gridfs", "services-sqlite"
+]
+
+# Minimal alias for core
+minimal = ["core"]
+
 # we build cp311-abi3 and cp310 wheels now, move this to pyo3 after we drop cp310
 abi3 = ["pyo3/abi3-py311"]
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -97,6 +97,16 @@ Build API docs:
 uv run mkdocs build
 ```
 
+Build with specific feature groups:
+
+```shell
+# Build with core services only (fs, s3, memory, http)
+maturin develop --features=core
+
+# Build with database services
+maturin develop --features=database
+```
+
 ## Used by
 
 Check out the [users](./users.md) list for more details on who is using OpenDAL.


### PR DESCRIPTION
- Add core, stable, database, minimal feature groups
- Following C bindings pattern (PR #6143)
- Zero breaking changes: default unchanged

# Which issue does this PR close?

Related to #4939. This PR enables selective service building as a foundation, though it does not fully implement the package splitting proposed in that issue.

# Rationale for this change

Following the successful pattern from C bindings (PR #6143), this adds optional feature groups to Python bindings. Currently users can only choose between default (14 services) or services-all (40+ services), with no intermediate options for specific use cases.

# What changes are included in this PR?

- Add feature groups to 'Cargo.tom]': 'core' , 'stable' 'database' 

- Update 'README.md' with usage examples

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
