### PR TITLE
feat(services/sftp): add write_with_if_not_exists support

### DIFF
--- a/core/services/sftp/src/backend.rs
+++ b/core/services/sftp/src/backend.rs
@@ -29,6 +29,7 @@ use super::config::SftpConfig;
 use super::core::SftpCore;
 use super::deleter::SftpDeleter;
 use super::error::is_not_found;
+use super::error::is_sftp_failure;
 use super::error::is_sftp_protocol_error;
 use super::error::parse_sftp_error;
 use super::lister::SftpLister;
@@ -172,6 +173,7 @@ impl Builder for SftpBuilder {
 
                 write: true,
                 write_can_multi: true,
+                write_with_if_not_exists: true,
 
                 create_dir: true,
                 delete: true,
@@ -287,14 +289,35 @@ impl Access for SftpBackend {
         let path = fs.canonicalize(path).await.map_err(parse_sftp_error)?;
 
         let mut option = client.options();
-        option.create(true);
+        if op.if_not_exists() {
+            option.create_new(true);
+        } else {
+            option.create(true);
+        }
+
         if op.append() {
             option.append(true);
         } else {
             option.write(true).truncate(true);
         }
 
-        let file = option.open(path).await.map_err(parse_sftp_error)?;
+        let res = option.open(&path).await;
+        let file = match res {
+            Ok(f) => f,
+            Err(e) if op.if_not_exists() && is_sftp_failure(&e) => {
+                // OpenSSH returns Failure for create_new if file exists.
+                // We perform a post-check to confirm if it was a ConditionNotMatch.
+                if fs.metadata(&path).await.is_ok() {
+                    return Err(Error::new(
+                        ErrorKind::ConditionNotMatch,
+                        "file already exists, doesn't match the condition if_not_exists",
+                    )
+                    .set_source(e));
+                }
+                return Err(parse_sftp_error(e));
+            }
+            Err(e) => return Err(parse_sftp_error(e)),
+        };
 
         Ok((RpWrite::new(), SftpWriter::new(file)))
     }

--- a/core/services/sftp/src/error.rs
+++ b/core/services/sftp/src/error.rs
@@ -55,3 +55,7 @@ pub(super) fn is_not_found(e: &SftpClientError) -> bool {
 pub(super) fn is_sftp_protocol_error(e: &SftpClientError) -> bool {
     matches!(e, SftpClientError::SftpError(_, _))
 }
+
+pub(super) fn is_sftp_failure(e: &SftpClientError) -> bool {
+    matches!(e, SftpClientError::SftpError(SftpErrorKind::Failure, _))
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7252.

# Rationale for this change

Support conditional write for SFTP service using the `if_not_exists` flag.

# What changes are included in this PR?

- Enable `write_with_if_not_exists` capability for SFTP backend.
- Integrate `create_new(true)` in SFTP write operation.
- Implement a post-check stat to handle OpenSSH servers returning generic `Failure` for exclusive create failures, ensuring correct `ErrorKind::ConditionNotMatch` reporting.

# Are there any user-facing changes?

This adds the `write_with_if_not_exists` capability to the SFTP service.

# AI Usage Statement

This PR was built using Gemini CLI v0.34.0 with the Gemini 3 Flash Preview model.