### PR TITLE
fix(s3): fix incorrect md5 for list operations

### DIFF
--- a/core/services/s3/src/lister.rs
+++ b/core/services/s3/src/lister.rs
@@ -142,7 +142,6 @@ impl oio::PageList for S3ListerV1 {
             meta.set_is_current(true);
             if let Some(etag) = &object.etag {
                 meta.set_etag(etag);
-                meta.set_content_md5(etag.trim_matches('"'));
             }
             meta.set_content_length(object.size);
 
@@ -252,7 +251,6 @@ impl oio::PageList for S3ListerV2 {
             meta.set_is_current(true);
             if let Some(etag) = &object.etag {
                 meta.set_etag(etag);
-                meta.set_content_md5(etag.trim_matches('"'));
             }
             meta.set_content_length(object.size);
 
@@ -372,7 +370,6 @@ impl oio::PageList for S3ObjectVersionsLister {
 
             if let Some(etag) = version_object.etag {
                 meta.set_etag(&etag);
-                meta.set_content_md5(etag.trim_matches('"'));
             }
 
             let entry = oio::Entry::new(&path, meta);


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7297

# Rationale for this change

As described in the issue, we're now referring MD5 from ETag and set it to returned object metadata.
But checking doc (link attached in the issue), all involved list operations don't return MD5, which means we're returning incorrect metadata.

# What changes are included in this PR?

The MD5 field in the object metadata is optional, so in this PR I simply leave it empty.

# Are there any user-facing changes?

No.

# AI Usage Statement

No AI involvement. 