### PR TITLE
chore(types)!: remove deprecated `Operator::from_map` and `Operator::via_map`

### DIFF
--- a/core/src/types/operator/builder.rs
+++ b/core/src/types/operator/builder.rs
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::layers::*;
@@ -330,69 +329,6 @@ impl Operator {
         Ok(op)
     }
 
-    /// Create a new operator from given map.
-    ///
-    /// # Notes
-    ///
-    /// from_map is using static dispatch layers which is zero cost. via_map is
-    /// using dynamic dispatch layers which has a bit runtime overhead with an
-    /// extra vtable lookup and unable to inline. But from_map requires generic
-    /// type parameter which is not always easy to be used.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use anyhow::Result;
-    /// use std::collections::HashMap;
-    ///
-    /// use opendal::services::Memory;
-    /// use opendal::Operator;
-    /// async fn test() -> Result<()> {
-    ///     let map = HashMap::new();
-    ///
-    ///     // Build an `Operator` to start operating the storage.
-    ///     let op: Operator = Operator::from_map::<Memory>(map)?.finish();
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    #[deprecated = "use from_iter instead"]
-    pub fn from_map<B: Builder>(
-        map: HashMap<String, String>,
-    ) -> Result<OperatorBuilder<impl Access>> {
-        Self::from_iter::<B>(map)
-    }
-
-    /// Create a new operator from given scheme and map.
-    ///
-    /// # Notes
-    ///
-    /// from_map is using static dispatch layers which is zero cost. via_map is
-    /// using dynamic dispatch layers which has a bit runtime overhead with an
-    /// extra vtable lookup and unable to inline. But from_map requires generic
-    /// type parameter which is not always easy to be used.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use anyhow::Result;
-    /// use std::collections::HashMap;
-    ///
-    /// use opendal::Operator;
-    /// async fn test() -> Result<()> {
-    ///     let map = HashMap::new();
-    ///
-    ///     // Build an `Operator` to start operating the storage.
-    ///     let op: Operator = Operator::via_map(opendal::services::MEMORY_SCHEME, map)?;
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    #[deprecated = "use via_iter instead"]
-    pub fn via_map(scheme: impl AsRef<str>, map: HashMap<String, String>) -> Result<Operator> {
-        Self::via_iter(scheme, map)
-    }
-
     /// Create a new layer with dynamic dispatch.
     ///
     /// Please note that `Layer` can modify internal contexts such as `HttpClient`
@@ -459,7 +395,7 @@ impl Operator {
 /// use opendal::Result;
 ///
 /// fn init_service<B: Builder>(cfg: HashMap<String, String>) -> Result<Operator> {
-///     let op = Operator::from_map::<B>(cfg)?
+///     let op = Operator::from_iter::<B>(cfg)?
 ///         .layer(LoggingLayer::default())
 ///         .layer(RetryLayer::new())
 ///         .finish();

--- a/integrations/unftp-sbe/src/lib.rs
+++ b/integrations/unftp-sbe/src/lib.rs
@@ -32,7 +32,7 @@
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
 //!     // Create any service desired
-//!     let op = opendal::Operator::from_map::<services::S3>(
+//!     let op = opendal::Operator::from_iter::<services::S3>(
 //!         [
 //!             ("bucket".to_string(), "my_bucket".to_string()),
 //!             ("access_key".to_string(), "my_access_key".to_string()),


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Since v0.48, these two methods have been deprecated and replaced by the `from_iter` and `via_iter` methods. 
Given that v0.55 has now been released, I think it is time to remove them.

Additionally, I think the community may need to establish a cleanup strategy for deprecated code (perhaps such a strategy already exists within the community, but I have yet to discover it).
For example, if the community is preparing to release version 0.55, code marked as deprecated several versions earlier could be removed from the codebase—such as eliminating code associated with `#[deprecated(since = "...", note = "...")]` annotations from three versions prior.

# What changes are included in this PR?

- remove deprecated `Operator::from_map`
- remove deprecated `Operator::via_map`

# Are there any user-facing changes?

- remove deprecated `Operator::from_map`
- remove deprecated `Operator::via_map`
