### PR TITLE
fix(backend): Fix version id encoded into URL

### DIFF
--- a/core/services/cos/src/core.rs
+++ b/core/services/cos/src/core.rs
@@ -120,7 +120,7 @@ impl CosCore {
             query_args.push(format!(
                 "{}={}",
                 constants::COS_QUERY_VERSION_ID,
-                percent_decode_path(version)
+                percent_encode_path(version)
             ))
         }
         if !query_args.is_empty() {
@@ -225,7 +225,7 @@ impl CosCore {
             query_args.push(format!(
                 "{}={}",
                 constants::COS_QUERY_VERSION_ID,
-                percent_decode_path(version)
+                percent_encode_path(version)
             ))
         }
         if !query_args.is_empty() {
@@ -259,7 +259,7 @@ impl CosCore {
             query_args.push(format!(
                 "{}={}",
                 constants::COS_QUERY_VERSION_ID,
-                percent_decode_path(version)
+                percent_encode_path(version)
             ))
         }
         if !query_args.is_empty() {

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -388,7 +388,7 @@ impl S3Core {
             query_args.push(format!(
                 "{}={}",
                 constants::S3_QUERY_VERSION_ID,
-                percent_decode_path(version)
+                percent_encode_path(version)
             ))
         }
         if !query_args.is_empty() {
@@ -462,7 +462,7 @@ impl S3Core {
             query_args.push(format!(
                 "{}={}",
                 constants::S3_QUERY_VERSION_ID,
-                percent_decode_path(version)
+                percent_encode_path(version)
             ))
         }
         if !query_args.is_empty() {


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7287

# Rationale for this change

Apologize if I mis-understand! My understanding simple: encode should be used to compose URL before sending requests, while decode is made for responses.

# What changes are included in this PR?

Change a few places where we use **decode** before sending to **encode**.

# Are there any user-facing changes?

No

# AI Usage Statement

Opus 4.6 helped me figure out code places to update.