### PR TITLE
chore(services): remove empty list operation and update docs of all services

### DIFF
--- a/core/src/services/aliyun_drive/docs.md
+++ b/core/src/services/aliyun_drive/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [x] rename
-- [x] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/alluxio/docs.md
+++ b/core/src/services/alluxio/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [ ] copy
 - [x] rename
-- [x] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/azblob/docs.md
+++ b/core/src/services/azblob/docs.md
@@ -2,17 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] append
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [ ] rename
-- [x] list
 - [x] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/azdls/docs.md
+++ b/core/src/services/azdls/docs.md
@@ -10,16 +10,15 @@ This service will visit the [ABFS](https://learn.microsoft.com/en-us/azure/stora
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [ ] copy
 - [x] rename
-- [x] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/azfile/docs.md
+++ b/core/src/services/azfile/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [ ] copy
 - [x] rename
-- [x] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/b2/docs.md
+++ b/core/src/services/b2/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [ ] rename
-- [x] list
 - [x] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/cacache/docs.md
+++ b/core/src/services/cacache/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] ~~presign~~
-- [x] blocking
 
 ## Configuration
 

--- a/core/src/services/cloudflare_kv/docs.md
+++ b/core/src/services/cloudflare_kv/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [ ] copy
 - [ ] rename
-- [x] list
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/cos/docs.md
+++ b/core/src/services/cos/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [ ] rename
-- [x] list
-- [ ] presign
-- [ ] blocking
+- [x] presign
 
 ## Configuration
 

--- a/core/src/services/d1/backend.rs
+++ b/core/src/services/d1/backend.rs
@@ -278,9 +278,4 @@ impl Access for D1Backend {
             oio::OneShotDeleter::new(D1Deleter::new(self.core.clone(), self.root.clone())),
         ))
     }
-
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let _ = build_abs_path(&self.root, path);
-        Ok((RpList::default(), ()))
-    }
 }

--- a/core/src/services/d1/docs.md
+++ b/core/src/services/d1/docs.md
@@ -7,9 +7,9 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] ~~presign~~
 
 ## Configuration

--- a/core/src/services/dashmap/docs.md
+++ b/core/src/services/dashmap/docs.md
@@ -2,14 +2,14 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
-- [x] copy
-- [x] rename
 - [x] list
+- [ ] copy
+- [ ] rename
 - [ ] presign
 
 ## Configuration

--- a/core/src/services/dbfs/docs.md
+++ b/core/src/services/dbfs/docs.md
@@ -4,16 +4,15 @@ This service will visit the [DBFS API](https://docs.databricks.com/api/azure/wor
 
 This service can be used to:
 
-- [x] stat
-- [x] read
-- [x] write
 - [x] create_dir
+- [x] stat
+- [ ] read
+- [x] write
 - [x] delete
 - [ ] copy
 - [x] rename
 - [x] list
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Configurations
 

--- a/core/src/services/dropbox/docs.md
+++ b/core/src/services/dropbox/docs.md
@@ -2,16 +2,14 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [x] rename
-- [x] list
-- [x] batch
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/etcd/docs.md
+++ b/core/src/services/etcd/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
-- [x] copy
-- [x] rename
 - [x] list
+- [ ] copy
+- [ ] rename
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/foundationdb/backend.rs
+++ b/core/src/services/foundationdb/backend.rs
@@ -180,9 +180,4 @@ impl Access for FoundationdbBackend {
             )),
         ))
     }
-
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let _ = build_abs_path(&self.root, path);
-        Ok((RpList::default(), ()))
-    }
 }

--- a/core/src/services/foundationdb/docs.md
+++ b/core/src/services/foundationdb/docs.md
@@ -7,9 +7,9 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] ~~presign~~
 
 **Note**: As for [Known Limitations - FoundationDB](https://apple.github.io/foundationdb/known-limitations), keys cannot exceed 10,000 bytes in size, and values cannot exceed 100,000 bytes in size. Errors will be raised by OpenDAL if these limits are exceeded.

--- a/core/src/services/fs/docs.md
+++ b/core/src/services/fs/docs.md
@@ -2,17 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] append
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [x] rename
-- [x] list
 - [ ] ~~presign~~
-- [x] blocking
 
 ## Configuration
 

--- a/core/src/services/ftp/docs.md
+++ b/core/src/services/ftp/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [ ] copy
 - [ ] rename
-- [x] list
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/gcs/docs.md
+++ b/core/src/services/gcs/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [ ] rename
-- [x] list
 - [x] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/gdrive/docs.md
+++ b/core/src/services/gdrive/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
 - [x] delete
-- [x] create_dir
 - [x] list
 - [x] copy
 - [x] rename
-- [ ] batch
-
+- [ ] presign
 
 # Configuration
 
@@ -62,4 +61,3 @@ async fn main() -> Result<()> {
 
     Ok(())
 }
-

--- a/core/src/services/ghac/docs.md
+++ b/core/src/services/ghac/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
-- [x] delete
-- [x] copy
-- [ ] rename
+- [ ] delete
 - [ ] list
+- [ ] copy
+- [ ] rename
 - [ ] presign
-- [ ] blocking
 
 ## Notes
 

--- a/core/src/services/github/docs.md
+++ b/core/src/services/github/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [ ] create_dir
 - [x] delete
+- [x] list
 - [ ] copy
 - [ ] rename
-- [x] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/gridfs/backend.rs
+++ b/core/src/services/gridfs/backend.rs
@@ -234,9 +234,4 @@ impl Access for GridfsBackend {
             oio::OneShotDeleter::new(GridfsDeleter::new(self.core.clone(), self.root.clone())),
         ))
     }
-
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let _ = build_abs_path(&self.root, path);
-        Ok((RpList::default(), ()))
-    }
 }

--- a/core/src/services/gridfs/docs.md
+++ b/core/src/services/gridfs/docs.md
@@ -7,9 +7,9 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] ~~presign~~
 
 ## Configuration

--- a/core/src/services/hdfs/docs.md
+++ b/core/src/services/hdfs/docs.md
@@ -4,17 +4,15 @@ A distributed file system that provides high-throughput access to application da
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [ ] copy
 - [x] rename
-- [x] list
 - [ ] ~~presign~~
-- [x] blocking
-- [x] append
 
 ## Differences with webhdfs
 

--- a/core/src/services/hdfs_native/docs.md
+++ b/core/src/services/hdfs_native/docs.md
@@ -5,15 +5,15 @@ Using [Native Rust HDFS client](https://github.com/Kimahriman/hdfs-native).
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
-- [x] rename
 - [x] list
-- [x] blocking
-- [x] append
+- [ ] copy
+- [x] rename
+- [ ] ~~presign~~
 
 ## Differences with webhdfs
 
@@ -31,5 +31,4 @@ HDFS-native support needs to enable feature `services-hdfs-native`.
 
 - `root`: Set the work dir for backend.
 - `name_node`: Set the name node for backend.
-- `enable_append`: enable the append capacity. Default is false. 
-
+- `enable_append`: enable the append capacity. Default is false.

--- a/core/src/services/http/docs.md
+++ b/core/src/services/http/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] ~~create_dir~~
 - [x] stat
 - [x] read
 - [ ] ~~write~~
-- [ ] ~~create_dir~~
 - [ ] ~~delete~~
+- [ ] ~~list~~
 - [ ] ~~copy~~
 - [ ] ~~rename~~
-- [ ] ~~list~~
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Notes
 

--- a/core/src/services/huggingface/docs.md
+++ b/core/src/services/huggingface/docs.md
@@ -7,16 +7,15 @@ Huggingface doesn't host official HTTP API docs. Detailed HTTP request API infor
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [ ] write
-- [ ] create_dir
 - [ ] delete
+- [x] list
 - [ ] copy
 - [ ] rename
-- [x] list
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Configurations
 

--- a/core/src/services/ipfs/docs.md
+++ b/core/src/services/ipfs/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] ~~create_dir~~
 - [x] stat
 - [x] read
 - [ ] ~~write~~
-- [ ] ~~create_dir~~
 - [ ] ~~delete~~
+- [x] list
 - [ ] ~~copy~~
 - [ ] ~~rename~~
-- [x] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/ipmfs/docs.md
+++ b/core/src/services/ipmfs/docs.md
@@ -2,13 +2,12 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [ ] create_dir
 - [x] delete
+- [x] list
 - [ ] copy
 - [ ] rename
-- [x] list
 - [ ] presign
-- [ ] blocking

--- a/core/src/services/koofr/docs.md
+++ b/core/src/services/koofr/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [x] rename
-- [x] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/lakefs/docs.md
+++ b/core/src/services/lakefs/docs.md
@@ -7,16 +7,15 @@ Lakefs doesn't host official HTTP API docs. Detailed HTTP request API informatio
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [ ] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [ ] rename
-- [x] list
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Configurations
 

--- a/core/src/services/memcached/backend.rs
+++ b/core/src/services/memcached/backend.rs
@@ -234,9 +234,4 @@ impl Access for MemcachedBackend {
             oio::OneShotDeleter::new(MemcachedDeleter::new(self.core.clone(), self.root.clone())),
         ))
     }
-
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let _ = build_abs_path(&self.root, path);
-        Ok((RpList::default(), ()))
-    }
 }

--- a/core/src/services/memcached/docs.md
+++ b/core/src/services/memcached/docs.md
@@ -7,9 +7,9 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] ~~presign~~
 
 ## Configuration

--- a/core/src/services/memory/docs.md
+++ b/core/src/services/memory/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
-- [x] copy
-- [x] rename
-- [ ] list
+- [x] list
+- [ ] copy
+- [ ] rename
 - [ ] presign
-- [ ] blocking
 
 ## Example
 

--- a/core/src/services/mini_moka/docs.md
+++ b/core/src/services/mini_moka/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] presign
-- [ ] blocking
 
 ## Notes
 

--- a/core/src/services/moka/docs.md
+++ b/core/src/services/moka/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/mongodb/backend.rs
+++ b/core/src/services/mongodb/backend.rs
@@ -252,9 +252,4 @@ impl Access for MongodbBackend {
             oio::OneShotDeleter::new(MongodbDeleter::new(self.core.clone(), self.root.clone())),
         ))
     }
-
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let _ = build_abs_path(&self.root, path);
-        Ok((RpList::default(), ()))
-    }
 }

--- a/core/src/services/mongodb/docs.md
+++ b/core/src/services/mongodb/docs.md
@@ -7,9 +7,9 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] ~~presign~~
 
 ## Configuration

--- a/core/src/services/monoiofs/docs.md
+++ b/core/src/services/monoiofs/docs.md
@@ -2,17 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] append
-- [x] create_dir
 - [x] delete
+- [ ] list
 - [x] copy
 - [x] rename
-- [ ] list
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/mysql/backend.rs
+++ b/core/src/services/mysql/backend.rs
@@ -232,9 +232,4 @@ impl Access for MysqlBackend {
             oio::OneShotDeleter::new(MysqlDeleter::new(self.core.clone(), self.root.clone())),
         ))
     }
-
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let _ = build_abs_path(&self.root, path);
-        Ok((RpList::default(), ()))
-    }
 }

--- a/core/src/services/mysql/docs.md
+++ b/core/src/services/mysql/docs.md
@@ -7,9 +7,9 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] ~~presign~~
 
 ## Configuration

--- a/core/src/services/obs/docs.md
+++ b/core/src/services/obs/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [ ] rename
-- [x] list
 - [x] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/onedrive/docs.md
+++ b/core/src/services/onedrive/docs.md
@@ -2,17 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [ ] append
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [x] rename
-- [x] list
 - [ ] presign
-- [ ] blocking
 
 ## Notes
 

--- a/core/src/services/opfs/docs.md
+++ b/core/src/services/opfs/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [ ] stat
 - [ ] read
 - [ ] write
-- [ ] create_dir
 - [ ] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/oss/docs.md
+++ b/core/src/services/oss/docs.md
@@ -4,17 +4,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] append
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [ ] rename
-- [x] list
 - [x] presign
-- [ ] blocking
 
 # Configuration
 

--- a/core/src/services/pcloud/docs.md
+++ b/core/src/services/pcloud/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [x] rename
-- [x] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/persy/backend.rs
+++ b/core/src/services/persy/backend.rs
@@ -197,9 +197,4 @@ impl Access for PersyBackend {
             oio::OneShotDeleter::new(PersyDeleter::new(self.core.clone(), self.root.clone())),
         ))
     }
-
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let _ = build_abs_path(&self.root, path);
-        Ok((RpList::default(), ()))
-    }
 }

--- a/core/src/services/persy/docs.md
+++ b/core/src/services/persy/docs.md
@@ -7,9 +7,9 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] ~~presign~~
 
 ## Configuration

--- a/core/src/services/postgresql/backend.rs
+++ b/core/src/services/postgresql/backend.rs
@@ -235,9 +235,4 @@ impl Access for PostgresqlBackend {
             oio::OneShotDeleter::new(PostgresqlDeleter::new(self.core.clone(), self.root.clone())),
         ))
     }
-
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let _ = build_abs_path(&self.root, path);
-        Ok((RpList::default(), ()))
-    }
 }

--- a/core/src/services/postgresql/docs.md
+++ b/core/src/services/postgresql/docs.md
@@ -7,9 +7,9 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] ~~presign~~
 
 ## Configuration

--- a/core/src/services/redb/backend.rs
+++ b/core/src/services/redb/backend.rs
@@ -215,9 +215,4 @@ impl Access for RedbBackend {
             oio::OneShotDeleter::new(RedbDeleter::new(self.core.clone(), self.root.clone())),
         ))
     }
-
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let _ = build_abs_path(&self.root, path);
-        Ok((RpList::default(), ()))
-    }
 }

--- a/core/src/services/redb/docs.md
+++ b/core/src/services/redb/docs.md
@@ -7,9 +7,9 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] ~~presign~~
 
 ## Configuration

--- a/core/src/services/redis/backend.rs
+++ b/core/src/services/redis/backend.rs
@@ -351,10 +351,4 @@ impl Access for RedisBackend {
             oio::OneShotDeleter::new(RedisDeleter::new(self.core.clone(), self.root.clone())),
         ))
     }
-
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let _ = build_abs_path(&self.root, path);
-        // Redis doesn't support listing keys, return empty list
-        Ok((RpList::default(), ()))
-    }
 }

--- a/core/src/services/redis/docs.md
+++ b/core/src/services/redis/docs.md
@@ -2,14 +2,14 @@
 
 This service can be used to:
 
+- [ ] ~~create_dir~~
 - [x] stat
 - [x] read
 - [x] write
 - [x] delete
-- [ ] ~~create_dir~~
+- [ ] ~~list~~
 - [ ] ~~copy~~
 - [ ] ~~rename~~
-- [ ] ~~list~~
 - [ ] ~~presign~~
 
 ## Configuration

--- a/core/src/services/rocksdb/docs.md
+++ b/core/src/services/rocksdb/docs.md
@@ -7,9 +7,9 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
+- [x] list
 - [ ] copy
 - [ ] rename
-- [x] list
 - [ ] ~~presign~~
 
 ## Note

--- a/core/src/services/s3/docs.md
+++ b/core/src/services/s3/docs.md
@@ -2,17 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] append
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [ ] rename
-- [x] list
 - [x] presign
-- [ ] blocking
 
 ## Configuration
 
@@ -241,4 +239,3 @@ async fn main() -> Result<()> {
     Ok(())
 }
 ```
-

--- a/core/src/services/seafile/docs.md
+++ b/core/src/services/seafile/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [ ] copy
 - [ ] rename
-- [x] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/sftp/docs.md
+++ b/core/src/services/sftp/docs.md
@@ -2,17 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] append
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [x] rename
-- [x] list
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/sled/docs.md
+++ b/core/src/services/sled/docs.md
@@ -7,9 +7,9 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
+- [x] list
 - [ ] copy
 - [ ] rename
-- [x] list
 - [ ] ~~presign~~
 
 ## Configuration

--- a/core/src/services/sqlite/docs.md
+++ b/core/src/services/sqlite/docs.md
@@ -2,15 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [x] list
-- [ ] blocking
+- [ ] presign
 
 ## Configuration
 

--- a/core/src/services/surrealdb/backend.rs
+++ b/core/src/services/surrealdb/backend.rs
@@ -283,9 +283,4 @@ impl Access for SurrealdbBackend {
             oio::OneShotDeleter::new(SurrealdbDeleter::new(self.core.clone(), self.root.clone())),
         ))
     }
-
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let _ = build_abs_path(&self.root, path);
-        Ok((RpList::default(), ()))
-    }
 }

--- a/core/src/services/surrealdb/docs.md
+++ b/core/src/services/surrealdb/docs.md
@@ -7,9 +7,9 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] ~~presign~~
 
 ## Configuration

--- a/core/src/services/swift/docs.md
+++ b/core/src/services/swift/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [ ] ~~rename~~
-- [x] list
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Configurations
 

--- a/core/src/services/tikv/backend.rs
+++ b/core/src/services/tikv/backend.rs
@@ -188,9 +188,4 @@ impl Access for TikvBackend {
             oio::OneShotDeleter::new(TikvDeleter::new(self.core.clone(), self.root.clone())),
         ))
     }
-
-    async fn list(&self, path: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
-        let _ = build_abs_path(&self.root, path);
-        Ok((RpList::default(), ()))
-    }
 }

--- a/core/src/services/tikv/docs.md
+++ b/core/src/services/tikv/docs.md
@@ -7,9 +7,9 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
+- [ ] list
 - [ ] copy
 - [ ] rename
-- [ ] list
 - [ ] ~~presign~~
 
 ## Configuration

--- a/core/src/services/upyun/docs.md
+++ b/core/src/services/upyun/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [x] rename
-- [x] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/vercel_artifacts/docs.md
+++ b/core/src/services/vercel_artifacts/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
-- [ ] stat
+- [ ] create_dir
+- [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
-- [x] delete
+- [ ] delete
+- [ ] ~~list~~
 - [ ] ~~copy~~
 - [ ] ~~rename~~
-- [ ] ~~list~~
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/vercel_blob/docs.md
+++ b/core/src/services/vercel_blob/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [ ] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [ ] rename
-- [x] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 

--- a/core/src/services/webdav/docs.md
+++ b/core/src/services/webdav/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [x] rename
-- [x] list
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Notes
 

--- a/core/src/services/webhdfs/docs.md
+++ b/core/src/services/webhdfs/docs.md
@@ -7,16 +7,15 @@ There two implementations of WebHDFS REST API:
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [ ] copy
 - [ ] rename
-- [x] list
 - [ ] ~~presign~~
-- [ ] blocking
 
 ## Differences with HDFS
 

--- a/core/src/services/yandex_disk/docs.md
+++ b/core/src/services/yandex_disk/docs.md
@@ -2,16 +2,15 @@
 
 This service can be used to:
 
+- [x] create_dir
 - [x] stat
 - [x] read
 - [x] write
-- [x] create_dir
 - [x] delete
+- [x] list
 - [x] copy
 - [x] rename
-- [x] list
 - [ ] presign
-- [ ] blocking
 
 ## Configuration
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of #6755

# Rationale for this change

Currently, some services include an empty list implementation.
if list operations are not supported or have not yet been implemented, it is sufficient to simply omit the implementation.

# What changes are included in this PR?

- remove empty list operation of some servces.
- update docs of all services

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
