### PR TITLE
feat(webdav): disable_create_dir for servers without PROPFIND

### DIFF
--- a/core/services/webdav/src/config.rs
+++ b/core/services/webdav/src/config.rs
@@ -39,6 +39,17 @@ pub struct WebdavConfig {
     pub root: Option<String>,
     /// WebDAV Service doesn't support copy.
     pub disable_copy: bool,
+    /// Disable automatic parent directory creation before write operations.
+    ///
+    /// By default, OpenDAL creates parent directories using MKCOL before writing files.
+    /// This requires PROPFIND support to check directory existence.
+    ///
+    /// Some WebDAV-compatible servers (e.g., bazel-remote) don't support PROPFIND
+    /// or don't require explicit directory creation. Enable this option to skip
+    /// the MKCOL calls and write files directly.
+    ///
+    /// Default: false
+    pub disable_create_dir: bool,
     /// Enable user metadata support via WebDAV PROPPATCH.
     ///
     /// This feature requires the WebDAV server to support RFC4918 PROPPATCH method.
@@ -71,6 +82,7 @@ impl Debug for WebdavConfig {
             .field("username", &self.username)
             .field("root", &self.root)
             .field("disable_copy", &self.disable_copy)
+            .field("disable_create_dir", &self.disable_create_dir)
             .field("enable_user_metadata", &self.enable_user_metadata)
             .field("user_metadata_prefix", &self.user_metadata_prefix)
             .field("user_metadata_uri", &self.user_metadata_uri)
@@ -143,5 +155,17 @@ mod tests {
 
         let cfg = WebdavConfig::from_uri(&uri).unwrap();
         assert!(cfg.disable_copy);
+    }
+
+    #[test]
+    fn from_uri_propagates_disable_create_dir() {
+        let uri = OperatorUri::new(
+            "webdav://dav.example.com",
+            vec![("disable_create_dir".to_string(), "true".to_string())],
+        )
+        .unwrap();
+
+        let cfg = WebdavConfig::from_uri(&uri).unwrap();
+        assert!(cfg.disable_create_dir);
     }
 }

--- a/core/services/webdav/src/core.rs
+++ b/core/services/webdav/src/core.rs
@@ -93,6 +93,8 @@ pub struct WebdavCore {
     pub user_metadata_prefix: String,
     /// XML namespace URI for user metadata properties.
     pub user_metadata_uri: String,
+    /// Skip automatic parent directory creation before writes.
+    pub disable_create_dir: bool,
 }
 
 impl Debug for WebdavCore {
@@ -102,6 +104,7 @@ impl Debug for WebdavCore {
             .field("root", &self.root)
             .field("user_metadata_prefix", &self.user_metadata_prefix)
             .field("user_metadata_uri", &self.user_metadata_uri)
+            .field("disable_create_dir", &self.disable_create_dir)
             .finish_non_exhaustive()
     }
 }


### PR DESCRIPTION
Some WebDAV-compatible servers like bazel-remote don't implement the
full WebDAV protocol. Specifically, they don't support the PROPFIND
method and don't require explicit directory creation before writing
files.

Currently, OpenDAL's WebDAV `write()` always calls `webdav_mkcol()`
before writing to ensure parent directories exist. This uses PROPFIND
to check directory existence, which fails on servers that don't
support it. For example, bazel-remote returns `405 Method Not Allowed.

This adds a new `disable_create_dir` configuration option that skips
the automatic parent directory creation in write operations.

* Builder API:
  ```rust
  let op = Webdav::default()
      .endpoint("http://bazel-remote:8080")
      .disable_create_dir(true)
      .build()?;
  ```

* Via URI:
  ```
  webdav://bazel-remote:8080?disable_create_dir=true
  ```

* Environment variable:
  ```
  OPENDAL_WEBDAV_DISABLE_CREATE_DIR=true
  ```

cc <https://github.com/mozilla/sccache/issues/2278>