### PR TITLE
chore(ci): upgrade 1password/load-secrets-action v3

### DIFF
--- a/.github/services/aliyun_drive/aliyun_drive/disable_action.yml
+++ b/.github/services/aliyun_drive/aliyun_drive/disable_action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/azblob/azure_azblob/action.yml
+++ b/.github/services/azblob/azure_azblob/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/azdls/azdls/action.yml
+++ b/.github/services/azdls/azdls/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/azfile/azfile/action.yml
+++ b/.github/services/azfile/azfile/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/b2/b2/action.yml
+++ b/.github/services/b2/b2/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/cos/cos/action.yml
+++ b/.github/services/cos/cos/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/dropbox/dropbox/disable_action.yml
+++ b/.github/services/dropbox/dropbox/disable_action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup credentials
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/gcs/gcs/action.yml
+++ b/.github/services/gcs/gcs/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/gcs/gcs_with_default_storage_class/action.yml
+++ b/.github/services/gcs/gcs_with_default_storage_class/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/gdrive/gdrive/action.yml
+++ b/.github/services/gdrive/gdrive/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/hdfs/hdfs_default_gcs/action.yml
+++ b/.github/services/hdfs/hdfs_default_gcs/action.yml
@@ -27,7 +27,7 @@ runs:
         distribution: temurin
         java-version: "11"
     - name: Load secrets
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/koofr/koofr/disable_action.yml
+++ b/.github/services/koofr/koofr/disable_action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/oss/oss/action.yml
+++ b/.github/services/oss/oss/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/oss/oss_with_versioning/action.yml
+++ b/.github/services/oss/oss_with_versioning/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3/action.yml
+++ b/.github/services/s3/aws_s3/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3_with_list_objects_v1/action.yml
+++ b/.github/services/s3/aws_s3_with_list_objects_v1/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3_with_sse_c/action.yml
+++ b/.github/services/s3/aws_s3_with_sse_c/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3_with_versioning/action.yml
+++ b/.github/services/s3/aws_s3_with_versioning/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3_with_virtual_host/action.yml
+++ b/.github/services/s3/aws_s3_with_virtual_host/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/services/s3/r2/disabled_action.yml
+++ b/.github/services/s3/r2/disabled_action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@v2
+      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
       with:
         export-env: true
       env:

--- a/.github/workflows/ci_bindings_haskell.yml
+++ b/.github/workflows/ci_bindings_haskell.yml
@@ -122,7 +122,7 @@ jobs:
 #          name: bindings-haskell-sdist
 #      - name: Load secret
 #        id: op-load-secret
-#        uses: 1password/load-secrets-action@v2
+#        uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
 #        with:
 #          export-env: true
 #        env:

--- a/.github/workflows/ci_weekly_update.yml
+++ b/.github/workflows/ci_weekly_update.yml
@@ -51,14 +51,13 @@ jobs:
           uv pip install --system -e .
 
       - name: Setup 1Password Connect
-        if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v3
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}
 
       - name: Setup
-        uses: 1password/load-secrets-action@v2
+        uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
         with:
           export-env: true
         env:

--- a/.github/workflows/test_behavior_bin_ofs.yml
+++ b/.github/workflows/test_behavior_bin_ofs.yml
@@ -45,13 +45,8 @@ jobs:
           need-rocksdb: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: 1Password doesn't support Windows
-      #
-      # Enable this step when the issue is resolved:
-      # https://github.com/1Password/load-secrets-action/issues/46 is resolved
       - name: Setup 1Password Connect
-        if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v3
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/test_behavior_binding_c.yml
+++ b/.github/workflows/test_behavior_binding_c.yml
@@ -45,13 +45,8 @@ jobs:
           need-rocksdb: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: 1Password doesn't support Windows
-      #
-      # Enable this step when the issue is resolved:
-      # https://github.com/1Password/load-secrets-action/issues/46 is resolved
       - name: Setup 1Password Connect
-        if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v3
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/test_behavior_binding_cpp.yml
+++ b/.github/workflows/test_behavior_binding_cpp.yml
@@ -45,12 +45,8 @@ jobs:
           need-rocksdb: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: 1password is only supported on linux
-      #
-      # Waiting for https://github.com/1Password/load-secrets-action/issues/46
       - name: Setup 1Password Connect
-        if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v1
+        uses: 1password/load-secrets-action/configure@v3
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}
@@ -87,4 +83,4 @@ jobs:
         with:
           setup: ${{ matrix.cases.setup }}
           service: ${{ matrix.cases.service }}
-          feature: ${{ matrix.cases.feature }} 
+          feature: ${{ matrix.cases.feature }}

--- a/.github/workflows/test_behavior_binding_go.yml
+++ b/.github/workflows/test_behavior_binding_go.yml
@@ -52,13 +52,8 @@ jobs:
           need-rocksdb: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: 1Password doesn't support Windows
-      #
-      # Enable this step when the issue is resolved:
-      # https://github.com/1Password/load-secrets-action/issues/46 is resolved
       - name: Setup 1Password Connect
-        if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v3
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/test_behavior_binding_java.yml
+++ b/.github/workflows/test_behavior_binding_java.yml
@@ -45,13 +45,8 @@ jobs:
           need-rocksdb: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: 1Password doesn't support Windows
-      #
-      # Enable this step when the issue is resolved:
-      # https://github.com/1Password/load-secrets-action/issues/46 is resolved
       - name: Setup 1Password Connect
-        if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v3
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/test_behavior_binding_nodejs.yml
+++ b/.github/workflows/test_behavior_binding_nodejs.yml
@@ -45,13 +45,8 @@ jobs:
           need-rocksdb: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: 1Password doesn't support Windows
-      #
-      # Enable this step when the issue is resolved:
-      # https://github.com/1Password/load-secrets-action/issues/46 is resolved
       - name: Setup 1Password Connect
-        if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v3
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/test_behavior_binding_python.yml
+++ b/.github/workflows/test_behavior_binding_python.yml
@@ -45,13 +45,8 @@ jobs:
           need-rocksdb: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: 1Password doesn't support Windows
-      #
-      # Enable this step when the issue is resolved:
-      # https://github.com/1Password/load-secrets-action/issues/46 is resolved
       - name: Setup 1Password Connect
-        if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v3
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/test_behavior_core.yml
+++ b/.github/workflows/test_behavior_core.yml
@@ -44,13 +44,8 @@ jobs:
           need-rocksdb: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: 1Password doesn't support Windows
-      #
-      # Enable this step when the issue is resolved:
-      # https://github.com/1Password/load-secrets-action/issues/46 is resolved
       - name: Setup 1Password Connect
-        if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v3
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}

--- a/.github/workflows/test_behavior_integration_object_store.yml
+++ b/.github/workflows/test_behavior_integration_object_store.yml
@@ -45,13 +45,8 @@ jobs:
           need-rocksdb: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: 1Password doesn't support Windows
-      #
-      # Enable this step when the issue is resolved:
-      # https://github.com/1Password/load-secrets-action/issues/46 is resolved
       - name: Setup 1Password Connect
-        if: runner.os == 'Linux'
-        uses: 1password/load-secrets-action/configure@v2
+        uses: 1password/load-secrets-action/configure@v3
         with:
           connect-host: ${{ secrets.OP_CONNECT_HOST }}
           connect-token: ${{ secrets.OP_CONNECT_TOKEN }}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
1password/load-secrets-action v3 already supported Windows
https://github.com/1Password/load-secrets-action/issues/46
https://github.com/1Password/load-secrets-action/pull/109

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
