### PR TITLE
fix(copy): Fix error propagation operation

### DIFF
--- a/core/core/src/types/operator/operator.rs
+++ b/core/core/src/types/operator/operator.rs
@@ -1173,7 +1173,7 @@ impl Operator {
         if !validate_path(&from, EntryMode::FILE) {
             return Err(
                 Error::new(ErrorKind::IsADirectory, "from path is a directory")
-                    .with_operation("Operator::move_")
+                    .with_operation(Operation::Rename)
                     .with_context("service", self.info().scheme())
                     .with_context("from", from),
             );
@@ -1184,7 +1184,7 @@ impl Operator {
         if !validate_path(&to, EntryMode::FILE) {
             return Err(
                 Error::new(ErrorKind::IsADirectory, "to path is a directory")
-                    .with_operation("Operator::move_")
+                    .with_operation(Operation::Rename)
                     .with_context("service", self.info().scheme())
                     .with_context("to", to),
             );
@@ -1193,7 +1193,7 @@ impl Operator {
         if from == to {
             return Err(
                 Error::new(ErrorKind::IsSameFile, "from and to paths are same")
-                    .with_operation("Operator::move_")
+                    .with_operation(Operation::Rename)
                     .with_context("service", self.info().scheme())
                     .with_context("from", from)
                     .with_context("to", to),


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7317

# Rationale for this change

We should use `rename` as operation name in error propagation.

# What changes are included in this PR?

Use Enum instead of string to avoid error.

# Are there any user-facing changes?

No.

# AI Usage Statement

Opus 4.6 helped me craft tests to identify the issue.