### PR TITLE
fix(services/swift): add missing copy capability flag

### DIFF
--- a/core/services/swift/src/backend.rs
+++ b/core/services/swift/src/backend.rs
@@ -152,6 +152,8 @@ impl Builder for SwiftBuilder {
 
                             delete: true,
 
+                            copy: true,
+
                             list: true,
                             list_with_recursive: true,
 


### PR DESCRIPTION
## Summary
- Fixes #7203
- The Swift backend implements `copy()` but the `Capability` struct is missing `copy: true`, so the operation is rejected by the framework before reaching the implementation

## Test plan
- Existing behavior tests `test_copy` now execute instead of being skipped
- All 101 behavior tests pass against both local SAIO and a real Swift cluster