### PR TITLE
[core split] Layer: retry

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -5741,6 +5741,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "opendal-layer-retry"
+version = "0.55.0"
+dependencies = [
+ "anyhow",
+ "backon",
+ "bytes",
+ "futures",
+ "log",
+ "opendal-core",
+ "tokio",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "opendal-service-aliyun-drive"
 version = "0.55.0"
 dependencies = [

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,6 +40,7 @@ rust-version = "1.85"
 version = "0.55.0"
 
 [workspace.dependencies]
+backon = "1.6"
 base64 = "0.22"
 bytes = "1.10"
 ctor = "0.6"

--- a/core/core/Cargo.toml
+++ b/core/core/Cargo.toml
@@ -173,7 +173,7 @@ doctest = false
 [dependencies]
 # Required dependencies
 anyhow = { version = "1.0.100", features = ["std"] }
-backon = { version = "1.6", features = ["tokio-sleep"] }
+backon = { workspace = true, features = ["tokio-sleep"] }
 base64 = { workspace = true }
 bytes = { workspace = true }
 ctor = { workspace = true }
@@ -325,7 +325,7 @@ tracing = { version = "0.1", optional = true }
 probe = { version = "0.5.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-backon = { version = "1.6", features = ["gloo-timers-sleep"] }
+backon = { workspace = true, features = ["gloo-timers-sleep"] }
 getrandom = { version = "0.2", features = ["js"] }
 jiff = { version = "0.2.15", features = ["serde", "js"] }
 tokio = { workspace = true, features = ["time"] }

--- a/core/core/src/layers/mod.rs
+++ b/core/core/src/layers/mod.rs
@@ -52,6 +52,7 @@ mod mime_guess;
 #[cfg(feature = "layers-mime-guess")]
 pub use self::mime_guess::MimeGuessLayer;
 
+#[path = "../../../layers/retry/src/lib.rs"]
 mod retry;
 pub use self::retry::RetryInterceptor;
 pub use self::retry::RetryLayer;

--- a/core/core/src/lib.rs
+++ b/core/core/src/lib.rs
@@ -154,6 +154,8 @@
 // Make sure all our public APIs have docs.
 #![deny(missing_docs)]
 
+extern crate self as opendal_core;
+
 // Private module with public types, they will be accessed via `opendal::Xxxx`
 mod types;
 pub use types::*;

--- a/core/core/src/raw/ops.rs
+++ b/core/core/src/raw/ops.rs
@@ -334,6 +334,7 @@ impl OpRead {
     }
 
     /// Returns a mutable range to allow updating.
+    #[allow(dead_code)]
     pub(crate) fn range_mut(&mut self) -> &mut BytesRange {
         &mut self.range
     }

--- a/core/layers/retry/Cargo.toml
+++ b/core/layers/retry/Cargo.toml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+description = "Apache OpenDAL retry layer"
+name = "opendal-layer-retry"
+
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+backon = { workspace = true, features = ["tokio-sleep"] }
+log = { workspace = true }
+opendal-core = { path = "../../core", version = "0.55.0", default-features = false, features = ["services-memory"] }
+
+[dev-dependencies]
+anyhow = { version = "1.0.100", features = ["std"] }
+bytes = { workspace = true }
+futures = { workspace = true, default-features = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log"] }

--- a/core/layers/retry/src/lib.rs
+++ b/core/layers/retry/src/lib.rs
@@ -23,8 +23,8 @@ use backon::ExponentialBuilder;
 use backon::Retryable;
 use log::warn;
 
-use crate::raw::*;
-use crate::*;
+use opendal_core::raw::*;
+use opendal_core::*;
 
 /// Add retry for temporary failed operations.
 ///
@@ -409,7 +409,9 @@ impl<A: Access> oio::Read for RetryReader<A, A::Reader> {
                 Some(mut reader) => {
                     let buf = reader.read().await?;
                     self.reader = Some(reader);
-                    self.args.range_mut().advance(buf.len() as u64);
+                    let mut range = self.args.range();
+                    range.advance(buf.len() as u64);
+                    self.args = self.args.clone().with_range(range);
                     return Ok(buf);
                 }
             }
@@ -623,7 +625,7 @@ mod tests {
     use tracing_subscriber::filter::LevelFilter;
 
     use super::*;
-    use crate::layers::LoggingLayer;
+    use opendal_core::layers::LoggingLayer;
 
     #[derive(Default, Clone)]
     struct MockBuilder {


### PR DESCRIPTION
Closes #6947  

This PR splits the layer `retry` out of `core` as part of the core-split effort and follows the tracking issue #6829.  

**Summary**  
- Keep public API/behavior unchanged.  
- Move the retry layer source into the new crate layout described in the tracking issue.  
- Add/update feature flags and tests as required. 