### PR TITLE
refactor(services): impl Debug for all service builders

### DIFF
--- a/core/src/services/aliyun_drive/backend.rs
+++ b/core/src/services/aliyun_drive/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -26,6 +25,7 @@ use log::debug;
 use tokio::sync::Mutex;
 
 use super::ALIYUN_DRIVE_SCHEME;
+use super::config::AliyunDriveConfig;
 use super::core::*;
 use super::delete::AliyunDriveDeleter;
 use super::error::parse_error;
@@ -33,7 +33,6 @@ use super::lister::AliyunDriveLister;
 use super::lister::AliyunDriveParent;
 use super::writer::AliyunDriveWriter;
 use crate::raw::*;
-use crate::services::AliyunDriveConfig;
 use crate::*;
 
 #[doc = include_str!("docs.md")]
@@ -46,11 +45,10 @@ pub struct AliyunDriveBuilder {
 }
 
 impl Debug for AliyunDriveBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("AliyunDriveBuilder");
-
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AliyunDriveBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/aliyun_drive/config.rs
+++ b/core/src/services/aliyun_drive/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::AliyunDriveBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::AliyunDriveBuilder;
 
 /// Config for Aliyun Drive services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -62,13 +62,11 @@ pub struct AliyunDriveConfig {
 }
 
 impl Debug for AliyunDriveConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("AliyunDriveConfig");
-
-        d.field("root", &self.root)
-            .field("drive_type", &self.drive_type);
-
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AliyunDriveConfig")
+            .field("root", &self.root)
+            .field("drive_type", &self.drive_type)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/alluxio/backend.rs
+++ b/core/src/services/alluxio/backend.rs
@@ -16,13 +16,13 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Response;
 use log::debug;
 
 use super::ALLUXIO_SCHEME;
+use super::config::AlluxioConfig;
 use super::core::AlluxioCore;
 use super::delete::AlluxioDeleter;
 use super::error::parse_error;
@@ -30,7 +30,6 @@ use super::lister::AlluxioLister;
 use super::writer::AlluxioWriter;
 use super::writer::AlluxioWriters;
 use crate::raw::*;
-use crate::services::AlluxioConfig;
 use crate::*;
 
 /// [Alluxio](https://www.alluxio.io/) services support.
@@ -44,11 +43,10 @@ pub struct AlluxioBuilder {
 }
 
 impl Debug for AlluxioBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("AlluxioBuilder");
-
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AlluxioBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/alluxio/config.rs
+++ b/core/src/services/alluxio/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::AlluxioBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::AlluxioBuilder;
 
 /// Config for alluxio services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -40,13 +40,11 @@ pub struct AlluxioConfig {
 }
 
 impl Debug for AlluxioConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("AlluxioConfig");
-
-        d.field("root", &self.root)
-            .field("endpoint", &self.endpoint);
-
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AlluxioConfig")
+            .field("root", &self.root)
+            .field("endpoint", &self.endpoint)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/alluxio/core.rs
+++ b/core/src/services/alluxio/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -41,8 +40,8 @@ pub struct AlluxioCore {
 }
 
 impl Debug for AlluxioCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AlluxioCore")
             .field("root", &self.root)
             .field("endpoint", &self.endpoint)
             .finish_non_exhaustive()

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use base64::Engine;
@@ -31,6 +30,7 @@ use sha2::Digest;
 use sha2::Sha256;
 
 use super::AZBLOB_SCHEME;
+use super::config::AzblobConfig;
 use super::core::AzblobCore;
 use super::core::constants::X_MS_META_PREFIX;
 use super::core::constants::X_MS_VERSION_ID;
@@ -40,8 +40,8 @@ use super::lister::AzblobLister;
 use super::writer::AzblobWriter;
 use super::writer::AzblobWriters;
 use crate::raw::*;
-use crate::services::AzblobConfig;
 use crate::*;
+
 const AZBLOB_BATCH_LIMIT: usize = 256;
 
 impl From<AzureStorageConfig> for AzblobConfig {
@@ -57,7 +57,7 @@ impl From<AzureStorageConfig> for AzblobConfig {
 }
 
 #[doc = include_str!("docs.md")]
-#[derive(Default, Clone)]
+#[derive(Default)]
 pub struct AzblobBuilder {
     pub(super) config: AzblobConfig,
 
@@ -66,12 +66,10 @@ pub struct AzblobBuilder {
 }
 
 impl Debug for AzblobBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("AzblobBuilder");
-
-        ds.field("config", &self.config);
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AzblobBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/azblob/config.rs
+++ b/core/src/services/azblob/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::AzblobBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::AzblobBuilder;
 
 /// Azure Storage Blob services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -79,24 +79,12 @@ pub struct AzblobConfig {
 }
 
 impl Debug for AzblobConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("AzblobConfig");
-
-        ds.field("root", &self.root);
-        ds.field("container", &self.container);
-        ds.field("endpoint", &self.endpoint);
-
-        if self.account_name.is_some() {
-            ds.field("account_name", &"<redacted>");
-        }
-        if self.account_key.is_some() {
-            ds.field("account_key", &"<redacted>");
-        }
-        if self.sas_token.is_some() {
-            ds.field("sas_token", &"<redacted>");
-        }
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AzblobConfig")
+            .field("root", &self.root)
+            .field("container", &self.container)
+            .field("endpoint", &self.endpoint)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/azblob/core.rs
+++ b/core/src/services/azblob/core.rs
@@ -15,9 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt;
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -77,7 +75,7 @@ pub struct AzblobCore {
 }
 
 impl Debug for AzblobCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AzblobCore")
             .field("container", &self.container)
             .field("root", &self.root)

--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Response;
@@ -27,6 +26,7 @@ use reqsign::AzureStorageLoader;
 use reqsign::AzureStorageSigner;
 
 use super::AZDLS_SCHEME;
+use super::config::AzdlsConfig;
 use super::core::AzdlsCore;
 use super::core::DIRECTORY;
 use super::delete::AzdlsDeleter;
@@ -35,8 +35,8 @@ use super::lister::AzdlsLister;
 use super::writer::AzdlsWriter;
 use super::writer::AzdlsWriters;
 use crate::raw::*;
-use crate::services::AzdlsConfig;
 use crate::*;
+
 impl From<AzureStorageConfig> for AzdlsConfig {
     fn from(config: AzureStorageConfig) -> Self {
         AzdlsConfig {
@@ -55,7 +55,7 @@ impl From<AzureStorageConfig> for AzdlsConfig {
 
 /// Azure Data Lake Storage Gen2 Support.
 #[doc = include_str!("docs.md")]
-#[derive(Default, Clone)]
+#[derive(Default)]
 pub struct AzdlsBuilder {
     pub(super) config: AzdlsConfig,
 
@@ -64,12 +64,10 @@ pub struct AzdlsBuilder {
 }
 
 impl Debug for AzdlsBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("AzdlsBuilder");
-
-        ds.field("config", &self.config);
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AzdlsBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/azdls/config.rs
+++ b/core/src/services/azdls/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::AzdlsBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::AzdlsBuilder;
 
 /// Azure Data Lake Storage Gen2 Support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -60,32 +60,12 @@ pub struct AzdlsConfig {
 }
 
 impl Debug for AzdlsConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("AzdlsConfig");
-
-        ds.field("root", &self.root);
-        ds.field("filesystem", &self.filesystem);
-        ds.field("endpoint", &self.endpoint);
-
-        if self.account_name.is_some() {
-            ds.field("account_name", &"<redacted>");
-        }
-        if self.account_key.is_some() {
-            ds.field("account_key", &"<redacted>");
-        }
-        if self.client_secret.is_some() {
-            ds.field("client_secret", &"<redacted>");
-        }
-        if self.tenant_id.is_some() {
-            ds.field("tenant_id", &"<redacted>");
-        }
-        if self.client_id.is_some() {
-            ds.field("client_id", &"<redacted>");
-        }
-        if self.sas_token.is_some() {
-            ds.field("sas_token", &"<redacted>");
-        }
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AzdlsConfig")
+            .field("root", &self.root)
+            .field("filesystem", &self.filesystem)
+            .field("endpoint", &self.endpoint)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/azdls/core.rs
+++ b/core/src/services/azdls/core.rs
@@ -15,9 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt;
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::HeaderName;
@@ -54,7 +52,7 @@ pub struct AzdlsCore {
 }
 
 impl Debug for AzdlsCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AzdlsCore")
             .field("filesystem", &self.filesystem)
             .field("root", &self.root)

--- a/core/src/services/azfile/backend.rs
+++ b/core/src/services/azfile/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Response;
@@ -27,6 +26,7 @@ use reqsign::AzureStorageLoader;
 use reqsign::AzureStorageSigner;
 
 use super::AZFILE_SCHEME;
+use super::config::AzfileConfig;
 use super::core::AzfileCore;
 use super::delete::AzfileDeleter;
 use super::error::parse_error;
@@ -34,8 +34,8 @@ use super::lister::AzfileLister;
 use super::writer::AzfileWriter;
 use super::writer::AzfileWriters;
 use crate::raw::*;
-use crate::services::AzfileConfig;
 use crate::*;
+
 impl From<AzureStorageConfig> for AzfileConfig {
     fn from(config: AzureStorageConfig) -> Self {
         AzfileConfig {
@@ -51,7 +51,7 @@ impl From<AzureStorageConfig> for AzfileConfig {
 
 /// Azure File services support.
 #[doc = include_str!("docs.md")]
-#[derive(Default, Clone)]
+#[derive(Default)]
 pub struct AzfileBuilder {
     pub(super) config: AzfileConfig,
 
@@ -60,12 +60,10 @@ pub struct AzfileBuilder {
 }
 
 impl Debug for AzfileBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("AzfileBuilder");
-
-        ds.field("config", &self.config);
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AzfileBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/azfile/config.rs
+++ b/core/src/services/azfile/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::AzfileBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::AzfileBuilder;
 
 /// Azure File services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -40,24 +40,12 @@ pub struct AzfileConfig {
 }
 
 impl Debug for AzfileConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("AzfileConfig");
-
-        ds.field("root", &self.root);
-        ds.field("share_name", &self.share_name);
-        ds.field("endpoint", &self.endpoint);
-
-        if self.account_name.is_some() {
-            ds.field("account_name", &"<redacted>");
-        }
-        if self.account_key.is_some() {
-            ds.field("account_key", &"<redacted>");
-        }
-        if self.sas_token.is_some() {
-            ds.field("sas_token", &"<redacted>");
-        }
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AzfileConfig")
+            .field("root", &self.root)
+            .field("endpoint", &self.endpoint)
+            .field("share_name", &self.share_name)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/azfile/core.rs
+++ b/core/src/services/azfile/core.rs
@@ -17,7 +17,6 @@
 
 use std::collections::VecDeque;
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::HeaderName;
@@ -54,7 +53,7 @@ pub struct AzfileCore {
 }
 
 impl Debug for AzfileCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AzfileCore")
             .field("root", &self.root)
             .field("endpoint", &self.endpoint)

--- a/core/src/services/b2/backend.rs
+++ b/core/src/services/b2/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Request;
@@ -26,6 +25,7 @@ use log::debug;
 use tokio::sync::RwLock;
 
 use super::B2_SCHEME;
+use super::config::B2Config;
 use super::core::B2Core;
 use super::core::B2Signer;
 use super::core::constants;
@@ -36,7 +36,6 @@ use super::lister::B2Lister;
 use super::writer::B2Writer;
 use super::writer::B2Writers;
 use crate::raw::*;
-use crate::services::B2Config;
 use crate::*;
 
 /// [b2](https://www.backblaze.com/cloud-storage) services support.
@@ -50,11 +49,10 @@ pub struct B2Builder {
 }
 
 impl Debug for B2Builder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("B2Builder");
-
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("B2Builder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/b2/config.rs
+++ b/core/src/services/b2/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::B2Builder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::B2Builder;
 
 /// Config for backblaze b2 services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -52,15 +52,13 @@ pub struct B2Config {
 }
 
 impl Debug for B2Config {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("B2Config");
-
-        d.field("root", &self.root)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("B2Config")
+            .field("root", &self.root)
             .field("application_key_id", &self.application_key_id)
             .field("bucket_id", &self.bucket_id)
-            .field("bucket", &self.bucket);
-
-        d.finish_non_exhaustive()
+            .field("bucket", &self.bucket)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/b2/core.rs
+++ b/core/src/services/b2/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -57,8 +56,8 @@ pub struct B2Core {
 }
 
 impl Debug for B2Core {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("B2Core")
             .field("root", &self.root)
             .field("bucket", &self.bucket)
             .field("bucket_id", &self.bucket_id)

--- a/core/src/services/cacache/backend.rs
+++ b/core/src/services/cacache/backend.rs
@@ -15,20 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::raw::*;
-use crate::services::CacacheConfig;
-use crate::*;
-use std::fmt::Debug;
 use std::sync::Arc;
 
 use super::CACACHE_SCHEME;
+use super::config::CacacheConfig;
 use super::core::CacacheCore;
 use super::delete::CacacheDeleter;
 use super::writer::CacacheWriter;
+use crate::raw::*;
+use crate::*;
 
 /// cacache service support.
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct CacacheBuilder {
     pub(super) config: CacacheConfig,
 }

--- a/core/src/services/cacache/config.rs
+++ b/core/src/services/cacache/config.rs
@@ -17,9 +17,10 @@
 
 use std::fmt::Debug;
 
-use super::backend::CacacheBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::CacacheBuilder;
 
 /// cacache service support.
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/core/src/services/cloudflare_kv/backend.rs
+++ b/core/src/services/cloudflare_kv/backend.rs
@@ -16,23 +16,22 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::Duration;
 
-use super::CLOUDFLARE_KV_SCHEME;
-use crate::ErrorKind;
-use crate::raw::*;
-use crate::services::CloudflareKvConfig;
-use crate::services::cloudflare_kv::core::CloudflareKvCore;
-use crate::services::cloudflare_kv::delete::CloudflareKvDeleter;
-use crate::services::cloudflare_kv::error::parse_error;
-use crate::services::cloudflare_kv::lister::CloudflareKvLister;
-use crate::services::cloudflare_kv::model::*;
-use crate::services::cloudflare_kv::writer::CloudflareWriter;
-use crate::*;
 use bytes::Buf;
 use http::StatusCode;
+
+use super::CLOUDFLARE_KV_SCHEME;
+use super::config::CloudflareKvConfig;
+use super::core::CloudflareKvCore;
+use super::delete::CloudflareKvDeleter;
+use super::error::parse_error;
+use super::lister::CloudflareKvLister;
+use super::model::*;
+use super::writer::CloudflareWriter;
+use crate::raw::*;
+use crate::*;
 
 #[doc = include_str!("docs.md")]
 #[derive(Default)]
@@ -40,14 +39,15 @@ pub struct CloudflareKvBuilder {
     pub(super) config: CloudflareKvConfig,
 
     /// The HTTP client used to communicate with CloudFlare.
+    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
     pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for CloudflareKvBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CloudFlareKvBuilder")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CloudflareKvBuilder")
             .field("config", &self.config)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/cloudflare_kv/config.rs
+++ b/core/src/services/cloudflare_kv/config.rs
@@ -16,12 +16,12 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::time::Duration;
 
-use super::backend::CloudflareKvBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::CloudflareKvBuilder;
 
 /// Cloudflare KV Service Support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -40,18 +40,13 @@ pub struct CloudflareKvConfig {
 }
 
 impl Debug for CloudflareKvConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("CloudflareKvConfig");
-
-        ds.field("root", &self.root);
-        ds.field("account_id", &self.account_id);
-        ds.field("namespace_id", &self.namespace_id);
-
-        if self.api_token.is_some() {
-            ds.field("api_token", &"<redacted>");
-        }
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CloudflareKvConfig")
+            .field("account_id", &self.account_id)
+            .field("namespace_id", &self.namespace_id)
+            .field("default_ttl", &self.default_ttl)
+            .field("root", &self.root)
+            .finish_non_exhaustive()
     }
 }
 
@@ -97,6 +92,7 @@ impl crate::Configurator for CloudflareKvConfig {
         Self::from_iter(map)
     }
 
+    #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
         CloudflareKvBuilder {
             config: self,

--- a/core/src/services/compfs/backend.rs
+++ b/core/src/services/compfs/backend.rs
@@ -22,18 +22,17 @@ use compio::dispatcher::Dispatcher;
 use compio::fs::OpenOptions;
 
 use super::COMPFS_SCHEME;
+use super::config::CompfsConfig;
 use super::core::CompfsCore;
 use super::delete::CompfsDeleter;
 use super::lister::CompfsLister;
 use super::reader::CompfsReader;
 use super::writer::CompfsWriter;
-use crate::raw::oio::OneShotDeleter;
 use crate::raw::*;
-use crate::services::CompfsConfig;
 use crate::*;
 
 /// [`compio`]-based file system support.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct CompfsBuilder {
     pub(super) config: CompfsConfig,
 }
@@ -128,7 +127,7 @@ impl Access for CompfsBackend {
     type Reader = CompfsReader;
     type Writer = CompfsWriter;
     type Lister = Option<CompfsLister>;
-    type Deleter = OneShotDeleter<CompfsDeleter>;
+    type Deleter = oio::OneShotDeleter<CompfsDeleter>;
 
     fn info(&self) -> Arc<AccessorInfo> {
         self.core.info.clone()
@@ -168,7 +167,7 @@ impl Access for CompfsBackend {
     async fn delete(&self) -> Result<(RpDelete, Self::Deleter)> {
         Ok((
             RpDelete::default(),
-            OneShotDeleter::new(CompfsDeleter::new(self.core.clone())),
+            oio::OneShotDeleter::new(CompfsDeleter::new(self.core.clone())),
         ))
     }
 

--- a/core/src/services/compfs/config.rs
+++ b/core/src/services/compfs/config.rs
@@ -17,9 +17,10 @@
 
 use std::fmt::Debug;
 
-use super::backend::CompfsBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::CompfsBuilder;
 
 /// compio-based file system support.
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/core/src/services/cos/config.rs
+++ b/core/src/services/cos/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::CosBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::CosBuilder;
 
 /// Tencent-Cloud COS services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -43,13 +43,13 @@ pub struct CosConfig {
 }
 
 impl Debug for CosConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CosConfig")
             .field("root", &self.root)
             .field("endpoint", &self.endpoint)
-            .field("secret_id", &"<redacted>")
-            .field("secret_key", &"<redacted>")
             .field("bucket", &self.bucket)
+            .field("enable_versioning", &self.enable_versioning)
+            .field("disable_config_load", &self.disable_config_load)
             .finish_non_exhaustive()
     }
 }

--- a/core/src/services/cos/core.rs
+++ b/core/src/services/cos/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -57,8 +56,8 @@ pub struct CosCore {
 }
 
 impl Debug for CosCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CosCore")
             .field("root", &self.root)
             .field("bucket", &self.bucket)
             .field("endpoint", &self.endpoint)

--- a/core/src/services/d1/backend.rs
+++ b/core/src/services/d1/backend.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use super::config::D1Config;
@@ -29,7 +30,16 @@ use crate::*;
 pub struct D1Builder {
     pub(super) config: D1Config,
 
+    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
     pub(super) http_client: Option<HttpClient>,
+}
+
+impl Debug for D1Builder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("D1Builder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
 }
 
 impl D1Builder {
@@ -134,6 +144,7 @@ impl Builder for D1Builder {
             ));
         };
 
+        #[allow(deprecated)]
         let client = if let Some(client) = self.http_client {
             client
         } else {

--- a/core/src/services/d1/config.rs
+++ b/core/src/services/d1/config.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -46,13 +45,13 @@ pub struct D1Config {
 }
 
 impl Debug for D1Config {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("D1Config");
-        ds.field("root", &self.root);
-        ds.field("table", &self.table);
-        ds.field("key_field", &self.key_field);
-        ds.field("value_field", &self.value_field);
-        ds.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("D1Config")
+            .field("root", &self.root)
+            .field("table", &self.table)
+            .field("key_field", &self.key_field)
+            .field("value_field", &self.value_field)
+            .finish_non_exhaustive()
     }
 }
 
@@ -98,6 +97,7 @@ impl crate::Configurator for D1Config {
         Self::from_iter(map)
     }
 
+    #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
         D1Builder {
             config: self,

--- a/core/src/services/d1/core.rs
+++ b/core/src/services/d1/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use http::Request;
 use http::StatusCode;
@@ -41,12 +40,12 @@ pub struct D1Core {
 }
 
 impl Debug for D1Core {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("D1Core");
-        ds.field("table", &self.table);
-        ds.field("key_field", &self.key_field);
-        ds.field("value_field", &self.value_field);
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("D1Core")
+            .field("table", &self.table)
+            .field("key_field", &self.key_field)
+            .field("value_field", &self.value_field)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/dashmap/backend.rs
+++ b/core/src/services/dashmap/backend.rs
@@ -15,36 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use dashmap::DashMap;
 use log::debug;
 
 use super::DASHMAP_SCHEME;
+use super::config::DashmapConfig;
 use super::core::DashmapCore;
 use super::delete::DashmapDeleter;
 use super::lister::DashmapLister;
 use super::writer::DashmapWriter;
-use crate::raw::oio;
 use crate::raw::*;
-use crate::services::DashmapConfig;
 use crate::*;
 
 /// [dashmap](https://github.com/xacrimon/dashmap) backend support.
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct DashmapBuilder {
     pub(super) config: DashmapConfig,
-}
-
-impl Debug for DashmapBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DashmapBuilder")
-            .field("config", &self.config)
-            .finish()
-    }
 }
 
 impl DashmapBuilder {

--- a/core/src/services/dashmap/config.rs
+++ b/core/src/services/dashmap/config.rs
@@ -15,26 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use super::backend::DashmapBuilder;
-use serde::Deserialize;
-use serde::Serialize;
 use std::fmt::Debug;
 
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::backend::DashmapBuilder;
+
 /// Config for Dashmap services support.
-#[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 #[non_exhaustive]
 pub struct DashmapConfig {
     /// root path of this backend
     pub root: Option<String>,
-}
-
-impl Debug for DashmapConfig {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DashmapConfig")
-            .field("root", &self.root)
-            .finish_non_exhaustive()
-    }
 }
 
 impl crate::Configurator for DashmapConfig {

--- a/core/src/services/dashmap/core.rs
+++ b/core/src/services/dashmap/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use dashmap::DashMap;
 
@@ -37,7 +36,7 @@ pub struct DashmapCore {
 }
 
 impl Debug for DashmapCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DashmapCore")
             .field("size", &self.cache.len())
             .finish()

--- a/core/src/services/dbfs/backend.rs
+++ b/core/src/services/dbfs/backend.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -36,19 +34,9 @@ use crate::*;
 
 /// [Dbfs](https://docs.databricks.com/api/azure/workspace/dbfs)'s REST API support.
 #[doc = include_str!("docs.md")]
-#[derive(Default, Clone)]
+#[derive(Debug, Default)]
 pub struct DbfsBuilder {
     pub(super) config: DbfsConfig,
-}
-
-impl Debug for DbfsBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("DbfsBuilder");
-
-        ds.field("config", &self.config);
-
-        ds.finish()
-    }
 }
 
 impl DbfsBuilder {

--- a/core/src/services/dbfs/config.rs
+++ b/core/src/services/dbfs/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::DbfsBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::DbfsBuilder;
 
 /// [Dbfs](https://docs.databricks.com/api/azure/workspace/dbfs)'s REST API support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -34,17 +34,11 @@ pub struct DbfsConfig {
 }
 
 impl Debug for DbfsConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("DbfsConfig");
-
-        ds.field("root", &self.root);
-        ds.field("endpoint", &self.endpoint);
-
-        if self.token.is_some() {
-            ds.field("token", &"<redacted>");
-        }
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DbfsConfig")
+            .field("root", &self.root)
+            .field("endpoint", &self.endpoint)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/dbfs/error.rs
+++ b/core/src/services/dbfs/error.rs
@@ -33,12 +33,11 @@ struct DbfsError {
 
 impl Debug for DbfsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut de = f.debug_struct("DbfsError");
-        de.field("error_code", &self.error_code);
-        // replace `\n` to ` ` for better reading.
-        de.field("message", &self.message.replace('\n', " "));
-
-        de.finish()
+        f.debug_struct("DbfsError")
+            .field("error_code", &self.error_code)
+            // replace `\n` to ` ` for better reading.
+            .field("message", &self.message.replace('\n', " "))
+            .finish()
     }
 }
 

--- a/core/src/services/dropbox/backend.rs
+++ b/core/src/services/dropbox/backend.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
 use std::sync::Arc;
 
 use bytes::Buf;

--- a/core/src/services/dropbox/builder.rs
+++ b/core/src/services/dropbox/builder.rs
@@ -16,16 +16,16 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
+
 use tokio::sync::Mutex;
 
 use super::DROPBOX_SCHEME;
 use super::backend::DropboxBackend;
+use super::config::DropboxConfig;
 use super::core::DropboxCore;
 use super::core::DropboxSigner;
 use crate::raw::*;
-use crate::services::DropboxConfig;
 use crate::*;
 
 /// [Dropbox](https://www.dropbox.com/) backend support.
@@ -39,10 +39,10 @@ pub struct DropboxBuilder {
 }
 
 impl Debug for DropboxBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Builder")
-            .field("root", &self.config.root)
-            .finish()
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/dropbox/config.rs
+++ b/core/src/services/dropbox/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::builder::DropboxBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::builder::DropboxBuilder;
 
 /// Config for [Dropbox](https://www.dropbox.com/) backend support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -40,7 +40,7 @@ pub struct DropboxConfig {
 }
 
 impl Debug for DropboxConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DropBoxConfig")
             .field("root", &self.root)
             .finish_non_exhaustive()

--- a/core/src/services/dropbox/core.rs
+++ b/core/src/services/dropbox/core.rs
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::time::Duration;
+
 use bytes::Buf;
 use bytes::Bytes;
 use http::Request;
@@ -25,11 +29,6 @@ use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
 use serde::Deserialize;
 use serde::Serialize;
-use std::default::Default;
-use std::fmt::Debug;
-use std::fmt::Formatter;
-use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::Mutex;
 
 use super::error::parse_error;
@@ -43,10 +42,10 @@ pub struct DropboxCore {
 }
 
 impl Debug for DropboxCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DropboxCore")
             .field("root", &self.root)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/etcd/backend.rs
+++ b/core/src/services/etcd/backend.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use etcd_client::Certificate;
@@ -26,29 +24,20 @@ use etcd_client::TlsOptions;
 use tokio::sync::OnceCell;
 
 use super::ETCD_SCHEME;
+use super::config::EtcdConfig;
 use super::core::EtcdCore;
 use super::core::constants::DEFAULT_ETCD_ENDPOINTS;
 use super::deleter::EtcdDeleter;
 use super::lister::EtcdLister;
 use super::writer::EtcdWriter;
 use crate::raw::*;
-use crate::services::EtcdConfig;
 use crate::*;
 
 /// [Etcd](https://etcd.io/) services support.
 #[doc = include_str!("docs.md")]
-#[derive(Clone, Default)]
+#[derive(Debug, Default)]
 pub struct EtcdBuilder {
     pub(super) config: EtcdConfig,
-}
-
-impl Debug for EtcdBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("Builder");
-
-        ds.field("config", &self.config);
-        ds.finish()
-    }
 }
 
 impl EtcdBuilder {

--- a/core/src/services/etcd/config.rs
+++ b/core/src/services/etcd/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::EtcdBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::EtcdBuilder;
 
 /// Config for Etcd services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -60,34 +60,21 @@ pub struct EtcdConfig {
 }
 
 impl Debug for EtcdConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("EtcdConfig");
-
-        ds.field("root", &self.root);
-        if let Some(endpoints) = self.endpoints.clone() {
-            ds.field("endpoints", &endpoints);
-        }
-        if let Some(username) = self.username.clone() {
-            ds.field("username", &username);
-        }
-        if self.password.is_some() {
-            ds.field("password", &"<redacted>");
-        }
-        if let Some(ca_path) = self.ca_path.clone() {
-            ds.field("ca_path", &ca_path);
-        }
-        if let Some(cert_path) = self.cert_path.clone() {
-            ds.field("cert_path", &cert_path);
-        }
-        if let Some(key_path) = self.key_path.clone() {
-            ds.field("key_path", &key_path);
-        }
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EtcdConfig")
+            .field("root", &self.root)
+            .field("endpoints", &self.endpoints)
+            .field("username", &self.username)
+            .field("ca_path", &self.ca_path)
+            .field("cert_path", &self.cert_path)
+            .field("key_path", &self.key_path)
+            .finish_non_exhaustive()
     }
 }
 
 impl crate::Configurator for EtcdConfig {
     type Builder = EtcdBuilder;
+
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let mut map = uri.options().clone();
 

--- a/core/src/services/etcd/core.rs
+++ b/core/src/services/etcd/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use bb8::PooledConnection;
 use bb8::RunError;
@@ -68,11 +67,11 @@ pub struct EtcdCore {
 }
 
 impl Debug for EtcdCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EtcdCore")
             .field("endpoints", &self.endpoints.join(","))
             .field("options", &self.options.clone())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/foundationdb/backend.rs
+++ b/core/src/services/foundationdb/backend.rs
@@ -28,7 +28,7 @@ use crate::raw::*;
 use crate::*;
 
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct FoundationdbBuilder {
     pub(super) config: FoundationdbConfig,
 }

--- a/core/src/services/foundationdb/config.rs
+++ b/core/src/services/foundationdb/config.rs
@@ -21,14 +21,14 @@ use serde::Serialize;
 use super::backend::FoundationdbBuilder;
 
 /// [foundationdb](https://www.foundationdb.org/) service support.
-///Config for FoundationDB.
+/// Config for FoundationDB.
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 #[non_exhaustive]
 pub struct FoundationdbConfig {
-    ///root of the backend.
+    /// root of the backend.
     pub root: Option<String>,
-    ///config_path for the backend.
+    /// config_path for the backend.
     pub config_path: Option<String>,
 }
 

--- a/core/src/services/foundationdb/core.rs
+++ b/core/src/services/foundationdb/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use foundationdb::Database;
@@ -31,9 +30,8 @@ pub struct FoundationdbCore {
 }
 
 impl Debug for FoundationdbCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("FoundationdbCore");
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FoundationdbCore").finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/fs/backend.rs
+++ b/core/src/services/fs/backend.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use log::debug;
 
 use super::FS_SCHEME;
+use super::config::FsConfig;
 use super::core::*;
 use super::delete::FsDeleter;
 use super::lister::FsLister;
@@ -28,12 +29,11 @@ use super::reader::FsReader;
 use super::writer::FsWriter;
 use super::writer::FsWriters;
 use crate::raw::*;
-use crate::services::FsConfig;
 use crate::*;
 
 /// POSIX file system support.
 #[doc = include_str!("docs.md")]
-#[derive(Default, Debug)]
+#[derive(Debug, Default)]
 pub struct FsBuilder {
     pub(super) config: FsConfig,
 }

--- a/core/src/services/fs/config.rs
+++ b/core/src/services/fs/config.rs
@@ -15,11 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-
-use super::backend::FsBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::FsBuilder;
 
 /// config for file system
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/core/src/services/ftp/backend.rs
+++ b/core/src/services/ftp/backend.rs
@@ -16,8 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
-use std::str;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -31,6 +29,7 @@ use suppaftp::types::Response;
 use tokio::sync::OnceCell;
 
 use super::FTP_SCHEME;
+use super::config::FtpConfig;
 use super::core::FtpCore;
 use super::delete::FtpDeleter;
 use super::err::parse_error;
@@ -38,22 +37,13 @@ use super::lister::FtpLister;
 use super::reader::FtpReader;
 use super::writer::FtpWriter;
 use crate::raw::*;
-use crate::services::FtpConfig;
 use crate::*;
 
 /// FTP and FTPS services support.
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct FtpBuilder {
     pub(super) config: FtpConfig,
-}
-
-impl Debug for FtpBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("FtpBuilder")
-            .field("config", &self.config)
-            .finish()
-    }
 }
 
 impl FtpBuilder {
@@ -199,8 +189,8 @@ pub struct FtpBackend {
 }
 
 impl Debug for FtpBackend {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend").finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FtpBackend").finish()
     }
 }
 

--- a/core/src/services/ftp/config.rs
+++ b/core/src/services/ftp/config.rs
@@ -16,12 +16,12 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
+
+use serde::Deserialize;
+use serde::Serialize;
 
 use super::FTP_SCHEME;
 use super::backend::FtpBuilder;
-use serde::Deserialize;
-use serde::Serialize;
 
 /// Config for Ftp services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -39,7 +39,7 @@ pub struct FtpConfig {
 }
 
 impl Debug for FtpConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FtpConfig")
             .field("endpoint", &self.endpoint)
             .field("root", &self.root)

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Response;
@@ -28,16 +27,16 @@ use reqsign::GoogleTokenLoad;
 use reqsign::GoogleTokenLoader;
 
 use super::GCS_SCHEME;
+use super::config::GcsConfig;
 use super::core::*;
 use super::delete::GcsDeleter;
 use super::error::parse_error;
 use super::lister::GcsLister;
 use super::writer::GcsWriter;
 use super::writer::GcsWriters;
-use crate::raw::oio::BatchDeleter;
 use crate::raw::*;
-use crate::services::GcsConfig;
 use crate::*;
+
 const DEFAULT_GCS_ENDPOINT: &str = "https://storage.googleapis.com";
 const DEFAULT_GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.read_write";
 
@@ -53,11 +52,10 @@ pub struct GcsBuilder {
 }
 
 impl Debug for GcsBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("GcsBuilder");
-
-        ds.field("config", &self.config);
-        ds.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GcsBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 
@@ -431,7 +429,7 @@ impl Access for GcsBackend {
     async fn delete(&self) -> Result<(RpDelete, Self::Deleter)> {
         Ok((
             RpDelete::default(),
-            BatchDeleter::new(GcsDeleter::new(self.core.clone())),
+            oio::BatchDeleter::new(GcsDeleter::new(self.core.clone())),
         ))
     }
 

--- a/core/src/services/gcs/config.rs
+++ b/core/src/services/gcs/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::GcsBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::GcsBuilder;
 
 /// [Google Cloud Storage](https://cloud.google.com/storage) services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -74,7 +74,7 @@ pub struct GcsConfig {
 }
 
 impl Debug for GcsConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GcsConfig")
             .field("root", &self.root)
             .field("bucket", &self.bucket)

--- a/core/src/services/gcs/core.rs
+++ b/core/src/services/gcs/core.rs
@@ -17,7 +17,6 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::fmt::Write;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -77,9 +76,9 @@ pub struct GcsCore {
 }
 
 impl Debug for GcsCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut de = f.debug_struct("Backend");
-        de.field("endpoint", &self.endpoint)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GcsCore")
+            .field("endpoint", &self.endpoint)
             .field("bucket", &self.bucket)
             .field("root", &self.root)
             .finish_non_exhaustive()

--- a/core/src/services/gdrive/backend.rs
+++ b/core/src/services/gdrive/backend.rs
@@ -18,6 +18,10 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use bytes::Buf;
+use http::Response;
+use http::StatusCode;
+
 use super::core::GdriveCore;
 use super::core::GdriveFile;
 use super::delete::GdriveDeleter;
@@ -26,9 +30,6 @@ use super::lister::GdriveLister;
 use super::writer::GdriveWriter;
 use crate::raw::*;
 use crate::*;
-use bytes::Buf;
-use http::Response;
-use http::StatusCode;
 
 #[derive(Clone, Debug)]
 pub struct GdriveBackend {

--- a/core/src/services/gdrive/builder.rs
+++ b/core/src/services/gdrive/builder.rs
@@ -15,25 +15,19 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use log::debug;
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
+
+use log::debug;
 use tokio::sync::Mutex;
 
 use super::GDRIVE_SCHEME;
 use super::backend::GdriveBackend;
+use super::config::GdriveConfig;
 use super::core::GdriveCore;
 use super::core::GdrivePathQuery;
 use super::core::GdriveSigner;
-use crate::Scheme;
-use crate::raw::Access;
-use crate::raw::AccessorInfo;
-use crate::raw::HttpClient;
-use crate::raw::PathCacher;
-use crate::raw::Timestamp;
-use crate::raw::normalize_root;
-use crate::services::GdriveConfig;
+use crate::raw::*;
 use crate::*;
 
 /// [GoogleDrive](https://drive.google.com/) backend support.
@@ -47,10 +41,10 @@ pub struct GdriveBuilder {
 }
 
 impl Debug for GdriveBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GdriveBuilder")
             .field("config", &self.config)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/gdrive/config.rs
+++ b/core/src/services/gdrive/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::builder::GdriveBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::builder::GdriveBuilder;
 
 /// [GoogleDrive](https://drive.google.com/) configuration.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -40,7 +40,7 @@ pub struct GdriveConfig {
 }
 
 impl Debug for GdriveConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GdriveConfig")
             .field("root", &self.root)
             .finish_non_exhaustive()

--- a/core/src/services/gdrive/core.rs
+++ b/core/src/services/gdrive/core.rs
@@ -15,7 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use bytes;
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::time::Duration;
+
 use bytes::Buf;
 use bytes::Bytes;
 use http::Request;
@@ -24,10 +27,6 @@ use http::StatusCode;
 use http::header;
 use serde::Deserialize;
 use serde_json::json;
-use std::fmt::Debug;
-use std::fmt::Formatter;
-use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::Mutex;
 
 use super::error::parse_error;
@@ -46,10 +45,10 @@ pub struct GdriveCore {
 }
 
 impl Debug for GdriveCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut de = f.debug_struct("GdriveCore");
-        de.field("root", &self.root);
-        de.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GdriveCore")
+            .field("root", &self.root)
+            .finish()
     }
 }
 

--- a/core/src/services/ghac/backend.rs
+++ b/core/src/services/ghac/backend.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::env;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use http::Response;
@@ -24,13 +25,14 @@ use log::debug;
 use sha2::Digest;
 
 use super::GHAC_SCHEME;
+use super::config::GhacConfig;
+use super::core::GhacCore;
 use super::core::*;
 use super::error::parse_error;
 use super::writer::GhacWriter;
 use crate::raw::*;
-use crate::services::GhacConfig;
-use crate::services::ghac::core::GhacCore;
 use crate::*;
+
 fn value_or_env(
     explicit_value: Option<String>,
     env_var_name: &str,
@@ -50,12 +52,20 @@ fn value_or_env(
 
 /// GitHub Action Cache Services support.
 #[doc = include_str!("docs.md")]
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct GhacBuilder {
     pub(super) config: GhacConfig,
 
     #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
     pub(super) http_client: Option<HttpClient>,
+}
+
+impl Debug for GhacBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GhacBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
 }
 
 impl GhacBuilder {

--- a/core/src/services/ghac/config.rs
+++ b/core/src/services/ghac/config.rs
@@ -17,12 +17,13 @@
 
 use std::fmt::Debug;
 
-use super::backend::GhacBuilder;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::backend::GhacBuilder;
+
 /// Config for GitHub Action Cache Services support.
-#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 #[non_exhaustive]
 pub struct GhacConfig {
@@ -34,6 +35,16 @@ pub struct GhacConfig {
     pub endpoint: Option<String>,
     /// The runtime token for ghac service.
     pub runtime_token: Option<String>,
+}
+
+impl Debug for GhacConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GhacConfig")
+            .field("root", &self.root)
+            .field("version", &self.version)
+            .field("endpoint", &self.endpoint)
+            .finish_non_exhaustive()
+    }
 }
 
 impl crate::Configurator for GhacConfig {

--- a/core/src/services/ghac/core.rs
+++ b/core/src/services/ghac/core.rs
@@ -17,7 +17,6 @@
 
 use std::env;
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -89,7 +88,7 @@ pub struct GhacCore {
 }
 
 impl Debug for GhacCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GhacCore")
             .field("root", &self.root)
             .field("cache_url", &self.cache_url)

--- a/core/src/services/github/backend.rs
+++ b/core/src/services/github/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -25,6 +24,7 @@ use http::StatusCode;
 use log::debug;
 
 use super::GITHUB_SCHEME;
+use super::config::GithubConfig;
 use super::core::Entry;
 use super::core::GithubCore;
 use super::delete::GithubDeleter;
@@ -33,7 +33,6 @@ use super::lister::GithubLister;
 use super::writer::GithubWriter;
 use super::writer::GithubWriters;
 use crate::raw::*;
-use crate::services::GithubConfig;
 use crate::*;
 
 /// [github contents](https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#create-or-update-file-contents) services support.
@@ -47,11 +46,10 @@ pub struct GithubBuilder {
 }
 
 impl Debug for GithubBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("GithubBuilder");
-
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GithubBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/github/config.rs
+++ b/core/src/services/github/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::GithubBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::GithubBuilder;
 
 /// Config for GitHub services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -48,14 +48,12 @@ pub struct GithubConfig {
 }
 
 impl Debug for GithubConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("GithubConfig");
-
-        d.field("root", &self.root)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GithubConfig")
+            .field("root", &self.root)
             .field("owner", &self.owner)
-            .field("repo", &self.repo);
-
-        d.finish_non_exhaustive()
+            .field("repo", &self.repo)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/github/core.rs
+++ b/core/src/services/github/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use base64::Engine;
@@ -49,8 +48,8 @@ pub struct GithubCore {
 }
 
 impl Debug for GithubCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GithubCore")
             .field("root", &self.root)
             .field("owner", &self.owner)
             .field("repo", &self.repo)

--- a/core/src/services/gridfs/backend.rs
+++ b/core/src/services/gridfs/backend.rs
@@ -27,7 +27,7 @@ use crate::raw::*;
 use crate::*;
 
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct GridfsBuilder {
     pub(super) config: GridfsConfig,
 }

--- a/core/src/services/gridfs/config.rs
+++ b/core/src/services/gridfs/config.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -41,13 +40,13 @@ pub struct GridfsConfig {
 }
 
 impl Debug for GridfsConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GridFsConfig")
             .field("database", &self.database)
             .field("bucket", &self.bucket)
             .field("chunk_size", &self.chunk_size)
             .field("root", &self.root)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/gridfs/core.rs
+++ b/core/src/services/gridfs/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use futures::AsyncReadExt;
 use futures::AsyncWriteExt;
@@ -39,12 +38,12 @@ pub struct GridfsCore {
 }
 
 impl Debug for GridfsCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GridfsCore")
             .field("database", &self.database)
             .field("bucket", &self.bucket)
             .field("chunk_size", &self.chunk_size)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -15,35 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::io;
 use std::sync::Arc;
 
 use log::debug;
 
 use super::HDFS_SCHEME;
+use super::config::HdfsConfig;
 use super::core::HdfsCore;
 use super::delete::HdfsDeleter;
 use super::lister::HdfsLister;
 use super::reader::HdfsReader;
 use super::writer::HdfsWriter;
 use crate::raw::*;
-use crate::services::HdfsConfig;
 use crate::*;
 
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct HdfsBuilder {
     pub(super) config: HdfsConfig,
-}
-
-impl Debug for HdfsBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HdfsBuilder")
-            .field("config", &self.config)
-            .finish()
-    }
 }
 
 impl HdfsBuilder {

--- a/core/src/services/hdfs/config.rs
+++ b/core/src/services/hdfs/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::HdfsBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::HdfsBuilder;
 
 /// [Hadoop Distributed File System (HDFS™)](https://hadoop.apache.org/) support.
 ///
@@ -44,7 +44,7 @@ pub struct HdfsConfig {
 }
 
 impl Debug for HdfsConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HdfsConfig")
             .field("root", &self.root)
             .field("name_node", &self.name_node)

--- a/core/src/services/hdfs/core.rs
+++ b/core/src/services/hdfs/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::io;
 use std::io::SeekFrom;
 use std::sync::Arc;
@@ -34,7 +33,7 @@ pub struct HdfsCore {
 }
 
 impl Debug for HdfsCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HdfsCore")
             .field("root", &self.root)
             .field("atomic_write_dir", &self.atomic_write_dir)

--- a/core/src/services/hdfs_native/backend.rs
+++ b/core/src/services/hdfs_native/backend.rs
@@ -15,13 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use log::debug;
 
 use super::HDFS_NATIVE_SCHEME;
+use super::config::HdfsNativeConfig;
 use super::core::HdfsNativeCore;
 use super::delete::HdfsNativeDeleter;
 use super::error::parse_hdfs_error;
@@ -29,22 +28,14 @@ use super::lister::HdfsNativeLister;
 use super::reader::HdfsNativeReader;
 use super::writer::HdfsNativeWriter;
 use crate::raw::*;
-use crate::services::HdfsNativeConfig;
 use crate::*;
+
 /// [Hadoop Distributed File System (HDFS™)](https://hadoop.apache.org/) support.
 /// Using [Native Rust HDFS client](https://github.com/Kimahriman/hdfs-native).
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct HdfsNativeBuilder {
     pub(super) config: HdfsNativeConfig,
-}
-
-impl Debug for HdfsNativeBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HdfsNativeBuilder")
-            .field("config", &self.config)
-            .finish()
-    }
 }
 
 impl HdfsNativeBuilder {

--- a/core/src/services/hdfs_native/config.rs
+++ b/core/src/services/hdfs_native/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::HdfsNativeBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::HdfsNativeBuilder;
 
 /// Config for HdfsNative services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -36,7 +36,7 @@ pub struct HdfsNativeConfig {
 }
 
 impl Debug for HdfsNativeConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HdfsNativeConfig")
             .field("root", &self.root)
             .field("name_node", &self.name_node)

--- a/core/src/services/hdfs_native/core.rs
+++ b/core/src/services/hdfs_native/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use hdfs_native::HdfsError;
@@ -36,7 +35,7 @@ pub struct HdfsNativeCore {
 }
 
 impl Debug for HdfsNativeCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HdfsNativeCore")
             .field("root", &self.root)
             .field("enable_append", &self.enable_append)

--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Response;
@@ -24,10 +23,10 @@ use http::StatusCode;
 use log::debug;
 
 use super::HTTP_SCHEME;
+use super::config::HttpConfig;
 use super::core::HttpCore;
 use super::error::parse_error;
 use crate::raw::*;
-use crate::services::HttpConfig;
 use crate::*;
 
 /// HTTP Read-only service support like [Nginx](https://www.nginx.com/) and [Caddy](https://caddyserver.com/).
@@ -41,10 +40,10 @@ pub struct HttpBuilder {
 }
 
 impl Debug for HttpBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut de = f.debug_struct("HttpBuilder");
-
-        de.field("config", &self.config).finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 
@@ -187,17 +186,9 @@ impl Builder for HttpBuilder {
 }
 
 /// Backend is used to serve `Accessor` support for http.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct HttpBackend {
     core: Arc<HttpCore>,
-}
-
-impl Debug for HttpBackend {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HttpBackend")
-            .field("core", &self.core)
-            .finish()
-    }
 }
 
 impl Access for HttpBackend {

--- a/core/src/services/http/config.rs
+++ b/core/src/services/http/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::HttpBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::HttpBuilder;
 
 /// Config for Http service support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -40,12 +40,11 @@ pub struct HttpConfig {
 }
 
 impl Debug for HttpConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut de = f.debug_struct("HttpConfig");
-        de.field("endpoint", &self.endpoint);
-        de.field("root", &self.root);
-
-        de.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpConfig")
+            .field("endpoint", &self.endpoint)
+            .field("root", &self.root)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/http/core.rs
+++ b/core/src/services/http/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Request;
@@ -38,11 +37,11 @@ pub struct HttpCore {
 }
 
 impl Debug for HttpCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HttpCore")
             .field("endpoint", &self.endpoint)
             .field("root", &self.root)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/huggingface/backend.rs
+++ b/core/src/services/huggingface/backend.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -25,28 +23,19 @@ use http::StatusCode;
 use log::debug;
 
 use super::HUGGINGFACE_SCHEME;
+use super::config::HuggingfaceConfig;
 use super::core::HuggingfaceCore;
 use super::core::HuggingfaceStatus;
 use super::error::parse_error;
 use super::lister::HuggingfaceLister;
 use crate::raw::*;
-use crate::services::HuggingfaceConfig;
 use crate::*;
 
 /// [Huggingface](https://huggingface.co/docs/huggingface_hub/package_reference/hf_api)'s API support.
 #[doc = include_str!("docs.md")]
-#[derive(Default, Clone)]
+#[derive(Debug, Default)]
 pub struct HuggingfaceBuilder {
     pub(super) config: HuggingfaceConfig,
-}
-
-impl Debug for HuggingfaceBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("Builder");
-
-        ds.field("config", &self.config);
-        ds.finish()
-    }
 }
 
 impl HuggingfaceBuilder {

--- a/core/src/services/huggingface/config.rs
+++ b/core/src/services/huggingface/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::HuggingfaceBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::HuggingfaceBuilder;
 
 /// Configuration for Huggingface service support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -52,26 +52,13 @@ pub struct HuggingfaceConfig {
 }
 
 impl Debug for HuggingfaceConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("HuggingfaceConfig");
-
-        if let Some(repo_type) = &self.repo_type {
-            ds.field("repo_type", &repo_type);
-        }
-        if let Some(repo_id) = &self.repo_id {
-            ds.field("repo_id", &repo_id);
-        }
-        if let Some(revision) = &self.revision {
-            ds.field("revision", &revision);
-        }
-        if let Some(root) = &self.root {
-            ds.field("root", &root);
-        }
-        if self.token.is_some() {
-            ds.field("token", &"<redacted>");
-        }
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HuggingfaceConfig")
+            .field("repo_type", &self.repo_type)
+            .field("repo_id", &self.repo_id)
+            .field("revision", &self.revision)
+            .field("root", &self.root)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/huggingface/error.rs
+++ b/core/src/services/huggingface/error.rs
@@ -32,10 +32,9 @@ struct HuggingfaceError {
 
 impl Debug for HuggingfaceError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut de = f.debug_struct("HuggingfaceError");
-        de.field("message", &self.error.replace('\n', " "));
-
-        de.finish()
+        f.debug_struct("HuggingfaceError")
+            .field("message", &self.error.replace('\n', " "))
+            .finish()
     }
 }
 

--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Response;
@@ -25,21 +24,29 @@ use log::debug;
 use prost::Message;
 
 use super::IPFS_SCHEME;
+use super::config::IpfsConfig;
 use super::core::IpfsCore;
 use super::error::parse_error;
 use super::ipld::PBNode;
 use crate::raw::*;
-use crate::services::IpfsConfig;
 use crate::*;
 
 /// IPFS file system support based on [IPFS HTTP Gateway](https://docs.ipfs.tech/concepts/ipfs-gateway/).
 #[doc = include_str!("docs.md")]
-#[derive(Default, Clone, Debug)]
+#[derive(Default)]
 pub struct IpfsBuilder {
     pub(super) config: IpfsConfig,
 
     #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
     pub(super) http_client: Option<HttpClient>,
+}
+
+impl Debug for IpfsBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IpfsBuilder")
+            .field("config", &self.config)
+            .finish()
+    }
 }
 
 impl IpfsBuilder {
@@ -146,17 +153,9 @@ impl Builder for IpfsBuilder {
 }
 
 /// Backend for IPFS.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct IpfsBackend {
     core: Arc<IpfsCore>,
-}
-
-impl Debug for IpfsBackend {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IpfsBackend")
-            .field("core", &self.core)
-            .finish()
-    }
 }
 
 impl Access for IpfsBackend {

--- a/core/src/services/ipfs/config.rs
+++ b/core/src/services/ipfs/config.rs
@@ -17,9 +17,10 @@
 
 use std::fmt::Debug;
 
-use super::backend::IpfsBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::IpfsBuilder;
 
 /// Config for IPFS file system support.
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/core/src/services/ipfs/core.rs
+++ b/core/src/services/ipfs/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Request;
@@ -34,11 +33,11 @@ pub struct IpfsCore {
 }
 
 impl Debug for IpfsCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IpfsCore")
             .field("endpoint", &self.endpoint)
             .field("root", &self.root)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/ipmfs/backend.rs
+++ b/core/src/services/ipmfs/backend.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt;
-use std::str;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -34,17 +32,9 @@ use crate::*;
 
 /// IPFS Mutable File System (IPMFS) backend.
 #[doc = include_str!("docs.md")]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct IpmfsBackend {
     pub core: Arc<IpmfsCore>,
-}
-
-impl fmt::Debug for IpmfsBackend {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("IpmfsBackend")
-            .field("core", &self.core)
-            .finish()
-    }
 }
 
 impl Access for IpmfsBackend {

--- a/core/src/services/ipmfs/builder.rs
+++ b/core/src/services/ipmfs/builder.rs
@@ -15,15 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use log::debug;
 
 use super::IPMFS_SCHEME;
 use super::backend::IpmfsBackend;
+use super::config::IpmfsConfig;
 use super::core::IpmfsCore;
 use crate::raw::*;
-use crate::services::IpmfsConfig;
 use crate::*;
 
 /// IPFS file system support based on [IPFS MFS](https://docs.ipfs.tech/concepts/file-systems/) API.
@@ -66,12 +67,20 @@ use crate::*;
 ///     Ok(())
 /// }
 /// ```
-#[derive(Default, Debug)]
+#[derive(Default)]
 pub struct IpmfsBuilder {
     pub(super) config: IpmfsConfig,
 
     #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
     pub(super) http_client: Option<HttpClient>,
+}
+
+impl Debug for IpmfsBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IpmfsBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
 }
 
 impl IpmfsBuilder {

--- a/core/src/services/ipmfs/config.rs
+++ b/core/src/services/ipmfs/config.rs
@@ -15,11 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-
-use super::builder::IpmfsBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::builder::IpmfsBuilder;
 
 /// Config for IPFS MFS support.
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/core/src/services/ipmfs/core.rs
+++ b/core/src/services/ipmfs/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::fmt::Write;
 use std::sync::Arc;
 
@@ -33,11 +32,11 @@ pub struct IpmfsCore {
 }
 
 impl Debug for IpmfsCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IpmfsCore")
             .field("root", &self.root)
             .field("endpoint", &self.endpoint)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/koofr/backend.rs
+++ b/core/src/services/koofr/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -27,6 +26,7 @@ use tokio::sync::Mutex;
 use tokio::sync::OnceCell;
 
 use super::KOOFR_SCHEME;
+use super::config::KoofrConfig;
 use super::core::File;
 use super::core::KoofrCore;
 use super::core::KoofrSigner;
@@ -36,7 +36,6 @@ use super::lister::KoofrLister;
 use super::writer::KoofrWriter;
 use super::writer::KoofrWriters;
 use crate::raw::*;
-use crate::services::KoofrConfig;
 use crate::*;
 
 /// [Koofr](https://app.koofr.net/) services support.
@@ -50,11 +49,10 @@ pub struct KoofrBuilder {
 }
 
 impl Debug for KoofrBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("KoofrBuilder");
-
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KoofrBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/koofr/config.rs
+++ b/core/src/services/koofr/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::KoofrBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::KoofrBuilder;
 
 /// Config for Koofr services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -40,13 +40,11 @@ pub struct KoofrConfig {
 }
 
 impl Debug for KoofrConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("Config");
-
-        ds.field("root", &self.root);
-        ds.field("email", &self.email);
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KoofrConfig")
+            .field("root", &self.root)
+            .field("email", &self.email)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/koofr/core.rs
+++ b/core/src/services/koofr/core.rs
@@ -17,7 +17,6 @@
 
 use std::collections::VecDeque;
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -56,8 +55,8 @@ pub struct KoofrCore {
 }
 
 impl Debug for KoofrCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KoofrCore")
             .field("root", &self.root)
             .field("endpoint", &self.endpoint)
             .field("email", &self.email)

--- a/core/src/services/lakefs/backend.rs
+++ b/core/src/services/lakefs/backend.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -25,6 +23,7 @@ use http::StatusCode;
 use log::debug;
 
 use super::LAKEFS_SCHEME;
+use super::config::LakefsConfig;
 use super::core::LakefsCore;
 use super::core::LakefsStatus;
 use super::delete::LakefsDeleter;
@@ -32,23 +31,13 @@ use super::error::parse_error;
 use super::lister::LakefsLister;
 use super::writer::LakefsWriter;
 use crate::raw::*;
-use crate::services::LakefsConfig;
 use crate::*;
 
 /// [Lakefs](https://docs.lakefs.io/reference/api.html#/)'s API support.
 #[doc = include_str!("docs.md")]
-#[derive(Default, Clone)]
+#[derive(Debug, Default)]
 pub struct LakefsBuilder {
     pub(super) config: LakefsConfig,
-}
-
-impl Debug for LakefsBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("Builder");
-
-        ds.field("config", &self.config);
-        ds.finish()
-    }
 }
 
 impl LakefsBuilder {

--- a/core/src/services/lakefs/config.rs
+++ b/core/src/services/lakefs/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::LakefsBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::LakefsBuilder;
 
 /// Configuration for Lakefs service support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -55,29 +55,13 @@ pub struct LakefsConfig {
 }
 
 impl Debug for LakefsConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("LakefsConfig");
-
-        if let Some(endpoint) = &self.endpoint {
-            ds.field("endpoint", &endpoint);
-        }
-        if let Some(_username) = &self.username {
-            ds.field("username", &"<redacted>");
-        }
-        if let Some(_password) = &self.password {
-            ds.field("password", &"<redacted>");
-        }
-        if let Some(root) = &self.root {
-            ds.field("root", &root);
-        }
-        if let Some(repository) = &self.repository {
-            ds.field("repository", &repository);
-        }
-        if let Some(branch) = &self.branch {
-            ds.field("branch", &branch);
-        }
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LakefsConfig")
+            .field("endpoint", &self.endpoint)
+            .field("root", &self.root)
+            .field("repository", &self.repository)
+            .field("branch", &self.branch)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/lakefs/error.rs
+++ b/core/src/services/lakefs/error.rs
@@ -32,10 +32,9 @@ struct LakefsError {
 
 impl Debug for LakefsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut de = f.debug_struct("LakefsError");
-        de.field("message", &self.error.replace('\n', " "));
-
-        de.finish()
+        f.debug_struct("LakefsError")
+            .field("message", &self.error.replace('\n', " "))
+            .finish()
     }
 }
 

--- a/core/src/services/memcached/backend.rs
+++ b/core/src/services/memcached/backend.rs
@@ -29,7 +29,7 @@ use crate::*;
 
 /// [Memcached](https://memcached.org/) service support.
 #[doc = include_str!("docs.md")]
-#[derive(Clone, Default)]
+#[derive(Debug, Default)]
 pub struct MemcachedBuilder {
     pub(super) config: MemcachedConfig,
 }

--- a/core/src/services/memcached/config.rs
+++ b/core/src/services/memcached/config.rs
@@ -18,12 +18,13 @@
 use std::fmt::Debug;
 use std::time::Duration;
 
-use super::backend::MemcachedBuilder;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::backend::MemcachedBuilder;
+
 /// Config for MemCached services support
-#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 #[non_exhaustive]
 pub struct MemcachedConfig {
@@ -41,6 +42,17 @@ pub struct MemcachedConfig {
     pub password: Option<String>,
     /// The default ttl for put operations.
     pub default_ttl: Option<Duration>,
+}
+
+impl Debug for MemcachedConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemcachedConfig")
+            .field("endpoint", &self.endpoint)
+            .field("root", &self.root)
+            .field("username", &self.username)
+            .field("default_ttl", &self.default_ttl)
+            .finish_non_exhaustive()
+    }
 }
 
 impl crate::Configurator for MemcachedConfig {

--- a/core/src/services/memory/backend.rs
+++ b/core/src/services/memory/backend.rs
@@ -19,18 +19,18 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use super::MEMORY_SCHEME;
+use super::config::MemoryConfig;
 use super::core::*;
 use super::delete::MemoryDeleter;
 use super::lister::MemoryLister;
 use super::writer::MemoryWriter;
 use crate::raw::oio;
 use crate::raw::*;
-use crate::services::MemoryConfig;
 use crate::*;
 
 /// In memory service support. (BTreeMap Based)
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct MemoryBuilder {
     pub(super) config: MemoryConfig,
 }

--- a/core/src/services/memory/config.rs
+++ b/core/src/services/memory/config.rs
@@ -17,9 +17,10 @@
 
 use std::fmt::Debug;
 
-use super::backend::MemoryBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::MemoryBuilder;
 
 /// Config for memory.
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/core/src/services/mini_moka/config.rs
+++ b/core/src/services/mini_moka/config.rs
@@ -15,15 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
-
-use super::backend::MiniMokaBuilder;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::backend::MiniMokaBuilder;
+
 /// Config for mini-moka support.
-#[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 #[non_exhaustive]
 pub struct MiniMokaConfig {
@@ -42,17 +40,6 @@ pub struct MiniMokaConfig {
 
     /// root path of this backend
     pub root: Option<String>,
-}
-
-impl Debug for MiniMokaConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MiniMokaConfig")
-            .field("max_capacity", &self.max_capacity)
-            .field("time_to_live", &self.time_to_live)
-            .field("time_to_idle", &self.time_to_idle)
-            .field("root", &self.root)
-            .finish()
-    }
 }
 
 impl crate::Configurator for MiniMokaConfig {

--- a/core/src/services/mini_moka/core.rs
+++ b/core/src/services/mini_moka/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use mini_moka::sync::Cache;
 
@@ -37,7 +36,7 @@ pub struct MiniMokaCore {
 }
 
 impl Debug for MiniMokaCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MiniMokaCore")
             .field("size", &self.cache.weighted_size())
             .field("count", &self.cache.entry_count())

--- a/core/src/services/moka/backend.rs
+++ b/core/src/services/moka/backend.rs
@@ -16,13 +16,13 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::Duration;
 
 use log::debug;
 
 use super::MOKA_SCHEME;
+use super::config::MokaConfig;
 use super::core::*;
 use super::delete::MokaDeleter;
 use super::lister::MokaLister;
@@ -30,7 +30,6 @@ use super::writer::MokaWriter;
 use crate::raw::oio;
 use crate::raw::signed_to_duration;
 use crate::raw::*;
-use crate::services::MokaConfig;
 use crate::*;
 
 /// Type alias of [`moka::future::Cache`](https://docs.rs/moka/latest/moka/future/struct.Cache.html)
@@ -47,10 +46,10 @@ pub struct MokaBuilder {
 }
 
 impl Debug for MokaBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MokaBuilder")
             .field("config", &self.config)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/moka/config.rs
+++ b/core/src/services/moka/config.rs
@@ -15,15 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
-
-use super::backend::MokaBuilder;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::backend::MokaBuilder;
+
 /// Config for Moka services support.
-#[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
 #[non_exhaustive]
 pub struct MokaConfig {
@@ -44,18 +42,6 @@ pub struct MokaConfig {
 
     /// root path of this backend
     pub root: Option<String>,
-}
-
-impl Debug for MokaConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MokaConfig")
-            .field("name", &self.name)
-            .field("max_capacity", &self.max_capacity)
-            .field("time_to_live", &self.time_to_live)
-            .field("time_to_idle", &self.time_to_idle)
-            .field("root", &self.root)
-            .finish_non_exhaustive()
-    }
 }
 
 impl crate::Configurator for MokaConfig {

--- a/core/src/services/moka/core.rs
+++ b/core/src/services/moka/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use moka::future::Cache;
 
@@ -37,7 +36,7 @@ pub struct MokaCore {
 }
 
 impl Debug for MokaCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MokaCore")
             .field("size", &self.cache.weighted_size())
             .field("count", &self.cache.entry_count())

--- a/core/src/services/mongodb/backend.rs
+++ b/core/src/services/mongodb/backend.rs
@@ -27,7 +27,7 @@ use crate::raw::*;
 use crate::*;
 
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct MongodbBuilder {
     pub(super) config: MongodbConfig,
 }

--- a/core/src/services/mongodb/config.rs
+++ b/core/src/services/mongodb/config.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -43,14 +42,14 @@ pub struct MongodbConfig {
 }
 
 impl Debug for MongodbConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MongodbConfig")
             .field("database", &self.database)
             .field("collection", &self.collection)
             .field("root", &self.root)
             .field("key_field", &self.key_field)
             .field("value_field", &self.value_field)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/mongodb/core.rs
+++ b/core/src/services/mongodb/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use mongodb::bson::Binary;
 use mongodb::bson::Document;
@@ -37,14 +36,13 @@ pub struct MongodbCore {
 }
 
 impl Debug for MongodbCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MongodbCore")
-            .field("connection_string", &self.connection_string)
             .field("database", &self.database)
             .field("collection", &self.collection)
             .field("key_field", &self.key_field)
             .field("value_field", &self.value_field)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/monoiofs/backend.rs
+++ b/core/src/services/monoiofs/backend.rs
@@ -15,24 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use monoio::fs::OpenOptions;
 use std::fmt::Debug;
 use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use monoio::fs::OpenOptions;
+
+use super::config::MonoiofsConfig;
 use super::core::BUFFER_SIZE;
 use super::core::MonoiofsCore;
 use super::delete::MonoiofsDeleter;
 use super::reader::MonoiofsReader;
 use super::writer::MonoiofsWriter;
 use crate::raw::*;
-use crate::services::MonoiofsConfig;
 use crate::*;
 
 /// File system support via [`monoio`].
 #[doc = include_str!("docs.md")]
-#[derive(Default, Debug)]
+#[derive(Debug, Default)]
 pub struct MonoiofsBuilder {
     pub(super) config: MonoiofsConfig,
 }

--- a/core/src/services/monoiofs/config.rs
+++ b/core/src/services/monoiofs/config.rs
@@ -15,11 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-
-use super::backend::MonoiofsBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::MonoiofsBuilder;
 
 /// Config for monoiofs services support.
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/core/src/services/mysql/backend.rs
+++ b/core/src/services/mysql/backend.rs
@@ -30,17 +30,9 @@ use crate::raw::*;
 use crate::*;
 
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct MysqlBuilder {
     pub(super) config: MysqlConfig,
-}
-
-impl Debug for MysqlBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("MysqlBuilder");
-
-        d.field("config", &self.config).finish()
-    }
 }
 
 impl MysqlBuilder {

--- a/core/src/services/mysql/config.rs
+++ b/core/src/services/mysql/config.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -52,18 +51,13 @@ pub struct MysqlConfig {
 }
 
 impl Debug for MysqlConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("MysqlConfig");
-
-        if self.connection_string.is_some() {
-            d.field("connection_string", &"<redacted>");
-        }
-
-        d.field("root", &self.root)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MysqlConfig")
+            .field("root", &self.root)
             .field("table", &self.table)
             .field("key_field", &self.key_field)
             .field("value_field", &self.value_field)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -17,7 +17,6 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Response;
@@ -29,6 +28,7 @@ use reqsign::HuaweicloudObsCredentialLoader;
 use reqsign::HuaweicloudObsSigner;
 
 use super::OBS_SCHEME;
+use super::config::ObsConfig;
 use super::core::ObsCore;
 use super::core::constants;
 use super::delete::ObsDeleter;
@@ -37,12 +37,11 @@ use super::lister::ObsLister;
 use super::writer::ObsWriter;
 use super::writer::ObsWriters;
 use crate::raw::*;
-use crate::services::ObsConfig;
 use crate::*;
 
 /// Huawei-Cloud Object Storage Service (OBS) support
 #[doc = include_str!("docs.md")]
-#[derive(Default, Clone)]
+#[derive(Default)]
 pub struct ObsBuilder {
     pub(super) config: ObsConfig,
 
@@ -51,10 +50,10 @@ pub struct ObsBuilder {
 }
 
 impl Debug for ObsBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("ObsBuilder");
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ObsBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/obs/config.rs
+++ b/core/src/services/obs/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::ObsBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::ObsBuilder;
 
 /// Config for Huawei-Cloud Object Storage Service (OBS) support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -42,14 +42,13 @@ pub struct ObsConfig {
 }
 
 impl Debug for ObsConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ObsConfig")
             .field("root", &self.root)
             .field("endpoint", &self.endpoint)
-            .field("access_key_id", &"<redacted>")
-            .field("secret_access_key", &"<redacted>")
             .field("bucket", &self.bucket)
-            .finish()
+            .field("enable_versioning", &self.enable_versioning)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/obs/core.rs
+++ b/core/src/services/obs/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -54,8 +53,8 @@ pub struct ObsCore {
 }
 
 impl Debug for ObsCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ObsCore")
             .field("root", &self.root)
             .field("bucket", &self.bucket)
             .field("endpoint", &self.endpoint)

--- a/core/src/services/onedrive/backend.rs
+++ b/core/src/services/onedrive/backend.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Response;
@@ -30,17 +28,9 @@ use super::writer::OneDriveWriter;
 use crate::raw::*;
 use crate::*;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct OnedriveBackend {
     pub core: Arc<OneDriveCore>,
-}
-
-impl Debug for OnedriveBackend {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("OnedriveBackend")
-            .field("core", &self.core)
-            .finish()
-    }
 }
 
 impl Access for OnedriveBackend {

--- a/core/src/services/onedrive/builder.rs
+++ b/core/src/services/onedrive/builder.rs
@@ -15,23 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::fmt::Debug;
+use std::sync::Arc;
+
 use log::debug;
 use services::onedrive::core::OneDriveCore;
 use services::onedrive::core::OneDriveSigner;
-use std::fmt::Debug;
-use std::fmt::Formatter;
-use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use super::ONEDRIVE_SCHEME;
 use super::backend::OnedriveBackend;
-use crate::Scheme;
-use crate::raw::Access;
-use crate::raw::AccessorInfo;
-use crate::raw::HttpClient;
-use crate::raw::Timestamp;
-use crate::raw::normalize_root;
-use crate::services::OnedriveConfig;
+use super::config::OnedriveConfig;
+use crate::raw::*;
 use crate::*;
 
 /// Microsoft [OneDrive](https://onedrive.com) backend support.
@@ -39,14 +34,16 @@ use crate::*;
 #[derive(Default)]
 pub struct OnedriveBuilder {
     pub(super) config: OnedriveConfig,
+
+    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
     pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for OnedriveBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OnedriveBuilder")
             .field("config", &self.config)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/onedrive/config.rs
+++ b/core/src/services/onedrive/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::builder::OnedriveBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::builder::OnedriveBuilder;
 
 /// Config for [OneDrive](https://onedrive.com) backend support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -42,9 +42,10 @@ pub struct OnedriveConfig {
 }
 
 impl Debug for OnedriveConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OnedriveConfig")
             .field("root", &self.root)
+            .field("enable_versioning", &self.enable_versioning)
             .finish_non_exhaustive()
     }
 }
@@ -70,6 +71,7 @@ impl crate::Configurator for OnedriveConfig {
         Self::from_iter(map)
     }
 
+    #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
         OnedriveBuilder {
             config: self,

--- a/core/src/services/onedrive/core.rs
+++ b/core/src/services/onedrive/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -40,7 +39,7 @@ pub struct OneDriveCore {
 }
 
 impl Debug for OneDriveCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OneDriveCore")
             .field("root", &self.root)
             .finish_non_exhaustive()

--- a/core/src/services/opfs/backend.rs
+++ b/core/src/services/opfs/backend.rs
@@ -17,11 +17,12 @@
 
 use std::fmt::Debug;
 use std::sync::Arc;
+
 use web_sys::FileSystemGetDirectoryOptions;
 
 use super::utils::*;
-use crate::Result;
 use crate::raw::*;
+use crate::*;
 
 /// OPFS Service backend
 #[derive(Default, Debug, Clone)]

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Response;
@@ -28,6 +27,7 @@ use reqsign::AliyunLoader;
 use reqsign::AliyunOssSigner;
 
 use super::OSS_SCHEME;
+use super::config::OssConfig;
 use super::core::*;
 use super::delete::OssDeleter;
 use super::error::parse_error;
@@ -37,8 +37,8 @@ use super::lister::OssObjectVersionsLister;
 use super::writer::OssWriter;
 use super::writer::OssWriters;
 use crate::raw::*;
-use crate::services::OssConfig;
 use crate::*;
+
 const DEFAULT_BATCH_MAX_OPERATIONS: usize = 1000;
 
 /// Aliyun Object Storage Service (OSS) support
@@ -52,11 +52,10 @@ pub struct OssBuilder {
 }
 
 impl Debug for OssBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("OssBuilder");
-
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OssBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/oss/config.rs
+++ b/core/src/services/oss/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::OssBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::OssBuilder;
 
 /// Config for Aliyun Object Storage Service (OSS) support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -102,14 +102,13 @@ pub struct OssConfig {
 }
 
 impl Debug for OssConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("Builder");
-        d.field("root", &self.root)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Builder")
+            .field("root", &self.root)
             .field("bucket", &self.bucket)
             .field("endpoint", &self.endpoint)
-            .field("allow_anonymous", &self.allow_anonymous);
-
-        d.finish_non_exhaustive()
+            .field("allow_anonymous", &self.allow_anonymous)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/oss/core.rs
+++ b/core/src/services/oss/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -83,8 +82,8 @@ pub struct OssCore {
 }
 
 impl Debug for OssCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OssCore")
             .field("root", &self.root)
             .field("bucket", &self.bucket)
             .field("endpoint", &self.endpoint)

--- a/core/src/services/pcloud/backend.rs
+++ b/core/src/services/pcloud/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -25,6 +24,7 @@ use http::StatusCode;
 use log::debug;
 
 use super::PCLOUD_SCHEME;
+use super::config::PcloudConfig;
 use super::core::*;
 use super::delete::PcloudDeleter;
 use super::error::PcloudError;
@@ -33,7 +33,6 @@ use super::lister::PcloudLister;
 use super::writer::PcloudWriter;
 use super::writer::PcloudWriters;
 use crate::raw::*;
-use crate::services::PcloudConfig;
 use crate::*;
 
 /// [pCloud](https://www.pcloud.com/) services support.
@@ -47,11 +46,10 @@ pub struct PcloudBuilder {
 }
 
 impl Debug for PcloudBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("PcloudBuilder");
-
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PcloudBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/pcloud/config.rs
+++ b/core/src/services/pcloud/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::PcloudBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::PcloudBuilder;
 
 /// Config for Pcloud services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -31,7 +31,7 @@ pub struct PcloudConfig {
     ///
     /// All operations will happen under this root.
     pub root: Option<String>,
-    ///pCloud  endpoint address.
+    /// pCloud endpoint address.
     pub endpoint: String,
     /// pCloud username.
     pub username: Option<String>,
@@ -40,14 +40,12 @@ pub struct PcloudConfig {
 }
 
 impl Debug for PcloudConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("Config");
-
-        ds.field("root", &self.root);
-        ds.field("endpoint", &self.endpoint);
-        ds.field("username", &self.username);
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PcloudConfig")
+            .field("root", &self.root)
+            .field("endpoint", &self.endpoint)
+            .field("username", &self.username)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/pcloud/core.rs
+++ b/core/src/services/pcloud/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -46,8 +45,8 @@ pub struct PcloudCore {
 }
 
 impl Debug for PcloudCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PcloudCore")
             .field("root", &self.root)
             .field("endpoint", &self.endpoint)
             .field("username", &self.username)

--- a/core/src/services/pcloud/error.rs
+++ b/core/src/services/pcloud/error.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use http::Response;
 use serde::Deserialize;
@@ -32,7 +31,7 @@ pub(super) struct PcloudError {
 }
 
 impl Debug for PcloudError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PcloudError")
             .field("result", &self.result)
             .field("error", &self.error)

--- a/core/src/services/persy/backend.rs
+++ b/core/src/services/persy/backend.rs
@@ -27,7 +27,7 @@ use crate::*;
 
 /// persy service support.
 #[doc = include_str!("docs.md")]
-#[derive(Default, Debug)]
+#[derive(Debug, Default)]
 pub struct PersyBuilder {
     pub(super) config: PersyConfig,
 }

--- a/core/src/services/persy/core.rs
+++ b/core/src/services/persy/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use crate::*;
 
@@ -29,12 +28,12 @@ pub struct PersyCore {
 }
 
 impl Debug for PersyCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("Adapter");
-        ds.field("path", &self.datafile);
-        ds.field("segment", &self.segment);
-        ds.field("index", &self.index);
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PersyCore")
+            .field("path", &self.datafile)
+            .field("segment", &self.segment)
+            .field("index", &self.index)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/postgresql/backend.rs
+++ b/core/src/services/postgresql/backend.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use sqlx::postgres::PgConnectOptions;
@@ -31,18 +29,9 @@ use crate::*;
 
 /// [PostgreSQL](https://www.postgresql.org/) services support.
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct PostgresqlBuilder {
     pub(super) config: PostgresqlConfig,
-}
-
-impl Debug for PostgresqlBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("PostgresqlBuilder");
-
-        d.field("config", &self.config);
-        d.finish()
-    }
 }
 
 impl PostgresqlBuilder {

--- a/core/src/services/postgresql/config.rs
+++ b/core/src/services/postgresql/config.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -52,18 +51,13 @@ pub struct PostgresqlConfig {
 }
 
 impl Debug for PostgresqlConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("PostgresqlConfig");
-
-        if self.connection_string.is_some() {
-            d.field("connection_string", &"<redacted>");
-        }
-
-        d.field("root", &self.root)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PostgresqlConfig")
+            .field("root", &self.root)
             .field("table", &self.table)
             .field("key_field", &self.key_field)
             .field("value_field", &self.value_field)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/redb/backend.rs
+++ b/core/src/services/redb/backend.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use super::config::RedbConfig;
@@ -26,11 +27,19 @@ use crate::*;
 
 /// Redb service support.
 #[doc = include_str!("docs.md")]
-#[derive(Default, Debug)]
+#[derive(Default)]
 pub struct RedbBuilder {
     pub(super) config: RedbConfig,
 
     pub(super) database: Option<Arc<redb::Database>>,
+}
+
+impl Debug for RedbBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RedbBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
 }
 
 impl RedbBuilder {

--- a/core/src/services/redb/core.rs
+++ b/core/src/services/redb/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use crate::*;
@@ -29,11 +28,11 @@ pub struct RedbCore {
 }
 
 impl Debug for RedbCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("RedbCore");
-        ds.field("path", &self.datadir)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RedbCore")
+            .field("path", &self.datadir)
             .field("table", &self.table)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/redis/backend.rs
+++ b/core/src/services/redis/backend.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -30,30 +28,21 @@ use redis::cluster::ClusterClientBuilder;
 use tokio::sync::OnceCell;
 
 use super::REDIS_SCHEME;
+use super::config::RedisConfig;
 use super::core::*;
 use super::delete::RedisDeleter;
 use super::writer::RedisWriter;
-use crate::raw::oio;
 use crate::raw::*;
-use crate::services::RedisConfig;
 use crate::*;
+
 const DEFAULT_REDIS_ENDPOINT: &str = "tcp://127.0.0.1:6379";
 const DEFAULT_REDIS_PORT: u16 = 6379;
 
 /// [Redis](https://redis.io/) services support.
 #[doc = include_str!("docs.md")]
-#[derive(Clone, Default)]
+#[derive(Debug, Default)]
 pub struct RedisBuilder {
     pub(super) config: RedisConfig,
-}
-
-impl Debug for RedisBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("RedisBuilder");
-
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
-    }
 }
 
 impl RedisBuilder {

--- a/core/src/services/redis/config.rs
+++ b/core/src/services/redis/config.rs
@@ -16,12 +16,12 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::time::Duration;
 
-use super::backend::RedisBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::RedisBuilder;
 
 /// Config for Redis services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -57,25 +57,15 @@ pub struct RedisConfig {
 }
 
 impl Debug for RedisConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("RedisConfig");
-
-        d.field("db", &self.db.to_string());
-        d.field("root", &self.root);
-        if let Some(endpoint) = self.endpoint.clone() {
-            d.field("endpoint", &endpoint);
-        }
-        if let Some(cluster_endpoints) = self.cluster_endpoints.clone() {
-            d.field("cluster_endpoints", &cluster_endpoints);
-        }
-        if let Some(username) = self.username.clone() {
-            d.field("username", &username);
-        }
-        if self.password.is_some() {
-            d.field("password", &"<redacted>");
-        }
-
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RedisConfig")
+            .field("endpoint", &self.endpoint)
+            .field("cluster_endpoints", &self.cluster_endpoints)
+            .field("username", &self.username)
+            .field("root", &self.root)
+            .field("db", &self.db)
+            .field("default_ttl", &self.default_ttl)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/redis/core.rs
+++ b/core/src/services/redis/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::time::Duration;
 
 use bb8::RunError;
@@ -123,10 +122,10 @@ pub struct RedisCore {
 }
 
 impl Debug for RedisCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("RedisCore");
-        ds.field("addr", &self.addr);
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RedisCore")
+            .field("addr", &self.addr)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/rocksdb/backend.rs
+++ b/core/src/services/rocksdb/backend.rs
@@ -29,7 +29,7 @@ use crate::*;
 
 /// RocksDB service support.
 #[doc = include_str!("docs.md")]
-#[derive(Clone, Default)]
+#[derive(Debug, Default)]
 pub struct RocksdbBuilder {
     pub(super) config: RocksdbConfig,
 }

--- a/core/src/services/rocksdb/config.rs
+++ b/core/src/services/rocksdb/config.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/core/src/services/rocksdb/core.rs
+++ b/core/src/services/rocksdb/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use rocksdb::DB;
@@ -29,10 +28,10 @@ pub struct RocksdbCore {
 }
 
 impl Debug for RocksdbCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("RocksdbCore");
-        ds.field("path", &self.db.path());
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RocksdbCore")
+            .field("path", &self.db.path())
+            .finish()
     }
 }
 

--- a/core/src/services/s3/config.rs
+++ b/core/src/services/s3/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::S3Builder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::S3Builder;
 
 /// Config for Aws S3 and compatible services (including minio, digitalocean space, Tencent Cloud Object Storage(COS) and so on) support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -219,15 +219,13 @@ pub struct S3Config {
 }
 
 impl Debug for S3Config {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("S3Config");
-
-        d.field("root", &self.root)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3Config")
+            .field("root", &self.root)
             .field("bucket", &self.bucket)
             .field("endpoint", &self.endpoint)
-            .field("region", &self.region);
-
-        d.finish_non_exhaustive()
+            .field("region", &self.region)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/s3/core.rs
+++ b/core/src/services/s3/core.rs
@@ -15,10 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Display;
-use std::fmt::Formatter;
 use std::fmt::Write;
 use std::sync::Arc;
 use std::sync::atomic;
@@ -111,7 +109,7 @@ pub struct S3Core {
 }
 
 impl Debug for S3Core {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("S3Core")
             .field("bucket", &self.bucket)
             .field("endpoint", &self.endpoint)
@@ -1270,7 +1268,7 @@ impl ChecksumAlgorithm {
     }
 }
 impl Display for ChecksumAlgorithm {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "{}",

--- a/core/src/services/seafile/backend.rs
+++ b/core/src/services/seafile/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Response;
@@ -25,6 +24,7 @@ use log::debug;
 use tokio::sync::RwLock;
 
 use super::SEAFILE_SCHEME;
+use super::config::SeafileConfig;
 use super::core::SeafileCore;
 use super::core::SeafileSigner;
 use super::core::parse_dir_detail;
@@ -35,7 +35,6 @@ use super::lister::SeafileLister;
 use super::writer::SeafileWriter;
 use super::writer::SeafileWriters;
 use crate::raw::*;
-use crate::services::SeafileConfig;
 use crate::*;
 
 /// [seafile](https://www.seafile.com) services support.
@@ -49,11 +48,10 @@ pub struct SeafileBuilder {
 }
 
 impl Debug for SeafileBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("SeafileBuilder");
-
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SeafileBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/seafile/config.rs
+++ b/core/src/services/seafile/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::SeafileBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::SeafileBuilder;
 
 /// Config for seafile services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -44,15 +44,13 @@ pub struct SeafileConfig {
 }
 
 impl Debug for SeafileConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("SeafileConfig");
-
-        d.field("root", &self.root)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SeafileConfig")
+            .field("root", &self.root)
             .field("endpoint", &self.endpoint)
             .field("username", &self.username)
-            .field("repo_name", &self.repo_name);
-
-        d.finish_non_exhaustive()
+            .field("repo_name", &self.repo_name)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/seafile/core.rs
+++ b/core/src/services/seafile/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -52,8 +51,8 @@ pub struct SeafileCore {
 }
 
 impl Debug for SeafileCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SeafileCore")
             .field("root", &self.root)
             .field("endpoint", &self.endpoint)
             .field("username", &self.username)

--- a/core/src/services/sftp/backend.rs
+++ b/core/src/services/sftp/backend.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::io::SeekFrom;
 use std::path::Path;
 use std::path::PathBuf;
@@ -28,6 +26,7 @@ use tokio::io::AsyncSeekExt;
 use tokio::sync::OnceCell;
 
 use super::SFTP_SCHEME;
+use super::config::SftpConfig;
 use super::core::SftpCore;
 use super::delete::SftpDeleter;
 use super::error::is_not_found;
@@ -37,7 +36,6 @@ use super::lister::SftpLister;
 use super::reader::SftpReader;
 use super::writer::SftpWriter;
 use crate::raw::*;
-use crate::services::SftpConfig;
 use crate::*;
 
 /// SFTP services support. (only works on unix)
@@ -50,17 +48,9 @@ use crate::*;
 /// For example, the default value is 255 in macOS, and 1024 in linux. If you want to open
 /// lots of files, you should pay attention to close the file after using it.
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct SftpBuilder {
     pub(super) config: SftpConfig,
-}
-
-impl Debug for SftpBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SftpBuilder")
-            .field("config", &self.config)
-            .finish()
-    }
 }
 
 impl SftpBuilder {
@@ -215,17 +205,9 @@ impl Builder for SftpBuilder {
 }
 
 /// Backend is used to serve `Accessor` support for sftp.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SftpBackend {
     pub core: Arc<SftpCore>,
-}
-
-impl Debug for SftpBackend {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SftpBackend")
-            .field("core", &self.core)
-            .finish()
-    }
 }
 
 impl Access for SftpBackend {

--- a/core/src/services/sftp/config.rs
+++ b/core/src/services/sftp/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::SftpBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::SftpBuilder;
 
 /// Config for Sftp Service support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -42,7 +42,7 @@ pub struct SftpConfig {
 }
 
 impl Debug for SftpConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SftpConfig")
             .field("endpoint", &self.endpoint)
             .field("root", &self.root)

--- a/core/src/services/sftp/core.rs
+++ b/core/src/services/sftp/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -48,11 +47,11 @@ pub struct SftpCore {
 }
 
 impl Debug for SftpCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SftpCore")
             .field("endpoint", &self.endpoint)
             .field("root", &self.root)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/sled/backend.rs
+++ b/core/src/services/sled/backend.rs
@@ -30,7 +30,7 @@ const DEFAULT_TREE_ID: &str = r#"__sled__default"#;
 
 /// Sled services support.
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct SledBuilder {
     pub(super) config: SledConfig,
 }

--- a/core/src/services/sled/config.rs
+++ b/core/src/services/sled/config.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -37,12 +36,11 @@ pub struct SledConfig {
 }
 
 impl Debug for SledConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SledConfig")
-            .field("datadir", &self.datadir)
             .field("tree", &self.tree)
             .field("root", &self.root)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/sled/core.rs
+++ b/core/src/services/sled/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use crate::*;
 
@@ -27,10 +26,10 @@ pub struct SledCore {
 }
 
 impl Debug for SledCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("SledCore");
-        ds.field("path", &self.datadir);
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SledCore")
+            .field("path", &self.datadir)
+            .finish()
     }
 }
 

--- a/core/src/services/sqlite/backend.rs
+++ b/core/src/services/sqlite/backend.rs
@@ -15,32 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::raw::oio;
-use crate::raw::*;
-use crate::services::SqliteConfig;
-use crate::services::sqlite::core::SqliteCore;
-use crate::services::sqlite::delete::SqliteDeleter;
-use crate::services::sqlite::writer::SqliteWriter;
-use crate::*;
-use sqlx::sqlite::SqliteConnectOptions;
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::str::FromStr;
+
+use sqlx::sqlite::SqliteConnectOptions;
 use tokio::sync::OnceCell;
 
+use super::config::SqliteConfig;
+use super::core::SqliteCore;
+use super::delete::SqliteDeleter;
+use super::writer::SqliteWriter;
+use crate::raw::oio;
+use crate::raw::*;
+use crate::*;
+
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct SqliteBuilder {
     pub(super) config: SqliteConfig,
-}
-
-impl Debug for SqliteBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("SqliteBuilder");
-
-        ds.field("config", &self.config);
-        ds.finish()
-    }
 }
 
 impl SqliteBuilder {

--- a/core/src/services/sqlite/config.rs
+++ b/core/src/services/sqlite/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::SqliteBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::SqliteBuilder;
 
 /// Config for Sqlite support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -57,21 +57,19 @@ pub struct SqliteConfig {
 }
 
 impl Debug for SqliteConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("SqliteConfig");
-
-        d.field("connection_string", &self.connection_string)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqliteConfig")
             .field("table", &self.table)
             .field("key_field", &self.key_field)
             .field("value_field", &self.value_field)
-            .field("root", &self.root);
-
-        d.finish_non_exhaustive()
+            .field("root", &self.root)
+            .finish_non_exhaustive()
     }
 }
 
 impl crate::Configurator for SqliteConfig {
     type Builder = SqliteBuilder;
+
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let mut map = uri.options().clone();
 

--- a/core/src/services/surrealdb/backend.rs
+++ b/core/src/services/surrealdb/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use tokio::sync::OnceCell;
@@ -29,17 +28,9 @@ use crate::raw::*;
 use crate::*;
 
 #[doc = include_str!("docs.md")]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct SurrealdbBuilder {
     pub(super) config: SurrealdbConfig,
-}
-
-impl Debug for SurrealdbBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SurrealdbBuilder")
-            .field("config", &self.config)
-            .finish()
-    }
 }
 
 impl SurrealdbBuilder {

--- a/core/src/services/surrealdb/config.rs
+++ b/core/src/services/surrealdb/config.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -49,19 +48,16 @@ pub struct SurrealdbConfig {
 }
 
 impl Debug for SurrealdbConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("SurrealdbConfig");
-
-        d.field("connection_string", &self.connection_string)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SurrealdbConfig")
             .field("username", &self.username)
-            .field("password", &"<redacted>")
             .field("namespace", &self.namespace)
             .field("database", &self.database)
             .field("table", &self.table)
             .field("key_field", &self.key_field)
             .field("value_field", &self.value_field)
             .field("root", &self.root)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/surrealdb/core.rs
+++ b/core/src/services/surrealdb/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use surrealdb::Surreal;
@@ -42,17 +41,16 @@ pub struct SurrealdbCore {
 }
 
 impl Debug for SurrealdbCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SurrealdbCore")
             .field("connection_string", &self.connection_string)
             .field("username", &self.username)
-            .field("password", &"<redacted>")
             .field("namespace", &self.namespace)
             .field("database", &self.database)
             .field("table", &self.table)
             .field("key_field", &self.key_field)
             .field("value_field", &self.value_field)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/swift/backend.rs
+++ b/core/src/services/swift/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Response;
@@ -37,17 +36,9 @@ use crate::*;
 /// For more information about swift-compatible services, refer to [Compatible Services](#compatible-services).
 #[doc = include_str!("docs.md")]
 #[doc = include_str!("compatible_services.md")]
-#[derive(Default, Clone)]
+#[derive(Debug, Default)]
 pub struct SwiftBuilder {
     pub(super) config: SwiftConfig,
-}
-
-impl Debug for SwiftBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("SwiftBuilder");
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
-    }
 }
 
 impl SwiftBuilder {

--- a/core/src/services/swift/config.rs
+++ b/core/src/services/swift/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::SwiftBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::SwiftBuilder;
 
 /// Config for OpenStack Swift support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -38,18 +38,12 @@ pub struct SwiftConfig {
 }
 
 impl Debug for SwiftConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("SwiftConfig");
-
-        ds.field("root", &self.root);
-        ds.field("endpoint", &self.endpoint);
-        ds.field("container", &self.container);
-
-        if self.token.is_some() {
-            ds.field("token", &"<redacted>");
-        }
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SwiftConfig")
+            .field("endpoint", &self.endpoint)
+            .field("container", &self.container)
+            .field("root", &self.root)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/tikv/backend.rs
+++ b/core/src/services/tikv/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use tokio::sync::OnceCell;
@@ -30,18 +29,9 @@ use crate::*;
 
 /// TiKV backend builder
 #[doc = include_str!("docs.md")]
-#[derive(Clone, Default)]
+#[derive(Debug, Default)]
 pub struct TikvBuilder {
     pub(super) config: TikvConfig,
-}
-
-impl Debug for TikvBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("TikvBuilder");
-
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
-    }
 }
 
 impl TikvBuilder {

--- a/core/src/services/tikv/config.rs
+++ b/core/src/services/tikv/config.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -41,15 +40,14 @@ pub struct TikvConfig {
 }
 
 impl Debug for TikvConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("TikvConfig");
-
-        d.field("endpoints", &self.endpoints)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TikvConfig")
+            .field("endpoints", &self.endpoints)
             .field("insecure", &self.insecure)
             .field("ca_path", &self.ca_path)
             .field("cert_path", &self.cert_path)
             .field("key_path", &self.key_path)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/tikv/core.rs
+++ b/core/src/services/tikv/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
 use tikv_client::Config;
 use tikv_client::RawClient;
@@ -36,7 +35,7 @@ pub struct TikvCore {
 }
 
 impl Debug for TikvCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TikvCore")
             .field("endpoints", &self.endpoints)
             .field("insecure", &self.insecure)

--- a/core/src/services/upyun/backend.rs
+++ b/core/src/services/upyun/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use http::Response;
@@ -24,6 +23,7 @@ use http::StatusCode;
 use log::debug;
 
 use super::UPYUN_SCHEME;
+use super::config::UpyunConfig;
 use super::core::*;
 use super::delete::UpyunDeleter;
 use super::error::parse_error;
@@ -31,7 +31,6 @@ use super::lister::UpyunLister;
 use super::writer::UpyunWriter;
 use super::writer::UpyunWriters;
 use crate::raw::*;
-use crate::services::UpyunConfig;
 use crate::*;
 
 /// [upyun](https://www.upyun.com/products/file-storage) services support.
@@ -45,11 +44,10 @@ pub struct UpyunBuilder {
 }
 
 impl Debug for UpyunBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("UpyunBuilder");
-
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpyunBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/upyun/config.rs
+++ b/core/src/services/upyun/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::UpyunBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::UpyunBuilder;
 
 /// Config for upyun services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -40,14 +40,12 @@ pub struct UpyunConfig {
 }
 
 impl Debug for UpyunConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("Config");
-
-        ds.field("root", &self.root);
-        ds.field("bucket", &self.bucket);
-        ds.field("operator", &self.operator);
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpyunConfig")
+            .field("root", &self.root)
+            .field("bucket", &self.bucket)
+            .field("operator", &self.operator)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/upyun/core.rs
+++ b/core/src/services/upyun/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use base64::Engine;
@@ -69,8 +68,8 @@ pub struct UpyunCore {
 }
 
 impl Debug for UpyunCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpyunCore")
             .field("root", &self.root)
             .field("bucket", &self.bucket)
             .field("operator", &self.operator)

--- a/core/src/services/vercel_artifacts/backend.rs
+++ b/core/src/services/vercel_artifacts/backend.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
 use std::sync::Arc;
 
 use http::Response;
@@ -28,17 +27,9 @@ use crate::raw::*;
 use crate::*;
 
 #[doc = include_str!("docs.md")]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct VercelArtifactsBackend {
     pub core: Arc<VercelArtifactsCore>,
-}
-
-impl Debug for VercelArtifactsBackend {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VercelArtifactsBackend")
-            .field("core", &self.core)
-            .finish()
-    }
 }
 
 impl Access for VercelArtifactsBackend {

--- a/core/src/services/vercel_artifacts/builder.rs
+++ b/core/src/services/vercel_artifacts/builder.rs
@@ -16,16 +16,13 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use super::VERCEL_ARTIFACTS_SCHEME;
 use super::backend::VercelArtifactsBackend;
+use super::config::VercelArtifactsConfig;
 use super::core::VercelArtifactsCore;
-use crate::raw::Access;
-use crate::raw::AccessorInfo;
-use crate::raw::HttpClient;
-use crate::services::VercelArtifactsConfig;
+use crate::raw::*;
 use crate::*;
 
 /// [Vercel Cache](https://vercel.com/docs/concepts/monorepos/remote-caching) backend support.
@@ -39,10 +36,10 @@ pub struct VercelArtifactsBuilder {
 }
 
 impl Debug for VercelArtifactsBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("VercelArtifactsBuilder");
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VercelArtifactsBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/vercel_artifacts/config.rs
+++ b/core/src/services/vercel_artifacts/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::builder::VercelArtifactsBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::builder::VercelArtifactsBuilder;
 
 /// Config for Vercel Cache support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -32,10 +32,9 @@ pub struct VercelArtifactsConfig {
 }
 
 impl Debug for VercelArtifactsConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("VercelArtifactsConfig")
-            .field("access_token", &"<redacted>")
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/vercel_artifacts/core.rs
+++ b/core/src/services/vercel_artifacts/core.rs
@@ -32,9 +32,8 @@ pub struct VercelArtifactsCore {
 
 impl Debug for VercelArtifactsCore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut de = f.debug_struct("VercelArtifactsCore");
-        de.field("access_token", &self.access_token);
-        de.finish()
+        f.debug_struct("VercelArtifactsCore")
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/vercel_blob/backend.rs
+++ b/core/src/services/vercel_blob/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -48,11 +47,10 @@ pub struct VercelBlobBuilder {
 }
 
 impl Debug for VercelBlobBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("VercelBlobBuilder");
-
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VercelBlobBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/vercel_blob/config.rs
+++ b/core/src/services/vercel_blob/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::VercelBlobBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::VercelBlobBuilder;
 
 /// Config for VercelBlob services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -36,12 +36,10 @@ pub struct VercelBlobConfig {
 }
 
 impl Debug for VercelBlobConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("Config");
-
-        ds.field("root", &self.root);
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VercelBlobConfig")
+            .field("root", &self.root)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/vercel_blob/core.rs
+++ b/core/src/services/vercel_blob/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -65,8 +64,8 @@ pub struct VercelBlobCore {
 }
 
 impl Debug for VercelBlobCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VercelBlobCore")
             .field("root", &self.root)
             .finish_non_exhaustive()
     }

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -25,13 +24,13 @@ use http::StatusCode;
 use log::debug;
 
 use super::WEBDAV_SCHEME;
+use super::config::WebdavConfig;
 use super::core::*;
 use super::delete::WebdavDeleter;
 use super::error::parse_error;
 use super::lister::WebdavLister;
 use super::writer::WebdavWriter;
 use crate::raw::*;
-use crate::services::WebdavConfig;
 use crate::*;
 
 /// [WebDAV](https://datatracker.ietf.org/doc/html/rfc4918) backend support.
@@ -45,12 +44,10 @@ pub struct WebdavBuilder {
 }
 
 impl Debug for WebdavBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("WebdavBuilder");
-
-        d.field("config", &self.config);
-
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebdavBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 
@@ -208,17 +205,9 @@ impl Builder for WebdavBuilder {
 }
 
 /// Backend is used to serve `Accessor` support for http.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct WebdavBackend {
     core: Arc<WebdavCore>,
-}
-
-impl Debug for WebdavBackend {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("WebdavBackend")
-            .field("core", &self.core)
-            .finish()
-    }
 }
 
 impl Access for WebdavBackend {

--- a/core/src/services/webdav/config.rs
+++ b/core/src/services/webdav/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::WebdavBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::WebdavBuilder;
 
 /// Config for [WebDAV](https://datatracker.ietf.org/doc/html/rfc4918) backend support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -42,14 +42,13 @@ pub struct WebdavConfig {
 }
 
 impl Debug for WebdavConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("WebdavConfig");
-
-        d.field("endpoint", &self.endpoint)
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebdavConfig")
+            .field("endpoint", &self.endpoint)
             .field("username", &self.username)
-            .field("root", &self.root);
-
-        d.finish_non_exhaustive()
+            .field("root", &self.root)
+            .field("disable_copy", &self.disable_copy)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/webdav/core.rs
+++ b/core/src/services/webdav/core.rs
@@ -16,9 +16,7 @@
 // under the License.
 
 use std::collections::VecDeque;
-use std::fmt;
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -78,7 +76,7 @@ pub struct WebdavCore {
 }
 
 impl Debug for WebdavCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WebdavCore")
             .field("endpoint", &self.endpoint)
             .field("root", &self.root)

--- a/core/src/services/webhdfs/backend.rs
+++ b/core/src/services/webhdfs/backend.rs
@@ -15,8 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use core::fmt::Debug;
-use std::fmt::Formatter;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -26,6 +25,7 @@ use log::debug;
 use tokio::sync::OnceCell;
 
 use super::WEBHDFS_SCHEME;
+use super::config::WebhdfsConfig;
 use super::core::WebhdfsCore;
 use super::delete::WebhdfsDeleter;
 use super::error::parse_error;
@@ -36,23 +36,15 @@ use super::message::FileStatusWrapper;
 use super::writer::WebhdfsWriter;
 use super::writer::WebhdfsWriters;
 use crate::raw::*;
-use crate::services::WebhdfsConfig;
 use crate::*;
+
 const WEBHDFS_DEFAULT_ENDPOINT: &str = "http://127.0.0.1:9870";
 
 /// [WebHDFS](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/WebHDFS.html)'s REST API support.
 #[doc = include_str!("docs.md")]
-#[derive(Default, Clone)]
+#[derive(Debug, Default)]
 pub struct WebhdfsBuilder {
     pub(super) config: WebhdfsConfig,
-}
-
-impl Debug for WebhdfsBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("WebhdfsBuilder");
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
-    }
 }
 
 impl WebhdfsBuilder {

--- a/core/src/services/webhdfs/config.rs
+++ b/core/src/services/webhdfs/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::WebhdfsBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::WebhdfsBuilder;
 
 /// Config for WebHDFS support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -42,11 +42,12 @@ pub struct WebhdfsConfig {
 }
 
 impl Debug for WebhdfsConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WebhdfsConfig")
             .field("root", &self.root)
             .field("endpoint", &self.endpoint)
             .field("user_name", &self.user_name)
+            .field("disable_list_batch", &self.disable_list_batch)
             .field("atomic_write_dir", &self.atomic_write_dir)
             .finish_non_exhaustive()
     }

--- a/core/src/services/webhdfs/core.rs
+++ b/core/src/services/webhdfs/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -45,11 +44,11 @@ pub struct WebhdfsCore {
 }
 
 impl Debug for WebhdfsCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WebhdfsCore")
             .field("root", &self.root)
             .field("endpoint", &self.endpoint)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/yandex_disk/backend.rs
+++ b/core/src/services/yandex_disk/backend.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -25,6 +24,7 @@ use http::StatusCode;
 use log::debug;
 
 use super::YANDEX_DISK_SCHEME;
+use super::config::YandexDiskConfig;
 use super::core::*;
 use super::delete::YandexDiskDeleter;
 use super::error::parse_error;
@@ -32,7 +32,6 @@ use super::lister::YandexDiskLister;
 use super::writer::YandexDiskWriter;
 use super::writer::YandexDiskWriters;
 use crate::raw::*;
-use crate::services::YandexDiskConfig;
 use crate::*;
 
 /// [YandexDisk](https://360.yandex.com/disk/) services support.
@@ -46,11 +45,10 @@ pub struct YandexDiskBuilder {
 }
 
 impl Debug for YandexDiskBuilder {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut d = f.debug_struct("YandexDiskBuilder");
-
-        d.field("config", &self.config);
-        d.finish_non_exhaustive()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("YandexDiskBuilder")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/yandex_disk/config.rs
+++ b/core/src/services/yandex_disk/config.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 
-use super::backend::YandexDiskBuilder;
 use serde::Deserialize;
 use serde::Serialize;
+
+use super::backend::YandexDiskBuilder;
 
 /// Config for YandexDisk services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -36,12 +36,10 @@ pub struct YandexDiskConfig {
 }
 
 impl Debug for YandexDiskConfig {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let mut ds = f.debug_struct("Config");
-
-        ds.field("root", &self.root);
-
-        ds.finish()
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("YandexDiskConfig")
+            .field("root", &self.root)
+            .finish_non_exhaustive()
     }
 }
 

--- a/core/src/services/yandex_disk/core.rs
+++ b/core/src/services/yandex_disk/core.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::fmt::Debug;
-use std::fmt::Formatter;
 use std::sync::Arc;
 
 use bytes::Buf;
@@ -41,8 +40,8 @@ pub struct YandexDiskCore {
 }
 
 impl Debug for YandexDiskCore {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Backend")
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("YandexDiskCore")
             .field("root", &self.root)
             .finish_non_exhaustive()
     }


### PR DESCRIPTION
# Which issue does this PR close?

Part of #6755

# Rationale for this change

- Unify these coding details to improve service code consistency and maintainability
- Most service builders include corresponding service config fields. Special attention should be paid to whether sensitive information might be printed in the debug implementation.

# What changes are included in this PR?

 * all service builders only implement the `Debug` and `Default` traits
 * audit sensitive data fields in the service config to prevent them from being exposed when using Debug trait

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
