### PR TITLE
fix(services/azblob): Remove let-chain for Rust 1.85 support

### DIFF
--- a/core/services/azblob/src/error.rs
+++ b/core/services/azblob/src/error.rs
@@ -82,17 +82,20 @@ pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     };
 
     // If there is no body here, fill with error code.
-    if message.is_empty()
-        && let Some(v) = parts.headers.get("x-ms-error-code")
-        && let Ok(code) = v.to_str()
-    {
-        message = format!(
-            "{:?}",
-            AzblobError {
-                code: code.to_string(),
-                ..Default::default()
-            }
-        )
+    if message.is_empty() {
+        if let Some(code) = parts
+            .headers
+            .get("x-ms-error-code")
+            .and_then(|v| v.to_str().ok())
+        {
+            message = format!(
+                "{:?}",
+                AzblobError {
+                    code: code.to_string(),
+                    ..Default::default()
+                }
+            );
+        }
     }
 
     let mut err = Error::new(kind, &message);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7335

# Rationale for this change

The minimum Rust version for this crate is 1.85, and let-chains are only supported in 1.88.

Without this fix, the crate fails to compile on Rust 1.85.

```
error[E0658]: `let` expressions in this position are unstable
  --> /home/runner/.cargo/git/checkouts/opendal-89f1f92334d3adc5/2c3bbc7/core/services/azblob/src/error.rs:86:12
   |
86 |         && let Some(v) = parts.headers.get("x-ms-error-code")
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information

error[E0658]: `let` expressions in this position are unstable
  --> /home/runner/.cargo/git/checkouts/opendal-89f1f92334d3adc5/2c3bbc7/core/services/azblob/src/error.rs:87:12
   |
87 |         && let Ok(code) = v.to_str()
   |            ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
```

# What changes are included in this PR?

Removal of let-chain only.

# Are there any user-facing changes?

No

# AI Usage Statement

Built w/Claude Opus 4.6