### PR TITLE
fix(bindings/ocaml): fix ocaml format on CI

### DIFF
--- a/bindings/ocaml/lib/operator.mli
+++ b/bindings/ocaml/lib/operator.mli
@@ -26,17 +26,15 @@
     {2 Basic Usage}
 
     {[
-      (* Create an operator for local filesystem *)
-      let op =
-        Operator.new_operator "fs" [ ("root", "/tmp") ] |> Result.get_ok
-      in
+    (* Create an operator for local filesystem *)
+    let op = Operator.new_operator "fs" [ ("root", "/tmp") ] |> Result.get_ok in
 
-      (* Write data to a file *)
-      let _ = Operator.write op "hello.txt" (Bytes.of_string "Hello, World!") in
+    (* Write data to a file *)
+    let _ = Operator.write op "hello.txt" (Bytes.of_string "Hello, World!") in
 
-      (* Read data back *)
-      let content = Operator.read op "hello.txt" |> Result.get_ok in
-      print_endline (String.of_bytes content)
+    (* Read data back *)
+    let content = Operator.read op "hello.txt" |> Result.get_ok in
+    print_endline (String.of_bytes content)
     ]} *)
 
 (** {2 Core Operations} *)


### PR DESCRIPTION
# Rationale for this change

I submitted a PR and see ocaml formatting failures on CI, error message here: https://productionresultssa0.blob.core.windows.net/actions-results/32cf6fa8-4c21-4a03-bed2-45af78fd3f26/workflow-job-run-2b40f9b3-b69c-585b-9ada-57b6ee98619f/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-03-21T00%3A22%3A54Z&sig=yJfOvreAa25RHBHQWZKh7UbfuqQUVQ1jqtpNxlYOa3U%3D&ske=2026-03-21T03%3A30%3A20Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-03-20T23%3A30%3A20Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-03-21T00%3A12%3A49Z&sv=2025-11-05

Check the error logging, it's kinda clear to me that `ocamlformat` tool expects the code inside the `{[ ... ]}` documentation block to be indented at 4 spaces, but the current code uses 6-space indentation and has a different line-wrapping style. 

# What changes are included in this PR?

Attempts to fix the ocaml-related formatting, as reported in the error logging.

# Are there any user-facing changes?

No

# AI Usage Statement

Opus 4.6 helps me made the change.
