### PR TITLE
feat(services/git): Add Git service with transparent LFS support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,14 @@
 # fs
 OPENDAL_FS_ROOT=/path/to/dir
 OPENDAL_FS_ATOMIC_WRITE_DIR=/path/to/tempdir
+# git (read-only service with LFS support)
+# For HuggingFace: use your HF username and token
+# For GitLab/GitHub: use your username and PAT
+OPENDAL_GIT_REPOSITORY=https://huggingface.co/Qwen/Qwen3-0.6B
+OPENDAL_GIT_USERNAME=<username>
+OPENDAL_GIT_PASSWORD=<token>
+OPENDAL_GIT_REFERENCE=main
+OPENDAL_GIT_RESOLVE_LFS=true
 # cos
 OPENDAL_COS_BUCKET=opendal-testing-1318209832
 OPENDAL_COS_ENDPOINT=https://cos.ap-singapore.myqcloud.com

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ OpenDAL's development is guided by its vision of **One Layer, All Storage** and 
 | Key-Value Storage Services     | [cacache] [cloudflare-kv] [dashmap] memory [etcd] <br> [foundationdb] [persy] [redis] [rocksdb] [sled] <br> [redb] [tikv] |
 | Database Storage Services      | [d1] [mongodb] [mysql] [postgresql] [sqlite] [surrealdb]                                                                  |
 | Cache Storage Services         | [ghac] [memcached] [mini-moka] [moka] [vercel-artifacts]                                                                  |
-| Git Based Storage Services     | [huggingface]                                                                                                             |
+| Git Based Storage Services     | [git] [huggingface]                                                                                                       |
 
 [sftp]: https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02
 [webdav]: https://datatracker.ietf.org/doc/html/rfc4918
@@ -205,6 +205,7 @@ OpenDAL's development is guided by its vision of **One Layer, All Storage** and 
 [moka]: https://github.com/moka-rs/moka
 [vercel-artifacts]: https://vercel.com/docs/concepts/monorepos/remote-caching
 
+[git]: https://git-scm.com/
 [huggingface]: https://huggingface.co/
 
 ## Examples

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1403,6 +1403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -1472,6 +1473,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,7 +1499,7 @@ dependencies = [
  "futures",
  "hex",
  "libc",
- "memmap2",
+ "memmap2 0.5.10",
  "miette",
  "reflink-copy",
  "serde",
@@ -1755,6 +1762,12 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "clru"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
 
 [[package]]
 name = "cmake"
@@ -2994,6 +3007,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless 0.8.0",
+ "serde",
+]
+
+[[package]]
 name = "fastmetrics"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3073,6 +3096,18 @@ checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3699,6 +3734,900 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60beff35667fb0ac935c4c45941868d9cf5025e4b85c58deb3c5a65113e22ce4"
+dependencies = [
+ "gix-actor",
+ "gix-archive",
+ "gix-attributes",
+ "gix-blame",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-credentials",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-mailmap",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-prompt",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-transport",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
+ "parking_lot 0.12.5",
+ "regex",
+ "signal-hook",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "694f6c16eb88b16b00b1d811e4e4bda6f79e9eb467a1b04fd5b848da677baa81"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-utils",
+ "itoa",
+ "thiserror 2.0.17",
+ "winnow",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1573842ddcd6debcca7c19158ba473dfb5c096a280d3275f6050795528edd348"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-object",
+ "gix-worktree-stream",
+ "jiff",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6591add69314fc43db078076a8da6f07957c65abb0b21c3e1b6a3cf50aa18d"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.17",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e150161b8a75b5860521cb876b506879a3376d3adc857ec7a9d35e7c6a5e531"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7c62ee6ebdfe8a21d23609d7e73e45f13a0ec9308aec7d7303640d7bf80fbc"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c356b3825677cb6ff579551bb8311a81821e184453cbd105e2fc5311b288eeb"
+dependencies = [
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "095c8367c9dc4872a7706fbc39c7f34271b88b541120a4365ff0e36366f66e62"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826994ff6c01f1ff00d6a1844d7506717810a91ffed143da71e3bf39369751ef"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-hash",
+ "memmap2 0.9.9",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9419284839421488b5ab9b9b88386bdc1e159a986c08e17ffa3e9a5cd2b139f5"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "smallvec",
+ "thiserror 2.0.17",
+ "unicode-bom",
+ "winnow",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c489abb061c74b0c3ad790e24a606ef968cebab48ec673d6a891ece7d5aef64"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5576b03b6396d2df102c98a4bd639797f1922dd06599c92830dfc68fcff287"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value",
+ "gix-date",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-trace",
+ "gix-url",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f94626a5bc591a57025361a3a890092469e47c7667e59fc143439cd6eaf47fe"
+dependencies = [
+ "bstr",
+ "itoa",
+ "jiff",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc7735ca267da78c37e916e9b32d67b0b0e3fc9401378920e9469b5d497dccf"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "imara-diff",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9a55642e31c81d235e6ab2a7f00343c0f79e70973245a8a1e1d16c498e3e86"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809f8dba9fbd7a054894ec222815742b96def1ca08e18c38b1dbc1f737dd213d"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-hash",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa64593d1586135102307fb57fb3a9d3868b6b1f45a4da1352cce5070f8916a"
+dependencies = [
+ "bytes",
+ "bytesize",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "libz-rs-sys",
+ "once_cell",
+ "parking_lot 0.12.5",
+ "prodash",
+ "thiserror 2.0.17",
+ "walkdir",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e137e7df1ae40fe2b49dcb2845c6bf7ac04cd53a320d72e761c598a6fd452ed"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1ecd896258cdc5ccd94d18386d17906b8de265ad2ecf68e3bea6b007f6a28f"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74254992150b0a88fdb3ad47635ab649512dff2cbbefca7916bb459894fc9d56"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826036a9bee95945b0be1e2394c64cd4289916c34a639818f8fd5153906985c1"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27d4a3ea9640da504a2657fef3419c517fd71f1767ad8935298bcc805edd195"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.16.1",
+ "parking_lot 0.12.5",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93b6a9679a1488123b7f2929684bacfd9cd2a24f286b52203b8752cbb8d7fc49"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab6410318b98750883eb3e35eb999abfb155b407eb0580726d4d868b60cde04"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2 0.9.9",
+ "rustix 1.1.2",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-lock"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729d7857429a66023bc0c29d60fa21d0d6ae8862f33c1937ba89e0f74dd5c67f"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-mailmap"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a97041c66c8b6c2f34cf6b8585a36e28a07401a611a69d8a5d2cee0eea2aa72"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7ecfa02c9bddd371ec2cf938ee207fe242616386578f2bfc09d1f8f81d25f9"
+dependencies = [
+ "bitflags 2.10.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84743d1091c501a56f00d7f4c595cb30f20fcef6503b32ac0a1ff3817efd7b5d"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-path",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.17",
+ "winnow",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.72.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f81b480252f3a4d55f87e6e358c4c6f7615f98b1742e1e70118c57282a92e82"
+dependencies = [
+ "arc-swap",
+ "gix-date",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "parking_lot 0.12.5",
+ "tempfile",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e868463538731a0fd99f3950637957413bbfbe69143520c0b5c1e163303577"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "memmap2 0.9.9",
+ "parking_lot 0.12.5",
+ "smallvec",
+ "thiserror 2.0.17",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad0ffb982a289888087a165d3e849cbac724f2aa5431236b050dd2cb9c7de31"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.10.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e28457dca7c65a2dbe118869aab922a5bd382b7bb10cff5354f366845c128"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868e6516dfa16fdcbc5f8c935167d085f2ae65ccd4c9476a4319579d12a69d8d"
+dependencies = [
+ "gix-command",
+ "gix-config-value",
+ "parking_lot 0.12.5",
+ "rustix 1.1.2",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6947d3b919ec8d10738f4251905a8485366ffdd24942cdbe9c6b69376bf57d64"
+dependencies = [
+ "bstr",
+ "gix-credentials",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-lock",
+ "gix-negotiate",
+ "gix-object",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revwalk",
+ "gix-shallow",
+ "gix-trace",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "thiserror 2.0.17",
+ "winnow",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e912ec04b7b1566a85ad486db0cab6b9955e3e32bcd3c3a734542ab3af084c5b"
+dependencies = [
+ "bstr",
+ "gix-utils",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51330a32f173c8e831731dfef8e93a748c23c057f4b028841f222564cad84cb"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2 0.9.9",
+ "thiserror 2.0.17",
+ "winnow",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f88233214a302d61e60bb9d1387043c1759b761dba4a8704b341fecbf6b1266"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe7f489bd27e7e388885210bc189088012db6062ccc75d713d1cef8eff56883"
+dependencies = [
+ "bitflags 2.10.0",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2fae8449d97fb92078c46cb63544e0024955f43738a610d24277a3b01d5a00"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea9962ed6d9114f7f100efe038752f41283c225bb507a2888903ac593dffa6be"
+dependencies = [
+ "bitflags 2.10.0",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2374692db1ee1ffa0eddcb9e86ec218f7c4cdceda800ebc5a9fdf73a8c08223"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c9ad16b4d9da73d527eb6d1be05de9e0641855b8084b362dd657255684f81f"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b79f64c669d8578f45046b3ffb8d4d9cc4beb798871ff638a7b5c1f59dbd2fc"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "19.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e265fc6b54e57693232a79d84038381ebfda7b1a3b1b8a9320d4d5fe6e820086"
+dependencies = [
+ "dashmap 6.1.0",
+ "gix-fs",
+ "libc",
+ "parking_lot 0.12.5",
+ "signal-hook",
+ "signal-hook-registry",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3f59a8de2934f6391b6b3a1a7654eae18961fcb9f9c843533fed34ad0f3457"
+
+[[package]]
+name = "gix-transport"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e058d6667165dba7642b3c293d7c355e2a964acef9bc9408604547d952943a8f"
+dependencies = [
+ "base64 0.22.1",
+ "bstr",
+ "gix-command",
+ "gix-credentials",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "reqwest",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054c79f4c3f87e794ff7dc1fec8306a2bb563cfb38f6be2dc0e4c0fa82f74d59"
+dependencies = [
+ "bitflags 2.10.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d995249a1cf1ad79ba10af6499d4bf37cb78035c0983eaa09ec5910da694957c"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
+dependencies = [
+ "bstr",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "428e8928e0e27341b58aa89e20adaf643efd6a8f863bc9cdf3ec6199c2110c96"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-features",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e12c7c67138e02717dd87d3cd63065cdd1b6abf8e2aca46f575dc6a99def48c"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2ccc885b308d918b7de0d7273377990f191706b5716eabb730baeea4d883c6"
+dependencies = [
+ "gix-attributes",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot 0.12.5",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4179,6 +5108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "human_format"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3b1f728c459d27b12448862017b96ad4767b1ec2ec5e6434e99f1577f085b8"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4465,6 +5400,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "imara-diff"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4528,6 +5472,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4735,6 +5689,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4909,6 +5872,15 @@ dependencies = [
  "anstyle",
  "clap",
  "escape8259",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -5260,6 +6232,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5298,6 +6281,15 @@ name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
 ]
@@ -5934,6 +6926,7 @@ dependencies = [
  "opendal-service-gcs",
  "opendal-service-gdrive",
  "opendal-service-ghac",
+ "opendal-service-git",
  "opendal-service-github",
  "opendal-service-gridfs",
  "opendal-service-hdfs",
@@ -6628,6 +7621,22 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tokio",
+]
+
+[[package]]
+name = "opendal-service-git"
+version = "0.55.0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "gix",
+ "http 1.4.0",
+ "log",
+ "opendal-core",
+ "serde",
+ "serde_json",
+ "tempfile",
  "tokio",
 ]
 
@@ -7950,6 +8959,17 @@ checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
  "bitflags 2.10.0",
  "hex",
+]
+
+[[package]]
+name = "prodash"
+version = "30.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139"
+dependencies = [
+ "bytesize",
+ "human_format",
+ "parking_lot 0.12.5",
 ]
 
 [[package]]
@@ -9518,6 +10538,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest",
+ "sha1",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9550,10 +10580,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -11228,6 +12274,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11238,6 +12293,12 @@ name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-ident"
@@ -12324,6 +13385,12 @@ checksum = "70b40401a28d86ce16a330b863b86fd7dbee4d7c940587ab09ab8c019f9e3fdf"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -136,6 +136,7 @@ services-foundationdb = ["dep:opendal-service-foundationdb"]
 services-fs = ["dep:opendal-service-fs"]
 services-ftp = ["dep:opendal-service-ftp"]
 services-gcs = ["dep:opendal-service-gcs"]
+services-git = ["dep:opendal-service-git"]
 services-gdrive = ["dep:opendal-service-gdrive"]
 services-ghac = ["dep:opendal-service-ghac"]
 services-github = ["dep:opendal-service-github"]
@@ -250,6 +251,7 @@ opendal-service-foundationdb = { path = "services/foundationdb", version = "0.55
 opendal-service-fs = { path = "services/fs", version = "0.55.0", optional = true, default-features = false }
 opendal-service-ftp = { path = "services/ftp", version = "0.55.0", optional = true, default-features = false }
 opendal-service-gcs = { path = "services/gcs", version = "0.55.0", optional = true, default-features = false }
+opendal-service-git = { path = "services/git", version = "0.55.0", optional = true, default-features = false }
 opendal-service-gdrive = { path = "services/gdrive", version = "0.55.0", optional = true, default-features = false }
 opendal-service-ghac = { path = "services/ghac", version = "0.55.0", optional = true, default-features = false }
 opendal-service-github = { path = "services/github", version = "0.55.0", optional = true, default-features = false }

--- a/core/services/git/Cargo.toml
+++ b/core/services/git/Cargo.toml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+description = "Apache OpenDAL Git service implementation"
+name = "opendal-service-git"
+
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+base64 = { workspace = true }
+bytes = { workspace = true }
+gix = { version = "0.75", features = ["blocking-http-transport-reqwest"] }
+http = { workspace = true }
+log = { workspace = true }
+opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tempfile = "3.8"
+tokio = { workspace = true, features = ["rt", "macros"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/git/src/backend.rs
+++ b/core/services/git/src/backend.rs
@@ -1,0 +1,293 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+
+use log::debug;
+
+use super::GIT_SCHEME;
+use super::config::GitConfig;
+use super::core::GitCore;
+use super::lister::GitLister;
+use super::reader::GitReader;
+use opendal_core::raw::*;
+use opendal_core::*;
+
+/// Git service support with transparent LFS handling.
+#[doc = include_str!("docs.md")]
+#[derive(Debug, Default)]
+pub struct GitBuilder {
+    pub(super) config: GitConfig,
+}
+
+impl GitBuilder {
+    /// Set the repository URL (required).
+    ///
+    /// Examples:
+    /// - https://github.com/apache/opendal.git
+    /// - https://gitlab.com/user/repo.git
+    /// - https://huggingface.co/meta-llama/Llama-2-7b
+    pub fn repository(mut self, repository: &str) -> Self {
+        if !repository.is_empty() {
+            self.config.repository = Some(repository.to_string());
+        }
+        self
+    }
+
+    /// Set the Git reference (branch, tag, or commit hash).
+    ///
+    /// If not set, will use whatever HEAD points to in the remote repository
+    /// (typically "main", "master", "dev", etc.).
+    pub fn reference(mut self, reference: &str) -> Self {
+        if !reference.is_empty() {
+            self.config.reference = Some(reference.to_string());
+        }
+        self
+    }
+
+    /// Set root path within the repository.
+    ///
+    /// All operations will happen under this root.
+    pub fn root(mut self, root: &str) -> Self {
+        self.config.root = if root.is_empty() {
+            None
+        } else {
+            Some(root.to_string())
+        };
+        self
+    }
+
+    /// Set username for authentication.
+    pub fn username(mut self, username: &str) -> Self {
+        if !username.is_empty() {
+            self.config.username = Some(username.to_string());
+        }
+        self
+    }
+
+    /// Set password or personal access token for authentication.
+    pub fn password(mut self, password: &str) -> Self {
+        if !password.is_empty() {
+            self.config.password = Some(password.to_string());
+        }
+        self
+    }
+
+    /// Set whether to resolve Git LFS pointer files.
+    ///
+    /// When enabled (default), the service will automatically detect
+    /// Git LFS pointer files and stream the actual LFS content.
+    ///
+    /// Default is true.
+    pub fn resolve_lfs(mut self, resolve_lfs: bool) -> Self {
+        self.config.resolve_lfs = Some(resolve_lfs);
+        self
+    }
+}
+
+impl Builder for GitBuilder {
+    type Config = GitConfig;
+
+    fn build(self) -> Result<impl Access> {
+        debug!("backend build started: {:?}", &self);
+
+        let repository = match self.config.repository.clone() {
+            Some(v) => v,
+            None => {
+                return Err(
+                    Error::new(ErrorKind::ConfigInvalid, "repository is required")
+                        .with_context("service", GIT_SCHEME),
+                );
+            }
+        };
+
+        // Use "HEAD" as a sentinel value if no reference is provided
+        // This will be resolved to the actual default branch when connecting
+        let reference = self
+            .config
+            .reference
+            .clone()
+            .unwrap_or_else(|| "HEAD".to_string());
+        let root = self.config.root.clone().unwrap_or_else(|| "/".to_string());
+        let resolve_lfs = self.config.resolve_lfs.unwrap_or(true);
+
+        debug!(
+            "backend build finished: repository={}, reference={}, root={}, resolve_lfs={}",
+            repository, reference, root, resolve_lfs
+        );
+
+        Ok(GitBackend {
+            core: Arc::new(GitCore::new(
+                repository,
+                reference,
+                root,
+                self.config.username.clone(),
+                self.config.password.clone(),
+                resolve_lfs,
+            )),
+        })
+    }
+}
+
+/// Backend for Git service.
+#[derive(Debug, Clone)]
+pub struct GitBackend {
+    core: Arc<GitCore>,
+}
+
+impl Access for GitBackend {
+    type Reader = GitReader;
+    type Writer = ();
+    type Lister = GitLister;
+    type Deleter = ();
+
+    fn info(&self) -> Arc<AccessorInfo> {
+        let info = AccessorInfo::default();
+        info.set_scheme(GIT_SCHEME)
+            .set_root(&self.core.root)
+            .set_native_capability(Capability {
+                stat: true,
+                read: true,
+                list: true,
+                ..Default::default()
+            });
+
+        info.into()
+    }
+
+    async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {
+        let core = self.core.clone();
+        let path = path.to_string();
+
+        let (size, is_dir, last_modified) =
+            tokio::task::spawn_blocking(move || core.stat_file_blocking(&path))
+                .await
+                .map_err(|e| {
+                    Error::new(ErrorKind::Unexpected, "failed to join task").set_source(e)
+                })??;
+
+        let mut metadata = if is_dir {
+            Metadata::new(EntryMode::DIR)
+        } else {
+            Metadata::new(EntryMode::FILE).with_content_length(size)
+        };
+
+        // Set last_modified to commit time
+        if let Ok(timestamp) = Timestamp::from_second(last_modified) {
+            metadata.set_last_modified(timestamp);
+        }
+
+        Ok(RpStat::new(metadata))
+    }
+
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        let core = self.core.clone();
+        let path_str = path.to_string();
+        let range = args.range();
+
+        // Read blob from git object database
+        let content = tokio::task::spawn_blocking(move || core.read_blob_blocking(&path_str))
+            .await
+            .map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "failed to join task").set_source(e)
+            })??;
+
+        let is_lfs = GitCore::is_lfs_pointer(&content);
+
+        let final_content = if self.core.resolve_lfs && is_lfs {
+            if let Ok(pointer) = GitCore::parse_lfs_pointer(&content) {
+                self.core.fetch_lfs_http(&pointer, range).await?
+            } else {
+                content
+            }
+        } else if !range.is_full() {
+            let offset = range.offset() as usize;
+            if offset >= content.len() {
+                return Err(Error::new(
+                    ErrorKind::RangeNotSatisfied,
+                    "range start offset exceeds content length",
+                ));
+            }
+
+            let size = range.size().map(|s| s as usize);
+            let end = size.map_or(content.len(), |s| (offset + s).min(content.len()));
+            content.slice(offset..end)
+        } else {
+            content
+        };
+
+        Ok((RpRead::new(), GitReader::new(final_content)))
+    }
+
+    async fn list(&self, path: &str, _args: OpList) -> Result<(RpList, Self::Lister)> {
+        let core = self.core.clone();
+        let path_str = path.to_string();
+
+        let entries = tokio::task::spawn_blocking(move || core.list_dir_blocking(&path_str))
+            .await
+            .map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "failed to join task").set_source(e)
+            })??;
+
+        Ok((RpList::default(), GitLister::new(path.to_string(), entries)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_builder_repository_required() {
+        let builder = GitBuilder::default();
+        let result = builder.build();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("repository is required")
+        );
+    }
+
+    #[test]
+    fn test_builder_with_repository() {
+        let builder = GitBuilder::default().repository("https://github.com/apache/opendal.git");
+        let result = builder.build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_builder_defaults() {
+        let builder = GitBuilder::default().repository("https://github.com/apache/opendal.git");
+        let _backend = builder.build().unwrap();
+    }
+
+    #[test]
+    fn test_builder_with_all_options() {
+        let builder = GitBuilder::default()
+            .repository("https://github.com/apache/opendal.git")
+            .reference("main")
+            .root("/core/src")
+            .username("testuser")
+            .password("testtoken")
+            .resolve_lfs(false);
+
+        let result = builder.build();
+        assert!(result.is_ok());
+    }
+}

--- a/core/services/git/src/config.rs
+++ b/core/services/git/src/config.rs
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::fmt::Debug;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::backend::GitBuilder;
+
+/// Configuration for Git service support.
+#[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(default)]
+#[non_exhaustive]
+pub struct GitConfig {
+    /// Git repository URL (required).
+    ///
+    /// Examples:
+    /// - https://github.com/apache/opendal.git
+    /// - https://gitlab.com/user/repo.git
+    /// - https://huggingface.co/meta-llama/Llama-2-7b
+    pub repository: Option<String>,
+
+    /// Git reference (branch, tag, or commit hash).
+    ///
+    /// If not set, will use whatever HEAD points to in the remote repository.
+    pub reference: Option<String>,
+
+    /// Root path within the repository.
+    ///
+    /// Default is "/".
+    pub root: Option<String>,
+
+    /// Username for authentication (optional).
+    pub username: Option<String>,
+
+    /// Password or personal access token for authentication (optional).
+    pub password: Option<String>,
+
+    /// Whether to resolve Git LFS pointer files.
+    ///
+    /// When enabled (default), the service will automatically detect
+    /// Git LFS pointer files and stream the actual LFS content instead
+    /// of the pointer file itself.
+    ///
+    /// Default is true.
+    pub resolve_lfs: Option<bool>,
+}
+
+impl Debug for GitConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GitConfig")
+            .field("repository", &self.repository)
+            .field("reference", &self.reference)
+            .field("root", &self.root)
+            .field("username", &self.username)
+            .field("resolve_lfs", &self.resolve_lfs)
+            .finish_non_exhaustive()
+    }
+}
+
+impl opendal_core::Configurator for GitConfig {
+    type Builder = GitBuilder;
+
+    fn into_builder(self) -> Self::Builder {
+        GitBuilder { config: self }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_git_config_default() {
+        let config = GitConfig::default();
+        assert_eq!(config.repository, None);
+        assert_eq!(config.reference, None);
+        assert_eq!(config.root, None);
+    }
+}

--- a/core/services/git/src/core.rs
+++ b/core/services/git/src/core.rs
@@ -1,0 +1,539 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+
+use base64::Engine;
+
+use opendal_core::raw::*;
+use opendal_core::*;
+
+// Constants for Git references and LFS
+const GIT_HEAD_REF: &str = "HEAD";
+const LFS_VERSION_PREFIX: &str = "version https://git-lfs.github.com/spec/v1";
+const LFS_CONTENT_TYPE: &str = "application/vnd.git-lfs+json";
+const LFS_OID_PREFIX: &str = "oid sha256:";
+const LFS_SIZE_PREFIX: &str = "size ";
+
+/// Git LFS pointer information
+#[derive(Debug, Clone)]
+pub struct LfsPointer {
+    pub oid: String,
+    pub size: u64,
+}
+
+/// Wrapper for gix repository with auto-cleanup temp dir
+#[derive(Clone)]
+struct RepoHolder {
+    repo: gix::Repository,
+    _tempdir: Arc<tempfile::TempDir>,
+}
+
+/// Cached LFS download URL from batch API
+#[derive(Clone, Debug)]
+struct LfsDownloadUrl {
+    url: String,
+}
+
+/// Core functionality for Git operations.
+pub struct GitCore {
+    pub repository: String,
+    pub reference: String,
+    pub root: String,
+    pub username: Option<String>,
+    pub password: Option<String>,
+    pub resolve_lfs: bool,
+    repo_cell: Arc<Mutex<Option<RepoHolder>>>,
+    commit_oid_cache: Arc<Mutex<Option<gix::hash::ObjectId>>>,
+    commit_info_cache: Arc<Mutex<Option<(gix::hash::ObjectId, i64)>>>,
+    lfs_url_cache: Arc<Mutex<HashMap<String, LfsDownloadUrl>>>,
+}
+
+impl Debug for GitCore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GitCore")
+            .field("repository", &self.repository)
+            .field("reference", &self.reference)
+            .field("root", &self.root)
+            .field("username", &self.username)
+            .field("password", &"<redacted>")
+            .field("resolve_lfs", &self.resolve_lfs)
+            .finish_non_exhaustive()
+    }
+}
+
+impl GitCore {
+    /// Create a new GitCore instance
+    pub fn new(
+        repository: String,
+        reference: String,
+        root: String,
+        username: Option<String>,
+        password: Option<String>,
+        resolve_lfs: bool,
+    ) -> Self {
+        Self {
+            repository,
+            reference,
+            root,
+            username,
+            password,
+            resolve_lfs,
+            repo_cell: Arc::new(Mutex::new(None)),
+            commit_oid_cache: Arc::new(Mutex::new(None)),
+            commit_info_cache: Arc::new(Mutex::new(None)),
+            lfs_url_cache: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn get_or_create_repo(&self) -> Result<gix::Repository> {
+        let mut cell = self
+            .repo_cell
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::Unexpected, "repository lock poisoned"))?;
+
+        if cell.is_none() {
+            let temp_dir = tempfile::tempdir().map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "failed to create temp dir").set_source(e)
+            })?;
+
+            // Build URL with credentials if provided
+            let clone_url =
+                if let (Some(username), Some(password)) = (&self.username, &self.password) {
+                    // Parse the URL and inject credentials
+                    let url = self.repository.as_str();
+                    if let Some(scheme_end) = url.find("://") {
+                        let (scheme, rest) = url.split_at(scheme_end + 3);
+                        format!("{}{}:{}@{}", scheme, username, password, rest)
+                    } else {
+                        self.repository.clone()
+                    }
+                } else {
+                    self.repository.clone()
+                };
+
+            let mut prepare =
+                gix::prepare_clone(clone_url.as_str(), temp_dir.path()).map_err(|e| {
+                    Error::new(ErrorKind::Unexpected, "failed to prepare clone").set_source(e)
+                })?;
+
+            // Use shallow clone for HEAD, full clone for specific refs
+            if self.reference == GIT_HEAD_REF {
+                use std::num::NonZeroU32;
+                let depth = NonZeroU32::new(1).expect("1 is non-zero");
+                prepare = prepare.with_shallow(gix::remote::fetch::Shallow::DepthAtRemote(depth));
+            }
+
+            let (repo, _) = prepare
+                .fetch_only(gix::progress::Discard, &gix::interrupt::IS_INTERRUPTED)
+                .map_err(|e| {
+                    Error::new(ErrorKind::Unexpected, "failed to fetch repository").set_source(e)
+                })?;
+
+            *cell = Some(RepoHolder {
+                repo,
+                _tempdir: Arc::new(temp_dir),
+            });
+        }
+
+        Ok(cell
+            .as_ref()
+            .ok_or_else(|| Error::new(ErrorKind::Unexpected, "repository not initialized"))?
+            .repo
+            .clone())
+    }
+
+    /// Get commit tree and time from OID
+    fn get_commit_tree<'a>(
+        &self,
+        repo: &'a gix::Repository,
+        commit_oid: gix::hash::ObjectId,
+    ) -> Result<(gix::Tree<'a>, i64)> {
+        if let Some((tree_oid, commit_time)) = *self
+            .commit_info_cache
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::Unexpected, "commit info cache lock poisoned"))?
+        {
+            let tree = repo
+                .find_object(tree_oid)
+                .map_err(|e| Error::new(ErrorKind::NotFound, "tree not found").set_source(e))?
+                .into_tree();
+            return Ok((tree, commit_time));
+        }
+
+        let commit = repo
+            .find_object(commit_oid)
+            .map_err(|e| Error::new(ErrorKind::NotFound, "commit not found").set_source(e))?
+            .peel_to_commit()
+            .map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "failed to peel to commit").set_source(e)
+            })?;
+
+        let commit_time = commit
+            .time()
+            .map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "failed to get commit time").set_source(e)
+            })?
+            .seconds;
+
+        let tree = commit
+            .tree()
+            .map_err(|e| Error::new(ErrorKind::Unexpected, "failed to get tree").set_source(e))?;
+
+        let tree_id = tree.id().detach();
+        *self
+            .commit_info_cache
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::Unexpected, "commit info cache lock poisoned"))? =
+            Some((tree_id, commit_time));
+
+        Ok((tree, commit_time))
+    }
+
+    /// Resolve reference to commit OID (blocking operation)
+    fn resolve_reference(&self, repo: &gix::Repository) -> Result<gix::hash::ObjectId> {
+        // Return cached OID if available
+        if let Some(oid) = *self
+            .commit_oid_cache
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::Unexpected, "commit cache lock poisoned"))?
+        {
+            return Ok(oid);
+        }
+
+        let commit_oid = if self.reference == GIT_HEAD_REF {
+            let mut head = repo.head().map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "failed to get HEAD").set_source(e)
+            })?;
+            head.peel_to_commit()
+                .map_err(|e| {
+                    Error::new(ErrorKind::Unexpected, "failed to peel HEAD to commit").set_source(e)
+                })?
+                .id()
+                .into()
+        } else {
+            // Try as SHA first, then as ref name
+            if let Ok(oid) = gix::hash::ObjectId::from_hex(self.reference.as_bytes()) {
+                oid
+            } else {
+                // Try as ref name (branch/tag)
+                let reference = repo.find_reference(&self.reference).map_err(|e| {
+                    Error::new(
+                        ErrorKind::NotFound,
+                        format!("reference not found: {}", self.reference),
+                    )
+                    .set_source(e)
+                })?;
+                let object = reference.into_fully_peeled_id().map_err(|e| {
+                    Error::new(ErrorKind::Unexpected, "failed to peel reference").set_source(e)
+                })?;
+                object.detach()
+            }
+        };
+
+        // Cache result for subsequent operations
+        *self
+            .commit_oid_cache
+            .lock()
+            .map_err(|_| Error::new(ErrorKind::Unexpected, "commit cache lock poisoned"))? =
+            Some(commit_oid);
+
+        Ok(commit_oid)
+    }
+
+    /// Get file metadata (blocking operation) - returns (size, is_dir, last_modified)
+    pub fn stat_file_blocking(&self, path: &str) -> Result<(u64, bool, i64)> {
+        let repo = self.get_or_create_repo()?;
+        let commit_oid = self.resolve_reference(&repo)?;
+        let (tree, commit_time) = self.get_commit_tree(&repo, commit_oid)?;
+
+        let path = path.trim_start_matches('/');
+        let entry = tree
+            .lookup_entry_by_path(path)
+            .map_err(|e| Error::new(ErrorKind::Unexpected, "failed to lookup path").set_source(e))?
+            .ok_or_else(|| Error::new(ErrorKind::NotFound, format!("path not found: {}", path)))?;
+
+        let is_dir = entry.mode().is_tree();
+
+        if is_dir {
+            return Ok((0, true, commit_time));
+        }
+
+        let obj = entry
+            .object()
+            .map_err(|e| Error::new(ErrorKind::Unexpected, "failed to get object").set_source(e))?;
+        let blob = obj.into_blob();
+        let mut size = blob.data.len() as u64;
+
+        if self.resolve_lfs && Self::is_lfs_pointer(&blob.data) {
+            if let Ok(pointer) = Self::parse_lfs_pointer(&blob.data) {
+                size = pointer.size;
+            }
+        }
+
+        Ok((size, false, commit_time))
+    }
+
+    /// List directory contents (blocking operation) - returns Vec<(name, is_dir, size, last_modified)>
+    pub fn list_dir_blocking(&self, path: &str) -> Result<Vec<(String, bool, u64, i64)>> {
+        let repo = self.get_or_create_repo()?;
+        let commit_oid = self.resolve_reference(&repo)?;
+        let (mut tree, commit_time) = self.get_commit_tree(&repo, commit_oid)?;
+
+        let path = path.trim_start_matches('/').trim_end_matches('/');
+        if !path.is_empty() {
+            let entry = tree
+                .lookup_entry_by_path(path)
+                .map_err(|e| {
+                    Error::new(ErrorKind::Unexpected, "failed to lookup path").set_source(e)
+                })?
+                .ok_or_else(|| {
+                    Error::new(ErrorKind::NotFound, format!("path not found: {}", path))
+                })?;
+
+            if !entry.mode().is_tree() {
+                return Err(Error::new(
+                    ErrorKind::NotADirectory,
+                    "path is not a directory",
+                ));
+            }
+
+            let obj = entry.object().map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "failed to get object").set_source(e)
+            })?;
+            tree = obj.into_tree();
+        }
+
+        let mut entries = Vec::new();
+        for entry in tree.iter() {
+            let entry = entry.map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "failed to read entry").set_source(e)
+            })?;
+            let name = entry.filename().to_string();
+            let is_dir = entry.mode().is_tree();
+
+            let size = if is_dir {
+                0
+            } else {
+                let obj = entry.object().map_err(|e| {
+                    Error::new(ErrorKind::Unexpected, "failed to get object").set_source(e)
+                })?;
+                let blob = obj.into_blob();
+                let mut size = blob.data.len() as u64;
+
+                if self.resolve_lfs && Self::is_lfs_pointer(&blob.data) {
+                    if let Ok(pointer) = Self::parse_lfs_pointer(&blob.data) {
+                        size = pointer.size;
+                    }
+                }
+
+                size
+            };
+
+            entries.push((name, is_dir, size, commit_time));
+        }
+
+        Ok(entries)
+    }
+
+    /// Get blob content (blocking operation) - reads from git objects directly
+    pub fn read_blob_blocking(&self, path: &str) -> Result<bytes::Bytes> {
+        let repo = self.get_or_create_repo()?;
+        let commit_oid = self.resolve_reference(&repo)?;
+        let (tree, _commit_time) = self.get_commit_tree(&repo, commit_oid)?;
+
+        let path = path.trim_start_matches('/');
+        let entry = tree
+            .lookup_entry_by_path(path)
+            .map_err(|e| Error::new(ErrorKind::Unexpected, "failed to lookup path").set_source(e))?
+            .ok_or_else(|| Error::new(ErrorKind::NotFound, format!("path not found: {}", path)))?;
+
+        if entry.mode().is_tree() {
+            return Err(Error::new(ErrorKind::IsADirectory, "path is a directory"));
+        }
+
+        let obj = entry
+            .object()
+            .map_err(|e| Error::new(ErrorKind::Unexpected, "failed to get object").set_source(e))?;
+        let blob = obj.into_blob();
+
+        Ok(bytes::Bytes::copy_from_slice(&blob.data))
+    }
+
+    /// Check if file content is a Git LFS pointer
+    pub fn is_lfs_pointer(content: &[u8]) -> bool {
+        if let Ok(text) = std::str::from_utf8(&content[..256.min(content.len())]) {
+            text.starts_with(LFS_VERSION_PREFIX)
+        } else {
+            false
+        }
+    }
+
+    /// Parse LFS pointer to extract OID and size
+    pub fn parse_lfs_pointer(content: &[u8]) -> Result<LfsPointer> {
+        let text = std::str::from_utf8(content)
+            .map_err(|e| Error::new(ErrorKind::Unexpected, "invalid LFS pointer").set_source(e))?;
+
+        let mut oid = None;
+        let mut size = None;
+
+        for line in text.lines() {
+            if let Some(oid_str) = line.strip_prefix(LFS_OID_PREFIX) {
+                oid = Some(oid_str.trim().to_string());
+            } else if let Some(size_str) = line.strip_prefix(LFS_SIZE_PREFIX) {
+                size = size_str.trim().parse().ok();
+            }
+        }
+
+        match (oid, size) {
+            (Some(oid), Some(size)) => Ok(LfsPointer { oid, size }),
+            _ => Err(Error::new(
+                ErrorKind::Unexpected,
+                "invalid LFS pointer format",
+            )),
+        }
+    }
+
+    /// Get LFS download URL from cache or batch API
+    async fn get_lfs_download_url(&self, pointer: &LfsPointer) -> Result<String> {
+        // Check cache first
+        {
+            let cache = self
+                .lfs_url_cache
+                .lock()
+                .map_err(|_| Error::new(ErrorKind::Unexpected, "LFS cache lock poisoned"))?;
+            if let Some(cached) = cache.get(&pointer.oid) {
+                return Ok(cached.url.clone());
+            }
+        }
+
+        // Not in cache, call batch API
+        let http_client = HttpClient::new()?;
+        let base_url = self
+            .repository
+            .strip_suffix(".git")
+            .unwrap_or(&self.repository);
+        let batch_url = format!("{}.git/info/lfs/objects/batch", base_url);
+
+        let batch_body = format!(
+            r#"{{"operation":"download","transfers":["basic"],"objects":[{{"oid":"{}","size":{}}}]}}"#,
+            pointer.oid, pointer.size
+        );
+
+        let mut batch_req = http::Request::builder()
+            .method(http::Method::POST)
+            .uri(&batch_url)
+            .header("Content-Type", LFS_CONTENT_TYPE)
+            .header("Accept", LFS_CONTENT_TYPE);
+
+        // Add credentials if provided
+        if let (Some(username), Some(password)) = (&self.username, &self.password) {
+            let auth = format!("{}:{}", username, password);
+            let encoded = base64::prelude::BASE64_STANDARD.encode(auth.as_bytes());
+            batch_req = batch_req.header("Authorization", format!("Basic {}", encoded));
+        }
+
+        let batch_req = batch_req.body(Buffer::from(batch_body)).map_err(|e| {
+            Error::new(ErrorKind::Unexpected, "failed to build batch request").set_source(e)
+        })?;
+
+        let batch_resp = http_client.send(batch_req).await?;
+
+        if !batch_resp.status().is_success() {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                format!("LFS batch API failed with status: {}", batch_resp.status()),
+            ));
+        }
+
+        // Parse batch response to get download URL
+        let batch_data = batch_resp.into_body().to_bytes();
+        let batch_json: serde_json::Value = serde_json::from_slice(&batch_data).map_err(|e| {
+            Error::new(ErrorKind::Unexpected, "failed to parse batch response").set_source(e)
+        })?;
+
+        let download_url = batch_json["objects"][0]["actions"]["download"]["href"]
+            .as_str()
+            .ok_or_else(|| Error::new(ErrorKind::Unexpected, "no download URL in batch response"))?
+            .to_string();
+
+        // Cache the URL for reuse
+        {
+            let mut cache = self
+                .lfs_url_cache
+                .lock()
+                .map_err(|_| Error::new(ErrorKind::Unexpected, "LFS cache lock poisoned"))?;
+            cache.insert(
+                pointer.oid.clone(),
+                LfsDownloadUrl {
+                    url: download_url.clone(),
+                },
+            );
+        }
+
+        Ok(download_url)
+    }
+
+    /// Fetch LFS file content via HTTP with range support
+    pub async fn fetch_lfs_http(
+        &self,
+        pointer: &LfsPointer,
+        range: BytesRange,
+    ) -> Result<bytes::Bytes> {
+        let http_client = HttpClient::new()?;
+
+        // Get download URL (from cache or batch API)
+        let download_url = self.get_lfs_download_url(pointer).await?;
+
+        // Download from the URL with range support
+        let mut download_req = http::Request::builder()
+            .method(http::Method::GET)
+            .uri(&download_url);
+
+        // Add Range header if specified
+        if !range.is_full() {
+            download_req = download_req.header("Range", range.to_header());
+        }
+
+        // Add credentials if provided
+        if let (Some(username), Some(password)) = (&self.username, &self.password) {
+            let auth = format!("{}:{}", username, password);
+            let encoded = base64::prelude::BASE64_STANDARD.encode(auth.as_bytes());
+            download_req = download_req.header("Authorization", format!("Basic {}", encoded));
+        }
+
+        let download_req = download_req.body(Buffer::new()).map_err(|e| {
+            Error::new(ErrorKind::Unexpected, "failed to build download request").set_source(e)
+        })?;
+
+        let download_resp = http_client.send(download_req).await?;
+
+        if !download_resp.status().is_success() {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                format!(
+                    "LFS download failed with status: {}",
+                    download_resp.status()
+                ),
+            ));
+        }
+
+        Ok(download_resp.into_body().to_bytes())
+    }
+}

--- a/core/services/git/src/docs.md
+++ b/core/services/git/src/docs.md
@@ -1,0 +1,56 @@
+This service provides access to Git repositories with transparent Git LFS support.
+
+The service uses [gix](https://github.com/GitoxideLabs/gitoxide) for efficient Git operations and automatically resolves Git LFS pointer files by streaming the actual LFS content. This allows access to repositories hosted on GitHub, GitLab, Hugging Face, and custom Git servers.
+
+## Capabilities
+
+This service can be used to:
+
+- [ ] create_dir
+- [x] stat
+- [x] read
+- [ ] write
+- [ ] delete
+- [x] list
+- [ ] copy
+- [ ] rename
+- [ ] ~~presign~~
+
+## Configuration
+
+- `repository`: The Git repository URL (required)
+- `reference`: The Git reference (branch, tag, or commit hash). If not set, uses whatever HEAD points to in the repository.
+- `root`: Set the work directory for backend.
+- `username`: Username for authentication (optional)
+- `password`: Password or personal access token for authentication (optional)
+- `resolve_lfs`: Whether to resolve Git LFS pointer files (default: true)
+
+You can refer to [`GitBuilder`]'s docs for more information.
+
+## Notes
+
+- `resolve_lfs` defaults to `true` and returns LFS file contents instead of pointer files.
+
+## Example
+
+### Via Builder
+
+```rust,no_run
+use opendal_core::Operator;
+use opendal_core::Result;
+use opendal_service_git::Git;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut builder = Git::default()
+        .repository("https://github.com/apache/opendal.git")
+        .reference("main")
+        .root("/core/src")
+        .username("your-username")
+        .password("your-token");
+
+    let op: Operator = Operator::new(builder)?.finish();
+
+    Ok(())
+}
+```

--- a/core/services/git/src/error.rs
+++ b/core/services/git/src/error.rs
@@ -1,0 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Error handling for Git service

--- a/core/services/git/src/lib.rs
+++ b/core/services/git/src/lib.rs
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+/// Default scheme for git service.
+pub const GIT_SCHEME: &str = "git";
+
+/// Register this service into the given registry.
+pub fn register_git_service(registry: &opendal_core::OperatorRegistry) {
+    registry.register::<Git>(GIT_SCHEME);
+}
+
+mod backend;
+mod config;
+mod core;
+mod error;
+mod lister;
+mod reader;
+
+pub use backend::GitBuilder as Git;
+pub use config::GitConfig;

--- a/core/services/git/src/lister.rs
+++ b/core/services/git/src/lister.rs
@@ -1,0 +1,175 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use opendal_core::raw::*;
+use opendal_core::*;
+
+/// Lister for Git service
+pub struct GitLister {
+    entries: Vec<(String, bool, u64, i64)>,
+    base_path: String,
+    index: usize,
+}
+
+impl GitLister {
+    pub fn new(base_path: String, entries: Vec<(String, bool, u64, i64)>) -> Self {
+        Self {
+            entries,
+            base_path,
+            index: 0,
+        }
+    }
+}
+
+impl oio::List for GitLister {
+    async fn next(&mut self) -> Result<Option<oio::Entry>> {
+        if self.index >= self.entries.len() {
+            return Ok(None);
+        }
+
+        let (name, is_dir, size, last_modified) = &self.entries[self.index];
+        self.index += 1;
+
+        // Construct full path from base path + name
+        let full_path = if self.base_path == "/" {
+            name.clone()
+        } else {
+            format!("{}/{}", self.base_path.trim_end_matches('/'), name)
+        };
+
+        // Ensure dir paths end with `/`
+        let path = if *is_dir && !full_path.ends_with('/') {
+            format!("{}/", full_path)
+        } else {
+            full_path
+        };
+
+        let mut metadata = if *is_dir {
+            Metadata::new(EntryMode::DIR)
+        } else {
+            Metadata::new(EntryMode::FILE).with_content_length(*size)
+        };
+
+        // Set last_modified to commit time
+        if let Ok(timestamp) = Timestamp::from_second(*last_modified) {
+            metadata.set_last_modified(timestamp);
+        }
+
+        Ok(Some(oio::Entry::new(&path, metadata)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opendal_core::raw::oio::List;
+
+    #[tokio::test]
+    async fn test_lister_empty() {
+        let mut lister = GitLister::new("/".to_string(), vec![]);
+        let entry = lister.next().await.unwrap();
+        assert!(entry.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_lister_with_entries_root() {
+        let commit_time = 1234567890; // Example timestamp
+        let entries = vec![
+            ("file1.txt".to_string(), false, 100, commit_time),
+            ("dir1".to_string(), true, 0, commit_time),
+            ("file2.txt".to_string(), false, 200, commit_time),
+        ];
+        let mut lister = GitLister::new("/".to_string(), entries);
+
+        let entry1 = lister.next().await.unwrap().unwrap();
+        assert_eq!(entry1.path(), "file1.txt");
+        assert_eq!(entry1.mode(), EntryMode::FILE);
+
+        let entry2 = lister.next().await.unwrap().unwrap();
+        assert_eq!(entry2.path(), "dir1/");
+        assert_eq!(entry2.mode(), EntryMode::DIR);
+
+        let entry3 = lister.next().await.unwrap().unwrap();
+        assert_eq!(entry3.path(), "file2.txt");
+        assert_eq!(entry3.mode(), EntryMode::FILE);
+
+        let entry4 = lister.next().await.unwrap();
+        assert!(entry4.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_lister_with_subdirectory_path() {
+        let commit_time = 1234567890;
+        let entries = vec![
+            ("nested.txt".to_string(), false, 500, commit_time),
+            ("subdir".to_string(), true, 0, commit_time),
+        ];
+        let mut lister = GitLister::new(".config/".to_string(), entries);
+
+        let entry1 = lister.next().await.unwrap().unwrap();
+        assert_eq!(entry1.path(), ".config/nested.txt");
+        assert_eq!(entry1.mode(), EntryMode::FILE);
+
+        let entry2 = lister.next().await.unwrap().unwrap();
+        assert_eq!(entry2.path(), ".config/subdir/");
+        assert_eq!(entry2.mode(), EntryMode::DIR);
+
+        let entry3 = lister.next().await.unwrap();
+        assert!(entry3.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_lister_with_deeply_nested_path() {
+        let commit_time = 1234567890;
+        let entries = vec![("action.yml".to_string(), false, 1788, commit_time)];
+        let mut lister = GitLister::new(".github/actions/fuzz_test/".to_string(), entries);
+
+        let entry = lister.next().await.unwrap().unwrap();
+        assert_eq!(entry.path(), ".github/actions/fuzz_test/action.yml");
+        assert_eq!(entry.mode(), EntryMode::FILE);
+    }
+
+    #[tokio::test]
+    async fn test_lister_preserves_last_modified() {
+        let commit_time = 1609459200; // 2021-01-01 00:00:00 UTC
+        let entries = vec![("test.txt".to_string(), false, 100, commit_time)];
+        let mut lister = GitLister::new("/".to_string(), entries);
+
+        let entry = lister.next().await.unwrap().unwrap();
+        assert_eq!(entry.path(), "test.txt");
+        assert_eq!(entry.mode(), EntryMode::FILE);
+
+        // Timestamp is set correctly in the Entry metadata
+        // The actual verification happens through the metadata() call in production
+    }
+
+    #[tokio::test]
+    async fn test_lister_handles_trailing_slash_in_base_path() {
+        let commit_time = 1234567890;
+        let entries = vec![("file.txt".to_string(), false, 100, commit_time)];
+
+        // Test with trailing slash
+        let mut lister1 = GitLister::new("dir/".to_string(), entries.clone());
+        let entry1 = lister1.next().await.unwrap().unwrap();
+        assert_eq!(entry1.path(), "dir/file.txt");
+
+        // Test without trailing slash
+        let mut lister2 = GitLister::new("dir".to_string(), entries.clone());
+        let entry2 = lister2.next().await.unwrap().unwrap();
+        assert_eq!(entry2.path(), "dir/file.txt");
+    }
+}

--- a/core/services/git/src/reader.rs
+++ b/core/services/git/src/reader.rs
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use bytes::Bytes;
+
+use opendal_core::raw::*;
+use opendal_core::*;
+
+/// Reader for Git blob content
+pub struct GitReader {
+    content: Bytes,
+    offset: u64,
+}
+
+impl GitReader {
+    /// Create a new GitReader from bytes
+    pub fn new(content: Bytes) -> Self {
+        Self { content, offset: 0 }
+    }
+}
+
+impl oio::Read for GitReader {
+    async fn read(&mut self) -> Result<Buffer> {
+        if self.offset >= self.content.len() as u64 {
+            return Ok(Buffer::new());
+        }
+
+        let start = self.offset as usize;
+        let chunk = self.content.slice(start..);
+        self.offset = self.content.len() as u64;
+
+        Ok(Buffer::from(chunk))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opendal_core::raw::oio::Read;
+
+    #[tokio::test]
+    async fn test_reader_empty() {
+        let mut reader = GitReader::new(Bytes::new());
+        let buf = reader.read().await.unwrap();
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_reader_with_content() {
+        let content = Bytes::from("Hello, world!");
+        let mut reader = GitReader::new(content);
+
+        let buf = reader.read().await.unwrap();
+        assert_eq!(buf.len(), 13);
+        assert_eq!(&buf.to_bytes()[..], b"Hello, world!");
+
+        // Second read should be empty
+        let buf = reader.read().await.unwrap();
+        assert_eq!(buf.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_reader_large_content() {
+        let content = Bytes::from(vec![0u8; 1024 * 1024]); // 1MB
+        let mut reader = GitReader::new(content);
+
+        let buf = reader.read().await.unwrap();
+        assert_eq!(buf.len(), 1024 * 1024);
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -107,6 +107,9 @@ fn init_default_registry_inner(registry: &opendal_core::OperatorRegistry) {
     #[cfg(feature = "services-gcs")]
     opendal_service_gcs::register_gcs_service(registry);
 
+    #[cfg(feature = "services-git")]
+    opendal_service_git::register_git_service(registry);
+
     #[cfg(feature = "services-gdrive")]
     opendal_service_gdrive::register_gdrive_service(registry);
 
@@ -280,6 +283,8 @@ pub mod services {
     pub use opendal_service_ftp::*;
     #[cfg(feature = "services-gcs")]
     pub use opendal_service_gcs::*;
+    #[cfg(feature = "services-git")]
+    pub use opendal_service_git::*;
     #[cfg(feature = "services-gdrive")]
     pub use opendal_service_gdrive::*;
     #[cfg(feature = "services-ghac")]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6831.

# Rationale for this change

OpenDAL has support for specific git service providers like HuggingFace, but not a generic git provider with LFS support. These changes provide generic git + LFS file streaming support using an OpenDAL service `git`.

# What changes are included in this PR?

A new service `git`, documentation, and crate features for the new service.

# Are there any user-facing changes?

A new service back end!

NOTE - I tested these changes pretty comprehensively on LFS repositories in my private Gitlab instance as well as on HuggingFace, both with and without credentials on private and public repositories, and I tested non-LFS repos as well including on Github.

I created a companion demo project [here](https://github.com/siomporas/zzz-opendal-gix-lfs-demo) that bootstraps this particular version of OpenDAL using a git submodule, and provides a simple CLI tool to clone git repository states including LFS to the local file system to demonstrate the new service.