### PR TITLE
fix(integrations/unftp-sbe): avoid copy flush amplification

### DIFF
--- a/integrations/unftp-sbe/src/lib.rs
+++ b/integrations/unftp-sbe/src/lib.rs
@@ -64,6 +64,7 @@ use libunftp::auth::UserDetail;
 use libunftp::storage::{self, Error, StorageBackend};
 use opendal::Operator;
 
+use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 
@@ -135,6 +136,25 @@ fn convert_path(path: &Path) -> storage::Result<&str> {
             "Path is not a valid UTF-8 string",
         )
     })
+}
+
+async fn copy_read_write_loop<R, W>(input: &mut R, output: &mut W) -> std::io::Result<u64>
+where
+    R: tokio::io::AsyncRead + Unpin + ?Sized,
+    W: tokio::io::AsyncWrite + Unpin + ?Sized,
+{
+    let mut copied = 0u64;
+    let mut buf = [0u8; 8 * 1024];
+
+    loop {
+        let n = input.read(&mut buf).await?;
+        if n == 0 {
+            return Ok(copied);
+        }
+
+        output.write_all(&buf[..n]).await?;
+        copied += n as u64;
+    }
 }
 
 #[async_trait::async_trait]
@@ -214,7 +234,8 @@ impl<User: UserDetail> StorageBackend<User> for OpendalStorage {
             .map_err(convert_err)?
             .into_futures_async_write()
             .compat_write();
-        let copy_result = tokio::io::copy(&mut input, &mut w).await;
+        // Avoid `tokio::io::copy`'s pending-read flush path and keep buffering policy explicit.
+        let copy_result = copy_read_write_loop(&mut input, &mut w).await;
         let shutdown_result = w.shutdown().await;
         match (copy_result, shutdown_result) {
             (Ok(len), Ok(())) => Ok(len),


### PR DESCRIPTION
# Which issue does this PR close?

N/A (related to discussion [#7200](https://github.com/apache/opendal/discussions/7200)).

# Rationale for this change

`unftp-sbe` currently uses `tokio::io::copy` in `put`. Under slow uploads with small packets, `copy` can hit pending-read paths that flush the writer frequently, which interacts poorly with buffered multipart writers and can amplify memory usage.

# What changes are included in this PR?

- Replace `tokio::io::copy` with an explicit read/write loop in `integrations/unftp-sbe/src/lib.rs`.
- Keep transfer behavior simple and backpressure-driven via `read` + `write_all`.
- Keep existing shutdown and error handling behavior unchanged.

Validation:

- `cargo check --lib` (in `integrations/unftp-sbe`)
- `cargo clippy --lib -- -D warnings` (in `integrations/unftp-sbe`)
- `cargo test --lib` (in `integrations/unftp-sbe`)

# Are there any user-facing changes?

No API changes. This adjusts internal upload transfer behavior to be more stable under slow/small-packet upload patterns.

# AI Usage Statement

This PR was prepared with OpenAI Codex (GPT-5) for code editing and review support.
