### PR TITLE
chore(core): avoid inefficient to_string

### DIFF
--- a/core/core/src/raw/http_util/multipart.rs
+++ b/core/core/src/raw/http_util/multipart.rs
@@ -470,7 +470,7 @@ impl Part for MixedPart {
         let parts = http_response.split("\r\n\r\n").collect::<Vec<&str>>();
         let headers_content = parts[0];
         let body_content = parts.get(1).unwrap_or(&"");
-        let body_bytes = Buffer::from(body_content.to_string());
+        let body_bytes = Buffer::from(body_content.as_bytes().to_vec());
 
         let status_line = headers_content.lines().next().unwrap_or("");
         let status_code = status_line


### PR DESCRIPTION
# Which issue does this PR close?

Closes #N/A.

# Rationale for this change

Clippy flagged an inefficient `.to_string()` on a `&&str` in multipart parsing. Building the buffer from the raw bytes avoids the slower blanket impl and keeps the same behavior.

# What changes are included in this PR?

- Construct multipart body buffer from `&[u8]` instead of calling `.to_string()` on a `&&str`.

# Are there any user-facing changes?

No user-facing changes.
