### PR TITLE
refactor(services/cos): migrate to reqsign v2

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -6483,7 +6483,10 @@ dependencies = [
  "log",
  "opendal-core",
  "quick-xml",
- "reqsign",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "reqsign-http-send-reqwest",
+ "reqsign-tencent-cos",
  "reqwest",
  "serde",
  "tokio",
@@ -8790,6 +8793,22 @@ dependencies = [
  "log",
  "percent-encoding",
  "reqsign-core",
+]
+
+[[package]]
+name = "reqsign-tencent-cos"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3698e12fecf5976b9b6591c855afc0b3633c14526b935a61c885e573c2c9abd4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.4.0",
+ "log",
+ "percent-encoding",
+ "reqsign-core",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/core/services/cos/Cargo.toml
+++ b/core/services/cos/Cargo.toml
@@ -36,10 +36,10 @@ http = { workspace = true }
 log = { workspace = true }
 opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
-reqsign = { workspace = true, features = [
-  "services-tencent",
-  "reqwest_request",
-] }
+reqsign-core = { version = "2.0.1", default-features = false }
+reqsign-file-read-tokio = { version = "2.0.1", default-features = false }
+reqsign-http-send-reqwest = { version = "2.0.1", default-features = false }
+reqsign-tencent-cos = { version = "2.0.2", default-features = false }
 reqwest = { version = "0.12.24", default-features = false, features = [
   "stream",
 ] }

--- a/core/services/cos/src/writer.rs
+++ b/core/services/cos/src/writer.rs
@@ -69,11 +69,11 @@ impl CosWriter {
 
 impl oio::MultipartWrite for CosWriter {
     async fn write_once(&self, size: u64, body: Buffer) -> Result<Metadata> {
-        let mut req = self
+        let req = self
             .core
             .cos_put_object_request(&self.path, Some(size), &self.op, body)?;
 
-        self.core.sign(&mut req).await?;
+        let req = self.core.sign(req).await?;
 
         let resp = self.core.send(req).await?;
 
@@ -219,11 +219,11 @@ impl oio::AppendWrite for CosWriter {
     }
 
     async fn append(&self, offset: u64, size: u64, body: Buffer) -> Result<Metadata> {
-        let mut req = self
+        let req = self
             .core
             .cos_append_object_request(&self.path, offset, size, &self.op, body)?;
 
-        self.core.sign(&mut req).await?;
+        let req = self.core.sign(req).await?;
 
         let resp = self.core.send(req).await?;
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of #6553.

# Rationale for this change

`services/cos` was still using the old monolithic `reqsign` APIs (`TencentCosCredentialLoader` and `TencentCosSigner`).
This PR migrates COS to reqsign v2 (`reqsign-core` + `reqsign-tencent-cos`) and aligns signing with the unified `Signer<Credential>` model.

# What changes are included in this PR?

- Dependency migration in `services/cos`:
  - remove old `reqsign`
  - add `reqsign-core`, `reqsign-tencent-cos`, `reqsign-file-read-tokio`, `reqsign-http-send-reqwest`
- Backend credential wiring migration:
  - build `reqsign_core::Context` with tokio file reader and reqwest HTTP sender
  - replace old loader/signer setup with `reqsign_tencent_cos::DefaultCredentialProvider` + `reqsign_core::Signer`
  - keep explicit `secret_id`/`secret_key` as `StaticCredentialProvider` with highest priority (`push_front`)
  - preserve `disable_config_load` behavior by disabling default env/assume-role providers when enabled
- Core signing migration:
  - replace `TencentCosCredentialLoader + TencentCosSigner` with `Signer<reqsign_tencent_cos::Credential>`
  - convert signing APIs from in-place `&mut Request` to owned `Request -> Request`
  - update all signing call sites accordingly
- Writer migration:
  - update writer code paths to use the new owned signing flow

# Are there any user-facing changes?

No user-facing API changes are intended.

# AI Usage Statement

This PR was implemented with assistance from Codex (GPT-5) in the local development workflow.
