### PR TITLE
feat(services/fs): Add user defined metadata support

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -6173,6 +6173,7 @@ dependencies = [
  "opendal-core",
  "serde",
  "tokio",
+ "xattr",
 ]
 
 [[package]]
@@ -11615,6 +11616,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.2",
 ]
 
 [[package]]

--- a/core/services/fs/Cargo.toml
+++ b/core/services/fs/Cargo.toml
@@ -39,3 +39,6 @@ opendal-core = { path = "../../core", version = "0.55.0", default-features = fal
 ] }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
+
+[target.'cfg(unix)'.dependencies]
+xattr = "1"

--- a/core/services/fs/src/backend.rs
+++ b/core/services/fs/src/backend.rs
@@ -150,6 +150,8 @@ impl Builder for FsBuilder {
                             write_can_append: true,
                             write_can_multi: true,
                             write_with_if_not_exists: true,
+                            #[cfg(unix)]
+                            write_with_user_metadata: true,
 
                             create_dir: true,
                             delete: true,


### PR DESCRIPTION
# Which issue does this PR close?

Part of #4842.

# Rationale for this change

Issue #4842 tracks adding user defined metadata support for various services. This PR implements user metadata support for the `fs` service using extended attributes (xattr) on Unix systems.

# What changes are included in this PR?

- Add `xattr` crate dependency for Unix platforms
- Enable `write_with_user_metadata` capability in the fs backend
- Implement `get_user_metadata()` and `set_user_metadata()` methods using xattr
- Update `FsWriter` to store and write user metadata when closing files
- Update `fs_stat()` to read user metadata from xattr

User metadata is stored as extended attributes with the prefix `user.opendal.` on the filesystem.

# Are there any user-facing changes?

Yes. Users can now use `op.write_with("path", data).user_metadata(metadata)` to store custom metadata with files on the `fs` service (Unix only).

# AI Usage Statement

This PR was developed with assistance from GitHub Copilot using Claude Opus 4.5.