### PR TITLE
feat(services/mysql): support list

### DIFF
--- a/core/services/mysql/src/backend.rs
+++ b/core/services/mysql/src/backend.rs
@@ -25,6 +25,7 @@ use super::MYSQL_SCHEME;
 use super::config::MysqlConfig;
 use super::core::*;
 use super::deleter::MysqlDeleter;
+use super::lister::MysqlLister;
 use super::writer::MysqlWriter;
 use opendal_core::raw::oio;
 use opendal_core::raw::*;
@@ -164,6 +165,8 @@ impl MysqlBackend {
         info.set_root("/");
         info.set_native_capability(Capability {
             read: true,
+            list: true,
+            list_with_recursive: true,
             stat: true,
             write: true,
             write_can_empty: true,
@@ -189,7 +192,7 @@ impl MysqlBackend {
 impl Access for MysqlBackend {
     type Reader = Buffer;
     type Writer = MysqlWriter;
-    type Lister = ();
+    type Lister = oio::HierarchyLister<MysqlLister>;
     type Deleter = oio::OneShotDeleter<MysqlDeleter>;
 
     fn info(&self) -> Arc<AccessorInfo> {
@@ -231,5 +234,16 @@ impl Access for MysqlBackend {
             RpDelete::default(),
             oio::OneShotDeleter::new(MysqlDeleter::new(self.core.clone(), self.root.clone())),
         ))
+    }
+
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
+        let lister = MysqlLister::new(
+            self.core.clone(),
+            self.root.clone(),
+            path.to_string(),
+        )
+        .await?;
+        let lister = oio::HierarchyLister::new(lister, path, args.recursive());
+        Ok((RpList::default(), lister))
     }
 }

--- a/core/services/mysql/src/backend.rs
+++ b/core/services/mysql/src/backend.rs
@@ -237,12 +237,8 @@ impl Access for MysqlBackend {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
-        let lister = MysqlLister::new(
-            self.core.clone(),
-            self.root.clone(),
-            path.to_string(),
-        )
-        .await?;
+        let lister =
+            MysqlLister::new(self.core.clone(), self.root.clone(), path.to_string()).await?;
         let lister = oio::HierarchyLister::new(lister, path, args.recursive());
         Ok((RpList::default(), lister))
     }

--- a/core/services/mysql/src/core.rs
+++ b/core/services/mysql/src/core.rs
@@ -93,12 +93,12 @@ impl MysqlCore {
         let pool = self.get_client().await?;
 
         let mut sql = format!(
-            "SELECT `{}` FROM `{}` WHERE `{}` LIKE ? ESCAPE '{}'",
-            self.key_field, self.table, self.key_field, ESCAPE_CHAR
+            "SELECT `{}` FROM `{}` WHERE `{}` LIKE ? ESCAPE '\'",
+            self.key_field, self.table, self.key_field
         );
         sql.push_str(&format!(" ORDER BY `{}`", self.key_field));
 
-        let escaped = escape_like(path);
+        let escaped = escape_like(path, '\\');
         sqlx::query_scalar(&sql)
             .bind(format!("{escaped}%"))
             .fetch_all(pool)
@@ -107,18 +107,17 @@ impl MysqlCore {
     }
 }
 
-const ESCAPE_CHAR: char = '\\';
-
-fn escape_like(s: &str) -> String {
+/// Escape a string for use in SQL `LIKE ... ESCAPE <escape_char>` pattern.
+fn escape_like(s: &str, escape_char: char) -> String {
     let mut out = String::with_capacity(s.len());
     for ch in s.chars() {
         match ch {
-            c if c == ESCAPE_CHAR => {
-                out.push(ESCAPE_CHAR);
-                out.push(ESCAPE_CHAR);
+            c if c == escape_char => {
+                out.push(escape_char);
+                out.push(escape_char);
             }
             '%' | '_' => {
-                out.push(ESCAPE_CHAR);
+                out.push(escape_char);
                 out.push(ch);
             }
             _ => out.push(ch),
@@ -137,21 +136,21 @@ mod tests {
 
     #[test]
     fn test_escape_like_basic() {
-        assert_eq!(escape_like("abc"), "abc");
-        assert_eq!(escape_like("foo"), "foo");
+        assert_eq!(escape_like("abc", '\\'), "abc");
+        assert_eq!(escape_like("foo", '\\'), "foo");
     }
 
     #[test]
     fn test_escape_like_wildcards() {
-        assert_eq!(escape_like("%"), r"\%");
-        assert_eq!(escape_like("_"), r"\_");
-        assert_eq!(escape_like("a%b_c"), r"a\%b\_c");
+        assert_eq!(escape_like("%", '\\'), r"\%");
+        assert_eq!(escape_like("_", '\\'), r"\_");
+        assert_eq!(escape_like("a%b_c", '\\'), r"a\%b\_c");
     }
 
     #[test]
     fn test_escape_like_escape_char() {
-        assert_eq!(escape_like(r"\"), r"\\");
-        assert_eq!(escape_like(r"\%"), r"\\\%");
+        assert_eq!(escape_like(r"\", '\\'), r"\\");
+        assert_eq!(escape_like(r"\%", '\\'), r"\\\%");
     }
 
     #[test]
@@ -159,6 +158,6 @@ mod tests {
         let input = r"foo\%bar_baz%";
         let expected = r"foo\\\%bar\_baz\%";
 
-        assert_eq!(escape_like(input), expected);
+        assert_eq!(escape_like(input, '\\'), expected);
     }
 }

--- a/core/services/mysql/src/docs.md
+++ b/core/services/mysql/src/docs.md
@@ -7,7 +7,7 @@ This service can be used to:
 - [x] read
 - [x] write
 - [x] delete
-- [ ] list
+- [x] list
 - [ ] copy
 - [ ] rename
 - [ ] ~~presign~~

--- a/core/services/mysql/src/lib.rs
+++ b/core/services/mysql/src/lib.rs
@@ -24,6 +24,7 @@ mod backend;
 mod config;
 mod core;
 mod deleter;
+mod lister;
 mod writer;
 
 pub use backend::MysqlBuilder as Mysql;

--- a/core/services/mysql/src/lister.rs
+++ b/core/services/mysql/src/lister.rs
@@ -31,13 +31,8 @@ pub struct MysqlLister {
 }
 
 impl MysqlLister {
-    pub async fn new(
-        core: Arc<MysqlCore>,
-        root: String,
-        path: String,
-    ) -> Result<Self> {
+    pub async fn new(core: Arc<MysqlCore>, root: String, path: String) -> Result<Self> {
         let entries = core.list(&build_abs_path(&root, &path)).await?;
-
         Ok(Self {
             root,
             iter: entries.into_iter(),

--- a/core/services/mysql/src/lister.rs
+++ b/core/services/mysql/src/lister.rs
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+use std::vec::IntoIter;
+
+use opendal_core::Result;
+use opendal_core::raw::oio::{Entry, List};
+use opendal_core::raw::{build_abs_path, build_rel_path};
+use opendal_core::{EntryMode, Metadata};
+
+use super::core::MysqlCore;
+
+pub struct MysqlLister {
+    root: String,
+    iter: IntoIter<String>,
+}
+
+impl MysqlLister {
+    pub async fn new(
+        core: Arc<MysqlCore>,
+        root: String,
+        path: String,
+    ) -> Result<Self> {
+        let entries = core.list(&build_abs_path(&root, &path)).await?;
+
+        Ok(Self {
+            root,
+            iter: entries.into_iter(),
+        })
+    }
+}
+
+impl List for MysqlLister {
+    async fn next(&mut self) -> Result<Option<Entry>> {
+        if let Some(key) = self.iter.next() {
+            let mut path = build_rel_path(&self.root, &key);
+            if path.is_empty() {
+                path = "/".to_string();
+            }
+            let meta = Metadata::new(EntryMode::from_path(&path));
+            return Ok(Some(Entry::new(&path, meta)));
+        }
+        Ok(None)
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->


# Rationale for this change

- Support list for services/mysql.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

- Added a `list` method to `MysqlCore` that fetches keys matching a given path via SQL query.
- Added `MysqlLister` struct which implements the `List` trait.
- Declared list capabilities in `MysqlBackend`.
- Updated MySQL service docs to mark list as supported.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

- Yes. MySQL services now support list (including `list_with_recursive`) operations. Other list-related capabilities remain unimplemented, include `list_with_limit`, `list_with_start_after`, `list_with_versions`, `list_with_deleted` etc.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
