### PR TITLE
refactor(services/mongodb): split mongodb service into separate crate

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -5589,6 +5589,7 @@ dependencies = [
  "opendal-service-memcached",
  "opendal-service-mini-moka",
  "opendal-service-moka",
+ "opendal-service-mongodb",
  "opendal-service-monoiofs",
  "opendal-service-mysql",
  "opendal-service-obs",
@@ -5673,8 +5674,6 @@ dependencies = [
  "md-5",
  "mea",
  "moka",
- "mongodb",
- "mongodb-internal-macros",
  "percent-encoding",
  "pretty_assertions",
  "probe",
@@ -6431,6 +6430,19 @@ dependencies = [
  "ctor",
  "log",
  "moka",
+ "opendal-core",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "opendal-service-mongodb"
+version = "0.55.0"
+dependencies = [
+ "anyhow",
+ "ctor",
+ "mea",
+ "mongodb",
  "opendal-core",
  "serde",
  "tokio",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -148,7 +148,7 @@ services-memcached = ["dep:opendal-service-memcached"]
 services-memory = ["opendal-core/services-memory"]
 services-mini-moka = ["dep:opendal-service-mini-moka"]
 services-moka = ["dep:opendal-service-moka"]
-services-mongodb = ["opendal-core/services-mongodb"]
+services-mongodb = ["dep:opendal-service-mongodb"]
 services-monoiofs = ["dep:opendal-service-monoiofs"]
 services-mysql = ["dep:opendal-service-mysql"]
 services-obs = ["dep:opendal-service-obs"]
@@ -253,6 +253,7 @@ opendal-service-lakefs = { path = "services/lakefs", version = "0.55.0", optiona
 opendal-service-memcached = { path = "services/memcached", version = "0.55.0", optional = true, default-features = false }
 opendal-service-mini-moka = { path = "services/mini_moka", version = "0.55.0", optional = true, default-features = false }
 opendal-service-moka = { path = "services/moka", version = "0.55.0", optional = true, default-features = false }
+opendal-service-mongodb = { path = "services/mongodb", version = "0.55.0", optional = true, default-features = false }
 opendal-service-monoiofs = { path = "services/monoiofs", version = "0.55.0", optional = true, default-features = false }
 opendal-service-mysql = { path = "services/mysql", version = "0.55.0", optional = true, default-features = false }
 opendal-service-obs = { path = "services/obs", version = "0.55.0", optional = true, default-features = false }

--- a/core/core/Cargo.toml
+++ b/core/core/Cargo.toml
@@ -58,7 +58,6 @@ executors-tokio = ["tokio/rt"]
 layers-dtrace = ["dep:probe"]
 
 services-memory = []
-services-mongodb = ["dep:mongodb", "dep:mongodb-internal-macros"]
 services-redis = ["dep:redis", "dep:fastpool", "redis?/tokio-rustls-comp"]
 services-redis-native-tls = ["services-redis", "redis?/tokio-native-tls-comp"]
 services-rocksdb = ["dep:rocksdb", "internal-tokio-rt"]
@@ -103,9 +102,6 @@ reqsign = { workspace = true, features = ["reqwest_request"], optional = true }
 
 # for services-moka
 moka = { version = "0.12", optional = true, features = ["future", "sync"] }
-# for services-mongodb
-mongodb = { version = "3.3.0", optional = true }
-mongodb-internal-macros = { version = "3.2.4", optional = true }
 # for services-redis
 redis = { version = "1.0", features = [
   "cluster-async",

--- a/core/core/src/services/mod.rs
+++ b/core/core/src/services/mod.rs
@@ -24,11 +24,6 @@ mod memory;
 #[cfg(feature = "services-memory")]
 pub use self::memory::*;
 
-#[cfg(feature = "services-mongodb")]
-mod mongodb;
-#[cfg(feature = "services-mongodb")]
-pub use self::mongodb::*;
-
 #[cfg(feature = "services-redis")]
 mod redis;
 #[cfg(feature = "services-redis")]

--- a/core/services/mongodb/Cargo.toml
+++ b/core/services/mongodb/Cargo.toml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+description = "Apache OpenDAL Mongodb service implementation"
+name = "opendal-service-mongodb"
+
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+ctor = { workspace = true }
+mea = "0.5.1"
+mongodb = { version = "3.3.0" }
+opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+anyhow = { version = "1.0.100", features = ["std"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/mongodb/src/backend.rs
+++ b/core/services/mongodb/src/backend.rs
@@ -24,8 +24,8 @@ use super::config::MongodbConfig;
 use super::core::*;
 use super::deleter::MongodbDeleter;
 use super::writer::MongodbWriter;
-use crate::raw::*;
-use crate::*;
+use opendal_core::raw::*;
+use opendal_core::*;
 
 #[doc = include_str!("docs.md")]
 #[derive(Debug, Default)]

--- a/core/services/mongodb/src/config.rs
+++ b/core/services/mongodb/src/config.rs
@@ -53,10 +53,10 @@ impl Debug for MongodbConfig {
     }
 }
 
-impl crate::Configurator for MongodbConfig {
+impl opendal_core::Configurator for MongodbConfig {
     type Builder = MongodbBuilder;
 
-    fn from_uri(uri: &crate::types::OperatorUri) -> crate::Result<Self> {
+    fn from_uri(uri: &opendal_core::OperatorUri) -> opendal_core::Result<Self> {
         let mut map = uri.options().clone();
 
         if let Some(authority) = uri.authority() {
@@ -98,8 +98,8 @@ impl crate::Configurator for MongodbConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Configurator;
-    use crate::types::OperatorUri;
+    use opendal_core::Configurator;
+    use opendal_core::OperatorUri;
 
     #[test]
     fn from_uri_sets_connection_string_database_collection_and_root() {

--- a/core/services/mongodb/src/core.rs
+++ b/core/services/mongodb/src/core.rs
@@ -23,7 +23,7 @@ use mongodb::bson::Document;
 use mongodb::bson::doc;
 use mongodb::options::ClientOptions;
 
-use crate::*;
+use opendal_core::*;
 
 #[derive(Clone)]
 pub struct MongodbCore {

--- a/core/services/mongodb/src/deleter.rs
+++ b/core/services/mongodb/src/deleter.rs
@@ -18,9 +18,9 @@
 use std::sync::Arc;
 
 use super::core::*;
-use crate::raw::oio;
-use crate::raw::*;
-use crate::*;
+use opendal_core::raw::oio;
+use opendal_core::raw::*;
+use opendal_core::*;
 
 pub struct MongodbDeleter {
     core: Arc<MongodbCore>,

--- a/core/services/mongodb/src/docs.md
+++ b/core/services/mongodb/src/docs.md
@@ -27,7 +27,7 @@ This service can be used to:
 
 ```rust,no_run
 use anyhow::Result;
-use opendal_core::services::Mongodb;
+use opendal_service_mongodb::Mongodb;
 use opendal_core::Operator;
 
 #[tokio::main]

--- a/core/services/mongodb/src/lib.rs
+++ b/core/services/mongodb/src/lib.rs
@@ -18,7 +18,7 @@
 /// Default scheme for mongodb service.
 pub const MONGODB_SCHEME: &str = "mongodb";
 
-use crate::types::DEFAULT_OPERATOR_REGISTRY;
+use opendal_core::DEFAULT_OPERATOR_REGISTRY;
 
 mod backend;
 mod config;

--- a/core/services/mongodb/src/writer.rs
+++ b/core/services/mongodb/src/writer.rs
@@ -18,8 +18,8 @@
 use std::sync::Arc;
 
 use super::core::*;
-use crate::raw::oio;
-use crate::*;
+use opendal_core::raw::oio;
+use opendal_core::*;
 
 pub struct MongodbWriter {
     core: Arc<MongodbCore>,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -98,6 +98,8 @@ pub mod services {
     pub use opendal_service_mini_moka::*;
     #[cfg(feature = "services-moka")]
     pub use opendal_service_moka::*;
+    #[cfg(feature = "services-mongodb")]
+    pub use opendal_service_mongodb::*;
     #[cfg(feature = "services-monoiofs")]
     pub use opendal_service_monoiofs::*;
     #[cfg(feature = "services-mysql")]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6908

# Rationale for this change

Relates to #6829

# What changes are included in this PR?

This PR extracts the mongodb service implementation from `opendal-core` into a standalone crate `opendal-service-mongodb`, while keeping the public surface `opendal::services::Mongodb` unchanged.

 - Keeps feature flag `services-mongodb` intact.
 - Moves mongodb-specific dependencies to the new service crate.
 - Removed the old in-tree mongodb service module + its feature/deps from `opendal-core`.

# Are there any user-facing changes?

 No. The public API remains unchanged.

# AI Usage Statement

No AI has been used
