### PR TITLE
fix(util): Fix panic on invalid bytes range

### DIFF
--- a/core/core/src/raw/http_util/bytes_range.rs
+++ b/core/core/src/raw/http_util/bytes_range.rs
@@ -120,10 +120,9 @@ impl Display for BytesRange {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self.1 {
             None => write!(f, "{}-", self.0),
-            Some(size) => match (self.0 + size).checked_sub(1) {
-                Some(end) => write!(f, "{}-{}", self.0, end),
-                None => Err(std::fmt::Error),
-            },
+            // A zero-size range can't be represented as a valid HTTP Range.
+            Some(0) => Err(std::fmt::Error),
+            Some(size) => write!(f, "{}-{}", self.0, self.0 + size - 1),
         }
     }
 }
@@ -206,12 +205,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_bytes_range_display_zero_size_from_start() {
+    fn test_bytes_range_display_zero_size() {
+        // Zero-size at offset 0
         let range = BytesRange::new(0, Some(0));
-        assert!(
-            std::fmt::write(&mut String::new(), format_args!("{}", range)).is_err(),
-            "Display of empty range at offset 0 should return fmt::Error"
-        );
+        assert!(std::fmt::write(&mut String::new(), format_args!("{}", range)).is_err());
+
+        // Zero-size at nonzero offset
+        let range = BytesRange::new(5, Some(0));
+        assert!(std::fmt::write(&mut String::new(), format_args!("{}", range)).is_err());
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7313

# Rationale for this change

I don't think we shouldn't panic here, even for invalid input.

# What changes are included in this PR?

Returns error instead of panic for all zero-sized bytes range, it's not a valid HTTP range.

# Are there any user-facing changes?

No

# AI Usage Statement

Opus 4.6 generates random input and detects the bug.
