### PR TITLE
ci: skip azurite's version check

### DIFF
--- a/fixtures/azblob/docker-compose-azurite.yml
+++ b/fixtures/azblob/docker-compose-azurite.yml
@@ -20,3 +20,4 @@ services:
     image: mcr.microsoft.com/azure-storage/azurite
     ports:
       - 10000:10000
+    command: ["azurite", "--blobHost", "0.0.0.0", "--skipApiVersionCheck"]


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
The Azurite-based behavior tests keep failing with the error "The API version 2026-02-06 is not supported by Azurite. Please upgrade Azurite to latest version and retry"(https://github.com/apache/opendal/actions/runs/21290589051/job/61282854116?pr=7157). However, the latest version of Azurite still doesn't support API version 2026-02-26(https://github.com/Azure/Azurite/issues/2623). As a result, we need to skip the version check.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->

Github Copilot with GPT-5.2
