### PR TITLE
ci: Bump doc toolchain to allow opendal docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,8 +38,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # This same toolchain for rust 1.85.1 but nightly so we can use new features.
-  RUST_DOC_TOOLCHAIN: nightly-2025-03-18
+  # This is the toolchain used by docs.rs
+  # 
+  # Check this page for updating: https://docs.rs/crate/opendal/0.54.1/builds
+  RUST_DOC_TOOLCHAIN: nightly-2025-10-12
   # Enable cfg docsrs to make sure docs are built.
   RUSTDOCFLAGS: "--cfg docsrs"
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Follow up of https://github.com/apache/opendal/pull/6658

docs.rs always uses the latest toolchain to build docs which makes #6658 not work for this. This PR will bump our docs' toolchain to be same with docs.rs.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
