### PR TITLE
feat(services/opfs): Add `create_dir` support for OPFS

### DIFF
--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -233,6 +233,7 @@ jobs:
           FEATURES=(
             services-azblob
             services-gdrive
+            services-opfs
             services-s3
           )
           rustup target add wasm32-unknown-unknown

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -373,6 +373,7 @@ web-sys = { version = "0.3.77", optional = true, features = [
   "File",
   "FileSystemDirectoryHandle",
   "FileSystemFileHandle",
+  "FileSystemGetDirectoryOptions",
   "FileSystemGetFileOptions",
   "FileSystemWritableFileStream",
   "Navigator",

--- a/core/src/services/opfs/backend.rs
+++ b/core/src/services/opfs/backend.rs
@@ -17,9 +17,11 @@
 
 use std::fmt::Debug;
 use std::sync::Arc;
+use web_sys::FileSystemGetDirectoryOptions;
 
-use crate::raw::Access;
-use crate::raw::AccessorInfo;
+use super::utils::*;
+use crate::raw::*;
+use crate::Result;
 
 /// OPFS Service backend
 #[derive(Default, Debug, Clone)]
@@ -34,15 +36,15 @@ impl Access for OpfsBackend {
 
     type Deleter = ();
 
-    type BlockingReader = ();
-
-    type BlockingWriter = ();
-
-    type BlockingLister = ();
-
-    type BlockingDeleter = ();
-
     fn info(&self) -> Arc<AccessorInfo> {
         Arc::new(AccessorInfo::default())
+    }
+
+    async fn create_dir(&self, path: &str, _: OpCreateDir) -> Result<RpCreateDir> {
+        let opt = FileSystemGetDirectoryOptions::new();
+        opt.set_create(true);
+        get_directory_handle(path, &opt).await?;
+
+        Ok(RpCreateDir::default())
     }
 }

--- a/core/src/services/opfs/core.rs
+++ b/core/src/services/opfs/core.rs
@@ -15,72 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 use std::fmt::Debug;
 
 use wasm_bindgen::JsCast;
-use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;
-use web_sys::window;
 use web_sys::File;
-use web_sys::FileSystemDirectoryHandle;
-use web_sys::FileSystemFileHandle;
-use web_sys::FileSystemGetFileOptions;
 use web_sys::FileSystemWritableFileStream;
 
 use crate::Error;
-use crate::ErrorKind;
 use crate::Result;
 
-fn parse_js_error(msg: JsValue) -> Error {
-    Error::new(
-        ErrorKind::Unexpected,
-        msg.as_string().unwrap_or_else(String::new),
-    )
-}
-
-fn dyn_map_err<T: JsCast>(result: Result<JsValue, JsValue>) -> Result<T, Error> {
-    result.and_then(JsCast::dyn_into).map_err(parse_js_error)
-}
-
-async fn get_handle_by_filename(filename: &str) -> Result<FileSystemFileHandle, Error> {
-    let navigator = window().unwrap().navigator();
-    let storage_manager = navigator.storage();
-    let root: FileSystemDirectoryHandle = JsFuture::from(storage_manager.get_directory())
-        .await
-        .and_then(JsCast::dyn_into)
-        .map_err(parse_js_error)?;
-
-    // maybe the option should be exposed?
-    let opt = FileSystemGetFileOptions::new();
-    opt.set_create(true);
-
-    JsFuture::from(root.get_file_handle_with_options(filename, &opt))
-        .await
-        .and_then(JsCast::dyn_into)
-        .map_err(parse_js_error)
-}
+use super::error::*;
+use super::utils::*;
 
 #[derive(Default, Debug)]
 pub struct OpfsCore {}
 
 impl OpfsCore {
+    #[allow(unused)]
     async fn store_file(&self, file_name: &str, content: &[u8]) -> Result<(), Error> {
         let handle = get_handle_by_filename(file_name).await?;
 
@@ -105,6 +57,7 @@ impl OpfsCore {
         Ok(())
     }
 
+    #[allow(unused)]
     async fn read_file(&self, file_name: &str) -> Result<Vec<u8>, Error> {
         let handle = get_handle_by_filename(file_name).await?;
 

--- a/core/src/services/opfs/error.rs
+++ b/core/src/services/opfs/error.rs
@@ -15,16 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#[cfg(feature = "services-opfs")]
-mod backend;
-#[cfg(feature = "services-opfs")]
-mod core;
+use wasm_bindgen::JsValue;
 
-#[cfg(feature = "services-opfs")]
-mod config;
+use crate::{Error, ErrorKind};
 
-#[cfg(feature = "services-opfs")]
-mod error;
-
-#[cfg(feature = "services-opfs")]
-mod utils;
+pub(crate) fn parse_js_error(msg: JsValue) -> Error {
+    Error::new(
+        ErrorKind::Unexpected,
+        msg.as_string().unwrap_or_else(String::new),
+    )
+}

--- a/core/src/services/opfs/utils.rs
+++ b/core/src/services/opfs/utils.rs
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::Result;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{
+    window, FileSystemDirectoryHandle, FileSystemFileHandle, FileSystemGetDirectoryOptions,
+    FileSystemGetFileOptions,
+};
+
+use super::error::*;
+
+pub(crate) async fn get_root_directory_handle() -> Result<FileSystemDirectoryHandle> {
+    let navigator = window().unwrap().navigator();
+    let storage_manager = navigator.storage();
+    JsFuture::from(storage_manager.get_directory())
+        .await
+        .and_then(JsCast::dyn_into)
+        .map_err(parse_js_error)
+}
+
+pub(crate) async fn get_directory_handle(
+    dir: &str,
+    dir_opt: &FileSystemGetDirectoryOptions,
+) -> Result<FileSystemDirectoryHandle> {
+    let dirs: Vec<&str> = dir.trim_matches('/').split('/').collect();
+
+    let mut handle = get_root_directory_handle().await?;
+    for dir in dirs {
+        handle = JsFuture::from(handle.get_directory_handle_with_options(dir, dir_opt))
+            .await
+            .and_then(JsCast::dyn_into)
+            .map_err(parse_js_error)?;
+    }
+
+    Ok(handle)
+}
+
+pub(crate) async fn get_handle_by_filename(filename: &str) -> Result<FileSystemFileHandle> {
+    let navigator = window().unwrap().navigator();
+    let storage_manager = navigator.storage();
+    let root: FileSystemDirectoryHandle = JsFuture::from(storage_manager.get_directory())
+        .await
+        .and_then(JsCast::dyn_into)
+        .map_err(parse_js_error)?;
+
+    // maybe the option should be exposed?
+    let opt = FileSystemGetFileOptions::new();
+    opt.set_create(true);
+
+    JsFuture::from(root.get_file_handle_with_options(filename, &opt))
+        .await
+        .and_then(JsCast::dyn_into)
+        .map_err(parse_js_error)
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related to #. #5799 

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Implement `create_dir` for `OpfsBackend`
- Update CI for building OPFS service

I don't implement other methods because everything in wasm_bindgen is `!Send` and `!Sync` and I'm not sure if you can accept changing `Send` and `Sync` requirements of traits like `List` and `Write` to `MaybeSend` and `MaybeSync`.


# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
