### PR TITLE
feat(services/seafile): Implement write returns metadata

### DIFF
--- a/core/src/services/seafile/writer.rs
+++ b/core/src/services/seafile/writer.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 use http::StatusCode;
 
 use super::core::SeafileCore;
-use super::core::parse_file_detail;
 use super::error::parse_error;
 use crate::raw::*;
 use crate::*;
@@ -53,8 +52,7 @@ impl oio::OneShotWrite for SeafileWriter {
                 if self.path.ends_with('/') {
                     Ok(Metadata::new(EntryMode::DIR))
                 } else {
-                    let file_detail = self.core.file_detail(&self.path).await?;
-                    parse_file_detail(file_detail)
+                    Ok(Metadata::default())
                 }
             }
             _ => Err(parse_error(resp)),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Related #5693 

# What changes are included in this PR?
This PR fetches file metadata via file_detail API after upload since the upload response doesn't include it.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

none
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
