### PR TITLE
feat: support if_not_exists in the Memory service

### DIFF
--- a/core/core/src/services/memory/backend.rs
+++ b/core/core/src/services/memory/backend.rs
@@ -76,6 +76,7 @@ impl MemoryBackend {
             write_with_content_type: true,
             write_with_content_disposition: true,
             write_with_content_encoding: true,
+            write_with_if_not_exists: true,
             delete: true,
             stat: true,
             list: true,

--- a/core/core/src/services/memory/core.rs
+++ b/core/core/src/services/memory/core.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::collections::BTreeMap;
+use std::collections::btree_map::Entry;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -53,6 +54,20 @@ impl MemoryCore {
 
     pub fn set(&self, key: &str, value: MemoryValue) -> Result<()> {
         self.data.lock().unwrap().insert(key.to_string(), value);
+        Ok(())
+    }
+
+    pub fn set_if_not_exists(&self, key: &str, value: MemoryValue) -> Result<()> {
+        let mut data = self.data.lock().unwrap();
+        match data.entry(key.to_string()) {
+            Entry::Vacant(entry) => entry.insert(value),
+            Entry::Occupied(_) => {
+                return Err(Error::new(
+                    ErrorKind::ConditionNotMatch,
+                    "key already exists",
+                ));
+            }
+        };
         Ok(())
     }
 

--- a/core/core/src/services/memory/writer.rs
+++ b/core/core/src/services/memory/writer.rs
@@ -73,7 +73,11 @@ impl oio::Write for MemoryWriter {
             content,
         };
 
-        self.core.set(&self.path, value)?;
+        if self.op.if_not_exists() {
+            self.core.set_if_not_exists(&self.path, value)?;
+        } else {
+            self.core.set(&self.path, value)?;
+        }
 
         Ok(metadata)
     }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7035.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This makes the Memory service more of a drop-in replacement for other stores. I need this for testing in my project.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The if_not_exists capability was added to the Memory service.

# Are there any user-facing changes?

The Memory store now supports the `if_not_exists` capability.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

No AI was used in writing this code.

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
