### PR TITLE
chore: suppress noisy deny warnings

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -36,11 +36,11 @@ exceptions = [
 
   # malachite and its subcrates are introduced in the Python bindings (pyo3-stub-gen)
   # they are only used in proc-macro so they won't be included in the final library
-  { crate = "malachite", allow = ["LGPL-3.0"] },
-  { crate = "malachite-base", allow = ["LGPL-3.0"] },
-  { crate = "malachite-bigint", allow = ["LGPL-3.0"] },
-  { crate = "malachite-nz", allow = ["LGPL-3.0"] },
-  { crate = "malachite-q", allow = ["LGPL-3.0"] },
+  { crate = "malachite", allow = ["LGPL-3.0-only"] },
+  { crate = "malachite-base", allow = ["LGPL-3.0-only"] },
+  { crate = "malachite-bigint", allow = ["LGPL-3.0-only"] },
+  { crate = "malachite-nz", allow = ["LGPL-3.0-only"] },
+  { crate = "malachite-q", allow = ["LGPL-3.0-only"] },
 
   # open data licenses that SHOULD be OK
   { crate = "unicode_names2", allow = ["Unicode-DFS-2016"] },
@@ -49,3 +49,4 @@ exceptions = [
 
 # this config file is used for all crates; some of them would not encounter all the allowed licenses
 unused-allowed-license = "allow"
+unused-license-exception = "allow"


### PR DESCRIPTION
We're using the same `deny.toml` config for all crates. Since they are not under the same workspace, cargo-deny would print warnings when a rule is not used for specific crate (but it is used for another).