### PR TITLE
ci: Fix default branch name in Ruby release workflow

### DIFF
--- a/.github/workflows/release_ruby.yml
+++ b/.github/workflows/release_ruby.yml
@@ -145,7 +145,7 @@ jobs:
 
   publish:
     if: >-
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-'))
     needs: [build, build-native]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes the default branch name in the workflow
