### PR TITLE
feat(services/azdls): Add user defined metadata support

### DIFF
--- a/core/src/services/azdls/backend.rs
+++ b/core/src/services/azdls/backend.rs
@@ -294,6 +294,7 @@ impl Builder for AzdlsBuilder {
                             write_can_multi: true,
                             write_with_if_none_match: true,
                             write_with_if_not_exists: true,
+                            write_with_user_metadata: true,
 
                             create_dir: true,
                             delete: true,


### PR DESCRIPTION
# Which issue does this PR close?

Part of #4842.

# Rationale for this change

This PR adds user defined metadata support for the Azure Data Lake Storage Gen2 service (`azdls`), which allows users to write and read custom metadata along with their files.

# What changes are included in this PR?

- Add `X_MS_META_PREFIX` constant (`"x-ms-meta-"`) in `core.rs` for user metadata HTTP header prefix
- Add user metadata headers support in `azdls_create` function
- Enable `write_with_user_metadata` capability in the service
- Parse user metadata from response headers in `azdls_stat_metadata` function using `parse_prefixed_headers`

# Are there any user-facing changes?

Yes, users can now use `write_with().user_metadata()` to set custom metadata when writing files to Azure Data Lake Storage Gen2 service, and retrieve them via `stat()`.

Example:
```rust
let metadata = vec![("location".to_string(), "everywhere".to_string())];
op.write_with(&path, content)
    .user_metadata(metadata)
    .await?;

let meta = op.stat(&path).await?;
let user_meta = meta.user_metadata();