### PR TITLE
fix(services/gdrive): ensure directory paths end with trailing slash

### DIFF
--- a/core/services/gdrive/src/lister.rs
+++ b/core/services/gdrive/src/lister.rs
@@ -69,7 +69,13 @@ impl oio::PageList for GdriveLister {
 
         // Include the current directory itself when handling the first page of the listing.
         if ctx.token.is_empty() && !ctx.done {
-            let path = build_rel_path(&self.core.root, &self.path);
+            // Ensure directory path ends with / for proper EntryMode::DIR
+            let dir_path = if self.path.ends_with('/') {
+                self.path.clone()
+            } else {
+                format!("{}/", self.path)
+            };
+            let path = build_rel_path(&self.core.root, &dir_path);
             let e = oio::Entry::new(&path, Metadata::new(EntryMode::DIR));
             ctx.entries.push_back(e);
         }
@@ -216,7 +222,13 @@ impl GdriveFlatLister {
         };
 
         // Add the root directory entry first
-        let rel_path = build_rel_path(&self.core.root, &self.root_path);
+        // Ensure directory path ends with / for proper EntryMode::DIR
+        let dir_path = if self.root_path.ends_with('/') {
+            self.root_path.clone()
+        } else {
+            format!("{}/", self.root_path)
+        };
+        let rel_path = build_rel_path(&self.core.root, &dir_path);
         let entry = oio::Entry::new(&rel_path, Metadata::new(EntryMode::DIR));
         self.entry_buffer.push_back(entry);
 


### PR DESCRIPTION
## Summary

Fixes the test failures reported in #7059 by ensuring directory paths always end with a trailing `/`.

## Problem

The `debug_assert` in `oio::Entry` requires that paths with `EntryMode::DIR` must end with `/`:
```rust
debug_assert!(
    meta.mode().is_dir() == path.ends_with('/'),
    "mode {:?} not match with path {}",
);
```

Both `GdriveLister` and `GdriveFlatLister` were creating directory entries without ensuring the trailing slash, causing test failures:

- `test_list_prefix`
- `test_list_empty_dir`
- `test_remove_all_basic`
- `test_list_dir_with_file_path`
- `test_list_file_with_recursive`
- `test_list_dir_with_recursive_no_trailing_slash`

## Fix

Added path normalization to ensure directory paths end with `/` before creating `oio::Entry` with `EntryMode::DIR` in both lister implementations.

---

Follow-up fix to #7059 based on @Xuanwo's [test results](https://github.com/apache/opendal/pull/7059#issuecomment-3675536631).