### PR TITLE
test(core): remove assert_size tests

### DIFF
--- a/core/core/src/lib.rs
+++ b/core/core/src/lib.rs
@@ -173,21 +173,7 @@ pub mod services;
 
 #[cfg(test)]
 mod tests {
-    use std::mem::size_of;
-
     use super::*;
-    /// This is not a real test case.
-    ///
-    /// We assert our public structs here to make sure we don't introduce
-    /// unexpected struct/enum size change.
-    #[cfg(target_pointer_width = "64")]
-    #[test]
-    fn assert_size() {
-        assert_eq!(16, size_of::<Operator>());
-        assert_eq!(360, size_of::<Entry>());
-        assert_eq!(336, size_of::<Metadata>());
-        assert_eq!(1, size_of::<EntryMode>());
-    }
 
     trait AssertSendSync: Send + Sync {}
     impl AssertSendSync for Entry {}

--- a/core/core/src/types/error.rs
+++ b/core/core/src/types/error.rs
@@ -507,7 +507,6 @@ impl From<Error> for io::Error {
 
 #[cfg(test)]
 mod tests {
-    use std::mem::size_of;
     use std::sync::LazyLock;
 
     use anyhow::anyhow;
@@ -527,16 +526,6 @@ mod tests {
         source: Some(anyhow!("networking error")),
         backtrace: None,
     });
-
-    /// This is not a real test case.
-    ///
-    /// We assert our public structs here to make sure we don't introduce
-    /// unexpected struct/enum size change.
-    #[cfg(target_pointer_width = "64")]
-    #[test]
-    fn assert_size() {
-        assert_eq!(88, size_of::<Error>());
-    }
 
     #[test]
     fn test_error_display() {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7158.

# Rationale for this change

`assert_size` was intended as a development-only guard, but hard-coded struct sizes can legitimately vary across toolchains/platforms. This makes downstream packaging (e.g. Fedora) fail without any impact on correctness or user-facing behavior.

# What changes are included in this PR?

- Remove `tests::assert_size` from `opendal-core` crate root.
- Remove `types::error::tests::assert_size`.

# Are there any user-facing changes?

No.

# How was this tested?

- `cd core && cargo fmt`
- `cd core && cargo test --lib`
- `cd core && cargo clippy --all-targets --all-features -- -D warnings`

# AI Usage Statement

This PR was authored with assistance from OpenAI Codex CLI (GPT-5.2).
