### PR TITLE
chore(layers/prometheus-client): upgrade prometheus-client dependency to v0.24

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -6361,9 +6361,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
+checksum = "e4500adecd7af8e0e9f4dbce15cfee07ce913fbf6ad605cc468b83f2d531ee94"
 dependencies = [
  "dtoa",
  "itoa",
@@ -6373,9 +6373,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client-derive-encode"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -398,7 +398,7 @@ opentelemetry = { version = "0.30.0", optional = true }
 # for layers-prometheus
 prometheus = { version = "0.14", features = ["process"], optional = true }
 # for layers-prometheus-client
-prometheus-client = { version = "0.23.1", optional = true }
+prometheus-client = { version = "0.24", optional = true }
 # for fastmetrics
 fastmetrics = { version = "0.3.0", optional = true }
 # for layers-tracing

--- a/core/src/layers/prometheus_client.rs
+++ b/core/src/layers/prometheus_client.rs
@@ -489,7 +489,7 @@ struct OperationLabels {
 }
 
 impl EncodeLabelSet for OperationLabels {
-    fn encode(&self, mut encoder: LabelSetEncoder) -> Result<(), fmt::Error> {
+    fn encode(&self, encoder: &mut LabelSetEncoder<'_>) -> Result<(), fmt::Error> {
         (observe::LABEL_SCHEME, self.labels.scheme).encode(encoder.encode_label())?;
         (observe::LABEL_NAMESPACE, self.labels.namespace.as_ref())
             .encode(encoder.encode_label())?;


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

# What changes are included in this PR?

upgrade the prometheus-client dependency to v0.24


# Are there any user-facing changes?

