### PR TITLE
chore: fix haskell binding CI

### DIFF
--- a/.github/workflows/ci_bindings_haskell.yml
+++ b/.github/workflows/ci_bindings_haskell.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Haskell toolchain (ghc-9.4.8)
         run: |
           sudo apt-get update
-          sudo apt-get install -y happy
+          sudo apt-get install -y alex happy
           curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
           ghcup install ghc 9.4.8 --set
           ghcup install cabal --set
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Haskell toolchain (ghc-9.2.8)
         run: |
           sudo apt-get update
-          sudo apt-get install -y happy
+          sudo apt-get install -y alex happy
           curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
           ghcup install ghc 9.2.8 --set
           ghcup install cabal --set

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -248,7 +248,7 @@ jobs:
       - name: Setup Haskell toolchain (ghc-9.2.8)
         run: |
           sudo apt-get update
-          sudo apt-get install -y happy
+          sudo apt-get install -y alex happy
           curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
           ghcup install ghc 9.2.8 --set
           ghcup install cabal --set


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

> The Haskell CI failure was not caused by a direct dependency declared by OpenDAL itself. In OpenDAL, the Haskell package is declared as `build-type: Custom`, and its `custom-setup` only depends on `Cabal`, `base`, `directory`, and `process` in `bindings/haskell/opendal.cabal`. The custom `bindings/haskell/Setup.hs` only uses `Distribution.*` modules from Cabal. According to the Cabal package description documentation, `custom-setup.setup-depends` is only for Haskell packages needed to build `Setup.hs` itself, so it is not the right place to model bootstrap tools like `alex` or `happy`. Source: https://cabal.readthedocs.io/en/latest/cabal-package-description-file.html

 > The failure came from the transitive setup/build chain used during Cabal resolution: `opendal` setup -> `Cabal` / `Cabal-syntax` -> `alex` -> `happy`. Cabal can automatically solve and build some Haskell packages or declared build tools, however, the build later required pre-existing bootstrap executables on `PATH`, and those were not provisioned by our workflow. This is consistent with the upstream bootstrap notes: the Alex package documentation says bootstrapping Alex is tricky and that `alex` and `happy` may need to be installed first, and the Happy package documentation says a pre-built happy is required to build the full version by default. Sources: https://hackage.haskell.org/package/alex-3.2.5 and https://hackage.haskell.org/package/happy-1.21.0

> The fact that Haskell CI passed on March 20, 2026 but failed on March 21, 2026 does not contradict this explanation. The workflow runs `cabal update`, but the repository does not pin an `index-state` in a `cabal.project` file. That means fresh dependency resolution can vary from one day to the next even when the OpenDAL source tree does not change. GitHub Actions cache behavior can also affect whether the job reuses an older solved state or takes a colder build path, but the main issue is that the workflow depends on an unpinned Hackage/Cabal resolution path combined with missing bootstrap tools. Sources:
  https://cabal.readthedocs.io/en/latest/cabal-project-description-file.html and https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching

> The actual fix is to provision both `alex` and `happy `explicitly in CI before running Cabal. That is why the workflow was updated to install `alex` and `happy` in the Haskell setup steps in .`github/workflows/
  ci_bindings_haskell.yml` and `.github/workflows/docs.yml`. We did not add them to `custom-setup.setup-depends`, because they are not needed to compile OpenDAL’s `Setup.hs`; they are required to satisfy bootstrap requirements in an upstream transitive build path.
 
I'm not very familiar with the Haskell/Cabal toolchain, but based on the information provided by Codex, it seems that building the current OpenDAL Haskell binding requires constructing Alex/Happy. However, building Alex/Happy itself requires pre-built versions of Alex/Happy.

However, I noticed that the Haskell binding CI on the 20th did not encounter any issues. Therefore, I checked the corresponding CI logs and found that the dependencies for the 20th and 21st appear to be different.

20th: https://github.com/apache/opendal/actions/runs/23341528399/job/67896075196
<details>
<summary>
dependencies</summary>

```
Run cabal test
Resolving dependencies...
Build profile: -w ghc-9.4.8 -O1
In order, the following will be built (use -v for more details):
 - colour-2.3.7 (lib) (requires download & build)
 - syb-0.7.4 (lib) (requires download & build)
 - ansi-terminal-types-1.1.3 (lib) (requires download & build)
 - th-expand-syns-0.4.12.0 (lib) (requires download & build)
 - ansi-terminal-1.1.5 (lib) (requires download & build)
 - th-reify-many-0.1.10 (lib) (requires download & build)
 - prettyprinter-ansi-terminal-1.1.3 (lib) (requires download & build)
 - th-orphans-0.13.17 (lib) (requires download & build)
 - optparse-applicative-0.19.0.0 (lib) (requires download & build)
 - haskell-src-meta-0.8.15 (lib) (requires download & build)
 - tasty-1.5.3 (lib) (requires download & build)
 - bytebuild-0.3.17.0 (lib) (requires download & build)
 - tasty-hunit-0.10.2 (lib) (requires download & build)
 - chronos-1.1.6.2 (lib) (requires download & build)
 - co-log-0.6.1.2 (lib) (requires download & build)
 - opendal-0.1.0 (configuration changed)
```
</details>

21th: https://github.com/apache/opendal/actions/runs/23375748653/job/68007375724
<details>
<summary>dependencies</summary>

```
Run cabal test
Resolving dependencies...
Build profile: -w ghc-9.4.8 -O1
In order, the following will be built (use -v for more details):
 - alex-3.5.4.1 (exe:alex) (requires download & build)        <===========
 - colour-2.3.7 (lib) (requires download & build)
 - syb-0.7.4 (lib) (requires download & build)
 - Cabal-syntax-3.14.2.0 (lib) (requires download & build)    <===========
 - ansi-terminal-types-1.1.3 (lib) (requires download & build)
 - th-expand-syns-0.4.12.0 (lib) (requires download & build)
 - Cabal-3.14.1.0 (lib) (requires download & build)           <===========
 - ansi-terminal-1.1.5 (lib) (requires download & build)
 - th-reify-many-0.1.10 (lib) (requires download & build)
 - prettyprinter-ansi-terminal-1.1.3 (lib) (requires download & build)
 - th-orphans-0.13.17 (lib) (requires download & build)
 - optparse-applicative-0.19.0.0 (lib) (requires download & build)
 - haskell-src-meta-0.8.15 (lib) (requires download & build)
 - tasty-1.5.3 (lib) (requires download & build)
 - bytebuild-0.3.17.0 (lib) (requires download & build)
 - tasty-hunit-0.10.2 (lib) (requires download & build)
 - chronos-1.1.6.2 (lib) (requires download & build)
 - co-log-0.6.1.2 (lib) (requires download & build)
 - opendal-0.1.0 (configuration changed)
```
</details>

# What changes are included in this PR?

- install pre-built alex/happy dep in haskell binding CI

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

codex gpt-5.4 (xhigh)