### PR TITLE
feat(services/swift): add TempURL presigned URL support

### DIFF
--- a/.github/services/swift/swift/action.yml
+++ b/.github/services/swift/swift/action.yml
@@ -34,6 +34,8 @@ runs:
         token=$(echo "$response" | grep X-Auth-Token | head -n1 | awk '{print $2}' | tr -d '[:space:]')
         endpoint=$(echo "$response" | grep X-Storage-Url | head -n1 | awk '{print $2}' | tr -d '[:space:]')
         curl --location --request PUT "${endpoint}/testing" --header "X-Auth-Token: $token"
+        # Configure TempURL key on the account for presigned URL tests
+        curl -s -X POST -H "X-Auth-Token: $token" -H "X-Account-Meta-Temp-URL-Key: opendal-swift-test-key" "${endpoint}"
         echo "OPENDAL_SWIFT_TOKEN=${token}" >> $GITHUB_ENV
         echo "OPENDAL_SWIFT_ENDPOINT=${endpoint}" >> $GITHUB_ENV
 
@@ -42,5 +44,6 @@ runs:
       run: |
         cat << EOF >> $GITHUB_ENV
         OPENDAL_SWIFT_CONTAINER=testing
+        OPENDAL_SWIFT_TEMP_URL_KEY=opendal-swift-test-key
         OPENDAL_SWIFT_ROOT=/
         EOF

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -7043,13 +7043,18 @@ dependencies = [
 name = "opendal-service-swift"
 version = "0.55.0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "hmac",
  "http 1.4.0",
  "log",
  "opendal-core",
+ "percent-encoding",
  "quick-xml",
  "serde",
  "serde_json",
+ "sha1",
+ "sha2",
  "tokio",
  "uuid",
 ]

--- a/core/services/swift/Cargo.toml
+++ b/core/services/swift/Cargo.toml
@@ -31,13 +31,18 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
+base64 = { workspace = true }
 bytes = { workspace = true }
+hmac = "0.12.1"
 http = { workspace = true }
 log = { workspace = true }
 opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+percent-encoding = "2"
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+sha1 = "0.10.6"
+sha2 = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]

--- a/core/services/swift/src/config.rs
+++ b/core/services/swift/src/config.rs
@@ -36,6 +36,18 @@ pub struct SwiftConfig {
     pub root: Option<String>,
     /// The token for Swift.
     pub token: Option<String>,
+    /// The TempURL key for generating presigned URLs.
+    ///
+    /// This corresponds to the `X-Account-Meta-Temp-URL-Key` or
+    /// `X-Container-Meta-Temp-URL-Key` header value configured on the
+    /// Swift account or container.
+    pub temp_url_key: Option<String>,
+    /// The hash algorithm for TempURL signing.
+    ///
+    /// Supported values: `sha1`, `sha256`, `sha512`. Defaults to `sha256`.
+    /// The cluster must have the chosen algorithm in its
+    /// `tempurl.allowed_digests` (check `GET /info`).
+    pub temp_url_hash_algorithm: Option<String>,
 }
 
 impl Debug for SwiftConfig {

--- a/fixtures/swift/Dockerfile
+++ b/fixtures/swift/Dockerfile
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Multi-arch Swift All-In-One (SAIO) image
+#
+# Based on upstream: https://opendev.org/openstack/swift/src/branch/master/Dockerfile
+# Modified to support both amd64 and arm64 (Apple Silicon).
+#
+# Build for current platform:
+#   podman build -t opendal/swift-saio .
+#
+# Build multi-arch:
+#   docker buildx build --platform linux/amd64,linux/arm64 -t opendal/swift-saio .
+
+FROM alpine:3.16.2
+
+# TARGETARCH is automatically set by buildx/podman (amd64 or arm64).
+ARG TARGETARCH
+
+ENV S6_LOGGING=1
+ENV S6_VERSION=1.21.4.0
+ENV SOCKLOG_VERSION=3.0.1-1
+ENV BUILD_DIR="/tmp"
+ENV ENV="/etc/profile"
+
+# Map Docker arch names to s6-overlay arch names:
+#   amd64  -> amd64
+#   arm64  -> aarch64
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        echo "aarch64" > /tmp/s6_arch; \
+    else \
+        echo "$TARGETARCH" > /tmp/s6_arch; \
+    fi
+
+# Clone Swift source
+RUN apk add --no-cache git && \
+    git clone --depth 1 https://opendev.org/openstack/swift.git /opt/swift && \
+    apk del git
+
+# Download s6-overlay and socklog-overlay for the target architecture
+RUN S6_ARCH=$(cat /tmp/s6_arch) && \
+    wget -q -O /tmp/s6-overlay.tar.gz \
+        "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-${S6_ARCH}.tar.gz" && \
+    wget -q -O /tmp/s6-overlay.tar.gz.sig \
+        "https://github.com/just-containers/s6-overlay/releases/download/v${S6_VERSION}/s6-overlay-${S6_ARCH}.tar.gz.sig" && \
+    wget -q -O /tmp/socklog-overlay.tar.gz \
+        "https://github.com/just-containers/socklog-overlay/releases/download/v${SOCKLOG_VERSION}/socklog-overlay-${S6_ARCH}.tar.gz"
+
+RUN mkdir /etc/swift && \
+    echo "================   starting swift_needs  ===================" && \
+    /opt/swift/docker/install_scripts/00_swift_needs.sh && \
+    echo "================   starting apk_install_prereqs  ===================" && \
+    /opt/swift/docker/install_scripts/10_apk_install_prereqs.sh && \
+    echo "================   starting apk_install_py3  ===================" && \
+    /opt/swift/docker/install_scripts/21_apk_install_py3.sh && \
+    echo "================   starting swift_install  ===================" && \
+    /opt/swift/docker/install_scripts/50_swift_install.sh && \
+    echo "================   installing s6-overlay  ===================" && \
+    gpg --import /opt/swift/docker/s6-gpg-pub-key && \
+    gpg --verify /tmp/s6-overlay.tar.gz.sig /tmp/s6-overlay.tar.gz && \
+    gunzip -c /tmp/s6-overlay.tar.gz | tar -xf - -C / && \
+    gunzip -c /tmp/socklog-overlay.tar.gz | tar -xf - -C / && \
+    rm -rf /tmp/s6-overlay* /tmp/socklog-overlay* /tmp/s6_arch && \
+    echo "================   starting pip_uninstall_dev  ===================" && \
+    /opt/swift/docker/install_scripts/60_pip_uninstall_dev.sh && \
+    echo "================   starting apk_uninstall_dev  ===================" && \
+    /opt/swift/docker/install_scripts/99_apk_uninstall_dev.sh
+
+# The upstream Dockerfile uses "COPY docker/rootfs /" since it builds
+# from the Swift source tree. We cloned into /opt/swift, so copy from there.
+RUN cp -a /opt/swift/docker/rootfs/* /
+
+ENTRYPOINT ["/init"]

--- a/fixtures/swift/docker-compose-swift-local.yml
+++ b/fixtures/swift/docker-compose-swift-local.yml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Locally-built Swift SAIO for native arm64/aarch64 support.
+#
+# The upstream openstackswift/saio:py3 image is amd64-only.
+# This compose file builds from the Dockerfile which supports
+# both amd64 and arm64 natively.
+#
+# Usage:
+#   docker compose -f docker-compose-swift-local.yml up -d --build --wait
+#   podman compose -f docker-compose-swift-local.yml up -d --build --wait
+
+services:
+  swift:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: opendal-swift-saio:local
+    ports:
+      - 8080:8080
+    healthcheck:
+      test: ["CMD", "curl", "-i", "-H", "X-Storage-User: test:tester", "-H", "X-Storage-Pass: testing", "http://localhost:8080/"]
+      interval: 3s
+      timeout: 20s
+      retries: 10


### PR DESCRIPTION
## Summary
- Fixes #7213
- Add presigned URL support via Swift's TempURL middleware for stat, read, and write operations
- Uses prefixed base64 signature format (`sha256:<base64>`) which explicitly declares the algorithm
- Supports SHA1, SHA256 (default), and SHA512 via `temp_url_hash_algorithm` config
- Requires `temp_url_key` matching the key set on the Swift account/container
- Configure TempURL key on SAIO for CI presign test coverage
- Add multi-arch Dockerfile for native arm64 local testing

References:
- https://docs.openstack.org/swift/latest/api/temporary_url_middleware.html
- https://github.com/openstack/swift/blob/master/swift/common/digest.py

## Test plan
- `test_presign_stat`, `test_presign_read`, `test_presign_write`, `test_presign_read_expired` now execute
- All 97 behavior tests pass against both local SAIO and a real Swift cluster (SHA1, SHA256, SHA512 all verified)