### PR TITLE
fix(s3): respect content encoding for multipart upload initialization

### DIFF
--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -832,7 +832,7 @@ impl S3Core {
         // Set SSE headers.
         req = self.insert_sse_headers(req, true);
 
-        // Set SSE headers.
+        // Set checksum type headers.
         req = self.insert_checksum_type_header(req);
 
         // Inject operation to the request.


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7273

# Rationale for this change

content-encoding is a valid request header for multipart upload creation, but it doesn't seem to be respected now.
The issue was found when I used opus-4.6 to do a sanity check to compare the request header difference between plain PUT and multipart upload, seems to be the only left one.

# What changes are included in this PR?

Add the header to the request.

# Are there any user-facing changes?

No

# AI Usage Statement

Opus 4.6 helped me make the change.