### PR TITLE
fix(layers/throttle): await limiter before throttled writes

### DIFF
--- a/core/src/layers/throttle.rs
+++ b/core/src/layers/throttle.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 
 use governor::Quota;
 use governor::RateLimiter;
-use governor::clock::Clock;
 use governor::clock::DefaultClock;
 use governor::middleware::NoOpMiddleware;
 use governor::state::InMemoryState;
@@ -170,30 +169,29 @@ impl<R: oio::Read> oio::Read for ThrottleWrapper<R> {
 
 impl<R: oio::Write> oio::Write for ThrottleWrapper<R> {
     async fn write(&mut self, bs: Buffer) -> Result<()> {
-        let buf_length = NonZeroU32::new(bs.len() as u32).unwrap();
-
-        loop {
-            match self.limiter.check_n(buf_length) {
-                Ok(res) => match res {
-                    Ok(_) => return self.inner.write(bs).await,
-                    // the query is valid but the Decider can not accommodate them.
-                    Err(not_until) => {
-                        let _ = not_until.wait_time_from(DefaultClock::default().now());
-                        // TODO: Should lock the limiter and wait for the wait_time, or should let other small requests go first?
-
-                        // FIXME: we should sleep here.
-                        // tokio::time::sleep(wait_time).await;
-                    }
-                },
-                // the query was invalid as the rate limit parameters can "never" accommodate the number of cells queried for.
-                Err(_) => {
-                    return Err(Error::new(
-                        ErrorKind::RateLimited,
-                        "InsufficientCapacity due to burst size being smaller than the request size",
-                    ));
-                }
-            }
+        let len = bs.len();
+        if len == 0 {
+            return self.inner.write(bs).await;
         }
+
+        if len > u32::MAX as usize {
+            return Err(Error::new(
+                ErrorKind::RateLimited,
+                "request size exceeds throttle quota capacity",
+            ));
+        }
+
+        let buf_length =
+            NonZeroU32::new(len as u32).expect("len is non-zero so NonZeroU32 must exist");
+
+        self.limiter.until_n_ready(buf_length).await.map_err(|_| {
+            Error::new(
+                ErrorKind::RateLimited,
+                "burst size is smaller than the request size",
+            )
+        })?;
+
+        self.inner.write(bs).await
     }
 
     async fn abort(&mut self) -> Result<()> {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Throttle writes previously spun on the rate limiter and could panic on empty buffers. Awaiting the limiter and validating buffer sizes fixes correctness and removes unnecessary CPU burning.

# What changes are included in this PR?

- Guard zero-length and oversized buffers in the throttle wrapper before invoking the limiter.
- Await `RateLimiter::until_n_ready` to respect governor's scheduling instead of busy looping.
- Restore the required `DefaultClock` import so doctests compile.

# Are there any user-facing changes?

No user-facing API changes; throttled writes now reliably await their quota without panics.
