### PR TITLE
ci: update path filters for split core layout

### DIFF
--- a/.github/workflows/ci_bindings_php.yml
+++ b/.github/workflows/ci_bindings_php.yml
@@ -28,7 +28,7 @@ on:
       - main
     paths:
       - "bindings/php/**"
-      - ".github/workflows/bindings_php.yml"
+      - ".github/workflows/ci_bindings_php.yml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/service_test_ghac.yml
+++ b/.github/workflows/service_test_ghac.yml
@@ -25,11 +25,17 @@ on:
     branches:
       - main
     paths:
-      - "core/src/**"
+      - "core/Cargo.toml"
+      - "core/Cargo.lock"
+      - "core/core/Cargo.toml"
+      - "core/core/src/**"
+      - "core/layers/**"
+      - "core/testkit/**"
       - "core/tests/**"
-      - "!core/src/docs/**"
-      - "!core/src/services/**"
-      - "core/src/services/ghac/**"
+      - "!core/core/src/docs/**"
+      - "core/services/azblob/**"
+      - "core/services/azure-common/**"
+      - "core/services/ghac/**"
       - ".github/workflows/service_test_ghac.yml"
 
 concurrency:

--- a/.github/workflows/test_edge.yml
+++ b/.github/workflows/test_edge.yml
@@ -25,12 +25,19 @@ on:
     branches:
       - main
     paths:
-      - "core/src/**"
-      - "!core/src/docs/**"
-      - "!core/src/services/**"
-      - "core/src/services/fs/**"
-      - "core/src/services/s3/**"
-      - ".github/workflows/edge_test.yml"
+      - "core/Cargo.toml"
+      - "core/Cargo.lock"
+      - "core/core/Cargo.toml"
+      - "core/core/src/**"
+      - "core/layers/**"
+      - "core/testkit/**"
+      - "!core/core/src/docs/**"
+      - "core/edge/file_write_on_full_disk/**"
+      - "core/edge/s3_aws_assume_role_with_web_identity/**"
+      - "core/edge/s3_read_on_wasm/**"
+      - "core/services/fs/**"
+      - "core/services/s3/**"
+      - ".github/workflows/test_edge.yml"
 
 jobs:
   test_file_write_on_full_disk:

--- a/.github/workflows/test_fuzz.yml
+++ b/.github/workflows/test_fuzz.yml
@@ -25,10 +25,16 @@ on:
     branches:
       - main
     paths:
-      - "core/src/**"
+      - "core/Cargo.toml"
+      - "core/Cargo.lock"
+      - "core/core/Cargo.toml"
+      - "core/core/src/**"
       - "core/fuzz/**"
-      - "!core/src/docs/**"
-      - ".github/workflows/fuzz_test.yml"
+      - "core/layers/**"
+      - "core/services/**"
+      - "core/testkit/**"
+      - "!core/core/src/docs/**"
+      - ".github/workflows/test_fuzz.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

A few specialized workflows still assumed the pre-split `core/src/services/...` layout or referenced old workflow filenames. That causes important targeted CI jobs to stop triggering for real changes.

# What changes are included in this PR?

This updates the path filters for `test_fuzz.yml`, `test_edge.yml`, and `service_test_ghac.yml` to follow the current `core/core`, `core/services`, `core/layers`, and `core/testkit` structure. It also fixes the stale self-workflow path in those files and in `ci_bindings_php.yml`.

# Are there any user-facing changes?

No user-facing changes. This only restores CI coverage after the directory split.

# AI Usage Statement

Built with Codex using GPT-5.4 subagents.
