### PR TITLE
fix(services/cloudflare_kv): Use DEFAULT_SCHEME constant for Cloudflare KV scheme

### DIFF
--- a/core/src/services/cloudflare_kv/backend.rs
+++ b/core/src/services/cloudflare_kv/backend.rs
@@ -23,6 +23,7 @@ use std::time::Duration;
 use bytes::Buf;
 use http::StatusCode;
 
+use super::DEFAULT_SCHEME;
 use crate::raw::*;
 use crate::services::cloudflare_kv::core::CloudflareKvCore;
 use crate::services::cloudflare_kv::delete::CloudflareKvDeleter;
@@ -160,7 +161,7 @@ impl Builder for CloudflareKvBuilder {
                 expiration_ttl: self.config.default_ttl,
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(Scheme::CloudflareKv)
+                    am.set_scheme(DEFAULT_SCHEME)
                         .set_root(&root)
                         .set_native_capability(Capability {
                             create_dir: true,

--- a/core/src/services/cloudflare_kv/mod.rs
+++ b/core/src/services/cloudflare_kv/mod.rs
@@ -16,6 +16,8 @@
 // under the License.
 
 #[cfg(feature = "services-cloudflare-kv")]
+pub(super) const DEFAULT_SCHEME: &str = "cloudflare_kv";
+#[cfg(feature = "services-cloudflare-kv")]
 mod error;
 
 #[cfg(feature = "services-cloudflare-kv")]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

CI Failure: https://github.com/apache/opendal/actions/runs/17570066476/job/49904224657

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
