### PR TITLE
fix(services/swift): forward write headers to Swift API

### DIFF
--- a/core/services/swift/src/backend.rs
+++ b/core/services/swift/src/backend.rs
@@ -148,6 +148,10 @@ impl Builder for SwiftBuilder {
 
                             write: true,
                             write_can_empty: true,
+                            write_with_content_type: true,
+                            write_with_content_disposition: true,
+                            write_with_content_encoding: true,
+                            write_with_cache_control: true,
                             write_with_user_metadata: true,
 
                             delete: true,

--- a/core/services/swift/src/core.rs
+++ b/core/services/swift/src/core.rs
@@ -121,6 +121,19 @@ impl SwiftCore {
 
         let mut req = Request::put(&url);
 
+        if let Some(content_type) = args.content_type() {
+            req = req.header(header::CONTENT_TYPE, content_type);
+        }
+        if let Some(content_disposition) = args.content_disposition() {
+            req = req.header(header::CONTENT_DISPOSITION, content_disposition);
+        }
+        if let Some(content_encoding) = args.content_encoding() {
+            req = req.header(header::CONTENT_ENCODING, content_encoding);
+        }
+        if let Some(cache_control) = args.cache_control() {
+            req = req.header(header::CACHE_CONTROL, cache_control);
+        }
+
         // Set user metadata headers.
         if let Some(user_metadata) = args.user_metadata() {
             for (k, v) in user_metadata {


### PR DESCRIPTION
## Summary
- Fixes #7205
- Forward Content-Type, Content-Disposition, Content-Encoding, and Cache-Control headers from `OpWrite` to Swift's PUT request
- Declare the corresponding `write_with_*` capability flags

## Test plan
- `test_write_with_content_type`, `test_write_with_content_disposition`, `test_write_with_content_encoding`, `test_write_with_cache_control` now execute instead of being silently skipped
- All 93 behavior tests pass against both local SAIO and a real Swift cluster