### PR TITLE
fix(metrics): fix missing errors total counter

### DIFF
--- a/core/layers/observe-metrics-common/src/lib.rs
+++ b/core/layers/observe-metrics-common/src/lib.rs
@@ -1059,6 +1059,14 @@ impl<R, I: MetricsIntercept> MetricsWrapper<R, I> {
             completed: false,
         }
     }
+
+    fn record_error(&mut self, err: &Error) {
+        self.completed = true;
+        self.interceptor.observe(
+            self.labels.clone().with_error(err.kind()),
+            MetricValue::OperationErrorsTotal,
+        );
+    }
 }
 
 impl<R: oio::Read, I: MetricsIntercept> oio::Read for MetricsWrapper<R, I> {
@@ -1072,13 +1080,7 @@ impl<R: oio::Read, I: MetricsIntercept> oio::Read for MetricsWrapper<R, I> {
                 }
                 self.size += bs.len() as u64;
             })
-            .inspect_err(|err| {
-                self.completed = true;
-                self.interceptor.observe(
-                    self.labels.clone().with_error(err.kind()),
-                    MetricValue::OperationErrorsTotal,
-                );
-            })
+            .inspect_err(|err| self.record_error(err))
     }
 }
 
@@ -1092,33 +1094,25 @@ impl<R: oio::Write, I: MetricsIntercept> oio::Write for MetricsWrapper<R, I> {
             .inspect(|_| {
                 self.size += size as u64;
             })
-            .inspect_err(|err| {
-                self.completed = true;
-                self.interceptor.observe(
-                    self.labels.clone().with_error(err.kind()),
-                    MetricValue::OperationErrorsTotal,
-                );
-            })
+            .inspect_err(|err| self.record_error(err))
     }
 
     async fn close(&mut self) -> Result<Metadata> {
-        let result = self.inner.close().await.inspect_err(|err| {
-            self.interceptor.observe(
-                self.labels.clone().with_error(err.kind()),
-                MetricValue::OperationErrorsTotal,
-            );
-        });
+        let result = self
+            .inner
+            .close()
+            .await
+            .inspect_err(|err| self.record_error(err));
         self.completed = true;
         result
     }
 
     async fn abort(&mut self) -> Result<()> {
-        let result = self.inner.abort().await.inspect_err(|err| {
-            self.interceptor.observe(
-                self.labels.clone().with_error(err.kind()),
-                MetricValue::OperationErrorsTotal,
-            );
-        });
+        let result = self
+            .inner
+            .abort()
+            .await
+            .inspect_err(|err| self.record_error(err));
         self.completed = true;
         result
     }
@@ -1136,13 +1130,7 @@ impl<R: oio::List, I: MetricsIntercept> oio::List for MetricsWrapper<R, I> {
                     self.completed = true;
                 }
             })
-            .inspect_err(|err| {
-                self.completed = true;
-                self.interceptor.observe(
-                    self.labels.clone().with_error(err.kind()),
-                    MetricValue::OperationErrorsTotal,
-                );
-            })
+            .inspect_err(|err| self.record_error(err))
     }
 }
 
@@ -1154,22 +1142,15 @@ impl<R: oio::Delete, I: MetricsIntercept> oio::Delete for MetricsWrapper<R, I> {
             .inspect(|_| {
                 self.size += 1;
             })
-            .inspect_err(|err| {
-                self.completed = true;
-                self.interceptor.observe(
-                    self.labels.clone().with_error(err.kind()),
-                    MetricValue::OperationErrorsTotal,
-                );
-            })
+            .inspect_err(|err| self.record_error(err))
     }
 
     async fn close(&mut self) -> Result<()> {
-        let result = self.inner.close().await.inspect_err(|err| {
-            self.interceptor.observe(
-                self.labels.clone().with_error(err.kind()),
-                MetricValue::OperationErrorsTotal,
-            );
-        });
+        let result = self
+            .inner
+            .close()
+            .await
+            .inspect_err(|err| self.record_error(err));
         self.completed = true;
         result
     }


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7356

# Rationale for this change

In the issue I described cases where `OperationErrorsTotal` accounts and where we miss.

# What changes are included in this PR?

In this PR, I cover cases that we miss: operations' future could be cancelled (i.e., due to timeout), thus error counter is missed to update.

# Are there any user-facing changes?

No

# AI Usage Statement

No