### PR TITLE
docs: Add doc for http config

### DIFF
--- a/core/core/src/docs/performance/http_optimization.md
+++ b/core/core/src/docs/performance/http_optimization.md
@@ -10,7 +10,9 @@ Please note that the following optimizations are based on experience and may not
 
 According to benchmarks from OpenDAL users, `HTTP/1.1` is generally faster than `HTTP/2` for large-scale download and upload operations.
 
-`reqwest` tends to maintain only a single TCP connection for `HTTP/2`, relying on its built-in multiplexing capabilities. While this works well for small files, such as web page downloads, the design is not ideal for handling large files or massive file scan OLAP workloads.
+`reqwest` tends to maintain only a single TCP connection for `HTTP/2`, relying on its built-in multiplexing capabilities. There is a [known issue](https://github.com/hyperium/hyper/issues/3623) in the underlying `hyper-util` HTTP util library: an HTTP/2 connection will remain in the pool and continue to be reused unless it is poisoned or closed after an idle timeout, even when the connection's max concurrent streams limit has been reached, or the TCP connection is exhausted (i.e., close to the bandwidth limit). In practice, this means all requests funnel through a single TCP connection, creating a bottleneck under heavy workloads.
+
+For HTTP/1.1, new connections will be created whenever there's no idle ones in the pool. While it solves the connection reuse issue, it also brings up possibility of excessive TCP connection. It's suggested to set a max concurrent request limit to avoid server overload and host bandwidth exhaustion.
 
 When `HTTP/2` is disabled, `reqwest` falls back to `HTTP/1.1` and utilizes its default connection pool. This approach is better suited for large files, as it allows multiple TCP connections to be opened and used concurrently, significantly improving performance for large file downloads and uploads.
 


### PR DESCRIPTION
# Rationale for this change

I'm using opendal to do large blob transfer (50GBps network, 20-30 GBps cluster-wise throughput), and found current HTTP optimization miss some explanations.

# What changes are included in this PR?

Add some usage pattern I did in our production environment:
- `hyper-util` currently always reuse the TCP connection when HTTP/2, which leads to bottleneck on single TCP connections
  + To address, we could either maintain a `reqwest` client pool with multiple HTTP/2 connection underlying and round-robin; or actively act gating on max allowed concurrency so we don't create excessive connections
  + For my use case, I observe 1800 connections created on single host, if no limit applied, which is definitely bad for performance and reliability

# Are there any user-facing changes?
No

# AI Usage Statement
I update the doc myself, no AI involvement.
