### PR TITLE
feat(core): enable presign delete

### DIFF
--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -942,6 +942,7 @@ impl Builder for S3Builder {
                             presign_stat: true,
                             presign_read: true,
                             presign_write: true,
+                            presign_delete: true,
 
                             shared: true,
 
@@ -1123,10 +1124,7 @@ impl Access for S3Backend {
                 self.core
                     .s3_put_object_request(path, None, &v, Buffer::new())
             }
-            PresignOperation::Delete(_) => Err(Error::new(
-                ErrorKind::Unsupported,
-                "operation is not supported",
-            )),
+            PresignOperation::Delete(v) => self.core.s3_delete_object_request(path, &v),
             _ => Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",

--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -1006,6 +1006,7 @@ impl Builder for S3Builder {
                     presign_stat: true,
                     presign_read: true,
                     presign_write: true,
+                    presign_delete: true,
 
                     shared: true,
 
@@ -1209,10 +1210,7 @@ impl Service for S3Backend {
                 self.core
                     .s3_put_object_request(path, None, &v, Buffer::new())
             }
-            PresignOperation::Delete(_) => Err(Error::new(
-                ErrorKind::Unsupported,
-                "operation is not supported",
-            )),
+            PresignOperation::Delete(v) => self.core.s3_delete_object_request(path, &v),
             _ => Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -600,7 +600,11 @@ impl S3Core {
         self.send(req).await
     }
 
-    pub async fn s3_delete_object(&self, path: &str, args: &OpDelete) -> Result<Response<Buffer>> {
+    pub async fn s3_delete_object_request(
+        &self,
+        path: &str,
+        args: &OpDelete,
+    ) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
         let mut url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
@@ -630,7 +634,7 @@ impl S3Core {
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
-        self.send(req).await
+        Ok(req)
     }
 
     pub async fn s3_copy_object(&self, from: &str, to: &str) -> Result<Response<Buffer>> {

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -646,12 +646,11 @@ impl S3Core {
         self.send(ctx, req).await
     }
 
-    pub async fn s3_delete_object(
+    pub async fn s3_delete_object_request(
         &self,
-        ctx: &OperationContext,
         path: &str,
         args: &OpDelete,
-    ) -> Result<Response<Buffer>> {
+    ) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
         let mut url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
@@ -682,7 +681,7 @@ impl S3Core {
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
-        self.send(ctx, req).await
+        Ok(req)
     }
 
     pub async fn s3_copy_object(

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -646,11 +646,7 @@ impl S3Core {
         self.send(ctx, req).await
     }
 
-    pub async fn s3_delete_object_request(
-        &self,
-        path: &str,
-        args: &OpDelete,
-    ) -> Result<Request<Buffer>> {
+    pub fn s3_delete_object_request(&self, path: &str, args: &OpDelete) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
         let mut url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
@@ -682,6 +678,16 @@ impl S3Core {
             .map_err(new_request_build_error)?;
 
         Ok(req)
+    }
+
+    pub async fn s3_delete_object(
+        &self,
+        ctx: &OperationContext,
+        path: &str,
+        args: &OpDelete,
+    ) -> Result<Response<Buffer>> {
+        let req = self.s3_delete_object_request(path, args)?;
+        self.send(ctx, req).await
     }
 
     pub async fn s3_copy_object(

--- a/core/services/s3/src/deleter.rs
+++ b/core/services/s3/src/deleter.rs
@@ -44,7 +44,9 @@ impl oio::BatchDelete for S3Deleter {
             return Ok(());
         }
 
-        let resp = self.core.s3_delete_object(&path, &args).await?;
+        let req = self.core.s3_delete_object_request(&path, &args).await?;
+
+        let resp = self.core.send(req).await?;
 
         let status = resp.status();
 

--- a/core/services/s3/src/deleter.rs
+++ b/core/services/s3/src/deleter.rs
@@ -45,9 +45,7 @@ impl oio::BatchDelete for S3Deleter {
             return Ok(());
         }
 
-        let req = self.core.s3_delete_object_request(&path, &args).await?;
-
-        let resp = self.core.send(req).await?;
+        let resp = self.core.s3_delete_object(&self.ctx, &path, &args).await?;
 
         let status = resp.status();
 

--- a/core/services/s3/src/deleter.rs
+++ b/core/services/s3/src/deleter.rs
@@ -45,7 +45,9 @@ impl oio::BatchDelete for S3Deleter {
             return Ok(());
         }
 
-        let resp = self.core.s3_delete_object(&self.ctx, &path, &args).await?;
+        let req = self.core.s3_delete_object_request(&path, &args).await?;
+
+        let resp = self.core.send(req).await?;
 
         let status = resp.status();
 


### PR DESCRIPTION
# Which issue does this PR close?
The presign delete feature was implemented for feature request - #5427 by the PR - #5647, this PR is just enabling this feature.

# Rationale for this change
Enable Presign delete feature

# Are there any user-facing changes?
Yes, we used to generate PUT and DELETE presign URLs by the custom logic written by us, and we have recently moved to use opendal for this feature, but while testing we found although the feature is implemented, it was not enabled.