### PR TITLE
fix(observability): fix executing operation gauge on timeout

### DIFF
--- a/core/layers/observe-metrics-common/src/lib.rs
+++ b/core/layers/observe-metrics-common/src/lib.rs
@@ -503,10 +503,7 @@ impl<I: MetricsIntercept> ExecutingGuard<I> {
 impl<I: MetricsIntercept> Drop for ExecutingGuard<I> {
     fn drop(&mut self) {
         if let Some(ref interceptor) = self.interceptor {
-            interceptor.observe(
-                std::mem::take(&mut self.labels),
-                (self.metric_fn)(-1),
-            );
+            interceptor.observe(std::mem::take(&mut self.labels), (self.metric_fn)(-1));
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7300

# Rationale for this change

As described in the issue, I attach a code snippet to illustrate why current implementation is incorrect, and how we could use RAII-style metrics wrapper to fix the issue. This PR implements the same strategy.

# What changes are included in this PR?

Use RAII-wrapper for executing operations/requests gauge so it could be decremented correctly as long as the wrapper goes out-of-scope, even for cancellation due to timeout.

# Are there any user-facing changes?

No.

# AI Usage Statement

Opus 4.6 helped me make the change.