### PR TITLE
fix(observability): Fix executing operation gauge decrement on error

### DIFF
--- a/core/layers/observe-metrics-common/src/lib.rs
+++ b/core/layers/observe-metrics-common/src/lib.rs
@@ -672,6 +672,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                     labels.clone().with_error(err.kind()),
                     MetricValue::OperationErrorsTotal,
                 );
+                self.interceptor
+                    .observe(labels.clone(), MetricValue::OperationExecuting(-1));
             })?;
 
         Ok((
@@ -693,6 +695,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                 labels.clone().with_error(err.kind()),
                 MetricValue::OperationErrorsTotal,
             );
+            self.interceptor
+                .observe(labels.clone(), MetricValue::OperationExecuting(-1));
         })?;
 
         Ok((
@@ -804,6 +808,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                 labels.clone().with_error(err.kind()),
                 MetricValue::OperationErrorsTotal,
             );
+            self.interceptor
+                .observe(labels.clone(), MetricValue::OperationExecuting(-1));
         })?;
 
         Ok((
@@ -825,6 +831,8 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
                 labels.clone().with_error(err.kind()),
                 MetricValue::OperationErrorsTotal,
             );
+            self.interceptor
+                .observe(labels.clone(), MetricValue::OperationExecuting(-1));
         })?;
 
         Ok((


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7266

# Rationale for this change

If I don't read the code wrongly, I think in certain places we don't decrement the executing operation count on errors.

# What changes are included in this PR?

This PR decrements gauge value on these forgotten errors.
I thought about making a RAII object for `observe`, but we also have `MetricsWrapper` which is more or less a RAII wrapper, don't want to complicate things here, but could be a followup issue.

# Are there any user-facing changes?

No.

# AI Usage Statement

Opus 4.6 helped me make the change.
