### PR TITLE
feat: Add Operator Registry

### DIFF
--- a/core/src/blocking/operator.rs
+++ b/core/src/blocking/operator.rs
@@ -135,6 +135,15 @@ impl Operator {
         })
     }
 
+    /// Create a blocking operator from URI based configuration.
+    pub fn from_uri(
+        uri: &str,
+        options: impl IntoIterator<Item = (String, String)>,
+    ) -> Result<Self> {
+        let op = AsyncOperator::from_uri(uri, options)?;
+        Self::new(op)
+    }
+
     /// Get information of underlying accessor.
     ///
     /// # Examples

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -15,10 +15,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use log::debug;
+
+use http::Uri;
+use percent_encoding::percent_decode_str;
 
 use super::core::*;
 use super::delete::FsDeleter;
@@ -26,12 +30,34 @@ use super::lister::FsLister;
 use super::reader::FsReader;
 use super::writer::FsWriter;
 use super::writer::FsWriters;
-use super::DEFAULT_SCHEME;
+use super::FS_SCHEME;
 use crate::raw::*;
 use crate::services::FsConfig;
 use crate::*;
 impl Configurator for FsConfig {
     type Builder = FsBuilder;
+    fn from_uri(uri: &Uri, options: &HashMap<String, String>) -> Result<Self> {
+        let mut map = options.clone();
+
+        if !map.contains_key("root") {
+            let path = percent_decode_str(uri.path()).decode_utf8_lossy();
+            if path.is_empty() || path == "/" {
+                return Err(Error::new(
+                    ErrorKind::ConfigInvalid,
+                    "fs uri requires absolute path",
+                ));
+            }
+            if !path.starts_with('/') {
+                return Err(Error::new(
+                    ErrorKind::ConfigInvalid,
+                    "fs uri root must be absolute",
+                ));
+            }
+            map.insert("root".to_string(), path.to_string());
+        }
+
+        Self::from_iter(map)
+    }
     fn into_builder(self) -> Self::Builder {
         FsBuilder { config: self }
     }
@@ -144,7 +170,7 @@ impl Builder for FsBuilder {
             core: Arc::new(FsCore {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(DEFAULT_SCHEME)
+                    am.set_scheme(FS_SCHEME)
                         .set_root(&root.to_string_lossy())
                         .set_native_capability(Capability {
                             stat: true,

--- a/core/src/services/fs/mod.rs
+++ b/core/src/services/fs/mod.rs
@@ -17,7 +17,7 @@
 
 /// Default scheme for fs service.
 #[cfg(feature = "services-fs")]
-pub(super) const DEFAULT_SCHEME: &str = "fs";
+pub const FS_SCHEME: &str = "fs";
 #[cfg(feature = "services-fs")]
 mod core;
 #[cfg(feature = "services-fs")]

--- a/core/src/services/memory/mod.rs
+++ b/core/src/services/memory/mod.rs
@@ -17,7 +17,7 @@
 
 /// Default scheme for memory service.
 #[cfg(feature = "services-memory")]
-pub(super) const DEFAULT_SCHEME: &str = "memory";
+pub const MEMORY_SCHEME: &str = "memory";
 #[cfg(feature = "services-memory")]
 mod backend;
 #[cfg(feature = "services-memory")]

--- a/core/src/services/mod.rs
+++ b/core/src/services/mod.rs
@@ -68,8 +68,6 @@ mod foundationdb;
 pub use self::foundationdb::*;
 
 mod fs;
-#[cfg(feature = "services-fs")]
-pub use fs::FS_SCHEME;
 pub use fs::*;
 
 mod ftp;
@@ -118,8 +116,6 @@ mod memcached;
 pub use memcached::*;
 
 mod memory;
-#[cfg(feature = "services-memory")]
-pub use self::memory::MEMORY_SCHEME;
 pub use self::memory::*;
 
 mod mini_moka;
@@ -165,8 +161,6 @@ mod rocksdb;
 pub use self::rocksdb::*;
 
 mod s3;
-#[cfg(feature = "services-s3")]
-pub use s3::S3_SCHEME;
 pub use s3::*;
 
 mod seafile;

--- a/core/src/services/mod.rs
+++ b/core/src/services/mod.rs
@@ -68,6 +68,8 @@ mod foundationdb;
 pub use self::foundationdb::*;
 
 mod fs;
+#[cfg(feature = "services-fs")]
+pub use fs::FS_SCHEME;
 pub use fs::*;
 
 mod ftp;
@@ -116,6 +118,8 @@ mod memcached;
 pub use memcached::*;
 
 mod memory;
+#[cfg(feature = "services-memory")]
+pub use self::memory::MEMORY_SCHEME;
 pub use self::memory::*;
 
 mod mini_moka;
@@ -161,6 +165,8 @@ mod rocksdb;
 pub use self::rocksdb::*;
 
 mod s3;
+#[cfg(feature = "services-s3")]
+pub use s3::S3_SCHEME;
 pub use s3::*;
 
 mod seafile;

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -30,10 +30,12 @@ use constants::X_AMZ_META_PREFIX;
 use constants::X_AMZ_VERSION_ID;
 use http::Response;
 use http::StatusCode;
+use http::Uri;
 use log::debug;
 use log::warn;
 use md5::Digest;
 use md5::Md5;
+use percent_encoding::percent_decode_str;
 use reqsign::AwsAssumeRoleLoader;
 use reqsign::AwsConfig;
 use reqsign::AwsCredentialLoad;
@@ -50,7 +52,7 @@ use super::lister::S3Listers;
 use super::lister::S3ObjectVersionsLister;
 use super::writer::S3Writer;
 use super::writer::S3Writers;
-use super::DEFAULT_SCHEME;
+use super::S3_SCHEME;
 use crate::raw::oio::PageLister;
 use crate::raw::*;
 use crate::services::S3Config;
@@ -71,6 +73,30 @@ const DEFAULT_BATCH_MAX_OPERATIONS: usize = 1000;
 
 impl Configurator for S3Config {
     type Builder = S3Builder;
+
+    fn from_uri(uri: &Uri, options: &HashMap<String, String>) -> Result<Self> {
+        let mut map = options.clone();
+
+        let bucket_missing = map.get("bucket").map(|v| v.is_empty()).unwrap_or(true);
+        if bucket_missing {
+            let bucket = uri
+                .authority()
+                .map(|authority| authority.host())
+                .filter(|host| !host.is_empty())
+                .ok_or_else(|| Error::new(ErrorKind::ConfigInvalid, "s3 uri requires bucket"))?;
+            map.insert("bucket".to_string(), bucket.to_string());
+        }
+
+        if !map.contains_key("root") {
+            let path = percent_decode_str(uri.path()).decode_utf8_lossy();
+            let trimmed = path.trim_matches('/');
+            if !trimmed.is_empty() {
+                map.insert("root".to_string(), trimmed.to_string());
+            }
+        }
+
+        Self::from_iter(map)
+    }
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
@@ -904,7 +930,7 @@ impl Builder for S3Builder {
             core: Arc::new(S3Core {
                 info: {
                     let am = AccessorInfo::default();
-                    am.set_scheme(DEFAULT_SCHEME)
+                    am.set_scheme(S3_SCHEME)
                         .set_root(&root)
                         .set_name(bucket)
                         .set_native_capability(Capability {

--- a/core/src/services/s3/mod.rs
+++ b/core/src/services/s3/mod.rs
@@ -17,7 +17,7 @@
 
 /// Default scheme for s3 service.
 #[cfg(feature = "services-s3")]
-pub(super) const DEFAULT_SCHEME: &str = "s3";
+pub const S3_SCHEME: &str = "s3";
 #[cfg(feature = "services-s3")]
 mod core;
 #[cfg(feature = "services-s3")]

--- a/core/src/types/builder.rs
+++ b/core/src/types/builder.rs
@@ -15,8 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 
+use http::Uri;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -122,6 +124,11 @@ impl Builder for () {
 pub trait Configurator: Serialize + DeserializeOwned + Debug + 'static {
     /// Associated builder for this configuration.
     type Builder: Builder;
+
+    /// Build configuration from a URI plus merged options.
+    fn from_uri(_uri: &Uri, _options: &HashMap<String, String>) -> Result<Self> {
+        Err(Error::new(ErrorKind::Unsupported, "uri is not supported"))
+    }
 
     /// Deserialize from an iterator.
     ///

--- a/core/src/types/mod.rs
+++ b/core/src/types/mod.rs
@@ -46,7 +46,10 @@ mod operator;
 pub use operator::operator_futures;
 pub use operator::Operator;
 pub use operator::OperatorBuilder;
+pub use operator::OperatorFactory;
 pub use operator::OperatorInfo;
+pub use operator::OperatorRegistry;
+pub use operator::DEFAULT_OPERATOR_REGISTRY;
 
 mod builder;
 pub use builder::Builder;

--- a/core/src/types/operator/builder.rs
+++ b/core/src/types/operator/builder.rs
@@ -132,6 +132,27 @@ impl Operator {
         Ok(OperatorBuilder::new(acc))
     }
 
+    /// Create a new operator by parsing configuration from a URI.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use anyhow::Result;
+    /// use opendal::Operator;
+    ///
+    /// # fn example() -> Result<()> {
+    /// let op = Operator::from_uri("memory://localhost/", [])?;
+    /// # let _ = op;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn from_uri(
+        uri: &str,
+        options: impl IntoIterator<Item = (String, String)>,
+    ) -> Result<Operator> {
+        crate::DEFAULT_OPERATOR_REGISTRY.load(uri, options)
+    }
+
     /// Create a new operator via given scheme and iterator of config value in dynamic dispatch.
     ///
     /// # Notes

--- a/core/src/types/operator/mod.rs
+++ b/core/src/types/operator/mod.rs
@@ -28,3 +28,6 @@ mod info;
 pub use info::OperatorInfo;
 
 pub mod operator_futures;
+
+mod registry;
+pub use registry::{OperatorFactory, OperatorRegistry, DEFAULT_OPERATOR_REGISTRY};

--- a/core/src/types/operator/registry.rs
+++ b/core/src/types/operator/registry.rs
@@ -1,0 +1,129 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+use http::Uri;
+use percent_encoding::percent_decode_str;
+
+use crate::services;
+use crate::types::builder::{Builder, Configurator};
+use crate::{Error, ErrorKind, Operator, Result};
+
+/// Factory signature used to construct [`Operator`] from a URI and extra options.
+pub type OperatorFactory = fn(&str, Vec<(String, String)>) -> Result<Operator>;
+
+/// Default registry initialized with builtin services.
+pub static DEFAULT_OPERATOR_REGISTRY: LazyLock<OperatorRegistry> = LazyLock::new(|| {
+    let registry = OperatorRegistry::new();
+    register_builtin_services(&registry);
+    registry
+});
+
+/// Global registry that maps schemes to [`OperatorFactory`] functions.
+#[derive(Debug, Default)]
+pub struct OperatorRegistry {
+    factories: Mutex<HashMap<String, OperatorFactory>>,
+}
+
+impl OperatorRegistry {
+    /// Create a new, empty registry.
+    pub fn new() -> Self {
+        Self {
+            factories: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Register a builder for the given scheme.
+    pub fn register<B: Builder>(&self, scheme: &str) {
+        let key = scheme.to_ascii_lowercase();
+        let mut guard = self
+            .factories
+            .lock()
+            .expect("operator registry mutex poisoned");
+        guard.insert(key, factory::<B::Config>);
+    }
+
+    /// Load an [`Operator`] via the factory registered for the URI's scheme.
+    pub fn load(
+        &self,
+        uri: &str,
+        options: impl IntoIterator<Item = (String, String)>,
+    ) -> Result<Operator> {
+        let parsed = uri.parse::<Uri>().map_err(|err| {
+            Error::new(ErrorKind::ConfigInvalid, "failed to parse uri").set_source(err)
+        })?;
+
+        let scheme = parsed
+            .scheme_str()
+            .ok_or_else(|| Error::new(ErrorKind::ConfigInvalid, "uri scheme is required"))?;
+
+        let key = scheme.to_ascii_lowercase();
+        let factory = self
+            .factories
+            .lock()
+            .expect("operator registry mutex poisoned")
+            .get(key.as_str())
+            .copied()
+            .ok_or_else(|| {
+                Error::new(ErrorKind::Unsupported, "scheme is not registered")
+                    .with_context("scheme", scheme)
+            })?;
+
+        let opts: Vec<(String, String)> = options.into_iter().collect();
+        factory(uri, opts)
+    }
+}
+
+fn register_builtin_services(registry: &OperatorRegistry) {
+    #[cfg(feature = "services-memory")]
+    registry.register::<services::Memory>(services::MEMORY_SCHEME);
+    #[cfg(feature = "services-fs")]
+    registry.register::<services::Fs>(services::FS_SCHEME);
+    #[cfg(feature = "services-s3")]
+    registry.register::<services::S3>(services::S3_SCHEME);
+}
+
+/// Factory adapter that builds an operator from a configurator type.
+fn factory<C: Configurator>(uri: &str, options: Vec<(String, String)>) -> Result<Operator> {
+    let parsed = uri.parse::<Uri>().map_err(|err| {
+        Error::new(ErrorKind::ConfigInvalid, "failed to parse uri").set_source(err)
+    })?;
+
+    let mut params = HashMap::new();
+    if let Some(query) = parsed.query() {
+        for pair in query.split('&') {
+            if pair.is_empty() {
+                continue;
+            }
+            let mut parts = pair.splitn(2, '=');
+            let key = parts.next().unwrap_or("");
+            let value = parts.next().unwrap_or("");
+            let key = percent_decode_str(key).decode_utf8_lossy().to_string();
+            let value = percent_decode_str(value).decode_utf8_lossy().to_string();
+            params.insert(key.to_ascii_lowercase(), value);
+        }
+    }
+
+    for (key, value) in options {
+        params.insert(key.to_ascii_lowercase(), value);
+    }
+
+    let cfg = C::from_uri(&parsed, &params)?;
+    Ok(Operator::from_config(cfg)?.finish())
+}


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/opendal/issues/5445

# Rationale for this change

This PR will allow users to load operator from uri.

# What changes are included in this PR?

Added an `OperatorRegistry` in OpenDAL

# Are there any user-facing changes?

Users can now calling `Operator::from_uri("s3://bucket", [("region", "us-east-1")])`

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

---

**This PR was primarily authored with Codex using GPT-5-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**
