### PR TITLE
chore(layers/fastmetrics): upgrade fastmetrics dependency to v0.4

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2913,9 +2913,9 @@ dependencies = [
 
 [[package]]
 name = "fastmetrics"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "553e4250df074aee64ea2194037451e5506c205b8b9d14345d8cf026d696b39e"
+checksum = "eac771a461b9a329e634c75e6590ee56a045362b53f657be2287398ae9171ddd"
 dependencies = [
  "cfg-if",
  "dtoa",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -400,7 +400,7 @@ prometheus = { version = "0.14", features = ["process"], optional = true }
 # for layers-prometheus-client
 prometheus-client = { version = "0.23.1", optional = true }
 # for fastmetrics
-fastmetrics = { version = "0.3.0", optional = true }
+fastmetrics = { version = "0.4.0", optional = true }
 # for layers-tracing
 tracing = { version = "0.1", optional = true }
 # for layers-dtrace


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

# What changes are included in this PR?

upgrade the fastmetrics dependency to v0.4

# Are there any user-facing changes?
