### PR TITLE
docs: add 1password self-registration link for committers

### DIFF
--- a/website/community/committers/onboarding.md
+++ b/website/community/committers/onboarding.md
@@ -80,4 +80,6 @@ If you receive an email with the subject "WELCOME to dev@opendal.apache.org", yo
 
 OpenDAL offers a 1Password open-source team license for conducting local integration tests (Thanks to 1Password!). Once you have been added to OpenDAL's committer list, one of the PMC members will invite you to join the team.
 
+OpenDAL committers can also self-register to join the OpenDAL 1Password team by visiting <https://opendal.1password.com/teamjoin/invitation/DHRDX3DG45HDTNMYK63BK5BTQM> and completing the signup with their `apache.org` email address.
+
 Please download your preferred clients to begin using it. You can create your own vault that is accessible only by yourself. Neither the 1password team nor OpenDAL PMC members can access it unless you choose to share it.


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Provide OpenDAL committers with a documented self-service path to join the shared 1Password vaults.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

  - Update website/community/committers/onboarding.md to mention the invitation link, clarify that it’s for
    the OpenDAL 1Password team, and wrap the URL in angle brackets so it renders properly.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
