### PR TITLE
fix(bindings/nodejs): Change expires param to bigint in presign methods

### DIFF
--- a/bindings/nodejs/generated.d.ts
+++ b/bindings/nodejs/generated.d.ts
@@ -625,14 +625,14 @@ export declare class Operator {
    * ### Example
    *
    * ```javascript
-   * const req = await op.presignRead(path, parseInt(expires));
+   * const req = await op.presignRead(path, BigInt(expires));
    *
    * console.log("method: ", req.method);
    * console.log("url: ", req.url);
    * console.log("headers: ", req.headers);
    * ```
    */
-  presignRead(path: string, expires: number): Promise<PresignedRequest>
+  presignRead(path: string, expires: bigint): Promise<PresignedRequest>
   /**
    * Get a presigned request for `write`.
    *
@@ -641,14 +641,14 @@ export declare class Operator {
    * ### Example
    *
    * ```javascript
-   * const req = await op.presignWrite(path, parseInt(expires));
+   * const req = await op.presignWrite(path, BigInt(expires));
    *
    * console.log("method: ", req.method);
    * console.log("url: ", req.url);
    * console.log("headers: ", req.headers);
    * ```
    */
-  presignWrite(path: string, expires: number): Promise<PresignedRequest>
+  presignWrite(path: string, expires: bigint): Promise<PresignedRequest>
   /**
    * Get a presigned request for stat.
    *
@@ -657,14 +657,14 @@ export declare class Operator {
    * ### Example
    *
    * ```javascript
-   * const req = await op.presignStat(path, parseInt(expires));
+   * const req = await op.presignStat(path, BigInt(expires));
    *
    * console.log("method: ", req.method);
    * console.log("url: ", req.url);
    * console.log("headers: ", req.headers);
    * ```
    */
-  presignStat(path: string, expires: number): Promise<PresignedRequest>
+  presignStat(path: string, expires: bigint): Promise<PresignedRequest>
   /** Add a layer to this operator. */
   layer(layer: ExternalObject<Layer>): Operator
 }

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -642,17 +642,17 @@ impl Operator {
     /// ### Example
     ///
     /// ```javascript
-    /// const req = await op.presignRead(path, parseInt(expires));
+    /// const req = await op.presignRead(path, BigInt(expires));
     ///
     /// console.log("method: ", req.method);
     /// console.log("url: ", req.url);
     /// console.log("headers: ", req.headers);
     /// ```
     #[napi]
-    pub async fn presign_read(&self, path: String, expires: u32) -> Result<PresignedRequest> {
+    pub async fn presign_read(&self, path: String, expires: BigInt) -> Result<PresignedRequest> {
         let res = self
             .async_op
-            .presign_read(&path, Duration::from_secs(expires as u64))
+            .presign_read(&path, Duration::from_secs(expires.get_u64().1))
             .await
             .map_err(format_napi_error)?;
         Ok(PresignedRequest::new(res))
@@ -665,17 +665,17 @@ impl Operator {
     /// ### Example
     ///
     /// ```javascript
-    /// const req = await op.presignWrite(path, parseInt(expires));
+    /// const req = await op.presignWrite(path, BigInt(expires));
     ///
     /// console.log("method: ", req.method);
     /// console.log("url: ", req.url);
     /// console.log("headers: ", req.headers);
     /// ```
     #[napi]
-    pub async fn presign_write(&self, path: String, expires: u32) -> Result<PresignedRequest> {
+    pub async fn presign_write(&self, path: String, expires: BigInt) -> Result<PresignedRequest> {
         let res = self
             .async_op
-            .presign_write(&path, Duration::from_secs(expires as u64))
+            .presign_write(&path, Duration::from_secs(expires.get_u64().1))
             .await
             .map_err(format_napi_error)?;
         Ok(PresignedRequest::new(res))
@@ -688,17 +688,17 @@ impl Operator {
     /// ### Example
     ///
     /// ```javascript
-    /// const req = await op.presignStat(path, parseInt(expires));
+    /// const req = await op.presignStat(path, BigInt(expires));
     ///
     /// console.log("method: ", req.method);
     /// console.log("url: ", req.url);
     /// console.log("headers: ", req.headers);
     /// ```
     #[napi]
-    pub async fn presign_stat(&self, path: String, expires: u32) -> Result<PresignedRequest> {
+    pub async fn presign_stat(&self, path: String, expires: BigInt) -> Result<PresignedRequest> {
         let res = self
             .async_op
-            .presign_stat(&path, Duration::from_secs(expires as u64))
+            .presign_stat(&path, Duration::from_secs(expires.get_u64().1))
             .await
             .map_err(format_napi_error)?;
         Ok(PresignedRequest::new(res))


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
Changed the expires parameter type of the presign* method in the Node.js binding from number to bigint to support larger expiration times and avoid loss of precision.
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
