### PR TITLE
Bump libunftp version

### DIFF
--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -28,7 +28,7 @@ version = "0.4.0"
 
 [dependencies]
 async-trait = "0.1.88"
-libunftp = "0.21.0"
+libunftp = "0.22.0"
 opendal = { version = "0.55.0", path = "../../core" }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.7.11", features = ["compat"] }


### PR DESCRIPTION
This modifies  the`unftp-sbe` integration to use the latest [`libunftp`](https://crates.io/crates/libunftp) version.