### PR TITLE
fix(azblob): don't call AzureStorageConfig::from_env on wasm

### DIFF
--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -326,6 +326,9 @@ impl Builder for AzblobBuilder {
         }?;
         debug!("backend use endpoint {}", &container);
 
+        #[cfg(target_arch = "wasm32")]
+        let mut config_loader = AzureStorageConfig::default();
+        #[cfg(not(target_arch = "wasm32"))]
         let mut config_loader = AzureStorageConfig::default().from_env();
 
         if let Some(v) = self


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/6593

# What changes are included in this PR?

Gated the `AzblobConfig::from_env` behind a `#[cfg(not(target_arch = "wasm32"))]`

# Are there any user-facing changes?

No. I don't believe the functionality of loading the azblob backend from environment variables can ever work in the browser.