### PR TITLE
feat(services/s3): Add ACL on multipart upload

### DIFF
--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -817,6 +817,11 @@ impl S3Core {
             }
         }
 
+        // also set acl header if default_acl is set.
+        if let Some(acl) = &self.default_acl {
+            req = req.header(constants::X_AMZ_ACL, acl);
+        }
+
         // Set request payer header if enabled.
         req = self.insert_request_payer_header(req);
 


### PR DESCRIPTION
The ACL were only put on whole upload not multipart

# Which issue does this PR close?

Closes #7254

# Rationale for this change

Default ACL introduced by #7186 are broken for big file (> 6M in my experience, but I don't really know the mechanism to choose whether to multipart or not).

# What changes are included in this PR?

Like what is described in #7254, but adds ACL header to multipart upload (if defined as `default_acl`.

Note that since minio do not support file level ACL, I could not add integration tests for this.

# Are there any user-facing changes?

Nop, only working ACL for all files.

# AI Usage Statement

I did not use any AI to code this.