### PR TITLE
ci: temporarily disable gdrive behavior tests

### DIFF
--- a/.github/scripts/test_behavior/plan.py
+++ b/.github/scripts/test_behavior/plan.py
@@ -35,6 +35,14 @@ LANGUAGE_BINDING = ["java", "python", "nodejs", "go", "c", "cpp", "dotnet"]
 
 INTEGRATIONS = ["object_store"]
 
+TEMPORARILY_DISABLED_CORE_SERVICES = {
+    # FIXME: Re-enable gdrive behavior tests after #7384 is fixed.
+    # Gdrive is currently not reliable enough for CI: #6684 tracks missing
+    # freshly-created entries in listings, and existing behavior tests already
+    # document redirect loops caused by Google Drive abuse detection.
+    "gdrive",
+}
+
 
 def provided_cases() -> list[dict[str, str]]:
     root_dir = f"{GITHUB_DIR}/services"
@@ -58,6 +66,10 @@ def provided_cases() -> list[dict[str, str]]:
     # We will check if pattern `op://services` exist in content.
     if not os.getenv("GITHUB_HAS_SECRETS") == "true":
         cases[:] = [v for v in cases if "op://services" not in v["content"]]
+
+    cases[:] = [
+        v for v in cases if v["service"] not in TEMPORARILY_DISABLED_CORE_SERVICES
+    ]
 
     # Remove content from cases.
     cases = [

--- a/.github/scripts/test_behavior/test_plan.py
+++ b/.github/scripts/test_behavior/test_plan.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import unittest
+from unittest.mock import patch
 
 from plan import plan
 
@@ -73,6 +74,23 @@ class BehaviorTestPlan(unittest.TestCase):
         cases = [v["service"] for v in result["integration_object_store"][0]["cases"]]
         # Should contain fs
         self.assertTrue("fs" in cases)
+
+    @patch.dict("os.environ", {"GITHUB_HAS_SECRETS": "true"}, clear=False)
+    def test_gdrive_is_temporarily_disabled(self):
+        result = plan([".github/workflows/test_behavior.yml"])
+
+        self.assertTrue(result["components"]["core"])
+        core_cases = [v["service"] for target in result["core"] for v in target["cases"]]
+        self.assertFalse("gdrive" in core_cases)
+
+        for language in ["java", "python", "nodejs", "go", "c", "cpp", "dotnet"]:
+            self.assertTrue(result["components"][f"binding_{language}"])
+            binding_cases = [
+                v["service"]
+                for target in result[f"binding_{language}"]
+                for v in target["cases"]
+            ]
+            self.assertFalse("gdrive" in binding_cases)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Which issue does this PR close?

Related to #7384.

# Rationale for this change

Google Drive behavior tests are currently not reliable enough to keep enabled in CI. We already have `#6684` tracking non-deterministic listing behavior after writes, and the behavior test suite itself already documents Google Drive abuse-detection redirect loops for some list/delete-heavy cases.

Because the behavior workflow schedules gdrive across core and all bindings, a single unstable service can block the whole matrix.

# What changes are included in this PR?

This change removes `gdrive` from the behavior-test planner so it is no longer scheduled for core or binding behavior jobs. It also adds a planner test to lock that behavior in place until the underlying gdrive issue is fixed.

# Are there any user-facing changes?

No user-facing API changes. This only changes CI scheduling.

# AI Usage Statement

Used AI-assisted editing and validation during implementation.
