### PR TITLE
feat(services/azfile): Add user defined metadata support

### DIFF
--- a/core/src/services/azfile/core.rs
+++ b/core/src/services/azfile/core.rs
@@ -42,6 +42,7 @@ const X_MS_FILE_RENAME_SOURCE: &str = "x-ms-file-rename-source";
 const X_MS_CONTENT_LENGTH: &str = "x-ms-content-length";
 const X_MS_TYPE: &str = "x-ms-type";
 const X_MS_FILE_RENAME_REPLACE_IF_EXISTS: &str = "x-ms-file-rename-replace-if-exists";
+pub const X_MS_META_PREFIX: &str = "x-ms-meta-";
 
 pub struct AzfileCore {
     pub info: Arc<AccessorInfo>,
@@ -152,6 +153,13 @@ impl AzfileCore {
 
         if let Some(pos) = args.content_disposition() {
             req = req.header(CONTENT_DISPOSITION, pos);
+        }
+
+        // Set user metadata headers.
+        if let Some(user_metadata) = args.user_metadata() {
+            for (key, value) in user_metadata {
+                req = req.header(format!("{X_MS_META_PREFIX}{key}"), value);
+            }
         }
 
         let req = req.extension(Operation::Write);


### PR DESCRIPTION
# Which issue does this PR close?

Part of #4842.

# Rationale for this change

This PR adds user defined metadata support for the Azure File service (`azfile`), which allows users to write and read custom metadata along with their files.

# What changes are included in this PR?

- Add `X_MS_META_PREFIX` constant (`"x-ms-meta-"`) in `core.rs` for user metadata HTTP header prefix
- Add user metadata headers support in `azfile_create_file` function
- Enable `write_with_user_metadata` capability in the service
- Parse user metadata from response headers in `stat` function using `parse_prefixed_headers`

# Are there any user-facing changes?

Yes, users can now use `write_with().user_metadata()` to set custom metadata when writing files to Azure File service, and retrieve them via `stat()`.

Example:
```rust
let metadata = vec![("location".to_string(), "everywhere".to_string())];
op.write_with(&path, content)
    .user_metadata(metadata)
    .await?;

let meta = op.stat(&path).await?;
let user_meta = meta.user_metadata();