### PR TITLE
chore(services/s3)!: remove deprecated `S3::security_token`

### DIFF
--- a/core/src/services/s3/backend.rs
+++ b/core/src/services/s3/backend.rs
@@ -379,12 +379,6 @@ impl S3Builder {
         self
     }
 
-    /// Set temporary credential used in AWS S3 connections
-    #[deprecated(note = "Please use `session_token` instead")]
-    pub fn security_token(self, token: &str) -> Self {
-        self.session_token(token)
-    }
-
     /// Disable config load so that opendal will not load config from
     /// environment.
     ///


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Since v0.48, the method has been deprecated and replaced by the `session_token` method.
Given that v0.55 has been released now, I think it's time to remove it.

# What changes are included in this PR?

- remove deprecated `S3::security_token`

# Are there any user-facing changes?

- remove deprecated `S3::security_token`
