### PR TITLE
feat(bindings/python): support options for presign operations

### DIFF
--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -409,6 +409,15 @@ class AsyncOperator:
         self,
         path: builtins.str | os.PathLike | pathlib.Path,
         expire_second: builtins.int,
+        *,
+        version: builtins.str | None = ...,
+        if_match: builtins.str | None = ...,
+        if_none_match: builtins.str | None = ...,
+        if_modified_since: datetime.datetime = ...,
+        if_unmodified_since: datetime.datetime = ...,
+        content_type: builtins.str | None = ...,
+        cache_control: builtins.str | None = ...,
+        content_disposition: builtins.str | None = ...,
     ) -> collections.abc.Awaitable[opendal.types.PresignedRequest]:
         r"""
         Create a presigned request for a stat operation.
@@ -419,6 +428,22 @@ class AsyncOperator:
             The path of the object to stat.
         expire_second : int
             The number of seconds until the presigned URL expires.
+        version : str, optional
+            The version of the file.
+        if_match : str, optional
+            The ETag to match.
+        if_none_match : str, optional
+            The ETag to not match.
+        if_modified_since : datetime, optional
+            Only return if modified since this time.
+        if_unmodified_since : datetime, optional
+            Only return if unmodified since this time.
+        content_type : str, optional
+            Override the content type in the presigned response.
+        cache_control : str, optional
+            Override the cache control in the presigned response.
+        content_disposition : str, optional
+            Override the content disposition in the presigned response.
 
         Returns
         -------
@@ -429,6 +454,15 @@ class AsyncOperator:
         self,
         path: builtins.str | os.PathLike | pathlib.Path,
         expire_second: builtins.int,
+        *,
+        version: builtins.str | None = ...,
+        if_match: builtins.str | None = ...,
+        if_none_match: builtins.str | None = ...,
+        if_modified_since: datetime.datetime = ...,
+        if_unmodified_since: datetime.datetime = ...,
+        content_type: builtins.str | None = ...,
+        cache_control: builtins.str | None = ...,
+        content_disposition: builtins.str | None = ...,
     ) -> collections.abc.Awaitable[opendal.types.PresignedRequest]:
         r"""
         Create a presigned request for a read operation.
@@ -439,6 +473,22 @@ class AsyncOperator:
             The path of the object to read.
         expire_second : int
             The number of seconds until the presigned URL expires.
+        version : str, optional
+            The version of the file.
+        if_match : str, optional
+            The ETag to match.
+        if_none_match : str, optional
+            The ETag to not match.
+        if_modified_since : datetime, optional
+            Only return if modified since this time.
+        if_unmodified_since : datetime, optional
+            Only return if unmodified since this time.
+        content_type : str, optional
+            Override the content type in the presigned response.
+        cache_control : str, optional
+            Override the cache control in the presigned response.
+        content_disposition : str, optional
+            Override the content disposition in the presigned response.
 
         Returns
         -------
@@ -449,6 +499,15 @@ class AsyncOperator:
         self,
         path: builtins.str | os.PathLike | pathlib.Path,
         expire_second: builtins.int,
+        *,
+        content_type: builtins.str | None = ...,
+        content_disposition: builtins.str | None = ...,
+        content_encoding: builtins.str | None = ...,
+        cache_control: builtins.str | None = ...,
+        if_match: builtins.str | None = ...,
+        if_none_match: builtins.str | None = ...,
+        if_not_exists: builtins.bool | None = ...,
+        user_metadata: typing.Mapping[builtins.str, builtins.str] | None = ...,
     ) -> collections.abc.Awaitable[opendal.types.PresignedRequest]:
         r"""
         Create a presigned request for a write operation.
@@ -459,6 +518,22 @@ class AsyncOperator:
             The path of the object to write to.
         expire_second : int
             The number of seconds until the presigned URL expires.
+        content_type : str, optional
+            The content type header to set on the file.
+        content_disposition : str, optional
+            The content disposition header to set on the file.
+        content_encoding : str, optional
+            The content encoding header to set on the file.
+        cache_control : str, optional
+            The cache control header to set on the file.
+        if_match : str, optional
+            The ETag to match when writing the file.
+        if_none_match : str, optional
+            The ETag to not match when writing the file.
+        if_not_exists : bool, optional
+            Whether to fail if the file already exists.
+        user_metadata : dict, optional
+            The user metadata to set on the file.
 
         Returns
         -------
@@ -469,6 +544,8 @@ class AsyncOperator:
         self,
         path: builtins.str | os.PathLike | pathlib.Path,
         expire_second: builtins.int,
+        *,
+        version: builtins.str | None = ...,
     ) -> collections.abc.Awaitable[opendal.types.PresignedRequest]:
         r"""
         Create a presigned request for a delete operation.
@@ -479,6 +556,8 @@ class AsyncOperator:
             The path of the object to delete.
         expire_second : int
             The number of seconds until the presigned URL expires.
+        version : str, optional
+            The version of the file to delete.
 
         Returns
         -------

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -79,6 +79,7 @@ fn _opendal(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ReadOptions>()?;
     m.add_class::<ListOptions>()?;
     m.add_class::<StatOptions>()?;
+    m.add_class::<DeleteOptions>()?;
 
     // Exceptions module
     add_pyexceptions!(

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -1451,26 +1451,72 @@ impl AsyncOperator {
     ///     The path of the object to stat.
     /// expire_second : int
     ///     The number of seconds until the presigned URL expires.
+    /// version : str, optional
+    ///     The version of the file.
+    /// if_match : str, optional
+    ///     The ETag to match.
+    /// if_none_match : str, optional
+    ///     The ETag to not match.
+    /// if_modified_since : datetime, optional
+    ///     Only return if modified since this time.
+    /// if_unmodified_since : datetime, optional
+    ///     Only return if unmodified since this time.
+    /// content_type : str, optional
+    ///     Override the content type in the presigned response.
+    /// cache_control : str, optional
+    ///     Override the cache control in the presigned response.
+    /// content_disposition : str, optional
+    ///     Override the content disposition in the presigned response.
     ///
     /// Returns
     /// -------
     /// coroutine
     ///     An awaitable that returns a presigned request object.
+    #[allow(clippy::too_many_arguments)]
     #[gen_stub(override_return_type(
         type_repr="collections.abc.Awaitable[opendal.types.PresignedRequest]",
         imports=("collections.abc", "opendal.types")
     ))]
+    #[pyo3(signature = (path, expire_second, *,
+        version=None,
+        if_match=None,
+        if_none_match=None,
+        if_modified_since=None,
+        if_unmodified_since=None,
+        content_type=None,
+        cache_control=None,
+        content_disposition=None))]
     pub fn presign_stat<'p>(
         &'p self,
         py: Python<'p>,
         path: PathBuf,
         expire_second: u64,
+        version: Option<String>,
+        if_match: Option<String>,
+        if_none_match: Option<String>,
+        #[gen_stub(override_type(type_repr = "datetime.datetime", imports=("datetime")))]
+        if_modified_since: Option<jiff::Timestamp>,
+        #[gen_stub(override_type(type_repr = "datetime.datetime", imports=("datetime")))]
+        if_unmodified_since: Option<jiff::Timestamp>,
+        content_type: Option<String>,
+        cache_control: Option<String>,
+        content_disposition: Option<String>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let this = self.core.clone();
         let path = path.to_string_lossy().to_string();
+        let opts = StatOptions {
+            version,
+            if_match,
+            if_none_match,
+            if_modified_since,
+            if_unmodified_since,
+            content_type,
+            cache_control,
+            content_disposition,
+        };
         future_into_py(py, async move {
             let res = this
-                .presign_stat(&path, Duration::from_secs(expire_second))
+                .presign_stat_options(&path, Duration::from_secs(expire_second), opts.into())
                 .await
                 .map_err(format_pyerr)
                 .map(PresignedRequest)?;
@@ -1487,26 +1533,73 @@ impl AsyncOperator {
     ///     The path of the object to read.
     /// expire_second : int
     ///     The number of seconds until the presigned URL expires.
+    /// version : str, optional
+    ///     The version of the file.
+    /// if_match : str, optional
+    ///     The ETag to match.
+    /// if_none_match : str, optional
+    ///     The ETag to not match.
+    /// if_modified_since : datetime, optional
+    ///     Only return if modified since this time.
+    /// if_unmodified_since : datetime, optional
+    ///     Only return if unmodified since this time.
+    /// content_type : str, optional
+    ///     Override the content type in the presigned response.
+    /// cache_control : str, optional
+    ///     Override the cache control in the presigned response.
+    /// content_disposition : str, optional
+    ///     Override the content disposition in the presigned response.
     ///
     /// Returns
     /// -------
     /// coroutine
     ///     An awaitable that returns a presigned request object.
+    #[allow(clippy::too_many_arguments)]
     #[gen_stub(override_return_type(
         type_repr="collections.abc.Awaitable[opendal.types.PresignedRequest]",
         imports=("collections.abc", "opendal.types")
     ))]
+    #[pyo3(signature = (path, expire_second, *,
+        version=None,
+        if_match=None,
+        if_none_match=None,
+        if_modified_since=None,
+        if_unmodified_since=None,
+        content_type=None,
+        cache_control=None,
+        content_disposition=None))]
     pub fn presign_read<'p>(
         &'p self,
         py: Python<'p>,
         path: PathBuf,
         expire_second: u64,
+        version: Option<String>,
+        if_match: Option<String>,
+        if_none_match: Option<String>,
+        #[gen_stub(override_type(type_repr = "datetime.datetime", imports=("datetime")))]
+        if_modified_since: Option<jiff::Timestamp>,
+        #[gen_stub(override_type(type_repr = "datetime.datetime", imports=("datetime")))]
+        if_unmodified_since: Option<jiff::Timestamp>,
+        content_type: Option<String>,
+        cache_control: Option<String>,
+        content_disposition: Option<String>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let this = self.core.clone();
         let path = path.to_string_lossy().to_string();
+        let opts = ReadOptions {
+            version,
+            if_match,
+            if_none_match,
+            if_modified_since,
+            if_unmodified_since,
+            content_type,
+            cache_control,
+            content_disposition,
+            ..Default::default()
+        };
         future_into_py(py, async move {
             let res = this
-                .presign_read(&path, Duration::from_secs(expire_second))
+                .presign_read_options(&path, Duration::from_secs(expire_second), opts.into())
                 .await
                 .map_err(format_pyerr)
                 .map(PresignedRequest)?;
@@ -1523,26 +1616,71 @@ impl AsyncOperator {
     ///     The path of the object to write to.
     /// expire_second : int
     ///     The number of seconds until the presigned URL expires.
+    /// content_type : str, optional
+    ///     The content type header to set on the file.
+    /// content_disposition : str, optional
+    ///     The content disposition header to set on the file.
+    /// content_encoding : str, optional
+    ///     The content encoding header to set on the file.
+    /// cache_control : str, optional
+    ///     The cache control header to set on the file.
+    /// if_match : str, optional
+    ///     The ETag to match when writing the file.
+    /// if_none_match : str, optional
+    ///     The ETag to not match when writing the file.
+    /// if_not_exists : bool, optional
+    ///     Whether to fail if the file already exists.
+    /// user_metadata : dict, optional
+    ///     The user metadata to set on the file.
     ///
     /// Returns
     /// -------
     /// coroutine
     ///     An awaitable that returns a presigned request object.
+    #[allow(clippy::too_many_arguments)]
     #[gen_stub(override_return_type(
         type_repr="collections.abc.Awaitable[opendal.types.PresignedRequest]",
         imports=("collections.abc", "opendal.types")
     ))]
+    #[pyo3(signature = (path, expire_second, *,
+        content_type=None,
+        content_disposition=None,
+        content_encoding=None,
+        cache_control=None,
+        if_match=None,
+        if_none_match=None,
+        if_not_exists=None,
+        user_metadata=None))]
     pub fn presign_write<'p>(
         &'p self,
         py: Python<'p>,
         path: PathBuf,
         expire_second: u64,
+        content_type: Option<String>,
+        content_disposition: Option<String>,
+        content_encoding: Option<String>,
+        cache_control: Option<String>,
+        if_match: Option<String>,
+        if_none_match: Option<String>,
+        if_not_exists: Option<bool>,
+        user_metadata: Option<HashMap<String, String>>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let this = self.core.clone();
         let path = path.to_string_lossy().to_string();
+        let opts = WriteOptions {
+            content_type,
+            content_disposition,
+            content_encoding,
+            cache_control,
+            if_match,
+            if_none_match,
+            if_not_exists,
+            user_metadata,
+            ..Default::default()
+        };
         future_into_py(py, async move {
             let res = this
-                .presign_write(&path, Duration::from_secs(expire_second))
+                .presign_write_options(&path, Duration::from_secs(expire_second), opts.into())
                 .await
                 .map_err(format_pyerr)
                 .map(PresignedRequest)?;
@@ -1559,6 +1697,8 @@ impl AsyncOperator {
     ///     The path of the object to delete.
     /// expire_second : int
     ///     The number of seconds until the presigned URL expires.
+    /// version : str, optional
+    ///     The version of the file to delete.
     ///
     /// Returns
     /// -------
@@ -1568,17 +1708,20 @@ impl AsyncOperator {
         type_repr="collections.abc.Awaitable[opendal.types.PresignedRequest]",
         imports=("collections.abc", "opendal.types")
     ))]
+    #[pyo3(signature = (path, expire_second, *, version=None))]
     pub fn presign_delete<'p>(
         &'p self,
         py: Python<'p>,
         path: PathBuf,
         expire_second: u64,
+        version: Option<String>,
     ) -> PyResult<Bound<'p, PyAny>> {
         let this = self.core.clone();
         let path = path.to_string_lossy().to_string();
+        let opts = DeleteOptions { version };
         future_into_py(py, async move {
             let res = this
-                .presign_delete(&path, Duration::from_secs(expire_second))
+                .presign_delete_options(&path, Duration::from_secs(expire_second), opts.into())
                 .await
                 .map_err(format_pyerr)
                 .map(PresignedRequest)?;

--- a/bindings/python/src/options.rs
+++ b/bindings/python/src/options.rs
@@ -281,3 +281,18 @@ impl From<StatOptions> for ocore::options::StatOptions {
         }
     }
 }
+
+#[pyclass(module = "opendal")]
+#[derive(Default, Debug)]
+pub struct DeleteOptions {
+    pub version: Option<String>,
+}
+
+impl From<DeleteOptions> for ocore::options::DeleteOptions {
+    fn from(opts: DeleteOptions) -> Self {
+        Self {
+            version: opts.version,
+            ..Default::default()
+        }
+    }
+}


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7264.

# Rationale for this change

(copying from the issue)

The Python bindings' `presign_read`, `presign_write`, `presign_stat`, and `presign_delete` methods only accept `path` and `expire_second` with no way to override `content_disposition` or any other options.

The core already exposes [presign_(stat|read|write|delete)_options methods](https://github.com/apache/opendal/blob/e5db9f37/core/core/src/types/operator/operator.rs#L1941-L1949) that accept full option structs, and the Python bindings already pass options for [`stat`](https://github.com/apache/opendal/blob/e5db9f37/bindings/python/src/operator.rs#L1111), [`read`](https://github.com/apache/opendal/blob/e5db9f37/bindings/python/src/operator.rs#L919), and [`write`](https://github.com/apache/opendal/blob/e5db9f37/bindings/python/src/operator.rs#L1027). 

But the [presign methods](https://github.com/apache/opendal/blob/e5db9f37/bindings/python/src/operator.rs#L1463-L1588) call the no-options core variants and don't accept any kwargs.

This means there's no way to set `content_disposition` on a presigned read URL, so you can't control whether the browser renders inline vs forces a download, or set a custom filename. For stores serving user-uploaded content, rendering inline is an XSS risk as HTML/SVG files execute in the browser under your domain.

The fix is to add optional kwargs to the existing presign methods and call the core `presign_(stat|read|write|delete)_options` methods instead which is the same pattern already used by `stat`/`read`/`write`.

# What changes are included in this PR?

Adds optional kwargs to all 4 `AsyncOperator` presign methods, adds a `DeleteOptions` struct, and updates the stubs accordingly.

# Are there any user-facing changes?

Yes, though backwards compatible.

# AI Usage Statement

Yes, using Claude Code (claude-opus-4-6, 1m context, high thinking).