### PR TITLE
ci: Add full ci promote for testing PRs

### DIFF
--- a/.github/workflows/full-ci-promote.yml
+++ b/.github/workflows/full-ci-promote.yml
@@ -1,0 +1,123 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Full CI Promote
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+concurrency:
+  group: full-ci-promote-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  promote:
+    if: |
+      github.event.label.name == 'run-with-secrets' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Fetch contributor branch
+        env:
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          TARGET_BRANCH: ci/pr-${{ github.event.pull_request.number }}
+        run: |
+          git config user.name "opendal-bot"
+          git config user.email "opendal-bot@apache.org"
+          git fetch https://github.com/${PR_HEAD_REPO} ${PR_HEAD_REF}:refs/remotes/contrib/head
+          git checkout -B "${TARGET_BRANCH}" remotes/contrib/head
+          git push --force origin "${TARGET_BRANCH}"
+
+      - name: Create or update internal PR
+        id: create_internal_pr
+        uses: actions/github-script@v7
+        env:
+          TARGET_BRANCH: ci/pr-${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const targetBranch = process.env.TARGET_BRANCH;
+            const base = 'main';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const headParam = `${owner}:${targetBranch}`;
+
+            const { data: existing } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head: headParam,
+              base,
+              per_page: 1,
+            });
+
+            let internalPr = existing[0];
+            if (!internalPr) {
+              const title = `[CI] Full run for #${context.payload.pull_request.number}`;
+              const body = [
+                `Mirrored branch for PR #${context.payload.pull_request.number}.`,
+                'This PR is created automatically to run full CI with repository secrets after maintainer approval.',
+                'Do not edit manually.',
+              ].join('\n');
+
+              const createResp = await github.rest.pulls.create({ owner, repo, head: headParam, base, title, body });
+              internalPr = createResp.data;
+            }
+
+            core.setOutput('internal_pr_number', internalPr.number);
+            core.setOutput('internal_pr_html_url', internalPr.html_url);
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        env:
+          INTERNAL_PR: ${{ steps.create_internal_pr.outputs.internal_pr_number || '' }}
+          INTERNAL_PR_URL: ${{ steps.create_internal_pr.outputs.internal_pr_html_url || '' }}
+        with:
+          script: |
+            const marker = '<!-- ci-bot:full-ci -->';
+            const prNumber = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const internalUrl = process.env.INTERNAL_PR_URL;
+
+            const body = [
+              marker,
+              'Maintainer triggered full CI with repository secrets.',
+              `Please monitor the mirrored CI PR for results: ${internalUrl}`,
+              'Re-applying the label will refresh this mirror.',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number: prNumber, per_page: 100 });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+            }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

This PR added a new CI workflow so that maintainers of opendal can add label `run-with-secrets` for PRs to run the CI with secrets. This can help reduce a lot of CI failure in advance.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
