### PR TITLE
Add just and uv to devcontainer

### DIFF
--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -72,3 +72,9 @@ sudo apt install -y ninja-build
 
 # Setup for D binding
 sudo apt install -y dmd dub
+
+# Setup just for development tasks
+cargo install just
+
+# Setup uv for python project management
+curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6989 .

# What changes are included in this PR?

Update the .devcontainer/post_create.sh to install just using cargo, and uv using the install script listed on the website.

# Are there any user-facing changes?

No.

# AI Usage Statement

None.