### PR TITLE
feat(services/s3): add support for HTTP 429 TooManyRequests for S3-compatible services

### DIFF
--- a/core/src/services/s3/error.rs
+++ b/core/src/services/s3/error.rs
@@ -47,6 +47,7 @@ pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
         // Client Disconnect, we should retry it.
         499 => (ErrorKind::Unexpected, true),
         500 | 502 | 503 | 504 => (ErrorKind::Unexpected, true),
+        429 => (ErrorKind::RateLimited, true),
         _ => (ErrorKind::Unexpected, false),
     };
 
@@ -114,6 +115,10 @@ pub fn parse_s3_error_code(code: &str) -> Option<(ErrorKind, bool)> {
         // indicates a temporary issue with the service or server, such as high load,
         // maintenance, or an internal problem.
         "ServiceUnavailable" => Some((ErrorKind::Unexpected, true)),
+        // > Too Many Requests - rate limit exceeded.
+        //
+        // It's Ok to retry since later on the request rate may get reduced.
+        "TooManyRequests" => Some((ErrorKind::RateLimited, true)),
         _ => None,
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/6588

# Rationale for this change

OpenDAL's S3 service currently only handles AWS S3's rate limiting pattern (HTTP 503 with "SlowDown" error code). Many S3-compatible services like Oracle Cloud Infrastructure Object Storage, Scaleway, and others return HTTP 429 with "TooManyRequests" error codes .

When these services return HTTP 429, OpenDAL classifies them as non-retryable `ErrorKind::Unexpected` errors, causing applications to fail permanently instead of implementing proper retry logic with exponential backoff. This breaks rate limiting functionality for users of S3-compatible services.

# What changes are included in this PR?

- Add HTTP 429 status code mapping to `ErrorKind::RateLimited` in the `parse_error()` function
- Add "TooManyRequests" S3 error code mapping to `ErrorKind::RateLimited` in the `parse_s3_error_code()` function
- Both mappings mark errors as retryable (`true`) to enable proper retry behavior

