### PR TITLE
docs: require following PR template in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,9 @@ ci: Update GitHub Actions workflow
 refactor(core): Simplify error handling
 ```
 
+## Pull Request Requirements
+- Always follow OpenDAL's pull request template when creating a PR.
+
 ## Testing Approach
 - Unit tests in `src/tests/`
 - Behavior tests validate service implementations


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

Our agent guidance did not explicitly require using OpenDAL's pull request template when creating PRs.
This change adds that requirement so future PR creation stays consistent with repository expectations.

# What changes are included in this PR?

- Add a new `Pull Request Requirements` section in `AGENTS.md`.
- Add one rule: always follow OpenDAL's pull request template when creating a PR.

# Are there any user-facing changes?

No.

# AI Usage Statement

This PR was prepared with Codex (GPT-5), with human review before submission.
