### PR TITLE
feat(services/github): Implement write returns metadata

### DIFF
--- a/core/src/services/github/core.rs
+++ b/core/src/services/github/core.rs
@@ -348,3 +348,8 @@ pub struct Entry {
     #[serde(rename = "type")]
     pub type_field: String,
 }
+
+#[derive(Default, Debug, Clone, Deserialize)]
+pub struct ContentResponse {
+    pub content: Entry,
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related #5693 

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
This PR parsed the upload API response to return actual file metadata (sha, size) instead of empty metadata for Provider github .

# Are there any user-facing changes?

NONE
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
