### PR TITLE
fix(services/cos): preserve list metadata etag and last_modified

### DIFF
--- a/core/services/cos/src/core.rs
+++ b/core/services/cos/src/core.rs
@@ -615,6 +615,9 @@ pub struct CommonPrefix {
 #[serde(default, rename_all = "PascalCase")]
 pub struct ListObjectsOutputContent {
     pub key: String,
+    pub last_modified: String,
+    #[serde(rename = "ETag")]
+    pub etag: Option<String>,
     pub size: u64,
 }
 
@@ -718,6 +721,23 @@ mod tests {
         assert_eq!(
             out.contents.iter().map(|v| v.size).collect::<Vec<u64>>(),
             [9, 10],
+        );
+        assert_eq!(
+            out.contents
+                .iter()
+                .map(|v| v.last_modified.clone())
+                .collect::<Vec<String>>(),
+            ["2015-07-01T02:11:19.775Z", "2015-07-01T02:11:19.775Z"],
+        );
+        assert_eq!(
+            out.contents
+                .iter()
+                .map(|v| v.etag.clone())
+                .collect::<Vec<Option<String>>>(),
+            [
+                Some("\"a72e382246ac83e86bd203389849e71d\"".to_string()),
+                Some("\"a72e382246ac83e86bd203389849e71d\"".to_string()),
+            ],
         );
         assert_eq!(
             out.common_prefixes

--- a/core/services/cos/src/lister.rs
+++ b/core/services/cos/src/lister.rs
@@ -90,7 +90,13 @@ impl oio::PageList for CosLister {
                 path = "/".to_string();
             }
 
-            let meta = Metadata::new(EntryMode::from_path(&path)).with_content_length(object.size);
+            let mut meta =
+                Metadata::new(EntryMode::from_path(&path)).with_content_length(object.size);
+            meta.set_last_modified(object.last_modified.parse::<Timestamp>()?);
+            if let Some(etag) = object.etag {
+                meta.set_etag(&etag);
+                meta.set_content_md5(etag.trim_matches('"'));
+            }
 
             let de = oio::Entry::with(path, meta);
             ctx.entries.push_back(de);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7306.

# Rationale for this change

COS list responses include `ETag` and `LastModified`, but the normal list path only deserialized `key` and `size`, so list metadata lost those fields even though `stat()` could return them.

# What changes are included in this PR?

- deserialize `LastModified` and `ETag` in COS `ListObjectsOutputContent`
- populate `last_modified`, `etag`, and `content_md5` in the normal COS lister path
- extend the COS XML parsing unit test to cover both fields

# Are there any user-facing changes?

Users of COS list operations can now read `etag` and `last_modified` metadata from list results consistently across bindings.

# AI Usage Statement

Used Codex (GPT-5) to investigate the issue, implement the fix, run tests, and validate the behavior with a Python reproduction script.
