### PR TITLE
feat(bindings/python): Add from_uri constructors for Operators

### DIFF
--- a/bindings/python/justfile
+++ b/bindings/python/justfile
@@ -119,6 +119,11 @@ lint: setup
     @echo "{{ BOLD }}--- Running Python linter (Ruff) ---{{ NORMAL }}"
     @uv run ruff check
 
+[group('lint')]
+lint-fix: setup
+    @echo "{{ BOLD }}--- Running Python lint fixer (Ruff) ---{{ NORMAL }}"
+    @uv run ruff check --fix --unsafe-fixes
+
 # Format all code (Rust, Python, etc.)
 [group('lint')]
 fmt: setup

--- a/bindings/python/python/opendal/exceptions.pyi
+++ b/bindings/python/python/opendal/exceptions.pyi
@@ -23,38 +23,51 @@ import builtins
 class AlreadyExists(builtins.Exception):
     r"""Already exists."""
 
+
 class ConditionNotMatch(builtins.Exception):
     r"""Condition not match."""
+
 
 class ConfigInvalid(builtins.Exception):
     r"""Config is invalid."""
 
+
 class Error(builtins.Exception):
     r"""OpenDAL Base Exception."""
+
 
 class IsADirectory(builtins.Exception):
     r"""Is a directory."""
 
+
 class IsSameFile(builtins.Exception):
     r"""Is same file."""
+
 
 class NotADirectory(builtins.Exception):
     r"""Not a directory."""
 
+
 class NotFound(builtins.Exception):
     r"""Not found."""
+
 
 class PermissionDenied(builtins.Exception):
     r"""Permission denied."""
 
+
 class RangeNotSatisfied(builtins.Exception):
     r"""Range not satisfied."""
+
 
 class RateLimited(builtins.Exception):
     r"""Rate limited."""
 
+
 class Unexpected(builtins.Exception):
     r"""Unexpected errors."""
 
+
 class Unsupported(builtins.Exception):
     r"""Unsupported operation."""
+

--- a/bindings/python/python/opendal/layers.pyi
+++ b/bindings/python/python/opendal/layers.pyi
@@ -69,6 +69,7 @@ class ConcurrentLimitLayer(Layer):
 class Layer:
     r"""Layers are used to intercept the operations on the underlying storage."""
 
+
 @typing.final
 class MimeGuessLayer(Layer):
     r"""

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -45,6 +45,23 @@ class AsyncOperator:
     Operator
     """
 
+    @staticmethod
+    def from_uri(uri: builtins.str, **kwargs: typing.Any) -> AsyncOperator:
+        r"""
+        Create a new `AsyncOperator` from a URI.
+
+        Parameters
+        ----------
+        uri : str
+            The URI of the service.
+        **kwargs : dict
+            The options for the service.
+
+        Returns
+        -------
+        AsyncOperator
+            The new operator.
+        """
     def layer(self, layer: Layer) -> AsyncOperator:
         r"""
         Add a new layer to the operator.
@@ -942,6 +959,7 @@ class AsyncOperator:
         root: builtins.str = ...,
         secret_id: builtins.str = ...,
         secret_key: builtins.str = ...,
+        security_token: builtins.str = ...,
     ) -> typing.Self:
         r"""
         Create a new `AsyncOperator` for `cos` service.
@@ -964,6 +982,21 @@ class AsyncOperator:
             Secret ID of this backend.
         secret_key : builtins.str, optional
             Secret key of this backend.
+        security_token : builtins.str, optional
+            Security token (a.k.a.
+            session token) of this backend.
+            This is used for temporary credentials issued by
+            Tencent Cloud STS (e.g.
+            `GetFederationToken` / `AssumeRole`).
+            When `security_token` is provided, it will be used
+            together with `secret_id` and `secret_key` to sign
+            requests, and the `x-cos-security-token` header will
+            be attached automatically by the signer.
+            If this field is not set, OpenDAL will also fall
+            back to reading the token from environment variables
+            `TENCENTCLOUD_TOKEN`, `TENCENTCLOUD_SECURITY_TOKEN`
+            or `QCLOUD_SECRET_TOKEN` (unless
+            `disable_config_load` is enabled).
 
         Returns
         -------
@@ -1868,6 +1901,7 @@ class AsyncOperator:
         delete_max_size: builtins.int = ...,
         enable_versioning: builtins.bool = ...,
         endpoint: builtins.str = ...,
+        external_id: builtins.str = ...,
         oidc_provider_arn: builtins.str = ...,
         oidc_token_file: builtins.str = ...,
         presign_addressing_style: builtins.str = ...,
@@ -1911,6 +1945,8 @@ class AsyncOperator:
             default.
         endpoint : builtins.str, optional
             Endpoint for oss.
+        external_id : builtins.str, optional
+            external_id for this backend.
         oidc_provider_arn : builtins.str, optional
             `oidc_provider_arn` will be loaded from - this field
             if it's `is_some` - env value:
@@ -2372,7 +2408,8 @@ class AsyncOperator:
         Parameters
         ----------
         enable_copy : builtins.bool, optional
-            enable_copy of this backend
+            Deprecated: SFTP copy capability is enabled by
+            default.
         endpoint : builtins.str, optional
             endpoint of this backend
         key : builtins.str, optional
@@ -2817,6 +2854,23 @@ class Operator:
     AsyncOperator
     """
 
+    @staticmethod
+    def from_uri(uri: builtins.str, **kwargs: typing.Any) -> Operator:
+        r"""
+        Create a new blocking `Operator` from a URI.
+
+        Parameters
+        ----------
+        uri : str
+            The URI of the service.
+        **kwargs : dict
+            The options for the service.
+
+        Returns
+        -------
+        Operator
+            The new operator.
+        """
     def layer(self, layer: Layer) -> Operator:
         r"""
         Add a new layer to this operator.
@@ -3548,6 +3602,7 @@ class Operator:
         root: builtins.str = ...,
         secret_id: builtins.str = ...,
         secret_key: builtins.str = ...,
+        security_token: builtins.str = ...,
     ) -> typing.Self:
         r"""
         Create a new `Operator` for `cos` service.
@@ -3570,6 +3625,21 @@ class Operator:
             Secret ID of this backend.
         secret_key : builtins.str, optional
             Secret key of this backend.
+        security_token : builtins.str, optional
+            Security token (a.k.a.
+            session token) of this backend.
+            This is used for temporary credentials issued by
+            Tencent Cloud STS (e.g.
+            `GetFederationToken` / `AssumeRole`).
+            When `security_token` is provided, it will be used
+            together with `secret_id` and `secret_key` to sign
+            requests, and the `x-cos-security-token` header will
+            be attached automatically by the signer.
+            If this field is not set, OpenDAL will also fall
+            back to reading the token from environment variables
+            `TENCENTCLOUD_TOKEN`, `TENCENTCLOUD_SECURITY_TOKEN`
+            or `QCLOUD_SECRET_TOKEN` (unless
+            `disable_config_load` is enabled).
 
         Returns
         -------
@@ -4474,6 +4544,7 @@ class Operator:
         delete_max_size: builtins.int = ...,
         enable_versioning: builtins.bool = ...,
         endpoint: builtins.str = ...,
+        external_id: builtins.str = ...,
         oidc_provider_arn: builtins.str = ...,
         oidc_token_file: builtins.str = ...,
         presign_addressing_style: builtins.str = ...,
@@ -4517,6 +4588,8 @@ class Operator:
             default.
         endpoint : builtins.str, optional
             Endpoint for oss.
+        external_id : builtins.str, optional
+            external_id for this backend.
         oidc_provider_arn : builtins.str, optional
             `oidc_provider_arn` will be loaded from - this field
             if it's `is_some` - env value:
@@ -4978,7 +5051,8 @@ class Operator:
         Parameters
         ----------
         enable_copy : builtins.bool, optional
-            enable_copy of this backend
+            Deprecated: SFTP copy capability is enabled by
+            default.
         endpoint : builtins.str, optional
             endpoint of this backend
         key : builtins.str, optional

--- a/bindings/python/python/opendal/types.pyi
+++ b/bindings/python/python/opendal/types.pyi
@@ -96,7 +96,9 @@ class Metadata:
     def version(self) -> builtins.str | None:
         r"""The version of this entry."""
     @property
-    def user_metadata(self) -> builtins.dict[builtins.str, builtins.str] | None:
+    def user_metadata(
+        self,
+    ) -> builtins.dict[builtins.str, builtins.str] | None:
         r"""The user-defined metadata of this entry."""
 
 @typing.final

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -45,6 +45,26 @@ fn build_blocking_operator(
     Ok(op)
 }
 
+fn build_operator_from_uri(
+    uri: &str,
+    options: &HashMap<String, String>,
+) -> PyResult<ocore::Operator> {
+    let op = ocore::Operator::from_uri((uri, options)).map_err(format_pyerr)?;
+    Ok(op)
+}
+
+fn build_blocking_operator_from_uri(
+    uri: &str,
+    options: &HashMap<String, String>,
+) -> PyResult<ocore::blocking::Operator> {
+    let op = ocore::Operator::from_uri((uri, options)).map_err(format_pyerr)?;
+
+    let runtime = pyo3_async_runtimes::tokio::get_runtime();
+    let _guard = runtime.enter();
+    let op = ocore::blocking::Operator::new(op).map_err(format_pyerr)?;
+    Ok(op)
+}
+
 fn normalize_scheme(raw: &str) -> String {
     raw.trim().to_ascii_lowercase().replace('_', "-")
 }
@@ -109,6 +129,37 @@ impl Operator {
             core: build_blocking_operator(&scheme, map.clone())?,
             __scheme: scheme,
             __map: map,
+        })
+    }
+
+    /// Create a new blocking `Operator` from a URI.
+    ///
+    /// Parameters
+    /// ----------
+    /// uri : str
+    ///     The URI of the service.
+    /// **kwargs : dict
+    ///     The options for the service.
+    ///
+    /// Returns
+    /// -------
+    /// Operator
+    ///     The new operator.
+    #[staticmethod]
+    #[pyo3(signature = (uri, *, **kwargs))]
+    pub fn from_uri(uri: String, kwargs: Option<&Bound<PyDict>>) -> PyResult<Self> {
+        let __map = kwargs
+            .map(|v| {
+                v.extract::<HashMap<String, String>>()
+                    .expect("must be a valid hashmap")
+            })
+            .unwrap_or_default();
+        let core = build_blocking_operator_from_uri(&uri, &__map)?;
+        let __scheme = core.info().scheme().to_string();
+        Ok(Operator {
+            core,
+            __scheme,
+            __map,
         })
     }
 
@@ -782,6 +833,37 @@ impl AsyncOperator {
             core: build_operator(&scheme, map.clone())?,
             __scheme: scheme,
             __map: map,
+        })
+    }
+
+    /// Create a new `AsyncOperator` from a URI.
+    ///
+    /// Parameters
+    /// ----------
+    /// uri : str
+    ///     The URI of the service.
+    /// **kwargs : dict
+    ///     The options for the service.
+    ///
+    /// Returns
+    /// -------
+    /// AsyncOperator
+    ///     The new operator.
+    #[staticmethod]
+    #[pyo3(signature = (uri, *, **kwargs))]
+    pub fn from_uri(uri: String, kwargs: Option<&Bound<PyDict>>) -> PyResult<Self> {
+        let __map = kwargs
+            .map(|v| {
+                v.extract::<HashMap<String, String>>()
+                    .expect("must be a valid hashmap")
+            })
+            .unwrap_or_default();
+        let core = build_operator_from_uri(&uri, &__map)?;
+        let __scheme = core.info().scheme().to_string();
+        Ok(AsyncOperator {
+            core,
+            __scheme,
+            __map,
         })
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6984 .

# Rationale for this change

Instantiating Operators from URLs greatly increases flexibility for consumers of the openDAL API as an abstract backend.

# What changes are included in this PR?

Add from_uri static methods to the Operator and AsyncOperator classes in the python bindings.

# Are there any user-facing changes?

Two new methods are available to users of the python library.

# AI Usage Statement

None

# Other notes

I am having issues with my development environment which the devcontainer is not making any easier, so I'm flying a bit blind and relying on CI.
