### PR TITLE
feat(services/hdfs-native): service hdfs-native support high availability (HA) cluster

### DIFF
--- a/core/services/hdfs-native/src/backend.rs
+++ b/core/services/hdfs-native/src/backend.rs
@@ -15,12 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use log::debug;
 
 use super::HDFS_NATIVE_SCHEME;
+use super::config::HDFS_DEFAULT_AUTHORITY;
+use super::config::HDFS_SCHEME_PREFIX;
 use super::config::HdfsNativeConfig;
+use super::config::init_hdfs_config;
 use super::core::HdfsNativeCore;
 use super::deleter::HdfsNativeDeleter;
 use super::error::parse_hdfs_error;
@@ -58,9 +62,10 @@ impl HdfsNativeBuilder {
     ///
     /// - `default`: using the default setting based on hadoop config.
     /// - `hdfs://127.0.0.1:9000`: connect to hdfs cluster.
+    /// - `hdfs://namenode1:9000,namenode2:9000`: connect to hdfs ha cluster.
     pub fn name_node(mut self, name_node: &str) -> Self {
         if !name_node.is_empty() {
-            // Trim trailing `/` so that we can accept `http://127.0.0.1:9000/`
+            // Trim trailing `/` so that we can accept `hdfs://127.0.0.1:9000/`
             self.config.name_node = Some(name_node.trim_end_matches('/').to_string())
         }
 
@@ -72,6 +77,14 @@ impl HdfsNativeBuilder {
     /// This should be disabled when HDFS runs in non-distributed mode.
     pub fn enable_append(mut self, enable_append: bool) -> Self {
         self.config.enable_append = enable_append;
+        self
+    }
+
+    /// Set other hdfs-native client options of this backend.
+    ///
+    /// Currently the supported configs refer to (https://github.com/Kimahriman/hdfs-native)
+    pub fn options(mut self, options: HashMap<String, String>) -> Self {
+        self.config.options = Some(options);
         self
     }
 }
@@ -93,8 +106,14 @@ impl Builder for HdfsNativeBuilder {
         let root = normalize_root(&self.config.root.unwrap_or_default());
         debug!("backend use root {root}");
 
+        let mut hdfs_config = init_hdfs_config(name_node);
+        if let Some(options) = &self.config.options {
+            hdfs_config.extend(options.iter().map(|(k, v)| (k.clone(), v.clone())));
+        }
+
         let client = hdfs_native::ClientBuilder::new()
-            .with_url(name_node)
+            .with_url(format!("{}{}", HDFS_SCHEME_PREFIX, HDFS_DEFAULT_AUTHORITY))
+            .with_config(hdfs_config)
             .build()
             .map_err(parse_hdfs_error)?;
 

--- a/core/services/hdfs-native/src/config.rs
+++ b/core/services/hdfs-native/src/config.rs
@@ -15,12 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 
 use serde::Deserialize;
 use serde::Serialize;
 
 use super::backend::HdfsNativeBuilder;
+
+pub const HDFS_SCHEME_PREFIX: &str = "hdfs://";
+pub const HDFS_DEFAULT_AUTHORITY: &str = "nameservice";
+pub const HA_NAMENODES_PREFIX: &str = "dfs.ha.namenodes";
+pub const HA_NAMENODE_RPC_ADDRESS_PREFIX: &str = "dfs.namenode.rpc-address";
 
 /// Config for HdfsNative services support.
 #[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -33,6 +39,8 @@ pub struct HdfsNativeConfig {
     pub name_node: Option<String>,
     /// enable the append capacity
     pub enable_append: bool,
+    /// other options for hdfs client
+    pub options: Option<HashMap<String, String>>,
 }
 
 impl Debug for HdfsNativeConfig {
@@ -41,6 +49,7 @@ impl Debug for HdfsNativeConfig {
             .field("root", &self.root)
             .field("name_node", &self.name_node)
             .field("enable_append", &self.enable_append)
+            .field("options", &self.options)
             .finish_non_exhaustive()
     }
 }
@@ -68,6 +77,36 @@ impl opendal_core::Configurator for HdfsNativeConfig {
     }
 }
 
+pub fn init_hdfs_config(name_node_uri: &str) -> HashMap<String, String> {
+    let namenodes = name_node_uri
+        .split(",")
+        .filter_map(|s| {
+            if !s.is_empty() {
+                Some(s.trim_start_matches("hdfs://").trim_end_matches("/"))
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<&str>>();
+    let mut hdfs_config = HashMap::new();
+    let mut ha_config_namenodes_vec = Vec::new();
+    for (index, namenode) in namenodes.iter().enumerate() {
+        hdfs_config.insert(
+            format!(
+                "{}.{}.nn{}",
+                HA_NAMENODE_RPC_ADDRESS_PREFIX, HDFS_DEFAULT_AUTHORITY, index
+            ),
+            namenode.to_string(),
+        );
+        ha_config_namenodes_vec.push(format!("nn{}", index));
+    }
+    hdfs_config.insert(
+        format!("{}.{}", HA_NAMENODES_PREFIX, HDFS_DEFAULT_AUTHORITY),
+        ha_config_namenodes_vec.join(","),
+    );
+    hdfs_config
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -93,5 +132,39 @@ mod tests {
 
         let cfg = HdfsNativeConfig::from_uri(&uri).unwrap();
         assert!(cfg.name_node.is_none());
+    }
+
+    #[test]
+    fn init_hdfs_config_from_single_namenode() {
+        let hdfs_config = init_hdfs_config("hdfs://namenode1:9000/");
+        println!("{:?}", hdfs_config);
+        assert!(!hdfs_config.is_empty() && hdfs_config.len() == 2);
+        assert_eq!(
+            hdfs_config.get("dfs.ha.namenodes.nameservice"),
+            Some(&"nn0".to_string())
+        );
+        assert_eq!(
+            hdfs_config.get("dfs.namenode.rpc-address.nameservice.nn0"),
+            Some(&"namenode1:9000".to_string())
+        );
+    }
+
+    #[test]
+    fn init_hdfs_config_from_multi_namenodes() {
+        let hdfs_config = init_hdfs_config("hdfs://namenode1:9000,namenode2:9000/");
+        println!("{:?}", hdfs_config);
+        assert!(!hdfs_config.is_empty() && hdfs_config.len() == 3);
+        assert_eq!(
+            hdfs_config.get("dfs.ha.namenodes.nameservice"),
+            Some(&"nn0,nn1".to_string())
+        );
+        assert_eq!(
+            hdfs_config.get("dfs.namenode.rpc-address.nameservice.nn0"),
+            Some(&"namenode1:9000".to_string())
+        );
+        assert_eq!(
+            hdfs_config.get("dfs.namenode.rpc-address.nameservice.nn1"),
+            Some(&"namenode2:9000".to_string())
+        );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7246 .

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
The current service hdfs-native only supports connecting to HDFS clusters with a single active NameNode, such as `hdfs://127.0.0.1:9000`. If the HDFS cluster is started in High Availability (HA) mode, hdfs-native will fail to connect when the active NameNode failover.
# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
HdfsActiveBuilder supports both single active NameNode and High Availability (HA) modes via the name_node parameter.The builder automatically parses these URIs into standard configuration properties required to initialize the hdfs-native client. 
- Standalone Mode: Specify a single URI, e.g., `hdfs://127.0.0.1:9000`.
- HA Mode: Specify multiple NameNodes, e.g., `hdfs://namenode1:9000,namenode2:9000`.

Additionally, any other HDFS configurations(Currently the supported configs refer to https://github.com/Kimahriman/hdfs-native) can be passed via the `options` parameter.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
