### PR TITLE
fix(observability): do not account processed entries count when list none

### DIFF
--- a/core/layers/observe-metrics-common/src/lib.rs
+++ b/core/layers/observe-metrics-common/src/lib.rs
@@ -980,7 +980,7 @@ impl<R: oio::List, I: MetricsIntercept> oio::List for MetricsWrapper<R, I> {
             .next()
             .await
             .inspect(|entry| {
-                if entry.is_some() {    
+                if entry.is_some() {
                     self.size += 1;
                 }
             })


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7268

# Rationale for this change

As mentioned in the issue, I think when list operation returns None, it should be accounted as processed entries count.
But happy to discuss / close PR if maintainers have different opinions.

# Are there any user-facing changes?

No

# AI Usage Statement

No AI involvement
