### PR TITLE
fix: retry on 409 with AWS S3

### DIFF
--- a/core/src/services/s3/error.rs
+++ b/core/src/services/s3/error.rs
@@ -45,7 +45,7 @@ pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
         304 | 412 => (ErrorKind::ConditionNotMatch, false),
         // 409 Conflict can be returned e.g. when PutObject with conditions.
         // In this case the AWS docs say to retry.
-        409 => (ErrorKind::Conflict, true),
+        409 => (ErrorKind::ConditionNotMatch, true),
         // Service like R2 could return 499 error with a message like:
         // Client Disconnect, we should retry it.
         499 => (ErrorKind::Unexpected, true),


### PR DESCRIPTION
Trying to fix #6741 

I am not sure if we should do the same for other backends?

Also not sure if the error code is correct?