### PR TITLE
fix(observability): Fix failed operation/request gauge on timeout

### DIFF
--- a/core/layers/observe-metrics-common/src/lib.rs
+++ b/core/layers/observe-metrics-common/src/lib.rs
@@ -625,6 +625,7 @@ impl<I: MetricsIntercept> HttpFetch for MetricsHttpFetcher<I> {
                         labels: labels.clone(),
                         size: 0,
                         start: Instant::now(),
+                        succeeded: false,
                     })
                 });
 
@@ -641,6 +642,7 @@ struct MetricsStream<S, I: MetricsIntercept> {
     labels: MetricLabels,
     size: u64,
     start: Instant,
+    succeeded: bool,
 }
 
 impl<S, I> Stream for MetricsStream<S, I>
@@ -657,7 +659,10 @@ where
                 Poll::Ready(Some(Ok(bs)))
             }
             Some(Err(err)) => Poll::Ready(Some(Err(err))),
-            None => Poll::Ready(None),
+            None => {
+                self.succeeded = true;
+                Poll::Ready(None)
+            }
         }
     }
 }
@@ -666,6 +671,11 @@ impl<S, I: MetricsIntercept> Drop for MetricsStream<S, I> {
     fn drop(&mut self) {
         let resp_size = self.size;
         let resp_duration = self.start.elapsed();
+
+        if !self.succeeded {
+            self.interceptor
+                .observe(self.labels.clone(), MetricValue::HttpConnectionErrorsTotal);
+        }
 
         self.interceptor.observe(
             self.labels.clone(),


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7302
Closes https://github.com/apache/opendal/issues/7304

# Rationale for this change

In production usage, I saw a sudden large number of timeout failures, but the HTTP request and operation failure count doesn't increase a lot on the dashboard, so I think there's something wrong on how we record failure gauge.
Checking the source code I think it's of the same issue as the executing request/operation gauge miscount.

# What changes are included in this PR?

Followup fix for https://github.com/apache/opendal/pull/7301 -- sorry I should've fixed everything in one shot. :(
The fix is similar as well: reuse the same RAII guard and record failed operation/request duration and count on drop.

# Are there any user-facing changes?

No

# AI Usage Statement

Opus 4.6 helped me make the change, I double check there's no duplicate or missing metrics report.
Bytes processed and byte process rate are recorded by `MetricsStream` separately.
