### PR TITLE
chore(bindings/nodejs): replace custom sleep with setTimeout in tests

### DIFF
--- a/bindings/nodejs/tests/suites/asyncReadOptions.suite.mjs
+++ b/bindings/nodejs/tests/suites/asyncReadOptions.suite.mjs
@@ -21,8 +21,9 @@ import { randomUUID } from 'node:crypto'
 import { test, describe, expect, assert } from 'vitest'
 import { Writable } from 'node:stream'
 import { finished, pipeline } from 'node:stream/promises'
+import { setTimeout } from 'node:timers/promises'
 
-import { generateBytes, generateFixedBytes, sleep } from '../utils.mjs'
+import { generateBytes, generateFixedBytes } from '../utils.mjs'
 
 /**
  * @param {import("../../index").Operator} op
@@ -108,7 +109,7 @@ export function run(op) {
       const bs = await op.read(filename, { ifModifiedSince: sinceMinus.toISOString() })
       assert.equal(Buffer.compare(bs, content), 0)
 
-      await sleep(1000)
+      await setTimeout(1000)
 
       const sinceAdd = new Date(meta.lastModified)
       sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)
@@ -133,7 +134,7 @@ export function run(op) {
         'ConditionNotMatch',
       )
 
-      await sleep(1000)
+      await setTimeout(1000)
 
       const sinceAdd = new Date(meta.lastModified)
       sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)
@@ -275,7 +276,7 @@ export function run(op) {
       const buf = Buffer.concat(chunks)
       assert.equal(Buffer.compare(buf, content), 0)
 
-      await sleep(1000)
+      await setTimeout(1000)
 
       const sinceAdd = new Date(meta.lastModified)
       sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)
@@ -301,7 +302,7 @@ export function run(op) {
       const bs = Buffer.alloc(content.length)
       await expect(r.read(bs)).rejects.toThrowError('ConditionNotMatch')
 
-      await sleep(1000)
+      await setTimeout(1000)
 
       const sinceAdd = new Date(meta.lastModified)
       sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)

--- a/bindings/nodejs/tests/suites/asyncStatOptions.suite.mjs
+++ b/bindings/nodejs/tests/suites/asyncStatOptions.suite.mjs
@@ -19,8 +19,10 @@
 
 import { randomUUID } from 'node:crypto'
 import { test, describe, expect } from 'vitest'
+import { setTimeout } from 'node:timers/promises'
+
 import { EntryMode } from '../../index.mjs'
-import { generateFixedBytes, sleep } from '../utils.mjs'
+import { generateFixedBytes } from '../utils.mjs'
 
 /**
  * @param {import("../../index").Operator} op
@@ -90,7 +92,7 @@ export function run(op) {
       const metaMinus = await op.stat(filename, { ifModifiedSince: sinceMinus.toISOString() })
       expect(metaMinus.lastModified).toBe(meta.lastModified)
 
-      await sleep(1000)
+      await setTimeout(1000)
 
       const sinceAdd = new Date(meta.lastModified)
       sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)
@@ -120,7 +122,7 @@ export function run(op) {
         'ConditionNotMatch',
       )
 
-      await sleep(1000)
+      await setTimeout(1000)
 
       const sinceAdd = new Date(meta.lastModified)
       sinceAdd.setSeconds(sinceAdd.getSeconds() + 1)

--- a/bindings/nodejs/tests/utils.mjs
+++ b/bindings/nodejs/tests/utils.mjs
@@ -53,7 +53,3 @@ export function loadConfigFromEnv(scheme) {
       .map(([key, value]) => [key.replace(prefix, ''), value]),
   )
 }
-
-export function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Use Node.js built-in setTimeout to replace the custom sleep function.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
