### PR TITLE
feat(services/swift): add SLO multipart upload for large objects

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -7051,6 +7051,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/core/core/src/raw/oio/write/multipart_write.rs
+++ b/core/core/src/raw/oio/write/multipart_write.rs
@@ -118,6 +118,8 @@ pub struct MultipartPart {
     pub etag: String,
     /// The checksum of the part.
     pub checksum: Option<String>,
+    /// The size of the part in bytes.
+    pub size: Option<u64>,
 }
 
 struct WriteInput<W: MultipartWrite> {
@@ -391,6 +393,7 @@ mod tests {
                 part_number,
                 etag: "etag".to_string(),
                 checksum: None,
+                size: None,
             })
         }
 

--- a/core/services/b2/src/writer.rs
+++ b/core/services/b2/src/writer.rs
@@ -133,6 +133,7 @@ impl oio::MultipartWrite for B2Writer {
                     etag: result.content_sha1,
                     part_number,
                     checksum: None,
+                    size: None,
                 })
             }
             _ => Err(parse_error(resp)),

--- a/core/services/cos/src/writer.rs
+++ b/core/services/cos/src/writer.rs
@@ -141,6 +141,7 @@ impl oio::MultipartWrite for CosWriter {
                     part_number,
                     etag,
                     checksum: None,
+                    size: None,
                 })
             }
             _ => Err(parse_error(resp)),

--- a/core/services/gcs/src/writer.rs
+++ b/core/services/gcs/src/writer.rs
@@ -119,6 +119,7 @@ impl oio::MultipartWrite for GcsWriter {
             part_number,
             etag,
             checksum: None,
+            size: None,
         })
     }
 

--- a/core/services/obs/src/writer.rs
+++ b/core/services/obs/src/writer.rs
@@ -136,6 +136,7 @@ impl oio::MultipartWrite for ObsWriter {
                     part_number,
                     etag,
                     checksum: None,
+                    size: None,
                 })
             }
             _ => Err(parse_error(resp)),

--- a/core/services/oss/src/writer.rs
+++ b/core/services/oss/src/writer.rs
@@ -138,6 +138,7 @@ impl oio::MultipartWrite for OssWriter {
                     part_number,
                     etag,
                     checksum: None,
+                    size: None,
                 })
             }
             _ => Err(parse_error(resp)),

--- a/core/services/s3/src/writer.rs
+++ b/core/services/s3/src/writer.rs
@@ -143,6 +143,7 @@ impl oio::MultipartWrite for S3Writer {
                     part_number,
                     etag,
                     checksum,
+                    size: None,
                 })
             }
             _ => Err(parse_error(resp)),

--- a/core/services/swift/Cargo.toml
+++ b/core/services/swift/Cargo.toml
@@ -38,6 +38,7 @@ opendal-core = { path = "../../core", version = "0.55.0", default-features = fal
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/upyun/src/writer.rs
+++ b/core/services/upyun/src/writer.rs
@@ -95,6 +95,7 @@ impl oio::MultipartWrite for UpyunWriter {
                 part_number,
                 etag: "".to_string(),
                 checksum: None,
+                size: None,
             }),
             _ => Err(parse_error(resp)),
         }

--- a/core/services/vercel-blob/src/writer.rs
+++ b/core/services/vercel-blob/src/writer.rs
@@ -102,6 +102,7 @@ impl oio::MultipartWrite for VercelBlobWriter {
                     part_number,
                     etag: resp.etag,
                     checksum: None,
+                    size: None,
                 })
             }
             _ => Err(parse_error(resp)),

--- a/integrations/object_store/src/service/writer.rs
+++ b/integrations/object_store/src/service/writer.rs
@@ -156,6 +156,7 @@ impl oio::MultipartWrite for ObjectStoreWriter {
             part_number,
             etag,
             checksum: None, // No checksum for now
+            size: None,
         };
         Ok(multipart_part)
     }


### PR DESCRIPTION
## Summary
- Fixes #7211
- Replace `oio::OneShotWriter` with `oio::MultipartWriter` backed by Swift's Static Large Object (SLO) API
- `initiate_part()` generates a local UUID (no server call needed, unlike S3)
- `write_part()` uploads segments to `.segments/{path}/{upload_id}/{part_number:08}`
- `complete_part()` PUTs a JSON manifest to `{path}?multipart-manifest=put`
- `abort_part()` lists and deletes orphaned segments
- Small writes still go through `write_once()` as a single PUT — `oio::MultipartWriter` handles the decision automatically
- Supports concurrent part uploads via `args.concurrent()`
- Adds `uuid` dependency for upload ID generation

Reference: https://docs.openstack.org/swift/latest/overview_large_objects.html

## Test plan
- `test_writer_write`, `test_writer_write_with_overwrite`, `test_writer_write_with_concurrent`, `test_writer_sink`, `test_writer_abort` and other writer tests now execute
- All 93 behavior tests pass against both local SAIO and a real Swift cluster