### PR TITLE
fix(azdls): load Azure credentials from environment variables

### DIFF
--- a/core/services/azdls/src/backend.rs
+++ b/core/services/azdls/src/backend.rs
@@ -252,20 +252,37 @@ impl Builder for AzdlsBuilder {
         }?;
         debug!("backend use endpoint {}", &endpoint);
 
-        let config_loader = AzureStorageConfig {
-            account_name: self
-                .config
-                .account_name
-                .clone()
-                .or_else(|| azure_account_name_from_endpoint(endpoint.as_str())),
-            account_key: self.config.account_key.clone(),
-            sas_token: self.config.sas_token,
-            client_id: self.config.client_id.clone(),
-            client_secret: self.config.client_secret.clone(),
-            tenant_id: self.config.tenant_id.clone(),
-            authority_host: self.config.authority_host.clone(),
-            ..Default::default()
-        };
+        #[cfg(target_arch = "wasm32")]
+        let mut config_loader = AzureStorageConfig::default();
+        #[cfg(not(target_arch = "wasm32"))]
+        let mut config_loader = AzureStorageConfig::default().from_env();
+
+        if let Some(v) = self
+            .config
+            .account_name
+            .clone()
+            .or_else(|| azure_account_name_from_endpoint(endpoint.as_str()))
+        {
+            config_loader.account_name = Some(v);
+        }
+        if let Some(v) = self.config.account_key.clone() {
+            config_loader.account_key = Some(v);
+        }
+        if let Some(v) = self.config.sas_token {
+            config_loader.sas_token = Some(v);
+        }
+        if let Some(v) = self.config.client_id.clone() {
+            config_loader.client_id = Some(v);
+        }
+        if let Some(v) = self.config.client_secret.clone() {
+            config_loader.client_secret = Some(v);
+        }
+        if let Some(v) = self.config.tenant_id.clone() {
+            config_loader.tenant_id = Some(v);
+        }
+        if let Some(v) = self.config.authority_host.clone() {
+            config_loader.authority_host = Some(v);
+        }
 
         let cred_loader = AzureStorageLoader::new(config_loader);
         let signer = AzureStorageSigner::new();


### PR DESCRIPTION
The azdls backend was not calling `AzureStorageConfig::default().from_env()` unlike the azblob backend, which meant Azure Workload Identity environment variables (AZURE_FEDERATED_TOKEN_FILE, AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_AUTHORITY_HOST) were never loaded. This caused reqsign to skip the workload identity credential provider and fall through to IMDS, which fails in non-Azure-VM environments like AKS with Workload Identity.

This patch matches the pattern used in the azblob backend: start with `from_env()` and then overlay any explicitly configured values.

# Which issue does this PR close?

Closes #7224.

# Rationale for this change

The azdls backend was not loading Azure credentials from environment variables, unlike the azblob backend. Specifically, it was not calling `AzureStorageConfig::default().from_env()`, which meant Azure Workload Identity environment variables (`AZURE_FEDERATED_TOKEN_FILE`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_AUTHORITY_HOST`) were never loaded.

This caused reqsign to skip the workload identity credential provider and fall through to IMDS (Instance Metadata Service), which fails in non-Azure-VM environments like AKS (Azure Kubernetes Service) with Workload Identity enabled.

**Note**: We have been running this fix in an internal fork and can confirm it resolves the authentication issues in AKS with Workload Identity.

# What changes are included in this PR?

- Modified `AzdlsBuilder::build()` to use `AzureStorageConfig::default().from_env()` on non-wasm32 targets before overlaying explicitly configured values
- This matches the pattern already used in the azblob backend (implemented in PR #4705) for consistency
- Ensures Azure Workload Identity credentials are properly loaded from environment variables when available

# Are there any user-facing changes?

**Yes** - This is a bug fix that enables Azure Workload Identity authentication for the azdls backend.

Users running OpenDAL in Azure Kubernetes Service (AKS) with Workload Identity can now authenticate to Azure Data Lake Storage Gen2 using federated credentials without needing to explicitly configure credentials in code. The backend will automatically pick up the following environment variables:
- `AZURE_FEDERATED_TOKEN_FILE`
- `AZURE_CLIENT_ID`
- `AZURE_TENANT_ID`
- `AZURE_AUTHORITY_HOST`

This change is backward compatible - explicitly configured credentials still take precedence over environment variables.

# AI Usage Statement

Augment Agent (Claude Sonnet 4.5) was used to help during implementation and resolve merge conflicts during rebase.