### PR TITLE
fix(s3): add missing content write content disposition capability

### DIFF
--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -906,6 +906,7 @@ impl Builder for S3Builder {
 
                             write_with_cache_control: true,
                             write_with_content_type: true,
+                            write_with_content_disposition: true,
                             write_with_content_encoding: true,
                             write_with_if_match: !config.disable_write_with_if_match,
                             write_with_if_not_exists: true,


### PR DESCRIPTION
# Rationale for this change

S3 supports content disposition as part of the PUT request: https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax

S3 requests already fill in corresponding header here: https://github.com/apache/opendal/blob/4ea60b0b91b4a14a52663cbfd0299ed99e723aea/core/services/s3/src/core.rs#L305-L307

Before this fix, I think capability check layer validation will fail https://github.com/apache/opendal/blob/4ea60b0b91b4a14a52663cbfd0299ed99e723aea/core/layers/capability-check/src/lib.rs#L138

# What changes are included in this PR?

Declare S3 backend supports content disposition for write operations.

# Are there any user-facing changes?

No

# AI Usage Statement

Opus 4.6 helped me found the missing capability declaration.