### PR TITLE
feat(services/b2): Add user defined metadata support

### DIFF
--- a/core/services/b2/src/backend.rs
+++ b/core/services/b2/src/backend.rs
@@ -173,6 +173,7 @@ impl Builder for B2Builder {
                             write_can_empty: true,
                             write_can_multi: true,
                             write_with_content_type: true,
+                            write_with_user_metadata: true,
                             // The min multipart size of b2 is 5 MiB.
                             //
                             // ref: <https://www.backblaze.com/docs/cloud-storage-large-files>


### PR DESCRIPTION
# Which issue does this PR close?

Part of #4842.

# Rationale for this change

This PR adds user defined metadata support for the Backblaze B2 service (`b2`), which allows users to write and read custom metadata along with their files.

# What changes are included in this PR?

- Add `X_BZ_INFO_PREFIX` constant (`"X-Bz-Info-"`) in `core.rs` for user metadata HTTP header prefix
- Add `file_info` field to `File` struct to parse user metadata from B2 API responses
- Add user metadata headers support in `upload_file` function with URL-encoded values
- Update `parse_file_info` function to decode and return user metadata
- Enable `write_with_user_metadata` capability in the service

# Are there any user-facing changes?

Yes, users can now use `write_with().user_metadata()` to set custom metadata when writing files to Backblaze B2 service, and retrieve them via `stat()`.

Example:
```rust
let metadata = vec![("location".to_string(), "everywhere".to_string())];
op.write_with(&path, content)
    .user_metadata(metadata)
    .await?;

let meta = op.stat(&path).await?;
let user_meta = meta.user_metadata();