### PR TITLE
fix(core): fix deadlock for concurrent read and concurrent limit layer

### DIFF
--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -71,12 +71,20 @@ impl oio::Read for StreamingReader {
     }
 }
 
+/// Input for a chunked read task.
+struct ChunkedReadInput {
+    ctx: Arc<ReadContext>,
+    range: BytesRange,
+}
+
 /// ChunkedReader will read the file in chunks.
 ///
 /// ChunkedReader is good for concurrent read and optimized for throughput.
 pub struct ChunkedReader {
-    generator: ReadGenerator,
-    tasks: ConcurrentTasks<oio::Reader, Buffer>,
+    ctx: Arc<ReadContext>,
+    offset: u64,
+    remaining: Option<u64>,
+    tasks: ConcurrentTasks<ChunkedReadInput, Buffer>,
     done: bool,
 }
 
@@ -91,29 +99,65 @@ impl ChunkedReader {
             ctx.accessor().info().executor(),
             ctx.options().concurrent(),
             ctx.options().prefetch(),
-            |mut r: oio::Reader| {
-                Box::pin(async {
-                    match r.read_all().await {
-                        Ok(buf) => (r, Ok(buf)),
-                        Err(err) => (r, Err(err)),
+            |input: ChunkedReadInput| {
+                Box::pin(async move {
+                    let args = input.ctx.args().clone().with_range(input.range);
+                    let result = async {
+                        let (_, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
+                        r.read_all().await
                     }
+                    .await;
+                    (input, result)
                 })
             },
         );
-        let generator = ReadGenerator::new(ctx, range.offset(), range.size());
         Self {
-            generator,
+            ctx,
+            offset: range.offset(),
+            remaining: range.size(),
             tasks,
             done: false,
         }
+    }
+
+    /// Generate the next range to read, advancing internal state.
+    fn next_range(&mut self) -> Option<BytesRange> {
+        if self.remaining == Some(0) {
+            return None;
+        }
+
+        let next_offset = self.offset;
+        let next_size = match self.remaining {
+            None => {
+                self.remaining = Some(0);
+                None
+            }
+            Some(remaining) => {
+                let read_size = self
+                    .ctx
+                    .options()
+                    .chunk()
+                    .map_or(remaining, |chunk| remaining.min(chunk as u64));
+                self.offset += read_size;
+                self.remaining = Some(remaining - read_size);
+                Some(read_size)
+            }
+        };
+
+        Some(BytesRange::new(next_offset, next_size))
     }
 }
 
 impl oio::Read for ChunkedReader {
     async fn read(&mut self) -> Result<Buffer> {
         while self.tasks.has_remaining() && !self.done {
-            if let Some(r) = self.generator.next_reader().await? {
-                self.tasks.execute(r).await?;
+            if let Some(range) = self.next_range() {
+                self.tasks
+                    .execute(ChunkedReadInput {
+                        ctx: self.ctx.clone(),
+                        range,
+                    })
+                    .await?;
             } else {
                 self.done = true;
                 break;

--- a/core/layers/concurrent-limit/src/lib.rs
+++ b/core/layers/concurrent-limit/src/lib.rs
@@ -362,6 +362,7 @@ impl<R: oio::Delete, P: Send + Sync + 'static + Unpin> oio::Delete
 mod tests {
     use super::*;
     use opendal_core::Operator;
+    use opendal_core::OperatorBuilder;
     use opendal_core::services;
     use std::sync::Arc;
     use std::time::Duration;
@@ -395,6 +396,99 @@ mod tests {
             completed.is_ok(),
             "operation should proceed once permit is released"
         );
+    }
+
+    #[tokio::test]
+    async fn concurrent_chunked_read_with_http_limit() {
+        use opendal_core::raw::*;
+
+        struct EchoFetcher;
+
+        impl HttpFetch for EchoFetcher {
+            async fn fetch(&self, req: http::Request<Buffer>) -> Result<http::Response<HttpBody>> {
+                let data = req.into_body();
+                let len = data.len() as u64;
+                let body =
+                    HttpBody::new(Box::pin(stream::once(async move { Ok(data) })), Some(len));
+                Ok(http::Response::builder()
+                    .status(http::StatusCode::OK)
+                    .body(body)
+                    .unwrap())
+            }
+        }
+
+        #[derive(Clone, Debug)]
+        struct HttpBackend {
+            info: Arc<AccessorInfo>,
+            content: Buffer,
+        }
+
+        impl Access for HttpBackend {
+            type Reader = HttpBody;
+            type Writer = ();
+            type Lister = ();
+            type Deleter = ();
+
+            fn info(&self) -> Arc<AccessorInfo> {
+                self.info.clone()
+            }
+
+            async fn read(&self, _: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+                let range = args.range();
+                let start = range.offset() as usize;
+                let data = match range.size() {
+                    Some(sz) => self.content.slice(start..start + sz as usize),
+                    None => self.content.slice(start..),
+                };
+                let req = http::Request::get("http://fake").body(data).unwrap();
+                let resp = self.info.http_client().fetch(req).await?;
+                Ok((RpRead::default(), resp.into_body()))
+            }
+
+            async fn stat(&self, _: &str, _: OpStat) -> Result<RpStat> {
+                Ok(RpStat::new(
+                    Metadata::new(EntryMode::FILE).with_content_length(self.content.len() as u64),
+                ))
+            }
+
+            async fn write(&self, _: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {
+                Err(Error::new(ErrorKind::Unsupported, "not needed"))
+            }
+            async fn delete(&self) -> Result<(RpDelete, Self::Deleter)> {
+                Err(Error::new(ErrorKind::Unsupported, "not needed"))
+            }
+            async fn list(&self, _: &str, _: OpList) -> Result<(RpList, Self::Lister)> {
+                Err(Error::new(ErrorKind::Unsupported, "not needed"))
+            }
+        }
+
+        let content = Buffer::from(vec![0u8; 4096]);
+        let info = Arc::new(AccessorInfo::default());
+        info.update_http_client(|_| HttpClient::with(EchoFetcher));
+
+        let op = OperatorBuilder::new(HttpBackend {
+            info,
+            content: content.clone(),
+        })
+        .layer(ConcurrentLimitLayer::new(1024).with_http_concurrent_limit(2))
+        .finish();
+
+        // chunk=256 ⇒ 16 HTTP requests, concurrent=4, but only 2 HTTP permits.
+        let result = timeout(Duration::from_secs(5), async {
+            op.reader_with("test")
+                .chunk(256)
+                .concurrent(4)
+                .await
+                .expect("reader must build")
+                .read(..)
+                .await
+        })
+        .await;
+
+        let buf = result
+            .expect("read must not deadlock (timeout)")
+            .expect("read must succeed");
+        assert_eq!(buf.to_bytes(), content.to_bytes());
     }
 
     #[tokio::test]


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7338

# Rationale for this change

I met process stuck and deadlock in production environment, which turns out to be deadlock between concurrent limit & concurrent read.
This PR tries to fix the potential deadlock.

Before this PR
```sh
HTTP permits = 2, concurrent = 4

ChunkedReader::read():
│
│  while has_remaining() && !done:          # caller's serial loop
│  │
│  │  ┌─ generator.next_reader()
│  │  │    └─ acc.read("file", range=0..256)
│  │  │         └─ http_client.fetch()
│  │  │              ├─ permit = semaphore.acquire()   ← ACQUIRE permit #1
│  │  │              └─ return HttpBody { stream: ConcurrentLimitStream { _permit: permit#1 } }
│  │  │
│  │  └─ reader₁ holds permit#1
│  │
│  │  tasks.execute(reader₁)                # reader₁ (with permit#1) goes INTO the queue
│  │  │  └─ spawn background: reader₁.read_all()    # task running, permit#1 still held
│  │  │
│  │  has_result()? → no (task not done yet)
│  │  ─── loop ───
│  │
│  │  ┌─ generator.next_reader()
│  │  │    └─ acc.read("file", range=256..512)
│  │  │         └─ http_client.fetch()
│  │  │              ├─ permit = semaphore.acquire()   ← ACQUIRE permit #2
│  │  │              └─ return HttpBody { _permit: permit#2 }
│  │  └─ reader₂ holds permit#2
│  │
│  │  tasks.execute(reader₂)                # reader₂ (with permit#2) goes INTO the queue
│  │  ─── loop ───
│  │
│  │  ┌─ generator.next_reader()
│  │  │    └─ acc.read("file", range=512..768)
│  │  │         └─ http_client.fetch()
│  │  │              └─ semaphore.acquire()            ← BLOCKED (0 permits left)
│  │  │                                                   permit#1 stuck in queue (reader₁)
│  │  │                                                   permit#2 stuck in queue (reader₂)
│  │  │                                                   can never reach tasks.next()
│  │  │                                                   to drain the queue
│  │  │                                                   ═══ DEADLOCK ═══
```
After this change
```sh
HTTP permits = 2, concurrent = 4

ChunkedReader::read():
│
│  while has_remaining() && !done:          # caller's serial loop
│  │
│  │  range = next_range()  → 0..256       # just compute the range, no HTTP call
│  │
│  │  tasks.execute(ChunkedReadInput { range: 0..256 })
│  │  │  └─ spawn background task T1:
│  │  │       ├─ acc.read("file", range=0..256)
│  │  │       │    └─ http_client.fetch()
│  │  │       │         ├─ semaphore.acquire()         ← ACQUIRE permit #1
│  │  │       │         └─ return HttpBody { _permit: permit#1 }
│  │  │       ├─ reader.read_all()                     # consume all data
│  │  │       └─ drop reader                           ← RELEASE permit #1 ✓
│  │  │            return (input, Ok(data))             # no permit in the return value
│  │  │
│  │  ─── loop ───
│  │  range = next_range()  → 256..512
│  │  tasks.execute(ChunkedReadInput { range: 256..512 })   # spawn T2
│  │  ─── loop ───
│  │  range = next_range()  → 512..768
│  │  tasks.execute(ChunkedReadInput { range: 512..768 })   # spawn T3
│  │  ─── loop ───
│  │  range = next_range()  → 768..1024
│  │  tasks.execute(ChunkedReadInput { range: 768..1024 })
│  │  │  └─ !has_remaining() (4 tasks == concurrent limit)
│  │  │     await front task T1                        # T1 already completed and released permit
│  │  │     pop T1, push T4                            ← progress ✓
│  │  │
│  │  ... continues until all chunks are read ...
│
│  tasks.next() → return data

# T1–T4 each independently:  acquire permit → fetch → read_all → drop reader → release permit
# No permit ever crosses the task-queue boundary.
```

# What changes are included in this PR?

During the investigation I found only current read suffers the potential deadlock but not concurrent write.
This PR mimics what we do in concurrent write, which issues requests in the background so we don't block on the foreground when ConcurrentTasks issue new read requests.

# Are there any user-facing changes?

No.

# AI Usage Statement

Opus 4.6 made the code change.