### PR TITLE
chore(layers/timeout)!: remove deprecated `with_speed` method

### DIFF
--- a/core/src/layers/timeout.rs
+++ b/core/src/layers/timeout.rs
@@ -147,21 +147,6 @@ impl TimeoutLayer {
         self.io_timeout = timeout;
         self
     }
-
-    /// Set speed for TimeoutLayer with given value.
-    ///
-    /// # Notes
-    ///
-    /// The speed should be the lower bound of the IO speed. Set this value too
-    /// large could result in all write operations failing.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if speed is 0.
-    #[deprecated(note = "with speed is not supported anymore, please use with_io_timeout instead")]
-    pub fn with_speed(self, _: u64) -> Self {
-        self
-    }
 }
 
 impl<A: Access> Layer<A> for TimeoutLayer {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Since v0.45, the `with_speed` method has been deprecated.
Given that v0.55 has been released now, I think it's time to remove it.

# What changes are included in this PR?

- remove deprecated `with_speed` method

# Are there any user-facing changes?

- remove deprecated `with_speed` method
