### PR TITLE
[doc] Add concurrent limit layer usage along with operator concurrent read

### DIFF
--- a/core/layers/concurrent-limit/src/lib.rs
+++ b/core/layers/concurrent-limit/src/lib.rs
@@ -64,6 +64,19 @@ impl ConcurrentLimitSemaphore for Arc<Semaphore> {
 /// that the total number of concurrent requests across the entire
 /// application does not exceed the limit.
 ///
+/// # HTTP semaphore and deadlock risk
+///
+/// When interacting with `read_with().concurrent(N).chunk(C)` (same for write), which
+/// creates a task pool of size `N`. The pool eagerly creates readers (each issuing
+/// an HTTP request and acquiring a permit) to fill all `N` slots before it starts
+/// consuming any completed readers. If `N` exceeds the HTTP semaphore's permit count,
+/// the pool will exhaust all permits while still trying to create more readers, and
+/// no permits can be freed because the pool only releases readers when draining
+/// completed tasks — which it cannot reach while blocked on permit acquisition.
+///
+/// To avoid deadlocks, ensure that any `read_with().concurrent(N)` value does not
+/// exceed the HTTP semaphore permit count.
+///
 /// # Examples
 ///
 /// Add a concurrent limit layer to the operator:


### PR DESCRIPTION
# Rationale for this change

Hi team I want to add doc to concurrent limit layer since I made a stupid mistake, thought it might be good to document;
happy to reword and I'm ok to close the PR if you think unnecessary.

The bug I wrote is:
- I use `ConcurrentLimitLayer` to limit my read requests, let's say M
- Meanwhile for `operator.read_with(key).chunk(sz).concurrent(N)` I set N to be object size / a default read size 16MiB; when my customer is uploading super large object so N > M, based on the chunk reader implementation,
  + it will try to create N streams but never synchronize any of them
  + all streams are created inside of a deque, and only pop out when there're no free slots in the chunk reader
  + so we exhaust all M slots for concurrent limit layer => deadlock

# What changes are included in this PR?

Considering concurrent limit layer is a separate layer, chunk reader and executor is not supposed to have any knowledge on its rate limit, so I think it's good to document the issue.

# Are there any user-facing changes?

No.

# AI Usage Statement

No AI involvement.
