### PR TITLE
fix(services/seafile): avoid defaulting list size to zero

### DIFF
--- a/core/services/seafile/src/lister.rs
+++ b/core/services/seafile/src/lister.rs
@@ -56,9 +56,11 @@ impl oio::PageList for SeafileLister {
                         );
 
                         let entry = if info.type_field == "file" {
-                            let meta = Metadata::new(EntryMode::FILE)
-                                .with_last_modified(Timestamp::from_second(info.mtime)?)
-                                .with_content_length(info.size.unwrap_or(0));
+                            let mut meta = Metadata::new(EntryMode::FILE)
+                                .with_last_modified(Timestamp::from_second(info.mtime)?);
+                            if let Some(size) = info.size {
+                                meta.set_content_length(size);
+                            }
                             Entry::new(&rel_path, meta)
                         } else {
                             let path = format!("{rel_path}/");


### PR DESCRIPTION
# Which issue does this PR close?

Part of #7062.

# Rationale for this change

`seafile` lister currently maps missing `size` in list response to `0`.
This mixes "size is unknown in list response" with "real zero-byte file", which is semantically incorrect.

# What changes are included in this PR?

- Update `core/services/seafile/src/lister.rs`:
  - Remove `unwrap_or(0)` when setting file `content_length`.
  - Set `content_length` only when `info.size` exists.

This preserves correct zero-byte semantics while allowing core completion logic to fill missing sizes when needed.

Validation:

- `cargo fmt`
- `cargo check --features services-seafile,tests`
- `cargo test -p opendal-service-seafile`

# Are there any user-facing changes?

Yes.

For `seafile`, list entries no longer report `content_length = 0` when list response omits `size`.

# AI Usage Statement

This PR was developed with Codex (GPT-5) assistance.
