### PR TITLE
feat(services/azblob): support use_fabric_endpoint config

### DIFF
--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -634,7 +634,7 @@ mod tests {
             .container("test-container")
             .account_name("testaccount")
             .use_fabric_endpoint(true);
-        
+
         // Build should succeed with fabric endpoint
         let result = builder.build();
         assert!(result.is_ok());
@@ -646,12 +646,14 @@ mod tests {
         let builder = AzblobBuilder::default()
             .container("test-container")
             .use_fabric_endpoint(true);
-        
+
         // Build should fail without account_name
         let result = builder.build();
         assert!(result.is_err());
         if let Err(e) = result {
-            assert!(e.to_string().contains("use_fabric_endpoint requires account_name"));
+            assert!(e
+                .to_string()
+                .contains("use_fabric_endpoint requires account_name"));
         }
     }
 
@@ -663,12 +665,14 @@ mod tests {
             .account_name("testaccount")
             .endpoint("https://custom.endpoint.com")
             .use_fabric_endpoint(true);
-        
+
         // Build should fail when both are set
         let result = builder.build();
         assert!(result.is_err());
         if let Err(e) = result {
-            assert!(e.to_string().contains("cannot set both endpoint and use_fabric_endpoint"));
+            assert!(e
+                .to_string()
+                .contains("cannot set both endpoint and use_fabric_endpoint"));
         }
     }
 }

--- a/core/src/services/azblob/config.rs
+++ b/core/src/services/azblob/config.rs
@@ -82,7 +82,7 @@ pub struct AzblobConfig {
     /// Supported keys:
     /// - `azure_use_fabric_endpoint`
     /// - `use_fabric_endpoint`
-    #[serde(alias = "azure_use_fabric_endpoint", default)]
+    #[serde(alias = "azure_use_fabric_endpoint")]
     pub use_fabric_endpoint: bool,
 
     /// The maximum batch operations of Azblob service backend.


### PR DESCRIPTION
Support `use_fabric_endpoint` config which will set the endpoint to fabric one instead of windows. This config cannot be set together with the `endpoint` config.