### PR TITLE
chore: no need Error::map method

### DIFF
--- a/core/core/src/types/error.rs
+++ b/core/core/src/types/error.rs
@@ -368,14 +368,6 @@ impl Error {
         self
     }
 
-    /// Operate on error with map.
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: FnOnce(Self) -> Self,
-    {
-        f(self)
-    }
-
     /// Set permanent status for error.
     ///
     /// By set permanent, we indicate the retry must be stopped.

--- a/core/services/ghac/src/core.rs
+++ b/core/services/ghac/src/core.rs
@@ -243,9 +243,7 @@ impl GhacCore {
                         .map_err(new_json_deserialize_error)?;
                     reserve_resp.cache_id
                 } else {
-                    return Err(
-                        parse_error(resp).map(|err| err.with_operation("Backend::ghac_reserve"))
-                    );
+                    return Err(parse_error(resp).with_operation("Backend::ghac_reserve"));
                 };
 
                 let url = format!("{}{CACHE_URL_BASE}/caches/{cache_id}", self.cache_url);

--- a/core/services/ghac/src/writer.rs
+++ b/core/services/ghac/src/writer.rs
@@ -165,7 +165,7 @@ impl oio::Write for GhacWriterV1 {
 
         let resp = self.core.ghac_v1_write(&self.url, size, offset, bs).await?;
         if !resp.status().is_success() {
-            return Err(parse_error(resp).map(|err| err.with_operation("Backend::ghac_upload")));
+            return Err(parse_error(resp).with_operation("Backend::ghac_upload"));
         }
         self.size += size;
         Ok(())


### PR DESCRIPTION
Looks redundant.