### PR TITLE
chore(integrations/unftp): use unftp-core

### DIFF
--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -28,13 +28,14 @@ version = "0.4.0"
 
 [dependencies]
 async-trait = "0.1.88"
-libunftp = "0.22.0"
 opendal = { version = "0.55.0", path = "../../core" }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.7.11", features = ["compat"] }
+unftp-core = "0.1.0"
 
 [dev-dependencies]
 anyhow = "1"
+libunftp = "0.23.0"
 opendal = { version = "0.55.0", path = "../../core", features = [
   "services-s3",
 ] }

--- a/integrations/unftp-sbe/src/lib.rs
+++ b/integrations/unftp-sbe/src/lib.rs
@@ -60,9 +60,9 @@
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
-use libunftp::auth::UserDetail;
-use libunftp::storage::{self, Error, StorageBackend};
 use opendal::Operator;
+use unftp_core::auth::UserDetail;
+use unftp_core::storage::{self, Error, StorageBackend};
 
 use tokio::io::AsyncWriteExt;
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};


### PR DESCRIPTION
The latest release of libunftp splits unftp-core off libunftp and requires storage back-ends like this one to depdend on unftp-core.

See https://github.com/bolcom/libunftp/releases/tag/libunftp-0.23.0 and https://github.com/bolcom/libunftp/releases/tag/unftp-core-0.1.0.
