### PR TITLE
refactor: Consolidate opendal_core imports in tests

### DIFF
--- a/core/services/gcs/src/config.rs
+++ b/core/services/gcs/src/config.rs
@@ -112,8 +112,7 @@ impl opendal_core::Configurator for GcsConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opendal_core::Configurator;
-    use opendal_core::types::OperatorUri;
+    use opendal_core::{Configurator, OperatorUri};
 
     #[test]
     fn test_bucket_aliases() {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

In `opendal_core` it is mentioned that `Private module with public types, they will be accessed via opendal::Xxxx`.
https://github.com/apache/opendal/blob/a9625c81582eac3aa4b21a9866f5f2b74bb0acb4/core/core/src/lib.rs#L157C4-L157C16

The changed import was causing 
```
rustc: module `types` is private module [E0603]
```


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->


# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
