### PR TITLE
refactor(layers/dtrace): split dtrace layer into separate crate

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -5539,6 +5539,7 @@ dependencies = [
  "opendal-layer-capability-check",
  "opendal-layer-chaos",
  "opendal-layer-concurrent-limit",
+ "opendal-layer-dtrace",
  "opendal-layer-fastmetrics",
  "opendal-layer-fastrace",
  "opendal-layer-immutable-index",
@@ -5677,7 +5678,6 @@ dependencies = [
  "mongodb-internal-macros",
  "percent-encoding",
  "pretty_assertions",
- "probe",
  "quick-xml",
  "rand 0.8.5",
  "redis",
@@ -5771,6 +5771,15 @@ dependencies = [
  "http 1.4.0",
  "mea",
  "opendal-core",
+]
+
+[[package]]
+name = "opendal-layer-dtrace"
+version = "0.55.0"
+dependencies = [
+ "bytes",
+ "opendal-core",
+ "probe",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -96,7 +96,7 @@ layers-await-tree = ["dep:opendal-layer-await-tree"]
 layers-capability-check = ["dep:opendal-layer-capability-check"]
 layers-chaos = ["dep:opendal-layer-chaos"]
 layers-concurrent-limit = ["dep:opendal-layer-concurrent-limit"]
-layers-dtrace = ["opendal-core/layers-dtrace"]
+layers-dtrace = ["dep:opendal-layer-dtrace"]
 layers-fastmetrics = ["dep:opendal-layer-fastmetrics"]
 layers-fastrace = ["dep:opendal-layer-fastrace"]
 layers-immutable-index = ["dep:opendal-layer-immutable-index"]
@@ -203,6 +203,7 @@ opendal-layer-await-tree = { path = "layers/await-tree", version = "0.55.0", opt
 opendal-layer-capability-check = { path = "layers/capability-check", version = "0.55.0", optional = true, default-features = false }
 opendal-layer-chaos = { path = "layers/chaos", version = "0.55.0", optional = true, default-features = false }
 opendal-layer-concurrent-limit = { path = "layers/concurrent-limit", version = "0.55.0", optional = true, default-features = false }
+opendal-layer-dtrace = { path = "layers/dtrace", version = "0.55.0", optional = true, default-features = false }
 opendal-layer-fastmetrics = { path = "layers/fastmetrics", version = "0.55.0", optional = true, default-features = false }
 opendal-layer-fastrace = { path = "layers/fastrace", version = "0.55.0", optional = true, default-features = false }
 opendal-layer-immutable-index = { path = "layers/immutable-index", version = "0.55.0", optional = true, default-features = false }

--- a/core/core/Cargo.toml
+++ b/core/core/Cargo.toml
@@ -54,9 +54,6 @@ internal-tokio-rt = ["tokio/rt-multi-thread"]
 # Enable tokio executors support.
 executors-tokio = ["tokio/rt"]
 
-# Enable dtrace support.
-layers-dtrace = ["dep:probe"]
-
 services-memory = []
 services-mongodb = ["dep:mongodb", "dep:mongodb-internal-macros"]
 services-redis = ["dep:redis", "dep:fastpool", "redis?/tokio-rustls-comp"]
@@ -114,10 +111,6 @@ redis = { version = "1.0", features = [
 ], optional = true }
 # for services-rocksdb
 rocksdb = { version = "0.21.0", default-features = false, optional = true }
-
-# Layers
-# for layers-dtrace
-probe = { version = "0.5.1", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 backon = { version = "1.6", features = ["gloo-timers-sleep"] }

--- a/core/core/src/layers/mod.rs
+++ b/core/core/src/layers/mod.rs
@@ -29,11 +29,6 @@ pub(crate) use complete::CompleteLayer;
 mod simulate;
 pub use simulate::SimulateLayer;
 
-#[cfg(all(target_os = "linux", feature = "layers-dtrace"))]
-mod dtrace;
-#[cfg(all(target_os = "linux", feature = "layers-dtrace"))]
-pub use self::dtrace::DtraceLayer;
-
 mod correctness_check;
 pub(crate) use correctness_check::CorrectnessCheckLayer;
 

--- a/core/layers/dtrace/Cargo.toml
+++ b/core/layers/dtrace/Cargo.toml
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+description = "Apache OpenDAL dtrace layer"
+name = "opendal-layer-dtrace"
+
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+bytes = { workspace = true }
+opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+probe = { version = "0.5.1" }
+
+[dev-dependencies]
+opendal-core = { path = "../../core", version = "0.55.0" }

--- a/core/layers/dtrace/src/lib.rs
+++ b/core/layers/dtrace/src/lib.rs
@@ -22,9 +22,9 @@ use std::fmt::Formatter;
 use bytes::Buf;
 use probe::probe_lazy;
 
-use crate::raw::Access;
-use crate::raw::*;
-use crate::*;
+use opendal_core::raw::Access;
+use opendal_core::raw::*;
+use opendal_core::*;
 
 /// Support User Statically-Defined Tracing(aka USDT) on Linux
 ///

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -159,6 +159,8 @@ pub mod layers {
     pub use opendal_layer_chaos::*;
     #[cfg(feature = "layers-concurrent-limit")]
     pub use opendal_layer_concurrent_limit::*;
+    #[cfg(all(target_os = "linux", feature = "layers-dtrace"))]
+    pub use opendal_layer_dtrace::*;
     #[cfg(feature = "layers-fastmetrics")]
     pub use opendal_layer_fastmetrics::*;
     #[cfg(feature = "layers-fastrace")]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6935

# Rationale for this change

Relates to #6829

# What changes are included in this PR?

This PR extracts the dtrace layer implementation from `opendal-core` into a standalone crate `opendal-layer-dtrace`, while keeping the public surface `opendal::layers::DtraceLayer` unchanged.

- Keeps feature flag `layers-dtrace` intact.
- Moves dtrace-specific dependency (`probe`) to the new layer crate.
- Removed the old in-tree dtrace layer module and its feature/deps from `opendal-core`.

# Are there any user-facing changes?

No user-facing changes. The public API `opendal::layers::DtraceLayer` remains unchanged.

# AI Usage Statement

No AI has been used
