### PR TITLE
fix(tracing): fix trace span instrumentation

### DIFF
--- a/core/layers/tracing/src/lib.rs
+++ b/core/layers/tracing/src/lib.rs
@@ -186,11 +186,7 @@ impl HttpFetch for TracingHttpFetcher {
     async fn fetch(&self, req: http::Request<Buffer>) -> Result<http::Response<HttpBody>> {
         let span = span!(Level::DEBUG, "http::fetch", ?req);
 
-        let resp = self
-            .inner
-            .fetch(req)
-            .instrument(span.clone())
-            .await?;
+        let resp = self.inner.fetch(req).instrument(span.clone()).await?;
 
         let (parts, body) = resp.into_parts();
         let body = body.map_inner(|s| Box::new(TracingStream { inner: s, span }));
@@ -240,11 +236,7 @@ impl<A: Access> LayeredAccess for TracingAccessor<A> {
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let span = span!(Level::DEBUG, "read", path, ?args);
 
-        let (rp, r) = self
-            .inner
-            .read(path, args)
-            .instrument(span.clone())
-            .await?;
+        let (rp, r) = self.inner.read(path, args).instrument(span.clone()).await?;
 
         Ok((rp, TracingWrapper::new(span, r)))
     }
@@ -279,11 +271,7 @@ impl<A: Access> LayeredAccess for TracingAccessor<A> {
     async fn delete(&self) -> Result<(RpDelete, Self::Deleter)> {
         let span = span!(Level::DEBUG, "delete");
 
-        let (rp, r) = self
-            .inner
-            .delete()
-            .instrument(span.clone())
-            .await?;
+        let (rp, r) = self.inner.delete().instrument(span.clone()).await?;
 
         Ok((rp, TracingWrapper::new(span, r)))
     }
@@ -291,11 +279,7 @@ impl<A: Access> LayeredAccess for TracingAccessor<A> {
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
         let span = span!(Level::DEBUG, "list", path, ?args);
 
-        let (rp, r) = self
-            .inner
-            .list(path, args)
-            .instrument(span.clone())
-            .await?;
+        let (rp, r) = self.inner.list(path, args).instrument(span.clone()).await?;
 
         Ok((rp, TracingWrapper::new(span, r)))
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7291

# Rationale for this change

- enter call sets the current span as thread-local variable, with task to execute yields, another task could be scheduled to the current thread and mistakenly use this thread-local span, leading to incorrect traces
- when the current task gets re-scheduled, it could be scheduled to another thread with the span destructed in another thread....

# What changes are included in this PR?

Follow the documentation (https://github.com/apache/opendal/issues/7291) to use `instrument` instead of `enter` to annotate tasks to await.

# Are there any user-facing changes?

No

# AI Usage Statement

No AI involvement.