### PR TITLE
chore(core): pub message of Error struct

### DIFF
--- a/core/core/src/types/error.rs
+++ b/core/core/src/types/error.rs
@@ -450,6 +450,11 @@ impl Error {
         self.status == ErrorStatus::Persistent
     }
 
+    /// Return error's message.
+    pub fn message(&self) -> &str {
+        self.message.as_str()
+    }
+
     /// Return error's backtrace.
     ///
     /// Note: the standard way of exposing backtrace is the unstable feature [`error_generic_member_access`](https://github.com/rust-lang/rust/issues/99301).


### PR DESCRIPTION
# Which issue does this PR close?


Closes #.

# Rationale for this change

We need pure message except the contexts, but contexts are always included  `to_string` function.

# What changes are included in this PR?

chore(core): pub message of Error struct

# Are there any user-facing changes?

# AI Usage Statement

