### PR TITLE
feat(services/swift): add conditional request headers for stat and read

### DIFF
--- a/core/services/swift/src/backend.rs
+++ b/core/services/swift/src/backend.rs
@@ -144,7 +144,16 @@ impl Builder for SwiftBuilder {
                         .set_root(&root)
                         .set_native_capability(Capability {
                             stat: true,
+                            stat_with_if_match: true,
+                            stat_with_if_none_match: true,
+                            stat_with_if_modified_since: true,
+                            stat_with_if_unmodified_since: true,
+
                             read: true,
+                            read_with_if_match: true,
+                            read_with_if_none_match: true,
+                            read_with_if_modified_since: true,
+                            read_with_if_unmodified_since: true,
 
                             write: true,
                             write_can_empty: true,
@@ -186,8 +195,8 @@ impl Access for SwiftBackend {
         self.core.info.clone()
     }
 
-    async fn stat(&self, path: &str, _args: OpStat) -> Result<RpStat> {
-        let resp = self.core.swift_get_metadata(path).await?;
+    async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
+        let resp = self.core.swift_get_metadata(path, &args).await?;
 
         match resp.status() {
             StatusCode::OK | StatusCode::NO_CONTENT => {

--- a/core/services/swift/src/error.rs
+++ b/core/services/swift/src/error.rs
@@ -39,7 +39,9 @@ pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (kind, retryable) = match parts.status {
         StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
         StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
-        StatusCode::PRECONDITION_FAILED => (ErrorKind::ConditionNotMatch, false),
+        StatusCode::NOT_MODIFIED | StatusCode::PRECONDITION_FAILED => {
+            (ErrorKind::ConditionNotMatch, false)
+        }
         StatusCode::INTERNAL_SERVER_ERROR
         | StatusCode::BAD_GATEWAY
         | StatusCode::SERVICE_UNAVAILABLE


### PR DESCRIPTION
## Summary
- Fixes #7207
- Forward If-Match, If-None-Match, If-Modified-Since, If-Unmodified-Since headers on stat and read
- Map HTTP 304 Not Modified to `ConditionNotMatch` error kind
- Note: write conditionals not declared — Swift only supports `If-None-Match: *` on PUT, not specific etag values

## Test plan
- `test_stat_with_if_match`, `test_stat_with_if_none_match`, `test_stat_with_if_modified_since`, `test_stat_with_if_unmodified_since`, `test_read_with_if_match`, `test_read_with_if_none_match`, `test_read_with_if_modified_since`, `test_read_with_if_unmodified_since` now execute instead of being silently skipped
- All 93 behavior tests pass against both local SAIO and a real Swift cluster