### PR TITLE
Add `connection_pool_max_size` option to memcached and redis builders

### DIFF
--- a/core/src/services/memcached/backend.rs
+++ b/core/src/services/memcached/backend.rs
@@ -75,6 +75,20 @@ impl MemcachedBuilder {
         self.config.default_ttl = Some(ttl);
         self
     }
+
+    /// Sets the maximum number of connections managed by the pool.
+    ///
+    /// Defaults to 10.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `max_size` is 0.
+    #[must_use]
+    pub fn connection_pool_max_size(mut self, max_size: u32) -> Self {
+        assert!(max_size > 0, "max_size must be greater than zero!");
+        self.config.connection_pool_max_size = Some(max_size);
+        self
+    }
 }
 
 impl Builder for MemcachedBuilder {
@@ -144,6 +158,7 @@ impl Builder for MemcachedBuilder {
             username: self.config.username.clone(),
             password: self.config.password.clone(),
             default_ttl: self.config.default_ttl,
+            connection_pool_max_size: self.config.connection_pool_max_size,
         })
         .with_normalized_root(root))
     }

--- a/core/src/services/memcached/config.rs
+++ b/core/src/services/memcached/config.rs
@@ -42,6 +42,10 @@ pub struct MemcachedConfig {
     pub password: Option<String>,
     /// The default ttl for put operations.
     pub default_ttl: Option<Duration>,
+    /// The maximum number of connections allowed.
+    ///
+    /// default is 10
+    pub connection_pool_max_size: Option<u32>,
 }
 
 impl Debug for MemcachedConfig {

--- a/core/src/services/memcached/core.rs
+++ b/core/src/services/memcached/core.rs
@@ -76,6 +76,7 @@ pub struct MemcachedCore {
     pub username: Option<String>,
     pub password: Option<String>,
     pub default_ttl: Option<Duration>,
+    pub connection_pool_max_size: Option<u32>,
 }
 
 impl MemcachedCore {
@@ -89,10 +90,14 @@ impl MemcachedCore {
                     self.password.clone(),
                 );
 
-                bb8::Pool::builder().build(mgr).await.map_err(|err| {
-                    Error::new(ErrorKind::ConfigInvalid, "connect to memecached failed")
-                        .set_source(err)
-                })
+                bb8::Pool::builder()
+                    .max_size(self.connection_pool_max_size.unwrap_or(10))
+                    .build(mgr)
+                    .await
+                    .map_err(|err| {
+                        Error::new(ErrorKind::ConfigInvalid, "connect to memecached failed")
+                            .set_source(err)
+                    })
             })
             .await?;
 

--- a/core/src/services/redis/backend.rs
+++ b/core/src/services/redis/backend.rs
@@ -123,6 +123,20 @@ impl RedisBuilder {
 
         self
     }
+
+    /// Sets the maximum number of connections managed by the pool.
+    ///
+    /// Defaults to 10.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `max_size` is 0.
+    #[must_use]
+    pub fn connection_pool_max_size(mut self, max_size: u32) -> Self {
+        assert!(max_size > 0, "max_size must be greater than zero!");
+        self.config.connection_pool_max_size = Some(max_size);
+        self
+    }
 }
 
 impl Builder for RedisBuilder {
@@ -159,6 +173,7 @@ impl Builder for RedisBuilder {
                 cluster_client: Some(client),
                 conn,
                 default_ttl: self.config.default_ttl,
+                connection_pool_max_size: self.config.connection_pool_max_size,
             })
             .with_normalized_root(root))
         } else {
@@ -184,6 +199,7 @@ impl Builder for RedisBuilder {
                 cluster_client: None,
                 conn,
                 default_ttl: self.config.default_ttl,
+                connection_pool_max_size: self.config.connection_pool_max_size,
             })
             .with_normalized_root(root))
         }

--- a/core/src/services/redis/config.rs
+++ b/core/src/services/redis/config.rs
@@ -36,6 +36,10 @@ pub struct RedisConfig {
     ///
     /// default is None
     pub cluster_endpoints: Option<String>,
+    /// The maximum number of connections allowed.
+    ///
+    /// default is 10
+    pub connection_pool_max_size: Option<u32>,
     /// the username to connect redis service.
     ///
     /// default is None

--- a/core/src/services/redis/core.rs
+++ b/core/src/services/redis/core.rs
@@ -119,6 +119,7 @@ pub struct RedisCore {
     pub cluster_client: Option<ClusterClient>,
     pub conn: OnceCell<bb8::Pool<RedisConnectionManager>>,
     pub default_ttl: Option<Duration>,
+    pub connection_pool_max_size: Option<u32>,
 }
 
 impl Debug for RedisCore {
@@ -135,6 +136,7 @@ impl RedisCore {
             .conn
             .get_or_try_init(|| async {
                 bb8::Pool::builder()
+                    .max_size(self.connection_pool_max_size.unwrap_or(10))
                     .build(self.get_redis_connection_manager())
                     .await
                     .map_err(|err| {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6758

