### PR TITLE
fix(integrations/unftp-sbe): properly shutdown after write

### DIFF
--- a/integrations/unftp-sbe/src/lib.rs
+++ b/integrations/unftp-sbe/src/lib.rs
@@ -212,7 +212,13 @@ impl<User: UserDetail> StorageBackend<User> for OpendalStorage {
             .into_futures_async_write()
             .compat_write();
         let len = tokio::io::copy(&mut input, &mut w).await?;
-        w.shutdown().await.map_err(convert_err)?;
+        w.shutdown().await.map_err(|e| {
+            Error::new(
+                storage::ErrorKind::LocalError,
+                format!("Failed to shutdown writer: {}", e),
+            )
+        })?;
+
         Ok(len)
     }
 

--- a/integrations/unftp-sbe/src/lib.rs
+++ b/integrations/unftp-sbe/src/lib.rs
@@ -212,7 +212,7 @@ impl<User: UserDetail> StorageBackend<User> for OpendalStorage {
             .into_futures_async_write()
             .compat_write();
         let len = tokio::io::copy(&mut input, &mut w).await?;
-        w.shutdown().await.unwrap();
+        w.shutdown().await.map_err(convert_err)?;
         Ok(len)
     }
 

--- a/integrations/unftp-sbe/src/lib.rs
+++ b/integrations/unftp-sbe/src/lib.rs
@@ -211,15 +211,26 @@ impl<User: UserDetail> StorageBackend<User> for OpendalStorage {
             .map_err(convert_err)?
             .into_futures_async_write()
             .compat_write();
-        let len = tokio::io::copy(&mut input, &mut w).await?;
-        w.shutdown().await.map_err(|e| {
-            Error::new(
+        let copy_result = tokio::io::copy(&mut input, &mut w).await;
+        let shutdown_result = w.shutdown().await;
+        match (copy_result, shutdown_result) {
+            (Ok(len), Ok(())) => Ok(len),
+            (Err(copy_err), Ok(())) => Err(Error::new(
                 storage::ErrorKind::LocalError,
-                format!("Failed to shutdown writer: {}", e),
-            )
-        })?;
-
-        Ok(len)
+                format!("Failed to copy data: {}", copy_err),
+            )),
+            (Ok(_), Err(shutdown_err)) => Err(Error::new(
+                storage::ErrorKind::LocalError,
+                format!("Failed to shutdown writer: {}", shutdown_err),
+            )),
+            (Err(copy_err), Err(shutdown_err)) => Err(Error::new(
+                storage::ErrorKind::LocalError,
+                format!(
+                    "Failed to copy data: {} AND failed to shutdown writer: {}",
+                    copy_err, shutdown_err
+                ),
+            )),
+        }
     }
 
     async fn del<P: AsRef<Path> + Send + Debug>(&self, _: &User, path: P) -> storage::Result<()> {

--- a/integrations/unftp-sbe/src/lib.rs
+++ b/integrations/unftp-sbe/src/lib.rs
@@ -62,7 +62,7 @@ use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
 use libunftp::auth::UserDetail;
-use libunftp::storage::{self, StorageBackend};
+use libunftp::storage::{self, Error, StorageBackend};
 use opendal::Operator;
 
 use tokio::io::AsyncWriteExt;

--- a/integrations/unftp-sbe/src/lib.rs
+++ b/integrations/unftp-sbe/src/lib.rs
@@ -66,6 +66,7 @@ use libunftp::storage::{self, StorageBackend};
 use opendal::Operator;
 
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
+use tokio::io::AsyncWriteExt;
 
 #[derive(Debug, Clone)]
 pub struct OpendalStorage {
@@ -211,6 +212,7 @@ impl<User: UserDetail> StorageBackend<User> for OpendalStorage {
             .into_futures_async_write()
             .compat_write();
         let len = tokio::io::copy(&mut input, &mut w).await?;
+        w.shutdown().await.unwrap();
         Ok(len)
     }
 

--- a/integrations/unftp-sbe/src/lib.rs
+++ b/integrations/unftp-sbe/src/lib.rs
@@ -65,8 +65,8 @@ use libunftp::auth::UserDetail;
 use libunftp::storage::{self, StorageBackend};
 use opendal::Operator;
 
-use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 use tokio::io::AsyncWriteExt;
+use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 
 #[derive(Debug, Clone)]
 pub struct OpendalStorage {


### PR DESCRIPTION
The previous implem was not working: files were not being written to the object
storage, and writing was failing silently, with a warning from opendal.

The compat writer should be shutdown properly after write, as detailed in
https://github.com/apache/opendal/issues/4926.

This is the only simple change this PR proposes.
