### PR TITLE
fix(integrations/object_store): remove redundant into_iter() call

### DIFF
--- a/integrations/object_store/src/store.rs
+++ b/integrations/object_store/src/store.rs
@@ -188,7 +188,7 @@ impl ObjectStore for OpendalStore {
     ) -> object_store::Result<PutResult> {
         let mut future_write = self.inner.write_with(
             &percent_decode_path(location.as_ref()),
-            Buffer::from_iter(bytes.into_iter()),
+            Buffer::from_iter(bytes),
         );
         let opts_mode = opts.mode.clone();
         match opts.mode {


### PR DESCRIPTION
# Which issue does this PR close?

fix https://github.com/apache/opendal/actions/runs/16979213117/job/48135410768

# Rationale for this change

make clippy happy

# What changes are included in this PR?

remove redundant into_iter() call

# Are there any user-facing changes?

nope