### PR TITLE
chore: prefer Into<String> over ToString

### DIFF
--- a/core/src/types/error.rs
+++ b/core/src/types/error.rs
@@ -351,8 +351,8 @@ impl Error {
     }
 
     /// Add more context in error.
-    pub fn with_context(mut self, key: &'static str, value: impl ToString) -> Self {
-        self.context.push((key, value.to_string()));
+    pub fn with_context(mut self, key: &'static str, value: impl Into<String>) -> Self {
+        self.context.push((key, value.into()));
         self
     }
 


### PR DESCRIPTION
As the constructor, `Into<String>` on `String` just use the value itself, while `ToString` would run another format function.