### PR TITLE
fix(services/azfile): avoid defaulting list size to zero

### DIFF
--- a/core/services/azfile/src/lister.rs
+++ b/core/services/azfile/src/lister.rs
@@ -74,10 +74,12 @@ impl oio::PageList for AzfileLister {
         }
 
         for file in results.entries.file {
-            let meta = Metadata::new(EntryMode::FILE)
+            let mut meta = Metadata::new(EntryMode::FILE)
                 .with_etag(file.properties.etag)
-                .with_content_length(file.properties.content_length.unwrap_or(0))
                 .with_last_modified(Timestamp::parse_rfc2822(&file.properties.last_modified)?);
+            if let Some(size) = file.properties.content_length {
+                meta.set_content_length(size);
+            }
             let path = self.path.clone().trim_start_matches('/').to_string() + &file.name;
             ctx.entries.push_back(oio::Entry::new(&path, meta));
         }


### PR DESCRIPTION
# Which issue does this PR close?

Part of #7062.

# Rationale for this change

`azfile` lister currently treats missing `Content-Length` in list response as `0`.
This conflates "unknown size" with "real zero-byte file", which breaks the mandatory list content-length semantics introduced in core.

# What changes are included in this PR?

- Update `core/services/azfile/src/lister.rs`:
  - Stop using `unwrap_or(0)` for file `content_length`.
  - Set `content_length` only when the service response includes `Content-Length`.

This keeps real zero-byte files correct while allowing core fallback completion logic to handle missing sizes safely.

Validation:

- `cargo fmt`
- `cargo check --features services-azfile,tests`
- `cargo test -p opendal-service-azfile`

# Are there any user-facing changes?

Yes.

For `azfile`, list entries no longer report `content_length = 0` when Azure File list response omits content length.

# AI Usage Statement

This PR was developed with Codex (GPT-5) assistance.
