### PR TITLE
refactor(!): Remove deprecated http client config

### DIFF
--- a/core/core/src/docs/performance/http_optimization.md
+++ b/core/core/src/docs/performance/http_optimization.md
@@ -23,8 +23,8 @@ let client = reqwest::ClientBuilder::new()
   .build()
   .expect("http client must be created");
 
-// Update the http client in the operator.
-let op = op.update_http_client(|_| HttpClient::with(client));
+// Update the http client in the operator via layer.
+let op = op.layer(HttpClientLayer::new(HttpClient::with(client)));
 ```
 
 ## DNS Caching
@@ -42,8 +42,8 @@ let client = reqwest::ClientBuilder::new()
   .build()
   .expect("http client must be created");
 
-// Update the http client in the operator.
-let op = op.update_http_client(|_| HttpClient::with(client));
+// Update the http client in the operator via layer.
+let op = op.layer(HttpClientLayer::new(HttpClient::with(client)));
 ```
 
 The default DNS cache settings from `hickory_dns` are generally sufficient for most workloads. However, if you have specific requirements—such as sharing the same DNS cache across multiple HTTP clients or configuring the DNS cache size—you can use the `Xuanwo/reqwest-hickory-resolver` crate to set up a custom DNS resolver.
@@ -75,8 +75,8 @@ let client = reqwest::ClientBuilder::new()
   .build()
   .expect("http client must be created");
 
-// Update the http client in the operator.
-let op = op.update_http_client(|_| HttpClient::with(client));
+// Update the http client in the operator via layer.
+let op = op.layer(HttpClientLayer::new(HttpClient::with(client)));
 ```
 
 The `ResolverOpts` has many options that can be configured. For a complete list of options, please refer to the [hickory_resolver documentation](https://docs.rs/hickory-resolver/latest/hickory_resolver/config/struct.ResolverOpts.html).
@@ -102,8 +102,8 @@ let client = reqwest::ClientBuilder::new()
   .build()
   .expect("http client must be created");
 
-// Update the http client in the operator.
-let op = op.update_http_client(|_| HttpClient::with(client));
+// Update the http client in the operator via layer.
+let op = op.layer(HttpClientLayer::new(HttpClient::with(client)));
 ```
 
 It's also recommended to use opendal's [`TimeoutLayer`][crate::layers::TimeoutLayer] to prevent slow requests hangs forever. This layer will automatically cancel the request if it takes too long to complete.

--- a/core/core/src/services/aliyun_drive/backend.rs
+++ b/core/core/src/services/aliyun_drive/backend.rs
@@ -39,9 +39,6 @@ use crate::*;
 #[derive(Default)]
 pub struct AliyunDriveBuilder {
     pub(super) config: AliyunDriveConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for AliyunDriveBuilder {
@@ -98,19 +95,6 @@ impl AliyunDriveBuilder {
     pub fn drive_type(mut self, drive_type: &str) -> Self {
         self.config.drive_type = drive_type.to_string();
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }
@@ -186,12 +170,6 @@ impl Builder for AliyunDriveBuilder {
                             shared: true,
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/aliyun_drive/config.rs
+++ b/core/core/src/services/aliyun_drive/config.rs
@@ -93,10 +93,7 @@ impl crate::Configurator for AliyunDriveConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        AliyunDriveBuilder {
-            config: self,
-            http_client: None,
-        }
+        AliyunDriveBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/alluxio/backend.rs
+++ b/core/core/src/services/alluxio/backend.rs
@@ -37,9 +37,6 @@ use crate::*;
 #[derive(Default)]
 pub struct AlluxioBuilder {
     pub(super) config: AlluxioConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for AlluxioBuilder {
@@ -73,19 +70,6 @@ impl AlluxioBuilder {
             self.config.endpoint = Some(endpoint.trim_end_matches('/').to_string())
         }
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }
@@ -135,12 +119,6 @@ impl Builder for AlluxioBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/alluxio/config.rs
+++ b/core/core/src/services/alluxio/config.rs
@@ -68,10 +68,7 @@ impl crate::Configurator for AlluxioConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        AlluxioBuilder {
-            config: self,
-            http_client: None,
-        }
+        AlluxioBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/b2/backend.rs
+++ b/core/core/src/services/b2/backend.rs
@@ -43,9 +43,6 @@ use crate::*;
 #[derive(Default)]
 pub struct B2Builder {
     pub(super) config: B2Config,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for B2Builder {
@@ -105,19 +102,6 @@ impl B2Builder {
     pub fn bucket_id(mut self, bucket_id: &str) -> Self {
         self.config.bucket_id = bucket_id.to_string();
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }
@@ -219,12 +203,6 @@ impl Builder for B2Builder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/b2/config.rs
+++ b/core/core/src/services/b2/config.rs
@@ -81,10 +81,7 @@ impl crate::Configurator for B2Config {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        B2Builder {
-            config: self,
-            http_client: None,
-        }
+        B2Builder { config: self }
     }
 }
 

--- a/core/core/src/services/cloudflare_kv/backend.rs
+++ b/core/core/src/services/cloudflare_kv/backend.rs
@@ -36,10 +36,6 @@ use crate::*;
 #[derive(Default)]
 pub struct CloudflareKvBuilder {
     pub(super) config: CloudflareKvConfig,
-
-    /// The HTTP client used to communicate with CloudFlare.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for CloudflareKvBuilder {
@@ -181,12 +177,6 @@ impl Builder for CloudflareKvBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/cloudflare_kv/config.rs
+++ b/core/core/src/services/cloudflare_kv/config.rs
@@ -95,10 +95,7 @@ impl crate::Configurator for CloudflareKvConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        CloudflareKvBuilder {
-            config: self,
-            http_client: None,
-        }
+        CloudflareKvBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/cos/backend.rs
+++ b/core/core/src/services/cos/backend.rs
@@ -44,9 +44,6 @@ use crate::*;
 #[derive(Default)]
 pub struct CosBuilder {
     pub(super) config: CosConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for CosBuilder {
@@ -133,19 +130,6 @@ impl CosBuilder {
     /// - envs like `TENCENTCLOUD_SECRET_ID`
     pub fn disable_config_load(mut self) -> Self {
         self.config.disable_config_load = true;
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }
@@ -266,12 +250,6 @@ impl Builder for CosBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/cos/config.rs
+++ b/core/core/src/services/cos/config.rs
@@ -73,11 +73,7 @@ impl crate::Configurator for CosConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        CosBuilder {
-            config: self,
-
-            http_client: None,
-        }
+        CosBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/d1/backend.rs
+++ b/core/core/src/services/d1/backend.rs
@@ -30,9 +30,6 @@ use crate::*;
 #[derive(Default)]
 pub struct D1Builder {
     pub(super) config: D1Config,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for D1Builder {
@@ -145,15 +142,10 @@ impl Builder for D1Builder {
             ));
         };
 
-        #[allow(deprecated)]
-        let client = if let Some(client) = self.http_client {
-            client
-        } else {
-            HttpClient::new().map_err(|err| {
-                err.with_operation("Builder::build")
-                    .with_context("service", D1_SCHEME)
-            })?
-        };
+        let client = HttpClient::new().map_err(|err| {
+            err.with_operation("Builder::build")
+                .with_context("service", D1_SCHEME)
+        })?;
 
         let Some(table) = config.table.clone() else {
             return Err(Error::new(ErrorKind::ConfigInvalid, "table is required"));

--- a/core/core/src/services/d1/config.rs
+++ b/core/core/src/services/d1/config.rs
@@ -100,10 +100,7 @@ impl crate::Configurator for D1Config {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        D1Builder {
-            config: self,
-            http_client: None,
-        }
+        D1Builder { config: self }
     }
 }
 

--- a/core/core/src/services/dropbox/builder.rs
+++ b/core/core/src/services/dropbox/builder.rs
@@ -33,9 +33,6 @@ use crate::*;
 #[derive(Default)]
 pub struct DropboxBuilder {
     pub(super) config: DropboxConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for DropboxBuilder {
@@ -94,19 +91,6 @@ impl DropboxBuilder {
     /// This is required for OAuth 2.0 Flow with refresh the access token.
     pub fn client_secret(mut self, client_secret: &str) -> Self {
         self.config.client_secret = Some(client_secret.to_string());
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, http_client: HttpClient) -> Self {
-        self.http_client = Some(http_client);
         self
     }
 }
@@ -191,12 +175,6 @@ impl Builder for DropboxBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/dropbox/config.rs
+++ b/core/core/src/services/dropbox/config.rs
@@ -64,10 +64,7 @@ impl crate::Configurator for DropboxConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        DropboxBuilder {
-            config: self,
-            http_client: None,
-        }
+        DropboxBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/gcs/backend.rs
+++ b/core/core/src/services/gcs/backend.rs
@@ -45,9 +45,6 @@ const DEFAULT_GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.read
 #[derive(Default)]
 pub struct GcsBuilder {
     pub(super) config: GcsConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
     pub(super) customized_token_loader: Option<Box<dyn GoogleTokenLoad>>,
 }
 
@@ -138,19 +135,6 @@ impl GcsBuilder {
         if !path.is_empty() {
             self.config.credential_path = Some(path.to_string())
         };
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 
@@ -345,12 +329,6 @@ impl Builder for GcsBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/gcs/config.rs
+++ b/core/core/src/services/gcs/config.rs
@@ -105,7 +105,6 @@ impl crate::Configurator for GcsConfig {
     fn into_builder(self) -> Self::Builder {
         GcsBuilder {
             config: self,
-            http_client: None,
             customized_token_loader: None,
         }
     }

--- a/core/core/src/services/gdrive/builder.rs
+++ b/core/core/src/services/gdrive/builder.rs
@@ -35,9 +35,6 @@ use crate::*;
 #[doc = include_str!("docs.md")]
 pub struct GdriveBuilder {
     pub(super) config: GdriveConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for GdriveBuilder {
@@ -100,19 +97,6 @@ impl GdriveBuilder {
         self.config.client_secret = Some(client_secret.to_string());
         self
     }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, http_client: HttpClient) -> Self {
-        self.http_client = Some(http_client);
-        self
-    }
 }
 
 impl Builder for GdriveBuilder {
@@ -143,12 +127,6 @@ impl Builder for GdriveBuilder {
 
                 ..Default::default()
             });
-
-        // allow deprecated api here for compatibility
-        #[allow(deprecated)]
-        if let Some(client) = self.http_client {
-            info.update_http_client(|_| client);
-        }
 
         let accessor_info = Arc::new(info);
         let mut signer = GdriveSigner::new(accessor_info.clone());

--- a/core/core/src/services/gdrive/config.rs
+++ b/core/core/src/services/gdrive/config.rs
@@ -64,10 +64,7 @@ impl crate::Configurator for GdriveConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        GdriveBuilder {
-            config: self,
-            http_client: None,
-        }
+        GdriveBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/github/backend.rs
+++ b/core/core/src/services/github/backend.rs
@@ -40,9 +40,6 @@ use crate::*;
 #[derive(Default)]
 pub struct GithubBuilder {
     pub(super) config: GithubConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for GithubBuilder {
@@ -88,19 +85,6 @@ impl GithubBuilder {
     pub fn repo(mut self, repo: &str) -> Self {
         self.config.repo = repo.to_string();
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }
@@ -158,12 +142,6 @@ impl Builder for GithubBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/github/config.rs
+++ b/core/core/src/services/github/config.rs
@@ -106,10 +106,7 @@ impl crate::Configurator for GithubConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        GithubBuilder {
-            config: self,
-            http_client: None,
-        }
+        GithubBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/http/backend.rs
+++ b/core/core/src/services/http/backend.rs
@@ -34,9 +34,6 @@ use crate::*;
 #[derive(Default)]
 pub struct HttpBuilder {
     pub(super) config: HttpConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for HttpBuilder {
@@ -101,19 +98,6 @@ impl HttpBuilder {
 
         self
     }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
-        self
-    }
 }
 
 impl Builder for HttpBuilder {
@@ -165,12 +149,6 @@ impl Builder for HttpBuilder {
 
                 ..Default::default()
             });
-
-        // allow deprecated api here for compatibility
-        #[allow(deprecated)]
-        if let Some(client) = self.http_client {
-            info.update_http_client(|_| client);
-        }
 
         let accessor_info = Arc::new(info);
 

--- a/core/core/src/services/http/config.rs
+++ b/core/core/src/services/http/config.rs
@@ -69,10 +69,7 @@ impl crate::Configurator for HttpConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        HttpBuilder {
-            config: self,
-            http_client: None,
-        }
+        HttpBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/ipfs/backend.rs
+++ b/core/core/src/services/ipfs/backend.rs
@@ -36,9 +36,6 @@ use crate::*;
 #[derive(Default)]
 pub struct IpfsBuilder {
     pub(super) config: IpfsConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for IpfsBuilder {
@@ -84,19 +81,6 @@ impl IpfsBuilder {
             self.config.endpoint = Some(endpoint.trim_end_matches('/').to_string());
         }
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }

--- a/core/core/src/services/ipfs/config.rs
+++ b/core/core/src/services/ipfs/config.rs
@@ -51,10 +51,7 @@ impl crate::Configurator for IpfsConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        IpfsBuilder {
-            config: self,
-            http_client: None,
-        }
+        IpfsBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/ipmfs/builder.rs
+++ b/core/core/src/services/ipmfs/builder.rs
@@ -70,9 +70,6 @@ use crate::*;
 #[derive(Default)]
 pub struct IpmfsBuilder {
     pub(super) config: IpmfsConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for IpmfsBuilder {
@@ -104,19 +101,6 @@ impl IpmfsBuilder {
         } else {
             Some(endpoint.to_string())
         };
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }

--- a/core/core/src/services/ipmfs/config.rs
+++ b/core/core/src/services/ipmfs/config.rs
@@ -51,10 +51,7 @@ impl crate::Configurator for IpmfsConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        IpmfsBuilder {
-            config: self,
-            http_client: None,
-        }
+        IpmfsBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/koofr/backend.rs
+++ b/core/core/src/services/koofr/backend.rs
@@ -43,9 +43,6 @@ use crate::*;
 #[derive(Default)]
 pub struct KoofrBuilder {
     pub(super) config: KoofrConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for KoofrBuilder {
@@ -105,19 +102,6 @@ impl KoofrBuilder {
             Some(password.to_string())
         };
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }
@@ -185,12 +169,6 @@ impl Builder for KoofrBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/koofr/config.rs
+++ b/core/core/src/services/koofr/config.rs
@@ -87,10 +87,7 @@ impl crate::Configurator for KoofrConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        KoofrBuilder {
-            config: self,
-            http_client: None,
-        }
+        KoofrBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/obs/backend.rs
+++ b/core/core/src/services/obs/backend.rs
@@ -44,9 +44,6 @@ use crate::*;
 #[derive(Default)]
 pub struct ObsBuilder {
     pub(super) config: ObsConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for ObsBuilder {
@@ -123,19 +120,6 @@ impl ObsBuilder {
     pub fn enable_versioning(mut self, enabled: bool) -> Self {
         self.config.enable_versioning = enabled;
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }
@@ -261,12 +245,6 @@ impl Builder for ObsBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/obs/config.rs
+++ b/core/core/src/services/obs/config.rs
@@ -71,11 +71,7 @@ impl crate::Configurator for ObsConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        ObsBuilder {
-            config: self,
-
-            http_client: None,
-        }
+        ObsBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/onedrive/builder.rs
+++ b/core/core/src/services/onedrive/builder.rs
@@ -34,9 +34,6 @@ use crate::*;
 #[derive(Default)]
 pub struct OnedriveBuilder {
     pub(super) config: OnedriveConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for OnedriveBuilder {
@@ -56,19 +53,6 @@ impl OnedriveBuilder {
             Some(root.to_string())
         };
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, http_client: HttpClient) -> Self {
-        self.http_client = Some(http_client);
         self
     }
 
@@ -161,12 +145,6 @@ impl Builder for OnedriveBuilder {
 
                 ..Default::default()
             });
-
-        // allow deprecated api here for compatibility
-        #[allow(deprecated)]
-        if let Some(client) = self.http_client {
-            info.update_http_client(|_| client);
-        }
 
         let accessor_info = Arc::new(info);
         let mut signer = OneDriveSigner::new(accessor_info.clone());

--- a/core/core/src/services/onedrive/config.rs
+++ b/core/core/src/services/onedrive/config.rs
@@ -73,10 +73,7 @@ impl crate::Configurator for OnedriveConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        OnedriveBuilder {
-            config: self,
-            http_client: None,
-        }
+        OnedriveBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/oss/backend.rs
+++ b/core/core/src/services/oss/backend.rs
@@ -46,9 +46,6 @@ const DEFAULT_BATCH_MAX_OPERATIONS: usize = 1000;
 #[derive(Default)]
 pub struct OssBuilder {
     pub(super) config: OssConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for OssBuilder {
@@ -175,19 +172,6 @@ impl OssBuilder {
             self.config.security_token = Some(security_token.to_string())
         }
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 
@@ -560,12 +544,6 @@ impl Builder for OssBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/oss/config.rs
+++ b/core/core/src/services/oss/config.rs
@@ -131,11 +131,7 @@ impl crate::Configurator for OssConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        OssBuilder {
-            config: self,
-
-            http_client: None,
-        }
+        OssBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/pcloud/backend.rs
+++ b/core/core/src/services/pcloud/backend.rs
@@ -40,9 +40,6 @@ use crate::*;
 #[derive(Default)]
 pub struct PcloudBuilder {
     pub(super) config: PcloudConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for PcloudBuilder {
@@ -101,19 +98,6 @@ impl PcloudBuilder {
             Some(password.to_string())
         };
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }
@@ -176,12 +160,6 @@ impl Builder for PcloudBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/pcloud/config.rs
+++ b/core/core/src/services/pcloud/config.rs
@@ -69,10 +69,7 @@ impl crate::Configurator for PcloudConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        PcloudBuilder {
-            config: self,
-            http_client: None,
-        }
+        PcloudBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/seafile/backend.rs
+++ b/core/core/src/services/seafile/backend.rs
@@ -42,9 +42,6 @@ use crate::*;
 #[derive(Default)]
 pub struct SeafileBuilder {
     pub(super) config: SeafileConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for SeafileBuilder {
@@ -116,19 +113,6 @@ impl SeafileBuilder {
 
         self
     }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
-        self
-    }
 }
 
 impl Builder for SeafileBuilder {
@@ -193,12 +177,6 @@ impl Builder for SeafileBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/seafile/config.rs
+++ b/core/core/src/services/seafile/config.rs
@@ -89,10 +89,7 @@ impl crate::Configurator for SeafileConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        SeafileBuilder {
-            config: self,
-            http_client: None,
-        }
+        SeafileBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/upyun/backend.rs
+++ b/core/core/src/services/upyun/backend.rs
@@ -38,9 +38,6 @@ use crate::*;
 #[derive(Default)]
 pub struct UpyunBuilder {
     pub(super) config: UpyunConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for UpyunBuilder {
@@ -97,19 +94,6 @@ impl UpyunBuilder {
             Some(password.to_string())
         };
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }
@@ -186,12 +170,6 @@ impl Builder for UpyunBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/upyun/config.rs
+++ b/core/core/src/services/upyun/config.rs
@@ -68,10 +68,7 @@ impl crate::Configurator for UpyunConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        UpyunBuilder {
-            config: self,
-            http_client: None,
-        }
+        UpyunBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/vercel_artifacts/builder.rs
+++ b/core/core/src/services/vercel_artifacts/builder.rs
@@ -30,9 +30,6 @@ use crate::*;
 #[derive(Default)]
 pub struct VercelArtifactsBuilder {
     pub(super) config: VercelArtifactsConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for VercelArtifactsBuilder {
@@ -49,19 +46,6 @@ impl VercelArtifactsBuilder {
     /// default: no access token, which leads to failure
     pub fn access_token(mut self, access_token: &str) -> Self {
         self.config.access_token = Some(access_token.to_string());
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, http_client: HttpClient) -> Self {
-        self.http_client = Some(http_client);
         self
     }
 }
@@ -83,12 +67,6 @@ impl Builder for VercelArtifactsBuilder {
 
                 ..Default::default()
             });
-
-        // allow deprecated api here for compatibility
-        #[allow(deprecated)]
-        if let Some(client) = self.http_client {
-            info.update_http_client(|_| client);
-        }
 
         match self.config.access_token.clone() {
             Some(access_token) => Ok(VercelArtifactsBackend {

--- a/core/core/src/services/vercel_artifacts/config.rs
+++ b/core/core/src/services/vercel_artifacts/config.rs
@@ -47,10 +47,7 @@ impl crate::Configurator for VercelArtifactsConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        VercelArtifactsBuilder {
-            config: self,
-            http_client: None,
-        }
+        VercelArtifactsBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/vercel_blob/backend.rs
+++ b/core/core/src/services/vercel_blob/backend.rs
@@ -41,9 +41,6 @@ use crate::*;
 #[derive(Default)]
 pub struct VercelBlobBuilder {
     pub(super) config: VercelBlobConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for VercelBlobBuilder {
@@ -76,19 +73,6 @@ impl VercelBlobBuilder {
         if !token.is_empty() {
             self.config.token = Some(token.to_string());
         }
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }
@@ -137,12 +121,6 @@ impl Builder for VercelBlobBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/vercel_blob/config.rs
+++ b/core/core/src/services/vercel_blob/config.rs
@@ -60,10 +60,7 @@ impl crate::Configurator for VercelBlobConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        VercelBlobBuilder {
-            config: self,
-            http_client: None,
-        }
+        VercelBlobBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/webdav/backend.rs
+++ b/core/core/src/services/webdav/backend.rs
@@ -38,9 +38,6 @@ use crate::*;
 #[derive(Default)]
 pub struct WebdavBuilder {
     pub(super) config: WebdavConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for WebdavBuilder {
@@ -103,19 +100,6 @@ impl WebdavBuilder {
             Some(root.to_string())
         };
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }
@@ -186,12 +170,6 @@ impl Builder for WebdavBuilder {
 
                         ..Default::default()
                     });
-
-                // allow deprecated api here for compatibility
-                #[allow(deprecated)]
-                if let Some(client) = self.http_client {
-                    am.update_http_client(|_| client);
-                }
 
                 am.into()
             },

--- a/core/core/src/services/webdav/config.rs
+++ b/core/core/src/services/webdav/config.rs
@@ -70,10 +70,7 @@ impl crate::Configurator for WebdavConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        WebdavBuilder {
-            config: self,
-            http_client: None,
-        }
+        WebdavBuilder { config: self }
     }
 }
 

--- a/core/core/src/services/yandex_disk/backend.rs
+++ b/core/core/src/services/yandex_disk/backend.rs
@@ -39,9 +39,6 @@ use crate::*;
 #[derive(Default)]
 pub struct YandexDiskBuilder {
     pub(super) config: YandexDiskConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for YandexDiskBuilder {
@@ -73,19 +70,6 @@ impl YandexDiskBuilder {
     pub fn access_token(mut self, access_token: &str) -> Self {
         self.config.access_token = access_token.to_string();
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 }
@@ -136,12 +120,6 @@ impl Builder for YandexDiskBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/core/src/services/yandex_disk/config.rs
+++ b/core/core/src/services/yandex_disk/config.rs
@@ -60,10 +60,7 @@ impl crate::Configurator for YandexDiskConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        YandexDiskBuilder {
-            config: self,
-            http_client: None,
-        }
+        YandexDiskBuilder { config: self }
     }
 }
 

--- a/core/core/src/types/builder.rs
+++ b/core/core/src/types/builder.rs
@@ -29,7 +29,7 @@ use crate::*;
 /// This trait allows the developer to define a builder struct that can:
 ///
 /// - build a service via builder style API.
-/// - configure in-memory options like `http_client` or `customized_credential_load`.
+/// - configure in-memory options like `customized_credential_load`.
 ///
 /// Usually, users don't need to use or import this trait directly, they can use `Operator` API instead.
 ///

--- a/core/core/src/types/operator/operator.rs
+++ b/core/core/src/types/operator/operator.rs
@@ -201,55 +201,6 @@ impl Operator {
     pub fn update_executor(&self, f: impl FnOnce(Executor) -> Executor) {
         self.accessor.info().update_executor(f);
     }
-
-    /// Get the http client used by current operator.
-    #[deprecated(
-        since = "0.54.0",
-        note = "Use HttpClientLayer instead. This method will be removed in next version."
-    )]
-    pub fn http_client(&self) -> HttpClient {
-        self.accessor.info().http_client()
-    }
-
-    /// Update http client for the context.
-    ///
-    /// All cloned `Operator` instances share the same internal state, such as
-    /// `HttpClient` and `Runtime`. Some layers may modify the internal state of
-    /// the `Operator` too like inject logging and metrics for `HttpClient`.
-    ///
-    /// # Note
-    ///
-    /// Tasks must be forwarded to the old executor after the update. Otherwise, features such as retry, timeout, and metrics may not function properly.
-    ///
-    /// # Deprecated
-    ///
-    /// This method is deprecated since v0.54.0. Use [`HttpClientLayer`] instead.
-    ///
-    /// ## Migration Example
-    ///
-    /// Instead of:
-    /// ```ignore
-    /// let operator = Operator::new(service)?;
-    /// operator.update_http_client(|_| custom_client);
-    /// ```
-    ///
-    /// Use:
-    /// ```ignore
-    /// use opendal_core::layers::HttpClientLayer;
-    ///
-    /// let operator = Operator::new(service)?
-    ///     .layer(HttpClientLayer::new(custom_client))
-    ///     .finish();
-    /// ```
-    ///
-    /// [`HttpClientLayer`]: crate::layers::HttpClientLayer
-    #[deprecated(
-        since = "0.54.0",
-        note = "Use HttpClientLayer instead. This method will be removed in next version"
-    )]
-    pub fn update_http_client(&self, f: impl FnOnce(HttpClient) -> HttpClient) {
-        self.accessor.info().update_http_client(f);
-    }
 }
 
 /// # Operator async API.

--- a/core/services/azblob/src/backend.rs
+++ b/core/services/azblob/src/backend.rs
@@ -63,9 +63,6 @@ impl From<AzureStorageConfig> for AzblobConfig {
 #[derive(Default)]
 pub struct AzblobBuilder {
     pub(super) config: AzblobConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for AzblobBuilder {
@@ -230,19 +227,6 @@ impl AzblobBuilder {
             self.config.sas_token = Some(sas_token.to_string());
         }
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 
@@ -428,12 +412,6 @@ impl Builder for AzblobBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/services/azblob/src/config.rs
+++ b/core/services/azblob/src/config.rs
@@ -107,11 +107,7 @@ impl opendal_core::Configurator for AzblobConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        AzblobBuilder {
-            config: self,
-
-            http_client: None,
-        }
+        AzblobBuilder { config: self }
     }
 }
 

--- a/core/services/azdls/src/backend.rs
+++ b/core/services/azdls/src/backend.rs
@@ -61,9 +61,6 @@ impl From<AzureStorageConfig> for AzdlsConfig {
 #[derive(Default)]
 pub struct AzdlsBuilder {
     pub(super) config: AzdlsConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for AzdlsBuilder {
@@ -195,19 +192,6 @@ impl AzdlsBuilder {
         self
     }
 
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
-        self
-    }
-
     /// Create a new `AzdlsBuilder` instance from an [Azure Storage connection string][1].
     ///
     /// [1]: https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string
@@ -307,12 +291,6 @@ impl Builder for AzdlsBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/services/azdls/src/config.rs
+++ b/core/services/azdls/src/config.rs
@@ -119,10 +119,7 @@ impl opendal_core::Configurator for AzdlsConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        AzdlsBuilder {
-            config: self,
-            http_client: None,
-        }
+        AzdlsBuilder { config: self }
     }
 }
 

--- a/core/services/azfile/src/backend.rs
+++ b/core/services/azfile/src/backend.rs
@@ -58,9 +58,6 @@ impl From<AzureStorageConfig> for AzfileConfig {
 #[derive(Default)]
 pub struct AzfileBuilder {
     pub(super) config: AzfileConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for AzfileBuilder {
@@ -128,19 +125,6 @@ impl AzfileBuilder {
             self.config.share_name = share_name.to_string();
         }
 
-        self
-    }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
         self
     }
 
@@ -234,12 +218,6 @@ impl Builder for AzfileBuilder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = self.http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/services/azfile/src/config.rs
+++ b/core/services/azfile/src/config.rs
@@ -99,10 +99,7 @@ impl opendal_core::Configurator for AzfileConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        AzfileBuilder {
-            config: self,
-            http_client: None,
-        }
+        AzfileBuilder { config: self }
     }
 }
 

--- a/core/services/ghac/src/backend.rs
+++ b/core/services/ghac/src/backend.rs
@@ -55,9 +55,6 @@ fn value_or_env(
 #[derive(Default)]
 pub struct GhacBuilder {
     pub(super) config: GhacConfig,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
 }
 
 impl Debug for GhacBuilder {
@@ -118,19 +115,6 @@ impl GhacBuilder {
         }
         self
     }
-
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
-        self
-    }
 }
 
 impl Builder for GhacBuilder {
@@ -186,12 +170,6 @@ impl Builder for GhacBuilder {
 
                         ..Default::default()
                     });
-
-                // allow deprecated api here for compatibility
-                #[allow(deprecated)]
-                if let Some(client) = self.http_client {
-                    am.update_http_client(|_| client);
-                }
 
                 am.into()
             },

--- a/core/services/ghac/src/config.rs
+++ b/core/services/ghac/src/config.rs
@@ -79,10 +79,7 @@ impl opendal_core::Configurator for GhacConfig {
 
     #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
-        GhacBuilder {
-            config: self,
-            http_client: None,
-        }
+        GhacBuilder { config: self }
     }
 }
 

--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -81,9 +81,6 @@ const DEFAULT_BATCH_MAX_OPERATIONS: usize = 1000;
 #[derive(Default)]
 pub struct S3Builder {
     pub(super) config: S3Config,
-
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    pub(super) http_client: Option<HttpClient>,
     pub(super) credential_providers: Option<ProvideCredentialChain<Credential>>,
 }
 
@@ -449,19 +446,6 @@ impl S3Builder {
         self
     }
 
-    /// Specify the http client that used by this service.
-    ///
-    /// # Notes
-    ///
-    /// This API is part of OpenDAL's Raw API. `HttpClient` could be changed
-    /// during minor updates.
-    #[deprecated(since = "0.53.0", note = "Use `Operator::update_http_client` instead")]
-    #[allow(deprecated)]
-    pub fn http_client(mut self, client: HttpClient) -> Self {
-        self.http_client = Some(client);
-        self
-    }
-
     /// Set bucket versioning status for this backend
     pub fn enable_versioning(mut self, enabled: bool) -> Self {
         self.config.enable_versioning = enabled;
@@ -706,10 +690,8 @@ impl Builder for S3Builder {
     fn build(self) -> Result<impl Access> {
         debug!("backend build started: {:?}", &self);
 
-        #[allow(deprecated)]
         let S3Builder {
             mut config,
-            http_client,
             credential_providers,
         } = self;
 
@@ -961,12 +943,6 @@ impl Builder for S3Builder {
 
                             ..Default::default()
                         });
-
-                    // allow deprecated api here for compatibility
-                    #[allow(deprecated)]
-                    if let Some(client) = http_client {
-                        am.update_http_client(|_| client);
-                    }
 
                     am.into()
                 },

--- a/core/services/s3/src/config.rs
+++ b/core/services/s3/src/config.rs
@@ -255,7 +255,6 @@ impl Configurator for S3Config {
     fn into_builder(self) -> Self::Builder {
         S3Builder {
             config: self,
-            http_client: None,
             credential_providers: None,
         }
     }


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

Remove deprecated http client config APIs.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->
