### PR TITLE
fix(services/onedrive): fix url of onedrive_create_upload_session

### DIFF
--- a/core/services/onedrive/src/core.rs
+++ b/core/services/onedrive/src/core.rs
@@ -417,6 +417,17 @@ impl OneDriveCore {
         path: &str,
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
+        let mut request = self.onedrive_create_upload_session_request(path, args)?;
+        self.sign(ctx, &mut request).await?;
+
+        ctx.http_transport().send(request).await
+    }
+
+    pub(crate) fn onedrive_create_upload_session_request(
+        &self,
+        path: &str,
+        args: &OpWrite,
+    ) -> Result<Request<Buffer>> {
         let file_name = get_basename(path);
         let url = format!(
             "{}:/createUploadSession",
@@ -431,15 +442,13 @@ impl OneDriveCore {
         let body = OneDriveUploadSessionCreationRequestBody::new(file_name.to_string());
         let body_bytes = serde_json::to_vec(&body).map_err(new_json_serialize_error)?;
         let body = Buffer::from(Bytes::from(body_bytes));
-        let mut request = request
+        let request = request
             .extension(Operation::Write)
             .extension(ServiceOperation("CreateUploadSession"))
             .body(body)
             .map_err(new_request_build_error)?;
 
-        self.sign(ctx, &mut request).await?;
-
-        ctx.http_transport().send(request).await
+        Ok(request)
     }
 
     /// Create a directory
@@ -797,3 +806,62 @@ mod error {
 }
 
 pub(super) use error::*;
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use crate::ONEDRIVE_SCHEME;
+
+    use super::*;
+
+    fn get_request_json_body<T: for<'a> Deserialize<'a>>(request: Request<Buffer>) -> T {
+        let body = request.into_body();
+        let bytes = body.to_bytes(); // Buffer -> Bytes
+        let json: T = serde_json::from_slice(&bytes).expect("valid JSON");
+        json
+    }
+
+    fn make_onedrive(root: &str) -> OneDriveCore {
+        let info = ServiceInfo::new(ONEDRIVE_SCHEME, root, "");
+        let capability = Capability::default();
+        let mut signer = OneDriveSigner::new();
+        signer.access_token = "test-token".to_string();
+        signer.expires_in = Timestamp::MAX;
+        OneDriveCore {
+            info,
+            capability,
+            root: root.to_string(),
+            signer: Arc::new(Mutex::new(signer)),
+        }
+    }
+
+    #[test]
+    fn test_onedrive_create_upload_session_request() {
+        let root = "/";
+        let onedrive = make_onedrive(root);
+        let test_file_path = "test.file";
+        let request = onedrive
+            .onedrive_create_upload_session_request(test_file_path, &OpWrite::default())
+            .expect("failed to build request");
+        assert_eq!(
+            "https://graph.microsoft.com/v1.0/me/drive/root:/test.file:/createUploadSession"
+                .to_string(),
+            request.uri().to_string()
+        );
+        let actual = get_request_json_body::<OneDriveUploadSessionCreationRequestBody>(request);
+        assert_eq!(test_file_path.to_string(), actual.item.name);
+
+        let test_file_path = "dir/hello world.md";
+        let request = onedrive
+            .onedrive_create_upload_session_request(test_file_path, &OpWrite::default())
+            .expect("failed to build request");
+        assert_eq!(
+            "https://graph.microsoft.com/v1.0/me/drive/root:/dir/hello%20world.md:/createUploadSession"
+                .to_string(),
+            request.uri().to_string()
+        );
+        let actual = get_request_json_body::<OneDriveUploadSessionCreationRequestBody>(request);
+        assert_eq!("hello world.md", actual.item.name.as_str());
+    }
+}

--- a/core/services/onedrive/src/core.rs
+++ b/core/services/onedrive/src/core.rs
@@ -417,11 +417,10 @@ impl OneDriveCore {
         path: &str,
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let parent_path = get_parent(path);
         let file_name = get_basename(path);
         let url = format!(
             "{}:/createUploadSession",
-            self.onedrive_item_url(parent_path, true),
+            self.onedrive_item_url(path, true),
         );
         let mut request = Request::post(url).header(header::CONTENT_TYPE, "application/json");
 

--- a/core/services/onedrive/src/graph_model.rs
+++ b/core/services/onedrive/src/graph_model.rs
@@ -131,10 +131,10 @@ impl CreateDirPayload {
 struct EmptyStruct {}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct FileUploadItem {
+pub struct FileUploadItem {
     #[serde(rename = "@microsoft.graph.conflictBehavior")]
-    conflict_behavior: String,
-    name: String,
+    pub conflict_behavior: String,
+    pub name: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -146,7 +146,7 @@ pub struct OneDriveUploadSessionCreationResponseBody {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OneDriveUploadSessionCreationRequestBody {
-    item: FileUploadItem,
+    pub item: FileUploadItem,
 }
 
 impl OneDriveUploadSessionCreationRequestBody {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7256

# Rationale for this change

To fix the bug

# What changes are included in this PR?

change upload session url to include filename

# Are there any user-facing changes?

no

# AI Usage Statement

by hand

# NOTE

Need to test