### PR TITLE
chore(services): unify scheme usage

### DIFF
--- a/core/src/services/aliyun_drive/backend.rs
+++ b/core/src/services/aliyun_drive/backend.rs
@@ -141,7 +141,7 @@ impl Builder for AliyunDriveBuilder {
                     ErrorKind::ConfigInvalid,
                     "access_token and a set of client_id, client_secret, and refresh_token are both missing.")
                     .with_operation("Builder::build")
-                    .with_context("service", Scheme::AliyunDrive)),
+                    .with_context("service", ALIYUN_DRIVE_SCHEME)),
             },
         };
 

--- a/core/src/services/alluxio/backend.rs
+++ b/core/src/services/alluxio/backend.rs
@@ -104,7 +104,7 @@ impl Builder for AlluxioBuilder {
             Some(endpoint) => Ok(endpoint.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Alluxio)),
+                .with_context("service", ALLUXIO_SCHEME)),
         }?;
         debug!("backend use endpoint {}", &endpoint);
 

--- a/core/src/services/alluxio/config.rs
+++ b/core/src/services/alluxio/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::ALLUXIO_SCHEME;
 use super::backend::AlluxioBuilder;
 
 /// Config for alluxio services support.
@@ -54,7 +55,7 @@ impl crate::Configurator for AlluxioConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Alluxio)
+                .with_context("service", ALLUXIO_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/azblob/backend.rs
+++ b/core/src/services/azblob/backend.rs
@@ -299,7 +299,7 @@ impl Builder for AzblobBuilder {
             false => Ok(&self.config.container),
             true => Err(Error::new(ErrorKind::ConfigInvalid, "container is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Azblob)),
+                .with_context("service", AZBLOB_SCHEME)),
         }?;
         debug!("backend use container {}", &container);
 
@@ -307,7 +307,7 @@ impl Builder for AzblobBuilder {
             Some(endpoint) => Ok(endpoint.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Azblob)),
+                .with_context("service", AZBLOB_SCHEME)),
         }?;
         debug!("backend use endpoint {}", &container);
 
@@ -333,7 +333,7 @@ impl Builder for AzblobBuilder {
                     format!("invalid account_key: cannot decode as base64: {e}"),
                 )
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Azblob)
+                .with_context("service", AZBLOB_SCHEME)
                 .with_context("key", "account_key"));
             }
             config_loader.account_key = Some(v);

--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -248,7 +248,7 @@ impl Builder for AzdlsBuilder {
             false => Ok(&self.config.filesystem),
             true => Err(Error::new(ErrorKind::ConfigInvalid, "filesystem is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Azdls)),
+                .with_context("service", AZDLS_SCHEME)),
         }?;
         debug!("backend use filesystem {}", &filesystem);
 
@@ -256,7 +256,7 @@ impl Builder for AzdlsBuilder {
             Some(endpoint) => Ok(endpoint.clone().trim_end_matches('/').to_string()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Azdls)),
+                .with_context("service", AZDLS_SCHEME)),
         }?;
         debug!("backend use endpoint {}", &endpoint);
 

--- a/core/src/services/azdls/config.rs
+++ b/core/src/services/azdls/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::AZDLS_SCHEME;
 use super::backend::AzdlsBuilder;
 
 /// Azure Data Lake Storage Gen2 Support.
@@ -75,7 +76,7 @@ impl crate::Configurator for AzdlsConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Azdls)
+                .with_context("service", AZDLS_SCHEME)
         })?;
 
         let mut map = uri.options().clone();
@@ -97,7 +98,7 @@ impl crate::Configurator for AzdlsConfig {
                         crate::ErrorKind::ConfigInvalid,
                         "filesystem is required in uri path",
                     )
-                    .with_context("service", crate::Scheme::Azdls));
+                    .with_context("service", AZDLS_SCHEME));
                 }
                 map.insert("filesystem".to_string(), filesystem.to_string());
                 if !rest.is_empty() {
@@ -113,7 +114,7 @@ impl crate::Configurator for AzdlsConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "filesystem is required",
             )
-            .with_context("service", crate::Scheme::Azdls));
+            .with_context("service", AZDLS_SCHEME));
         }
 
         Self::from_iter(map)

--- a/core/src/services/azfile/backend.rs
+++ b/core/src/services/azfile/backend.rs
@@ -179,7 +179,7 @@ impl Builder for AzfileBuilder {
             Some(endpoint) => Ok(endpoint.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Azfile)),
+                .with_context("service", AZFILE_SCHEME)),
         }?;
         debug!("backend use endpoint {}", &endpoint);
 
@@ -194,7 +194,7 @@ impl Builder for AzfileBuilder {
             None => Err(
                 Error::new(ErrorKind::ConfigInvalid, "account_name is empty")
                     .with_operation("Builder::build")
-                    .with_context("service", Scheme::Azfile),
+                    .with_context("service", AZFILE_SCHEME),
             ),
         }?;
 

--- a/core/src/services/azfile/config.rs
+++ b/core/src/services/azfile/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::AZFILE_SCHEME;
 use super::backend::AzfileBuilder;
 
 /// Azure File services support.
@@ -55,7 +56,7 @@ impl crate::Configurator for AzfileConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Azfile)
+                .with_context("service", AZFILE_SCHEME)
         })?;
 
         let mut map = uri.options().clone();
@@ -77,7 +78,7 @@ impl crate::Configurator for AzfileConfig {
                         crate::ErrorKind::ConfigInvalid,
                         "share name is required in uri path",
                     )
-                    .with_context("service", crate::Scheme::Azfile));
+                    .with_context("service", AZFILE_SCHEME));
                 }
                 map.insert("share_name".to_string(), share.to_string());
                 if !rest.is_empty() {
@@ -93,7 +94,7 @@ impl crate::Configurator for AzfileConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "share name is required",
             )
-            .with_context("service", crate::Scheme::Azfile));
+            .with_context("service", AZFILE_SCHEME));
         }
 
         Self::from_iter(map)

--- a/core/src/services/b2/backend.rs
+++ b/core/src/services/b2/backend.rs
@@ -136,7 +136,7 @@ impl Builder for B2Builder {
         if self.config.bucket.is_empty() {
             return Err(Error::new(ErrorKind::ConfigInvalid, "bucket is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::B2));
+                .with_context("service", B2_SCHEME));
         }
 
         debug!("backend use bucket {}", &self.config.bucket);
@@ -145,7 +145,7 @@ impl Builder for B2Builder {
         if self.config.bucket_id.is_empty() {
             return Err(Error::new(ErrorKind::ConfigInvalid, "bucket_id is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::B2));
+                .with_context("service", B2_SCHEME));
         }
 
         debug!("backend bucket_id {}", &self.config.bucket_id);
@@ -155,7 +155,7 @@ impl Builder for B2Builder {
             None => Err(
                 Error::new(ErrorKind::ConfigInvalid, "application_key_id is empty")
                     .with_operation("Builder::build")
-                    .with_context("service", Scheme::B2),
+                    .with_context("service", B2_SCHEME),
             ),
         }?;
 
@@ -164,7 +164,7 @@ impl Builder for B2Builder {
             None => Err(
                 Error::new(ErrorKind::ConfigInvalid, "application_key is empty")
                     .with_operation("Builder::build")
-                    .with_context("service", Scheme::B2),
+                    .with_context("service", B2_SCHEME),
             ),
         }?;
 

--- a/core/src/services/cacache/backend.rs
+++ b/core/src/services/cacache/backend.rs
@@ -46,7 +46,7 @@ impl Builder for CacacheBuilder {
     fn build(self) -> Result<impl Access> {
         let datadir_path = self.config.datadir.ok_or_else(|| {
             Error::new(ErrorKind::ConfigInvalid, "datadir is required but not set")
-                .with_context("service", Scheme::Cacache)
+                .with_context("service", CACACHE_SCHEME)
         })?;
 
         let core = CacacheCore {

--- a/core/src/services/cloudflare_kv/config.rs
+++ b/core/src/services/cloudflare_kv/config.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::CLOUDFLARE_KV_SCHEME;
 use super::backend::CloudflareKvBuilder;
 
 /// Cloudflare KV Service Support.
@@ -59,7 +60,7 @@ impl crate::Configurator for CloudflareKvConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "uri host must contain account id",
             )
-            .with_context("service", crate::Scheme::CloudflareKv)
+            .with_context("service", CLOUDFLARE_KV_SCHEME)
         })?;
 
         let raw_root = uri.root().ok_or_else(|| {
@@ -67,7 +68,7 @@ impl crate::Configurator for CloudflareKvConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "uri path must contain namespace id",
             )
-            .with_context("service", crate::Scheme::CloudflareKv)
+            .with_context("service", CLOUDFLARE_KV_SCHEME)
         })?;
 
         let mut segments = raw_root.splitn(2, '/');
@@ -76,7 +77,7 @@ impl crate::Configurator for CloudflareKvConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "namespace id is required in uri path",
             )
-            .with_context("service", crate::Scheme::CloudflareKv)
+            .with_context("service", CLOUDFLARE_KV_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/cos/backend.rs
+++ b/core/src/services/cos/backend.rs
@@ -163,7 +163,7 @@ impl Builder for CosBuilder {
             Some(bucket) => Ok(bucket.to_string()),
             None => Err(
                 Error::new(ErrorKind::ConfigInvalid, "The bucket is misconfigured")
-                    .with_context("service", Scheme::Cos),
+                    .with_context("service", COS_SCHEME),
             ),
         }?;
         debug!("backend use bucket {}", &bucket);
@@ -171,12 +171,12 @@ impl Builder for CosBuilder {
         let uri = match &self.config.endpoint {
             Some(endpoint) => endpoint.parse::<Uri>().map_err(|err| {
                 Error::new(ErrorKind::ConfigInvalid, "endpoint is invalid")
-                    .with_context("service", Scheme::Cos)
+                    .with_context("service", COS_SCHEME)
                     .with_context("endpoint", endpoint)
                     .set_source(err)
             }),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
-                .with_context("service", Scheme::Cos)),
+                .with_context("service", COS_SCHEME)),
         }?;
 
         let scheme = match uri.scheme_str() {

--- a/core/src/services/d1/backend.rs
+++ b/core/src/services/d1/backend.rs
@@ -18,6 +18,7 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use super::D1_SCHEME;
 use super::config::D1Config;
 use super::core::*;
 use super::deleter::D1Deleter;
@@ -150,7 +151,7 @@ impl Builder for D1Builder {
         } else {
             HttpClient::new().map_err(|err| {
                 err.with_operation("Builder::build")
-                    .with_context("service", Scheme::D1)
+                    .with_context("service", D1_SCHEME)
             })?
         };
 
@@ -199,7 +200,7 @@ pub struct D1Backend {
 impl D1Backend {
     pub fn new(core: D1Core) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::D1.into_static());
+        info.set_scheme(D1_SCHEME);
         info.set_name(&core.table);
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/d1/config.rs
+++ b/core/src/services/d1/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::D1_SCHEME;
 use super::backend::D1Builder;
 
 /// Config for [Cloudflare D1](https://developers.cloudflare.com/d1) backend support.
@@ -64,7 +65,7 @@ impl crate::Configurator for D1Config {
                 crate::ErrorKind::ConfigInvalid,
                 "uri host must contain account id",
             )
-            .with_context("service", crate::Scheme::D1)
+            .with_context("service", D1_SCHEME)
         })?;
 
         let database_and_root = uri.root().ok_or_else(|| {
@@ -72,7 +73,7 @@ impl crate::Configurator for D1Config {
                 crate::ErrorKind::ConfigInvalid,
                 "uri path must contain database id",
             )
-            .with_context("service", crate::Scheme::D1)
+            .with_context("service", D1_SCHEME)
         })?;
 
         let mut segments = database_and_root.splitn(2, '/');
@@ -81,7 +82,7 @@ impl crate::Configurator for D1Config {
                 crate::ErrorKind::ConfigInvalid,
                 "database id is required in uri path",
             )
-            .with_context("service", crate::Scheme::D1)
+            .with_context("service", D1_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/d1/mod.rs
+++ b/core/src/services/d1/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for d1 service.
+pub const D1_SCHEME: &str = "d1";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/dbfs/backend.rs
+++ b/core/src/services/dbfs/backend.rs
@@ -91,7 +91,7 @@ impl Builder for DbfsBuilder {
             Some(endpoint) => Ok(endpoint.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Dbfs)),
+                .with_context("service", DBFS_SCHEME)),
         }?;
         debug!("backend use endpoint: {}", &endpoint);
 

--- a/core/src/services/dbfs/config.rs
+++ b/core/src/services/dbfs/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::DBFS_SCHEME;
 use super::backend::DbfsBuilder;
 
 /// [Dbfs](https://docs.databricks.com/api/azure/workspace/dbfs)'s REST API support.
@@ -48,7 +49,7 @@ impl crate::Configurator for DbfsConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Dbfs)
+                .with_context("service", DBFS_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/dropbox/builder.rs
+++ b/core/src/services/dropbox/builder.rs
@@ -130,14 +130,14 @@ impl Builder for DropboxBuilder {
                         ErrorKind::ConfigInvalid,
                         "client_id must be set when refresh_token is set",
                     )
-                    .with_context("service", Scheme::Dropbox)
+                    .with_context("service", DROPBOX_SCHEME)
                 })?;
                 let client_secret = self.config.client_secret.ok_or_else(|| {
                     Error::new(
                         ErrorKind::ConfigInvalid,
                         "client_secret must be set when refresh_token is set",
                     )
-                    .with_context("service", Scheme::Dropbox)
+                    .with_context("service", DROPBOX_SCHEME)
                 })?;
 
                 DropboxSigner {
@@ -152,14 +152,14 @@ impl Builder for DropboxBuilder {
                     ErrorKind::ConfigInvalid,
                     "access_token and refresh_token can not be set at the same time",
                 )
-                .with_context("service", Scheme::Dropbox));
+                .with_context("service", DROPBOX_SCHEME));
             }
             (None, None) => {
                 return Err(Error::new(
                     ErrorKind::ConfigInvalid,
                     "access_token or refresh_token must be set",
                 )
-                .with_context("service", Scheme::Dropbox));
+                .with_context("service", DROPBOX_SCHEME));
             }
         };
 

--- a/core/src/services/foundationdb/backend.rs
+++ b/core/src/services/foundationdb/backend.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use foundationdb::Database;
 
+use super::FOUNDATIONDB_SCHEME;
 use super::config::FoundationdbConfig;
 use super::core::*;
 use super::deleter::FoundationdbDeleter;
@@ -56,13 +57,13 @@ impl Builder for FoundationdbBuilder {
         if let Some(cfg_path) = &self.config.config_path {
             db = Database::from_path(cfg_path).map_err(|e| {
                 Error::new(ErrorKind::ConfigInvalid, "open foundation db")
-                    .with_context("service", Scheme::Foundationdb)
+                    .with_context("service", FOUNDATIONDB_SCHEME)
                     .set_source(e)
             })?;
         } else {
             db = Database::default().map_err(|e| {
                 Error::new(ErrorKind::ConfigInvalid, "open foundation db")
-                    .with_context("service", Scheme::Foundationdb)
+                    .with_context("service", FOUNDATIONDB_SCHEME)
                     .set_source(e)
             })?
         }
@@ -92,7 +93,7 @@ pub struct FoundationdbBackend {
 impl FoundationdbBackend {
     pub fn new(core: FoundationdbCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Foundationdb.into_static());
+        info.set_scheme(FOUNDATIONDB_SCHEME);
         info.set_name("foundationdb");
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/foundationdb/core.rs
+++ b/core/src/services/foundationdb/core.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use foundationdb::Database;
 use foundationdb::api::NetworkAutoStop;
 
+use super::FOUNDATIONDB_SCHEME;
 use crate::*;
 
 #[derive(Clone)]
@@ -78,5 +79,5 @@ impl FoundationdbCore {
 
 fn parse_transaction_commit_error(e: foundationdb::TransactionCommitError) -> Error {
     Error::new(ErrorKind::Unexpected, e.to_string().as_str())
-        .with_context("service", Scheme::Foundationdb)
+        .with_context("service", FOUNDATIONDB_SCHEME)
 }

--- a/core/src/services/foundationdb/mod.rs
+++ b/core/src/services/foundationdb/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for foundationdb service.
+pub const FOUNDATIONDB_SCHEME: &str = "foundationdb";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/ftp/config.rs
+++ b/core/src/services/ftp/config.rs
@@ -53,7 +53,7 @@ impl crate::Configurator for FtpConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Ftp)
+                .with_context("service", FTP_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/gcs/backend.rs
+++ b/core/src/services/gcs/backend.rs
@@ -233,7 +233,7 @@ impl Builder for GcsBuilder {
             true => Err(
                 Error::new(ErrorKind::ConfigInvalid, "The bucket is misconfigured")
                     .with_operation("Builder::build")
-                    .with_context("service", Scheme::Gcs),
+                    .with_context("service", GCS_SCHEME),
             ),
         }?;
 

--- a/core/src/services/gdrive/builder.rs
+++ b/core/src/services/gdrive/builder.rs
@@ -164,14 +164,14 @@ impl Builder for GdriveBuilder {
                         ErrorKind::ConfigInvalid,
                         "client_id must be set when refresh_token is set",
                     )
-                    .with_context("service", Scheme::Gdrive)
+                    .with_context("service", GDRIVE_SCHEME)
                 })?;
                 let client_secret = self.config.client_secret.ok_or_else(|| {
                     Error::new(
                         ErrorKind::ConfigInvalid,
                         "client_secret must be set when refresh_token is set",
                     )
-                    .with_context("service", Scheme::Gdrive)
+                    .with_context("service", GDRIVE_SCHEME)
                 })?;
 
                 signer.refresh_token = refresh_token;
@@ -183,14 +183,14 @@ impl Builder for GdriveBuilder {
                     ErrorKind::ConfigInvalid,
                     "access_token and refresh_token cannot be set at the same time",
                 )
-                .with_context("service", Scheme::Gdrive));
+                .with_context("service", GDRIVE_SCHEME));
             }
             (None, None) => {
                 return Err(Error::new(
                     ErrorKind::ConfigInvalid,
                     "access_token or refresh_token must be set",
                 )
-                .with_context("service", Scheme::Gdrive));
+                .with_context("service", GDRIVE_SCHEME));
             }
         };
 

--- a/core/src/services/github/backend.rs
+++ b/core/src/services/github/backend.rs
@@ -119,7 +119,7 @@ impl Builder for GithubBuilder {
         if self.config.owner.is_empty() {
             return Err(Error::new(ErrorKind::ConfigInvalid, "owner is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Github));
+                .with_context("service", GITHUB_SCHEME));
         }
 
         debug!("backend use owner {}", &self.config.owner);
@@ -128,7 +128,7 @@ impl Builder for GithubBuilder {
         if self.config.repo.is_empty() {
             return Err(Error::new(ErrorKind::ConfigInvalid, "repo is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Github));
+                .with_context("service", GITHUB_SCHEME));
         }
 
         debug!("backend use repo {}", &self.config.repo);

--- a/core/src/services/github/config.rs
+++ b/core/src/services/github/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::GITHUB_SCHEME;
 use super::backend::GithubBuilder;
 
 /// Config for GitHub services support.
@@ -66,7 +67,7 @@ impl crate::Configurator for GithubConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "uri host must contain owner",
             )
-            .with_context("service", crate::Scheme::Github)
+            .with_context("service", GITHUB_SCHEME)
         })?;
 
         let raw_path = uri.root().ok_or_else(|| {
@@ -74,7 +75,7 @@ impl crate::Configurator for GithubConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "uri path must contain repository",
             )
-            .with_context("service", crate::Scheme::Github)
+            .with_context("service", GITHUB_SCHEME)
         })?;
 
         let (repo, remainder) = match raw_path.split_once('/') {
@@ -87,7 +88,7 @@ impl crate::Configurator for GithubConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "repository name is required",
             )
-            .with_context("service", crate::Scheme::Github));
+            .with_context("service", GITHUB_SCHEME));
         }
 
         let mut map = uri.options().clone();

--- a/core/src/services/gridfs/backend.rs
+++ b/core/src/services/gridfs/backend.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use tokio::sync::OnceCell;
 
+use super::GRIDFS_SCHEME;
 use super::config::GridfsConfig;
 use super::core::*;
 use super::deleter::GridfsDeleter;
@@ -111,7 +112,7 @@ impl Builder for GridfsBuilder {
             None => {
                 return Err(
                     Error::new(ErrorKind::ConfigInvalid, "connection_string is required")
-                        .with_context("service", Scheme::Gridfs),
+                        .with_context("service", GRIDFS_SCHEME),
                 );
             }
         };
@@ -119,7 +120,7 @@ impl Builder for GridfsBuilder {
             Some(v) => v.clone(),
             None => {
                 return Err(Error::new(ErrorKind::ConfigInvalid, "database is required")
-                    .with_context("service", Scheme::Gridfs));
+                    .with_context("service", GRIDFS_SCHEME));
             }
         };
         let bucket = match &self.config.bucket.clone() {
@@ -158,7 +159,7 @@ pub struct GridfsBackend {
 impl GridfsBackend {
     pub fn new(core: GridfsCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Gridfs.into_static());
+        info.set_scheme(GRIDFS_SCHEME);
         info.set_name(&format!("{}/{}", core.database, core.bucket));
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/gridfs/mod.rs
+++ b/core/src/services/gridfs/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for gridfs service.
+pub const GRIDFS_SCHEME: &str = "gridfs";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/hdfs/backend.rs
+++ b/core/src/services/hdfs/backend.rs
@@ -116,7 +116,7 @@ impl Builder for HdfsBuilder {
             Some(v) => v,
             None => {
                 return Err(Error::new(ErrorKind::ConfigInvalid, "name node is empty")
-                    .with_context("service", Scheme::Hdfs));
+                    .with_context("service", HDFS_SCHEME));
             }
         };
 

--- a/core/src/services/hdfs/config.rs
+++ b/core/src/services/hdfs/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::HDFS_SCHEME;
 use super::backend::HdfsBuilder;
 
 /// [Hadoop Distributed File System (HDFS™)](https://hadoop.apache.org/) support.
@@ -65,7 +66,7 @@ impl crate::Configurator for HdfsConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Hdfs)
+                .with_context("service", HDFS_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/hdfs_native/backend.rs
+++ b/core/src/services/hdfs_native/backend.rs
@@ -86,7 +86,7 @@ impl Builder for HdfsNativeBuilder {
             Some(v) => v,
             None => {
                 return Err(Error::new(ErrorKind::ConfigInvalid, "name_node is empty")
-                    .with_context("service", Scheme::HdfsNative));
+                    .with_context("service", HDFS_NATIVE_SCHEME));
             }
         };
 

--- a/core/src/services/hdfs_native/config.rs
+++ b/core/src/services/hdfs_native/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::HDFS_NATIVE_SCHEME;
 use super::backend::HdfsNativeBuilder;
 
 /// Config for HdfsNative services support.
@@ -51,7 +52,7 @@ impl crate::Configurator for HdfsNativeConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::HdfsNative)
+                .with_context("service", HDFS_NATIVE_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/http/backend.rs
+++ b/core/src/services/http/backend.rs
@@ -126,7 +126,7 @@ impl Builder for HttpBuilder {
             Some(v) => v,
             None => {
                 return Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
-                    .with_context("service", Scheme::Http));
+                    .with_context("service", HTTP_SCHEME));
             }
         };
 

--- a/core/src/services/http/config.rs
+++ b/core/src/services/http/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::HTTP_SCHEME;
 use super::backend::HttpBuilder;
 
 /// Config for Http service support.
@@ -54,7 +55,7 @@ impl crate::Configurator for HttpConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Http)
+                .with_context("service", HTTP_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/huggingface/backend.rs
+++ b/core/src/services/huggingface/backend.rs
@@ -127,7 +127,7 @@ impl Builder for HuggingfaceBuilder {
                 format!("unknown repo_type: {repo_type}").as_str(),
             )
             .with_operation("Builder::build")
-            .with_context("service", Scheme::Huggingface)),
+            .with_context("service", HUGGINGFACE_SCHEME)),
             None => Ok(RepoType::Model),
         }?;
         debug!("backend use repo_type: {:?}", &repo_type);
@@ -136,7 +136,7 @@ impl Builder for HuggingfaceBuilder {
             Some(repo_id) => Ok(repo_id.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "repo_id is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Huggingface)),
+                .with_context("service", HUGGINGFACE_SCHEME)),
         }?;
         debug!("backend use repo_id: {}", &repo_id);
 

--- a/core/src/services/huggingface/config.rs
+++ b/core/src/services/huggingface/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::HUGGINGFACE_SCHEME;
 use super::backend::HuggingfaceBuilder;
 
 /// Configuration for Huggingface service support.
@@ -79,7 +80,7 @@ impl crate::Configurator for HuggingfaceConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "uri path must include owner and repo",
             )
-            .with_context("service", crate::Scheme::Huggingface)
+            .with_context("service", HUGGINGFACE_SCHEME)
         })?;
 
         let mut segments = raw_path.splitn(4, '/');
@@ -88,14 +89,14 @@ impl crate::Configurator for HuggingfaceConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "repository owner is required in uri path",
             )
-            .with_context("service", crate::Scheme::Huggingface)
+            .with_context("service", HUGGINGFACE_SCHEME)
         })?;
         let repo = segments.next().filter(|s| !s.is_empty()).ok_or_else(|| {
             crate::Error::new(
                 crate::ErrorKind::ConfigInvalid,
                 "repository name is required in uri path",
             )
-            .with_context("service", crate::Scheme::Huggingface)
+            .with_context("service", HUGGINGFACE_SCHEME)
         })?;
 
         map.insert("repo_id".to_string(), format!("{owner}/{repo}"));

--- a/core/src/services/ipfs/backend.rs
+++ b/core/src/services/ipfs/backend.rs
@@ -113,7 +113,7 @@ impl Builder for IpfsBuilder {
                 ErrorKind::ConfigInvalid,
                 "root must start with /ipfs/ or /ipns/",
             )
-            .with_context("service", Scheme::Ipfs)
+            .with_context("service", IPFS_SCHEME)
             .with_context("root", &root));
         }
         debug!("backend use root {root}");
@@ -121,7 +121,7 @@ impl Builder for IpfsBuilder {
         let endpoint = match &self.config.endpoint {
             Some(endpoint) => Ok(endpoint.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
-                .with_context("service", Scheme::Ipfs)
+                .with_context("service", IPFS_SCHEME)
                 .with_context("root", &root)),
         }?;
         debug!("backend use endpoint {}", &endpoint);

--- a/core/src/services/ipfs/config.rs
+++ b/core/src/services/ipfs/config.rs
@@ -18,6 +18,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::IPFS_SCHEME;
 use super::backend::IpfsBuilder;
 
 /// Config for IPFS file system support.
@@ -37,7 +38,7 @@ impl crate::Configurator for IpfsConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Ipfs)
+                .with_context("service", IPFS_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/ipmfs/config.rs
+++ b/core/src/services/ipmfs/config.rs
@@ -18,6 +18,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::IPMFS_SCHEME;
 use super::builder::IpmfsBuilder;
 
 /// Config for IPFS MFS support.
@@ -37,7 +38,7 @@ impl crate::Configurator for IpmfsConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Ipmfs)
+                .with_context("service", IPMFS_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/koofr/backend.rs
+++ b/core/src/services/koofr/backend.rs
@@ -135,7 +135,7 @@ impl Builder for KoofrBuilder {
         if self.config.endpoint.is_empty() {
             return Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Koofr));
+                .with_context("service", KOOFR_SCHEME));
         }
 
         debug!("backend use endpoint {}", &self.config.endpoint);
@@ -143,7 +143,7 @@ impl Builder for KoofrBuilder {
         if self.config.email.is_empty() {
             return Err(Error::new(ErrorKind::ConfigInvalid, "email is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Koofr));
+                .with_context("service", KOOFR_SCHEME));
         }
 
         debug!("backend use email {}", &self.config.email);
@@ -152,7 +152,7 @@ impl Builder for KoofrBuilder {
             Some(password) => Ok(password.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "password is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Koofr)),
+                .with_context("service", KOOFR_SCHEME)),
         }?;
 
         let signer = Arc::new(Mutex::new(KoofrSigner::default()));

--- a/core/src/services/koofr/config.rs
+++ b/core/src/services/koofr/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::KOOFR_SCHEME;
 use super::backend::KoofrBuilder;
 
 /// Config for Koofr services support.
@@ -54,7 +55,7 @@ impl crate::Configurator for KoofrConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Koofr)
+                .with_context("service", KOOFR_SCHEME)
         })?;
 
         let raw_path = uri.root().ok_or_else(|| {
@@ -62,7 +63,7 @@ impl crate::Configurator for KoofrConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "uri path must contain email",
             )
-            .with_context("service", crate::Scheme::Koofr)
+            .with_context("service", KOOFR_SCHEME)
         })?;
 
         let mut segments = raw_path.splitn(2, '/');
@@ -71,7 +72,7 @@ impl crate::Configurator for KoofrConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "email is required in uri path",
             )
-            .with_context("service", crate::Scheme::Koofr)
+            .with_context("service", KOOFR_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/lakefs/backend.rs
+++ b/core/src/services/lakefs/backend.rs
@@ -117,7 +117,7 @@ impl Builder for LakefsBuilder {
             Some(endpoint) => Ok(endpoint.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Lakefs)),
+                .with_context("service", LAKEFS_SCHEME)),
         }?;
         debug!("backend use endpoint: {:?}", &endpoint);
 
@@ -125,7 +125,7 @@ impl Builder for LakefsBuilder {
             Some(repository) => Ok(repository.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "repository is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Lakefs)),
+                .with_context("service", LAKEFS_SCHEME)),
         }?;
         debug!("backend use repository: {}", &repository);
 
@@ -142,14 +142,14 @@ impl Builder for LakefsBuilder {
             Some(username) => Ok(username.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "username is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Lakefs)),
+                .with_context("service", LAKEFS_SCHEME)),
         }?;
 
         let password = match &self.config.password {
             Some(password) => Ok(password.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "password is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Lakefs)),
+                .with_context("service", LAKEFS_SCHEME)),
         }?;
 
         Ok(LakefsBackend {

--- a/core/src/services/lakefs/config.rs
+++ b/core/src/services/lakefs/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::LAKEFS_SCHEME;
 use super::backend::LakefsBuilder;
 
 /// Configuration for Lakefs service support.
@@ -71,7 +72,7 @@ impl crate::Configurator for LakefsConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Lakefs)
+                .with_context("service", LAKEFS_SCHEME)
         })?;
 
         let raw_path = uri.root().ok_or_else(|| {
@@ -79,7 +80,7 @@ impl crate::Configurator for LakefsConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "uri path must contain repository",
             )
-            .with_context("service", crate::Scheme::Lakefs)
+            .with_context("service", LAKEFS_SCHEME)
         })?;
 
         let (repository, remainder) = match raw_path.split_once('/') {
@@ -97,7 +98,7 @@ impl crate::Configurator for LakefsConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "repository is required in uri path",
             )
-            .with_context("service", crate::Scheme::Lakefs)
+            .with_context("service", LAKEFS_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/memcached/backend.rs
+++ b/core/src/services/memcached/backend.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 
 use tokio::sync::OnceCell;
 
+use super::MEMCACHED_SCHEME;
 use super::config::MemcachedConfig;
 use super::core::*;
 use super::deleter::MemcachedDeleter;
@@ -83,11 +84,11 @@ impl Builder for MemcachedBuilder {
     fn build(self) -> Result<impl Access> {
         let endpoint = self.config.endpoint.clone().ok_or_else(|| {
             Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
-                .with_context("service", Scheme::Memcached)
+                .with_context("service", MEMCACHED_SCHEME)
         })?;
         let uri = http::Uri::try_from(&endpoint).map_err(|err| {
             Error::new(ErrorKind::ConfigInvalid, "endpoint is invalid")
-                .with_context("service", Scheme::Memcached)
+                .with_context("service", MEMCACHED_SCHEME)
                 .with_context("endpoint", &endpoint)
                 .set_source(err)
         })?;
@@ -102,7 +103,7 @@ impl Builder for MemcachedBuilder {
                         ErrorKind::ConfigInvalid,
                         "endpoint is using invalid scheme",
                     )
-                    .with_context("service", Scheme::Memcached)
+                    .with_context("service", MEMCACHED_SCHEME)
                     .with_context("endpoint", &endpoint)
                     .with_context("scheme", scheme.to_string()));
                 }
@@ -114,7 +115,7 @@ impl Builder for MemcachedBuilder {
         } else {
             return Err(
                 Error::new(ErrorKind::ConfigInvalid, "endpoint doesn't have host")
-                    .with_context("service", Scheme::Memcached)
+                    .with_context("service", MEMCACHED_SCHEME)
                     .with_context("endpoint", &endpoint),
             );
         };
@@ -123,7 +124,7 @@ impl Builder for MemcachedBuilder {
         } else {
             return Err(
                 Error::new(ErrorKind::ConfigInvalid, "endpoint doesn't have port")
-                    .with_context("service", Scheme::Memcached)
+                    .with_context("service", MEMCACHED_SCHEME)
                     .with_context("endpoint", &endpoint),
             );
         };
@@ -160,7 +161,7 @@ pub struct MemcachedBackend {
 impl MemcachedBackend {
     pub fn new(core: MemcachedCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Memcached.into_static());
+        info.set_scheme(MEMCACHED_SCHEME);
         info.set_name("memcached");
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/memcached/config.rs
+++ b/core/src/services/memcached/config.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::MEMCACHED_SCHEME;
 use super::backend::MemcachedBuilder;
 
 /// Config for MemCached services support
@@ -61,7 +62,7 @@ impl crate::Configurator for MemcachedConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Memcached)
+                .with_context("service", MEMCACHED_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/memcached/mod.rs
+++ b/core/src/services/memcached/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for memcached service.
+pub const MEMCACHED_SCHEME: &str = "memcached";
+
 mod backend;
 mod binary;
 mod config;

--- a/core/src/services/mongodb/backend.rs
+++ b/core/src/services/mongodb/backend.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use tokio::sync::OnceCell;
 
+use super::MONGODB_SCHEME;
 use super::config::MongodbConfig;
 use super::core::*;
 use super::deleter::MongodbDeleter;
@@ -118,7 +119,7 @@ impl Builder for MongodbBuilder {
             None => {
                 return Err(
                     Error::new(ErrorKind::ConfigInvalid, "connection_string is required")
-                        .with_context("service", Scheme::Mongodb),
+                        .with_context("service", MONGODB_SCHEME),
                 );
             }
         };
@@ -126,7 +127,7 @@ impl Builder for MongodbBuilder {
             Some(v) => v.clone(),
             None => {
                 return Err(Error::new(ErrorKind::ConfigInvalid, "database is required")
-                    .with_context("service", Scheme::Mongodb));
+                    .with_context("service", MONGODB_SCHEME));
             }
         };
         let collection = match &self.config.collection.clone() {
@@ -134,7 +135,7 @@ impl Builder for MongodbBuilder {
             None => {
                 return Err(
                     Error::new(ErrorKind::ConfigInvalid, "collection is required")
-                        .with_context("service", Scheme::Mongodb),
+                        .with_context("service", MONGODB_SCHEME),
                 );
             }
         };
@@ -176,7 +177,7 @@ pub struct MongodbBackend {
 impl MongodbBackend {
     pub fn new(core: MongodbCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Mongodb.into_static());
+        info.set_scheme(MONGODB_SCHEME);
         info.set_name(&format!("{}/{}", core.database, core.collection));
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/mongodb/mod.rs
+++ b/core/src/services/mongodb/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for mongodb service.
+pub const MONGODB_SCHEME: &str = "mongodb";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/mysql/backend.rs
+++ b/core/src/services/mysql/backend.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use sqlx::mysql::MySqlConnectOptions;
 use tokio::sync::OnceCell;
 
+use super::MYSQL_SCHEME;
 use super::config::MysqlConfig;
 use super::core::*;
 use super::deleter::MysqlDeleter;
@@ -108,14 +109,14 @@ impl Builder for MysqlBuilder {
             None => {
                 return Err(
                     Error::new(ErrorKind::ConfigInvalid, "connection_string is empty")
-                        .with_context("service", Scheme::Mysql),
+                        .with_context("service", MYSQL_SCHEME),
                 );
             }
         };
 
         let config = conn.parse::<MySqlConnectOptions>().map_err(|err| {
             Error::new(ErrorKind::ConfigInvalid, "connection_string is invalid")
-                .with_context("service", Scheme::Mysql)
+                .with_context("service", MYSQL_SCHEME)
                 .set_source(err)
         })?;
 
@@ -123,7 +124,7 @@ impl Builder for MysqlBuilder {
             Some(v) => v,
             None => {
                 return Err(Error::new(ErrorKind::ConfigInvalid, "table is empty")
-                    .with_context("service", Scheme::Mysql));
+                    .with_context("service", MYSQL_SCHEME));
             }
         };
 
@@ -158,7 +159,7 @@ pub struct MysqlBackend {
 impl MysqlBackend {
     pub fn new(core: MysqlCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Mysql.into_static());
+        info.set_scheme(MYSQL_SCHEME);
         info.set_name(&core.table);
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/mysql/mod.rs
+++ b/core/src/services/mysql/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for mysql service.
+pub const MYSQL_SCHEME: &str = "mysql";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/obs/backend.rs
+++ b/core/src/services/obs/backend.rs
@@ -153,7 +153,7 @@ impl Builder for ObsBuilder {
             Some(bucket) => Ok(bucket.to_string()),
             None => Err(
                 Error::new(ErrorKind::ConfigInvalid, "The bucket is misconfigured")
-                    .with_context("service", Scheme::Obs),
+                    .with_context("service", OBS_SCHEME),
             ),
         }?;
         debug!("backend use bucket {}", &bucket);
@@ -161,11 +161,11 @@ impl Builder for ObsBuilder {
         let uri = match &self.config.endpoint {
             Some(endpoint) => endpoint.parse::<Uri>().map_err(|err| {
                 Error::new(ErrorKind::ConfigInvalid, "endpoint is invalid")
-                    .with_context("service", Scheme::Obs)
+                    .with_context("service", OBS_SCHEME)
                     .set_source(err)
             }),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
-                .with_context("service", Scheme::Obs)),
+                .with_context("service", OBS_SCHEME)),
         }?;
 
         let scheme = match uri.scheme_str() {

--- a/core/src/services/onedrive/builder.rs
+++ b/core/src/services/onedrive/builder.rs
@@ -186,7 +186,7 @@ impl Builder for OnedriveBuilder {
                         ErrorKind::ConfigInvalid,
                         "client_id must be set when refresh_token is set",
                     )
-                    .with_context("service", Scheme::Onedrive)
+                    .with_context("service", ONEDRIVE_SCHEME)
                 })?;
 
                 signer.refresh_token = refresh_token;
@@ -200,14 +200,14 @@ impl Builder for OnedriveBuilder {
                     ErrorKind::ConfigInvalid,
                     "access_token and refresh_token cannot be set at the same time",
                 )
-                .with_context("service", Scheme::Onedrive));
+                .with_context("service", ONEDRIVE_SCHEME));
             }
             (None, None) => {
                 return Err(Error::new(
                     ErrorKind::ConfigInvalid,
                     "access_token or refresh_token must be set",
                 )
-                .with_context("service", Scheme::Onedrive));
+                .with_context("service", ONEDRIVE_SCHEME));
             }
         };
 

--- a/core/src/services/opfs/mod.rs
+++ b/core/src/services/opfs/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for opfs service.
+pub const OPFS_SCHEME: &str = "opfs";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/oss/backend.rs
+++ b/core/src/services/oss/backend.rs
@@ -202,13 +202,13 @@ impl OssBuilder {
             Some(ep) => {
                 let uri = ep.parse::<Uri>().map_err(|err| {
                     Error::new(ErrorKind::ConfigInvalid, "endpoint is invalid")
-                        .with_context("service", Scheme::Oss)
+                        .with_context("service", OSS_SCHEME)
                         .with_context("endpoint", &ep)
                         .set_source(err)
                 })?;
                 let host = uri.host().ok_or_else(|| {
                     Error::new(ErrorKind::ConfigInvalid, "endpoint host is empty")
-                        .with_context("service", Scheme::Oss)
+                        .with_context("service", OSS_SCHEME)
                         .with_context("endpoint", &ep)
                 })?;
                 let full_host = match addressing_style {
@@ -240,7 +240,7 @@ impl OssBuilder {
                                 ErrorKind::ConfigInvalid,
                                 "endpoint protocol is invalid",
                             )
-                            .with_context("service", Scheme::Oss));
+                            .with_context("service", OSS_SCHEME));
                         }
                     },
                     None => format!("https://{full_host}"),
@@ -253,7 +253,7 @@ impl OssBuilder {
             }
             None => {
                 return Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
-                    .with_context("service", Scheme::Oss));
+                    .with_context("service", OSS_SCHEME));
             }
         };
         Ok((endpoint, host))
@@ -386,7 +386,7 @@ impl TryFrom<&Option<String>> for AddressingStyle {
                 ErrorKind::ConfigInvalid,
                 "Invalid addressing style, available: `virtual`, `path`, `cname`",
             )
-            .with_context("service", Scheme::Oss)
+            .with_context("service", OSS_SCHEME)
             .with_context("addressing_style", v)),
         }
     }
@@ -406,7 +406,7 @@ impl Builder for OssBuilder {
             false => Ok(&self.config.bucket),
             true => Err(
                 Error::new(ErrorKind::ConfigInvalid, "The bucket is misconfigured")
-                    .with_context("service", Scheme::Oss),
+                    .with_context("service", OSS_SCHEME),
             ),
         }?;
 

--- a/core/src/services/pcloud/backend.rs
+++ b/core/src/services/pcloud/backend.rs
@@ -132,7 +132,7 @@ impl Builder for PcloudBuilder {
         if self.config.endpoint.is_empty() {
             return Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Pcloud));
+                .with_context("service", PCLOUD_SCHEME));
         }
 
         debug!("backend use endpoint {}", &self.config.endpoint);
@@ -141,14 +141,14 @@ impl Builder for PcloudBuilder {
             Some(username) => Ok(username.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "username is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Pcloud)),
+                .with_context("service", PCLOUD_SCHEME)),
         }?;
 
         let password = match &self.config.password {
             Some(password) => Ok(password.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "password is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Pcloud)),
+                .with_context("service", PCLOUD_SCHEME)),
         }?;
 
         Ok(PcloudBackend {

--- a/core/src/services/pcloud/config.rs
+++ b/core/src/services/pcloud/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::PCLOUD_SCHEME;
 use super::backend::PcloudBuilder;
 
 /// Config for Pcloud services support.
@@ -55,7 +56,7 @@ impl crate::Configurator for PcloudConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Pcloud)
+                .with_context("service", PCLOUD_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/persy/backend.rs
+++ b/core/src/services/persy/backend.rs
@@ -18,6 +18,7 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use super::PERSY_SCHEME;
 use super::config::PersyConfig;
 use super::core::*;
 use super::deleter::PersyDeleter;
@@ -58,19 +59,19 @@ impl Builder for PersyBuilder {
     fn build(self) -> Result<impl Access> {
         let datafile_path = self.config.datafile.ok_or_else(|| {
             Error::new(ErrorKind::ConfigInvalid, "datafile is required but not set")
-                .with_context("service", Scheme::Persy)
+                .with_context("service", PERSY_SCHEME)
         })?;
 
         let segment_name = self.config.segment.ok_or_else(|| {
             Error::new(ErrorKind::ConfigInvalid, "segment is required but not set")
-                .with_context("service", Scheme::Persy)
+                .with_context("service", PERSY_SCHEME)
         })?;
 
         let segment = segment_name.clone();
 
         let index_name = self.config.index.ok_or_else(|| {
             Error::new(ErrorKind::ConfigInvalid, "index is required but not set")
-                .with_context("service", Scheme::Persy)
+                .with_context("service", PERSY_SCHEME)
         })?;
 
         let index = index_name.clone();
@@ -81,7 +82,7 @@ impl Builder for PersyBuilder {
             .open(&datafile_path)
             .map_err(|e| {
                 Error::new(ErrorKind::ConfigInvalid, "open db")
-                    .with_context("service", Scheme::Persy)
+                    .with_context("service", PERSY_SCHEME)
                     .with_context("datafile", datafile_path.clone())
                     .set_source(e)
             })?;
@@ -127,7 +128,7 @@ pub struct PersyBackend {
 impl PersyBackend {
     pub fn new(core: PersyCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Persy.into_static());
+        info.set_scheme(PERSY_SCHEME);
         info.set_name(&core.datafile);
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/persy/mod.rs
+++ b/core/src/services/persy/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for persy service.
+pub const PERSY_SCHEME: &str = "persy";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/postgresql/backend.rs
+++ b/core/src/services/postgresql/backend.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use sqlx::postgres::PgConnectOptions;
 use tokio::sync::OnceCell;
 
+use super::POSTGRESQL_SCHEME;
 use super::config::PostgresqlConfig;
 use super::core::*;
 use super::deleter::PostgresqlDeleter;
@@ -103,14 +104,14 @@ impl Builder for PostgresqlBuilder {
             None => {
                 return Err(
                     Error::new(ErrorKind::ConfigInvalid, "connection_string is empty")
-                        .with_context("service", Scheme::Postgresql),
+                        .with_context("service", POSTGRESQL_SCHEME),
                 );
             }
         };
 
         let config = conn.parse::<PgConnectOptions>().map_err(|err| {
             Error::new(ErrorKind::ConfigInvalid, "connection_string is invalid")
-                .with_context("service", Scheme::Postgresql)
+                .with_context("service", POSTGRESQL_SCHEME)
                 .set_source(err)
         })?;
 
@@ -118,7 +119,7 @@ impl Builder for PostgresqlBuilder {
             Some(v) => v,
             None => {
                 return Err(Error::new(ErrorKind::ConfigInvalid, "table is empty")
-                    .with_context("service", Scheme::Postgresql));
+                    .with_context("service", POSTGRESQL_SCHEME));
             }
         };
 
@@ -153,7 +154,7 @@ pub struct PostgresqlBackend {
 impl PostgresqlBackend {
     pub fn new(core: PostgresqlCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Postgresql.into_static());
+        info.set_scheme(POSTGRESQL_SCHEME);
         info.set_name(&core.table);
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/postgresql/mod.rs
+++ b/core/src/services/postgresql/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for postgresql service.
+pub const POSTGRESQL_SCHEME: &str = "postgresql";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/redb/backend.rs
+++ b/core/src/services/redb/backend.rs
@@ -18,6 +18,7 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use super::REDB_SCHEME;
 use super::config::RedbConfig;
 use super::core::*;
 use super::deleter::RedbDeleter;
@@ -97,7 +98,7 @@ impl Builder for RedbBuilder {
     fn build(self) -> Result<impl Access> {
         let table_name = self.config.table.ok_or_else(|| {
             Error::new(ErrorKind::ConfigInvalid, "table is required but not set")
-                .with_context("service", Scheme::Redb)
+                .with_context("service", REDB_SCHEME)
         })?;
 
         let (datadir, db) = if let Some(db) = self.database {
@@ -105,7 +106,7 @@ impl Builder for RedbBuilder {
         } else {
             let datadir = self.config.datadir.ok_or_else(|| {
                 Error::new(ErrorKind::ConfigInvalid, "datadir is required but not set")
-                    .with_context("service", Scheme::Redb)
+                    .with_context("service", REDB_SCHEME)
             })?;
 
             let db = redb::Database::create(&datadir)
@@ -139,7 +140,7 @@ pub struct RedbBackend {
 impl RedbBackend {
     pub fn new(core: RedbCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Redb.into_static());
+        info.set_scheme(REDB_SCHEME);
         info.set_name(&core.table);
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/redb/mod.rs
+++ b/core/src/services/redb/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for redb service.
+pub const REDB_SCHEME: &str = "redb";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/redis/backend.rs
+++ b/core/src/services/redis/backend.rs
@@ -172,7 +172,7 @@ impl Builder for RedisBuilder {
             let client =
                 Client::open(self.get_connection_info(endpoint.clone())?).map_err(|e| {
                     Error::new(ErrorKind::ConfigInvalid, "invalid or unsupported scheme")
-                        .with_context("service", Scheme::Redis)
+                        .with_context("service", REDIS_SCHEME)
                         .with_context("endpoint", self.config.endpoint.as_ref().unwrap())
                         .with_context("db", self.config.db.to_string())
                         .set_source(e)
@@ -195,7 +195,7 @@ impl RedisBuilder {
     fn get_connection_info(&self, endpoint: String) -> Result<ConnectionInfo> {
         let ep_url = endpoint.parse::<Uri>().map_err(|e| {
             Error::new(ErrorKind::ConfigInvalid, "endpoint is invalid")
-                .with_context("service", Scheme::Redis)
+                .with_context("service", REDIS_SCHEME)
                 .with_context("endpoint", endpoint)
                 .set_source(e)
         })?;
@@ -229,7 +229,7 @@ impl RedisBuilder {
             Some(s) => {
                 return Err(
                     Error::new(ErrorKind::ConfigInvalid, "invalid or unsupported scheme")
-                        .with_context("service", Scheme::Redis)
+                        .with_context("service", REDIS_SCHEME)
                         .with_context("scheme", s),
                 );
             }

--- a/core/src/services/redis/config.rs
+++ b/core/src/services/redis/config.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::REDIS_SCHEME;
 use super::backend::RedisBuilder;
 
 /// Config for Redis services support.
@@ -83,7 +84,7 @@ impl crate::Configurator for RedisConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "endpoint or cluster_endpoints is required",
             )
-            .with_context("service", crate::Scheme::Redis));
+            .with_context("service", REDIS_SCHEME));
         }
 
         if let Some(path) = uri.root() {

--- a/core/src/services/rocksdb/backend.rs
+++ b/core/src/services/rocksdb/backend.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use rocksdb::DB;
 
+use super::ROCKSDB_SCHEME;
 use super::config::RocksdbConfig;
 use super::core::*;
 use super::deleter::RocksdbDeleter;
@@ -61,11 +62,11 @@ impl Builder for RocksdbBuilder {
     fn build(self) -> Result<impl Access> {
         let path = self.config.datadir.ok_or_else(|| {
             Error::new(ErrorKind::ConfigInvalid, "datadir is required but not set")
-                .with_context("service", Scheme::Rocksdb)
+                .with_context("service", ROCKSDB_SCHEME)
         })?;
         let db = DB::open_default(&path).map_err(|e| {
             Error::new(ErrorKind::ConfigInvalid, "open default transaction db")
-                .with_context("service", Scheme::Rocksdb)
+                .with_context("service", ROCKSDB_SCHEME)
                 .with_context("datadir", path)
                 .set_source(e)
         })?;
@@ -87,7 +88,7 @@ pub struct RocksdbBackend {
 impl RocksdbBackend {
     pub fn new(core: RocksdbCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Rocksdb.into_static())
+        info.set_scheme(ROCKSDB_SCHEME)
             .set_name(&core.db.path().to_string_lossy())
             .set_root("/")
             .set_native_capability(Capability {

--- a/core/src/services/rocksdb/mod.rs
+++ b/core/src/services/rocksdb/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for rocksdb service.
+pub const ROCKSDB_SCHEME: &str = "rocksdb";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -714,7 +714,7 @@ impl Builder for S3Builder {
         } else {
             Err(
                 Error::new(ErrorKind::ConfigInvalid, "The bucket is misconfigured")
-                    .with_context("service", Scheme::S3),
+                    .with_context("service", S3_SCHEME),
             )
         }?;
         debug!("backend use bucket {}", &bucket);
@@ -798,7 +798,7 @@ impl Builder for S3Builder {
                 "region is missing. Please find it by S3::detect_region() or set them in env.",
             )
             .with_operation("Builder::build")
-            .with_context("service", Scheme::S3));
+            .with_context("service", S3_SCHEME));
         }
 
         let region = cfg.region.to_owned().unwrap();
@@ -858,7 +858,7 @@ impl Builder for S3Builder {
                     ErrorKind::ConfigInvalid,
                     "The assume_role_loader is misconfigured",
                 )
-                .with_context("service", Scheme::S3)
+                .with_context("service", S3_SCHEME)
                 .set_source(err)
             })?;
             loader = Some(Box::new(assume_role_loader));

--- a/core/src/services/seafile/backend.rs
+++ b/core/src/services/seafile/backend.rs
@@ -145,7 +145,7 @@ impl Builder for SeafileBuilder {
         if self.config.repo_name.is_empty() {
             return Err(Error::new(ErrorKind::ConfigInvalid, "repo_name is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Seafile));
+                .with_context("service", SEAFILE_SCHEME));
         }
 
         debug!("backend use repo_name {}", &self.config.repo_name);
@@ -154,21 +154,21 @@ impl Builder for SeafileBuilder {
             Some(endpoint) => Ok(endpoint.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Seafile)),
+                .with_context("service", SEAFILE_SCHEME)),
         }?;
 
         let username = match &self.config.username {
             Some(username) => Ok(username.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "username is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Seafile)),
+                .with_context("service", SEAFILE_SCHEME)),
         }?;
 
         let password = match &self.config.password {
             Some(password) => Ok(password.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "password is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Seafile)),
+                .with_context("service", SEAFILE_SCHEME)),
         }?;
 
         Ok(SeafileBackend {

--- a/core/src/services/seafile/config.rs
+++ b/core/src/services/seafile/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::SEAFILE_SCHEME;
 use super::backend::SeafileBuilder;
 
 /// Config for seafile services support.
@@ -60,7 +61,7 @@ impl crate::Configurator for SeafileConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Seafile)
+                .with_context("service", SEAFILE_SCHEME)
         })?;
 
         let raw_path = uri.root().ok_or_else(|| {
@@ -68,7 +69,7 @@ impl crate::Configurator for SeafileConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "uri path must start with repo name",
             )
-            .with_context("service", crate::Scheme::Seafile)
+            .with_context("service", SEAFILE_SCHEME)
         })?;
 
         let mut segments = raw_path.splitn(2, '/');
@@ -77,7 +78,7 @@ impl crate::Configurator for SeafileConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "repo name is required in uri path",
             )
-            .with_context("service", crate::Scheme::Seafile)
+            .with_context("service", SEAFILE_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/sftp/config.rs
+++ b/core/src/services/sftp/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::SFTP_SCHEME;
 use super::backend::SftpBuilder;
 
 /// Config for Sftp Service support.
@@ -56,7 +57,7 @@ impl crate::Configurator for SftpConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Sftp)
+                .with_context("service", SFTP_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/sled/backend.rs
+++ b/core/src/services/sled/backend.rs
@@ -17,6 +17,7 @@
 
 use std::sync::Arc;
 
+use super::SLED_SCHEME;
 use super::config::SledConfig;
 use super::core::*;
 use super::deleter::SledDeleter;
@@ -66,12 +67,12 @@ impl Builder for SledBuilder {
     fn build(self) -> Result<impl Access> {
         let datadir_path = self.config.datadir.ok_or_else(|| {
             Error::new(ErrorKind::ConfigInvalid, "datadir is required but not set")
-                .with_context("service", Scheme::Sled)
+                .with_context("service", SLED_SCHEME)
         })?;
 
         let db = sled::open(&datadir_path).map_err(|e| {
             Error::new(ErrorKind::ConfigInvalid, "open db")
-                .with_context("service", Scheme::Sled)
+                .with_context("service", SLED_SCHEME)
                 .with_context("datadir", datadir_path.clone())
                 .set_source(e)
         })?;
@@ -84,7 +85,7 @@ impl Builder for SledBuilder {
 
         let tree = db.open_tree(&tree_name).map_err(|e| {
             Error::new(ErrorKind::ConfigInvalid, "open tree")
-                .with_context("service", Scheme::Sled)
+                .with_context("service", SLED_SCHEME)
                 .with_context("datadir", datadir_path.clone())
                 .with_context("tree", tree_name.clone())
                 .set_source(e)
@@ -111,7 +112,7 @@ pub struct SledBackend {
 impl SledBackend {
     pub fn new(core: SledCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Sled.into_static())
+        info.set_scheme(SLED_SCHEME)
             .set_name(&core.datadir)
             .set_root("/")
             .set_native_capability(Capability {

--- a/core/src/services/sled/mod.rs
+++ b/core/src/services/sled/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for sled service.
+pub const SLED_SCHEME: &str = "sled";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/sqlite/backend.rs
+++ b/core/src/services/sqlite/backend.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use sqlx::sqlite::SqliteConnectOptions;
 use tokio::sync::OnceCell;
 
+use super::SQLITE_SCHEME;
 use super::config::SqliteConfig;
 use super::core::SqliteCore;
 use super::deleter::SqliteDeleter;
@@ -109,13 +110,13 @@ impl Builder for SqliteBuilder {
                     ErrorKind::ConfigInvalid,
                     "connection_string is required but not set",
                 )
-                .with_context("service", Scheme::Sqlite));
+                .with_context("service", SQLITE_SCHEME));
             }
         };
 
         let config = SqliteConnectOptions::from_str(&conn).map_err(|err| {
             Error::new(ErrorKind::ConfigInvalid, "connection_string is invalid")
-                .with_context("service", Scheme::Sqlite)
+                .with_context("service", SQLITE_SCHEME)
                 .set_source(err)
         })?;
 
@@ -123,7 +124,7 @@ impl Builder for SqliteBuilder {
             Some(v) => v,
             None => {
                 return Err(Error::new(ErrorKind::ConfigInvalid, "table is empty")
-                    .with_context("service", Scheme::Sqlite));
+                    .with_context("service", SQLITE_SCHEME));
             }
         };
 
@@ -177,7 +178,7 @@ pub struct SqliteBackend {
 impl SqliteBackend {
     fn new(core: SqliteCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Sqlite.into());
+        info.set_scheme(SQLITE_SCHEME);
         info.set_name(&core.table);
         info.set_root("/");
         info.set_native_capability(Capability {
@@ -335,10 +336,7 @@ mod test {
 
         // Verify basic properties
         assert_eq!(accessor.root, "/");
-        assert_eq!(
-            accessor.info.scheme(),
-            <Scheme as Into<&'static str>>::into(Scheme::Sqlite)
-        );
+        assert_eq!(accessor.info.scheme(), SQLITE_SCHEME);
         assert!(accessor.info.native_capability().read);
         assert!(accessor.info.native_capability().write);
         assert!(accessor.info.native_capability().delete);

--- a/core/src/services/sqlite/mod.rs
+++ b/core/src/services/sqlite/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for sqlite service.
+pub const SQLITE_SCHEME: &str = "sqlite";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/surrealdb/backend.rs
+++ b/core/src/services/surrealdb/backend.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use tokio::sync::OnceCell;
 
+use super::SURREALDB_SCHEME;
 use super::config::SurrealdbConfig;
 use super::core::*;
 use super::deleter::SurrealdbDeleter;
@@ -134,7 +135,7 @@ impl Builder for SurrealdbBuilder {
             None => {
                 return Err(
                     Error::new(ErrorKind::ConfigInvalid, "connection_string is empty")
-                        .with_context("service", Scheme::Surrealdb),
+                        .with_context("service", SURREALDB_SCHEME),
                 );
             }
         };
@@ -143,21 +144,21 @@ impl Builder for SurrealdbBuilder {
             Some(v) => v,
             None => {
                 return Err(Error::new(ErrorKind::ConfigInvalid, "namespace is empty")
-                    .with_context("service", Scheme::Surrealdb));
+                    .with_context("service", SURREALDB_SCHEME));
             }
         };
         let database = match self.config.database.clone() {
             Some(v) => v,
             None => {
                 return Err(Error::new(ErrorKind::ConfigInvalid, "database is empty")
-                    .with_context("service", Scheme::Surrealdb));
+                    .with_context("service", SURREALDB_SCHEME));
             }
         };
         let table = match self.config.table.clone() {
             Some(v) => v,
             None => {
                 return Err(Error::new(ErrorKind::ConfigInvalid, "table is empty")
-                    .with_context("service", Scheme::Surrealdb));
+                    .with_context("service", SURREALDB_SCHEME));
             }
         };
 
@@ -207,7 +208,7 @@ pub struct SurrealdbBackend {
 impl SurrealdbBackend {
     pub fn new(core: SurrealdbCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Surrealdb.into_static());
+        info.set_scheme(SURREALDB_SCHEME);
         info.set_name(&core.table);
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/surrealdb/mod.rs
+++ b/core/src/services/surrealdb/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for surrealdb service.
+pub const SURREALDB_SCHEME: &str = "surrealdb";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/swift/config.rs
+++ b/core/src/services/swift/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::SWIFT_SCHEME;
 use super::backend::SwiftBuilder;
 
 /// Config for OpenStack Swift support.
@@ -59,7 +60,7 @@ impl crate::Configurator for SwiftConfig {
         } else if !map.contains_key("endpoint") {
             return Err(
                 crate::Error::new(crate::ErrorKind::ConfigInvalid, "endpoint is required")
-                    .with_context("service", crate::Scheme::Swift),
+                    .with_context("service", SWIFT_SCHEME),
             );
         }
 
@@ -81,7 +82,7 @@ impl crate::Configurator for SwiftConfig {
                 crate::ErrorKind::ConfigInvalid,
                 "container is required",
             )
-            .with_context("service", crate::Scheme::Swift));
+            .with_context("service", SWIFT_SCHEME));
         }
 
         Self::from_iter(map)

--- a/core/src/services/tikv/backend.rs
+++ b/core/src/services/tikv/backend.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use tokio::sync::OnceCell;
 
+use super::TIKV_SCHEME;
 use super::config::TikvConfig;
 use super::core::*;
 use super::deleter::TikvDeleter;
@@ -83,7 +84,7 @@ impl Builder for TikvBuilder {
                 ErrorKind::ConfigInvalid,
                 "endpoints is required but not set",
             )
-            .with_context("service", Scheme::Tikv)
+            .with_context("service", TIKV_SCHEME)
         })?;
 
         if self.config.insecure
@@ -93,7 +94,7 @@ impl Builder for TikvBuilder {
         {
             return Err(
                 Error::new(ErrorKind::ConfigInvalid, "invalid tls configuration")
-                    .with_context("service", Scheme::Tikv)
+                    .with_context("service", TIKV_SCHEME)
                     .with_context("endpoints", format!("{endpoints:?}")),
             )?;
         }
@@ -120,7 +121,7 @@ pub struct TikvBackend {
 impl TikvBackend {
     fn new(core: TikvCore) -> Self {
         let info = AccessorInfo::default();
-        info.set_scheme(Scheme::Tikv.into_static());
+        info.set_scheme(TIKV_SCHEME);
         info.set_name("TiKV");
         info.set_root("/");
         info.set_native_capability(Capability {

--- a/core/src/services/tikv/core.rs
+++ b/core/src/services/tikv/core.rs
@@ -21,6 +21,7 @@ use tikv_client::Config;
 use tikv_client::RawClient;
 use tokio::sync::OnceCell;
 
+use super::TIKV_SCHEME;
 use crate::*;
 
 /// TikvCore holds the configuration and client for interacting with TiKV.
@@ -65,7 +66,7 @@ impl TikvCore {
         } else {
             return Err(
                 Error::new(ErrorKind::ConfigInvalid, "invalid configuration")
-                    .with_context("service", Scheme::Tikv)
+                    .with_context("service", TIKV_SCHEME)
                     .with_context("endpoints", format!("{:?}", self.endpoints)),
             );
         };
@@ -106,6 +107,6 @@ fn parse_tikv_error(e: tikv_client::Error) -> Error {
 
 fn parse_tikv_config_error(e: tikv_client::Error) -> Error {
     Error::new(ErrorKind::ConfigInvalid, "invalid configuration")
-        .with_context("service", Scheme::Tikv)
+        .with_context("service", TIKV_SCHEME)
         .set_source(e)
 }

--- a/core/src/services/tikv/mod.rs
+++ b/core/src/services/tikv/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+/// Default scheme for tikv service.
+pub const TIKV_SCHEME: &str = "tikv";
+
 mod backend;
 mod config;
 mod core;

--- a/core/src/services/upyun/backend.rs
+++ b/core/src/services/upyun/backend.rs
@@ -128,7 +128,7 @@ impl Builder for UpyunBuilder {
         if self.config.bucket.is_empty() {
             return Err(Error::new(ErrorKind::ConfigInvalid, "bucket is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Upyun));
+                .with_context("service", UPYUN_SCHEME));
         }
 
         debug!("backend use bucket {}", &self.config.bucket);
@@ -137,14 +137,14 @@ impl Builder for UpyunBuilder {
             Some(operator) => Ok(operator.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "operator is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Upyun)),
+                .with_context("service", UPYUN_SCHEME)),
         }?;
 
         let password = match &self.config.password {
             Some(password) => Ok(password.clone()),
             None => Err(Error::new(ErrorKind::ConfigInvalid, "password is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::Upyun)),
+                .with_context("service", UPYUN_SCHEME)),
         }?;
 
         let signer = UpyunSigner {

--- a/core/src/services/vercel_blob/backend.rs
+++ b/core/src/services/vercel_blob/backend.rs
@@ -107,7 +107,7 @@ impl Builder for VercelBlobBuilder {
         let Some(token) = self.config.token.clone() else {
             return Err(Error::new(ErrorKind::ConfigInvalid, "token is empty")
                 .with_operation("Builder::build")
-                .with_context("service", Scheme::VercelBlob));
+                .with_context("service", VERCEL_BLOB_SCHEME));
         };
 
         Ok(VercelBlobBackend {

--- a/core/src/services/webdav/backend.rs
+++ b/core/src/services/webdav/backend.rs
@@ -130,14 +130,14 @@ impl Builder for WebdavBuilder {
             Some(v) => v,
             None => {
                 return Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
-                    .with_context("service", Scheme::Webdav));
+                    .with_context("service", WEBDAV_SCHEME));
             }
         };
         // Some services might return the path with suffix `/remote.php/webdav/`, we need to trim them.
         let server_path = http::Uri::from_str(endpoint)
             .map_err(|err| {
                 Error::new(ErrorKind::ConfigInvalid, "endpoint is invalid")
-                    .with_context("service", Scheme::Webdav)
+                    .with_context("service", WEBDAV_SCHEME)
                     .set_source(err)
             })?
             .path()

--- a/core/src/services/webdav/config.rs
+++ b/core/src/services/webdav/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::WEBDAV_SCHEME;
 use super::backend::WebdavBuilder;
 
 /// Config for [WebDAV](https://datatracker.ietf.org/doc/html/rfc4918) backend support.
@@ -58,7 +59,7 @@ impl crate::Configurator for WebdavConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Webdav)
+                .with_context("service", WEBDAV_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/webhdfs/config.rs
+++ b/core/src/services/webhdfs/config.rs
@@ -20,6 +20,7 @@ use std::fmt::Debug;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::WEBHDFS_SCHEME;
 use super::backend::WebhdfsBuilder;
 
 /// Config for WebHDFS support.
@@ -59,7 +60,7 @@ impl crate::Configurator for WebhdfsConfig {
     fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
         let authority = uri.authority().ok_or_else(|| {
             crate::Error::new(crate::ErrorKind::ConfigInvalid, "uri authority is required")
-                .with_context("service", crate::Scheme::Webhdfs)
+                .with_context("service", WEBHDFS_SCHEME)
         })?;
 
         let mut map = uri.options().clone();

--- a/core/src/services/yandex_disk/backend.rs
+++ b/core/src/services/yandex_disk/backend.rs
@@ -105,7 +105,7 @@ impl Builder for YandexDiskBuilder {
             return Err(
                 Error::new(ErrorKind::ConfigInvalid, "access_token is empty")
                     .with_operation("Builder::build")
-                    .with_context("service", Scheme::YandexDisk),
+                    .with_context("service", YANDEX_DISK_SCHEME),
             );
         }
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of #6755

# Rationale for this change

improve consistency

# What changes are included in this PR?

- Use string-based scheme specification over enum-based approach
- remove `Scheme` enum usage from core services

# Are there any user-facing changes?

