### PR TITLE
docs: refresh split release documentation

### DIFF
--- a/website/community/release/release.md
+++ b/website/community/release/release.md
@@ -75,10 +75,13 @@ Start a [tracking issue on GitHub](https://github.com/apache/opendal/issues/new?
 
 Update the version list in the `dev/src/release/package.rs` file.
 
+This file is the source of truth for the split source release layout. Each entry in this list produces an independent source archive named `apache-opendal-{package}-{version}-src.tar.gz`.
+
 For example:
 
 - If there is any breaking change, please bump the `minor` version instead of the `patch` version.
-- If this package is not ready for release, please skip.
+- If this package is not ready for release, please skip it from the release list.
+- Packages that have moved to separate repositories must not be included here.
 
 ## GitHub Side
 
@@ -103,7 +106,7 @@ Running `python3 ./scripts/dependencies.py generate` to update the dependency li
 
 ### Push release candidate tag
 
-After bump version PR gets merged, we can create a GitHub release for the release candidate:
+After bump version PR gets merged, push the release candidate tag:
 
 - Create a tag at `main` branch on the `Bump Version` / `Patch up version` commit: `git tag -s "v0.46.0-rc.1"`, please correctly check out the corresponding commit instead of directly tagging on the main branch.
 - Push tags to GitHub: `git push --tags`.
@@ -111,17 +114,18 @@ After bump version PR gets merged, we can create a GitHub release for the releas
 
 :::note
 
-Pushing a Git tag to GitHub repo will trigger a GitHub Actions workflow that creates a staging Maven release on https://repository.apache.org which can be verified on voting.
+Pushing an RC tag to GitHub will trigger the tag-based release workflows. In the current flow, this includes the Java staging artifacts on https://repository.apache.org and dry-run checks for other released packages.
 
 :::
 
 ### Check the GitHub action status
 
-After pushing the tag, we need to check the GitHub action status to make sure the release candidate is created successfully.
+After pushing the tag, check the GitHub action status to make sure the RC workflows finished successfully.
 
-- Python: [Bindings Python CI](https://github.com/apache/opendal/actions/workflows/ci_bindings_python.yml)
+- Rust packages: [Release Rust Packages](https://github.com/apache/opendal/actions/workflows/release_rust.yml)
 - Java: [Bindings Java CI](https://github.com/apache/opendal/actions/workflows/ci_bindings_java.yml) and [Bindings Java Release](https://github.com/apache/opendal/actions/workflows/release_java.yml)
-- Node.js: [Bindings Node.js CI](https://github.com/apache/opendal/actions/workflows/ci_bindings_nodejs.yml)
+- Node.js: [Bindings Node.js CI](https://github.com/apache/opendal/actions/workflows/ci_bindings_nodejs.yml) and [Release NodeJS Binding](https://github.com/apache/opendal/actions/workflows/release_nodejs.yml)
+- Docs: [Docs](https://github.com/apache/opendal/actions/workflows/docs.yml)
 
 In the most cases, it would be great to rerun the failed workflow directly when you find some failures. But if a new code patch is needed to fix the failure, you should create a new release candidate tag, increase the rc number and push it to GitHub.
 
@@ -135,15 +139,17 @@ Additionally, we should also drop the staging Maven artifacts on https://reposit
 
 ### Create an ASF Release
 
-After GitHub Release has been created, we can start to create ASF Release.
+After the RC tag has been pushed and the required workflows are green, create the ASF source release artifacts.
 
 - Checkout to released tag. (e.g. `git checkout v0.46.0-rc.1`, tag is created in the previous step)
 - Use the release script to create a new release: `just release`
-  - This script will generate the release candidate artifacts under `dist`, including:
+  - This script will generate the release candidate artifacts under `dist` for every package listed in `dev/src/release/package.rs`, including:
     - `apache-opendal-{package}-{version}-src.tar.gz`
     - `apache-opendal-{package}-{version}-src.tar.gz.asc`
     - `apache-opendal-{package}-{version}-src.tar.gz.sha512`
-- Push the newly created branch to GitHub
+  - Artifact names use each package's own version. The RC version is only used for the SVN directory name, such as `0.55.0-rc.1/`.
+  - Each archive contains `LICENSE`, `NOTICE`, the package directory itself, and any repo-local dependencies needed to build that package from source.
+  - This repository no longer produces a monolithic `apache-opendal-${opendal_version}-src.tar.gz` artifact or any `apache-opendal-bin-*` artifacts.
 
 This script will create a new release under `dist`.
 
@@ -151,21 +157,36 @@ For example:
 
 ```shell
 dist
-├── apache-opendal-bindings-c-0.44.2-src.tar.gz
-├── apache-opendal-bindings-c-0.44.2-src.tar.gz.asc
-├── apache-opendal-bindings-c-0.44.2-src.tar.gz.sha512
-...
-├── apache-opendal-core-0.45.0-src.tar.gz
-├── apache-opendal-core-0.45.0-src.tar.gz.asc
-├── apache-opendal-core-0.45.0-src.tar.gz.sha512
-├── apache-opendal-integrations-dav-server-0.0.0-src.tar.gz
-├── apache-opendal-integrations-dav-server-0.0.0-src.tar.gz.asc
-├── apache-opendal-integrations-dav-server-0.0.0-src.tar.gz.sha512
-├── apache-opendal-integrations-object_store-0.42.0-src.tar.gz
-├── apache-opendal-integrations-object_store-0.42.0-src.tar.gz.asc
-└── apache-opendal-integrations-object_store-0.42.0-src.tar.gz.sha512
-
-1 directory, 60 files
+├── apache-opendal-bindings-c-${c_version}-src.tar.gz
+├── apache-opendal-bindings-c-${c_version}-src.tar.gz.asc
+├── apache-opendal-bindings-c-${c_version}-src.tar.gz.sha512
+├── apache-opendal-bindings-cpp-${cpp_version}-src.tar.gz
+├── apache-opendal-bindings-cpp-${cpp_version}-src.tar.gz.asc
+├── apache-opendal-bindings-cpp-${cpp_version}-src.tar.gz.sha512
+├── apache-opendal-bindings-java-${java_version}-src.tar.gz
+├── apache-opendal-bindings-java-${java_version}-src.tar.gz.asc
+├── apache-opendal-bindings-java-${java_version}-src.tar.gz.sha512
+├── apache-opendal-bindings-nodejs-${nodejs_version}-src.tar.gz
+├── apache-opendal-bindings-nodejs-${nodejs_version}-src.tar.gz.asc
+├── apache-opendal-bindings-nodejs-${nodejs_version}-src.tar.gz.sha512
+├── apache-opendal-bindings-python-${python_version}-src.tar.gz
+├── apache-opendal-bindings-python-${python_version}-src.tar.gz.asc
+├── apache-opendal-bindings-python-${python_version}-src.tar.gz.sha512
+├── apache-opendal-core-${core_version}-src.tar.gz
+├── apache-opendal-core-${core_version}-src.tar.gz.asc
+├── apache-opendal-core-${core_version}-src.tar.gz.sha512
+├── apache-opendal-integrations-dav-server-${dav_server_version}-src.tar.gz
+├── apache-opendal-integrations-dav-server-${dav_server_version}-src.tar.gz.asc
+├── apache-opendal-integrations-dav-server-${dav_server_version}-src.tar.gz.sha512
+├── apache-opendal-integrations-object_store-${object_store_version}-src.tar.gz
+├── apache-opendal-integrations-object_store-${object_store_version}-src.tar.gz.asc
+├── apache-opendal-integrations-object_store-${object_store_version}-src.tar.gz.sha512
+├── apache-opendal-integrations-parquet-${parquet_version}-src.tar.gz
+├── apache-opendal-integrations-parquet-${parquet_version}-src.tar.gz.asc
+├── apache-opendal-integrations-parquet-${parquet_version}-src.tar.gz.sha512
+├── apache-opendal-integrations-unftp-sbe-${unftp_sbe_version}-src.tar.gz
+├── apache-opendal-integrations-unftp-sbe-${unftp_sbe_version}-src.tar.gz.asc
+└── apache-opendal-integrations-unftp-sbe-${unftp_sbe_version}-src.tar.gz.sha512
 ```
 
 ### Upload artifacts to the SVN dist repo
@@ -249,9 +270,9 @@ Hello, Apache OpenDAL Community,
 
 This is a call for a vote to release Apache OpenDAL version ${opendal_version}.
 
-The tag to be voted on is ${opendal_version}.
+The tag to be voted on is v${release_version}.
 
-The release candidate:
+The release candidate source packages:
 
 https://dist.apache.org/repos/dist/dev/opendal/${release_version}/
 

--- a/website/community/release/verify.md
+++ b/website/community/release/verify.md
@@ -24,24 +24,29 @@ However, you should clearly state which checks you did. The release manager need
 
 To verify the release candidate, you need to download the release candidate from the [dist](https://dist.apache.org/repos/dist/dev/opendal/) directory.
 
-Our current distribution contains many files, which we recommend downloading using svn.
+Our current distribution is a directory of split source packages, so we recommend downloading the whole RC directory with svn.
 
-Use the following command to download all artifacts, replace "${release_version}-${rc_version}" with the version ID of the version to be released:
+Use the following command to download all artifacts, replacing `${release_version}` with the RC directory name, such as `0.55.0-rc.1`:
 
 ```shell
-svn co https://dist.apache.org/repos/dist/dev/opendal/${release_version}-${rc_version}/
+svn co https://dist.apache.org/repos/dist/dev/opendal/${release_version} opendal-${release_version}
 ```
 
 ## Checksums and signatures
 
-Every file in a release candidate should have a checksum and signature file.
+Every source archive in a release candidate should have a checksum and signature file.
 
-For example, if the release candidate is `0.46.0-rc1`, the checksum and signature file should be like:
+For example, if the release candidate directory is `0.55.0-rc.1`, the checksum and signature files should look like:
 
 ```
-https://dist.apache.org/repos/dist/dev/opendal/0.46.0-rc1/apache-opendal-core-0.46.0-rc1-src.tar.gz.sha512
-https://dist.apache.org/repos/dist/dev/opendal/0.46.0-rc1/apache-opendal-core-0.46.0-rc1-src.tar.gz.asc
+https://dist.apache.org/repos/dist/dev/opendal/0.55.0-rc.1/apache-opendal-core-0.55.0-src.tar.gz.sha512
+https://dist.apache.org/repos/dist/dev/opendal/0.55.0-rc.1/apache-opendal-core-0.55.0-src.tar.gz.asc
+https://dist.apache.org/repos/dist/dev/opendal/0.55.0-rc.1/apache-opendal-bindings-java-0.48.2-src.tar.gz.sha512
+https://dist.apache.org/repos/dist/dev/opendal/0.55.0-rc.1/apache-opendal-bindings-java-0.48.2-src.tar.gz.asc
 ```
+
+The RC directory is versioned by the vote round, while each artifact keeps its package version.
+Do not expect a single `apache-opendal-${opendal_version}-src.tar.gz` artifact or any `apache-opendal-bin-*` artifacts in this repository.
 
 ### Verify checksums and signatures
 
@@ -98,6 +103,8 @@ The script is in the `scripts` directory of our repository.
 You can download it directly from [here](https://raw.githubusercontent.com/apache/opendal/main/scripts/verify.py).
 Please put it in the same directory as the release candidate.
 
+The script checks every `*.tar.gz` in the RC directory that has matching `.asc` and `.sha512` files, extracts each `apache-opendal-*-src` tree, verifies `LICENSE` and `NOTICE`, builds `core`, and builds `bindings/java` when that package is present.
+
 Run the script in a specific release candidate's folder:
 
 ```shell
@@ -108,21 +115,24 @@ You will see the following output if the verification is successful:
 
 ```shell
 $ python ./verify.py
-> Checking apache-opendal-bin-oli-0.41.3-src.tar.gz
-gpg: Signature made 五  6/ 7 20:57:06 2024 CST
+> Checking apache-opendal-core-0.55.0-src.tar.gz
+gpg: Signature made Fri Jun  7 20:57:06 2024 CST
 gpg:                using RSA key 8B374472FAD328E17F479863B379691FC6E298DD
 gpg: Good signature from "Zili Chen (CODE SIGNING KEY) <tison@apache.org>" [unknown]
 gpg: WARNING: This key is not certified with a trusted signature!
 gpg:          There is no indication that the signature belongs to the owner.
 Primary key fingerprint: 8B37 4472 FAD3 28E1 7F47  9863 B379 691F C6E2 98DD
-> Success to verify the gpg sign for apache-opendal-bin-oli-0.41.3-src.tar.gz
-apache-opendal-bin-oli-0.41.3-src.tar.gz: OK
-> Success to verify the checksum for apache-opendal-bin-oli-0.41.3-src.tar.gz
+> Success to verify the gpg sign for apache-opendal-core-0.55.0-src.tar.gz
+apache-opendal-core-0.55.0-src.tar.gz: OK
+> Success to verify the checksum for apache-opendal-core-0.55.0-src.tar.gz
+> Checking apache-opendal-bindings-java-0.48.2-src.tar.gz
+apache-opendal-bindings-java-0.48.2-src.tar.gz: OK
+> Success to verify the checksum for apache-opendal-bindings-java-0.48.2-src.tar.gz
 .......
-> Start checking LICENSE file in /Users/yan/Downloads/opendal-dev/apache-opendal-0.47.0-src
-> LICENSE file exists in /Users/yan/Downloads/opendal-dev/apache-opendal-0.47.0-src
-> Start checking NOTICE file in /Users/yan/Downloads/opendal-dev/apache-opendal-0.47.0-src
-> NOTICE file exists in /Users/yan/Downloads/opendal-dev/apache-opendal-0.47.0-src
+> Start checking LICENSE file in /Users/yan/Downloads/opendal-dev/apache-opendal-core-0.55.0-src
+> LICENSE file exists in /Users/yan/Downloads/opendal-dev/apache-opendal-core-0.55.0-src
+> Start checking NOTICE file in /Users/yan/Downloads/opendal-dev/apache-opendal-core-0.55.0-src
+> NOTICE file exists in /Users/yan/Downloads/opendal-dev/apache-opendal-core-0.55.0-src
 cargo 1.78.0 (54d8815d0 2024-03-26)
 Start building opendal core
 Success to build opendal core
@@ -133,10 +143,12 @@ Start building opendal java binding
 > Success to build opendal java binding
 ```
 
-## Check the file content of the source package
+## Check the file content of the source packages
 
-Unzip `apache-opendal-${release_version}-${rc_version}-src.tar.gz` and check the follows:
+Unpack each released source package, for example `apache-opendal-core-0.55.0-src.tar.gz` or `apache-opendal-bindings-java-0.48.2-src.tar.gz`, and check the following:
 
+- The package layout matches the package being released.
+- Repo-local dependencies needed by that package are included. For example, bindings and integrations packages include `core`.
 - LICENSE and NOTICE files are correct for the repository.
 - All files have ASF license headers if necessary.
 - Building is OK.


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

The release and verification docs still described the old monolithic source archive and in-repo `bin-*` artifacts. That no longer matches the current split package release flow.

# What changes are included in this PR?

This refreshes the release guide and verification guide to describe the current per-package source archives, the RC directory naming scheme, and the workflows that should be checked after pushing a release tag. It also replaces outdated verification examples that still referenced removed artifacts.

# Are there any user-facing changes?

Yes. The release process documentation is updated to match the current repository layout.

# AI Usage Statement

Built with Codex using GPT-5.4 subagents.
