### PR TITLE
fix(bindings/d): Enhance D bindings build script and tests for OpenDAL

### DIFF
--- a/bindings/d/README.md
+++ b/bindings/d/README.md
@@ -11,6 +11,8 @@ To compile OpenDAL d binding from source code, you need:
 - [dmd/ldc/gdc](https://dlang.org/download)
 
 ```bash
+# Test a specific backend
+export OPENDAL_TEST=memory
 # build libopendal_c (underneath call make -C ../c)
 dub build -b release
 # build and run unit tests

--- a/bindings/d/build.d
+++ b/bindings/d/build.d
@@ -1,42 +1,231 @@
+#!/usr/bin/env dub
+/+ dub.sdl:
+    name "build"
+    dependency "std" version="*"
++/
+
+/**
+ * OpenDAL D Bindings Build Script
+ *
+ * This script builds the OpenDAL C library with specified features
+ * and copies the necessary files for D bindings.
+ *
+ * This script is automatically executed during:
+ *   dub build
+ *   dub test
+ *   dub run
+ *
+ * For manual execution with custom options:
+ *   OPENDAL_TEST=memory dmd -run build.d
+ *   OPENDAL_TEST=fs OPENDAL_VERBOSE=1 dmd -run build.d release
+ */
 module build;
-import std.stdio: writeln;
-import std.path: buildPath;
-import std.process: spawnShell, wait;
-import std.exception;
-import std.file: copy, mkdir, exists;
-import std.conv: to;
+
+import std.stdio : writeln, stderr;
+import std.path : buildPath;
+import std.process : spawnShell, wait, environment;
+import std.exception : enforce;
+import std.file : copy, mkdir, exists;
+import std.conv : to;
+import std.string : startsWith, split, strip, toLower;
+import std.array : join;
+
 
 version (Windows)
     enum staticlib = "opendal_c.lib";
 else
     enum staticlib = "libopendal_c.a";
 
-void main (string[] args)
+struct BuildConfig
 {
-    bool isRelease = args.length > 1 && args[1] == "release";
-    string buildType = isRelease ? "release" : "debug";
+    bool isRelease;
+    string[] services;
+    bool verbose;
+    bool help;
+}
 
-    // Run cargo build
-    auto cargoCmd = "cargo build --manifest-path " ~ buildPath(
-        "..", "c", "Cargo.toml") ~ (isRelease ? " --release" : "");
+void printHelp()
+{
+    writeln("OpenDAL D Bindings Build Script");
+    writeln();
+    writeln("This script is automatically executed during:");
+    writeln("  dub build    - Build the D bindings");
+    writeln("  dub test     - Run unit tests");
+    writeln("  dub run      - Build and run examples");
+    writeln();
+    writeln("Environment Variables (for use with dub commands):");
+    writeln("  OPENDAL_TEST         The service to test (e.g., fs, s3, memory, etc.)");
+    writeln("  OPENDAL_{SERVICE}_*  Service-specific configuration (e.g., OPENDAL_FS_ROOT)");
+    writeln("  OPENDAL_VERBOSE      Set to '1' or 'true' for verbose output");
+    writeln();
+    writeln("Examples with environment variables:");
+    writeln("  OPENDAL_TEST=memory dub build");
+    writeln("  OPENDAL_TEST=fs OPENDAL_FS_ROOT=/tmp/test dub test");
+    writeln("  OPENDAL_TEST=memory OPENDAL_VERBOSE=1 dub build -b release");
+    writeln();
+    writeln("For manual execution with command line options:");
+    writeln("  dmd -run build.d [options]");
+    writeln();
+    writeln("Command line options:");
+    writeln("  release              Build in release mode (default: debug)");
+    writeln("  --verbose            Enable verbose output");
+    writeln("  --help               Show this help message");
+    writeln();
+    writeln("Manual execution examples:");
+    writeln("  OPENDAL_TEST=memory dmd -run build.d");
+    writeln("  OPENDAL_TEST=fs OPENDAL_FS_ROOT=/tmp/test dmd -run build.d release");
+    writeln("  OPENDAL_TEST=fs OPENDAL_FS_ROOT=/tmp OPENDAL_VERBOSE=1 dmd -run build.d release");
+}
+
+BuildConfig parseArgs(string[] args)
+{
+    BuildConfig config;
+    config.services = []; // No default services - user must specify
+
+    // Check environment variables first
+    auto envTest = environment.get("OPENDAL_TEST", "");
+    if (envTest.length > 0)
+    {
+        config.services = [envTest];
+    }
+
+    auto envVerbose = environment.get("OPENDAL_VERBOSE", "");
+    if (envVerbose == "1" || envVerbose.toLower() == "true")
+    {
+        config.verbose = true;
+    }
+
+    foreach (arg; args[1..$])
+    {
+        if (arg == "release")
+        {
+            config.isRelease = true;
+        }
+        else if (arg == "--verbose")
+        {
+            config.verbose = true;
+        }
+        else if (arg == "--help" || arg == "-h")
+        {
+            config.help = true;
+        }
+
+        else
+        {
+            stderr.writeln("Unknown argument: ", arg);
+            stderr.writeln("Use --help for usage information");
+        }
+    }
+
+    return config;
+}
+
+void buildCargoLibrary(BuildConfig config)
+{
+    // Check if services are specified
+    if (config.services.length == 0)
+    {
+        stderr.writeln("Warning: No OpenDAL service specified for testing!");
+        stderr.writeln("Use OPENDAL_TEST environment variable to specify the service to test.");
+        stderr.writeln("Example: OPENDAL_TEST=memory dub build");
+        stderr.writeln("Available services: memory, fs, s3, etc. (see OpenDAL documentation)");
+        stderr.writeln();
+        stderr.writeln("Building with only core functionality (no storage backends)...");
+    }
+
+    // Build features list
+    string[] features = ["opendal/blocking"];
+    foreach (service; config.services)
+    {
+        features ~= "opendal/services-" ~ service.strip();
+    }
+
+    // Construct cargo command
+    auto cargoCmd = "cargo build --manifest-path " ~ buildPath("..", "c", "Cargo.toml");
+
+    if (config.isRelease)
+        cargoCmd ~= " --release";
+
+    cargoCmd ~= " --features \"" ~ features.join(",") ~ "\"";
+
+    if (config.verbose)
+        cargoCmd ~= " --verbose";
+
+    writeln("Building OpenDAL C library...");
+    writeln("Features: ", features.join(", "));
+    if (config.verbose)
+        writeln("Command: ", cargoCmd);
 
     auto status = wait(spawnShell(cargoCmd));
-    if (status != 0)
-    {
-        throw new Exception("Cargo build failed with status: " ~ status.to!string);
-    }
-    else
-    {
-        writeln("Cargo build completed successfully");
-    }
+    enforce(status == 0, "Cargo build failed with status: " ~ status.to!string);
 
-    // Get opendal.h
-    copy(buildPath("..", "c", "include", "opendal.h"), buildPath("source", "opendal", "opendal.h"));
+    writeln("✓ Cargo build completed successfully");
+}
 
-    // Get libopendal_c.a
-    auto libPath = buildPath("..", "c", "target", buildType, staticlib);
-    writeln("Copying ", libPath, " to ", buildPath("lib", staticlib));
+void copyArtifacts(BuildConfig config)
+{
+    string buildType = config.isRelease ? "release" : "debug";
+
+    writeln("Copying build artifacts...");
+
+    // Copy header file
+    auto headerSrc = buildPath("..", "c", "include", "opendal.h");
+    auto headerDst = buildPath("source", "opendal", "opendal.h");
+
+    if (config.verbose)
+        writeln("Copying header: ", headerSrc, " -> ", headerDst);
+
+    copy(headerSrc, headerDst);
+
+    // Ensure lib directory exists
     if (!exists("lib"))
-        mkdir ("lib");
-    copy(libPath, buildPath("lib", staticlib));
+    {
+        if (config.verbose)
+            writeln("Creating lib directory");
+        mkdir("lib");
+    }
+
+    // Copy static library
+    auto libSrc = buildPath("..", "c", "target", buildType, staticlib);
+    auto libDst = buildPath("lib", staticlib);
+
+    if (config.verbose)
+        writeln("Copying library: ", libSrc, " -> ", libDst);
+
+    copy(libSrc, libDst);
+
+    writeln("✓ Build artifacts copied successfully");
+}
+
+void main(string[] args)
+{
+    try
+    {
+        auto config = parseArgs(args);
+
+        if (config.help)
+        {
+            printHelp();
+            return;
+        }
+
+        writeln("OpenDAL D Bindings Build");
+        writeln("========================");
+        writeln("Build mode: ", config.isRelease ? "release" : "debug");
+        writeln("Services: ", config.services.join(", "));
+        writeln();
+
+        buildCargoLibrary(config);
+        copyArtifacts(config);
+
+        writeln();
+        writeln("✓ Build completed successfully!");
+        writeln("Ready for: dub build, dub test, or dub run");
+    }
+    catch (Exception e)
+    {
+        stderr.writeln("❌ Build failed: ", e.msg);
+        import core.stdc.stdlib : exit;
+        exit(1);
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related #6340.

<b>This PR was primarily authored with Kiro using Claude Sonnet 4 and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.</b>

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

CI failure: https://github.com/apache/opendal/actions/runs/17574060053/job/49915435369

The original test used the `fs` backend in the test, but the c-bindings do not have the fs backend enabled by default, so the test failed.

https://github.com/apache/opendal/blob/5e074cc49bc7662c790d88fb9be31e7c67899d64/bindings/d/source/opendal/package.d#L56

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

 - Enhanced the D bindings build script (‎`build.d`) to support automatic configuration of test backends and build options via environment variables and command-line arguments, with improved help messages and error handling.
 - Improved D bindings unit tests (‎`package.d`) to automatically read test backend and related configuration from environment variables, making test cases more generic and extensible, and added resource cleanup logic.
 - Updated ‎`README.md` with instructions on compiling and testing D bindings using environment variables and command-line options.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
