### PR TITLE
fix(s3): fix missing complete multipart upload headers

### DIFF
--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -900,6 +900,7 @@ impl S3Core {
         path: &str,
         upload_id: &str,
         parts: Vec<CompleteMultipartUploadRequestPart>,
+        args: &OpWrite,
     ) -> Result<Response<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
@@ -921,6 +922,14 @@ impl S3Core {
         req = req.header(CONTENT_LENGTH, content.len());
         // Set content-type to `application/xml` to avoid mixed with form post.
         req = req.header(CONTENT_TYPE, "application/xml");
+
+        // Set conditional write headers.
+        if let Some(if_match) = args.if_match() {
+            req = req.header(IF_MATCH, if_match);
+        }
+        if args.if_not_exists() {
+            req = req.header(IF_NONE_MATCH, "*");
+        }
 
         // Set request payer header if enabled.
         req = self.insert_request_payer_header(req);

--- a/core/services/s3/src/writer.rs
+++ b/core/services/s3/src/writer.rs
@@ -180,7 +180,7 @@ impl oio::MultipartWrite for S3Writer {
 
         let resp = self
             .core
-            .s3_complete_multipart_upload(&self.path, upload_id, parts)
+            .s3_complete_multipart_upload(&self.path, upload_id, parts, &self.op)
             .await?;
 
         let status = resp.status();


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7326

# Rationale for this change

S3 complete multipart upload request headers miss conditional write support.

# What changes are included in this PR?

This PR adds the missing headers for S3-compatible conditional write request.

# Are there any user-facing changes?

No.

# AI Usage Statement

Cursor auto-completion made the code change for me.