### PR TITLE
ci(fixtures): pin owncloud image tag

### DIFF
--- a/fixtures/webdav/docker-compose-webdav-owncloud.yml
+++ b/fixtures/webdav/docker-compose-webdav-owncloud.yml
@@ -17,7 +17,7 @@
 
 services:
   owncloud:
-    image: owncloud/server
+    image: owncloud/server:10.16.0
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

The WebDAV ownCloud behavior test can fail before the test suite starts because the fixture pulls `owncloud/server:latest`, and that floating tag returned `manifest unknown` in a recent CI run:
https://github.com/apache/opendal/actions/runs/23524165649/job/68473661735

Pinning the image to a concrete version removes this external drift and makes the setup deterministic again.

# What changes are included in this PR?

Pin the ownCloud fixture image from the implicit `latest` tag to `owncloud/server:10.16.0`.

# Are there any user-facing changes?

No.

# AI Usage Statement

Used Codex (GPT-5-based coding agent) to inspect the failing CI job, prepare the patch, and validate the pinned image tag.
