### PR TITLE
fix(services/moka): prevent the weigher from being overwritten

### DIFF
--- a/core/src/services/moka/backend.rs
+++ b/core/src/services/moka/backend.rs
@@ -166,8 +166,6 @@ impl Builder for MokaBuilder {
 
         let mut builder = self.builder;
 
-        // Use entries' bytes as capacity weigher.
-        builder = builder.weigher(|k, v| (k.len() + v.content.len()) as u32);
         if let Some(v) = &self.config.name {
             builder = builder.name(v);
         }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

User-defined moka weigher will be overwritten

# What changes are included in this PR?

Remove the existing weigher

# Are there any user-facing changes?

