### PR TITLE
fix(integrations/cloud_filter): upgrade cloud_filter to resolve CI failures after Rust 1.90.0

### DIFF
--- a/bin/ofs/Cargo.lock
+++ b/bin/ofs/Cargo.lock
@@ -270,9 +270,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cloud-filter"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1539aee4f516aaa087c746280d5c6de8ade13223562de7b4bdda5af1f6819289"
+checksum = "e14c1f7a726923ec7bb56faa4ef71b8e7be56b98f2bb8e406d35cb7e5efe7894"
 dependencies = [
  "flagset",
  "memoffset",

--- a/bin/ofs/Cargo.toml
+++ b/bin/ofs/Cargo.toml
@@ -51,7 +51,7 @@ libc = "0.2.154"
 nix = { version = "0.30.1", features = ["user"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-cloud-filter = { version = "0.0.5" }
+cloud-filter = { version = "0.0.6" }
 cloud_filter_opendal = { version = "0.0.12", path = "../../integrations/cloud_filter" }
 
 [features]

--- a/bin/ofs/DEPENDENCIES.rust.tsv
+++ b/bin/ofs/DEPENDENCIES.rust.tsv
@@ -1,246 +1,246 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-addr2line@0.24.2		X								X			
-adler2@2.0.0	X	X								X			
-aho-corasick@1.1.3										X		X	
-android-tzdata@0.1.1		X								X			
-android_system_properties@0.1.5		X								X			
-anstream@0.6.18		X								X			
-anstyle@1.0.10		X								X			
-anstyle-parse@0.2.6		X								X			
-anstyle-query@1.1.2		X								X			
-anstyle-wincon@3.0.7		X								X			
-anyhow@1.0.98		X								X			
-async-notify@0.3.0										X			
-async-trait@0.1.88		X								X			
-autocfg@1.4.0		X								X			
-backon@1.5.0		X											
-backtrace@0.3.75		X								X			
-base64@0.22.1		X								X			
-bincode@1.3.3										X			
-bitflags@2.9.1		X								X			
-block-buffer@0.10.4		X								X			
-bumpalo@3.17.0		X								X			
-bytes@1.10.1										X			
-cc@1.2.23		X								X			
-cfg-if@1.0.0		X								X			
-cfg_aliases@0.2.1										X			
-chrono@0.4.41		X								X			
-clap@4.5.40		X								X			
-clap_builder@4.5.40		X								X			
-clap_derive@4.5.40		X								X			
-clap_lex@0.7.4		X								X			
-cloud-filter@0.0.5										X			
-cloud_filter_opendal@0.0.12		X											
-colorchoice@1.0.3		X								X			
-concurrent-queue@2.5.0		X								X			
-const-oid@0.9.6		X								X			
-core-foundation-sys@0.8.7		X								X			
-cpufeatures@0.2.17		X								X			
-crc32c@0.6.8		X								X			
-crossbeam-utils@0.8.21		X								X			
-crypto-common@0.1.6		X								X			
-deranged@0.4.0		X								X			
-digest@0.10.7		X								X			
-displaydoc@0.2.5		X								X			
-dotenvy@0.15.7										X			
-either@1.15.0		X								X			
-env_filter@0.1.3		X								X			
-errno@0.3.12		X								X			
-event-listener@4.0.3		X								X			
-fastrand@2.3.0		X								X			
-flagset@0.4.7		X											
-fnv@1.0.7		X								X			
-form_urlencoded@1.2.1		X								X			
-fuse3@0.8.1										X			
-fuse3_opendal@0.0.19		X											
-futures@0.3.31		X								X			
-futures-channel@0.3.31		X								X			
-futures-core@0.3.31		X								X			
-futures-executor@0.3.31		X								X			
-futures-io@0.3.31		X								X			
-futures-macro@0.3.31		X								X			
-futures-sink@0.3.31		X								X			
-futures-task@0.3.31		X								X			
-futures-util@0.3.31		X								X			
-generic-array@0.14.7										X			
-getrandom@0.2.16		X								X			
-getrandom@0.3.3		X								X			
-gimli@0.31.1		X								X			
-gloo-timers@0.3.0		X								X			
-heck@0.5.0		X								X			
-hex@0.4.3		X								X			
-hmac@0.12.1		X								X			
-home@0.5.11		X								X			
-http@1.3.1		X								X			
-http-body@1.0.1										X			
-http-body-util@0.1.3										X			
-httparse@1.10.1		X								X			
-hyper@1.6.0										X			
-hyper-rustls@0.27.5		X						X		X			
-hyper-util@0.1.12										X			
-iana-time-zone@0.1.63		X								X			
-iana-time-zone-haiku@0.1.2		X								X			
-icu_collections@2.0.0											X		
-icu_locale_core@2.0.0											X		
-icu_normalizer@2.0.0											X		
-icu_normalizer_data@2.0.0											X		
-icu_properties@2.0.1											X		
-icu_properties_data@2.0.1											X		
-icu_provider@2.0.0											X		
-idna@1.0.3		X								X			
-idna_adapter@1.2.1		X								X			
-io-uring@0.7.8		X								X			
-ipnet@2.11.0		X								X			
-iri-string@0.7.8		X								X			
-is_terminal_polyfill@1.70.1		X								X			
-itoa@1.0.15		X								X			
-jiff@0.2.14										X		X	
-jiff-tzdb@0.1.4										X		X	
-jiff-tzdb-platform@0.1.3										X		X	
-js-sys@0.3.77		X								X			
-lazy_static@1.5.0		X								X			
-libc@0.2.172		X								X			
-linux-raw-sys@0.4.15		X	X							X			
-litemap@0.8.0											X		
-log@0.4.27		X								X			
-logforth@0.27.0		X											
-md-5@0.10.6		X								X			
-memchr@2.7.4										X		X	
-memoffset@0.9.1										X			
+addr2line@0.24.2		X								X
+adler2@2.0.0	X	X								X
+aho-corasick@1.1.3										X		X
+android-tzdata@0.1.1		X								X
+android_system_properties@0.1.5		X								X
+anstream@0.6.18		X								X
+anstyle@1.0.10		X								X
+anstyle-parse@0.2.6		X								X
+anstyle-query@1.1.2		X								X
+anstyle-wincon@3.0.7		X								X
+anyhow@1.0.98		X								X
+async-notify@0.3.0										X
+async-trait@0.1.88		X								X
+autocfg@1.4.0		X								X
+backon@1.5.0		X
+backtrace@0.3.75		X								X
+base64@0.22.1		X								X
+bincode@1.3.3										X
+bitflags@2.9.1		X								X
+block-buffer@0.10.4		X								X
+bumpalo@3.17.0		X								X
+bytes@1.10.1										X
+cc@1.2.23		X								X
+cfg-if@1.0.0		X								X
+cfg_aliases@0.2.1										X
+chrono@0.4.41		X								X
+clap@4.5.40		X								X
+clap_builder@4.5.40		X								X
+clap_derive@4.5.40		X								X
+clap_lex@0.7.4		X								X
+cloud-filter@0.0.6										X
+cloud_filter_opendal@0.0.12		X
+colorchoice@1.0.3		X								X
+concurrent-queue@2.5.0		X								X
+const-oid@0.9.6		X								X
+core-foundation-sys@0.8.7		X								X
+cpufeatures@0.2.17		X								X
+crc32c@0.6.8		X								X
+crossbeam-utils@0.8.21		X								X
+crypto-common@0.1.6		X								X
+deranged@0.4.0		X								X
+digest@0.10.7		X								X
+displaydoc@0.2.5		X								X
+dotenvy@0.15.7										X
+either@1.15.0		X								X
+env_filter@0.1.3		X								X
+errno@0.3.12		X								X
+event-listener@4.0.3		X								X
+fastrand@2.3.0		X								X
+flagset@0.4.7		X
+fnv@1.0.7		X								X
+form_urlencoded@1.2.1		X								X
+fuse3@0.8.1										X
+fuse3_opendal@0.0.19		X
+futures@0.3.31		X								X
+futures-channel@0.3.31		X								X
+futures-core@0.3.31		X								X
+futures-executor@0.3.31		X								X
+futures-io@0.3.31		X								X
+futures-macro@0.3.31		X								X
+futures-sink@0.3.31		X								X
+futures-task@0.3.31		X								X
+futures-util@0.3.31		X								X
+generic-array@0.14.7										X
+getrandom@0.2.16		X								X
+getrandom@0.3.3		X								X
+gimli@0.31.1		X								X
+gloo-timers@0.3.0		X								X
+heck@0.5.0		X								X
+hex@0.4.3		X								X
+hmac@0.12.1		X								X
+home@0.5.11		X								X
+http@1.3.1		X								X
+http-body@1.0.1										X
+http-body-util@0.1.3										X
+httparse@1.10.1		X								X
+hyper@1.6.0										X
+hyper-rustls@0.27.5		X						X		X
+hyper-util@0.1.12										X
+iana-time-zone@0.1.63		X								X
+iana-time-zone-haiku@0.1.2		X								X
+icu_collections@2.0.0											X
+icu_locale_core@2.0.0											X
+icu_normalizer@2.0.0											X
+icu_normalizer_data@2.0.0											X
+icu_properties@2.0.1											X
+icu_properties_data@2.0.1											X
+icu_provider@2.0.0											X
+idna@1.0.3		X								X
+idna_adapter@1.2.1		X								X
+io-uring@0.7.8		X								X
+ipnet@2.11.0		X								X
+iri-string@0.7.8		X								X
+is_terminal_polyfill@1.70.1		X								X
+itoa@1.0.15		X								X
+jiff@0.2.14										X		X
+jiff-tzdb@0.1.4										X		X
+jiff-tzdb-platform@0.1.3										X		X
+js-sys@0.3.77		X								X
+lazy_static@1.5.0		X								X
+libc@0.2.172		X								X
+linux-raw-sys@0.4.15		X	X							X
+litemap@0.8.0											X
+log@0.4.27		X								X
+logforth@0.27.0		X
+md-5@0.10.6		X								X
+memchr@2.7.4										X		X
+memoffset@0.9.1										X
 miniz_oxide@0.8.8		X								X			X
-mio@1.0.3										X			
-nix@0.29.0										X			
-nix@0.30.1										X			
-nt-time@0.8.1		X								X			
-num-conv@0.1.0		X								X			
-num-traits@0.2.19		X								X			
-object@0.36.7		X								X			
-ofs@0.0.24		X											
-once_cell@1.21.3		X								X			
-opendal@0.54.1		X											
-parking@2.2.1		X								X			
-percent-encoding@2.3.1		X								X			
-pin-project-lite@0.2.16		X								X			
-pin-utils@0.1.0		X								X			
-portable-atomic@1.11.0		X								X			
-portable-atomic-util@0.2.4		X								X			
-potential_utf@0.1.2											X		
-powerfmt@0.2.0		X								X			
-ppv-lite86@0.2.21		X								X			
-proc-macro2@1.0.95		X								X			
-quick-xml@0.37.5										X			
-quick-xml@0.38.0										X			
-quote@1.0.40		X								X			
-r-efi@5.2.0		X							X	X			
-rand@0.8.5		X								X			
-rand_chacha@0.3.1		X								X			
-rand_core@0.6.4		X								X			
-regex@1.11.1		X								X			
-regex-automata@0.4.9		X								X			
-regex-syntax@0.8.5		X								X			
-reqsign@0.16.5		X											
-reqwest@0.12.22		X								X			
-ring@0.17.14		X						X					
-rustc-demangle@0.1.24		X								X			
-rustc_version@0.4.1		X								X			
-rustix@0.38.44		X	X							X			
-rustls@0.23.27		X						X		X			
-rustls-pki-types@1.12.0		X								X			
-rustls-webpki@0.103.3								X					
-rustversion@1.0.20		X								X			
-ryu@1.0.20		X				X							
-semver@1.0.26		X								X			
-serde@1.0.219		X								X			
-serde_derive@1.0.219		X								X			
-serde_json@1.0.140		X								X			
-serde_urlencoded@0.7.1		X								X			
-sha1@0.10.6		X								X			
-sha2@0.10.9		X								X			
-sharded-slab@0.1.7										X			
-shlex@1.3.0		X								X			
-signal-hook-registry@1.4.5		X								X			
-slab@0.4.9										X			
-smallvec@1.15.0		X								X			
-socket2@0.5.9		X								X			
-socket2@0.6.0		X								X			
-stable_deref_trait@1.2.0		X								X			
-strsim@0.11.1										X			
-subtle@2.6.1					X								
-syn@2.0.101		X								X			
-sync_wrapper@1.0.2		X											
-synstructure@0.13.2										X			
-time@0.3.41		X								X			
-time-core@0.1.4		X								X			
-time-macros@0.2.22		X								X			
-tinystr@0.8.1											X		
-tokio@1.47.0										X			
-tokio-macros@2.5.0										X			
-tokio-rustls@0.26.2		X								X			
-tokio-util@0.7.15										X			
-tower@0.5.2										X			
-tower-http@0.6.6										X			
-tower-layer@0.3.3										X			
-tower-service@0.3.3										X			
-tracing@0.1.41										X			
-tracing-attributes@0.1.28										X			
-tracing-core@0.1.33										X			
-trait-make@0.1.0		X								X			
-try-lock@0.2.5										X			
-typenum@1.18.0		X								X			
-unicode-ident@1.0.18		X								X	X		
-untrusted@0.9.0								X					
-url@2.5.4		X								X			
-utf8_iter@1.0.4		X								X			
-utf8parse@0.2.2		X								X			
-uuid@1.17.0		X								X			
-version_check@0.9.5		X								X			
-want@0.3.1										X			
-wasi@0.11.0+wasi-snapshot-preview1		X	X							X			
-wasi@0.14.2+wasi-0.2.4		X	X							X			
-wasm-bindgen@0.2.100		X								X			
-wasm-bindgen-backend@0.2.100		X								X			
-wasm-bindgen-futures@0.4.50		X								X			
-wasm-bindgen-macro@0.2.100		X								X			
-wasm-bindgen-macro-support@0.2.100		X								X			
-wasm-bindgen-shared@0.2.100		X								X			
-wasm-streams@0.4.2		X								X			
-web-sys@0.3.77		X								X			
-webpki-roots@0.26.11							X						
-webpki-roots@1.0.0							X						
-which@6.0.3										X			
-widestring@1.2.0		X								X			
-windows@0.58.0		X								X			
-windows-core@0.58.0		X								X			
-windows-core@0.61.2		X								X			
-windows-implement@0.58.0		X								X			
-windows-implement@0.60.0		X								X			
-windows-interface@0.58.0		X								X			
-windows-interface@0.59.1		X								X			
-windows-link@0.1.1		X								X			
-windows-result@0.2.0		X								X			
-windows-result@0.3.4		X								X			
-windows-strings@0.1.0		X								X			
-windows-strings@0.4.2		X								X			
-windows-sys@0.52.0		X								X			
-windows-sys@0.59.0		X								X			
-windows-targets@0.52.6		X								X			
-windows_aarch64_gnullvm@0.52.6		X								X			
-windows_aarch64_msvc@0.52.6		X								X			
-windows_i686_gnu@0.52.6		X								X			
-windows_i686_gnullvm@0.52.6		X								X			
-windows_i686_msvc@0.52.6		X								X			
-windows_x86_64_gnu@0.52.6		X								X			
-windows_x86_64_gnullvm@0.52.6		X								X			
-windows_x86_64_msvc@0.52.6		X								X			
-winsafe@0.0.19										X			
-wit-bindgen-rt@0.39.0		X	X							X			
-writeable@0.6.1											X		
-yoke@0.8.0											X		
-yoke-derive@0.8.0											X		
-zerocopy@0.8.25		X		X						X			
-zerofrom@0.1.6											X		
-zerofrom-derive@0.1.6											X		
-zeroize@1.8.1		X								X			
-zerotrie@0.2.2											X		
-zerovec@0.11.2											X		
-zerovec-derive@0.11.1											X		
+mio@1.0.3										X
+nix@0.29.0										X
+nix@0.30.1										X
+nt-time@0.8.1		X								X
+num-conv@0.1.0		X								X
+num-traits@0.2.19		X								X
+object@0.36.7		X								X
+ofs@0.0.24		X
+once_cell@1.21.3		X								X
+opendal@0.54.1		X
+parking@2.2.1		X								X
+percent-encoding@2.3.1		X								X
+pin-project-lite@0.2.16		X								X
+pin-utils@0.1.0		X								X
+portable-atomic@1.11.0		X								X
+portable-atomic-util@0.2.4		X								X
+potential_utf@0.1.2											X
+powerfmt@0.2.0		X								X
+ppv-lite86@0.2.21		X								X
+proc-macro2@1.0.95		X								X
+quick-xml@0.37.5										X
+quick-xml@0.38.0										X
+quote@1.0.40		X								X
+r-efi@5.2.0		X							X	X
+rand@0.8.5		X								X
+rand_chacha@0.3.1		X								X
+rand_core@0.6.4		X								X
+regex@1.11.1		X								X
+regex-automata@0.4.9		X								X
+regex-syntax@0.8.5		X								X
+reqsign@0.16.5		X
+reqwest@0.12.22		X								X
+ring@0.17.14		X						X
+rustc-demangle@0.1.24		X								X
+rustc_version@0.4.1		X								X
+rustix@0.38.44		X	X							X
+rustls@0.23.27		X						X		X
+rustls-pki-types@1.12.0		X								X
+rustls-webpki@0.103.3								X
+rustversion@1.0.20		X								X
+ryu@1.0.20		X				X
+semver@1.0.26		X								X
+serde@1.0.219		X								X
+serde_derive@1.0.219		X								X
+serde_json@1.0.140		X								X
+serde_urlencoded@0.7.1		X								X
+sha1@0.10.6		X								X
+sha2@0.10.9		X								X
+sharded-slab@0.1.7										X
+shlex@1.3.0		X								X
+signal-hook-registry@1.4.5		X								X
+slab@0.4.9										X
+smallvec@1.15.0		X								X
+socket2@0.5.9		X								X
+socket2@0.6.0		X								X
+stable_deref_trait@1.2.0		X								X
+strsim@0.11.1										X
+subtle@2.6.1					X
+syn@2.0.101		X								X
+sync_wrapper@1.0.2		X
+synstructure@0.13.2										X
+time@0.3.41		X								X
+time-core@0.1.4		X								X
+time-macros@0.2.22		X								X
+tinystr@0.8.1											X
+tokio@1.47.0										X
+tokio-macros@2.5.0										X
+tokio-rustls@0.26.2		X								X
+tokio-util@0.7.15										X
+tower@0.5.2										X
+tower-http@0.6.6										X
+tower-layer@0.3.3										X
+tower-service@0.3.3										X
+tracing@0.1.41										X
+tracing-attributes@0.1.28										X
+tracing-core@0.1.33										X
+trait-make@0.1.0		X								X
+try-lock@0.2.5										X
+typenum@1.18.0		X								X
+unicode-ident@1.0.18		X								X	X
+untrusted@0.9.0								X
+url@2.5.4		X								X
+utf8_iter@1.0.4		X								X
+utf8parse@0.2.2		X								X
+uuid@1.17.0		X								X
+version_check@0.9.5		X								X
+want@0.3.1										X
+wasi@0.11.0+wasi-snapshot-preview1		X	X							X
+wasi@0.14.2+wasi-0.2.4		X	X							X
+wasm-bindgen@0.2.100		X								X
+wasm-bindgen-backend@0.2.100		X								X
+wasm-bindgen-futures@0.4.50		X								X
+wasm-bindgen-macro@0.2.100		X								X
+wasm-bindgen-macro-support@0.2.100		X								X
+wasm-bindgen-shared@0.2.100		X								X
+wasm-streams@0.4.2		X								X
+web-sys@0.3.77		X								X
+webpki-roots@0.26.11							X
+webpki-roots@1.0.0							X
+which@6.0.3										X
+widestring@1.2.0		X								X
+windows@0.58.0		X								X
+windows-core@0.58.0		X								X
+windows-core@0.61.2		X								X
+windows-implement@0.58.0		X								X
+windows-implement@0.60.0		X								X
+windows-interface@0.58.0		X								X
+windows-interface@0.59.1		X								X
+windows-link@0.1.1		X								X
+windows-result@0.2.0		X								X
+windows-result@0.3.4		X								X
+windows-strings@0.1.0		X								X
+windows-strings@0.4.2		X								X
+windows-sys@0.52.0		X								X
+windows-sys@0.59.0		X								X
+windows-targets@0.52.6		X								X
+windows_aarch64_gnullvm@0.52.6		X								X
+windows_aarch64_msvc@0.52.6		X								X
+windows_i686_gnu@0.52.6		X								X
+windows_i686_gnullvm@0.52.6		X								X
+windows_i686_msvc@0.52.6		X								X
+windows_x86_64_gnu@0.52.6		X								X
+windows_x86_64_gnullvm@0.52.6		X								X
+windows_x86_64_msvc@0.52.6		X								X
+winsafe@0.0.19										X
+wit-bindgen-rt@0.39.0		X	X							X
+writeable@0.6.1											X
+yoke@0.8.0											X
+yoke-derive@0.8.0											X
+zerocopy@0.8.25		X		X						X
+zerofrom@0.1.6											X
+zerofrom-derive@0.1.6											X
+zeroize@1.8.1		X								X
+zerotrie@0.2.2											X
+zerovec@0.11.2											X
+zerovec-derive@0.11.1											X

--- a/integrations/cloud_filter/Cargo.toml
+++ b/integrations/cloud_filter/Cargo.toml
@@ -32,7 +32,7 @@ default-target = "x86_64-pc-windows-msvc"
 [dependencies]
 anyhow = "1.0.86"
 bincode = "1.3.3"
-cloud-filter = "0.0.5"
+cloud-filter = "0.0.6"
 futures = "0.3.30"
 log = "0.4.17"
 opendal = { version = "0.54.0", path = "../../core" }

--- a/integrations/cloud_filter/DEPENDENCIES.rust.tsv
+++ b/integrations/cloud_filter/DEPENDENCIES.rust.tsv
@@ -1,199 +1,199 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-addr2line@0.24.2		X								X			
-adler2@2.0.1	X	X								X			
-android-tzdata@0.1.1		X								X			
-android_system_properties@0.1.5		X								X			
-anyhow@1.0.98		X								X			
-async-trait@0.1.88		X								X			
-autocfg@1.5.0		X								X			
-backon@1.5.1		X											
-backtrace@0.3.75		X								X			
-base64@0.22.1		X								X			
-bincode@1.3.3										X			
-bitflags@2.9.1		X								X			
-block-buffer@0.10.4		X								X			
-bumpalo@3.19.0		X								X			
-bytes@1.10.1										X			
-cc@1.2.29		X								X			
-cfg-if@1.0.1		X								X			
-chrono@0.4.41		X								X			
-cloud-filter@0.0.5										X			
-cloud_filter_opendal@0.0.12		X											
-const-oid@0.9.6		X								X			
-core-foundation-sys@0.8.7		X								X			
-cpufeatures@0.2.17		X								X			
-crc32c@0.6.8		X								X			
-crypto-common@0.1.6		X								X			
-deranged@0.4.0		X								X			
-digest@0.10.7		X								X			
-displaydoc@0.2.5		X								X			
-dotenvy@0.15.7										X			
-fastrand@2.3.0		X								X			
-flagset@0.4.7		X											
-fnv@1.0.7		X								X			
-form_urlencoded@1.2.1		X								X			
-futures@0.3.31		X								X			
-futures-channel@0.3.31		X								X			
-futures-core@0.3.31		X								X			
-futures-executor@0.3.31		X								X			
-futures-io@0.3.31		X								X			
-futures-macro@0.3.31		X								X			
-futures-sink@0.3.31		X								X			
-futures-task@0.3.31		X								X			
-futures-util@0.3.31		X								X			
-generic-array@0.14.7										X			
-getrandom@0.2.16		X								X			
-getrandom@0.3.3		X								X			
-gimli@0.31.1		X								X			
-gloo-timers@0.3.0		X								X			
-hex@0.4.3		X								X			
-hmac@0.12.1		X								X			
-home@0.5.11		X								X			
-http@1.3.1		X								X			
-http-body@1.0.1										X			
-http-body-util@0.1.3										X			
-httparse@1.10.1		X								X			
-hyper@1.6.0										X			
-hyper-rustls@0.27.7		X						X		X			
-hyper-util@0.1.15										X			
-iana-time-zone@0.1.63		X								X			
-iana-time-zone-haiku@0.1.2		X								X			
-icu_collections@2.0.0											X		
-icu_locale_core@2.0.0											X		
-icu_normalizer@2.0.0											X		
-icu_normalizer_data@2.0.0											X		
-icu_properties@2.0.1											X		
-icu_properties_data@2.0.1											X		
-icu_provider@2.0.0											X		
-idna@1.0.3		X								X			
-idna_adapter@1.2.1		X								X			
-io-uring@0.7.8		X								X			
-ipnet@2.11.0		X								X			
-iri-string@0.7.8		X								X			
-itoa@1.0.15		X								X			
-js-sys@0.3.77		X								X			
-libc@0.2.174		X								X			
-litemap@0.8.0											X		
-log@0.4.27		X								X			
-md-5@0.10.6		X								X			
-memchr@2.7.5										X		X	
-memoffset@0.9.1										X			
+addr2line@0.24.2		X								X
+adler2@2.0.1	X	X								X
+android-tzdata@0.1.1		X								X
+android_system_properties@0.1.5		X								X
+anyhow@1.0.98		X								X
+async-trait@0.1.88		X								X
+autocfg@1.5.0		X								X
+backon@1.5.1		X
+backtrace@0.3.75		X								X
+base64@0.22.1		X								X
+bincode@1.3.3										X
+bitflags@2.9.1		X								X
+block-buffer@0.10.4		X								X
+bumpalo@3.19.0		X								X
+bytes@1.10.1										X
+cc@1.2.29		X								X
+cfg-if@1.0.1		X								X
+chrono@0.4.41		X								X
+cloud-filter@0.0.6										X
+cloud_filter_opendal@0.0.12		X
+const-oid@0.9.6		X								X
+core-foundation-sys@0.8.7		X								X
+cpufeatures@0.2.17		X								X
+crc32c@0.6.8		X								X
+crypto-common@0.1.6		X								X
+deranged@0.4.0		X								X
+digest@0.10.7		X								X
+displaydoc@0.2.5		X								X
+dotenvy@0.15.7										X
+fastrand@2.3.0		X								X
+flagset@0.4.7		X
+fnv@1.0.7		X								X
+form_urlencoded@1.2.1		X								X
+futures@0.3.31		X								X
+futures-channel@0.3.31		X								X
+futures-core@0.3.31		X								X
+futures-executor@0.3.31		X								X
+futures-io@0.3.31		X								X
+futures-macro@0.3.31		X								X
+futures-sink@0.3.31		X								X
+futures-task@0.3.31		X								X
+futures-util@0.3.31		X								X
+generic-array@0.14.7										X
+getrandom@0.2.16		X								X
+getrandom@0.3.3		X								X
+gimli@0.31.1		X								X
+gloo-timers@0.3.0		X								X
+hex@0.4.3		X								X
+hmac@0.12.1		X								X
+home@0.5.11		X								X
+http@1.3.1		X								X
+http-body@1.0.1										X
+http-body-util@0.1.3										X
+httparse@1.10.1		X								X
+hyper@1.6.0										X
+hyper-rustls@0.27.7		X						X		X
+hyper-util@0.1.15										X
+iana-time-zone@0.1.63		X								X
+iana-time-zone-haiku@0.1.2		X								X
+icu_collections@2.0.0											X
+icu_locale_core@2.0.0											X
+icu_normalizer@2.0.0											X
+icu_normalizer_data@2.0.0											X
+icu_properties@2.0.1											X
+icu_properties_data@2.0.1											X
+icu_provider@2.0.0											X
+idna@1.0.3		X								X
+idna_adapter@1.2.1		X								X
+io-uring@0.7.8		X								X
+ipnet@2.11.0		X								X
+iri-string@0.7.8		X								X
+itoa@1.0.15		X								X
+js-sys@0.3.77		X								X
+libc@0.2.174		X								X
+litemap@0.8.0											X
+log@0.4.27		X								X
+md-5@0.10.6		X								X
+memchr@2.7.5										X		X
+memoffset@0.9.1										X
 miniz_oxide@0.8.9		X								X			X
-mio@1.0.4										X			
-nt-time@0.8.1		X								X			
-num-conv@0.1.0		X								X			
-num-traits@0.2.19		X								X			
-object@0.36.7		X								X			
-once_cell@1.21.3		X								X			
-opendal@0.54.1		X											
-percent-encoding@2.3.1		X								X			
-pin-project-lite@0.2.16		X								X			
-pin-utils@0.1.0		X								X			
-potential_utf@0.1.2											X		
-powerfmt@0.2.0		X								X			
-ppv-lite86@0.2.21		X								X			
-proc-macro2@1.0.95		X								X			
-quick-xml@0.37.5										X			
-quick-xml@0.38.0										X			
-quote@1.0.40		X								X			
-r-efi@5.3.0		X							X	X			
-rand@0.8.5		X								X			
-rand_chacha@0.3.1		X								X			
-rand_core@0.6.4		X								X			
-reqsign@0.16.5		X											
-reqwest@0.12.22		X								X			
-ring@0.17.14		X						X					
-rustc-demangle@0.1.25		X								X			
-rustc_version@0.4.1		X								X			
-rustls@0.23.29		X						X		X			
-rustls-pki-types@1.12.0		X								X			
-rustls-webpki@0.103.4								X					
-rustversion@1.0.21		X								X			
-ryu@1.0.20		X				X							
-semver@1.0.26		X								X			
-serde@1.0.219		X								X			
-serde_derive@1.0.219		X								X			
-serde_json@1.0.140		X								X			
-serde_urlencoded@0.7.1		X								X			
-sha1@0.10.6		X								X			
-sha2@0.10.9		X								X			
-shlex@1.3.0		X								X			
-signal-hook-registry@1.4.5		X								X			
-slab@0.4.10										X			
-smallvec@1.15.1		X								X			
-socket2@0.5.10		X								X			
-socket2@0.6.0		X								X			
-stable_deref_trait@1.2.0		X								X			
-subtle@2.6.1					X								
-syn@2.0.104		X								X			
-sync_wrapper@1.0.2		X											
-synstructure@0.13.2										X			
-time@0.3.41		X								X			
-time-core@0.1.4		X								X			
-time-macros@0.2.22		X								X			
-tinystr@0.8.1											X		
-tokio@1.47.1										X			
-tokio-macros@2.5.0										X			
-tokio-rustls@0.26.2		X								X			
-tokio-util@0.7.15										X			
-tower@0.5.2										X			
-tower-http@0.6.6										X			
-tower-layer@0.3.3										X			
-tower-service@0.3.3										X			
-tracing@0.1.41										X			
-tracing-core@0.1.34										X			
-try-lock@0.2.5										X			
-typenum@1.18.0		X								X			
-unicode-ident@1.0.18		X								X	X		
-untrusted@0.9.0								X					
-url@2.5.4		X								X			
-utf8_iter@1.0.4		X								X			
-uuid@1.17.0		X								X			
-version_check@0.9.5		X								X			
-want@0.3.1										X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X							X			
-wasi@0.14.2+wasi-0.2.4		X	X							X			
-wasm-bindgen@0.2.100		X								X			
-wasm-bindgen-backend@0.2.100		X								X			
-wasm-bindgen-futures@0.4.50		X								X			
-wasm-bindgen-macro@0.2.100		X								X			
-wasm-bindgen-macro-support@0.2.100		X								X			
-wasm-bindgen-shared@0.2.100		X								X			
-wasm-streams@0.4.2		X								X			
-web-sys@0.3.77		X								X			
-webpki-roots@1.0.1							X						
-widestring@1.2.0		X								X			
-windows@0.58.0		X								X			
-windows-core@0.58.0		X								X			
-windows-core@0.61.2		X								X			
-windows-implement@0.58.0		X								X			
-windows-implement@0.60.0		X								X			
-windows-interface@0.58.0		X								X			
-windows-interface@0.59.1		X								X			
-windows-link@0.1.3		X								X			
-windows-result@0.2.0		X								X			
-windows-result@0.3.4		X								X			
-windows-strings@0.1.0		X								X			
-windows-strings@0.4.2		X								X			
-windows-sys@0.52.0		X								X			
-windows-sys@0.59.0		X								X			
-windows-targets@0.52.6		X								X			
-windows_aarch64_gnullvm@0.52.6		X								X			
-windows_aarch64_msvc@0.52.6		X								X			
-windows_i686_gnu@0.52.6		X								X			
-windows_i686_gnullvm@0.52.6		X								X			
-windows_i686_msvc@0.52.6		X								X			
-windows_x86_64_gnu@0.52.6		X								X			
-windows_x86_64_gnullvm@0.52.6		X								X			
-windows_x86_64_msvc@0.52.6		X								X			
-wit-bindgen-rt@0.39.0		X	X							X			
-writeable@0.6.1											X		
-yoke@0.8.0											X		
-yoke-derive@0.8.0											X		
-zerocopy@0.8.26		X		X						X			
-zerofrom@0.1.6											X		
-zerofrom-derive@0.1.6											X		
-zeroize@1.8.1		X								X			
-zerotrie@0.2.2											X		
-zerovec@0.11.2											X		
-zerovec-derive@0.11.1											X		
+mio@1.0.4										X
+nt-time@0.8.1		X								X
+num-conv@0.1.0		X								X
+num-traits@0.2.19		X								X
+object@0.36.7		X								X
+once_cell@1.21.3		X								X
+opendal@0.54.1		X
+percent-encoding@2.3.1		X								X
+pin-project-lite@0.2.16		X								X
+pin-utils@0.1.0		X								X
+potential_utf@0.1.2											X
+powerfmt@0.2.0		X								X
+ppv-lite86@0.2.21		X								X
+proc-macro2@1.0.95		X								X
+quick-xml@0.37.5										X
+quick-xml@0.38.0										X
+quote@1.0.40		X								X
+r-efi@5.3.0		X							X	X
+rand@0.8.5		X								X
+rand_chacha@0.3.1		X								X
+rand_core@0.6.4		X								X
+reqsign@0.16.5		X
+reqwest@0.12.22		X								X
+ring@0.17.14		X						X
+rustc-demangle@0.1.25		X								X
+rustc_version@0.4.1		X								X
+rustls@0.23.29		X						X		X
+rustls-pki-types@1.12.0		X								X
+rustls-webpki@0.103.4								X
+rustversion@1.0.21		X								X
+ryu@1.0.20		X				X
+semver@1.0.26		X								X
+serde@1.0.219		X								X
+serde_derive@1.0.219		X								X
+serde_json@1.0.140		X								X
+serde_urlencoded@0.7.1		X								X
+sha1@0.10.6		X								X
+sha2@0.10.9		X								X
+shlex@1.3.0		X								X
+signal-hook-registry@1.4.5		X								X
+slab@0.4.10										X
+smallvec@1.15.1		X								X
+socket2@0.5.10		X								X
+socket2@0.6.0		X								X
+stable_deref_trait@1.2.0		X								X
+subtle@2.6.1					X
+syn@2.0.104		X								X
+sync_wrapper@1.0.2		X
+synstructure@0.13.2										X
+time@0.3.41		X								X
+time-core@0.1.4		X								X
+time-macros@0.2.22		X								X
+tinystr@0.8.1											X
+tokio@1.47.1										X
+tokio-macros@2.5.0										X
+tokio-rustls@0.26.2		X								X
+tokio-util@0.7.15										X
+tower@0.5.2										X
+tower-http@0.6.6										X
+tower-layer@0.3.3										X
+tower-service@0.3.3										X
+tracing@0.1.41										X
+tracing-core@0.1.34										X
+try-lock@0.2.5										X
+typenum@1.18.0		X								X
+unicode-ident@1.0.18		X								X	X
+untrusted@0.9.0								X
+url@2.5.4		X								X
+utf8_iter@1.0.4		X								X
+uuid@1.17.0		X								X
+version_check@0.9.5		X								X
+want@0.3.1										X
+wasi@0.11.1+wasi-snapshot-preview1		X	X							X
+wasi@0.14.2+wasi-0.2.4		X	X							X
+wasm-bindgen@0.2.100		X								X
+wasm-bindgen-backend@0.2.100		X								X
+wasm-bindgen-futures@0.4.50		X								X
+wasm-bindgen-macro@0.2.100		X								X
+wasm-bindgen-macro-support@0.2.100		X								X
+wasm-bindgen-shared@0.2.100		X								X
+wasm-streams@0.4.2		X								X
+web-sys@0.3.77		X								X
+webpki-roots@1.0.1							X
+widestring@1.2.0		X								X
+windows@0.58.0		X								X
+windows-core@0.58.0		X								X
+windows-core@0.61.2		X								X
+windows-implement@0.58.0		X								X
+windows-implement@0.60.0		X								X
+windows-interface@0.58.0		X								X
+windows-interface@0.59.1		X								X
+windows-link@0.1.3		X								X
+windows-result@0.2.0		X								X
+windows-result@0.3.4		X								X
+windows-strings@0.1.0		X								X
+windows-strings@0.4.2		X								X
+windows-sys@0.52.0		X								X
+windows-sys@0.59.0		X								X
+windows-targets@0.52.6		X								X
+windows_aarch64_gnullvm@0.52.6		X								X
+windows_aarch64_msvc@0.52.6		X								X
+windows_i686_gnu@0.52.6		X								X
+windows_i686_gnullvm@0.52.6		X								X
+windows_i686_msvc@0.52.6		X								X
+windows_x86_64_gnu@0.52.6		X								X
+windows_x86_64_gnullvm@0.52.6		X								X
+windows_x86_64_msvc@0.52.6		X								X
+wit-bindgen-rt@0.39.0		X	X							X
+writeable@0.6.1											X
+yoke@0.8.0											X
+yoke-derive@0.8.0											X
+zerocopy@0.8.26		X		X						X
+zerofrom@0.1.6											X
+zerofrom-derive@0.1.6											X
+zeroize@1.8.1		X								X
+zerotrie@0.2.2											X
+zerovec@0.11.2											X
+zerovec-derive@0.11.1											X


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related https://github.com/apache/opendal/actions/runs/18054308829/job/51381863340.

Refs: https://github.com/ho-229/cloud-filter-rs/pull/9

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
