### PR TITLE
refactor(services/webdav): split webdav service into separate crate

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -5603,6 +5603,7 @@ dependencies = [
  "opendal-service-tikv",
  "opendal-service-upyun",
  "opendal-service-vercel-blob",
+ "opendal-service-webdav",
  "opendal-service-yandex-disk",
  "opendal-testkit",
  "opentelemetry",
@@ -6648,6 +6649,22 @@ dependencies = [
  "quick-xml",
  "serde",
  "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "opendal-service-webdav"
+version = "0.55.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "ctor",
+ "http 1.4.0",
+ "log",
+ "mea",
+ "opendal-core",
+ "quick-xml",
+ "serde",
  "tokio",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -171,7 +171,7 @@ services-tikv = ["dep:opendal-service-tikv"]
 services-upyun = ["dep:opendal-service-upyun"]
 services-vercel-artifacts = ["opendal-core/services-vercel-artifacts"]
 services-vercel-blob = ["dep:opendal-service-vercel-blob"]
-services-webdav = ["opendal-core/services-webdav"]
+services-webdav = ["dep:opendal-service-webdav"]
 services-webhdfs = ["opendal-core/services-webhdfs"]
 services-yandex-disk = ["dep:opendal-service-yandex-disk"]
 tests = ["opendal-testkit"]
@@ -264,6 +264,7 @@ opendal-service-swift = { path = "services/swift", version = "0.55.0", optional 
 opendal-service-tikv = { path = "services/tikv", version = "0.55.0", optional = true, default-features = false }
 opendal-service-upyun = { path = "services/upyun", version = "0.55.0", optional = true, default-features = false }
 opendal-service-vercel-blob = { path = "services/vercel-blob", version = "0.55.0", optional = true, default-features = false }
+opendal-service-webdav = { path = "services/webdav", version = "0.55.0", optional = true, default-features = false }
 opendal-service-yandex-disk = { path = "services/yandex-disk", version = "0.55.0", optional = true, default-features = false }
 opendal-testkit = { path = "testkit", version = "0.55.0", optional = true }
 

--- a/core/core/Cargo.toml
+++ b/core/core/Cargo.toml
@@ -68,7 +68,6 @@ services-redis-native-tls = ["services-redis", "redis?/tokio-native-tls-comp"]
 services-rocksdb = ["dep:rocksdb", "internal-tokio-rt"]
 services-sftp = ["dep:openssh", "dep:openssh-sftp-client", "dep:fastpool"]
 services-vercel-artifacts = []
-services-webdav = []
 services-webhdfs = []
 
 [lib]

--- a/core/core/src/services/mod.rs
+++ b/core/core/src/services/mod.rs
@@ -64,11 +64,6 @@ mod sftp;
 #[cfg(feature = "services-sftp")]
 pub use sftp::*;
 
-#[cfg(feature = "services-webdav")]
-mod webdav;
-#[cfg(feature = "services-webdav")]
-pub use webdav::*;
-
 #[cfg(feature = "services-webhdfs")]
 mod webhdfs;
 #[cfg(feature = "services-webhdfs")]

--- a/core/services/webdav/Cargo.toml
+++ b/core/services/webdav/Cargo.toml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+description = "Apache OpenDAL Webdav service implementation"
+name = "opendal-service-webdav"
+
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+anyhow = { version = "1.0.100", features = ["std"] }
+bytes = { workspace = true }
+ctor = { workspace = true }
+http = { workspace = true }
+log = { workspace = true }
+mea = "0.5.1"
+opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/webdav/src/backend.rs
+++ b/core/services/webdav/src/backend.rs
@@ -30,8 +30,9 @@ use super::deleter::WebdavDeleter;
 use super::error::parse_error;
 use super::lister::WebdavLister;
 use super::writer::WebdavWriter;
-use crate::raw::*;
-use crate::*;
+use opendal_core::raw::oio;
+use opendal_core::raw::*;
+use opendal_core::*;
 
 /// [WebDAV](https://datatracker.ietf.org/doc/html/rfc4918) backend support.
 #[doc = include_str!("docs.md")]

--- a/core/services/webdav/src/config.rs
+++ b/core/services/webdav/src/config.rs
@@ -52,10 +52,10 @@ impl Debug for WebdavConfig {
     }
 }
 
-impl crate::Configurator for WebdavConfig {
+impl opendal_core::Configurator for WebdavConfig {
     type Builder = WebdavBuilder;
 
-    fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
+    fn from_uri(uri: &opendal_core::OperatorUri) -> opendal_core::Result<Self> {
         let mut map = uri.options().clone();
         if let Some(authority) = uri.authority() {
             map.insert("endpoint".to_string(), format!("https://{authority}"));
@@ -76,8 +76,8 @@ impl crate::Configurator for WebdavConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Configurator;
-    use crate::types::OperatorUri;
+    use opendal_core::Configurator;
+    use opendal_core::OperatorUri;
 
     #[test]
     fn from_uri_sets_endpoint_and_root() {

--- a/core/services/webdav/src/core.rs
+++ b/core/services/webdav/src/core.rs
@@ -27,8 +27,8 @@ use http::header;
 use serde::Deserialize;
 
 use super::error::parse_error;
-use crate::raw::*;
-use crate::*;
+use opendal_core::raw::*;
+use opendal_core::*;
 
 /// The request to query all properties of a file or directory.
 ///

--- a/core/services/webdav/src/deleter.rs
+++ b/core/services/webdav/src/deleter.rs
@@ -15,23 +15,34 @@
 // specific language governing permissions and limitations
 // under the License.
 
-/// Default scheme for webdav service.
-pub const WEBDAV_SCHEME: &str = "webdav";
+use std::sync::Arc;
 
-use crate::types::DEFAULT_OPERATOR_REGISTRY;
+use http::StatusCode;
 
-mod backend;
-mod config;
-mod core;
-mod deleter;
-mod error;
-mod lister;
-mod writer;
+use super::core::*;
+use super::error::parse_error;
+use opendal_core::raw::oio;
+use opendal_core::raw::*;
+use opendal_core::*;
 
-pub use backend::WebdavBuilder as Webdav;
-pub use config::WebdavConfig;
+pub struct WebdavDeleter {
+    core: Arc<WebdavCore>,
+}
 
-#[ctor::ctor]
-fn register_webdav_service() {
-    DEFAULT_OPERATOR_REGISTRY.register::<Webdav>(WEBDAV_SCHEME);
+impl WebdavDeleter {
+    pub fn new(core: Arc<WebdavCore>) -> Self {
+        Self { core }
+    }
+}
+
+impl oio::OneShotDelete for WebdavDeleter {
+    async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
+        let resp = self.core.webdav_delete(&path).await?;
+
+        let status = resp.status();
+        match status {
+            StatusCode::NO_CONTENT | StatusCode::NOT_FOUND => Ok(()),
+            _ => Err(parse_error(resp)),
+        }
+    }
 }

--- a/core/services/webdav/src/docs.md
+++ b/core/services/webdav/src/docs.md
@@ -30,7 +30,7 @@ You can refer to [`WebdavBuilder`]'s docs for more information
 
 ```rust,no_run
 use anyhow::Result;
-use opendal_core::services::Webdav;
+use opendal_service_webdav::Webdav;
 use opendal_core::Operator;
 
 #[tokio::main]

--- a/core/services/webdav/src/error.rs
+++ b/core/services/webdav/src/error.rs
@@ -18,8 +18,8 @@
 use http::Response;
 use http::StatusCode;
 
-use crate::raw::*;
-use crate::*;
+use opendal_core::raw::*;
+use opendal_core::*;
 
 /// Parse error response into Error.
 pub(super) fn parse_error(resp: Response<Buffer>) -> Error {

--- a/core/services/webdav/src/lib.rs
+++ b/core/services/webdav/src/lib.rs
@@ -15,33 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
+/// Default scheme for webdav service.
+pub const WEBDAV_SCHEME: &str = "webdav";
 
-use http::StatusCode;
+use opendal_core::DEFAULT_OPERATOR_REGISTRY;
 
-use super::core::*;
-use super::error::parse_error;
-use crate::raw::*;
-use crate::*;
+mod backend;
+mod config;
+mod core;
+mod deleter;
+mod error;
+mod lister;
+mod writer;
 
-pub struct WebdavDeleter {
-    core: Arc<WebdavCore>,
-}
+pub use backend::WebdavBuilder as Webdav;
+pub use config::WebdavConfig;
 
-impl WebdavDeleter {
-    pub fn new(core: Arc<WebdavCore>) -> Self {
-        Self { core }
-    }
-}
-
-impl oio::OneShotDelete for WebdavDeleter {
-    async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let resp = self.core.webdav_delete(&path).await?;
-
-        let status = resp.status();
-        match status {
-            StatusCode::NO_CONTENT | StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
-        }
-    }
+#[ctor::ctor]
+fn register_webdav_service() {
+    DEFAULT_OPERATOR_REGISTRY.register::<Webdav>(WEBDAV_SCHEME);
 }

--- a/core/services/webdav/src/lister.rs
+++ b/core/services/webdav/src/lister.rs
@@ -21,8 +21,9 @@ use http::StatusCode;
 
 use super::core::*;
 use super::error::*;
-use crate::raw::*;
-use crate::*;
+use opendal_core::raw::oio;
+use opendal_core::raw::*;
+use opendal_core::*;
 
 pub struct WebdavLister {
     core: Arc<WebdavCore>,

--- a/core/services/webdav/src/writer.rs
+++ b/core/services/webdav/src/writer.rs
@@ -21,8 +21,8 @@ use http::StatusCode;
 
 use super::core::*;
 use super::error::parse_error;
-use crate::raw::*;
-use crate::*;
+use opendal_core::raw::*;
+use opendal_core::*;
 
 pub struct WebdavWriter {
     core: Arc<WebdavCore>,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -128,6 +128,8 @@ pub mod services {
     pub use opendal_service_upyun::*;
     #[cfg(feature = "services-vercel-blob")]
     pub use opendal_service_vercel_blob::*;
+    #[cfg(feature = "services-webdav")]
+    pub use opendal_service_webdav::*;
     #[cfg(feature = "services-yandex-disk")]
     pub use opendal_service_yandex_disk::*;
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6930 

# Rationale for this change

Relates to #6829 

# What changes are included in this PR?

This PR extracts the webdav service implementation from `opendal-core` into a standalone crate `opendal-service-webdav`, while keeping the public
   surface `opendal::services::Webdav` unchanged.
- Keeps feature flag `services-webdav` intact.
- Moves webdav-specific dependencies (anyhow, mea, quick-xml with serialization features) to the new service crate.
- Removed the old in-tree webdav service module + its feature/deps from `opendal-core`.

# Are there any user-facing changes?

No. The public API `opendal::services::Webdav` remains unchanged and accessible via the `services-webdav` feature flag.

# AI Usage Statement

None AI was used for the task
