### PR TITLE
fix(bindings/ocaml): clean up OCaml API docs

### DIFF
--- a/bindings/ocaml/lib/operator.mli
+++ b/bindings/ocaml/lib/operator.mli
@@ -63,16 +63,18 @@ val new_operator :
 
     Example:
     {[
-      (* Local filesystem *)
-      let fs_op = new_operator "fs" [("root", "/tmp")] in
+    (* Local filesystem *)
+    let fs_op = new_operator "fs" [ ("root", "/tmp") ]
 
-      (* S3 storage *)
-      let s3_op = new_operator "s3" [
-        ("bucket", "my-bucket");
-        ("region", "us-east-1");
-        ("access_key_id", "...");
-        ("secret_access_key", "...")
-      ] in
+    (* S3 storage *)
+    let s3_op =
+      new_operator "s3"
+        [
+          ("bucket", "my-bucket");
+          ("region", "us-east-1");
+          ("access_key_id", "...");
+          ("secret_access_key", "...");
+        ]
     ]} *)
 
 val list :


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

The OCaml binding interface docs used odoc/ocamlformat-incompatible comment markup. That caused documentation-related CI failures and also left a couple of cross references ambiguous in the rendered API docs.

# What changes are included in this PR?

- rewrite the OCaml API doc examples in `bindings/ocaml/lib/operator.mli` to use odoc-compatible example blocks
- align the interface with `ocamlformat` output so `dune build @fmt` stays clean
- disambiguate the `lister` and `reader` value references in the rendered docs

# Are there any user-facing changes?

OCaml API documentation now renders with clearer examples and correct links for `lister` and `reader`.

# AI Usage Statement

This PR was prepared with Codex (GPT-5).
