### PR TITLE
fix(s3): Fix entry mode and raw entry assertion

### DIFF
--- a/core/services/s3/src/lister.rs
+++ b/core/services/s3/src/lister.rs
@@ -383,7 +383,7 @@ impl oio::PageList for S3ObjectVersionsLister {
                     path = "/".to_owned();
                 }
 
-                let mut meta = Metadata::new(EntryMode::FILE);
+                let mut meta = Metadata::new(EntryMode::from_path(&path));
                 meta.set_version(&delete_marker.version_id);
                 meta.set_is_deleted(true);
                 meta.set_is_current(delete_marker.is_latest);


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7307

# Rationale for this change

There's an invariant check that if object key ends with slash, it should be of directory entry type;
for deleted keys returned, they're possible to suffix with slash, but somehow we hard-code them to be file type.

# What changes are included in this PR?

Just always use `Entry::with_path` to construct an entry.

# Are there any user-facing changes?

No

# AI Usage Statement

No AI involvement.
