### PR TITLE
ci: Auto add ML thread link in github discussion

### DIFF
--- a/.github/workflows/discussion-thread-link.yml
+++ b/.github/workflows/discussion-thread-link.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Append mailing-list thread link to new Discussion
 
 on:


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/opendal/discussions/6687#discussioncomment-14708818

# Rationale for this change

Make our lives easier.

# What changes are included in this PR?

Add a new action to auto update github discussion with ML's thread link.

# Are there any user-facing changes?

Not related to users.

---

**This PR was primarily authored with Codex using GPT-5-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**