### PR TITLE
fix(bindings/ruby): fix release build error

### DIFF
--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -34,8 +34,11 @@ name = "opendal_ruby"
 
 [dependencies]
 magnus = { version = "0.8", features = ["bytes", "io"] }
-# 1. this crate won't be published, we always use the local version
-# 2. we use the symbolink to allow released gem to find core's source files.
+# 1. we don't use published core but a local copy
+# 2. for a source release, this path must be the local "./core".
+#   we set it via rake copy_core. Read more in:
+#     - Rakefile
+#     - opendal.gemspec
 opendal = { version = ">=0", path = "../../core", features = [
   "blocking",
   "layers-throttle",

--- a/bindings/ruby/Rakefile
+++ b/bindings/ruby/Rakefile
@@ -25,6 +25,33 @@ require "standard/rake"
 GEMSPEC = Gem::Specification.load("opendal.gemspec")
 CRATE_PACKAGE_NAME = "opendal-ruby"
 
+desc "Copy core files for compilation"
+task :copy_core do
+  core_dir = "../../core"
+  distributed_core_dir = "core"
+
+  puts "Copying core files from #{core_dir} to #{distributed_core_dir}..."
+  FileUtils.rm_rf(distributed_core_dir, secure: true)
+  system("cp", "-Lr", core_dir, distributed_core_dir) # resolves symbolic links to a copy
+
+  # Verify core files were copied
+  core_files_count = `git -C #{File.expand_path(core_dir, __dir__)} ls-files -z`.split("\x0").length
+  puts "Copied #{core_files_count} files from core directory"
+
+  # Patch Cargo.toml for source distribution
+  # When core files are copied locally, update Cargo.toml to reference the local copy
+  if File.directory?(distributed_core_dir)
+    cargo_toml = File.read("Cargo.toml")
+
+    # Only patch if we haven't already and we're using the relative path
+    if cargo_toml.include?('path = "../../core"')
+      puts "Patching Cargo.toml to use local core directory..."
+      cargo_toml.gsub!('path = "../../core"', 'path = "core"')
+      File.write("Cargo.toml", cargo_toml)
+    end
+  end
+end
+
 RbSys::ExtensionTask.new(CRATE_PACKAGE_NAME, GEMSPEC) do |ext|
   ext.name = "opendal_ruby"
   ext.ext_dir = "."
@@ -93,16 +120,8 @@ task :version do
   print GEMSPEC.version
 end
 
-desc "Copy the core directory for gem packaging" # Read more in `./.github/workflows/release-ruby.yml`
-task :copy_core do
-  puts "Copy the core directory for packaging..."
-  src = "../../core"
-  dst = "./core"
-  `cp -RL #{src} #{dst}`
-end
-
-# Hook into build task to copy the core directory first
-Rake::Task["build"].enhance([:copy_core]) if Rake::Task.task_defined?("build")
+# Ensure core files are copied before compilation and packaging
+Rake::Task["build"].enhance(["copy_core"]) if Rake::Task.task_defined?("build")
 
 Rake::Task["release"].clear # clear the existing release task to allow override
 Rake::Task["release:rubygem_push"].clear if Rake::Task.task_defined?("release:rubygem_push")


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Ruby binding will build with this pr.

Resolves symlinks in core when copying core folder for a release. This fixes a release error where ruby source gem release can't find opendal core. 

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
