### PR TITLE
feat(services/fs): add `file` as an alias scheme for `fs`

### DIFF
--- a/core/services/fs/src/config.rs
+++ b/core/services/fs/src/config.rs
@@ -63,4 +63,12 @@ mod tests {
         let cfg = FsConfig::from_uri(&uri).unwrap();
         assert_eq!(cfg.root.as_deref(), Some("/tmp/data"));
     }
+
+    #[test]
+    fn from_uri_with_file_scheme() {
+        // "file" is an alias for "fs" to support standard file:// URIs
+        let uri = OperatorUri::new("file:///tmp/data", Vec::<(String, String)>::new()).unwrap();
+        let cfg = FsConfig::from_uri(&uri).unwrap();
+        assert_eq!(cfg.root.as_deref(), Some("/tmp/data"));
+    }
 }

--- a/core/services/fs/src/lib.rs
+++ b/core/services/fs/src/lib.rs
@@ -33,8 +33,12 @@ pub use config::FsConfig;
 
 /// Default scheme for fs service.
 pub const FS_SCHEME: &str = "fs";
+/// Alias scheme for fs service that follows the standard URI scheme.
+pub const FILE_SCHEME: &str = "file";
 
 #[ctor::ctor]
 fn register_fs_service() {
     opendal_core::DEFAULT_OPERATOR_REGISTRY.register::<Fs>(FS_SCHEME);
+    // Register "file" as an alias for "fs" to support standard file:// URIs
+    opendal_core::DEFAULT_OPERATOR_REGISTRY.register::<Fs>(FILE_SCHEME);
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7066.

# Rationale for this change

The recently-added URI feature uses OpenDAL's existing idea of a scheme, which in most cases matches the commonly-used schemes for different services. However, the filesystem service uses the scheme `fs`, while standard file system URIs use the scheme `file`. This is confusing for users who expect to use `file://` URIs.

By adding `file` as an alias for `fs`, users can use the standard URI scheme while maintaining backward compatibility with the existing `fs` scheme.

> Note: I noticed @clbarnes indicated willingness to contribute on this issue. If you're already working on this, please let me know and I'm happy to close this PR.

# What changes are included in this PR?

- Added `FILE_SCHEME` constant (`"file"`) in `core/services/fs/src/lib.rs`
- Registered `file` as an alias for `Fs` service in the operator registry
- Added a test case to verify `file://` URIs work correctly

# Are there any user-facing changes?

Yes. Users can now use the standard `file://` URI scheme to create filesystem operators, in addition to the existing `fs://` scheme. This is fully backward compatible.

```rust
// Both of these now work:
let op1 = Operator::from_uri("fs:///tmp/data")?;
let op2 = Operator::from_uri("file:///tmp/data")?;
```

# AI Usage Statement

This PR was developed with the assistance of Claude (Anthropic).