### PR TITLE
feat: added gdrive shared files params

### DIFF
--- a/core/src/services/gdrive/builder.rs
+++ b/core/src/services/gdrive/builder.rs
@@ -219,6 +219,7 @@ impl Builder for GdriveBuilder {
             core: Arc::new(GdriveCore {
                 info: accessor_info.clone(),
                 root,
+                include_shared_files: self.config.shared_files.unwrap_or_default(),
                 signer: signer.clone(),
                 path_cache: PathCacher::new(GdrivePathQuery::new(accessor_info, signer))
                     .with_lock(),

--- a/core/src/services/gdrive/config.rs
+++ b/core/src/services/gdrive/config.rs
@@ -36,6 +36,8 @@ pub struct GdriveConfig {
     pub client_id: Option<String>,
     /// Client secret for gdrive.
     pub client_secret: Option<String>,
+    /// Enable viewing shared files in list
+    pub shared_files: Option<bool>,
 }
 
 impl Debug for GdriveConfig {


### PR DESCRIPTION
<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# Added shared files query param

Modified the gdrive implementation to allow users to query files shared with their drive

# Are there any user-facing changes?

Add a config option to GdriveConfig to allow this to be used

no breaking changes at this is additive
