### PR TITLE
chore(core): typo: update comments on `BytesRange::new`

### DIFF
--- a/core/examples/basic/src/main.rs
+++ b/core/examples/basic/src/main.rs
@@ -25,6 +25,7 @@ async fn example(op: Operator) -> Result<()> {
 
     // Read data from s3.
     let bs = op.read("test.txt").await?;
+
     println!("read: {}", String::from_utf8(bs.to_vec()).unwrap());
 
     // Fetch metadata of s3.

--- a/core/src/raw/http_util/bytes_range.rs
+++ b/core/src/raw/http_util/bytes_range.rs
@@ -53,10 +53,10 @@ impl BytesRange {
     ///
     /// # Note
     ///
-    /// The behavior for `None` and `Some(0)` is different.
+    /// The behavior for `None` and `Some` of `size` is different.
     ///
-    /// - offset=None => `bytes=-<size>`, read `<size>` bytes from end.
-    /// - offset=Some(0) => `bytes=0-<size>`, read `<size>` bytes from start.
+    /// - size=None => `bytes=<offset>-`, read from `<offset>` until the end
+    /// - size=Some(1024) => `bytes=<offset>-<offset + 1024>`, read 1024 bytes starting from the `<offset>`
     pub fn new(offset: u64, size: Option<u64>) -> Self {
         BytesRange(offset, size)
     }


### PR DESCRIPTION
1. typo: update comments on `BytesRange::new`

# Which issue does this PR close?

Closes #.

# Rationale for this change

update comments

# What changes are included in this PR?

update comments

# Are there any user-facing changes?

nope

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
