### PR TITLE
feat(services/azblob): implement "undelete" operation in azblob

### DIFF
--- a/core/core/src/raw/layer.rs
+++ b/core/core/src/raw/layer.rs
@@ -164,6 +164,14 @@ pub trait LayeredAccess: Send + Sync + Debug + Unpin + 'static {
 
     fn delete(&self) -> impl Future<Output = Result<(RpDelete, Self::Deleter)>> + MaybeSend;
 
+    fn undelete(
+        &self,
+        path: &str,
+        args: OpUndelete,
+    ) -> impl Future<Output = Result<RpUndelete>> + MaybeSend {
+        self.inner().undelete(path, args)
+    }
+
     fn list(
         &self,
         path: &str,
@@ -215,6 +223,10 @@ impl<L: LayeredAccess> Access for L {
 
     async fn delete(&self) -> Result<(RpDelete, Self::Deleter)> {
         LayeredAccess::delete(self).await
+    }
+
+    async fn undelete(&self, path: &str, args: OpUndelete) -> Result<RpUndelete> {
+        LayeredAccess::undelete(self, path, args).await
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {

--- a/core/core/src/raw/operation.rs
+++ b/core/core/src/raw/operation.rs
@@ -45,6 +45,8 @@ pub enum Operation {
     Stat,
     /// Operation to delete files.
     Delete,
+    /// Operation to restore soft-deleted files.
+    Undelete,
     /// Operation to get the next file from the list.
     List,
     /// Operation to generate a presigned URL.
@@ -75,6 +77,7 @@ impl From<Operation> for &'static str {
             Operation::Rename => "rename",
             Operation::Stat => "stat",
             Operation::Delete => "delete",
+            Operation::Undelete => "undelete",
             Operation::List => "list",
             Operation::Presign => "presign",
         }

--- a/core/core/src/raw/ops.rs
+++ b/core/core/src/raw/ops.rs
@@ -99,6 +99,19 @@ impl OpDeleter {
     }
 }
 
+/// Args for `undelete` operation.
+///
+/// The path must be normalized.
+#[derive(Debug, Clone, Default)]
+pub struct OpUndelete {}
+
+impl OpUndelete {
+    /// Create a new `OpUndelete`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 /// Args for `list` operation.
 #[derive(Debug, Clone, Default)]
 pub struct OpList {

--- a/core/core/src/raw/rps.rs
+++ b/core/core/src/raw/rps.rs
@@ -28,6 +28,10 @@ pub struct RpCreateDir {}
 #[derive(Debug, Clone, Default)]
 pub struct RpDelete {}
 
+/// Reply for `undelete` operation
+#[derive(Debug, Clone, Default)]
+pub struct RpUndelete {}
+
 /// Reply for `list` operation.
 #[derive(Debug, Clone, Default)]
 pub struct RpList {}

--- a/core/core/src/types/capability.rs
+++ b/core/core/src/types/capability.rs
@@ -148,6 +148,9 @@ pub struct Capability {
     /// Maximum size supported for single delete operations.
     pub delete_max_size: Option<usize>,
 
+    /// Indicates if undelete (restore) operations are supported for soft-deleted objects.
+    pub undelete: bool,
+
     /// Indicates if copy operations are supported.
     pub copy: bool,
     /// Indicates if conditional copy operations with if-not-exists are supported.

--- a/core/core/src/types/operator/operator.rs
+++ b/core/core/src/types/operator/operator.rs
@@ -1422,6 +1422,34 @@ impl Operator {
         self.delete_with(path).recursive(true).await
     }
 
+    /// Restore a soft-deleted object.
+    ///
+    /// # Notes
+    ///
+    /// - This operation requires soft delete to be enabled on the storage backend.
+    /// - Restoring a non-existent or permanently deleted object will return an error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use anyhow::Result;
+    /// # use opendal_core::Operator;
+    /// #
+    /// # async fn test(op: Operator) -> Result<()> {
+    /// // Delete a file (with soft delete enabled, it's not permanently deleted)
+    /// op.delete("path/to/file").await?;
+    ///
+    /// // Restore the soft-deleted file
+    /// op.undelete("path/to/file").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn undelete(&self, path: &str) -> Result<()> {
+        let path = normalize_path(path);
+        self.inner().undelete(&path, OpUndelete::new()).await?;
+        Ok(())
+    }
+
     /// List entries whose paths start with the given prefix `path`.
     ///
     /// # Semantics

--- a/core/layers/logging/src/lib.rs
+++ b/core/layers/logging/src/lib.rs
@@ -477,6 +477,38 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
             })
     }
 
+    async fn undelete(&self, path: &str, args: OpUndelete) -> Result<RpUndelete> {
+        self.logger.log(
+            &self.info,
+            Operation::Undelete,
+            &[("path", path)],
+            "started",
+            None,
+        );
+
+        self.inner
+            .undelete(path, args)
+            .await
+            .inspect(|_| {
+                self.logger.log(
+                    &self.info,
+                    Operation::Undelete,
+                    &[("path", path)],
+                    "finished",
+                    None,
+                );
+            })
+            .inspect_err(|err| {
+                self.logger.log(
+                    &self.info,
+                    Operation::Undelete,
+                    &[("path", path)],
+                    "failed",
+                    Some(err),
+                );
+            })
+    }
+
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
         self.logger.log(
             &self.info,

--- a/core/layers/timeout/src/lib.rs
+++ b/core/layers/timeout/src/lib.rs
@@ -256,6 +256,11 @@ impl<A: Access> LayeredAccess for TimeoutAccessor<A> {
             .map(|(rp, r)| (rp, TimeoutWrapper::new(r, self.io_timeout)))
     }
 
+    async fn undelete(&self, path: &str, args: OpUndelete) -> Result<RpUndelete> {
+        self.timeout(Operation::Undelete, self.inner.undelete(path, args))
+            .await
+    }
+
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
         self.io_timeout(Operation::List, self.inner.list(path, args))
             .await

--- a/core/services/azblob/src/backend.rs
+++ b/core/services/azblob/src/backend.rs
@@ -237,6 +237,15 @@ impl AzblobBuilder {
         self
     }
 
+    /// Set the soft delete feature for this backend.
+    ///
+    /// If enabled, deleted blobs will be retained for the configured retention period
+    /// and can be listed using list_with_deleted.
+    pub fn enable_soft_deletes(mut self, enabled: bool) -> Self {
+        self.config.enable_soft_deletes = enabled;
+        self
+    }
+
     /// from_connection_string will make a builder from connection string
     ///
     /// connection string looks like:
@@ -402,6 +411,9 @@ impl Builder for AzblobBuilder {
 
                             list: true,
                             list_with_recursive: true,
+                            list_with_deleted: self.config.enable_soft_deletes,
+
+                            undelete: self.config.enable_soft_deletes,
 
                             presign: self.config.sas_token.is_some(),
                             presign_stat: self.config.sas_token.is_some(),
@@ -508,12 +520,24 @@ impl Access for AzblobBackend {
         ))
     }
 
+    async fn undelete(&self, path: &str, _args: OpUndelete) -> Result<RpUndelete> {
+        let resp = self.core.azblob_undelete_blob(path).await?;
+
+        let status = resp.status();
+
+        match status {
+            StatusCode::OK => Ok(RpUndelete::default()),
+            _ => Err(parse_error(resp)),
+        }
+    }
+
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
         let l = AzblobLister::new(
             self.core.clone(),
             path.to_string(),
             args.recursive(),
             args.limit(),
+            args.deleted(),
         );
 
         Ok((RpList::default(), oio::PageLister::new(l)))

--- a/core/services/azblob/src/config.rs
+++ b/core/services/azblob/src/config.rs
@@ -76,6 +76,10 @@ pub struct AzblobConfig {
 
     /// The maximum batch operations of Azblob service backend.
     pub batch_max_operations: Option<usize>,
+
+    /// Enable soft deletes for this storage account.
+    #[serde(default)]
+    pub enable_soft_deletes: bool,
 }
 
 impl Debug for AzblobConfig {
@@ -84,6 +88,7 @@ impl Debug for AzblobConfig {
             .field("root", &self.root)
             .field("container", &self.container)
             .field("endpoint", &self.endpoint)
+            .field("enable_soft_deletes", &self.enable_soft_deletes)
             .finish_non_exhaustive()
     }
 }

--- a/core/services/azblob/src/core.rs
+++ b/core/services/azblob/src/core.rs
@@ -566,6 +566,19 @@ impl AzblobCore {
         self.send(req).await
     }
 
+    pub async fn azblob_undelete_blob(&self, path: &str) -> Result<Response<Buffer>> {
+        let url = format!("{}?comp=undelete", self.build_path_url(path));
+
+        let mut req = Request::put(&url)
+            .header(CONTENT_LENGTH, 0)
+            .extension(Operation::Undelete)
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+
+        self.sign(&mut req).await?;
+        self.send(req).await
+    }
+
     pub async fn azblob_copy_blob(
         &self,
         from: &str,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Subtask of #https://github.com/apache/opendal/issues/4321. This PR also suggests a certain design for currently non-existing undelete API (massively inspired by existing API for `delete` though).

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

I'll add my 2 cents here. Iceberg Rust FileIO is powered by OpenDAL, which makes OpenDAL an important piece of the whole Iceberg infrastructure. There are known bugs in Iceberg causing involuntary file deletion. In order to secure our pipelines, currently our team has to maintain implementations of this logic on several languages. Ideally we would like to have a file restore (and later also full table restore) functionality available downstream.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Core Changes:                                                                                                                                                                 
                                                                                                                                                                                
  1. Added undelete capability to Capability struct (core/src/types/capability.rs)                                                                                              
  2. Created operation structs OpUndelete and RpUndelete (core/src/raw/ops.rs, core/src/raw/rps.rs)                                                                             
  3. Added Operation::Undelete variant (core/src/raw/operation.rs)                                                                                                              
  4. Extended Access trait with undelete method and added to all trait forwarding (core/src/raw/accessor.rs, core/src/raw/layer.rs)                                             
  5. Added public API Operator::undelete() method (core/src/types/operator/operator.rs)                                                                                         
                                                                                                                                                                                
### Layer APIs:                                                                                                                                                        
                                                                                                                                                                                
  1. RetryLayer - Added undelete with retry logic (core/layers/retry/src/lib.rs)                                                                                                
  2. TimeoutLayer - Added undelete with timeout handling (core/layers/timeout/src/lib.rs)                                                                                      
  3. LoggingLayer - Added undelete with logging (core/layers/logging/src/lib.rs) 
  4. ConcurrentLimitLayer - Added undelete with `semaphore.acquire` (core/layers/concurrent-limit/src/lib.rs)

NB: I checked all 20 layers that implement LayeredAccess. The others don't need explicit implementations because:                                                                 
                                                                                                                                                                                
  - Default forwarding works: They rely on the default LayeredAccess::undelete which forwards to self.inner().undelete()                                                        
  - No special behavior: They either:                                                                                                                                           
    - Don't modify simple operations (like throttle, which only affects read/write streaming)                                                                                   
    - Only affect specific operations (like chaos, which only adds errors to reads)                                                                                             
    - Are purely observability layers that use default forwarding   

### Concrete Azure Blob Storage Implementation:                                                                                                                                            
                                                                                                                                                                                
  1. Implemented azblob_undelete_blob in core/services/azblob/src/core.rs using Azure's PUT ?comp=undelete REST API                                                             
  2. Added undelete implementation to AzblobBackend in core/services/azblob/src/backend.rs                                                                                      
  3. Enabled capability when enable_soft_deletes=true in azblob config                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                                     
### Testing:                                                                                                                                                                      
                                                                                                                                                                                
  1. Added test_undelete_file behavior test in core/tests/behavior/async_delete.rs that:                                                                                       
    - Creates a file                                                                                                                                                            
    - Deletes it (soft delete)                                                                                                                                                  
    - Restores it using undelete                                                                                                                                                
    - Verifies the content is intact                                                                                                                                            
    - Exits early for filesystems that don't support undelete (Capability check)                                                                                                                                                                                                                                                                                       

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

New feature: `op.undelete(&file_path)` for Azblob when soft deletes are enabled.

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->

Claude Code with its default model (Claude Sonet)
