### PR TITLE
feat(services/oss): add support for security token for Aliyun OSS

### DIFF
--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -152,6 +152,18 @@ impl OssBuilder {
         self
     }
 
+    /// Set security_token for this backend.
+    ///
+    /// - If security_token is set, we will take user's input first.
+    /// - If not, we will try to load it from environment.
+    pub fn security_token(mut self, security_token: &str) -> Self {
+        if !security_token.is_empty() {
+            self.config.security_token = Some(security_token.to_string())
+        }
+
+        self
+    }
+
     /// Specify the http client that used by this service.
     ///
     /// # Notes
@@ -374,6 +386,10 @@ impl Builder for OssBuilder {
 
         if let Some(v) = self.config.access_key_secret {
             cfg.access_key_secret = Some(v);
+        }
+
+        if let Some(v) = self.config.security_token {
+            cfg.security_token = Some(v);
         }
 
         if let Some(v) = self.config.role_arn {

--- a/core/src/services/oss/config.rs
+++ b/core/src/services/oss/config.rs
@@ -49,9 +49,20 @@ pub struct OssConfig {
 
     // authenticate options
     /// Access key id for oss.
+    ///
+    /// - this field if it's `is_some`
+    /// - env value: [`ALIBABA_CLOUD_ACCESS_KEY_ID`]
     pub access_key_id: Option<String>,
     /// Access key secret for oss.
+    ///
+    /// - this field if it's `is_some`
+    /// - env value: [`ALIBABA_CLOUD_ACCESS_KEY_SECRET`]
     pub access_key_secret: Option<String>,
+    /// `security_token` will be loaded from
+    ///
+    /// - this field if it's `is_some`
+    /// - env value: [`ALIBABA_CLOUD_SECURITY_TOKEN`]
+    pub security_token: Option<String>,
     /// The size of max batch operations.
     #[deprecated(
         since = "0.52.0",
@@ -62,6 +73,9 @@ pub struct OssConfig {
     pub delete_max_size: Option<usize>,
     /// If `role_arn` is set, we will use already known config as source
     /// credential to assume role with `role_arn`.
+    ///
+    /// - this field if it's `is_some`
+    /// - env value: [`ALIBABA_CLOUD_ROLE_ARN`]
     pub role_arn: Option<String>,
     /// role_session_name for this backend.
     pub role_session_name: Option<String>,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #6507.

# Rationale for this change

> Security Token Service (STS) allows you to grant time-limited access to data stored on Object Storage Service (OSS) by using temporary access credentials. After the temporary access credentials expire, they can no longer be used to access the data. This helps improve flexibility and timeliness of access control.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- Add the field `security_token` in `OSSConfig`.
- Add the method `security_token` in `OSSBuilder`.
- Improve the documentation for the `access_key_id` and `access_key_secret` fields in `OssConfig`.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

- Add the method `security_token` in `OSSBuilder`.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
