### PR TITLE
feat(services/huggingface): Add repo_type=space support

### DIFF
--- a/core/src/services/huggingface/backend.rs
+++ b/core/src/services/huggingface/backend.rs
@@ -45,8 +45,8 @@ impl HuggingfaceBuilder {
     /// - model
     /// - dataset
     /// - datasets (alias for dataset)
+    /// - space
     ///
-    /// Currently, only models and datasets are supported.
     /// [Reference](https://huggingface.co/docs/hub/repositories)
     pub fn repo_type(mut self, repo_type: &str) -> Self {
         if !repo_type.is_empty() {
@@ -130,10 +130,7 @@ impl Builder for HuggingfaceBuilder {
         let repo_type = match self.config.repo_type.as_deref() {
             Some("model") => Ok(RepoType::Model),
             Some("dataset") | Some("datasets") => Ok(RepoType::Dataset),
-            Some("space") => Err(Error::new(
-                ErrorKind::ConfigInvalid,
-                "repo type \"space\" is unsupported",
-            )),
+            Some("space") => Ok(RepoType::Space),
             Some(repo_type) => Err(Error::new(
                 ErrorKind::ConfigInvalid,
                 format!("unknown repo_type: {repo_type}").as_str(),
@@ -284,12 +281,13 @@ impl Access for HuggingfaceBackend {
     }
 }
 
-/// Repository type of Huggingface. Currently, we only support `model` and `dataset`.
+/// Repository type of Huggingface. Supports `model`, `dataset`, and `space`.
 /// [Reference](https://huggingface.co/docs/hub/repositories)
 #[derive(Debug, Clone, Copy)]
 pub enum RepoType {
     Model,
     Dataset,
+    Space,
 }
 
 #[cfg(test)]
@@ -303,5 +301,14 @@ mod tests {
             .repo_type("datasets")
             .build()
             .expect("builder should accept datasets alias");
+    }
+
+    #[test]
+    fn build_accepts_space_repo_type() {
+        HuggingfaceBuilder::default()
+            .repo_id("org/space")
+            .repo_type("space")
+            .build()
+            .expect("builder should accept space repo type");
     }
 }


### PR DESCRIPTION
Enable HuggingFace Spaces support by extending the repo_type enum and URL templates to allow reading/listing Space repositories like models and datasets.



# Which issue does this PR close?
Part of #6830

# Rationale for this change
Currently, the HuggingFace service only supports `model` and `dataset` repository types. Users cannot access HuggingFace Spaces, which are an important repository type for hosting ML demos and applications.

This change enables full support for Spaces by:
  - Adding `Space` to the `RepoType` enum
  - Implementing URL patterns following HuggingFace's Spaces API structure
  - Allowing users to read files and list directories from Spaces repositories

# What changes are included in this PR?

**Core changes:**
  - Added `Space` variant to `RepoType` enum in `backend.rs`
  - Removed error that blocked space repo_type
  - Added URL patterns for Spaces API in `core.rs`:
    * `hf_path_info`: `/api/spaces/{repo_id}/paths-info/{revision}`
    * `hf_list`: `/api/spaces/{repo_id}/tree/{revision}/{path}`
    * `hf_resolve`: `/spaces/{repo_id}/resolve/{revision}/{path}`
  - Updated builder documentation to reflect space support

  **Tests added:**
  - `build_accepts_space_repo_type` -> Verifies builder accepts "space"
  - `test_hf_path_info_url_space` -> Tests paths-info URL generation
  - `test_hf_list_url_space` -> Tests tree listing URL generation
  - `test_hf_resolve_url_space` -> Tests file resolve URL generation

# Are there any user-facing changes?

**Yes - New Features:**
Users can now access HuggingFace Spaces by setting `repo_type("space")`:

```rust
let builder = Huggingface::default()
     .repo_type("space")  // NEW!
     .repo_id("username/space-name")
     .revision("main");
      
let op = Operator::new(builder)?.finish();
// Can now read/list files from Spaces!
```
  


<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
No breaking changes, Fully backward compatible with existing model and dataset usage.