### PR TITLE
chore(core): remove redundant clones

### DIFF
--- a/core/core/src/layers/retry.rs
+++ b/core/core/src/layers/retry.rs
@@ -635,7 +635,7 @@ mod tests {
 
         fn build(self) -> Result<impl Access> {
             Ok(MockService {
-                attempt: self.attempt.clone(),
+                attempt: self.attempt,
             })
         }
     }

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -41,7 +41,7 @@ impl StreamingReader {
     /// Create a new streaming reader.
     #[inline]
     fn new(ctx: Arc<ReadContext>, range: BytesRange) -> Self {
-        let generator = ReadGenerator::new(ctx.clone(), range.offset(), range.size());
+        let generator = ReadGenerator::new(ctx, range.offset(), range.size());
         Self {
             generator,
             reader: None,

--- a/core/core/src/types/read/reader.rs
+++ b/core/core/src/types/read/reader.rs
@@ -561,7 +561,7 @@ mod tests {
         let reader = op.reader_with(path).gap(1).await.unwrap();
 
         let ranges = vec![0..10, 10..20, 21..30, 40..50, 40..60, 45..59];
-        let merged = reader.merge_ranges(ranges.clone());
+        let merged = reader.merge_ranges(ranges);
         assert_eq!(merged, vec![0..30, 40..60]);
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #N/A.

# Rationale for this change

Remove redundant clones flagged by clippy to trim refcount bumps and allocations on hot paths.

# What changes are included in this PR?

- Stop cloning ReadContext when constructing StreamingReader’s generator.
- Move the shared Arc in retry layer test builder instead of cloning.
- Pass ranges by value in merge_ranges test to avoid an extra vector clone.

# Are there any user-facing changes?

No user-facing changes.
