### PR TITLE
fix(bindings/python): improve the typing discovering of the python package

### DIFF
--- a/bindings/python/python/opendal/__init__.py
+++ b/bindings/python/python/opendal/__init__.py
@@ -16,19 +16,25 @@
 # under the License.
 
 # ruff: noqa: D104
-import builtins
+from __future__ import annotations
 
-from opendal._opendal import (  # noqa: F403
-    capability,
-    exceptions,
-    file,
-    layers,
-    services,
-    types,
-)
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    __version__: str
+    from opendal import capability, exceptions, file, layers, services, types
+else:
+    from opendal._opendal import (
+        __version__,  # noqa: F401
+        capability,
+        exceptions,
+        file,
+        layers,
+        services,
+        types,
+    )
+
 from opendal.operator import AsyncOperator, Operator  # pyright:ignore
-
-__version__: builtins.str
 
 __all__ = [
     "capability",


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Currently the `opendal` python package exposes top level submodules so users can use it directly without needing to import them separately:

```python
import opendal
opendal.file.File
```
However, due to the fact they are exported by the binding so, the typing info are missing. Because we generate typing stubs *.pyi under the same directory, we need to import them in `__init__.py` as well.

Also, the `__version__` attribute was never imported actually, leading to an AttributeError when accessing `opendal.__version__`.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- improve the typing discovery by importing typing stubs under TYPE_CHECKING guard.
- Expose __version__ attribute correctly.


# Are there any user-facing changes?

Since all changes are typing level and guarded by `if TYPE_CHECKING`, it should not have any impact on runtime behavior.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
