### PR TITLE
feat(services/gcs): add configuration aliases for better Arrow object_store compatibility

### DIFF
--- a/core/src/services/gcs/config.rs
+++ b/core/src/services/gcs/config.rs
@@ -88,56 +88,81 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_config_aliases() {
-        // Test bucket aliases
-        let bucket_config = r#"{"google_bucket": "test-bucket"}"#;
-        let config: GcsConfig = serde_json::from_str(bucket_config).unwrap();
+    fn test_bucket_aliases() {
+        // Test google_bucket alias
+        let config_json = r#"{"google_bucket": "test-bucket"}"#;
+        let config: GcsConfig = serde_json::from_str(config_json).unwrap();
         assert_eq!("test-bucket", config.bucket);
 
-        let bucket_name_config = r#"{"google_bucket_name": "test-bucket-name"}"#;
-        let config: GcsConfig = serde_json::from_str(bucket_name_config).unwrap();
+        // Test google_bucket_name alias
+        let config_json = r#"{"google_bucket_name": "test-bucket-name"}"#;
+        let config: GcsConfig = serde_json::from_str(config_json).unwrap();
         assert_eq!("test-bucket-name", config.bucket);
 
-        let bucket_alias_config = r#"{"bucket_name": "test-bucket-alias"}"#;
-        let config: GcsConfig = serde_json::from_str(bucket_alias_config).unwrap();
+        // Test bucket_name alias
+        let config_json = r#"{"bucket_name": "test-bucket-alias"}"#;
+        let config: GcsConfig = serde_json::from_str(config_json).unwrap();
         assert_eq!("test-bucket-alias", config.bucket);
+    }
 
-        // Test service account aliases
-        let sa_config = r#"{"google_service_account": "/path/to/sa.json"}"#;
-        let config: GcsConfig = serde_json::from_str(sa_config).unwrap();
+    #[test]
+    fn test_service_account_aliases() {
+        // Test google_service_account alias
+        let config_json = r#"{"google_service_account": "/path/to/sa.json"}"#;
+        let config: GcsConfig = serde_json::from_str(config_json).unwrap();
         assert_eq!(Some("/path/to/sa.json".to_string()), config.service_account);
 
-        let sa_path_config = r#"{"service_account_path": "/path/to/sa2.json"}"#;
-        let config: GcsConfig = serde_json::from_str(sa_path_config).unwrap();
+        // Test google_service_account_path alias
+        let config_json = r#"{"google_service_account_path": "/path/to/sa2.json"}"#;
+        let config: GcsConfig = serde_json::from_str(config_json).unwrap();
         assert_eq!(
             Some("/path/to/sa2.json".to_string()),
             config.service_account
         );
 
-        // Test credential aliases
-        let cred_config = r#"{"google_service_account_key": "key-content"}"#;
-        let config: GcsConfig = serde_json::from_str(cred_config).unwrap();
+        // Test service_account_path alias
+        let config_json = r#"{"service_account_path": "/path/to/sa3.json"}"#;
+        let config: GcsConfig = serde_json::from_str(config_json).unwrap();
+        assert_eq!(
+            Some("/path/to/sa3.json".to_string()),
+            config.service_account
+        );
+    }
+
+    #[test]
+    fn test_credential_aliases() {
+        // Test google_service_account_key alias
+        let config_json = r#"{"google_service_account_key": "key-content"}"#;
+        let config: GcsConfig = serde_json::from_str(config_json).unwrap();
         assert_eq!(Some("key-content".to_string()), config.credential);
 
-        let cred_alias_config = r#"{"service_account_key": "key-content-2"}"#;
-        let config: GcsConfig = serde_json::from_str(cred_alias_config).unwrap();
+        // Test service_account_key alias
+        let config_json = r#"{"service_account_key": "key-content-2"}"#;
+        let config: GcsConfig = serde_json::from_str(config_json).unwrap();
         assert_eq!(Some("key-content-2".to_string()), config.credential);
+    }
 
-        // Test credential_path aliases
-        let app_cred_config = r#"{"google_application_credentials": "/path/to/app.json"}"#;
-        let config: GcsConfig = serde_json::from_str(app_cred_config).unwrap();
+    #[test]
+    fn test_credential_path_aliases() {
+        // Test google_application_credentials alias
+        let config_json = r#"{"google_application_credentials": "/path/to/app.json"}"#;
+        let config: GcsConfig = serde_json::from_str(config_json).unwrap();
         assert_eq!(
             Some("/path/to/app.json".to_string()),
             config.credential_path
         );
+    }
 
-        // Test allow_anonymous aliases
-        let skip_sig_config = r#"{"google_skip_signature": true}"#;
-        let config: GcsConfig = serde_json::from_str(skip_sig_config).unwrap();
+    #[test]
+    fn test_allow_anonymous_aliases() {
+        // Test google_skip_signature alias
+        let config_json = r#"{"google_skip_signature": true}"#;
+        let config: GcsConfig = serde_json::from_str(config_json).unwrap();
         assert!(config.allow_anonymous);
 
-        let skip_alias_config = r#"{"skip_signature": true}"#;
-        let config: GcsConfig = serde_json::from_str(skip_alias_config).unwrap();
+        // Test skip_signature alias
+        let config_json = r#"{"skip_signature": true}"#;
+        let config: GcsConfig = serde_json::from_str(config_json).unwrap();
         assert!(config.allow_anonymous);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds serde aliases to GcsConfig fields to support multiple configuration key naming conventions, enabling seamless migration from Arrow object_store and other file system libraries. Users can now use either OpenDAL's native field names or Google-prefixed alternatives.

## Changes

Added `#[serde(alias = "...")]` attributes to 5 key GCS configuration fields, following the exact same patterns used by [Apache Arrow's object_store library](https://github.com/apache/arrow-rs-object-store/blob/main/src/gcp/builder.rs).

### Example Usage

```json
// Original OpenDAL style (still works)
{
  "bucket": "my-bucket",
  "service_account": "/path/to/sa.json",
  "credential": "service-account-key-json"
}

// Google SDK style (now supported!)
{
  "google_bucket": "my-bucket", 
  "google_service_account": "/path/to/sa.json",
  "google_service_account_key": "service-account-key-json"
}
```

## Added Aliases

| OpenDAL Field | Added Aliases | Arrow Reference |
|---------------|---------------|-----------------|
| `bucket` | `google_bucket`, `google_bucket_name`, `bucket_name` | [L156-L160](https://github.com/apache/arrow-rs-object-store/blob/main/src/gcp/builder.rs#L156-L160) |
| `service_account` | `google_service_account`, `google_service_account_path`, `service_account_path` | [L136-L142](https://github.com/apache/arrow-rs-object-store/blob/main/src/gcp/builder.rs#L136-L142) |
| `credential` | `google_service_account_key`, `service_account_key` | [L146-L149](https://github.com/apache/arrow-rs-object-store/blob/main/src/gcp/builder.rs#L146-L149) |
| `credential_path` | `google_application_credentials` | [L164-L165](https://github.com/apache/arrow-rs-object-store/blob/main/src/gcp/builder.rs#L164-L165) |
| `allow_anonymous` | `google_skip_signature`, `skip_signature` | [L167-L168](https://github.com/apache/arrow-rs-object-store/blob/main/src/gcp/builder.rs#L167-L168) |

## Missing Configurations (Future Work)

These Arrow object_store configurations are not yet available in OpenDAL and could be added in future PRs:

### HTTP Client Configuration

| Arrow Configuration | Aliases | Description |
|-------------------|---------|-------------|
| `AllowHttp` | `google_allow_http`, `allow_http` | Allow non-TLS, i.e. non-HTTPS connections |
| `AllowInvalidCertificates` | `google_allow_invalid_certificates`, `allow_invalid_certificates` | Skip certificate validation on HTTPS connections |
| `ConnectTimeout` | `google_connect_timeout`, `connect_timeout` | Timeout for only the connect phase of a client |
| `DefaultContentType` | `google_default_content_type`, `default_content_type` | Default CONTENT_TYPE for uploads |
| `Http1Only` | `google_http1_only`, `http1_only` | Only use HTTP/1 connections |
| `Http2KeepAliveInterval` | `google_http2_keep_alive_interval`, `http2_keep_alive_interval` | Interval for HTTP2 Ping frames to keep connection alive |
| `Http2KeepAliveTimeout` | `google_http2_keep_alive_timeout`, `http2_keep_alive_timeout` | Timeout for receiving keep-alive ping acknowledgement |
| `Http2KeepAliveWhileIdle` | `google_http2_keep_alive_while_idle`, `http2_keep_alive_while_idle` | Enable HTTP2 keep alive pings for idle connections |
| `Http2MaxFrameSize` | `google_http2_max_frame_size`, `http2_max_frame_size` | Sets the maximum frame size for HTTP2 |
| `Http2Only` | `google_http2_only`, `http2_only` | Only use HTTP/2 connections |
| `PoolIdleTimeout` | `google_pool_idle_timeout`, `pool_idle_timeout` | The pool max idle timeout |
| `PoolMaxIdlePerHost` | `google_pool_max_idle_per_host`, `pool_max_idle_per_host` | Maximum number of idle connections per host |
| `ProxyUrl` | `google_proxy_url`, `proxy_url` | HTTP proxy to use for requests |
| `ProxyCaCertificate` | `google_proxy_ca_certificate`, `proxy_ca_certificate` | PEM-formatted CA certificate for proxy connections |
| `ProxyExcludes` | `google_proxy_excludes`, `proxy_excludes` | List of hosts that bypass proxy |
| `RandomizeAddresses` | `google_randomize_addresses`, `randomize_addresses` | Randomize DNS resolution order for load balancing |
| `Timeout` | `google_timeout`, `timeout` | Request timeout (connection to response completion) |
| `UserAgent` | `google_user_agent`, `user_agent` | User-Agent header to be used by this client |

### Notes on Missing Configurations

- **HTTP Client Options**: OpenDAL's GCS service doesn't currently expose low-level HTTP client configurations. These could be valuable for users who need fine-grained control over connection behavior, timeouts, and proxy settings.
- **Proxy Support**: While OpenDAL may have global proxy support, GCS-specific proxy configuration aliases are not available.
- **HTTP Version Control**: Arrow object_store allows forcing HTTP/1 or HTTP/2, which could be useful for compatibility with different GCS endpoints.

## Testing

- ✅ Added comprehensive unit tests covering all aliases
- ✅ All existing GCS tests pass
- ✅ Code compiles without warnings  
- ✅ Clippy passes without issues

## Backward Compatibility

This change is fully backward compatible. All existing configurations continue to work exactly as before, with the new aliases providing additional flexibility.

Similar to #6524