### PR TITLE
feat(s3): validate checksum before making HTTP requests

### DIFF
--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -833,6 +833,15 @@ impl S3Core {
         req = self.insert_sse_headers(req, true);
 
         // Set checksum type headers.
+        // For multipart upload creation, only CRC32 | CRC32C | SHA1 | SHA256 | CRC64NVME are accepted.
+        // Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
+        if matches!(self.checksum_algorithm, Some(ChecksumAlgorithm::Md5)) {
+            return Err(Error::new(
+                ErrorKind::Unsupported,
+                "checksum_algorithm \"md5\" is not supported for multipart uploads. \
+                 S3 CreateMultipartUpload only accepts: CRC32, CRC32C, SHA1, SHA256.",
+            ));
+        }
         req = self.insert_checksum_type_header(req);
 
         // Inject operation to the request.


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7295

# Rationale for this change

Hi team, I was using the following code to create multipart upload request and get a 400 Bad Request from in-house S3.
```rust
let op = Operator::new(S3::default().bucket(xxx).region(yyy).checksum_algorithm("md5"))?;
op.write(content).chunk(xxx).concurrent(yyy).await?;
```
The reason is multipart upload request doesn't support MD5 as checksum algorithm.
https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html#API_CreateMultipartUpload_RequestParameters

# What changes are included in this PR?

In this PR, I validate the checksum before sending out HTTP requests.

# Are there any user-facing changes?

No.

# AI Usage Statement

I made the code change, opus 4.6 did a sanity check for supported checksum algorithms for other type of requests.