### PR TITLE
fix(correctess check): validate copy capability and request

### DIFF
--- a/core/core/src/layers/correctness_check.rs
+++ b/core/core/src/layers/correctness_check.rs
@@ -210,6 +210,19 @@ impl<A: Access> LayeredAccess for CorrectnessAccessor<A> {
         })
     }
 
+    async fn copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
+        let capability = self.info.full_capability();
+        if args.if_not_exists() && !capability.copy_with_if_not_exists {
+            return Err(new_unsupported_error(
+                &self.info,
+                Operation::Copy,
+                "if_not_exists",
+            ));
+        }
+
+        self.inner.copy(from, to, args).await
+    }
+
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
         self.inner.list(path, args).await
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7321

# Rationale for this change

Correctness check layer is used to validate against user request and storage backend capability match-ness.
In the current implementation we never check `Copy` operation's.

# What changes are included in this PR?

This PR adds validation for conditional copy capability and request.

# Are there any user-facing changes?

No.

# AI Usage Statement

Opus 4.6 detected the issue for me by reading the correctness check layer, cursor autocompletion did the code change.