### PR TITLE
chore(types)!: remove deprecated `list_with_version` capability

### DIFF
--- a/core/src/raw/ops.rs
+++ b/core/src/raw/ops.rs
@@ -182,22 +182,9 @@ impl OpList {
     }
 
     /// Change the version of this list operation
-    #[deprecated(since = "0.51.1", note = "use with_versions instead")]
-    pub fn with_version(mut self, version: bool) -> Self {
-        self.versions = version;
-        self
-    }
-
-    /// Change the version of this list operation
     pub fn with_versions(mut self, versions: bool) -> Self {
         self.versions = versions;
         self
-    }
-
-    /// Get the version of this list operation
-    #[deprecated(since = "0.51.1", note = "use versions instead")]
-    pub fn version(&self) -> bool {
-        self.versions
     }
 
     /// Get the version of this list operation

--- a/core/src/types/capability.rs
+++ b/core/src/types/capability.rs
@@ -162,9 +162,6 @@ pub struct Capability {
     pub list_with_start_after: bool,
     /// Indicates if recursive listing is supported.
     pub list_with_recursive: bool,
-    /// Indicates if versions listing is supported.
-    #[deprecated(since = "0.51.1", note = "use with_versions instead")]
-    pub list_with_version: bool,
     /// Indicates if listing with versions included is supported.
     pub list_with_versions: bool,
     /// Indicates if listing with deleted files included is supported.


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Since v0.51.1, the `list_with_version` capability has been deprecated and replaced by the `list_with_versions`.
Given that v0.55 has been released now, I think it's time to remove it.

# What changes are included in this PR?

- remove deprecated `list_with_version`

# Are there any user-facing changes?

- remove deprecated `list_with_version`
