### PR TITLE
chore(release): prepare v0.56.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,335 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- Release notes generated with: gh release create v_draft --generate-notes --draft -->
 
+## [v0.56.0] - 2026-04-16
+
+### Breaking Changes
+* core: `Scheme`-based APIs are now fully string-based. Migrate `Operator::from_map` and `Operator::via_map` call sites to `from_iter` and `via_iter`, and stop matching on `Scheme` values directly.
+* core: service-builder `http_client` hooks and `TimeoutLayer::with_speed` have been removed after deprecation. Move HTTP customization to layered/client APIs and replace `with_speed` with `with_io_timeout`.
+* core: low-level test helpers moved out of `opendal::raw::tests`. Use `opendal::tests` or depend on `opendal-testkit` directly for out-of-tree services and integrations.
+* integrations/parquet: `parquet_opendal` now targets Arrow 58 and ships as `0.8.0`. Downstream integrations pinned to older Arrow releases must upgrade together.
+
+### Added
+* feat(hugginface): allow specifying huggingface endpoint by @kszucs in https://github.com/apache/opendal/pull/6801
+* feat(services/github): Implement write returns metadata by @rich7420 in https://github.com/apache/opendal/pull/6806
+* feat(services/koofr): Implement write returns metadata by @rich7420 in https://github.com/apache/opendal/pull/6809
+* feat: Implement concurrent write for azdls by @Xuanwo in https://github.com/apache/opendal/pull/6819
+* feat: Add simulation for delete with recursive by @Xuanwo in https://github.com/apache/opendal/pull/6824
+* feat: Add delete with recursive support for fs by @Xuanwo in https://github.com/apache/opendal/pull/6827
+* feat(services/huggingface): Add repo_type=space support by @AryanBagade in https://github.com/apache/opendal/pull/6833
+* feat(services/huggingface): Enrich metadata with ETag and security scan flags by @AryanBagade in https://github.com/apache/opendal/pull/6834
+* feat(services/azdls): Add user defined metadata support by @zhan7236 in https://github.com/apache/opendal/pull/6842
+* feat(services/azfile): Add user defined metadata support by @zhan7236 in https://github.com/apache/opendal/pull/6841
+* feat(services): split cacache, dbfs, dropbox, etcd, foundationdb into separate crates by @tao12345666333 in https://github.com/apache/opendal/pull/7031
+* feat: support if_not_exists in the Memory service by @carlsverre in https://github.com/apache/opendal/pull/7036
+* feat(services/b2): Add user defined metadata support by @zhan7236 in https://github.com/apache/opendal/pull/6844
+* feat(services/fs): Add user defined metadata support by @zhan7236 in https://github.com/apache/opendal/pull/7061
+* feat(services/gdrive): implement batch recursive listing for ~200x performance improvement by @mro68 in https://github.com/apache/opendal/pull/7059
+* feat(services/fs): add `file` as an alias scheme for `fs` by @userzhy in https://github.com/apache/opendal/pull/7075
+* feat(layers/hotpath): add HotpathLayer integration by @PsiACE in https://github.com/apache/opendal/pull/7083
+* feat(bindings/java): Speed up the performance of `OperatorInputStream` by @Xuanwo in https://github.com/apache/opendal/pull/7088
+* feat: Binding Java's createInputStream and createOutputStream to support options by @Sahil-Shadwal in https://github.com/apache/opendal/pull/7097
+* feat(services/webdav): Add user defined metadata support by @userzhy in https://github.com/apache/opendal/pull/7074
+* feat: introduce foyer layer by @MrCroxx in https://github.com/apache/opendal/pull/6366
+* feat(layers/route): impl route layer as rfc 7130 by @PsiACE in https://github.com/apache/opendal/pull/7137
+* feat(services/azdls): add recursive deletion for azdls by @meteorgan in https://github.com/apache/opendal/pull/7142
+* feat(services/hdfs): add delete with recursive support for hdfs by @meteorgan in https://github.com/apache/opendal/pull/7136
+* feat(bindings/go): support presign by @yuchanns in https://github.com/apache/opendal/pull/7147
+* feat(layers/concurrent-limit): accept custom semaphore without API break by @PsiACE in https://github.com/apache/opendal/pull/7082
+* feat(services/memcached): Support connection via unix domain socket by @zenyanle in https://github.com/apache/opendal/pull/7112
+* feat(webdav): disable_create_dir for servers without PROPFIND by @weihanglo in https://github.com/apache/opendal/pull/7177
+* feat(services/swift): add conditional request headers for stat and read by @benroeder in https://github.com/apache/opendal/pull/7208
+* feat(services/swift): add bulk delete support by @benroeder in https://github.com/apache/opendal/pull/7210
+* feat(services/swift): add SLO multipart upload for large objects by @benroeder in https://github.com/apache/opendal/pull/7212
+* feat(services/swift): add TempURL presigned URL support by @benroeder in https://github.com/apache/opendal/pull/7214
+* feat(services): reduce list fallback stat for local kv backends by @Xuanwo in https://github.com/apache/opendal/pull/7218
+* feat(services/s3): Add a way to specify a default object ACL by @antoine-de in https://github.com/apache/opendal/pull/7186
+* feat(services/tos): add volcengine TOS support by @ddupg in https://github.com/apache/opendal/pull/7233
+* feat(services/http): Add https as alias for http scheme by @clbarnes in https://github.com/apache/opendal/pull/7241
+* feat(bindings/dotnet): Bindings dotnet implement by @Fatorin in https://github.com/apache/opendal/pull/7238
+* feat(integrations/parquet): upgrade arrow-rs to 58.0.0 by @jo-migo in https://github.com/apache/opendal/pull/7250
+* feat(services/s3): Add ACL on multipart upload by @antoine-de in https://github.com/apache/opendal/pull/7255
+* feat(bindings/python): support options for presign operations by @atakiar in https://github.com/apache/opendal/pull/7265
+* feat(s3): validate checksum before making HTTP requests by @dentiny in https://github.com/apache/opendal/pull/7296
+* feat(services/sftp): add write_with_if_not_exists support by @unbrice in https://github.com/apache/opendal/pull/7251
+* feat(services/hdfs-native): service hdfs-native support high availability (HA) cluster by @qingfeng-occ in https://github.com/apache/opendal/pull/7248
+* feat(bindings/dotnet): standardize naming to OpenDAL and enforce RC releases by @Fatorin in https://github.com/apache/opendal/pull/7355
+* feat(services/vercel): Add additional options to Vercel cache backend by @mmastrac in https://github.com/apache/opendal/pull/7334
+* feat(hf): support writing and reading from both http and xet by @kszucs in https://github.com/apache/opendal/pull/7185
+* feat(services/azfile): return write metadata by @spereyra-dev in https://github.com/apache/opendal/pull/7381
+* feat: `get_ranges` 2x performance degradation  by @comphead in https://github.com/apache/opendal/pull/7380
+* feat: Add foyer service by @flaneur2020 in https://github.com/apache/opendal/pull/7160
+
+### Changed
+* refactor!: Migrate service s3 to reqsign-core 2.0 by @Xuanwo in https://github.com/apache/opendal/pull/6656
+* refactor: Implement SimulateLayer to make simulate logic more maintai… by @Xuanwo in https://github.com/apache/opendal/pull/6822
+* refactor!: Refactor oio::Delete to make it's API simple by @Xuanwo in https://github.com/apache/opendal/pull/6823
+* refactor: use web-time types on wasm32 target by @tisonkun in https://github.com/apache/opendal/pull/6852
+* refactor: Split core out to prepare for splitting by @Xuanwo in https://github.com/apache/opendal/pull/6858
+* refactor: Reuse from_uri logic inside via iter by @Xuanwo in https://github.com/apache/opendal/pull/6862
+* refactor: Remove scheme from python binding by @Xuanwo in https://github.com/apache/opendal/pull/6863
+* refactor!: Remove the concept of scheme by @Xuanwo in https://github.com/apache/opendal/pull/6864
+* refactor: Register service at the start of run time instead by @Xuanwo in https://github.com/apache/opendal/pull/6865
+* refactor: Move services s3 out as a crate by @Xuanwo in https://github.com/apache/opendal/pull/6866
+* refactor: Split async_backtrace layer to new crate by @Xuanwo in https://github.com/apache/opendal/pull/6867
+* refactor(services/moka): Move services moka out as a crate by @manchangfengxu in https://github.com/apache/opendal/pull/6868
+* refactor: Split all azure storage services and ghac by @Xuanwo in https://github.com/apache/opendal/pull/6874
+* refactor: Split await tree layer to new crate by @Xuanwo in https://github.com/apache/opendal/pull/6875
+* refactor(!): Remove deprecated http client config by @Xuanwo in https://github.com/apache/opendal/pull/6878
+* refactor: Split service aliyun drive to new crate by @Xuanwo in https://github.com/apache/opendal/pull/6879
+* refactor: Split capability check to seperate layer by @Xuanwo in https://github.com/apache/opendal/pull/6952
+* refactor: Split service hdfs-native to new crate by @chitralverma in https://github.com/apache/opendal/pull/6953
+* refactor: split metrics related crates to new crates by @Xuanwo in https://github.com/apache/opendal/pull/6954
+* refactor: Split service mysql to new crate  by @fenfeng9 in https://github.com/apache/opendal/pull/6960
+* refactor: split tracing layer to new crate by @ButterBright in https://github.com/apache/opendal/pull/6962
+* refactor: Split mime-guess layer to new crate by @koushiro in https://github.com/apache/opendal/pull/6966
+* refactor: Split tail-cut layer to new crate by @koushiro in https://github.com/apache/opendal/pull/6968
+* refactor: Split fastrace layer to new crate by @koushiro in https://github.com/apache/opendal/pull/6965
+* refactor: Split oteltrace layer to new crate by @koushiro in https://github.com/apache/opendal/pull/6969
+* refactor: Split service postgresql to new crate by @fenfeng9 in https://github.com/apache/opendal/pull/6973
+* refactor: Split service cloudflare-kv out of core by @tao12345666333 in https://github.com/apache/opendal/pull/6974
+* refactor: Split immutable-index layer to new crate by @koushiro in https://github.com/apache/opendal/pull/6967
+* refactor(services/ftp): split service into its own crate by @xxxuuu in https://github.com/apache/opendal/pull/6979
+* refactor: split throttle layer to new crate by @EricZZZ in https://github.com/apache/opendal/pull/6980
+* refactor(services/sled): split service into its own crate by @xxxuuu in https://github.com/apache/opendal/pull/6981
+* refactor(services/ipfs): extract ipfs service into separate crate by @XYenon in https://github.com/apache/opendal/pull/6991
+* refactor: Split service tikv to new crate by @fenfeng9 in https://github.com/apache/opendal/pull/6997
+* refactor: split oss service to new crate by @ButterBright in https://github.com/apache/opendal/pull/6978
+* refactor: Split service gcs out of core by @tao12345666333 in https://github.com/apache/opendal/pull/7002
+* refactor: Consolidate opendal_core imports in tests by @PiyushXCoder in https://github.com/apache/opendal/pull/7012
+* refactor: Split service alluxio to new crate by @EricZZZ in https://github.com/apache/opendal/pull/7006
+* refactor: Split service fs out of core by @tao12345666333 in https://github.com/apache/opendal/pull/6970
+* refactor: split chaos related to new crate by @zhanghuidinah in https://github.com/apache/opendal/pull/7010
+* refactor(services/sqlite): split sqlite service into separate crate by @yueneiqi in https://github.com/apache/opendal/pull/7014
+* refactor: Split service b2 out of core by @tao12345666333 in https://github.com/apache/opendal/pull/6982
+* refactor: Split mini-moka service to new crate by @koushiro in https://github.com/apache/opendal/pull/7020
+* refactor: Split dashmap service to new crate by @koushiro in https://github.com/apache/opendal/pull/7022
+* refactor: Split memcached service to new crate by @koushiro in https://github.com/apache/opendal/pull/7023
+* refactor!: split opendal_core::raw::tests module into a separate crate by @koushiro in https://github.com/apache/opendal/pull/7025
+* refactor: Split persy service to new crate by @WaterWhisperer in https://github.com/apache/opendal/pull/7024
+* refactor: Split service cos out of core by @tao12345666333 in https://github.com/apache/opendal/pull/7011
+* refactor: Split service github out of core by @tao12345666333 in https://github.com/apache/opendal/pull/7018
+* refactor: Split service d1 out of core by @tao12345666333 in https://github.com/apache/opendal/pull/7027
+* refactor: Deprecate remove_all API in favor of RFC-3911: Deleter API by @rich7420 in https://github.com/apache/opendal/pull/6785
+* refactor: Split redb service to new crate by @WaterWhisperer in https://github.com/apache/opendal/pull/7028
+* refactor: Split compfs service to new crate by @WaterWhisperer in https://github.com/apache/opendal/pull/7033
+* refactor(services/opfs): split opfs service into separate crate by @STRRL in https://github.com/apache/opendal/pull/7021
+* refactor: Split surrealdb service to new crate by @WaterWhisperer in https://github.com/apache/opendal/pull/7045
+* refactor(services/huggingface): split huggingface into separate crate by @tao12345666333 in https://github.com/apache/opendal/pull/7041
+* refactor(services/koofr): split koofr into separate crate by @tao12345666333 in https://github.com/apache/opendal/pull/7043
+* refactor: Split pcloud service to new crate by @koushiro in https://github.com/apache/opendal/pull/7047
+* refactor: Split upyun service to new crate by @koushiro in https://github.com/apache/opendal/pull/7048
+* refactor: split swift service into a separate crate by @Sahil-Shadwal in https://github.com/apache/opendal/pull/7054
+* refactor: Split seafile service into a separate crate by @Sahil-Shadwal in https://github.com/apache/opendal/pull/7029
+* refactor(services/http): Move services http out as a crate by @0lai0 in https://github.com/apache/opendal/pull/6870
+* refactor(services/onedrive): split into separate crate by @XYenon in https://github.com/apache/opendal/pull/6996
+* refactor(services/vercel-artifacts): Split vercel-artifacts into separate crate by @kenwoodjw in https://github.com/apache/opendal/pull/7009
+* refactor: Split lakefs service to new crate by @koushiro in https://github.com/apache/opendal/pull/7046
+* refactor: Split logging/retry/timeout layer to new crates by @koushiro in https://github.com/apache/opendal/pull/7053
+* refactor: Split yandex-disk service to new crate by @WaterWhisperer in https://github.com/apache/opendal/pull/7055
+* refactor(services/gdrive): split gdrive into separate crate by @tao12345666333 in https://github.com/apache/opendal/pull/7039
+* refactor(services/ipmfs): split ipmfs service into separate crate by @tao12345666333 in https://github.com/apache/opendal/pull/7042
+* refactor(services/webdav): split webdav service into separate crate by @PiyushXCoder in https://github.com/apache/opendal/pull/7065
+* refactor(services/hdfs): split hdfs into separate crate by @tao12345666333 in https://github.com/apache/opendal/pull/7040
+* refactor(services/webhdfs): split webhdfs service into separate crate by @PiyushXCoder in https://github.com/apache/opendal/pull/7067
+* refactor: split monoiofs service into a separate crate by @codxbrexx in https://github.com/apache/opendal/pull/7038
+* refactor: split sftp service into a separate crate by @Sahil-Shadwal in https://github.com/apache/opendal/pull/7060
+* refactor: split concurrent-limit layer as a crate by @PsiACE in https://github.com/apache/opendal/pull/7073
+* refactor: split gridfs service out as new crate by @codxbrexx in https://github.com/apache/opendal/pull/7037
+* refactor(services/mongodb): split mongodb service into separate crate by @PiyushXCoder in https://github.com/apache/opendal/pull/7079
+* refactor(layers/dtrace): split dtrace layer into separate crate by @PiyushXCoder in https://github.com/apache/opendal/pull/7078
+* refactor(services/rocksdb): split rocksdb service as a crate by @KarinaMilet in https://github.com/apache/opendal/pull/7081
+* refactor: Split redis service to new crate by @koushiro in https://github.com/apache/opendal/pull/7091
+* refactor: Register services only in opendal by @Xuanwo in https://github.com/apache/opendal/pull/7093
+* refactor(core): Optimize Writer::write_from to avoid extra copy by @zenyanle in https://github.com/apache/opendal/pull/7098
+* refactor(foyer): seperate mods from lib.rs by @flaneur2020 in https://github.com/apache/opendal/pull/7154
+* build(deps): move url to workspace dependencies by @zenyanle in https://github.com/apache/opendal/pull/7161
+* refactor: Migrate oss to reqsign core v2 by @Xuanwo in https://github.com/apache/opendal/pull/7165
+* refactor(hf): use the official `hf` scheme instead of `huggingface` by @kszucs in https://github.com/apache/opendal/pull/7193
+* refactor(core): allow opt-out ctor dependency by @tisonkun in https://github.com/apache/opendal/pull/7196
+* refactor(services/obs): migrate obs to reqsign-core v2 by @koushiro in https://github.com/apache/opendal/pull/7169
+* refactor(services/azure): migrate azblob azdls azfile to reqsign v2 by @Xuanwo in https://github.com/apache/opendal/pull/7226
+* refactor(services/cos): migrate to reqsign v2 by @Xuanwo in https://github.com/apache/opendal/pull/7228
+* refactor(services/gcs): migrate to reqsign v2 by @Xuanwo in https://github.com/apache/opendal/pull/7229
+* refactor(core): route reqsign send via accessor http client by @Xuanwo in https://github.com/apache/opendal/pull/7234
+
+### Fixed
+* fix(services/huggingface): Allow users to use datasets as an alias to dataset repo type by @Xuanwo in https://github.com/apache/opendal/pull/6826
+* fix(services/huggingface): Implement pagination with Link header for large repos by @AryanBagade in https://github.com/apache/opendal/pull/6832
+* bug: write operation won't split payload into chunks following configuration by @0lai0 in https://github.com/apache/opendal/pull/6796
+* fix(services/s3): add md5 to to list of available checksum algos by @Gabriel-J-Young in https://github.com/apache/opendal/pull/6854
+* chore: Format and update tomls by @chitralverma in https://github.com/apache/opendal/pull/6877
+* chore: Upgrade redis dependency to version 1 by @nihohit in https://github.com/apache/opendal/pull/6959
+* fix(bindings/java): Detach current thread while thread drop by @Xuanwo in https://github.com/apache/opendal/pull/7000
+* fix(core): add --workspace arg to clippy/test workflows of core ci by @koushiro in https://github.com/apache/opendal/pull/7050
+* fix(services/gdrive): include size and modifiedTime in list() metadata by @mro68 in https://github.com/apache/opendal/pull/7058
+* fix(services/gdrive): Fix prefix list not handeled correctly by @Xuanwo in https://github.com/apache/opendal/pull/7070
+* make sure CompleteWriter is enforcing the right invariants by @carlsverre in https://github.com/apache/opendal/pull/7056
+* fix(core): skip PermissionDenied errors in recursive lister by @userzhy in https://github.com/apache/opendal/pull/7096
+* test(core): remove assert_size tests by @Xuanwo in https://github.com/apache/opendal/pull/7167
+* fix(bindings/python): improve the typing discovering of the python package by @frostming in https://github.com/apache/opendal/pull/7180
+* fix(object_store): implement get_range() to avoid unnecessary stat() calls by @kszucs in https://github.com/apache/opendal/pull/7192
+* fix(services/swift): add missing copy capability flag by @benroeder in https://github.com/apache/opendal/pull/7204
+* fix(services/swift): forward write headers to Swift API by @benroeder in https://github.com/apache/opendal/pull/7206
+* fix(services/fs): add content length and modified time to metadata by @mhambre in https://github.com/apache/opendal/pull/7188
+* fix(core): enforce list file content length in complete layer by @Xuanwo in https://github.com/apache/opendal/pull/7201
+* fix(integrations/unftp-sbe): avoid copy flush amplification by @Xuanwo in https://github.com/apache/opendal/pull/7217
+* fix(services/seafile): avoid defaulting list size to zero by @Xuanwo in https://github.com/apache/opendal/pull/7221
+* fix(services/azfile): avoid defaulting list size to zero by @Xuanwo in https://github.com/apache/opendal/pull/7220
+* fix(core): skip NotFound during concurrent recursive listing by @Xuanwo in https://github.com/apache/opendal/pull/7230
+* fix(observability): Fix http logic error metrics collection by @dentiny in https://github.com/apache/opendal/pull/7259
+* fix(observability): Update stream metrics on stream errors and drops by @dentiny in https://github.com/apache/opendal/pull/7261
+* fix(observability): Fix TTFB histogram bucket by @dentiny in https://github.com/apache/opendal/pull/7271
+* fix(observability): Fix executing operation gauge decrement on error by @dentiny in https://github.com/apache/opendal/pull/7267
+* fix(observability): do not account processed entries count when list none by @dentiny in https://github.com/apache/opendal/pull/7269
+* fix(s3): Fix missing user-provided write operation for S3 on presign by @dentiny in https://github.com/apache/opendal/pull/7276
+* fix(s3): respect content encoding for multipart upload initialization by @dentiny in https://github.com/apache/opendal/pull/7274
+* fix(layers/timeout): Fix timeout wrapper for delete operation by @dentiny in https://github.com/apache/opendal/pull/7279
+* fix(reader): fix potential out-of-bound seek by @dentiny in https://github.com/apache/opendal/pull/7282
+* fix(reader): Fix reader fetch with empty ranges by @dentiny in https://github.com/apache/opendal/pull/7286
+* fix(s3): Fix improper handle for copy response by @dentiny in https://github.com/apache/opendal/pull/7294
+* fix(tracing): fix trace span instrumentation by @dentiny in https://github.com/apache/opendal/pull/7292
+* fix(observability): fix executing operation gauge on timeout by @dentiny in https://github.com/apache/opendal/pull/7301
+* fix(s3): fix incorrect md5 for list operations by @dentiny in https://github.com/apache/opendal/pull/7298
+* fix(observability): Fix failed operation/request gauge on timeout by @dentiny in https://github.com/apache/opendal/pull/7303
+* fix(s3): Fix entry mode and raw entry assertion by @dentiny in https://github.com/apache/opendal/pull/7308
+* fix(delete): poll deleter close future on exit by @dentiny in https://github.com/apache/opendal/pull/7316
+* fix(util): Fix panic on invalid bytes range by @dentiny in https://github.com/apache/opendal/pull/7314
+* fix(copy): Fix error propagation operation by @dentiny in https://github.com/apache/opendal/pull/7318
+* fix(correctness check): add missing conditional write capability check by @dentiny in https://github.com/apache/opendal/pull/7320
+* fix(correctess check): validate copy capability and request by @dentiny in https://github.com/apache/opendal/pull/7322
+* fix(s3): fix missing complete multipart upload headers by @dentiny in https://github.com/apache/opendal/pull/7327
+* fix(dev): sync release package versions by @Xuanwo in https://github.com/apache/opendal/pull/7342
+* fix(s3): add missing content write content disposition capability by @dentiny in https://github.com/apache/opendal/pull/7349
+* fix(metrics): fix missing errors total counter by @dentiny in https://github.com/apache/opendal/pull/7357
+* fix(core): use web-time only for wasm32-unknown-unknown target by @ngg in https://github.com/apache/opendal/pull/7360
+* fix(core): fix deadlock for concurrent read and concurrent limit layer by @dentiny in https://github.com/apache/opendal/pull/7346
+* ci(hf): isolate CI repos and stabilize binding tests by @Xuanwo in https://github.com/apache/opendal/pull/7368
+* fix(core): trim metadata debug output by @Xuanwo in https://github.com/apache/opendal/pull/7366
+* fix(core): spawn blocking ops onto worker pool to avoid stack overflow by @kszucs in https://github.com/apache/opendal/pull/7371
+* fix(hf): include folder deletions in git commit payload by @kszucs in https://github.com/apache/opendal/pull/7375
+* fix(services/cos): preserve list metadata etag and last_modified by @suyanhanx in https://github.com/apache/opendal/pull/7331
+
+### Docs
+* docs: add 1password self-registration link for committers by @PsiACE in https://github.com/apache/opendal/pull/6804
+* RFC-6817: Checksum by @Xuanwo in https://github.com/apache/opendal/pull/6817
+* docs: improve README of core/examples by @bettermultiply in https://github.com/apache/opendal/pull/6839
+* docs: Make it clear that opendal list returns prefix by @Xuanwo in https://github.com/apache/opendal/pull/6835
+* docs: Fix build for ruby docs by @Xuanwo in https://github.com/apache/opendal/pull/6876
+* docs: Correcting errors in the c-bindings README example by @bettermultiply in https://github.com/apache/opendal/pull/7100
+* docs: require following PR template in AGENTS.md by @Xuanwo in https://github.com/apache/opendal/pull/7219
+* docs: refresh split release documentation by @Xuanwo in https://github.com/apache/opendal/pull/7344
+
+### CI
+* ci(python): Build wheels in native runners by @Xuanwo in https://github.com/apache/opendal/pull/6821
+* ci: Add full ci promote for testing PRs by @Xuanwo in https://github.com/apache/opendal/pull/6845
+* ci: Trigger CI workflow correctly by @Xuanwo in https://github.com/apache/opendal/pull/6847
+* ci: Fix wrong permissions in YAML by @Xuanwo in https://github.com/apache/opendal/pull/6848
+* ci: Allow test_behavior to be called with dispatch by @Xuanwo in https://github.com/apache/opendal/pull/6850
+* ci: Add AI Usage Statement by @Xuanwo in https://github.com/apache/opendal/pull/6972
+* ci(bindings/ocaml): Use dyn link instead by @Xuanwo in https://github.com/apache/opendal/pull/6988
+* ci: Remove setup-protoc entirely by @Xuanwo in https://github.com/apache/opendal/pull/6994
+* ci: Add checks for taplo by @Xuanwo in https://github.com/apache/opendal/pull/7016
+* ci: Enable auto-merge for PRs by @Xuanwo in https://github.com/apache/opendal/pull/7017
+* ci: Fix doc test for yandex-disk by @Xuanwo in https://github.com/apache/opendal/pull/7063
+* ci: Split unit and doc tests by @Xuanwo in https://github.com/apache/opendal/pull/7064
+* ci(bindings/go): Remove unexpected list prefix tests by @Xuanwo in https://github.com/apache/opendal/pull/7084
+* ci: Refactor behavior test planner for services split by @Xuanwo in https://github.com/apache/opendal/pull/7085
+* ci: skip azurite's version check by @meteorgan in https://github.com/apache/opendal/pull/7162
+* ci: Try fixing haskell CI by @Xuanwo in https://github.com/apache/opendal/pull/7164
+* ci: use go-version-file by @tisonkun in https://github.com/apache/opendal/pull/7195
+* ci: Delete ci_weekly_update workflow by @Xuanwo in https://github.com/apache/opendal/pull/7202
+* ci: pin approved GitHub Actions refs by @Xuanwo in https://github.com/apache/opendal/pull/7290
+* ci(fixtures): pin owncloud image tag by @Xuanwo in https://github.com/apache/opendal/pull/7305
+* feat(bindings/dotnet):Bindings dotnet publish to nuget by @Fatorin in https://github.com/apache/opendal/pull/7323
+* ci: update path filters for split core layout by @Xuanwo in https://github.com/apache/opendal/pull/7343
+* ci: publish all rust crates in dependency order by @Xuanwo in https://github.com/apache/opendal/pull/7352
+* ci: migrate seafile fixture to 13.x by @Xuanwo in https://github.com/apache/opendal/pull/7373
+* ci: temporarily disable gdrive behavior tests by @Xuanwo in https://github.com/apache/opendal/pull/7385
+
+### Chore
+* chore(layers/timeout)!: remove deprecated `with_speed` method by @koushiro in https://github.com/apache/opendal/pull/6793
+* chore: random code and comments tidy by @tisonkun in https://github.com/apache/opendal/pull/6808
+* chore: ring has been migrated to new license  by @tisonkun in https://github.com/apache/opendal/pull/6811
+* chore: fine tune deny configs by @tisonkun in https://github.com/apache/opendal/pull/6812
+* chore: suppress noisy deny warnings by @tisonkun in https://github.com/apache/opendal/pull/6816
+* chore: move from tokio::sync to mea primitives  by @tisonkun in https://github.com/apache/opendal/pull/6818
+* chore: use fastpool as object pool impl  by @tisonkun in https://github.com/apache/opendal/pull/6820
+* chore: Migrate CLAUDE.md to AGENTS.md by @Xuanwo in https://github.com/apache/opendal/pull/6825
+* chore(deps): update datafusion requirement from 50.0.0 to 51.0.0 in /integrations/object_store by @dependabot[bot] in https://github.com/apache/opendal/pull/6840
+* chore(bindings): remove `Scheme` enum from some bindings by @koushiro in https://github.com/apache/opendal/pull/6776
+* chore(core): remove redundant clones by @TennyZhuang in https://github.com/apache/opendal/pull/6955
+* chore(core): avoid inefficient to_string by @TennyZhuang in https://github.com/apache/opendal/pull/6956
+* chore(core): clean up some miscs related to deprecated http client config by @koushiro in https://github.com/apache/opendal/pull/6957
+* chore(services/vercel-blob): split crate from core by @kenwoodjw in https://github.com/apache/opendal/pull/6971
+* chore(ci): make clippy happy when using rust 1.92.0 by @koushiro in https://github.com/apache/opendal/pull/6985
+* chore(services/obs): split obs service into standalone crate by @kenwoodjw in https://github.com/apache/opendal/pull/6977
+* chore(core): remove unused dependencies by @chitralverma in https://github.com/apache/opendal/pull/6987
+* chore(core): pub message of Error struct by @sundy-li in https://github.com/apache/opendal/pull/6986
+* chore: Upgrade logforth to 0.29.1 by @tisonkun in https://github.com/apache/opendal/pull/7015
+* chore: Update cargo.lock by @Xuanwo in https://github.com/apache/opendal/pull/7052
+* chore: fine tune OperatorInputStream by @tisonkun in https://github.com/apache/opendal/pull/7089
+* chore(layers): unify layer crates and gate dtrace on linux by @koushiro in https://github.com/apache/opendal/pull/7094
+* chore: volunteer to review all PRs by @tisonkun in https://github.com/apache/opendal/pull/7111
+* chore: no need Error::map method by @tisonkun in https://github.com/apache/opendal/pull/7110
+* chore(deps): bump the github-actions group with 5 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7121
+* chore(deps): bump tracing from 0.1.43 to 0.1.44 in /core in the logs-errors-checksums group by @dependabot[bot] in https://github.com/apache/opendal/pull/7123
+* chore(deps): bump the third-party-actions group with 6 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7125
+* chore(deps): bump the others group in /core with 11 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7126
+* chore(deps): bump the http-serialization-utils group in /core with 2 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7122
+* chore: upgrade to mea 0.6.0 by @tisonkun in https://github.com/apache/opendal/pull/7132
+* chore(layer/fastmetrics): upgrade fastmetrics to v0.6.0 by @koushiro in https://github.com/apache/opendal/pull/7135
+* chore: reduce tracing deps by @tisonkun in https://github.com/apache/opendal/pull/7146
+* chore(deps): bump the pyo3 group in /bindings/python with 2 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7120
+* chore(deps): bump the docusaur group in /website with 3 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7174
+* chore(docs): fix docs for writer_options by @meteorgan in https://github.com/apache/opendal/pull/7157
+* chore: binding java's dependency by @tisonkun in https://github.com/apache/opendal/pull/7198
+* chore(bindings/dotnet): update framework and use LibraryImport by @Fatorin in https://github.com/apache/opendal/pull/7222
+* chore(layer/fastmetrics): upgrade fastmetrics to v0.7.0 by @koushiro in https://github.com/apache/opendal/pull/7227
+* chore(deps-dev): bump the others group in /website with 2 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7232
+
+## New Contributors
+* @kszucs made their first contribution in https://github.com/apache/opendal/pull/6801
+* @rich7420 made their first contribution in https://github.com/apache/opendal/pull/6806
+* @AryanBagade made their first contribution in https://github.com/apache/opendal/pull/6832
+* @bettermultiply made their first contribution in https://github.com/apache/opendal/pull/6839
+* @zhan7236 made their first contribution in https://github.com/apache/opendal/pull/6842
+* @Gabriel-J-Young made their first contribution in https://github.com/apache/opendal/pull/6854
+* @manchangfengxu made their first contribution in https://github.com/apache/opendal/pull/6868
+* @nihohit made their first contribution in https://github.com/apache/opendal/pull/6959
+* @fenfeng9 made their first contribution in https://github.com/apache/opendal/pull/6960
+* @ButterBright made their first contribution in https://github.com/apache/opendal/pull/6962
+* @clbarnes made their first contribution in https://github.com/apache/opendal/pull/6990
+* @EricZZZ made their first contribution in https://github.com/apache/opendal/pull/6980
+* @PiyushXCoder made their first contribution in https://github.com/apache/opendal/pull/7012
+* @zhanghuidinah made their first contribution in https://github.com/apache/opendal/pull/7010
+* @yueneiqi made their first contribution in https://github.com/apache/opendal/pull/7014
+* @WaterWhisperer made their first contribution in https://github.com/apache/opendal/pull/7024
+* @carlsverre made their first contribution in https://github.com/apache/opendal/pull/7036
+* @Sahil-Shadwal made their first contribution in https://github.com/apache/opendal/pull/7054
+* @mro68 made their first contribution in https://github.com/apache/opendal/pull/7058
+* @codxbrexx made their first contribution in https://github.com/apache/opendal/pull/7038
+* @userzhy made their first contribution in https://github.com/apache/opendal/pull/7075
+* @KarinaMilet made their first contribution in https://github.com/apache/opendal/pull/7081
+* @zenyanle made their first contribution in https://github.com/apache/opendal/pull/7098
+* @weihanglo made their first contribution in https://github.com/apache/opendal/pull/7177
+* @benroeder made their first contribution in https://github.com/apache/opendal/pull/7204
+* @mhambre made their first contribution in https://github.com/apache/opendal/pull/7188
+* @Fatorin made their first contribution in https://github.com/apache/opendal/pull/7222
+* @antoine-de made their first contribution in https://github.com/apache/opendal/pull/7186
+* @ddupg made their first contribution in https://github.com/apache/opendal/pull/7233
+* @dentiny made their first contribution in https://github.com/apache/opendal/pull/7244
+* @jo-migo made their first contribution in https://github.com/apache/opendal/pull/7250
+* @atakiar made their first contribution in https://github.com/apache/opendal/pull/7265
+* @comphead made their first contribution in https://github.com/apache/opendal/pull/7243
+* @mmastrac made their first contribution in https://github.com/apache/opendal/pull/7336
+* @unbrice made their first contribution in https://github.com/apache/opendal/pull/7251
+* @qingfeng-occ made their first contribution in https://github.com/apache/opendal/pull/7248
+* @ngg made their first contribution in https://github.com/apache/opendal/pull/7360
+* @spereyra-dev made their first contribution in https://github.com/apache/opendal/pull/7381
+
+**Full Changelog**: https://github.com/apache/opendal/compare/v0.55.0...v0.56.0
+
 ## [v0.55.0] - 2025-11-11
 ### Added
 * feat(services/oss): allow users to specify endpoint addressing style by @howardlau1999 in https://github.com/apache/opendal/pull/6504

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -1,182 +1,215 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MPL-2.0	Unicode-3.0	Unlicense
-anstream@0.6.21	X							X			
-anstyle@1.0.13	X							X			
-anstyle-parse@0.2.7	X							X			
-anstyle-query@1.1.5	X							X			
-anstyle-wincon@3.0.11	X							X			
-anyhow@1.0.100	X							X			
-atomic-waker@1.1.2	X							X			
-backon@1.6.0	X										
-base64@0.22.1	X							X			
-bitflags@2.10.0	X							X			
-block-buffer@0.10.4	X							X			
-bumpalo@3.19.0	X							X			
-bytes@1.11.0								X			
-cbindgen@0.29.2									X		
-cc@1.2.47	X							X			
-cfg-if@1.0.4	X							X			
-clap@4.5.53	X							X			
-clap_builder@4.5.53	X							X			
-clap_lex@0.7.6	X							X			
-colorchoice@1.0.4	X							X			
-crypto-common@0.1.7	X							X			
-digest@0.10.7	X							X			
-displaydoc@0.2.5	X							X			
-equivalent@1.0.2	X							X			
-errno@0.3.14	X							X			
-fastrand@2.3.0	X							X			
-find-msvc-tools@0.1.5	X							X			
-fnv@1.0.7	X							X			
-form_urlencoded@1.2.2	X							X			
-futures@0.3.31	X							X			
-futures-channel@0.3.31	X							X			
-futures-core@0.3.31	X							X			
-futures-io@0.3.31	X							X			
-futures-macro@0.3.31	X							X			
-futures-sink@0.3.31	X							X			
-futures-task@0.3.31	X							X			
-futures-util@0.3.31	X							X			
-generic-array@0.14.7								X			
-getrandom@0.2.16	X							X			
-getrandom@0.3.4	X							X			
-gloo-timers@0.3.0	X							X			
-hashbrown@0.16.1	X							X			
-heck@0.5.0	X							X			
-http@1.3.1	X							X			
-http-body@1.0.1								X			
-http-body-util@0.1.3								X			
-httparse@1.10.1	X							X			
-hyper@1.8.1								X			
-hyper-rustls@0.27.7	X					X		X			
-hyper-util@0.1.18								X			
-icu_collections@2.1.1										X	
-icu_locale_core@2.1.1										X	
-icu_normalizer@2.1.1										X	
-icu_normalizer_data@2.1.1										X	
-icu_properties@2.1.1										X	
-icu_properties_data@2.1.1										X	
-icu_provider@2.1.1										X	
-idna@1.1.0	X							X			
-idna_adapter@1.2.1	X							X			
-indexmap@2.12.1	X							X			
-ipnet@2.11.0	X							X			
-iri-string@0.7.9	X							X			
-is_terminal_polyfill@1.70.2	X							X			
-itoa@1.0.15	X							X			
-jiff@0.2.16								X			X
-jiff-tzdb@0.1.4								X			X
-jiff-tzdb-platform@0.1.3								X			X
-js-sys@0.3.82	X							X			
-libc@0.2.177	X							X			
-linux-raw-sys@0.11.0	X	X						X			
-litemap@0.8.1										X	
-log@0.4.28	X							X			
-md-5@0.10.6	X							X			
-memchr@2.7.6								X			X
-mio@1.1.0								X			
-once_cell@1.21.3	X							X			
-once_cell_polyfill@1.70.2	X							X			
-opendal@0.55.0	X										
-opendal-c@0.0.0	X										
-percent-encoding@2.3.2	X							X			
-pin-project-lite@0.2.16	X							X			
-pin-utils@0.1.0	X							X			
-portable-atomic@1.11.1	X							X			
-portable-atomic-util@0.2.4	X							X			
-potential_utf@0.1.4										X	
-proc-macro2@1.0.103	X							X			
-quick-xml@0.38.4								X			
-quote@1.0.42	X							X			
-r-efi@5.3.0	X						X	X			
-reqwest@0.12.24	X							X			
-ring@0.17.14	X					X					
-rustix@1.1.2	X	X						X			
-rustls@0.23.35	X					X		X			
-rustls-pki-types@1.13.0	X							X			
-rustls-webpki@0.103.8						X					
-rustversion@1.0.22	X							X			
-ryu@1.0.20	X			X							
-serde@1.0.228	X							X			
-serde_core@1.0.228	X							X			
-serde_derive@1.0.228	X							X			
-serde_json@1.0.145	X							X			
-serde_spanned@1.0.3	X							X			
-serde_urlencoded@0.7.1	X							X			
-shlex@1.3.0	X							X			
-slab@0.4.11								X			
-smallvec@1.15.1	X							X			
-socket2@0.6.1	X							X			
-stable_deref_trait@1.2.1	X							X			
-strsim@0.11.1								X			
-subtle@2.6.1			X								
-syn@2.0.110	X							X			
-sync_wrapper@1.0.2	X										
-synstructure@0.13.2								X			
-tempfile@3.23.0	X							X			
-tinystr@0.8.2										X	
-tokio@1.48.0								X			
-tokio-macros@2.6.0								X			
-tokio-rustls@0.26.4	X							X			
-tokio-util@0.7.17								X			
-toml@0.9.8	X							X			
-toml_datetime@0.7.3	X							X			
-toml_parser@1.0.4	X							X			
-tower@0.5.2								X			
-tower-http@0.6.6								X			
-tower-layer@0.3.3								X			
-tower-service@0.3.3								X			
-tracing@0.1.41								X			
-tracing-core@0.1.34								X			
-try-lock@0.2.5								X			
-typenum@1.19.0	X							X			
-unicode-ident@1.0.22	X							X		X	
-untrusted@0.9.0						X					
-url@2.5.7	X							X			
-utf8_iter@1.0.4	X							X			
-utf8parse@0.2.2	X							X			
-uuid@1.18.1	X							X			
-version_check@0.9.5	X							X			
-want@0.3.1								X			
-wasi@0.11.1+wasi-snapshot-preview1	X	X						X			
-wasip2@1.0.1+wasi-0.2.4	X	X						X			
-wasm-bindgen@0.2.105	X							X			
-wasm-bindgen-futures@0.4.55	X							X			
-wasm-bindgen-macro@0.2.105	X							X			
-wasm-bindgen-macro-support@0.2.105	X							X			
-wasm-bindgen-shared@0.2.105	X							X			
-wasm-streams@0.4.2	X							X			
-web-sys@0.3.82	X							X			
-webpki-roots@1.0.4					X						
-windows-link@0.2.1	X							X			
-windows-sys@0.52.0	X							X			
-windows-sys@0.60.2	X							X			
-windows-sys@0.61.2	X							X			
-windows-targets@0.52.6	X							X			
-windows-targets@0.53.5	X							X			
-windows_aarch64_gnullvm@0.52.6	X							X			
-windows_aarch64_gnullvm@0.53.1	X							X			
-windows_aarch64_msvc@0.52.6	X							X			
-windows_aarch64_msvc@0.53.1	X							X			
-windows_i686_gnu@0.52.6	X							X			
-windows_i686_gnu@0.53.1	X							X			
-windows_i686_gnullvm@0.52.6	X							X			
-windows_i686_gnullvm@0.53.1	X							X			
-windows_i686_msvc@0.52.6	X							X			
-windows_i686_msvc@0.53.1	X							X			
-windows_x86_64_gnu@0.52.6	X							X			
-windows_x86_64_gnu@0.53.1	X							X			
-windows_x86_64_gnullvm@0.52.6	X							X			
-windows_x86_64_gnullvm@0.53.1	X							X			
-windows_x86_64_msvc@0.52.6	X							X			
-windows_x86_64_msvc@0.53.1	X							X			
-winnow@0.7.13								X			
-wit-bindgen@0.46.0	X	X						X			
-writeable@0.6.2										X	
-yoke@0.8.1										X	
-yoke-derive@0.8.1										X	
-zerofrom@0.1.6										X	
-zerofrom-derive@0.1.6										X	
-zeroize@1.8.2	X							X			
-zerotrie@0.2.3										X	
-zerovec@0.11.5										X	
-zerovec-derive@0.11.2										X	
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense
+anstream@1.0.0	X							X				
+anstyle@1.0.14	X							X				
+anstyle-parse@1.0.0	X							X				
+anstyle-query@1.1.5	X							X				
+anstyle-wincon@3.0.11	X							X				
+anyhow@1.0.102	X							X				
+atomic-waker@1.1.2	X							X				
+aws-lc-rs@1.16.3	X					X						
+aws-lc-sys@0.40.0	X		X			X		X	X			
+backon@1.6.0	X											
+base64@0.22.1	X							X				
+bitflags@2.11.1	X							X				
+block-buffer@0.10.4	X							X				
+bumpalo@3.20.2	X							X				
+bytes@1.11.1								X				
+cbindgen@0.29.2										X		
+cc@1.2.60	X							X				
+cesu8@1.1.0	X							X				
+cfg-if@1.0.4	X							X				
+clap@4.6.1	X							X				
+clap_builder@4.6.0	X							X				
+clap_lex@1.1.0	X							X				
+cmake@0.1.58	X							X				
+colorchoice@1.0.5	X							X				
+combine@4.6.7								X				
+const-oid@0.9.6	X							X				
+core-foundation@0.10.1	X							X				
+core-foundation-sys@0.8.7	X							X				
+cpufeatures@0.2.17	X							X				
+crypto-common@0.1.7	X							X				
+ctor@0.6.3	X							X				
+ctor-proc-macro@0.0.7	X							X				
+digest@0.10.7	X							X				
+displaydoc@0.2.5	X							X				
+dtor@0.1.1	X							X				
+dtor-proc-macro@0.0.6	X							X				
+dunce@1.0.5	X			X					X			
+equivalent@1.0.2	X							X				
+errno@0.3.14	X							X				
+fastrand@2.4.1	X							X				
+find-msvc-tools@0.1.9	X							X				
+form_urlencoded@1.2.2	X							X				
+fs_extra@1.3.0								X				
+futures@0.3.32	X							X				
+futures-channel@0.3.32	X							X				
+futures-core@0.3.32	X							X				
+futures-executor@0.3.32	X							X				
+futures-io@0.3.32	X							X				
+futures-macro@0.3.32	X							X				
+futures-sink@0.3.32	X							X				
+futures-task@0.3.32	X							X				
+futures-util@0.3.32	X							X				
+generic-array@0.14.7								X				
+getrandom@0.3.4	X							X				
+getrandom@0.4.2	X							X				
+gloo-timers@0.3.0	X							X				
+hashbrown@0.17.0	X							X				
+heck@0.5.0	X							X				
+hex@0.4.3	X							X				
+hmac@0.12.1	X							X				
+http@1.4.0	X							X				
+http-body@1.0.1								X				
+http-body-util@0.1.3								X				
+httparse@1.10.1	X							X				
+hyper@1.9.0								X				
+hyper-rustls@0.27.9	X					X		X				
+hyper-util@0.1.20								X				
+icu_collections@2.2.0											X	
+icu_locale_core@2.2.0											X	
+icu_normalizer@2.2.0											X	
+icu_normalizer_data@2.2.0											X	
+icu_properties@2.2.0											X	
+icu_properties_data@2.2.0											X	
+icu_provider@2.2.0											X	
+idna@1.1.0	X							X				
+idna_adapter@1.2.1	X							X				
+indexmap@2.14.0	X							X				
+ipnet@2.12.0	X							X				
+iri-string@0.7.12	X							X				
+is_terminal_polyfill@1.70.2	X							X				
+itoa@1.0.18	X							X				
+jiff@0.2.23								X				X
+jiff-tzdb@0.1.6								X				X
+jiff-tzdb-platform@0.1.3								X				X
+jni@0.21.1	X							X				
+jni-sys@0.3.1	X							X				
+jni-sys@0.4.1	X							X				
+jni-sys-macros@0.4.1	X							X				
+jobserver@0.1.34	X							X				
+js-sys@0.3.95	X							X				
+libc@0.2.185	X							X				
+linux-raw-sys@0.12.1	X	X						X				
+litemap@0.8.2											X	
+log@0.4.29	X							X				
+md-5@0.10.6	X							X				
+mea@0.6.3	X											
+memchr@2.8.0								X				X
+mio@1.2.0								X				
+once_cell@1.21.4	X							X				
+once_cell_polyfill@1.70.2	X							X				
+opendal@0.56.0	X											
+opendal-c@0.0.0	X											
+opendal-core@0.56.0	X											
+opendal-layer-concurrent-limit@0.56.0	X											
+opendal-layer-logging@0.56.0	X											
+opendal-layer-retry@0.56.0	X											
+opendal-layer-timeout@0.56.0	X											
+openssl-probe@0.2.1	X							X				
+percent-encoding@2.3.2	X							X				
+pin-project-lite@0.2.17	X							X				
+portable-atomic@1.13.1	X							X				
+portable-atomic-util@0.2.6	X							X				
+potential_utf@0.1.5											X	
+proc-macro2@1.0.106	X							X				
+quick-xml@0.38.4								X				
+quote@1.0.45	X							X				
+r-efi@5.3.0	X						X	X				
+r-efi@6.0.0	X						X	X				
+reqsign-core@3.0.0	X											
+reqwest@0.13.2	X							X				
+rustix@1.1.4	X	X						X				
+rustls@0.23.38	X					X		X				
+rustls-native-certs@0.8.3	X					X		X				
+rustls-pki-types@1.14.0	X							X				
+rustls-platform-verifier@0.6.2	X							X				
+rustls-platform-verifier-android@0.1.1	X							X				
+rustls-webpki@0.103.12						X						
+rustversion@1.0.22	X							X				
+same-file@1.0.6								X				X
+schannel@0.1.29								X				
+security-framework@3.7.0	X							X				
+security-framework-sys@2.17.0	X							X				
+serde@1.0.228	X							X				
+serde_core@1.0.228	X							X				
+serde_derive@1.0.228	X							X				
+serde_json@1.0.149	X							X				
+serde_spanned@1.1.1	X							X				
+sha1@0.10.6	X							X				
+sha2@0.10.9	X							X				
+shlex@1.3.0	X							X				
+slab@0.4.12								X				
+smallvec@1.15.1	X							X				
+socket2@0.6.3	X							X				
+stable_deref_trait@1.2.1	X							X				
+strsim@0.11.1								X				
+subtle@2.6.1			X									
+syn@2.0.117	X							X				
+sync_wrapper@1.0.2	X											
+synstructure@0.13.2								X				
+tempfile@3.27.0	X							X				
+thiserror@1.0.69	X							X				
+thiserror-impl@1.0.69	X							X				
+tinystr@0.8.3											X	
+tokio@1.52.0								X				
+tokio-macros@2.7.0								X				
+tokio-rustls@0.26.4	X							X				
+tokio-util@0.7.18								X				
+toml@0.9.12+spec-1.1.0	X							X				
+toml_datetime@0.7.5+spec-1.1.0	X							X				
+toml_parser@1.1.2+spec-1.1.0	X							X				
+tower@0.5.3								X				
+tower-http@0.6.8								X				
+tower-layer@0.3.3								X				
+tower-service@0.3.3								X				
+tracing@0.1.44								X				
+tracing-core@0.1.36								X				
+try-lock@0.2.5								X				
+typenum@1.19.0	X							X				
+unicode-ident@1.0.24	X							X			X	
+untrusted@0.9.0						X						
+url@2.5.8	X							X				
+utf8_iter@1.0.4	X							X				
+utf8parse@0.2.2	X							X				
+uuid@1.23.1	X							X				
+version_check@0.9.5	X							X				
+walkdir@2.5.0								X				X
+want@0.3.1								X				
+wasi@0.11.1+wasi-snapshot-preview1	X	X						X				
+wasip2@1.0.2+wasi-0.2.9	X	X						X				
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X						X				
+wasm-bindgen@0.2.118	X							X				
+wasm-bindgen-futures@0.4.68	X							X				
+wasm-bindgen-macro@0.2.118	X							X				
+wasm-bindgen-macro-support@0.2.118	X							X				
+wasm-bindgen-shared@0.2.118	X							X				
+wasm-streams@0.5.0	X							X				
+web-sys@0.3.95	X							X				
+web-time@1.1.0	X							X				
+webpki-root-certs@1.0.6					X							
+winapi-util@0.1.11								X				X
+windows-link@0.2.1	X							X				
+windows-sys@0.45.0	X							X				
+windows-sys@0.61.2	X							X				
+windows-targets@0.42.2	X							X				
+windows_aarch64_gnullvm@0.42.2	X							X				
+windows_aarch64_msvc@0.42.2	X							X				
+windows_i686_gnu@0.42.2	X							X				
+windows_i686_msvc@0.42.2	X							X				
+windows_x86_64_gnu@0.42.2	X							X				
+windows_x86_64_gnullvm@0.42.2	X							X				
+windows_x86_64_msvc@0.42.2	X							X				
+winnow@0.7.15								X				
+winnow@1.0.1								X				
+wit-bindgen@0.51.0	X	X						X				
+writeable@0.6.3											X	
+yoke@0.8.2											X	
+yoke-derive@0.8.2											X	
+zerofrom@0.1.7											X	
+zerofrom-derive@0.1.7											X	
+zeroize@1.8.2	X							X				
+zerotrie@0.2.4											X	
+zerovec@0.11.6											X	
+zerovec-derive@0.11.3											X	
+zmij@1.0.21								X				

--- a/bindings/cpp/DEPENDENCIES.rust.tsv
+++ b/bindings/cpp/DEPENDENCIES.rust.tsv
@@ -1,170 +1,201 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-anyhow@1.0.100	X							X			
-atomic-waker@1.1.2	X							X			
-backon@1.6.0	X										
-base64@0.22.1	X							X			
-bitflags@2.10.0	X							X			
-block-buffer@0.10.4	X							X			
-bumpalo@3.19.0	X							X			
-bytes@1.11.0								X			
-cc@1.2.47	X							X			
-cfg-if@1.0.4	X							X			
-codespan-reporting@0.13.1	X										
-crypto-common@0.1.7	X							X			
-cxx@1.0.189	X							X			
-cxx-build@1.0.189	X							X			
-cxxbridge-flags@1.0.189	X							X			
-cxxbridge-macro@1.0.189	X							X			
-digest@0.10.7	X							X			
-displaydoc@0.2.5	X							X			
-equivalent@1.0.2	X							X			
-fastrand@2.3.0	X							X			
-find-msvc-tools@0.1.5	X							X			
-fnv@1.0.7	X							X			
-foldhash@0.2.0											X
-form_urlencoded@1.2.2	X							X			
-futures@0.3.31	X							X			
-futures-channel@0.3.31	X							X			
-futures-core@0.3.31	X							X			
-futures-executor@0.3.31	X							X			
-futures-io@0.3.31	X							X			
-futures-macro@0.3.31	X							X			
-futures-sink@0.3.31	X							X			
-futures-task@0.3.31	X							X			
-futures-util@0.3.31	X							X			
-generic-array@0.14.7								X			
-getrandom@0.2.16	X							X			
-getrandom@0.3.4	X							X			
-gloo-timers@0.3.0	X							X			
-hashbrown@0.16.1	X							X			
-http@1.3.1	X							X			
-http-body@1.0.1								X			
-http-body-util@0.1.3								X			
-httparse@1.10.1	X							X			
-hyper@1.8.1								X			
-hyper-rustls@0.27.7	X					X		X			
-hyper-util@0.1.18								X			
-icu_collections@2.1.1									X		
-icu_locale_core@2.1.1									X		
-icu_normalizer@2.1.1									X		
-icu_normalizer_data@2.1.1									X		
-icu_properties@2.1.1									X		
-icu_properties_data@2.1.1									X		
-icu_provider@2.1.1									X		
-idna@1.1.0	X							X			
-idna_adapter@1.2.1	X							X			
-indexmap@2.12.1	X							X			
-ipnet@2.11.0	X							X			
-iri-string@0.7.9	X							X			
-itoa@1.0.15	X							X			
-jiff@0.2.16								X		X	
-jiff-tzdb@0.1.4								X		X	
-jiff-tzdb-platform@0.1.3								X		X	
-js-sys@0.3.82	X							X			
-libc@0.2.177	X							X			
-link-cplusplus@1.0.12	X							X			
-litemap@0.8.1									X		
-log@0.4.28	X							X			
-md-5@0.10.6	X							X			
-memchr@2.7.6								X		X	
-mio@1.1.0								X			
-once_cell@1.21.3	X							X			
-opendal@0.55.0	X										
-opendal-cpp@0.0.0	X										
-percent-encoding@2.3.2	X							X			
-pin-project-lite@0.2.16	X							X			
-pin-utils@0.1.0	X							X			
-portable-atomic@1.11.1	X							X			
-portable-atomic-util@0.2.4	X							X			
-potential_utf@0.1.4									X		
-proc-macro2@1.0.103	X							X			
-quick-xml@0.38.4								X			
-quote@1.0.42	X							X			
-r-efi@5.3.0	X						X	X			
-reqwest@0.12.24	X							X			
-ring@0.17.14	X					X					
-rustls@0.23.35	X					X		X			
-rustls-pki-types@1.13.0	X							X			
-rustls-webpki@0.103.8						X					
-rustversion@1.0.22	X							X			
-ryu@1.0.20	X			X							
-scratch@1.0.9	X							X			
-serde@1.0.228	X							X			
-serde_core@1.0.228	X							X			
-serde_derive@1.0.228	X							X			
-serde_json@1.0.145	X							X			
-serde_urlencoded@0.7.1	X							X			
-shlex@1.3.0	X							X			
-slab@0.4.11								X			
-smallvec@1.15.1	X							X			
-socket2@0.6.1	X							X			
-stable_deref_trait@1.2.1	X							X			
-subtle@2.6.1			X								
-syn@2.0.110	X							X			
-sync_wrapper@1.0.2	X										
-synstructure@0.13.2								X			
-termcolor@1.4.1								X		X	
-tinystr@0.8.2									X		
-tokio@1.48.0								X			
-tokio-macros@2.6.0								X			
-tokio-rustls@0.26.4	X							X			
-tokio-util@0.7.17								X			
-tower@0.5.2								X			
-tower-http@0.6.6								X			
-tower-layer@0.3.3								X			
-tower-service@0.3.3								X			
-tracing@0.1.41								X			
-tracing-core@0.1.34								X			
-try-lock@0.2.5								X			
-typenum@1.19.0	X							X			
-unicode-ident@1.0.22	X							X	X		
-unicode-width@0.2.2	X							X			
-untrusted@0.9.0						X					
-url@2.5.7	X							X			
-utf8_iter@1.0.4	X							X			
-uuid@1.18.1	X							X			
-version_check@0.9.5	X							X			
-want@0.3.1								X			
-wasi@0.11.1+wasi-snapshot-preview1	X	X						X			
-wasip2@1.0.1+wasi-0.2.4	X	X						X			
-wasm-bindgen@0.2.105	X							X			
-wasm-bindgen-futures@0.4.55	X							X			
-wasm-bindgen-macro@0.2.105	X							X			
-wasm-bindgen-macro-support@0.2.105	X							X			
-wasm-bindgen-shared@0.2.105	X							X			
-wasm-streams@0.4.2	X							X			
-web-sys@0.3.82	X							X			
-webpki-roots@1.0.4					X						
-winapi-util@0.1.11								X		X	
-windows-link@0.2.1	X							X			
-windows-sys@0.52.0	X							X			
-windows-sys@0.60.2	X							X			
-windows-sys@0.61.2	X							X			
-windows-targets@0.52.6	X							X			
-windows-targets@0.53.5	X							X			
-windows_aarch64_gnullvm@0.52.6	X							X			
-windows_aarch64_gnullvm@0.53.1	X							X			
-windows_aarch64_msvc@0.52.6	X							X			
-windows_aarch64_msvc@0.53.1	X							X			
-windows_i686_gnu@0.52.6	X							X			
-windows_i686_gnu@0.53.1	X							X			
-windows_i686_gnullvm@0.52.6	X							X			
-windows_i686_gnullvm@0.53.1	X							X			
-windows_i686_msvc@0.52.6	X							X			
-windows_i686_msvc@0.53.1	X							X			
-windows_x86_64_gnu@0.52.6	X							X			
-windows_x86_64_gnu@0.53.1	X							X			
-windows_x86_64_gnullvm@0.52.6	X							X			
-windows_x86_64_gnullvm@0.53.1	X							X			
-windows_x86_64_msvc@0.52.6	X							X			
-windows_x86_64_msvc@0.53.1	X							X			
-wit-bindgen@0.46.0	X	X						X			
-writeable@0.6.2									X		
-yoke@0.8.1									X		
-yoke-derive@0.8.1									X		
-zerofrom@0.1.6									X		
-zerofrom-derive@0.1.6									X		
-zeroize@1.8.2	X							X			
-zerotrie@0.2.3									X		
-zerovec@0.11.5									X		
-zerovec-derive@0.11.2									X		
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib
+anyhow@1.0.102	X							X				
+atomic-waker@1.1.2	X							X				
+aws-lc-rs@1.16.3	X					X						
+aws-lc-sys@0.40.0	X		X			X		X	X			
+backon@1.6.0	X											
+base64@0.22.1	X							X				
+bitflags@2.11.1	X							X				
+block-buffer@0.10.4	X							X				
+bumpalo@3.20.2	X							X				
+bytes@1.11.1								X				
+cc@1.2.60	X							X				
+cesu8@1.1.0	X							X				
+cfg-if@1.0.4	X							X				
+cmake@0.1.58	X							X				
+codespan-reporting@0.13.1	X											
+combine@4.6.7								X				
+const-oid@0.9.6	X							X				
+core-foundation@0.10.1	X							X				
+core-foundation-sys@0.8.7	X							X				
+cpufeatures@0.2.17	X							X				
+crypto-common@0.1.7	X							X				
+ctor@0.6.3	X							X				
+ctor-proc-macro@0.0.7	X							X				
+cxx@1.0.194	X							X				
+cxx-build@1.0.194	X							X				
+cxxbridge-flags@1.0.194	X							X				
+cxxbridge-macro@1.0.194	X							X				
+digest@0.10.7	X							X				
+displaydoc@0.2.5	X							X				
+dtor@0.1.1	X							X				
+dtor-proc-macro@0.0.6	X							X				
+dunce@1.0.5	X			X					X			
+equivalent@1.0.2	X							X				
+fastrand@2.4.1	X							X				
+find-msvc-tools@0.1.9	X							X				
+foldhash@0.2.0												X
+form_urlencoded@1.2.2	X							X				
+fs_extra@1.3.0								X				
+futures@0.3.32	X							X				
+futures-channel@0.3.32	X							X				
+futures-core@0.3.32	X							X				
+futures-executor@0.3.32	X							X				
+futures-io@0.3.32	X							X				
+futures-macro@0.3.32	X							X				
+futures-sink@0.3.32	X							X				
+futures-task@0.3.32	X							X				
+futures-util@0.3.32	X							X				
+generic-array@0.14.7								X				
+getrandom@0.3.4	X							X				
+getrandom@0.4.2	X							X				
+gloo-timers@0.3.0	X							X				
+hashbrown@0.17.0	X							X				
+hex@0.4.3	X							X				
+hmac@0.12.1	X							X				
+http@1.4.0	X							X				
+http-body@1.0.1								X				
+http-body-util@0.1.3								X				
+httparse@1.10.1	X							X				
+hyper@1.9.0								X				
+hyper-rustls@0.27.9	X					X		X				
+hyper-util@0.1.20								X				
+icu_collections@2.1.1										X		
+icu_locale_core@2.1.1										X		
+icu_normalizer@2.1.1										X		
+icu_normalizer_data@2.1.1										X		
+icu_properties@2.1.2										X		
+icu_properties_data@2.1.2										X		
+icu_provider@2.1.1										X		
+idna@1.1.0	X							X				
+idna_adapter@1.2.1	X							X				
+indexmap@2.14.0	X							X				
+ipnet@2.12.0	X							X				
+iri-string@0.7.12	X							X				
+itoa@1.0.18	X							X				
+jiff@0.2.23								X			X	
+jiff-tzdb@0.1.6								X			X	
+jiff-tzdb-platform@0.1.3								X			X	
+jni@0.21.1	X							X				
+jni-sys@0.3.1	X							X				
+jni-sys@0.4.1	X							X				
+jni-sys-macros@0.4.1	X							X				
+jobserver@0.1.34	X							X				
+js-sys@0.3.95	X							X				
+libc@0.2.185	X							X				
+link-cplusplus@1.0.12	X							X				
+litemap@0.8.2										X		
+log@0.4.29	X							X				
+md-5@0.10.6	X							X				
+mea@0.6.3	X											
+memchr@2.8.0								X			X	
+mio@1.2.0								X				
+once_cell@1.21.4	X							X				
+opendal@0.56.0	X											
+opendal-core@0.56.0	X											
+opendal-cpp@0.0.0	X											
+opendal-layer-concurrent-limit@0.56.0	X											
+opendal-layer-logging@0.56.0	X											
+opendal-layer-retry@0.56.0	X											
+opendal-layer-timeout@0.56.0	X											
+openssl-probe@0.2.1	X							X				
+percent-encoding@2.3.2	X							X				
+pin-project-lite@0.2.17	X							X				
+portable-atomic@1.13.1	X							X				
+portable-atomic-util@0.2.6	X							X				
+potential_utf@0.1.5										X		
+proc-macro2@1.0.106	X							X				
+quick-xml@0.38.4								X				
+quote@1.0.45	X							X				
+r-efi@5.3.0	X						X	X				
+r-efi@6.0.0	X						X	X				
+reqsign-core@3.0.0	X											
+reqwest@0.13.2	X							X				
+rustls@0.23.38	X					X		X				
+rustls-native-certs@0.8.3	X					X		X				
+rustls-pki-types@1.14.0	X							X				
+rustls-platform-verifier@0.6.2	X							X				
+rustls-platform-verifier-android@0.1.1	X							X				
+rustls-webpki@0.103.12						X						
+rustversion@1.0.22	X							X				
+same-file@1.0.6								X			X	
+schannel@0.1.29								X				
+scratch@1.0.9	X							X				
+security-framework@3.7.0	X							X				
+security-framework-sys@2.17.0	X							X				
+serde@1.0.228	X							X				
+serde_core@1.0.228	X							X				
+serde_derive@1.0.228	X							X				
+serde_json@1.0.149	X							X				
+sha1@0.10.6	X							X				
+sha2@0.10.9	X							X				
+shlex@1.3.0	X							X				
+slab@0.4.12								X				
+smallvec@1.15.1	X							X				
+socket2@0.6.3	X							X				
+stable_deref_trait@1.2.1	X							X				
+subtle@2.6.1			X									
+syn@2.0.117	X							X				
+sync_wrapper@1.0.2	X											
+synstructure@0.13.2								X				
+termcolor@1.4.1								X			X	
+thiserror@1.0.69	X							X				
+thiserror-impl@1.0.69	X							X				
+tinystr@0.8.3										X		
+tokio@1.52.0								X				
+tokio-macros@2.7.0								X				
+tokio-rustls@0.26.4	X							X				
+tokio-util@0.7.18								X				
+tower@0.5.3								X				
+tower-http@0.6.8								X				
+tower-layer@0.3.3								X				
+tower-service@0.3.3								X				
+tracing@0.1.44								X				
+tracing-core@0.1.36								X				
+try-lock@0.2.5								X				
+typenum@1.19.0	X							X				
+unicode-ident@1.0.24	X							X		X		
+unicode-width@0.2.2	X							X				
+untrusted@0.9.0						X						
+url@2.5.8	X							X				
+utf8_iter@1.0.4	X							X				
+uuid@1.23.1	X							X				
+version_check@0.9.5	X							X				
+walkdir@2.5.0								X			X	
+want@0.3.1								X				
+wasi@0.11.1+wasi-snapshot-preview1	X	X						X				
+wasip2@1.0.1+wasi-0.2.4	X	X						X				
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X						X				
+wasm-bindgen@0.2.118	X							X				
+wasm-bindgen-futures@0.4.68	X							X				
+wasm-bindgen-macro@0.2.118	X							X				
+wasm-bindgen-macro-support@0.2.118	X							X				
+wasm-bindgen-shared@0.2.118	X							X				
+wasm-streams@0.5.0	X							X				
+web-sys@0.3.95	X							X				
+web-time@1.1.0	X							X				
+webpki-root-certs@1.0.6					X							
+winapi-util@0.1.11								X			X	
+windows-link@0.2.1	X							X				
+windows-sys@0.45.0	X							X				
+windows-sys@0.61.2	X							X				
+windows-targets@0.42.2	X							X				
+windows_aarch64_gnullvm@0.42.2	X							X				
+windows_aarch64_msvc@0.42.2	X							X				
+windows_i686_gnu@0.42.2	X							X				
+windows_i686_msvc@0.42.2	X							X				
+windows_x86_64_gnu@0.42.2	X							X				
+windows_x86_64_gnullvm@0.42.2	X							X				
+windows_x86_64_msvc@0.42.2	X							X				
+wit-bindgen@0.46.0	X	X						X				
+wit-bindgen@0.51.0	X	X						X				
+writeable@0.6.3										X		
+yoke@0.8.2										X		
+yoke-derive@0.8.2										X		
+zerofrom@0.1.7										X		
+zerofrom-derive@0.1.7										X		
+zeroize@1.8.2	X							X				
+zerotrie@0.2.4										X		
+zerovec@0.11.6										X		
+zerovec-derive@0.11.3										X		
+zmij@1.0.21								X				

--- a/bindings/dotnet/DEPENDENCIES.rust.tsv
+++ b/bindings/dotnet/DEPENDENCIES.rust.tsv
@@ -1,243 +1,697 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense
-aes@0.8.4	X									X		
-android_system_properties@0.1.5	X									X		
-anyhow@1.0.100	X									X		
-async-trait@0.1.89	X									X		
-atomic-waker@1.1.2	X									X		
-autocfg@1.5.0	X									X		
-backon@1.6.0	X											
-base64@0.22.1	X									X		
-base64ct@1.8.0	X									X		
-bitflags@2.10.0	X									X		
-block-buffer@0.10.4	X									X		
-block-padding@0.3.3	X									X		
-bumpalo@3.19.0	X									X		
-bytes@1.11.0										X		
-cbc@0.1.2	X									X		
-cc@1.2.47	X									X		
-cfg-if@1.0.4	X									X		
-chrono@0.4.42	X									X		
-cipher@0.4.4	X									X		
-const-oid@0.9.6	X									X		
-const-random@0.1.18	X									X		
-const-random-macro@0.1.16	X									X		
-core-foundation-sys@0.8.7	X									X		
-cpufeatures@0.2.17	X									X		
-crc32c@0.6.8	X									X		
-crunchy@0.2.4										X		
-crypto-common@0.1.7	X									X		
-der@0.7.10	X									X		
-deranged@0.5.5	X									X		
-digest@0.10.7	X									X		
-displaydoc@0.2.5	X									X		
-dlv-list@0.5.2	X									X		
-either@1.15.0	X									X		
-fastrand@2.3.0	X									X		
-find-msvc-tools@0.1.5	X									X		
-fnv@1.0.7	X									X		
-form_urlencoded@1.2.2	X									X		
-futures@0.3.31	X									X		
-futures-channel@0.3.31	X									X		
-futures-core@0.3.31	X									X		
-futures-io@0.3.31	X									X		
-futures-macro@0.3.31	X									X		
-futures-sink@0.3.31	X									X		
-futures-task@0.3.31	X									X		
-futures-util@0.3.31	X									X		
-generic-array@0.14.7										X		
-getrandom@0.2.16	X									X		
-getrandom@0.3.4	X									X		
-ghac@0.2.0	X											
-gloo-timers@0.3.0	X									X		
-hashbrown@0.14.5	X									X		
-hex@0.4.3	X									X		
-hmac@0.12.1	X									X		
-home@0.5.11	X									X		
-http@1.3.1	X									X		
-http-body@1.0.1										X		
-http-body-util@0.1.3										X		
-httparse@1.10.1	X									X		
-hyper@1.8.1										X		
-hyper-rustls@0.27.7	X							X		X		
-hyper-util@0.1.18										X		
-iana-time-zone@0.1.64	X									X		
-iana-time-zone-haiku@0.1.2	X									X		
-icu_collections@2.1.1											X	
-icu_locale_core@2.1.1											X	
-icu_normalizer@2.1.1											X	
-icu_normalizer_data@2.1.1											X	
-icu_properties@2.1.1											X	
-icu_properties_data@2.1.1											X	
-icu_provider@2.1.1											X	
-idna@1.1.0	X									X		
-idna_adapter@1.2.1	X									X		
-inout@0.1.4	X									X		
-ipnet@2.11.0	X									X		
-iri-string@0.7.9	X									X		
-itertools@0.14.0	X									X		
-itoa@1.0.15	X									X		
-jiff@0.2.16										X		X
-jiff-tzdb@0.1.4										X		X
-jiff-tzdb-platform@0.1.3										X		X
-js-sys@0.3.82	X									X		
-jsonwebtoken@9.3.1										X		
-lazy_static@1.5.0	X									X		
-libc@0.2.177	X									X		
-libm@0.2.15										X		
-litemap@0.8.1											X	
-lock_api@0.4.14	X									X		
-log@0.4.28	X									X		
-md-5@0.10.6	X									X		
-memchr@2.7.6										X		X
-mio@1.1.0										X		
-num-bigint@0.4.6	X									X		
-num-bigint-dig@0.8.6	X									X		
-num-conv@0.1.0	X									X		
-num-integer@0.1.46	X									X		
-num-iter@0.1.45	X									X		
-num-traits@0.2.19	X									X		
-once_cell@1.21.3	X									X		
-opendal@0.55.0	X											
-opendal-dotnet@0.0.0	X											
-ordered-multimap@0.7.3										X		
-parking_lot@0.12.5	X									X		
-parking_lot_core@0.9.12	X									X		
-pbkdf2@0.12.2	X									X		
-pem@3.0.6										X		
-pem-rfc7468@0.7.0	X									X		
-percent-encoding@2.3.2	X									X		
-pin-project-lite@0.2.16	X									X		
-pin-utils@0.1.0	X									X		
-pkcs1@0.7.5	X									X		
-pkcs5@0.7.1	X									X		
-pkcs8@0.10.2	X									X		
-portable-atomic@1.11.1	X									X		
-portable-atomic-util@0.2.4	X									X		
-potential_utf@0.1.4											X	
-powerfmt@0.2.0	X									X		
-ppv-lite86@0.2.21	X									X		
-proc-macro2@1.0.103	X									X		
-prost@0.13.5	X											
-prost-derive@0.13.5	X											
-quick-xml@0.38.4										X		
-quote@1.0.42	X									X		
-r-efi@5.3.0	X								X	X		
-rand@0.8.5	X									X		
-rand_chacha@0.3.1	X									X		
-rand_core@0.6.4	X									X		
-redox_syscall@0.5.18										X		
-reqsign@0.16.5	X											
-reqsign-aws-v4@2.0.1	X											
-reqsign-core@2.0.1	X											
-reqsign-file-read-tokio@2.0.1	X											
-reqsign-http-send-reqwest@2.0.1	X											
-reqwest@0.12.24	X									X		
-ring@0.17.14	X							X				
-rsa@0.9.9	X									X		
-rust-ini@0.21.3										X		
-rustc_version@0.4.1	X									X		
-rustls@0.23.35	X							X		X		
-rustls-pki-types@1.13.0	X									X		
-rustls-webpki@0.103.8								X				
-rustversion@1.0.22	X									X		
-ryu@1.0.20	X				X							
-salsa20@0.10.2	X									X		
-scopeguard@1.2.0	X									X		
-scrypt@0.11.0	X									X		
-semver@1.0.27	X									X		
-serde@1.0.228	X									X		
-serde_core@1.0.228	X									X		
-serde_derive@1.0.228	X									X		
-serde_json@1.0.145	X									X		
-serde_urlencoded@0.7.1	X									X		
-sha1@0.10.6	X									X		
-sha2@0.10.9	X									X		
-shlex@1.3.0	X									X		
-signal-hook-registry@1.4.6	X									X		
-signature@2.2.0	X									X		
-simple_asn1@0.6.3								X				
-slab@0.4.11										X		
-smallvec@1.15.1	X									X		
-socket2@0.6.1	X									X		
-spin@0.9.8										X		
-spki@0.7.3	X									X		
-stable_deref_trait@1.2.1	X									X		
-subtle@2.6.1				X								
-syn@2.0.110	X									X		
-sync_wrapper@1.0.2	X											
-synstructure@0.13.2										X		
-thiserror@2.0.17	X									X		
-thiserror-impl@2.0.17	X									X		
-time@0.3.44	X									X		
-time-core@0.1.6	X									X		
-time-macros@0.2.24	X									X		
-tiny-keccak@2.0.2						X						
-tinystr@0.8.2											X	
-tokio@1.48.0										X		
-tokio-macros@2.6.0										X		
-tokio-rustls@0.26.4	X									X		
-tokio-util@0.7.17										X		
-tower@0.5.2										X		
-tower-http@0.6.6										X		
-tower-layer@0.3.3										X		
-tower-service@0.3.3										X		
-tracing@0.1.41										X		
-tracing-core@0.1.34										X		
-try-lock@0.2.5										X		
-typenum@1.19.0	X									X		
-unicode-ident@1.0.22	X									X	X	
-untrusted@0.9.0								X				
-url@2.5.7	X									X		
-utf8_iter@1.0.4	X									X		
-uuid@1.18.1	X									X		
-version_check@0.9.5	X									X		
-want@0.3.1										X		
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X		
-wasip2@1.0.1+wasi-0.2.4	X	X								X		
-wasm-bindgen@0.2.105	X									X		
-wasm-bindgen-futures@0.4.55	X									X		
-wasm-bindgen-macro@0.2.105	X									X		
-wasm-bindgen-macro-support@0.2.105	X									X		
-wasm-bindgen-shared@0.2.105	X									X		
-wasm-streams@0.4.2	X									X		
-web-sys@0.3.82	X									X		
-webpki-roots@1.0.4							X					
-windows-core@0.62.2	X									X		
-windows-implement@0.60.2	X									X		
-windows-interface@0.59.3	X									X		
-windows-link@0.2.1	X									X		
-windows-result@0.4.1	X									X		
-windows-strings@0.5.1	X									X		
-windows-sys@0.52.0	X									X		
-windows-sys@0.59.0	X									X		
-windows-sys@0.60.2	X									X		
-windows-sys@0.61.2	X									X		
-windows-targets@0.52.6	X									X		
-windows-targets@0.53.5	X									X		
-windows_aarch64_gnullvm@0.52.6	X									X		
-windows_aarch64_gnullvm@0.53.1	X									X		
-windows_aarch64_msvc@0.52.6	X									X		
-windows_aarch64_msvc@0.53.1	X									X		
-windows_i686_gnu@0.52.6	X									X		
-windows_i686_gnu@0.53.1	X									X		
-windows_i686_gnullvm@0.52.6	X									X		
-windows_i686_gnullvm@0.53.1	X									X		
-windows_i686_msvc@0.52.6	X									X		
-windows_i686_msvc@0.53.1	X									X		
-windows_x86_64_gnu@0.52.6	X									X		
-windows_x86_64_gnu@0.53.1	X									X		
-windows_x86_64_gnullvm@0.52.6	X									X		
-windows_x86_64_gnullvm@0.53.1	X									X		
-windows_x86_64_msvc@0.52.6	X									X		
-windows_x86_64_msvc@0.53.1	X									X		
-wit-bindgen@0.46.0	X	X								X		
-writeable@0.6.2											X	
-yoke@0.8.1											X	
-yoke-derive@0.8.1											X	
-zerocopy@0.8.28	X		X							X		
-zerofrom@0.1.6											X	
-zerofrom-derive@0.1.6											X	
-zeroize@1.8.2	X									X		
-zerotrie@0.2.3											X	
-zerovec@0.11.5											X	
-zerovec-derive@0.11.2											X	
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib
+aes@0.8.4	X									X					
+ahash@0.8.12	X									X					
+aho-corasick@1.1.4										X				X	
+allocator-api2@0.2.21	X									X					
+android_system_properties@0.1.5	X									X					
+anstream@1.0.0	X									X					
+anstyle@1.0.14	X									X					
+anstyle-parse@1.0.0	X									X					
+anstyle-query@1.1.5	X									X					
+anstyle-wincon@3.0.11	X									X					
+anyhow@1.0.102	X									X					
+approx@0.5.1	X														
+arc-swap@1.9.1	X									X					
+arcstr@1.2.0	X									X					X
+arrayref@0.3.9			X												
+arrayvec@0.7.6	X									X					
+async-lock@3.4.2	X									X					
+async-recursion@0.3.2	X									X					
+async-stream@0.3.6										X					
+async-stream-impl@0.3.6										X					
+async-task@4.7.1	X									X					
+async-trait@0.1.89	X									X					
+atoi@2.0.0										X					
+atomic-waker@1.1.2	X									X					
+auto-const-array@0.2.2	X									X					
+autocfg@1.5.0	X									X					
+awaitable@0.4.0										X					
+awaitable-error@0.1.0										X					
+aws-lc-rs@1.16.3	X							X							
+aws-lc-sys@0.40.0	X			X				X		X	X				
+axum@0.6.20										X					
+axum@0.8.9										X					
+axum-core@0.3.4										X					
+axum-core@0.5.6										X					
+backon@1.6.0	X														
+base64@0.21.7	X									X					
+base64@0.22.1	X									X					
+base64ct@1.8.3	X									X					
+bitflags@1.3.2	X									X					
+bitflags@2.11.1	X									X					
+bitvec@1.0.1										X					
+blake3@1.8.4	X	X				X									
+block-buffer@0.10.4	X									X					
+block-padding@0.3.3	X									X					
+bson@2.15.0										X					
+bstr@1.12.1	X									X					
+bumpalo@3.20.2	X									X					
+bytecount@0.6.9	X									X					
+bytemuck@1.25.0	X									X					X
+byteorder@1.5.0										X				X	
+bytes@1.11.1										X					
+cacache@13.1.0	X														
+camino@1.2.2	X									X					
+cargo-platform@0.1.9	X									X					
+cargo_metadata@0.14.2										X					
+cbc@0.1.2	X									X					
+cc@1.2.60	X									X					
+cesu8@1.1.0	X									X					
+cfg-if@0.1.10	X									X					
+cfg-if@1.0.4	X									X					
+cfg_aliases@0.2.1										X					
+chacha20@0.10.0	X									X					
+chrono@0.4.44	X									X					
+cipher@0.4.4	X									X					
+clap@4.6.1	X									X					
+clap_builder@4.6.0	X									X					
+clap_derive@4.6.1	X									X					
+clap_lex@1.1.0	X									X					
+cmake@0.1.58	X									X					
+colorchoice@1.0.5	X									X					
+colored@3.1.1												X			
+combine@4.6.7										X					
+compio@0.17.0										X					
+compio-buf@0.7.2										X					
+compio-dispatcher@0.9.0										X					
+compio-driver@0.10.0										X					
+compio-fs@0.10.0										X					
+compio-io@0.8.4										X					
+compio-log@0.1.0										X					
+compio-net@0.10.0										X					
+compio-runtime@0.10.1										X					
+concurrent-queue@2.5.0	X									X					
+concurrent_arena@0.1.11										X					
+const-oid@0.9.6	X									X					
+const-random@0.1.18	X									X					
+const-random-macro@0.1.16	X									X					
+const-str@1.1.0										X					
+const_panic@0.2.15															X
+constant_time_eq@0.4.2	X					X					X				
+convert_case@0.10.0										X					
+core-foundation@0.10.1	X									X					
+core-foundation@0.9.4	X									X					
+core-foundation-sys@0.8.7	X									X					
+core_affinity@0.8.3	X									X					
+countio@0.3.0										X					
+cpufeatures@0.2.17	X									X					
+cpufeatures@0.3.0	X									X					
+crc@3.4.0	X									X					
+crc-catalog@2.4.0	X									X					
+crc16@0.4.0										X					
+crc32c@0.6.8	X									X					
+crc32fast@1.5.0	X									X					
+critical-section@1.2.0	X									X					
+crossbeam-channel@0.5.15	X									X					
+crossbeam-epoch@0.9.18	X									X					
+crossbeam-queue@0.3.12	X									X					
+crossbeam-utils@0.8.21	X									X					
+crunchy@0.2.4										X					
+crypto-common@0.1.7	X									X					
+csv@1.4.0										X				X	
+csv-core@0.1.13										X				X	
+ctor@0.6.3	X									X					
+ctor-proc-macro@0.0.7	X									X					
+darling@0.21.3										X					
+darling_core@0.21.3										X					
+darling_macro@0.21.3										X					
+dashmap@5.5.3										X					
+dashmap@6.1.0										X					
+data-encoding@2.10.0										X					
+der@0.7.10	X									X					
+deranged@0.5.8	X									X					
+derivative@2.2.0	X									X					
+derive-new@0.5.9										X					
+derive-syn-parse@0.2.0	X									X					
+derive-where@1.6.1	X									X					
+derive_destructure2@0.1.3	X									X					
+derive_more@2.1.1										X					
+derive_more-impl@2.1.1										X					
+digest@0.10.7	X									X					
+dirs@6.0.0	X									X					
+dirs-sys@0.5.0	X									X					
+displaydoc@0.2.5	X									X					
+dlv-list@0.5.2	X									X					
+dotenvy@0.15.7										X					
+dtor@0.1.1	X									X					
+dtor-proc-macro@0.0.6	X									X					
+dunce@1.0.5	X					X					X				
+either@1.15.0	X									X					
+enum-as-inner@0.6.1	X									X					
+equivalent@1.0.2	X									X					
+errno@0.3.14	X									X					
+error-chain@0.12.4	X									X					
+etcd-client@0.17.0	X									X					
+etcetera@0.8.0	X									X					
+event-listener@5.4.1	X									X					
+event-listener-strategy@0.5.4	X									X					
+fail@0.4.0	X														
+fastpool@1.1.0	X														
+fastrand@2.4.1	X									X					
+find-msvc-tools@0.1.9	X									X					
+fixedbitset@0.5.7	X									X					
+flume@0.11.1	X									X					
+flume@0.12.0	X									X					
+fnv@1.0.7	X									X					
+foldhash@0.1.5															X
+form_urlencoded@1.2.2	X									X					
+fs2@0.4.3	X									X					
+fs_extra@1.3.0										X					
+funty@2.0.0										X					
+futures@0.3.32	X									X					
+futures-channel@0.3.32	X									X					
+futures-core@0.3.32	X									X					
+futures-executor@0.3.32	X									X					
+futures-intrusive@0.5.0	X									X					
+futures-io@0.3.32	X									X					
+futures-macro@0.3.32	X									X					
+futures-sink@0.3.32	X									X					
+futures-task@0.3.32	X									X					
+futures-util@0.3.32	X									X					
+fxhash@0.2.1	X									X					
+gearhash@0.1.3	X									X					
+generic-array@0.14.7										X					
+getrandom@0.1.16	X									X					
+getrandom@0.2.17	X									X					
+getrandom@0.3.4	X									X					
+getrandom@0.4.2	X									X					
+ghac@0.2.0	X														
+git-version@0.3.9			X												
+git-version-macro@0.3.9			X												
+glob@0.3.3	X									X					
+gloo-timers@0.3.0	X									X					
+h2@0.3.27										X					
+h2@0.4.13										X					
+hashbrown@0.12.3	X									X					
+hashbrown@0.14.5	X									X					
+hashbrown@0.15.5	X									X					
+hashbrown@0.17.0	X									X					
+hashlink@0.10.0	X									X					
+heapify@0.2.0	X									X					
+heck@0.5.0	X									X					
+hermit-abi@0.5.2	X									X					
+hex@0.4.3	X									X					
+hf-xet@1.5.1	X														
+hickory-proto@0.25.2	X									X					
+hickory-resolver@0.25.2	X									X					
+hkdf@0.12.4	X									X					
+hmac@0.12.1	X									X					
+home@0.5.11	X									X					
+http@0.2.12	X									X					
+http@1.4.0	X									X					
+http-body@0.4.6										X					
+http-body@1.0.1										X					
+http-body-util@0.1.3										X					
+httparse@1.10.1	X									X					
+httpdate@1.0.3	X									X					
+humantime@2.3.0	X									X					
+hyper@0.14.32										X					
+hyper@1.9.0										X					
+hyper-rustls@0.27.9	X							X		X					
+hyper-timeout@0.4.1	X									X					
+hyper-timeout@0.5.2	X									X					
+hyper-util@0.1.20										X					
+iana-time-zone@0.1.65	X									X					
+iana-time-zone-haiku@0.1.2	X									X					
+icu_collections@2.1.1													X		
+icu_locale_core@2.1.1													X		
+icu_normalizer@2.1.1													X		
+icu_normalizer_data@2.1.1													X		
+icu_properties@2.1.2													X		
+icu_properties_data@2.1.2													X		
+icu_provider@2.1.1													X		
+ident_case@1.0.1	X									X					
+idna@1.1.0	X									X					
+idna_adapter@1.2.1	X									X					
+indexmap@1.9.3	X									X					
+indexmap@2.14.0	X									X					
+inout@0.1.4	X									X					
+instant@0.1.13				X											
+io-uring@0.6.4	X									X					
+io-uring@0.7.11	X									X					
+io_uring_buf_ring@0.2.3										X					
+ipconfig@0.3.4	X									X					
+ipnet@2.12.0	X									X					
+iri-string@0.7.12	X									X					
+is_terminal_polyfill@1.70.2	X									X					
+itertools@0.12.1	X									X					
+itertools@0.14.0	X									X					
+itoa@1.0.18	X									X					
+jiff@0.2.23										X				X	
+jiff-tzdb@0.1.6										X				X	
+jiff-tzdb-platform@0.1.3										X				X	
+jni@0.21.1	X									X					
+jni-sys@0.3.1	X									X					
+jni-sys@0.4.1	X									X					
+jni-sys-macros@0.4.1	X									X					
+jobserver@0.1.34	X									X					
+js-sys@0.3.95	X									X					
+jsonwebtoken@10.3.0										X					
+konst@0.4.3															X
+konst_proc_macros@0.4.1															X
+lazy_static@1.5.0	X									X					
+libc@0.2.185	X									X					
+libm@0.2.16										X					
+libredox@0.1.16										X					
+libsqlite3-sys@0.30.1										X					
+linked-hash-map@0.5.6	X									X					
+linux-raw-sys@0.12.1	X	X								X					
+litemap@0.8.2													X		
+lock_api@0.4.14	X									X					
+log@0.4.29	X									X					
+lz4_flex@0.13.0										X					
+macro_magic@0.5.1										X					
+macro_magic_core@0.5.1										X					
+macro_magic_core_macros@0.5.1										X					
+macro_magic_macros@0.5.1										X					
+matchers@0.2.0										X					
+matchit@0.7.3				X						X					
+matchit@0.8.4				X						X					
+md-5@0.10.6	X									X					
+mea@0.6.3	X														
+memchr@2.8.0										X				X	
+memmap2@0.5.10	X									X					
+memoffset@0.7.1										X					
+miette@5.10.0	X														
+miette-derive@5.10.0	X														
+mime@0.3.17	X									X					
+mini-moka@0.10.3	X									X					
+mio@0.8.11										X					
+mio@1.2.0										X					
+moka@0.12.15	X									X					
+mongodb@3.5.2	X														
+mongodb-internal-macros@3.5.2	X														
+monoio@0.2.4	X									X					
+monoio-macros@0.1.0	X									X					
+more-asserts@0.3.1	X					X				X				X	
+multimap@0.10.1	X									X					
+nanorand@0.7.0															X
+nix@0.26.4										X					
+ntapi@0.4.3	X									X					
+nu-ansi-term@0.50.3										X					
+num-bigint@0.4.6	X									X					
+num-bigint-dig@0.8.6	X									X					
+num-conv@0.2.1	X									X					
+num-derive@0.4.2	X									X					
+num-integer@0.1.46	X									X					
+num-iter@0.1.45	X									X					
+num-traits@0.2.19	X									X					
+num_cpus@1.17.0	X									X					
+objc2-core-foundation@0.3.2	X									X					X
+objc2-io-kit@0.3.2	X									X					X
+objc2-system-configuration@0.3.2	X									X					X
+once_cell@1.21.4	X									X					
+once_cell_polyfill@1.70.2	X									X					
+oneshot@0.1.13	X									X					
+opendal@0.56.0	X														
+opendal-core@0.56.0	X														
+opendal-dotnet@0.0.0	X														
+opendal-layer-concurrent-limit@0.56.0	X														
+opendal-layer-logging@0.56.0	X														
+opendal-layer-retry@0.56.0	X														
+opendal-layer-timeout@0.56.0	X														
+opendal-service-aliyun-drive@0.56.0	X														
+opendal-service-alluxio@0.56.0	X														
+opendal-service-azblob@0.56.0	X														
+opendal-service-azdls@0.56.0	X														
+opendal-service-azfile@0.56.0	X														
+opendal-service-azure-common@0.56.0	X														
+opendal-service-b2@0.56.0	X														
+opendal-service-cacache@0.56.0	X														
+opendal-service-compfs@0.56.0	X														
+opendal-service-cos@0.56.0	X														
+opendal-service-dashmap@0.56.0	X														
+opendal-service-dropbox@0.56.0	X														
+opendal-service-etcd@0.56.0	X														
+opendal-service-fs@0.56.0	X														
+opendal-service-gcs@0.56.0	X														
+opendal-service-gdrive@0.56.0	X														
+opendal-service-ghac@0.56.0	X														
+opendal-service-gridfs@0.56.0	X														
+opendal-service-hf@0.56.0	X														
+opendal-service-http@0.56.0	X														
+opendal-service-ipfs@0.56.0	X														
+opendal-service-ipmfs@0.56.0	X														
+opendal-service-koofr@0.56.0	X														
+opendal-service-memcached@0.56.0	X														
+opendal-service-mini-moka@0.56.0	X														
+opendal-service-moka@0.56.0	X														
+opendal-service-mongodb@0.56.0	X														
+opendal-service-monoiofs@0.56.0	X														
+opendal-service-mysql@0.56.0	X														
+opendal-service-obs@0.56.0	X														
+opendal-service-onedrive@0.56.0	X														
+opendal-service-oss@0.56.0	X														
+opendal-service-persy@0.56.0	X														
+opendal-service-postgresql@0.56.0	X														
+opendal-service-redb@0.56.0	X														
+opendal-service-redis@0.56.0	X														
+opendal-service-s3@0.56.0	X														
+opendal-service-seafile@0.56.0	X														
+opendal-service-sftp@0.56.0	X														
+opendal-service-sled@0.56.0	X														
+opendal-service-sqlite@0.56.0	X														
+opendal-service-swift@0.56.0	X														
+opendal-service-tikv@0.56.0	X														
+opendal-service-upyun@0.56.0	X														
+opendal-service-vercel-artifacts@0.56.0	X														
+opendal-service-webdav@0.56.0	X														
+opendal-service-webhdfs@0.56.0	X														
+opendal-service-yandex-disk@0.56.0	X														
+openssh@0.11.6	X									X					
+openssh-sftp-client@0.15.6										X					
+openssh-sftp-client-lowlevel@0.7.2										X					
+openssh-sftp-error@0.5.1										X					
+openssh-sftp-protocol@0.24.1										X					
+openssh-sftp-protocol-error@0.1.1										X					
+openssl-probe@0.2.1	X									X					
+option-ext@0.2.0												X			
+ordered-multimap@0.7.3										X					
+os_pipe@1.2.3										X					
+os_str_bytes@6.6.1	X									X					
+parking@2.2.1	X									X					
+parking_lot@0.11.2	X									X					
+parking_lot@0.12.5	X									X					
+parking_lot_core@0.8.6	X									X					
+parking_lot_core@0.9.12	X									X					
+paste@1.0.15	X									X					
+pbkdf2@0.12.2	X									X					
+pem@3.0.6										X					
+pem-rfc7468@0.7.0	X									X					
+percent-encoding@2.3.2	X									X					
+persy@1.7.1												X			
+petgraph@0.8.3	X									X					
+pin-project@1.1.11	X									X					
+pin-project-internal@1.1.11	X									X					
+pin-project-lite@0.2.17	X									X					
+pin-utils@0.1.0	X									X					
+pkcs1@0.7.5	X									X					
+pkcs5@0.7.1	X									X					
+pkcs8@0.10.2	X									X					
+pkg-config@0.3.33	X									X					
+plain@0.2.3	X									X					
+polling@3.11.0	X									X					
+portable-atomic@1.13.1	X									X					
+portable-atomic-util@0.2.6	X									X					
+potential_utf@0.1.5													X		
+powerfmt@0.2.0	X									X					
+ppv-lite86@0.2.21	X									X					
+prettyplease@0.2.37	X									X					
+proc-macro2@1.0.106	X									X					
+prometheus@0.13.4	X														
+prost@0.12.6	X														
+prost@0.13.5	X														
+prost@0.14.3	X														
+prost-build@0.14.3	X														
+prost-derive@0.12.6	X														
+prost-derive@0.13.5	X														
+prost-derive@0.14.3	X														
+prost-types@0.14.3	X														
+pulldown-cmark@0.13.3										X					
+pulldown-cmark@0.9.6										X					
+pulldown-cmark-to-cmark@22.0.0	X														
+quick-xml@0.38.4										X					
+quick-xml@0.39.2										X					
+quote@1.0.45	X									X					
+r-efi@5.3.0	X								X	X					
+r-efi@6.0.0	X								X	X					
+radium@0.7.0										X					
+rand@0.10.1	X									X					
+rand@0.7.3	X									X					
+rand@0.8.5	X									X					
+rand@0.9.4	X									X					
+rand_chacha@0.2.2	X									X					
+rand_chacha@0.3.1	X									X					
+rand_chacha@0.9.0	X									X					
+rand_core@0.10.1	X									X					
+rand_core@0.5.1	X									X					
+rand_core@0.6.4	X									X					
+rand_core@0.9.5	X									X					
+rand_hc@0.2.0	X									X					
+redb@2.6.3	X									X					
+redb@3.1.3	X									X					
+redis@1.2.0				X											
+redox_syscall@0.2.16										X					
+redox_syscall@0.5.18										X					
+redox_users@0.5.2										X					
+reflink-copy@0.1.29	X									X					
+regex@1.12.3	X									X					
+regex-automata@0.4.14	X									X					
+regex-syntax@0.8.10	X									X					
+reqsign-aliyun-oss@3.0.0	X														
+reqsign-aws-v4@3.0.0	X														
+reqsign-azure-storage@3.0.0	X														
+reqsign-core@3.0.0	X														
+reqsign-file-read-tokio@3.0.0	X														
+reqsign-google@3.0.0	X														
+reqsign-huaweicloud-obs@3.0.0	X														
+reqsign-tencent-cos@3.0.0	X														
+reqwest@0.13.2	X									X					
+reqwest-middleware@0.5.1	X									X					
+reqwest-retry@0.9.1	X									X					
+resolv-conf@0.7.6	X									X					
+retry-policies@0.5.1	X									X					
+ring@0.17.14	X							X							
+rsa@0.9.10	X									X					
+rust-ini@0.21.3										X					
+rustc_version@0.4.1	X									X					
+rustc_version_runtime@0.3.0										X					
+rustix@1.1.4	X	X								X					
+rustls@0.21.12	X							X		X					
+rustls@0.23.38	X							X		X					
+rustls-native-certs@0.8.3	X							X		X					
+rustls-pemfile@1.0.4	X							X		X					
+rustls-pki-types@1.14.0	X									X					
+rustls-platform-verifier@0.6.2	X									X					
+rustls-platform-verifier-android@0.1.1	X									X					
+rustls-webpki@0.101.7								X							
+rustls-webpki@0.103.12								X							
+rustversion@1.0.22	X									X					
+ryu@1.0.23	X				X										
+safe-transmute@0.11.3										X					
+salsa20@0.10.2	X									X					
+same-file@1.0.6										X				X	
+schannel@0.1.29										X					
+scoped-tls@1.0.1	X									X					
+scopeguard@1.2.0	X									X					
+scrypt@0.11.0	X									X					
+sct@0.7.1	X							X		X					
+security-framework@3.7.0	X									X					
+security-framework-sys@2.17.0	X									X					
+semver@1.0.28	X									X					
+serde@1.0.228	X									X					
+serde_bytes@0.11.19	X									X					
+serde_core@1.0.228	X									X					
+serde_derive@1.0.228	X									X					
+serde_json@1.0.149	X									X					
+serde_repr@0.1.20	X									X					
+serde_urlencoded@0.7.1	X									X					
+serde_with@3.17.0	X									X					
+serde_with_macros@3.17.0	X									X					
+sha-1@0.10.1	X									X					
+sha1@0.10.6	X									X					
+sha1_smol@1.0.1				X											
+sha2@0.10.9	X									X					
+sha2-asm@0.6.4										X					
+sharded-slab@0.1.7										X					
+shell-escape@0.1.5	X									X					
+shellexpand@3.1.2	X									X					
+shlex@1.3.0	X									X					
+signal-hook-registry@1.4.8	X									X					
+signature@2.2.0	X									X					
+simple_asn1@0.6.4								X							
+skeptic@0.13.7	X									X					
+slab@0.4.12										X					
+sled@0.34.7	X									X					
+smallvec@1.15.1	X									X					
+socket2@0.5.10	X									X					
+socket2@0.6.3	X									X					
+spin@0.9.8										X					
+spki@0.7.3	X									X					
+sqlx@0.8.6	X									X					
+sqlx-core@0.8.6	X									X					
+sqlx-macros@0.8.6	X									X					
+sqlx-macros-core@0.8.6	X									X					
+sqlx-mysql@0.8.6	X									X					
+sqlx-postgres@0.8.6	X									X					
+sqlx-sqlite@0.8.6	X									X					
+ssh_format@0.14.1										X					
+ssh_format_error@0.1.0										X					
+ssri@9.2.0	X														
+stable_deref_trait@1.2.1	X									X					
+static_assertions@1.1.0	X									X					
+statrs@0.18.0										X					
+stringprep@0.1.5	X									X					
+strsim@0.11.1										X					
+subtle@2.6.1				X											
+syn@1.0.109	X									X					
+syn@2.0.117	X									X					
+sync_wrapper@0.1.2	X														
+sync_wrapper@1.0.2	X														
+synstructure@0.13.2										X					
+sysinfo@0.38.4										X					
+system-configuration@0.7.0	X									X					
+system-configuration-sys@0.6.0	X									X					
+tagptr@0.2.0	X									X					
+take_mut@0.2.2										X					
+tap@1.0.1										X					
+tempfile@3.27.0	X									X					
+thin-vec@0.2.16	X									X					
+thiserror@1.0.69	X									X					
+thiserror@2.0.18	X									X					
+thiserror-impl@1.0.69	X									X					
+thiserror-impl@2.0.18	X									X					
+thread_local@1.1.9	X									X					
+threadpool@1.8.1	X									X					
+tikv-client@0.3.0	X														
+time@0.3.47	X									X					
+time-core@0.1.8	X									X					
+time-macros@0.2.27	X									X					
+tiny-keccak@2.0.2						X									
+tinystr@0.8.3													X		
+tinyvec@1.11.0	X									X					X
+tinyvec_macros@0.1.1	X									X					X
+tokio@1.52.0										X					
+tokio-io-timeout@1.2.1	X									X					
+tokio-io-utility@0.7.6										X					
+tokio-macros@2.7.0										X					
+tokio-retry@0.3.1										X					
+tokio-rustls@0.24.1	X									X					
+tokio-rustls@0.26.4	X									X					
+tokio-stream@0.1.18										X					
+tokio-util@0.7.18										X					
+tonic@0.10.2										X					
+tonic@0.14.5										X					
+tonic-build@0.14.5										X					
+tonic-prost@0.14.5										X					
+tonic-prost-build@0.14.5										X					
+tower@0.4.13										X					
+tower@0.5.3										X					
+tower-http@0.6.8										X					
+tower-layer@0.3.3										X					
+tower-service@0.3.3										X					
+tracing@0.1.44										X					
+tracing-appender@0.2.4										X					
+tracing-attributes@0.1.31										X					
+tracing-core@0.1.36										X					
+tracing-log@0.2.0										X					
+tracing-serde@0.2.0										X					
+tracing-subscriber@0.3.23										X					
+triomphe@0.1.15	X									X					
+try-lock@0.2.5										X					
+twox-hash@2.1.2										X					
+typed-builder@0.22.0	X									X					
+typed-builder-macro@0.22.0	X									X					
+typenum@1.19.0	X									X					
+typewit@1.15.2															X
+ulid@1.2.1										X					
+unicase@2.9.0	X									X					
+unicode-bidi@0.3.18	X									X					
+unicode-ident@1.0.24	X									X			X		
+unicode-normalization@0.1.25	X									X					
+unicode-properties@0.1.4	X									X					
+unicode-segmentation@1.13.2	X									X					
+unicode-width@0.1.14	X									X					
+unicode-xid@0.2.6	X									X					
+unsigned-varint@0.8.0										X					
+untrusted@0.7.1								X							
+untrusted@0.9.0								X							
+url@2.5.8	X									X					
+urlencoding@2.1.3										X					
+utf8_iter@1.0.4	X									X					
+utf8parse@0.2.2	X									X					
+uuid@1.23.1	X									X					
+vcpkg@0.2.15	X									X					
+vec-strings@0.4.8										X					
+version_check@0.9.5	X									X					
+walkdir@2.5.0										X				X	
+want@0.3.1										X					
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X					
+wasi@0.14.7+wasi-0.2.4	X	X								X					
+wasi@0.9.0+wasi-snapshot-preview1	X	X								X					
+wasip2@1.0.1+wasi-0.2.4	X	X								X					
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X					
+wasite@0.1.0	X				X					X					
+wasite@1.0.2	X				X					X					
+wasm-bindgen@0.2.118	X									X					
+wasm-bindgen-futures@0.4.68	X									X					
+wasm-bindgen-macro@0.2.118	X									X					
+wasm-bindgen-macro-support@0.2.118	X									X					
+wasm-bindgen-shared@0.2.118	X									X					
+wasm-streams@0.5.0	X									X					
+wasmtimer@0.4.3										X					
+web-sys@0.3.95	X									X					
+web-time@1.1.0	X									X					
+webpki-root-certs@1.0.6							X								
+webpki-roots@0.26.11							X								
+webpki-roots@1.0.6							X								
+whoami@1.6.1	X				X					X					
+whoami@2.1.1	X				X					X					
+widestring@1.2.1	X									X					
+winapi@0.3.9	X									X					
+winapi-i686-pc-windows-gnu@0.4.0	X									X					
+winapi-util@0.1.11										X				X	
+winapi-x86_64-pc-windows-gnu@0.4.0	X									X					
+windows@0.62.2	X									X					
+windows-collections@0.3.2	X									X					
+windows-core@0.62.2	X									X					
+windows-future@0.3.2	X									X					
+windows-implement@0.60.2	X									X					
+windows-interface@0.59.3	X									X					
+windows-link@0.2.1	X									X					
+windows-numerics@0.3.1	X									X					
+windows-registry@0.6.1	X									X					
+windows-result@0.4.1	X									X					
+windows-strings@0.5.1	X									X					
+windows-sys@0.45.0	X									X					
+windows-sys@0.48.0	X									X					
+windows-sys@0.52.0	X									X					
+windows-sys@0.59.0	X									X					
+windows-sys@0.61.2	X									X					
+windows-targets@0.42.2	X									X					
+windows-targets@0.48.5	X									X					
+windows-targets@0.52.6	X									X					
+windows-threading@0.2.1	X									X					
+windows_aarch64_gnullvm@0.42.2	X									X					
+windows_aarch64_gnullvm@0.48.5	X									X					
+windows_aarch64_gnullvm@0.52.6	X									X					
+windows_aarch64_msvc@0.42.2	X									X					
+windows_aarch64_msvc@0.48.5	X									X					
+windows_aarch64_msvc@0.52.6	X									X					
+windows_i686_gnu@0.42.2	X									X					
+windows_i686_gnu@0.48.5	X									X					
+windows_i686_gnu@0.52.6	X									X					
+windows_i686_gnullvm@0.52.6	X									X					
+windows_i686_msvc@0.42.2	X									X					
+windows_i686_msvc@0.48.5	X									X					
+windows_i686_msvc@0.52.6	X									X					
+windows_x86_64_gnu@0.42.2	X									X					
+windows_x86_64_gnu@0.48.5	X									X					
+windows_x86_64_gnu@0.52.6	X									X					
+windows_x86_64_gnullvm@0.42.2	X									X					
+windows_x86_64_gnullvm@0.48.5	X									X					
+windows_x86_64_gnullvm@0.52.6	X									X					
+windows_x86_64_msvc@0.42.2	X									X					
+windows_x86_64_msvc@0.48.5	X									X					
+windows_x86_64_msvc@0.52.6	X									X					
+wit-bindgen@0.46.0	X	X								X					
+wit-bindgen@0.51.0	X	X								X					
+writeable@0.6.3													X		
+wyz@0.5.1										X					
+xattr@1.6.1	X									X					
+xet-client@1.5.1	X														
+xet-core-structures@1.5.1	X														
+xet-data@1.5.1	X														
+xet-runtime@1.5.1	X														
+xxhash-rust@0.8.15					X										
+yoke@0.8.2													X		
+yoke-derive@0.8.2													X		
+zerocopy@0.8.48	X		X							X					
+zerofrom@0.1.7													X		
+zerofrom-derive@0.1.7													X		
+zeroize@1.8.2	X									X					
+zerotrie@0.2.4													X		
+zerovec@0.11.6													X		
+zerovec-derive@0.11.3													X		
+zigzag@0.1.0										X					
+zmij@1.0.21										X					

--- a/bindings/dotnet/OpenDAL.Tests/Behavior/BehaviorOperatorFixture.cs
+++ b/bindings/dotnet/OpenDAL.Tests/Behavior/BehaviorOperatorFixture.cs
@@ -18,6 +18,7 @@
  */
 
 using System.Collections;
+using OpenDAL.Layer;
 
 namespace OpenDAL.Tests;
 
@@ -47,7 +48,7 @@ public sealed class BehaviorOperatorFixture : IDisposable
             options["root"] = BuildRandomRoot(baseRoot);
         }
 
-        op = new Operator(scheme, options);
+        op = new Operator(scheme, options).WithLayer(new RetryLayer());
     }
 
     public bool IsEnabled => op is not null;

--- a/bindings/haskell/DEPENDENCIES.rust.tsv
+++ b/bindings/haskell/DEPENDENCIES.rust.tsv
@@ -1,243 +1,284 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense
-aes@0.8.4	X									X		
-android_system_properties@0.1.5	X									X		
-anyhow@1.0.100	X									X		
-async-trait@0.1.89	X									X		
-atomic-waker@1.1.2	X									X		
-autocfg@1.5.0	X									X		
-backon@1.6.0	X											
-base64@0.22.1	X									X		
-base64ct@1.8.0	X									X		
-bitflags@2.10.0	X									X		
-block-buffer@0.10.4	X									X		
-block-padding@0.3.3	X									X		
-bumpalo@3.19.0	X									X		
-bytes@1.11.0										X		
-cbc@0.1.2	X									X		
-cc@1.2.47	X									X		
-cfg-if@1.0.4	X									X		
-chrono@0.4.42	X									X		
-cipher@0.4.4	X									X		
-const-oid@0.9.6	X									X		
-const-random@0.1.18	X									X		
-const-random-macro@0.1.16	X									X		
-core-foundation-sys@0.8.7	X									X		
-cpufeatures@0.2.17	X									X		
-crc32c@0.6.8	X									X		
-crunchy@0.2.4										X		
-crypto-common@0.1.7	X									X		
-der@0.7.10	X									X		
-deranged@0.5.5	X									X		
-digest@0.10.7	X									X		
-displaydoc@0.2.5	X									X		
-dlv-list@0.5.2	X									X		
-either@1.15.0	X									X		
-fastrand@2.3.0	X									X		
-find-msvc-tools@0.1.5	X									X		
-fnv@1.0.7	X									X		
-form_urlencoded@1.2.2	X									X		
-futures@0.3.31	X									X		
-futures-channel@0.3.31	X									X		
-futures-core@0.3.31	X									X		
-futures-io@0.3.31	X									X		
-futures-macro@0.3.31	X									X		
-futures-sink@0.3.31	X									X		
-futures-task@0.3.31	X									X		
-futures-util@0.3.31	X									X		
-generic-array@0.14.7										X		
-getrandom@0.2.16	X									X		
-getrandom@0.3.4	X									X		
-ghac@0.2.0	X											
-gloo-timers@0.3.0	X									X		
-hashbrown@0.14.5	X									X		
-hex@0.4.3	X									X		
-hmac@0.12.1	X									X		
-home@0.5.11	X									X		
-http@1.3.1	X									X		
-http-body@1.0.1										X		
-http-body-util@0.1.3										X		
-httparse@1.10.1	X									X		
-hyper@1.8.1										X		
-hyper-rustls@0.27.7	X							X		X		
-hyper-util@0.1.18										X		
-iana-time-zone@0.1.64	X									X		
-iana-time-zone-haiku@0.1.2	X									X		
-icu_collections@2.1.1											X	
-icu_locale_core@2.1.1											X	
-icu_normalizer@2.1.1											X	
-icu_normalizer_data@2.1.1											X	
-icu_properties@2.1.1											X	
-icu_properties_data@2.1.1											X	
-icu_provider@2.1.1											X	
-idna@1.1.0	X									X		
-idna_adapter@1.2.1	X									X		
-inout@0.1.4	X									X		
-ipnet@2.11.0	X									X		
-iri-string@0.7.9	X									X		
-itertools@0.14.0	X									X		
-itoa@1.0.15	X									X		
-jiff@0.2.16										X		X
-jiff-tzdb@0.1.4										X		X
-jiff-tzdb-platform@0.1.3										X		X
-js-sys@0.3.82	X									X		
-jsonwebtoken@9.3.1										X		
-lazy_static@1.5.0	X									X		
-libc@0.2.177	X									X		
-libm@0.2.15										X		
-litemap@0.8.1											X	
-lock_api@0.4.14	X									X		
-log@0.4.28	X									X		
-md-5@0.10.6	X									X		
-memchr@2.7.6										X		X
-mio@1.1.0										X		
-num-bigint@0.4.6	X									X		
-num-bigint-dig@0.8.6	X									X		
-num-conv@0.1.0	X									X		
-num-integer@0.1.46	X									X		
-num-iter@0.1.45	X									X		
-num-traits@0.2.19	X									X		
-once_cell@1.21.3	X									X		
-opendal@0.55.0	X											
-opendal-hs@0.0.0	X											
-ordered-multimap@0.7.3										X		
-parking_lot@0.12.5	X									X		
-parking_lot_core@0.9.12	X									X		
-pbkdf2@0.12.2	X									X		
-pem@3.0.6										X		
-pem-rfc7468@0.7.0	X									X		
-percent-encoding@2.3.2	X									X		
-pin-project-lite@0.2.16	X									X		
-pin-utils@0.1.0	X									X		
-pkcs1@0.7.5	X									X		
-pkcs5@0.7.1	X									X		
-pkcs8@0.10.2	X									X		
-portable-atomic@1.11.1	X									X		
-portable-atomic-util@0.2.4	X									X		
-potential_utf@0.1.4											X	
-powerfmt@0.2.0	X									X		
-ppv-lite86@0.2.21	X									X		
-proc-macro2@1.0.103	X									X		
-prost@0.13.5	X											
-prost-derive@0.13.5	X											
-quick-xml@0.38.4										X		
-quote@1.0.42	X									X		
-r-efi@5.3.0	X								X	X		
-rand@0.8.5	X									X		
-rand_chacha@0.3.1	X									X		
-rand_core@0.6.4	X									X		
-redox_syscall@0.5.18										X		
-reqsign@0.16.5	X											
-reqsign-aws-v4@2.0.1	X											
-reqsign-core@2.0.1	X											
-reqsign-file-read-tokio@2.0.1	X											
-reqsign-http-send-reqwest@2.0.1	X											
-reqwest@0.12.24	X									X		
-ring@0.17.14	X							X				
-rsa@0.9.9	X									X		
-rust-ini@0.21.3										X		
-rustc_version@0.4.1	X									X		
-rustls@0.23.35	X							X		X		
-rustls-pki-types@1.13.0	X									X		
-rustls-webpki@0.103.8								X				
-rustversion@1.0.22	X									X		
-ryu@1.0.20	X				X							
-salsa20@0.10.2	X									X		
-scopeguard@1.2.0	X									X		
-scrypt@0.11.0	X									X		
-semver@1.0.27	X									X		
-serde@1.0.228	X									X		
-serde_core@1.0.228	X									X		
-serde_derive@1.0.228	X									X		
-serde_json@1.0.145	X									X		
-serde_urlencoded@0.7.1	X									X		
-sha1@0.10.6	X									X		
-sha2@0.10.9	X									X		
-shlex@1.3.0	X									X		
-signal-hook-registry@1.4.6	X									X		
-signature@2.2.0	X									X		
-simple_asn1@0.6.3								X				
-slab@0.4.11										X		
-smallvec@1.15.1	X									X		
-socket2@0.6.1	X									X		
-spin@0.9.8										X		
-spki@0.7.3	X									X		
-stable_deref_trait@1.2.1	X									X		
-subtle@2.6.1				X								
-syn@2.0.110	X									X		
-sync_wrapper@1.0.2	X											
-synstructure@0.13.2										X		
-thiserror@2.0.17	X									X		
-thiserror-impl@2.0.17	X									X		
-time@0.3.44	X									X		
-time-core@0.1.6	X									X		
-time-macros@0.2.24	X									X		
-tiny-keccak@2.0.2						X						
-tinystr@0.8.2											X	
-tokio@1.48.0										X		
-tokio-macros@2.6.0										X		
-tokio-rustls@0.26.4	X									X		
-tokio-util@0.7.17										X		
-tower@0.5.2										X		
-tower-http@0.6.6										X		
-tower-layer@0.3.3										X		
-tower-service@0.3.3										X		
-tracing@0.1.41										X		
-tracing-core@0.1.34										X		
-try-lock@0.2.5										X		
-typenum@1.19.0	X									X		
-unicode-ident@1.0.22	X									X	X	
-untrusted@0.9.0								X				
-url@2.5.7	X									X		
-utf8_iter@1.0.4	X									X		
-uuid@1.18.1	X									X		
-version_check@0.9.5	X									X		
-want@0.3.1										X		
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X		
-wasip2@1.0.1+wasi-0.2.4	X	X								X		
-wasm-bindgen@0.2.105	X									X		
-wasm-bindgen-futures@0.4.55	X									X		
-wasm-bindgen-macro@0.2.105	X									X		
-wasm-bindgen-macro-support@0.2.105	X									X		
-wasm-bindgen-shared@0.2.105	X									X		
-wasm-streams@0.4.2	X									X		
-web-sys@0.3.82	X									X		
-webpki-roots@1.0.4							X					
-windows-core@0.62.2	X									X		
-windows-implement@0.60.2	X									X		
-windows-interface@0.59.3	X									X		
-windows-link@0.2.1	X									X		
-windows-result@0.4.1	X									X		
-windows-strings@0.5.1	X									X		
-windows-sys@0.52.0	X									X		
-windows-sys@0.59.0	X									X		
-windows-sys@0.60.2	X									X		
-windows-sys@0.61.2	X									X		
-windows-targets@0.52.6	X									X		
-windows-targets@0.53.5	X									X		
-windows_aarch64_gnullvm@0.52.6	X									X		
-windows_aarch64_gnullvm@0.53.1	X									X		
-windows_aarch64_msvc@0.52.6	X									X		
-windows_aarch64_msvc@0.53.1	X									X		
-windows_i686_gnu@0.52.6	X									X		
-windows_i686_gnu@0.53.1	X									X		
-windows_i686_gnullvm@0.52.6	X									X		
-windows_i686_gnullvm@0.53.1	X									X		
-windows_i686_msvc@0.52.6	X									X		
-windows_i686_msvc@0.53.1	X									X		
-windows_x86_64_gnu@0.52.6	X									X		
-windows_x86_64_gnu@0.53.1	X									X		
-windows_x86_64_gnullvm@0.52.6	X									X		
-windows_x86_64_gnullvm@0.53.1	X									X		
-windows_x86_64_msvc@0.52.6	X									X		
-windows_x86_64_msvc@0.53.1	X									X		
-wit-bindgen@0.46.0	X	X								X		
-writeable@0.6.2											X	
-yoke@0.8.1											X	
-yoke-derive@0.8.1											X	
-zerocopy@0.8.28	X		X							X		
-zerofrom@0.1.6											X	
-zerofrom-derive@0.1.6											X	
-zeroize@1.8.2	X									X		
-zerotrie@0.2.3											X	
-zerovec@0.11.5											X	
-zerovec-derive@0.11.2											X	
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
+aes@0.8.4	X									X			
+anyhow@1.0.102	X									X			
+async-trait@0.1.89	X									X			
+atomic-waker@1.1.2	X									X			
+autocfg@1.5.0	X									X			
+aws-lc-rs@1.16.3	X							X					
+aws-lc-sys@0.40.0	X			X				X		X	X		
+backon@1.6.0	X												
+base64@0.22.1	X									X			
+base64ct@1.8.3	X									X			
+bitflags@2.11.1	X									X			
+block-buffer@0.10.4	X									X			
+block-padding@0.3.3	X									X			
+bumpalo@3.20.2	X									X			
+bytes@1.11.1										X			
+cbc@0.1.2	X									X			
+cc@1.2.60	X									X			
+cesu8@1.1.0	X									X			
+cfg-if@1.0.4	X									X			
+cipher@0.4.4	X									X			
+cmake@0.1.58	X									X			
+combine@4.6.7										X			
+const-oid@0.9.6	X									X			
+const-random@0.1.18	X									X			
+const-random-macro@0.1.16	X									X			
+core-foundation@0.10.1	X									X			
+core-foundation-sys@0.8.7	X									X			
+cpufeatures@0.2.17	X									X			
+crc32c@0.6.8	X									X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7	X									X			
+ctor@0.6.3	X									X			
+ctor-proc-macro@0.0.7	X									X			
+der@0.7.10	X									X			
+deranged@0.5.8	X									X			
+digest@0.10.7	X									X			
+displaydoc@0.2.5	X									X			
+dlv-list@0.5.2	X									X			
+dtor@0.1.1	X									X			
+dtor-proc-macro@0.0.6	X									X			
+dunce@1.0.5	X					X					X		
+either@1.15.0	X									X			
+errno@0.3.14	X									X			
+fastrand@2.4.1	X									X			
+find-msvc-tools@0.1.9	X									X			
+form_urlencoded@1.2.2	X									X			
+fs_extra@1.3.0										X			
+futures@0.3.32	X									X			
+futures-channel@0.3.32	X									X			
+futures-core@0.3.32	X									X			
+futures-executor@0.3.32	X									X			
+futures-io@0.3.32	X									X			
+futures-macro@0.3.32	X									X			
+futures-sink@0.3.32	X									X			
+futures-task@0.3.32	X									X			
+futures-util@0.3.32	X									X			
+generic-array@0.14.7										X			
+getrandom@0.2.17	X									X			
+getrandom@0.3.4	X									X			
+getrandom@0.4.2	X									X			
+ghac@0.2.0	X												
+gloo-timers@0.3.0	X									X			
+hashbrown@0.14.5	X									X			
+hex@0.4.3	X									X			
+hmac@0.12.1	X									X			
+http@1.4.0	X									X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1	X									X			
+hyper@1.9.0										X			
+hyper-rustls@0.27.9	X							X		X			
+hyper-util@0.1.20										X			
+icu_collections@2.1.1												X	
+icu_locale_core@2.1.1												X	
+icu_normalizer@2.1.1												X	
+icu_normalizer_data@2.1.1												X	
+icu_properties@2.1.2												X	
+icu_properties_data@2.1.2												X	
+icu_provider@2.1.1												X	
+idna@1.1.0	X									X			
+idna_adapter@1.2.1	X									X			
+inout@0.1.4	X									X			
+ipnet@2.12.0	X									X			
+iri-string@0.7.12	X									X			
+itertools@0.14.0	X									X			
+itoa@1.0.18	X									X			
+jiff@0.2.23										X			X
+jiff-tzdb@0.1.6										X			X
+jiff-tzdb-platform@0.1.3										X			X
+jni@0.21.1	X									X			
+jni-sys@0.3.1	X									X			
+jni-sys@0.4.1	X									X			
+jni-sys-macros@0.4.1	X									X			
+jobserver@0.1.34	X									X			
+js-sys@0.3.95	X									X			
+jsonwebtoken@10.3.0										X			
+lazy_static@1.5.0	X									X			
+libc@0.2.185	X									X			
+libm@0.2.16										X			
+linux-raw-sys@0.12.1	X	X								X			
+litemap@0.8.2												X	
+lock_api@0.4.14	X									X			
+log@0.4.29	X									X			
+md-5@0.10.6	X									X			
+mea@0.6.3	X												
+memchr@2.8.0										X			X
+mio@1.2.0										X			
+num-bigint@0.4.6	X									X			
+num-bigint-dig@0.8.6	X									X			
+num-conv@0.2.1	X									X			
+num-integer@0.1.46	X									X			
+num-iter@0.1.45	X									X			
+num-traits@0.2.19	X									X			
+once_cell@1.21.4	X									X			
+opendal@0.56.0	X												
+opendal-core@0.56.0	X												
+opendal-hs@0.0.0	X												
+opendal-layer-concurrent-limit@0.56.0	X												
+opendal-layer-logging@0.56.0	X												
+opendal-layer-retry@0.56.0	X												
+opendal-layer-timeout@0.56.0	X												
+opendal-service-azblob@0.56.0	X												
+opendal-service-azdls@0.56.0	X												
+opendal-service-azfile@0.56.0	X												
+opendal-service-azure-common@0.56.0	X												
+opendal-service-cos@0.56.0	X												
+opendal-service-fs@0.56.0	X												
+opendal-service-gcs@0.56.0	X												
+opendal-service-ghac@0.56.0	X												
+opendal-service-http@0.56.0	X												
+opendal-service-ipmfs@0.56.0	X												
+opendal-service-obs@0.56.0	X												
+opendal-service-oss@0.56.0	X												
+opendal-service-s3@0.56.0	X												
+opendal-service-webdav@0.56.0	X												
+opendal-service-webhdfs@0.56.0	X												
+openssl-probe@0.2.1	X									X			
+ordered-multimap@0.7.3										X			
+parking_lot@0.12.5	X									X			
+parking_lot_core@0.9.12	X									X			
+pbkdf2@0.12.2	X									X			
+pem@3.0.6										X			
+pem-rfc7468@0.7.0	X									X			
+percent-encoding@2.3.2	X									X			
+pin-project-lite@0.2.17	X									X			
+pkcs1@0.7.5	X									X			
+pkcs5@0.7.1	X									X			
+pkcs8@0.10.2	X									X			
+portable-atomic@1.13.1	X									X			
+portable-atomic-util@0.2.6	X									X			
+potential_utf@0.1.5												X	
+powerfmt@0.2.0	X									X			
+ppv-lite86@0.2.21	X									X			
+proc-macro2@1.0.106	X									X			
+prost@0.13.5	X												
+prost-derive@0.13.5	X												
+quick-xml@0.38.4										X			
+quick-xml@0.39.2										X			
+quote@1.0.45	X									X			
+r-efi@5.3.0	X								X	X			
+r-efi@6.0.0	X								X	X			
+rand@0.8.5	X									X			
+rand_chacha@0.3.1	X									X			
+rand_core@0.6.4	X									X			
+redox_syscall@0.5.18										X			
+reqsign-aliyun-oss@3.0.0	X												
+reqsign-aws-v4@3.0.0	X												
+reqsign-azure-storage@3.0.0	X												
+reqsign-core@3.0.0	X												
+reqsign-file-read-tokio@3.0.0	X												
+reqsign-google@3.0.0	X												
+reqsign-huaweicloud-obs@3.0.0	X												
+reqsign-tencent-cos@3.0.0	X												
+reqwest@0.13.2	X									X			
+rsa@0.9.10	X									X			
+rust-ini@0.21.3										X			
+rustc_version@0.4.1	X									X			
+rustix@1.1.4	X	X								X			
+rustls@0.23.38	X							X		X			
+rustls-native-certs@0.8.3	X							X		X			
+rustls-pki-types@1.14.0	X									X			
+rustls-platform-verifier@0.6.2	X									X			
+rustls-platform-verifier-android@0.1.1	X									X			
+rustls-webpki@0.103.12								X					
+rustversion@1.0.22	X									X			
+ryu@1.0.23	X				X								
+salsa20@0.10.2	X									X			
+same-file@1.0.6										X			X
+schannel@0.1.29										X			
+scopeguard@1.2.0	X									X			
+scrypt@0.11.0	X									X			
+security-framework@3.7.0	X									X			
+security-framework-sys@2.17.0	X									X			
+semver@1.0.28	X									X			
+serde@1.0.228	X									X			
+serde_core@1.0.228	X									X			
+serde_derive@1.0.228	X									X			
+serde_json@1.0.149	X									X			
+serde_urlencoded@0.7.1	X									X			
+sha1@0.10.6	X									X			
+sha2@0.10.9	X									X			
+shlex@1.3.0	X									X			
+signal-hook-registry@1.4.8	X									X			
+signature@2.2.0	X									X			
+simple_asn1@0.6.4								X					
+slab@0.4.12										X			
+smallvec@1.15.1	X									X			
+socket2@0.6.3	X									X			
+spin@0.9.8										X			
+spki@0.7.3	X									X			
+stable_deref_trait@1.2.1	X									X			
+subtle@2.6.1				X									
+syn@2.0.117	X									X			
+sync_wrapper@1.0.2	X												
+synstructure@0.13.2										X			
+thiserror@1.0.69	X									X			
+thiserror@2.0.18	X									X			
+thiserror-impl@1.0.69	X									X			
+thiserror-impl@2.0.18	X									X			
+time@0.3.47	X									X			
+time-core@0.1.8	X									X			
+time-macros@0.2.27	X									X			
+tiny-keccak@2.0.2						X							
+tinystr@0.8.3												X	
+tokio@1.52.0										X			
+tokio-macros@2.7.0										X			
+tokio-rustls@0.26.4	X									X			
+tokio-util@0.7.18										X			
+tower@0.5.3										X			
+tower-http@0.6.8										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-core@0.1.36										X			
+try-lock@0.2.5										X			
+typenum@1.19.0	X									X			
+unicode-ident@1.0.24	X									X		X	
+untrusted@0.7.1								X					
+untrusted@0.9.0								X					
+url@2.5.8	X									X			
+utf8_iter@1.0.4	X									X			
+uuid@1.23.1	X									X			
+version_check@0.9.5	X									X			
+walkdir@2.5.0										X			X
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
+wasip2@1.0.1+wasi-0.2.4	X	X								X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
+wasm-bindgen@0.2.118	X									X			
+wasm-bindgen-futures@0.4.68	X									X			
+wasm-bindgen-macro@0.2.118	X									X			
+wasm-bindgen-macro-support@0.2.118	X									X			
+wasm-bindgen-shared@0.2.118	X									X			
+wasm-streams@0.5.0	X									X			
+web-sys@0.3.95	X									X			
+web-time@1.1.0	X									X			
+webpki-root-certs@1.0.6							X						
+winapi-util@0.1.11										X			X
+windows-link@0.2.1	X									X			
+windows-sys@0.45.0	X									X			
+windows-sys@0.61.2	X									X			
+windows-targets@0.42.2	X									X			
+windows_aarch64_gnullvm@0.42.2	X									X			
+windows_aarch64_msvc@0.42.2	X									X			
+windows_i686_gnu@0.42.2	X									X			
+windows_i686_msvc@0.42.2	X									X			
+windows_x86_64_gnu@0.42.2	X									X			
+windows_x86_64_gnullvm@0.42.2	X									X			
+windows_x86_64_msvc@0.42.2	X									X			
+wit-bindgen@0.46.0	X	X								X			
+wit-bindgen@0.51.0	X	X								X			
+writeable@0.6.3												X	
+xattr@1.6.1	X									X			
+yoke@0.8.2												X	
+yoke-derive@0.8.2												X	
+zerocopy@0.8.48	X		X							X			
+zerofrom@0.1.7												X	
+zerofrom-derive@0.1.7												X	
+zeroize@1.8.2	X									X			
+zerotrie@0.2.4												X	
+zerovec@0.11.6												X	
+zerovec-derive@0.11.3												X	
+zmij@1.0.21										X			

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -1,288 +1,665 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense
-aes@0.8.4	X									X		
-android_system_properties@0.1.5	X									X		
-anyhow@1.0.100	X									X		
-arc-swap@1.7.1	X									X		
-async-trait@0.1.89	X									X		
-atomic-waker@1.1.2	X									X		
-autocfg@1.5.0	X									X		
-awaitable@0.4.0										X		
-awaitable-error@0.1.0										X		
-backon@1.6.0	X											
-base64@0.22.1	X									X		
-base64ct@1.8.0	X									X		
-bb8@0.9.0										X		
-bitflags@2.10.0	X									X		
-block-buffer@0.10.4	X									X		
-block-padding@0.3.3	X									X		
-bumpalo@3.19.0	X									X		
-bytes@1.11.0										X		
-cbc@0.1.2	X									X		
-cc@1.2.47	X									X		
-cesu8@1.1.0	X									X		
-cfg-if@1.0.4	X									X		
-chrono@0.4.42	X									X		
-cipher@0.4.4	X									X		
-combine@4.6.7										X		
-concurrent_arena@0.1.11										X		
-const-oid@0.9.6	X									X		
-const-random@0.1.18	X									X		
-const-random-macro@0.1.16	X									X		
-core-foundation-sys@0.8.7	X									X		
-cpufeatures@0.2.17	X									X		
-crc32c@0.6.8	X									X		
-crunchy@0.2.4										X		
-crypto-common@0.1.7	X									X		
-der@0.7.10	X									X		
-deranged@0.5.5	X									X		
-derive_destructure2@0.1.3	X									X		
-digest@0.10.7	X									X		
-displaydoc@0.2.5	X									X		
-dlv-list@0.5.2	X									X		
-either@1.15.0	X									X		
-errno@0.3.14	X									X		
-fastrand@2.3.0	X									X		
-find-msvc-tools@0.1.5	X									X		
-fnv@1.0.7	X									X		
-form_urlencoded@1.2.2	X									X		
-futures@0.3.31	X									X		
-futures-channel@0.3.31	X									X		
-futures-core@0.3.31	X									X		
-futures-io@0.3.31	X									X		
-futures-macro@0.3.31	X									X		
-futures-sink@0.3.31	X									X		
-futures-task@0.3.31	X									X		
-futures-util@0.3.31	X									X		
-generic-array@0.14.7										X		
-getrandom@0.2.16	X									X		
-getrandom@0.3.4	X									X		
-ghac@0.2.0	X											
-gloo-timers@0.3.0	X									X		
-hashbrown@0.14.5	X									X		
-hex@0.4.3	X									X		
-hmac@0.12.1	X									X		
-home@0.5.11	X									X		
-http@1.3.1	X									X		
-http-body@1.0.1										X		
-http-body-util@0.1.3										X		
-httparse@1.10.1	X									X		
-hyper@1.8.1										X		
-hyper-rustls@0.27.7	X							X		X		
-hyper-util@0.1.18										X		
-iana-time-zone@0.1.64	X									X		
-iana-time-zone-haiku@0.1.2	X									X		
-icu_collections@2.1.1											X	
-icu_locale_core@2.1.1											X	
-icu_normalizer@2.1.1											X	
-icu_normalizer_data@2.1.1											X	
-icu_properties@2.1.1											X	
-icu_properties_data@2.1.1											X	
-icu_provider@2.1.1											X	
-idna@1.1.0	X									X		
-idna_adapter@1.2.1	X									X		
-inout@0.1.4	X									X		
-ipnet@2.11.0	X									X		
-iri-string@0.7.9	X									X		
-itertools@0.14.0	X									X		
-itoa@1.0.15	X									X		
-jiff@0.2.16										X		X
-jiff-tzdb@0.1.4										X		X
-jiff-tzdb-platform@0.1.3										X		X
-jni@0.21.1	X									X		
-jni-sys@0.3.0	X									X		
-js-sys@0.3.82	X									X		
-jsonwebtoken@9.3.1										X		
-lazy_static@1.5.0	X									X		
-libc@0.2.177	X									X		
-libm@0.2.15										X		
-linux-raw-sys@0.11.0	X	X								X		
-litemap@0.8.1											X	
-lock_api@0.4.14	X									X		
-log@0.4.28	X									X		
-md-5@0.10.6	X									X		
-memchr@2.7.6										X		X
-mio@1.1.0										X		
-num-bigint@0.4.6	X									X		
-num-bigint-dig@0.8.6	X									X		
-num-conv@0.1.0	X									X		
-num-derive@0.4.2	X									X		
-num-integer@0.1.46	X									X		
-num-iter@0.1.45	X									X		
-num-traits@0.2.19	X									X		
-once_cell@1.21.3	X									X		
-opendal@0.55.0	X											
-opendal-java@0.0.0	X											
-openssh@0.11.5	X									X		
-openssh-sftp-client@0.15.4										X		
-openssh-sftp-client-lowlevel@0.7.2										X		
-openssh-sftp-error@0.5.1										X		
-openssh-sftp-protocol@0.24.1										X		
-openssh-sftp-protocol-error@0.1.1										X		
-ordered-multimap@0.7.3										X		
-parking_lot@0.12.5	X									X		
-parking_lot_core@0.9.12	X									X		
-pbkdf2@0.12.2	X									X		
-pem@3.0.6										X		
-pem-rfc7468@0.7.0	X									X		
-percent-encoding@2.3.2	X									X		
-pin-project@1.1.10	X									X		
-pin-project-internal@1.1.10	X									X		
-pin-project-lite@0.2.16	X									X		
-pin-utils@0.1.0	X									X		
-pkcs1@0.7.5	X									X		
-pkcs5@0.7.1	X									X		
-pkcs8@0.10.2	X									X		
-portable-atomic@1.11.1	X									X		
-portable-atomic-util@0.2.4	X									X		
-potential_utf@0.1.4											X	
-powerfmt@0.2.0	X									X		
-ppv-lite86@0.2.21	X									X		
-proc-macro2@1.0.103	X									X		
-prost@0.13.5	X											
-prost-derive@0.13.5	X											
-quick-xml@0.38.4										X		
-quote@1.0.42	X									X		
-r-efi@5.3.0	X								X	X		
-rand@0.8.5	X									X		
-rand_chacha@0.3.1	X									X		
-rand_core@0.6.4	X									X		
-redox_syscall@0.5.18										X		
-reqsign@0.16.5	X											
-reqsign-aws-v4@2.0.1	X											
-reqsign-core@2.0.1	X											
-reqsign-file-read-tokio@2.0.1	X											
-reqsign-http-send-reqwest@2.0.1	X											
-reqwest@0.12.24	X									X		
-ring@0.17.14	X							X				
-rsa@0.9.9	X									X		
-rust-ini@0.21.3										X		
-rustc_version@0.4.1	X									X		
-rustix@1.1.2	X	X								X		
-rustls@0.23.35	X							X		X		
-rustls-pki-types@1.13.0	X									X		
-rustls-webpki@0.103.8								X				
-rustversion@1.0.22	X									X		
-ryu@1.0.20	X				X							
-salsa20@0.10.2	X									X		
-same-file@1.0.6										X		X
-scopeguard@1.2.0	X									X		
-scrypt@0.11.0	X									X		
-semver@1.0.27	X									X		
-serde@1.0.228	X									X		
-serde_core@1.0.228	X									X		
-serde_derive@1.0.228	X									X		
-serde_json@1.0.145	X									X		
-serde_urlencoded@0.7.1	X									X		
-sha1@0.10.6	X									X		
-sha2@0.10.9	X									X		
-shell-escape@0.1.5	X									X		
-shlex@1.3.0	X									X		
-signal-hook-registry@1.4.6	X									X		
-signature@2.2.0	X									X		
-simple_asn1@0.6.3								X				
-slab@0.4.11										X		
-smallvec@1.15.1	X									X		
-socket2@0.6.1	X									X		
-spin@0.9.8										X		
-spki@0.7.3	X									X		
-ssh_format@0.14.1										X		
-ssh_format_error@0.1.0										X		
-stable_deref_trait@1.2.1	X									X		
-subtle@2.6.1				X								
-syn@2.0.110	X									X		
-sync_wrapper@1.0.2	X											
-synstructure@0.13.2										X		
-tempfile@3.23.0	X									X		
-thin-vec@0.2.14	X									X		
-thiserror@1.0.69	X									X		
-thiserror@2.0.17	X									X		
-thiserror-impl@1.0.69	X									X		
-thiserror-impl@2.0.17	X									X		
-time@0.3.44	X									X		
-time-core@0.1.6	X									X		
-time-macros@0.2.24	X									X		
-tiny-keccak@2.0.2						X						
-tinystr@0.8.2											X	
-tokio@1.48.0										X		
-tokio-io-utility@0.7.6										X		
-tokio-macros@2.6.0										X		
-tokio-rustls@0.26.4	X									X		
-tokio-util@0.7.17										X		
-tower@0.5.2										X		
-tower-http@0.6.6										X		
-tower-layer@0.3.3										X		
-tower-service@0.3.3										X		
-tracing@0.1.41										X		
-tracing-attributes@0.1.30										X		
-tracing-core@0.1.34										X		
-triomphe@0.1.15	X									X		
-try-lock@0.2.5										X		
-typenum@1.19.0	X									X		
-unicode-ident@1.0.22	X									X	X	
-untrusted@0.9.0								X				
-url@2.5.7	X									X		
-utf8_iter@1.0.4	X									X		
-uuid@1.18.1	X									X		
-vec-strings@0.4.8										X		
-version_check@0.9.5	X									X		
-walkdir@2.5.0										X		X
-want@0.3.1										X		
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X		
-wasip2@1.0.1+wasi-0.2.4	X	X								X		
-wasm-bindgen@0.2.105	X									X		
-wasm-bindgen-futures@0.4.55	X									X		
-wasm-bindgen-macro@0.2.105	X									X		
-wasm-bindgen-macro-support@0.2.105	X									X		
-wasm-bindgen-shared@0.2.105	X									X		
-wasm-streams@0.4.2	X									X		
-web-sys@0.3.82	X									X		
-webpki-roots@1.0.4							X					
-winapi-util@0.1.11										X		X
-windows-core@0.62.2	X									X		
-windows-implement@0.60.2	X									X		
-windows-interface@0.59.3	X									X		
-windows-link@0.2.1	X									X		
-windows-result@0.4.1	X									X		
-windows-strings@0.5.1	X									X		
-windows-sys@0.45.0	X									X		
-windows-sys@0.52.0	X									X		
-windows-sys@0.59.0	X									X		
-windows-sys@0.60.2	X									X		
-windows-sys@0.61.2	X									X		
-windows-targets@0.42.2	X									X		
-windows-targets@0.52.6	X									X		
-windows-targets@0.53.5	X									X		
-windows_aarch64_gnullvm@0.42.2	X									X		
-windows_aarch64_gnullvm@0.52.6	X									X		
-windows_aarch64_gnullvm@0.53.1	X									X		
-windows_aarch64_msvc@0.42.2	X									X		
-windows_aarch64_msvc@0.52.6	X									X		
-windows_aarch64_msvc@0.53.1	X									X		
-windows_i686_gnu@0.42.2	X									X		
-windows_i686_gnu@0.52.6	X									X		
-windows_i686_gnu@0.53.1	X									X		
-windows_i686_gnullvm@0.52.6	X									X		
-windows_i686_gnullvm@0.53.1	X									X		
-windows_i686_msvc@0.42.2	X									X		
-windows_i686_msvc@0.52.6	X									X		
-windows_i686_msvc@0.53.1	X									X		
-windows_x86_64_gnu@0.42.2	X									X		
-windows_x86_64_gnu@0.52.6	X									X		
-windows_x86_64_gnu@0.53.1	X									X		
-windows_x86_64_gnullvm@0.42.2	X									X		
-windows_x86_64_gnullvm@0.52.6	X									X		
-windows_x86_64_gnullvm@0.53.1	X									X		
-windows_x86_64_msvc@0.42.2	X									X		
-windows_x86_64_msvc@0.52.6	X									X		
-windows_x86_64_msvc@0.53.1	X									X		
-wit-bindgen@0.46.0	X	X								X		
-writeable@0.6.2											X	
-yoke@0.8.1											X	
-yoke-derive@0.8.1											X	
-zerocopy@0.8.28	X		X							X		
-zerofrom@0.1.6											X	
-zerofrom-derive@0.1.6											X	
-zeroize@1.8.2	X									X		
-zerotrie@0.2.3											X	
-zerovec@0.11.5											X	
-zerovec-derive@0.11.2											X	
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib
+aes@0.8.4	X									X					
+ahash@0.8.12	X									X					
+aho-corasick@1.1.4										X				X	
+allocator-api2@0.2.21	X									X					
+android_system_properties@0.1.5	X									X					
+anstream@1.0.0	X									X					
+anstyle@1.0.14	X									X					
+anstyle-parse@1.0.0	X									X					
+anstyle-query@1.1.5	X									X					
+anstyle-wincon@3.0.11	X									X					
+anyhow@1.0.102	X									X					
+approx@0.5.1	X														
+arc-swap@1.9.1	X									X					
+arcstr@1.2.0	X									X					X
+arrayref@0.3.9			X												
+arrayvec@0.7.6	X									X					
+async-lock@3.4.2	X									X					
+async-recursion@0.3.2	X									X					
+async-stream@0.3.6										X					
+async-stream-impl@0.3.6										X					
+async-trait@0.1.89	X									X					
+atoi@2.0.0										X					
+atomic-waker@1.1.2	X									X					
+autocfg@1.5.0	X									X					
+awaitable@0.4.0										X					
+awaitable-error@0.1.0										X					
+aws-lc-rs@1.16.3	X							X							
+aws-lc-sys@0.40.0	X			X				X		X	X				
+axum@0.6.20										X					
+axum@0.8.9										X					
+axum-core@0.3.4										X					
+axum-core@0.5.6										X					
+backon@1.6.0	X														
+base64@0.21.7	X									X					
+base64@0.22.1	X									X					
+base64ct@1.8.3	X									X					
+bitflags@1.3.2	X									X					
+bitflags@2.11.1	X									X					
+bitvec@1.0.1										X					
+blake3@1.8.4	X	X				X									
+block-buffer@0.10.4	X									X					
+block-padding@0.3.3	X									X					
+bson@2.15.0										X					
+bstr@1.12.1	X									X					
+bumpalo@3.20.2	X									X					
+bytecount@0.6.9	X									X					
+bytemuck@1.25.0	X									X					X
+byteorder@1.5.0										X				X	
+bytes@1.11.1										X					
+cacache@13.1.0	X														
+camino@1.2.2	X									X					
+cargo-platform@0.1.9	X									X					
+cargo_metadata@0.14.2										X					
+cbc@0.1.2	X									X					
+cc@1.2.60	X									X					
+cesu8@1.1.0	X									X					
+cfg-if@0.1.10	X									X					
+cfg-if@1.0.4	X									X					
+chacha20@0.10.0	X									X					
+chrono@0.4.44	X									X					
+cipher@0.4.4	X									X					
+clap@4.6.1	X									X					
+clap_builder@4.6.0	X									X					
+clap_derive@4.6.1	X									X					
+clap_lex@1.1.0	X									X					
+cmake@0.1.58	X									X					
+colorchoice@1.0.5	X									X					
+colored@3.1.1												X			
+combine@4.6.7										X					
+concurrent-queue@2.5.0	X									X					
+concurrent_arena@0.1.11										X					
+const-oid@0.9.6	X									X					
+const-random@0.1.18	X									X					
+const-random-macro@0.1.16	X									X					
+const-str@1.1.0										X					
+const_panic@0.2.15															X
+constant_time_eq@0.4.2	X					X					X				
+convert_case@0.10.0										X					
+core-foundation@0.10.1	X									X					
+core-foundation@0.9.4	X									X					
+core-foundation-sys@0.8.7	X									X					
+countio@0.3.0										X					
+cpufeatures@0.2.17	X									X					
+cpufeatures@0.3.0	X									X					
+crc@3.4.0	X									X					
+crc-catalog@2.4.0	X									X					
+crc16@0.4.0										X					
+crc32c@0.6.8	X									X					
+crc32fast@1.5.0	X									X					
+critical-section@1.2.0	X									X					
+crossbeam-channel@0.5.15	X									X					
+crossbeam-epoch@0.9.18	X									X					
+crossbeam-queue@0.3.12	X									X					
+crossbeam-utils@0.8.21	X									X					
+crunchy@0.2.4										X					
+crypto-common@0.1.7	X									X					
+csv@1.4.0										X				X	
+csv-core@0.1.13										X				X	
+ctor@0.6.3	X									X					
+ctor-proc-macro@0.0.7	X									X					
+darling@0.21.3										X					
+darling_core@0.21.3										X					
+darling_macro@0.21.3										X					
+dashmap@5.5.3										X					
+dashmap@6.1.0										X					
+data-encoding@2.10.0										X					
+der@0.7.10	X									X					
+deranged@0.5.8	X									X					
+derivative@2.2.0	X									X					
+derive-new@0.5.9										X					
+derive-syn-parse@0.2.0	X									X					
+derive-where@1.6.1	X									X					
+derive_destructure2@0.1.3	X									X					
+derive_more@2.1.1										X					
+derive_more-impl@2.1.1										X					
+digest@0.10.7	X									X					
+dirs@6.0.0	X									X					
+dirs-sys@0.5.0	X									X					
+displaydoc@0.2.5	X									X					
+dlv-list@0.5.2	X									X					
+dotenvy@0.15.7										X					
+dtor@0.1.1	X									X					
+dtor-proc-macro@0.0.6	X									X					
+dunce@1.0.5	X					X					X				
+either@1.15.0	X									X					
+enum-as-inner@0.6.1	X									X					
+equivalent@1.0.2	X									X					
+errno@0.3.14	X									X					
+error-chain@0.12.4	X									X					
+etcd-client@0.17.0	X									X					
+etcetera@0.8.0	X									X					
+event-listener@5.4.1	X									X					
+event-listener-strategy@0.5.4	X									X					
+fail@0.4.0	X														
+fastpool@1.1.0	X														
+fastrand@2.4.1	X									X					
+find-msvc-tools@0.1.9	X									X					
+fixedbitset@0.5.7	X									X					
+flume@0.11.1	X									X					
+fnv@1.0.7	X									X					
+foldhash@0.1.5															X
+form_urlencoded@1.2.2	X									X					
+fs2@0.4.3	X									X					
+fs_extra@1.3.0										X					
+funty@2.0.0										X					
+futures@0.3.32	X									X					
+futures-channel@0.3.32	X									X					
+futures-core@0.3.32	X									X					
+futures-executor@0.3.32	X									X					
+futures-intrusive@0.5.0	X									X					
+futures-io@0.3.32	X									X					
+futures-macro@0.3.32	X									X					
+futures-sink@0.3.32	X									X					
+futures-task@0.3.32	X									X					
+futures-util@0.3.32	X									X					
+fxhash@0.2.1	X									X					
+gearhash@0.1.3	X									X					
+generic-array@0.14.7										X					
+getrandom@0.1.16	X									X					
+getrandom@0.2.17	X									X					
+getrandom@0.3.4	X									X					
+getrandom@0.4.2	X									X					
+ghac@0.2.0	X														
+git-version@0.3.9			X												
+git-version-macro@0.3.9			X												
+glob@0.3.3	X									X					
+gloo-timers@0.3.0	X									X					
+h2@0.3.27										X					
+h2@0.4.13										X					
+hashbrown@0.12.3	X									X					
+hashbrown@0.14.5	X									X					
+hashbrown@0.15.5	X									X					
+hashbrown@0.17.0	X									X					
+hashlink@0.10.0	X									X					
+heapify@0.2.0	X									X					
+heck@0.5.0	X									X					
+hex@0.4.3	X									X					
+hf-xet@1.5.1	X														
+hickory-proto@0.25.2	X									X					
+hickory-resolver@0.25.2	X									X					
+hkdf@0.12.4	X									X					
+hmac@0.12.1	X									X					
+home@0.5.11	X									X					
+http@0.2.12	X									X					
+http@1.4.0	X									X					
+http-body@0.4.6										X					
+http-body@1.0.1										X					
+http-body-util@0.1.3										X					
+httparse@1.10.1	X									X					
+httpdate@1.0.3	X									X					
+humantime@2.3.0	X									X					
+hyper@0.14.32										X					
+hyper@1.9.0										X					
+hyper-rustls@0.27.9	X							X		X					
+hyper-timeout@0.4.1	X									X					
+hyper-timeout@0.5.2	X									X					
+hyper-util@0.1.20										X					
+iana-time-zone@0.1.65	X									X					
+iana-time-zone-haiku@0.1.2	X									X					
+icu_collections@2.1.1													X		
+icu_locale_core@2.1.1													X		
+icu_normalizer@2.1.1													X		
+icu_normalizer_data@2.1.1													X		
+icu_properties@2.1.2													X		
+icu_properties_data@2.1.2													X		
+icu_provider@2.1.1													X		
+ident_case@1.0.1	X									X					
+idna@1.1.0	X									X					
+idna_adapter@1.2.1	X									X					
+indexmap@1.9.3	X									X					
+indexmap@2.14.0	X									X					
+inout@0.1.4	X									X					
+instant@0.1.13				X											
+ipconfig@0.3.4	X									X					
+ipnet@2.12.0	X									X					
+iri-string@0.7.12	X									X					
+is_terminal_polyfill@1.70.2	X									X					
+itertools@0.12.1	X									X					
+itertools@0.14.0	X									X					
+itoa@1.0.18	X									X					
+jiff@0.2.23										X				X	
+jiff-tzdb@0.1.6										X				X	
+jiff-tzdb-platform@0.1.3										X				X	
+jni@0.21.1	X									X					
+jni-sys@0.3.1	X									X					
+jni-sys@0.4.1	X									X					
+jni-sys-macros@0.4.1	X									X					
+jobserver@0.1.34	X									X					
+js-sys@0.3.95	X									X					
+jsonwebtoken@10.3.0										X					
+konst@0.4.3															X
+konst_proc_macros@0.4.1															X
+lazy_static@1.5.0	X									X					
+libc@0.2.185	X									X					
+libm@0.2.16										X					
+libredox@0.1.16										X					
+libsqlite3-sys@0.30.1										X					
+linked-hash-map@0.5.6	X									X					
+linux-raw-sys@0.12.1	X	X								X					
+litemap@0.8.2													X		
+lock_api@0.4.14	X									X					
+log@0.4.29	X									X					
+lz4_flex@0.13.0										X					
+macro_magic@0.5.1										X					
+macro_magic_core@0.5.1										X					
+macro_magic_core_macros@0.5.1										X					
+macro_magic_macros@0.5.1										X					
+matchers@0.2.0										X					
+matchit@0.7.3				X						X					
+matchit@0.8.4				X						X					
+md-5@0.10.6	X									X					
+mea@0.6.3	X														
+memchr@2.8.0										X				X	
+memmap2@0.5.10	X									X					
+miette@5.10.0	X														
+miette-derive@5.10.0	X														
+mime@0.3.17	X									X					
+mini-moka@0.10.3	X									X					
+mio@1.2.0										X					
+moka@0.12.15	X									X					
+mongodb@3.5.2	X														
+mongodb-internal-macros@3.5.2	X														
+more-asserts@0.3.1	X					X				X				X	
+multimap@0.10.1	X									X					
+ntapi@0.4.3	X									X					
+nu-ansi-term@0.50.3										X					
+num-bigint@0.4.6	X									X					
+num-bigint-dig@0.8.6	X									X					
+num-conv@0.2.1	X									X					
+num-derive@0.4.2	X									X					
+num-integer@0.1.46	X									X					
+num-iter@0.1.45	X									X					
+num-traits@0.2.19	X									X					
+objc2-core-foundation@0.3.2	X									X					X
+objc2-io-kit@0.3.2	X									X					X
+objc2-system-configuration@0.3.2	X									X					X
+once_cell@1.21.4	X									X					
+once_cell_polyfill@1.70.2	X									X					
+oneshot@0.1.13	X									X					
+opendal@0.56.0	X														
+opendal-core@0.56.0	X														
+opendal-java@0.0.0	X														
+opendal-layer-concurrent-limit@0.56.0	X														
+opendal-layer-logging@0.56.0	X														
+opendal-layer-retry@0.56.0	X														
+opendal-layer-timeout@0.56.0	X														
+opendal-service-aliyun-drive@0.56.0	X														
+opendal-service-alluxio@0.56.0	X														
+opendal-service-azblob@0.56.0	X														
+opendal-service-azdls@0.56.0	X														
+opendal-service-azfile@0.56.0	X														
+opendal-service-azure-common@0.56.0	X														
+opendal-service-b2@0.56.0	X														
+opendal-service-cacache@0.56.0	X														
+opendal-service-cos@0.56.0	X														
+opendal-service-dashmap@0.56.0	X														
+opendal-service-dropbox@0.56.0	X														
+opendal-service-etcd@0.56.0	X														
+opendal-service-fs@0.56.0	X														
+opendal-service-gcs@0.56.0	X														
+opendal-service-gdrive@0.56.0	X														
+opendal-service-ghac@0.56.0	X														
+opendal-service-gridfs@0.56.0	X														
+opendal-service-hf@0.56.0	X														
+opendal-service-http@0.56.0	X														
+opendal-service-ipfs@0.56.0	X														
+opendal-service-ipmfs@0.56.0	X														
+opendal-service-koofr@0.56.0	X														
+opendal-service-memcached@0.56.0	X														
+opendal-service-mini-moka@0.56.0	X														
+opendal-service-moka@0.56.0	X														
+opendal-service-mongodb@0.56.0	X														
+opendal-service-mysql@0.56.0	X														
+opendal-service-obs@0.56.0	X														
+opendal-service-onedrive@0.56.0	X														
+opendal-service-oss@0.56.0	X														
+opendal-service-persy@0.56.0	X														
+opendal-service-postgresql@0.56.0	X														
+opendal-service-redb@0.56.0	X														
+opendal-service-redis@0.56.0	X														
+opendal-service-s3@0.56.0	X														
+opendal-service-seafile@0.56.0	X														
+opendal-service-sftp@0.56.0	X														
+opendal-service-sled@0.56.0	X														
+opendal-service-sqlite@0.56.0	X														
+opendal-service-swift@0.56.0	X														
+opendal-service-tikv@0.56.0	X														
+opendal-service-upyun@0.56.0	X														
+opendal-service-vercel-artifacts@0.56.0	X														
+opendal-service-webdav@0.56.0	X														
+opendal-service-webhdfs@0.56.0	X														
+opendal-service-yandex-disk@0.56.0	X														
+openssh@0.11.6	X									X					
+openssh-sftp-client@0.15.6										X					
+openssh-sftp-client-lowlevel@0.7.2										X					
+openssh-sftp-error@0.5.1										X					
+openssh-sftp-protocol@0.24.1										X					
+openssh-sftp-protocol-error@0.1.1										X					
+openssl-probe@0.2.1	X									X					
+option-ext@0.2.0												X			
+ordered-multimap@0.7.3										X					
+os_str_bytes@6.6.1	X									X					
+parking@2.2.1	X									X					
+parking_lot@0.11.2	X									X					
+parking_lot@0.12.5	X									X					
+parking_lot_core@0.8.6	X									X					
+parking_lot_core@0.9.12	X									X					
+pbkdf2@0.12.2	X									X					
+pem@3.0.6										X					
+pem-rfc7468@0.7.0	X									X					
+percent-encoding@2.3.2	X									X					
+persy@1.7.1												X			
+petgraph@0.8.3	X									X					
+pin-project@1.1.11	X									X					
+pin-project-internal@1.1.11	X									X					
+pin-project-lite@0.2.17	X									X					
+pin-utils@0.1.0	X									X					
+pkcs1@0.7.5	X									X					
+pkcs5@0.7.1	X									X					
+pkcs8@0.10.2	X									X					
+pkg-config@0.3.33	X									X					
+plain@0.2.3	X									X					
+portable-atomic@1.13.1	X									X					
+portable-atomic-util@0.2.6	X									X					
+potential_utf@0.1.5													X		
+powerfmt@0.2.0	X									X					
+ppv-lite86@0.2.21	X									X					
+prettyplease@0.2.37	X									X					
+proc-macro2@1.0.106	X									X					
+prometheus@0.13.4	X														
+prost@0.12.6	X														
+prost@0.13.5	X														
+prost@0.14.3	X														
+prost-build@0.14.3	X														
+prost-derive@0.12.6	X														
+prost-derive@0.13.5	X														
+prost-derive@0.14.3	X														
+prost-types@0.14.3	X														
+pulldown-cmark@0.13.3										X					
+pulldown-cmark@0.9.6										X					
+pulldown-cmark-to-cmark@22.0.0	X														
+quick-xml@0.38.4										X					
+quick-xml@0.39.2										X					
+quote@1.0.45	X									X					
+r-efi@5.3.0	X								X	X					
+r-efi@6.0.0	X								X	X					
+radium@0.7.0										X					
+rand@0.10.1	X									X					
+rand@0.7.3	X									X					
+rand@0.8.5	X									X					
+rand@0.9.4	X									X					
+rand_chacha@0.2.2	X									X					
+rand_chacha@0.3.1	X									X					
+rand_chacha@0.9.0	X									X					
+rand_core@0.10.1	X									X					
+rand_core@0.5.1	X									X					
+rand_core@0.6.4	X									X					
+rand_core@0.9.5	X									X					
+rand_hc@0.2.0	X									X					
+redb@2.6.3	X									X					
+redb@3.1.3	X									X					
+redis@1.2.0				X											
+redox_syscall@0.2.16										X					
+redox_syscall@0.5.18										X					
+redox_users@0.5.2										X					
+reflink-copy@0.1.29	X									X					
+regex@1.12.3	X									X					
+regex-automata@0.4.14	X									X					
+regex-syntax@0.8.10	X									X					
+reqsign-aliyun-oss@3.0.0	X														
+reqsign-aws-v4@3.0.0	X														
+reqsign-azure-storage@3.0.0	X														
+reqsign-core@3.0.0	X														
+reqsign-file-read-tokio@3.0.0	X														
+reqsign-google@3.0.0	X														
+reqsign-huaweicloud-obs@3.0.0	X														
+reqsign-tencent-cos@3.0.0	X														
+reqwest@0.13.2	X									X					
+reqwest-middleware@0.5.1	X									X					
+reqwest-retry@0.9.1	X									X					
+resolv-conf@0.7.6	X									X					
+retry-policies@0.5.1	X									X					
+ring@0.17.14	X							X							
+rsa@0.9.10	X									X					
+rust-ini@0.21.3										X					
+rustc_version@0.4.1	X									X					
+rustc_version_runtime@0.3.0										X					
+rustix@1.1.4	X	X								X					
+rustls@0.21.12	X							X		X					
+rustls@0.23.38	X							X		X					
+rustls-native-certs@0.8.3	X							X		X					
+rustls-pemfile@1.0.4	X							X		X					
+rustls-pki-types@1.14.0	X									X					
+rustls-platform-verifier@0.6.2	X									X					
+rustls-platform-verifier-android@0.1.1	X									X					
+rustls-webpki@0.101.7								X							
+rustls-webpki@0.103.12								X							
+rustversion@1.0.22	X									X					
+ryu@1.0.23	X				X										
+safe-transmute@0.11.3										X					
+salsa20@0.10.2	X									X					
+same-file@1.0.6										X				X	
+schannel@0.1.29										X					
+scopeguard@1.2.0	X									X					
+scrypt@0.11.0	X									X					
+sct@0.7.1	X							X		X					
+security-framework@3.7.0	X									X					
+security-framework-sys@2.17.0	X									X					
+semver@1.0.28	X									X					
+serde@1.0.228	X									X					
+serde_bytes@0.11.19	X									X					
+serde_core@1.0.228	X									X					
+serde_derive@1.0.228	X									X					
+serde_json@1.0.149	X									X					
+serde_repr@0.1.20	X									X					
+serde_urlencoded@0.7.1	X									X					
+serde_with@3.17.0	X									X					
+serde_with_macros@3.17.0	X									X					
+sha-1@0.10.1	X									X					
+sha1@0.10.6	X									X					
+sha1_smol@1.0.1				X											
+sha2@0.10.9	X									X					
+sha2-asm@0.6.4										X					
+sharded-slab@0.1.7										X					
+shell-escape@0.1.5	X									X					
+shellexpand@3.1.2	X									X					
+shlex@1.3.0	X									X					
+signal-hook-registry@1.4.8	X									X					
+signature@2.2.0	X									X					
+simple_asn1@0.6.4								X							
+skeptic@0.13.7	X									X					
+slab@0.4.12										X					
+sled@0.34.7	X									X					
+smallvec@1.15.1	X									X					
+socket2@0.5.10	X									X					
+socket2@0.6.3	X									X					
+spin@0.9.8										X					
+spki@0.7.3	X									X					
+sqlx@0.8.6	X									X					
+sqlx-core@0.8.6	X									X					
+sqlx-macros@0.8.6	X									X					
+sqlx-macros-core@0.8.6	X									X					
+sqlx-mysql@0.8.6	X									X					
+sqlx-postgres@0.8.6	X									X					
+sqlx-sqlite@0.8.6	X									X					
+ssh_format@0.14.1										X					
+ssh_format_error@0.1.0										X					
+ssri@9.2.0	X														
+stable_deref_trait@1.2.1	X									X					
+static_assertions@1.1.0	X									X					
+statrs@0.18.0										X					
+stringprep@0.1.5	X									X					
+strsim@0.11.1										X					
+subtle@2.6.1				X											
+syn@1.0.109	X									X					
+syn@2.0.117	X									X					
+sync_wrapper@0.1.2	X														
+sync_wrapper@1.0.2	X														
+synstructure@0.13.2										X					
+sysinfo@0.38.4										X					
+system-configuration@0.7.0	X									X					
+system-configuration-sys@0.6.0	X									X					
+tagptr@0.2.0	X									X					
+take_mut@0.2.2										X					
+tap@1.0.1										X					
+tempfile@3.27.0	X									X					
+thin-vec@0.2.16	X									X					
+thiserror@1.0.69	X									X					
+thiserror@2.0.18	X									X					
+thiserror-impl@1.0.69	X									X					
+thiserror-impl@2.0.18	X									X					
+thread_local@1.1.9	X									X					
+tikv-client@0.3.0	X														
+time@0.3.47	X									X					
+time-core@0.1.8	X									X					
+time-macros@0.2.27	X									X					
+tiny-keccak@2.0.2						X									
+tinystr@0.8.3													X		
+tinyvec@1.11.0	X									X					X
+tinyvec_macros@0.1.1	X									X					X
+tokio@1.52.0										X					
+tokio-io-timeout@1.2.1	X									X					
+tokio-io-utility@0.7.6										X					
+tokio-macros@2.7.0										X					
+tokio-retry@0.3.1										X					
+tokio-rustls@0.24.1	X									X					
+tokio-rustls@0.26.4	X									X					
+tokio-stream@0.1.18										X					
+tokio-util@0.7.18										X					
+tonic@0.10.2										X					
+tonic@0.14.5										X					
+tonic-build@0.14.5										X					
+tonic-prost@0.14.5										X					
+tonic-prost-build@0.14.5										X					
+tower@0.4.13										X					
+tower@0.5.3										X					
+tower-http@0.6.8										X					
+tower-layer@0.3.3										X					
+tower-service@0.3.3										X					
+tracing@0.1.44										X					
+tracing-appender@0.2.4										X					
+tracing-attributes@0.1.31										X					
+tracing-core@0.1.36										X					
+tracing-log@0.2.0										X					
+tracing-serde@0.2.0										X					
+tracing-subscriber@0.3.23										X					
+triomphe@0.1.15	X									X					
+try-lock@0.2.5										X					
+twox-hash@2.1.2										X					
+typed-builder@0.22.0	X									X					
+typed-builder-macro@0.22.0	X									X					
+typenum@1.19.0	X									X					
+typewit@1.15.2															X
+ulid@1.2.1										X					
+unicase@2.9.0	X									X					
+unicode-bidi@0.3.18	X									X					
+unicode-ident@1.0.24	X									X			X		
+unicode-normalization@0.1.25	X									X					
+unicode-properties@0.1.4	X									X					
+unicode-segmentation@1.13.2	X									X					
+unicode-width@0.1.14	X									X					
+unicode-xid@0.2.6	X									X					
+unsigned-varint@0.8.0										X					
+untrusted@0.7.1								X							
+untrusted@0.9.0								X							
+url@2.5.8	X									X					
+urlencoding@2.1.3										X					
+utf8_iter@1.0.4	X									X					
+utf8parse@0.2.2	X									X					
+uuid@1.23.1	X									X					
+vcpkg@0.2.15	X									X					
+vec-strings@0.4.8										X					
+version_check@0.9.5	X									X					
+walkdir@2.5.0										X				X	
+want@0.3.1										X					
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X					
+wasi@0.14.7+wasi-0.2.4	X	X								X					
+wasi@0.9.0+wasi-snapshot-preview1	X	X								X					
+wasip2@1.0.1+wasi-0.2.4	X	X								X					
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X					
+wasite@0.1.0	X				X					X					
+wasite@1.0.2	X				X					X					
+wasm-bindgen@0.2.118	X									X					
+wasm-bindgen-futures@0.4.68	X									X					
+wasm-bindgen-macro@0.2.118	X									X					
+wasm-bindgen-macro-support@0.2.118	X									X					
+wasm-bindgen-shared@0.2.118	X									X					
+wasm-streams@0.5.0	X									X					
+wasmtimer@0.4.3										X					
+web-sys@0.3.95	X									X					
+web-time@1.1.0	X									X					
+webpki-root-certs@1.0.6							X								
+webpki-roots@0.26.11							X								
+webpki-roots@1.0.6							X								
+whoami@1.6.1	X				X					X					
+whoami@2.1.1	X				X					X					
+widestring@1.2.1	X									X					
+winapi@0.3.9	X									X					
+winapi-i686-pc-windows-gnu@0.4.0	X									X					
+winapi-util@0.1.11										X				X	
+winapi-x86_64-pc-windows-gnu@0.4.0	X									X					
+windows@0.62.2	X									X					
+windows-collections@0.3.2	X									X					
+windows-core@0.62.2	X									X					
+windows-future@0.3.2	X									X					
+windows-implement@0.60.2	X									X					
+windows-interface@0.59.3	X									X					
+windows-link@0.2.1	X									X					
+windows-numerics@0.3.1	X									X					
+windows-registry@0.6.1	X									X					
+windows-result@0.4.1	X									X					
+windows-strings@0.5.1	X									X					
+windows-sys@0.45.0	X									X					
+windows-sys@0.48.0	X									X					
+windows-sys@0.52.0	X									X					
+windows-sys@0.59.0	X									X					
+windows-sys@0.61.2	X									X					
+windows-targets@0.42.2	X									X					
+windows-targets@0.48.5	X									X					
+windows-targets@0.52.6	X									X					
+windows-threading@0.2.1	X									X					
+windows_aarch64_gnullvm@0.42.2	X									X					
+windows_aarch64_gnullvm@0.48.5	X									X					
+windows_aarch64_gnullvm@0.52.6	X									X					
+windows_aarch64_msvc@0.42.2	X									X					
+windows_aarch64_msvc@0.48.5	X									X					
+windows_aarch64_msvc@0.52.6	X									X					
+windows_i686_gnu@0.42.2	X									X					
+windows_i686_gnu@0.48.5	X									X					
+windows_i686_gnu@0.52.6	X									X					
+windows_i686_gnullvm@0.52.6	X									X					
+windows_i686_msvc@0.42.2	X									X					
+windows_i686_msvc@0.48.5	X									X					
+windows_i686_msvc@0.52.6	X									X					
+windows_x86_64_gnu@0.42.2	X									X					
+windows_x86_64_gnu@0.48.5	X									X					
+windows_x86_64_gnu@0.52.6	X									X					
+windows_x86_64_gnullvm@0.42.2	X									X					
+windows_x86_64_gnullvm@0.48.5	X									X					
+windows_x86_64_gnullvm@0.52.6	X									X					
+windows_x86_64_msvc@0.42.2	X									X					
+windows_x86_64_msvc@0.48.5	X									X					
+windows_x86_64_msvc@0.52.6	X									X					
+wit-bindgen@0.46.0	X	X								X					
+wit-bindgen@0.51.0	X	X								X					
+writeable@0.6.3													X		
+wyz@0.5.1										X					
+xattr@1.6.1	X									X					
+xet-client@1.5.1	X														
+xet-core-structures@1.5.1	X														
+xet-data@1.5.1	X														
+xet-runtime@1.5.1	X														
+xxhash-rust@0.8.15					X										
+yoke@0.8.2													X		
+yoke-derive@0.8.2													X		
+zerocopy@0.8.48	X		X							X					
+zerofrom@0.1.7													X		
+zerofrom-derive@0.1.7													X		
+zeroize@1.8.2	X									X					
+zerotrie@0.2.4													X		
+zerovec@0.11.6													X		
+zerovec-derive@0.11.3													X		
+zigzag@0.1.0										X					
+zmij@1.0.21										X					

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal</artifactId>
-    <version>0.48.2</version> <!-- update version number -->
+    <version>0.48.3</version> <!-- update version number -->
 
     <name>Apache OpenDAL™</name>
     <description>

--- a/bindings/lua/DEPENDENCIES.rust.tsv
+++ b/bindings/lua/DEPENDENCIES.rust.tsv
@@ -1,257 +1,298 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense
-aes@0.8.4	X									X		
-aho-corasick@1.1.4										X		X
-android_system_properties@0.1.5	X									X		
-anyhow@1.0.100	X									X		
-async-trait@0.1.89	X									X		
-atomic-waker@1.1.2	X									X		
-autocfg@1.5.0	X									X		
-backon@1.6.0	X											
-base64@0.22.1	X									X		
-base64ct@1.8.0	X									X		
-bitflags@2.10.0	X									X		
-block-buffer@0.10.4	X									X		
-block-padding@0.3.3	X									X		
-bstr@1.12.1	X									X		
-bumpalo@3.19.0	X									X		
-bytes@1.11.0										X		
-cbc@0.1.2	X									X		
-cc@1.2.47	X									X		
-cfg-if@1.0.4	X									X		
-chrono@0.4.42	X									X		
-cipher@0.4.4	X									X		
-const-oid@0.9.6	X									X		
-const-random@0.1.18	X									X		
-const-random-macro@0.1.16	X									X		
-core-foundation-sys@0.8.7	X									X		
-cpufeatures@0.2.17	X									X		
-crc32c@0.6.8	X									X		
-crunchy@0.2.4										X		
-crypto-common@0.1.7	X									X		
-der@0.7.10	X									X		
-deranged@0.5.5	X									X		
-digest@0.10.7	X									X		
-displaydoc@0.2.5	X									X		
-dlv-list@0.5.2	X									X		
-either@1.15.0	X									X		
-fastrand@2.3.0	X									X		
-find-msvc-tools@0.1.5	X									X		
-fnv@1.0.7	X									X		
-form_urlencoded@1.2.2	X									X		
-futures@0.3.31	X									X		
-futures-channel@0.3.31	X									X		
-futures-core@0.3.31	X									X		
-futures-io@0.3.31	X									X		
-futures-macro@0.3.31	X									X		
-futures-sink@0.3.31	X									X		
-futures-task@0.3.31	X									X		
-futures-util@0.3.31	X									X		
-generic-array@0.14.7										X		
-getrandom@0.2.16	X									X		
-getrandom@0.3.4	X									X		
-ghac@0.2.0	X											
-gloo-timers@0.3.0	X									X		
-hashbrown@0.14.5	X									X		
-hex@0.4.3	X									X		
-hmac@0.12.1	X									X		
-home@0.5.11	X									X		
-http@1.3.1	X									X		
-http-body@1.0.1										X		
-http-body-util@0.1.3										X		
-httparse@1.10.1	X									X		
-hyper@1.8.1										X		
-hyper-rustls@0.27.7	X							X		X		
-hyper-util@0.1.18										X		
-iana-time-zone@0.1.64	X									X		
-iana-time-zone-haiku@0.1.2	X									X		
-icu_collections@2.1.1											X	
-icu_locale_core@2.1.1											X	
-icu_normalizer@2.1.1											X	
-icu_normalizer_data@2.1.1											X	
-icu_properties@2.1.1											X	
-icu_properties_data@2.1.1											X	
-icu_provider@2.1.1											X	
-idna@1.1.0	X									X		
-idna_adapter@1.2.1	X									X		
-inout@0.1.4	X									X		
-ipnet@2.11.0	X									X		
-iri-string@0.7.9	X									X		
-itertools@0.12.1	X									X		
-itertools@0.14.0	X									X		
-itoa@1.0.15	X									X		
-jiff@0.2.16										X		X
-jiff-tzdb@0.1.4										X		X
-jiff-tzdb-platform@0.1.3										X		X
-js-sys@0.3.82	X									X		
-jsonwebtoken@9.3.1										X		
-lazy_static@1.5.0	X									X		
-libc@0.2.177	X									X		
-libm@0.2.15										X		
-litemap@0.8.1											X	
-lock_api@0.4.14	X									X		
-log@0.4.28	X									X		
-md-5@0.10.6	X									X		
-memchr@2.7.6										X		X
-mio@1.1.0										X		
-mlua@0.9.9										X		
-mlua-sys@0.6.8										X		
-mlua_derive@0.9.3										X		
-num-bigint@0.4.6	X									X		
-num-bigint-dig@0.8.6	X									X		
-num-conv@0.1.0	X									X		
-num-integer@0.1.46	X									X		
-num-iter@0.1.45	X									X		
-num-traits@0.2.19	X									X		
-once_cell@1.21.3	X									X		
-opendal@0.55.0	X											
-opendal-lua@0.0.0	X											
-ordered-multimap@0.7.3										X		
-parking_lot@0.12.5	X									X		
-parking_lot_core@0.9.12	X									X		
-pbkdf2@0.12.2	X									X		
-pem@3.0.6										X		
-pem-rfc7468@0.7.0	X									X		
-percent-encoding@2.3.2	X									X		
-pin-project-lite@0.2.16	X									X		
-pin-utils@0.1.0	X									X		
-pkcs1@0.7.5	X									X		
-pkcs5@0.7.1	X									X		
-pkcs8@0.10.2	X									X		
-pkg-config@0.3.32	X									X		
-portable-atomic@1.11.1	X									X		
-portable-atomic-util@0.2.4	X									X		
-potential_utf@0.1.4											X	
-powerfmt@0.2.0	X									X		
-ppv-lite86@0.2.21	X									X		
-proc-macro-error@1.0.4	X									X		
-proc-macro-error-attr@1.0.4	X									X		
-proc-macro2@1.0.103	X									X		
-prost@0.13.5	X											
-prost-derive@0.13.5	X											
-quick-xml@0.38.4										X		
-quote@1.0.42	X									X		
-r-efi@5.3.0	X								X	X		
-rand@0.8.5	X									X		
-rand_chacha@0.3.1	X									X		
-rand_core@0.6.4	X									X		
-redox_syscall@0.5.18										X		
-regex@1.12.2	X									X		
-regex-automata@0.4.13	X									X		
-regex-syntax@0.8.8	X									X		
-reqsign@0.16.5	X											
-reqsign-aws-v4@2.0.1	X											
-reqsign-core@2.0.1	X											
-reqsign-file-read-tokio@2.0.1	X											
-reqsign-http-send-reqwest@2.0.1	X											
-reqwest@0.12.24	X									X		
-ring@0.17.14	X							X				
-rsa@0.9.9	X									X		
-rust-ini@0.21.3										X		
-rustc-hash@2.1.1	X									X		
-rustc_version@0.4.1	X									X		
-rustls@0.23.35	X							X		X		
-rustls-pki-types@1.13.0	X									X		
-rustls-webpki@0.103.8								X				
-rustversion@1.0.22	X									X		
-ryu@1.0.20	X				X							
-salsa20@0.10.2	X									X		
-scopeguard@1.2.0	X									X		
-scrypt@0.11.0	X									X		
-semver@1.0.27	X									X		
-serde@1.0.228	X									X		
-serde_core@1.0.228	X									X		
-serde_derive@1.0.228	X									X		
-serde_json@1.0.145	X									X		
-serde_urlencoded@0.7.1	X									X		
-sha1@0.10.6	X									X		
-sha2@0.10.9	X									X		
-shlex@1.3.0	X									X		
-signal-hook-registry@1.4.6	X									X		
-signature@2.2.0	X									X		
-simple_asn1@0.6.3								X				
-slab@0.4.11										X		
-smallvec@1.15.1	X									X		
-socket2@0.6.1	X									X		
-spin@0.9.8										X		
-spki@0.7.3	X									X		
-stable_deref_trait@1.2.1	X									X		
-subtle@2.6.1				X								
-syn@1.0.109	X									X		
-syn@2.0.110	X									X		
-sync_wrapper@1.0.2	X											
-synstructure@0.13.2										X		
-thiserror@2.0.17	X									X		
-thiserror-impl@2.0.17	X									X		
-time@0.3.44	X									X		
-time-core@0.1.6	X									X		
-time-macros@0.2.24	X									X		
-tiny-keccak@2.0.2						X						
-tinystr@0.8.2											X	
-tokio@1.48.0										X		
-tokio-macros@2.6.0										X		
-tokio-rustls@0.26.4	X									X		
-tokio-util@0.7.17										X		
-tower@0.5.2										X		
-tower-http@0.6.6										X		
-tower-layer@0.3.3										X		
-tower-service@0.3.3										X		
-tracing@0.1.41										X		
-tracing-core@0.1.34										X		
-try-lock@0.2.5										X		
-typenum@1.19.0	X									X		
-unicode-ident@1.0.22	X									X	X	
-untrusted@0.9.0								X				
-url@2.5.7	X									X		
-utf8_iter@1.0.4	X									X		
-uuid@1.18.1	X									X		
-version_check@0.9.5	X									X		
-want@0.3.1										X		
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X		
-wasip2@1.0.1+wasi-0.2.4	X	X								X		
-wasm-bindgen@0.2.105	X									X		
-wasm-bindgen-futures@0.4.55	X									X		
-wasm-bindgen-macro@0.2.105	X									X		
-wasm-bindgen-macro-support@0.2.105	X									X		
-wasm-bindgen-shared@0.2.105	X									X		
-wasm-streams@0.4.2	X									X		
-web-sys@0.3.82	X									X		
-webpki-roots@1.0.4							X					
-windows-core@0.62.2	X									X		
-windows-implement@0.60.2	X									X		
-windows-interface@0.59.3	X									X		
-windows-link@0.2.1	X									X		
-windows-result@0.4.1	X									X		
-windows-strings@0.5.1	X									X		
-windows-sys@0.52.0	X									X		
-windows-sys@0.59.0	X									X		
-windows-sys@0.60.2	X									X		
-windows-sys@0.61.2	X									X		
-windows-targets@0.52.6	X									X		
-windows-targets@0.53.5	X									X		
-windows_aarch64_gnullvm@0.52.6	X									X		
-windows_aarch64_gnullvm@0.53.1	X									X		
-windows_aarch64_msvc@0.52.6	X									X		
-windows_aarch64_msvc@0.53.1	X									X		
-windows_i686_gnu@0.52.6	X									X		
-windows_i686_gnu@0.53.1	X									X		
-windows_i686_gnullvm@0.52.6	X									X		
-windows_i686_gnullvm@0.53.1	X									X		
-windows_i686_msvc@0.52.6	X									X		
-windows_i686_msvc@0.53.1	X									X		
-windows_x86_64_gnu@0.52.6	X									X		
-windows_x86_64_gnu@0.53.1	X									X		
-windows_x86_64_gnullvm@0.52.6	X									X		
-windows_x86_64_gnullvm@0.53.1	X									X		
-windows_x86_64_msvc@0.52.6	X									X		
-windows_x86_64_msvc@0.53.1	X									X		
-wit-bindgen@0.46.0	X	X								X		
-writeable@0.6.2											X	
-yoke@0.8.1											X	
-yoke-derive@0.8.1											X	
-zerocopy@0.8.28	X		X							X		
-zerofrom@0.1.6											X	
-zerofrom-derive@0.1.6											X	
-zeroize@1.8.2	X									X		
-zerotrie@0.2.3											X	
-zerovec@0.11.5											X	
-zerovec-derive@0.11.2											X	
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
+aes@0.8.4	X									X			
+aho-corasick@1.1.4										X			X
+anyhow@1.0.102	X									X			
+async-trait@0.1.89	X									X			
+atomic-waker@1.1.2	X									X			
+autocfg@1.5.0	X									X			
+aws-lc-rs@1.16.3	X							X					
+aws-lc-sys@0.40.0	X			X				X		X	X		
+backon@1.6.0	X												
+base64@0.22.1	X									X			
+base64ct@1.8.3	X									X			
+bitflags@2.11.1	X									X			
+block-buffer@0.10.4	X									X			
+block-padding@0.3.3	X									X			
+bstr@1.12.1	X									X			
+bumpalo@3.20.2	X									X			
+bytes@1.11.1										X			
+cbc@0.1.2	X									X			
+cc@1.2.60	X									X			
+cesu8@1.1.0	X									X			
+cfg-if@1.0.4	X									X			
+cipher@0.4.4	X									X			
+cmake@0.1.58	X									X			
+combine@4.6.7										X			
+const-oid@0.9.6	X									X			
+const-random@0.1.18	X									X			
+const-random-macro@0.1.16	X									X			
+core-foundation@0.10.1	X									X			
+core-foundation-sys@0.8.7	X									X			
+cpufeatures@0.2.17	X									X			
+crc32c@0.6.8	X									X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7	X									X			
+ctor@0.6.3	X									X			
+ctor-proc-macro@0.0.7	X									X			
+der@0.7.10	X									X			
+deranged@0.5.8	X									X			
+digest@0.10.7	X									X			
+displaydoc@0.2.5	X									X			
+dlv-list@0.5.2	X									X			
+dtor@0.1.1	X									X			
+dtor-proc-macro@0.0.6	X									X			
+dunce@1.0.5	X					X					X		
+either@1.15.0	X									X			
+errno@0.3.14	X									X			
+fastrand@2.4.1	X									X			
+find-msvc-tools@0.1.9	X									X			
+form_urlencoded@1.2.2	X									X			
+fs_extra@1.3.0										X			
+futures@0.3.32	X									X			
+futures-channel@0.3.32	X									X			
+futures-core@0.3.32	X									X			
+futures-executor@0.3.32	X									X			
+futures-io@0.3.32	X									X			
+futures-macro@0.3.32	X									X			
+futures-sink@0.3.32	X									X			
+futures-task@0.3.32	X									X			
+futures-util@0.3.32	X									X			
+generic-array@0.14.7										X			
+getrandom@0.2.17	X									X			
+getrandom@0.3.4	X									X			
+getrandom@0.4.2	X									X			
+ghac@0.2.0	X												
+gloo-timers@0.3.0	X									X			
+hashbrown@0.14.5	X									X			
+hex@0.4.3	X									X			
+hmac@0.12.1	X									X			
+http@1.4.0	X									X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1	X									X			
+hyper@1.9.0										X			
+hyper-rustls@0.27.9	X							X		X			
+hyper-util@0.1.20										X			
+icu_collections@2.1.1												X	
+icu_locale_core@2.1.1												X	
+icu_normalizer@2.1.1												X	
+icu_normalizer_data@2.1.1												X	
+icu_properties@2.1.2												X	
+icu_properties_data@2.1.2												X	
+icu_provider@2.1.1												X	
+idna@1.1.0	X									X			
+idna_adapter@1.2.1	X									X			
+inout@0.1.4	X									X			
+ipnet@2.12.0	X									X			
+iri-string@0.7.12	X									X			
+itertools@0.12.1	X									X			
+itertools@0.14.0	X									X			
+itoa@1.0.18	X									X			
+jiff@0.2.23										X			X
+jiff-tzdb@0.1.6										X			X
+jiff-tzdb-platform@0.1.3										X			X
+jni@0.21.1	X									X			
+jni-sys@0.3.1	X									X			
+jni-sys@0.4.1	X									X			
+jni-sys-macros@0.4.1	X									X			
+jobserver@0.1.34	X									X			
+js-sys@0.3.95	X									X			
+jsonwebtoken@10.3.0										X			
+lazy_static@1.5.0	X									X			
+libc@0.2.185	X									X			
+libm@0.2.16										X			
+linux-raw-sys@0.12.1	X	X								X			
+litemap@0.8.2												X	
+lock_api@0.4.14	X									X			
+log@0.4.29	X									X			
+md-5@0.10.6	X									X			
+mea@0.6.3	X												
+memchr@2.8.0										X			X
+mio@1.2.0										X			
+mlua@0.9.9										X			
+mlua-sys@0.6.8										X			
+mlua_derive@0.9.3										X			
+num-bigint@0.4.6	X									X			
+num-bigint-dig@0.8.6	X									X			
+num-conv@0.2.1	X									X			
+num-integer@0.1.46	X									X			
+num-iter@0.1.45	X									X			
+num-traits@0.2.19	X									X			
+once_cell@1.21.4	X									X			
+opendal@0.56.0	X												
+opendal-core@0.56.0	X												
+opendal-layer-concurrent-limit@0.56.0	X												
+opendal-layer-logging@0.56.0	X												
+opendal-layer-retry@0.56.0	X												
+opendal-layer-timeout@0.56.0	X												
+opendal-lua@0.0.0	X												
+opendal-service-azblob@0.56.0	X												
+opendal-service-azdls@0.56.0	X												
+opendal-service-azfile@0.56.0	X												
+opendal-service-azure-common@0.56.0	X												
+opendal-service-cos@0.56.0	X												
+opendal-service-fs@0.56.0	X												
+opendal-service-gcs@0.56.0	X												
+opendal-service-ghac@0.56.0	X												
+opendal-service-http@0.56.0	X												
+opendal-service-ipmfs@0.56.0	X												
+opendal-service-obs@0.56.0	X												
+opendal-service-oss@0.56.0	X												
+opendal-service-s3@0.56.0	X												
+opendal-service-webdav@0.56.0	X												
+opendal-service-webhdfs@0.56.0	X												
+openssl-probe@0.2.1	X									X			
+ordered-multimap@0.7.3										X			
+parking_lot@0.12.5	X									X			
+parking_lot_core@0.9.12	X									X			
+pbkdf2@0.12.2	X									X			
+pem@3.0.6										X			
+pem-rfc7468@0.7.0	X									X			
+percent-encoding@2.3.2	X									X			
+pin-project-lite@0.2.17	X									X			
+pkcs1@0.7.5	X									X			
+pkcs5@0.7.1	X									X			
+pkcs8@0.10.2	X									X			
+pkg-config@0.3.33	X									X			
+portable-atomic@1.13.1	X									X			
+portable-atomic-util@0.2.6	X									X			
+potential_utf@0.1.5												X	
+powerfmt@0.2.0	X									X			
+ppv-lite86@0.2.21	X									X			
+proc-macro-error@1.0.4	X									X			
+proc-macro-error-attr@1.0.4	X									X			
+proc-macro2@1.0.106	X									X			
+prost@0.13.5	X												
+prost-derive@0.13.5	X												
+quick-xml@0.38.4										X			
+quick-xml@0.39.2										X			
+quote@1.0.45	X									X			
+r-efi@5.3.0	X								X	X			
+r-efi@6.0.0	X								X	X			
+rand@0.8.5	X									X			
+rand_chacha@0.3.1	X									X			
+rand_core@0.6.4	X									X			
+redox_syscall@0.5.18										X			
+regex@1.12.3	X									X			
+regex-automata@0.4.14	X									X			
+regex-syntax@0.8.10	X									X			
+reqsign-aliyun-oss@3.0.0	X												
+reqsign-aws-v4@3.0.0	X												
+reqsign-azure-storage@3.0.0	X												
+reqsign-core@3.0.0	X												
+reqsign-file-read-tokio@3.0.0	X												
+reqsign-google@3.0.0	X												
+reqsign-huaweicloud-obs@3.0.0	X												
+reqsign-tencent-cos@3.0.0	X												
+reqwest@0.13.2	X									X			
+rsa@0.9.10	X									X			
+rust-ini@0.21.3										X			
+rustc-hash@2.1.2	X									X			
+rustc_version@0.4.1	X									X			
+rustix@1.1.4	X	X								X			
+rustls@0.23.38	X							X		X			
+rustls-native-certs@0.8.3	X							X		X			
+rustls-pki-types@1.14.0	X									X			
+rustls-platform-verifier@0.6.2	X									X			
+rustls-platform-verifier-android@0.1.1	X									X			
+rustls-webpki@0.103.12								X					
+rustversion@1.0.22	X									X			
+ryu@1.0.23	X				X								
+salsa20@0.10.2	X									X			
+same-file@1.0.6										X			X
+schannel@0.1.29										X			
+scopeguard@1.2.0	X									X			
+scrypt@0.11.0	X									X			
+security-framework@3.7.0	X									X			
+security-framework-sys@2.17.0	X									X			
+semver@1.0.28	X									X			
+serde@1.0.228	X									X			
+serde_core@1.0.228	X									X			
+serde_derive@1.0.228	X									X			
+serde_json@1.0.149	X									X			
+serde_urlencoded@0.7.1	X									X			
+sha1@0.10.6	X									X			
+sha2@0.10.9	X									X			
+shlex@1.3.0	X									X			
+signal-hook-registry@1.4.8	X									X			
+signature@2.2.0	X									X			
+simple_asn1@0.6.4								X					
+slab@0.4.12										X			
+smallvec@1.15.1	X									X			
+socket2@0.6.3	X									X			
+spin@0.9.8										X			
+spki@0.7.3	X									X			
+stable_deref_trait@1.2.1	X									X			
+subtle@2.6.1				X									
+syn@1.0.109	X									X			
+syn@2.0.117	X									X			
+sync_wrapper@1.0.2	X												
+synstructure@0.13.2										X			
+thiserror@1.0.69	X									X			
+thiserror@2.0.18	X									X			
+thiserror-impl@1.0.69	X									X			
+thiserror-impl@2.0.18	X									X			
+time@0.3.47	X									X			
+time-core@0.1.8	X									X			
+time-macros@0.2.27	X									X			
+tiny-keccak@2.0.2						X							
+tinystr@0.8.3												X	
+tokio@1.52.0										X			
+tokio-macros@2.7.0										X			
+tokio-rustls@0.26.4	X									X			
+tokio-util@0.7.18										X			
+tower@0.5.3										X			
+tower-http@0.6.8										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-core@0.1.36										X			
+try-lock@0.2.5										X			
+typenum@1.19.0	X									X			
+unicode-ident@1.0.24	X									X		X	
+untrusted@0.7.1								X					
+untrusted@0.9.0								X					
+url@2.5.8	X									X			
+utf8_iter@1.0.4	X									X			
+uuid@1.23.1	X									X			
+version_check@0.9.5	X									X			
+walkdir@2.5.0										X			X
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
+wasip2@1.0.1+wasi-0.2.4	X	X								X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
+wasm-bindgen@0.2.118	X									X			
+wasm-bindgen-futures@0.4.68	X									X			
+wasm-bindgen-macro@0.2.118	X									X			
+wasm-bindgen-macro-support@0.2.118	X									X			
+wasm-bindgen-shared@0.2.118	X									X			
+wasm-streams@0.5.0	X									X			
+web-sys@0.3.95	X									X			
+web-time@1.1.0	X									X			
+webpki-root-certs@1.0.6							X						
+winapi-util@0.1.11										X			X
+windows-link@0.2.1	X									X			
+windows-sys@0.45.0	X									X			
+windows-sys@0.61.2	X									X			
+windows-targets@0.42.2	X									X			
+windows_aarch64_gnullvm@0.42.2	X									X			
+windows_aarch64_msvc@0.42.2	X									X			
+windows_i686_gnu@0.42.2	X									X			
+windows_i686_msvc@0.42.2	X									X			
+windows_x86_64_gnu@0.42.2	X									X			
+windows_x86_64_gnullvm@0.42.2	X									X			
+windows_x86_64_msvc@0.42.2	X									X			
+wit-bindgen@0.46.0	X	X								X			
+wit-bindgen@0.51.0	X	X								X			
+writeable@0.6.3												X	
+xattr@1.6.1	X									X			
+yoke@0.8.2												X	
+yoke-derive@0.8.2												X	
+zerocopy@0.8.48	X		X							X			
+zerofrom@0.1.7												X	
+zerofrom-derive@0.1.7												X	
+zeroize@1.8.2	X									X			
+zerotrie@0.2.4												X	
+zerovec@0.11.6												X	
+zerovec-derive@0.11.3												X	
+zmij@1.0.21										X			

--- a/bindings/nodejs/DEPENDENCIES.rust.tsv
+++ b/bindings/nodejs/DEPENDENCIES.rust.tsv
@@ -1,275 +1,311 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-aes@0.8.4	X									X			
-allocator-api2@0.2.21	X									X			
-android_system_properties@0.1.5	X									X			
-anyhow@1.0.100	X									X			
-async-trait@0.1.89	X									X			
-atomic-waker@1.1.2	X									X			
-autocfg@1.5.0	X									X			
-backon@1.6.0	X												
-base64@0.22.1	X									X			
-base64ct@1.8.0	X									X			
-bitflags@2.10.0	X									X			
-block-buffer@0.10.4	X									X			
-block-padding@0.3.3	X									X			
-bumpalo@3.19.0	X									X			
-bytes@1.11.0										X			
-cbc@0.1.2	X									X			
-cc@1.2.47	X									X			
-cfg-if@1.0.4	X									X			
-chrono@0.4.42	X									X			
-cipher@0.4.4	X									X			
-const-oid@0.9.6	X									X			
-const-random@0.1.18	X									X			
-const-random-macro@0.1.16	X									X			
-convert_case@0.8.0										X			
-core-foundation-sys@0.8.7	X									X			
-cpufeatures@0.2.17	X									X			
-crc32c@0.6.8	X									X			
-crossbeam-utils@0.8.21	X									X			
-crunchy@0.2.4										X			
-crypto-common@0.1.7	X									X			
-ctor@0.6.1	X									X			
-ctor-proc-macro@0.0.7	X									X			
-dashmap@6.1.0										X			
-der@0.7.10	X									X			
-deranged@0.5.5	X									X			
-digest@0.10.7	X									X			
-displaydoc@0.2.5	X									X			
-dlv-list@0.5.2	X									X			
-dtor@0.1.1	X									X			
-dtor-proc-macro@0.0.6	X									X			
-either@1.15.0	X									X			
-equivalent@1.0.2	X									X			
-fastrand@2.3.0	X									X			
-find-msvc-tools@0.1.5	X									X			
-fnv@1.0.7	X									X			
-foldhash@0.2.0													X
-form_urlencoded@1.2.2	X									X			
-futures@0.3.31	X									X			
-futures-channel@0.3.31	X									X			
-futures-core@0.3.31	X									X			
-futures-executor@0.3.31	X									X			
-futures-io@0.3.31	X									X			
-futures-macro@0.3.31	X									X			
-futures-sink@0.3.31	X									X			
-futures-task@0.3.31	X									X			
-futures-timer@3.0.3	X									X			
-futures-util@0.3.31	X									X			
-generic-array@0.14.7										X			
-getrandom@0.2.16	X									X			
-getrandom@0.3.4	X									X			
-ghac@0.2.0	X												
-gloo-timers@0.3.0	X									X			
-governor@0.10.2										X			
-hashbrown@0.14.5	X									X			
-hashbrown@0.16.1	X									X			
-hex@0.4.3	X									X			
-hmac@0.12.1	X									X			
-home@0.5.11	X									X			
-http@1.3.1	X									X			
-http-body@1.0.1										X			
-http-body-util@0.1.3										X			
-httparse@1.10.1	X									X			
-hyper@1.8.1										X			
-hyper-rustls@0.27.7	X							X		X			
-hyper-util@0.1.18										X			
-iana-time-zone@0.1.64	X									X			
-iana-time-zone-haiku@0.1.2	X									X			
-icu_collections@2.1.1											X		
-icu_locale_core@2.1.1											X		
-icu_normalizer@2.1.1											X		
-icu_normalizer_data@2.1.1											X		
-icu_properties@2.1.1											X		
-icu_properties_data@2.1.1											X		
-icu_provider@2.1.1											X		
-idna@1.1.0	X									X			
-idna_adapter@1.2.1	X									X			
-inout@0.1.4	X									X			
-ipnet@2.11.0	X									X			
-iri-string@0.7.9	X									X			
-itertools@0.14.0	X									X			
-itoa@1.0.15	X									X			
-jiff@0.2.16										X		X	
-jiff-tzdb@0.1.4										X		X	
-jiff-tzdb-platform@0.1.3										X		X	
-js-sys@0.3.82	X									X			
-jsonwebtoken@9.3.1										X			
-lazy_static@1.5.0	X									X			
-libc@0.2.177	X									X			
-libloading@0.8.9								X					
-libm@0.2.15										X			
-litemap@0.8.1											X		
-lock_api@0.4.14	X									X			
-log@0.4.28	X									X			
-md-5@0.10.6	X									X			
-memchr@2.7.6										X		X	
-mio@1.1.0										X			
-napi@3.4.0										X			
-napi-build@2.2.4										X			
-napi-derive@3.3.0										X			
-napi-derive-backend@3.0.0										X			
-napi-sys@3.0.1										X			
-nohash-hasher@0.2.0	X									X			
-nonzero_ext@0.3.0	X												
-num-bigint@0.4.6	X									X			
-num-bigint-dig@0.8.6	X									X			
-num-conv@0.1.0	X									X			
-num-integer@0.1.46	X									X			
-num-iter@0.1.45	X									X			
-num-traits@0.2.19	X									X			
-once_cell@1.21.3	X									X			
-opendal@0.55.0	X												
-opendal-nodejs@0.0.0	X												
-ordered-multimap@0.7.3										X			
-parking_lot@0.12.5	X									X			
-parking_lot_core@0.9.12	X									X			
-pbkdf2@0.12.2	X									X			
-pem@3.0.6										X			
-pem-rfc7468@0.7.0	X									X			
-percent-encoding@2.3.2	X									X			
-pin-project-lite@0.2.16	X									X			
-pin-utils@0.1.0	X									X			
-pkcs1@0.7.5	X									X			
-pkcs5@0.7.1	X									X			
-pkcs8@0.10.2	X									X			
-portable-atomic@1.11.1	X									X			
-portable-atomic-util@0.2.4	X									X			
-potential_utf@0.1.4											X		
-powerfmt@0.2.0	X									X			
-ppv-lite86@0.2.21	X									X			
-proc-macro2@1.0.103	X									X			
-prost@0.13.5	X												
-prost-derive@0.13.5	X												
-quanta@0.12.6										X			
-quick-xml@0.38.4										X			
-quote@1.0.42	X									X			
-r-efi@5.3.0	X								X	X			
-rand@0.8.5	X									X			
-rand@0.9.2	X									X			
-rand_chacha@0.3.1	X									X			
-rand_chacha@0.9.0	X									X			
-rand_core@0.6.4	X									X			
-rand_core@0.9.3	X									X			
-raw-cpuid@11.6.0										X			
-redox_syscall@0.5.18										X			
-reqsign@0.16.5	X												
-reqsign-aws-v4@2.0.1	X												
-reqsign-core@2.0.1	X												
-reqsign-file-read-tokio@2.0.1	X												
-reqsign-http-send-reqwest@2.0.1	X												
-reqwest@0.12.24	X									X			
-ring@0.17.14	X							X					
-rsa@0.9.9	X									X			
-rust-ini@0.21.3										X			
-rustc-hash@2.1.1	X									X			
-rustc_version@0.4.1	X									X			
-rustls@0.23.35	X							X		X			
-rustls-pki-types@1.13.0	X									X			
-rustls-webpki@0.103.8								X					
-rustversion@1.0.22	X									X			
-ryu@1.0.20	X				X								
-salsa20@0.10.2	X									X			
-scopeguard@1.2.0	X									X			
-scrypt@0.11.0	X									X			
-semver@1.0.27	X									X			
-serde@1.0.228	X									X			
-serde_core@1.0.228	X									X			
-serde_derive@1.0.228	X									X			
-serde_json@1.0.145	X									X			
-serde_urlencoded@0.7.1	X									X			
-sha1@0.10.6	X									X			
-sha2@0.10.9	X									X			
-shlex@1.3.0	X									X			
-signature@2.2.0	X									X			
-simple_asn1@0.6.3								X					
-slab@0.4.11										X			
-smallvec@1.15.1	X									X			
-socket2@0.6.1	X									X			
-spin@0.9.8										X			
-spinning_top@0.3.0	X									X			
-spki@0.7.3	X									X			
-stable_deref_trait@1.2.1	X									X			
-subtle@2.6.1				X									
-syn@2.0.110	X									X			
-sync_wrapper@1.0.2	X												
-synstructure@0.13.2										X			
-thiserror@2.0.17	X									X			
-thiserror-impl@2.0.17	X									X			
-time@0.3.44	X									X			
-time-core@0.1.6	X									X			
-time-macros@0.2.24	X									X			
-tiny-keccak@2.0.2						X							
-tinystr@0.8.2											X		
-tokio@1.48.0										X			
-tokio-rustls@0.26.4	X									X			
-tokio-util@0.7.17										X			
-tower@0.5.2										X			
-tower-http@0.6.6										X			
-tower-layer@0.3.3										X			
-tower-service@0.3.3										X			
-tracing@0.1.41										X			
-tracing-core@0.1.34										X			
-try-lock@0.2.5										X			
-typenum@1.19.0	X									X			
-unicode-ident@1.0.22	X									X	X		
-unicode-segmentation@1.12.0	X									X			
-untrusted@0.9.0								X					
-url@2.5.7	X									X			
-utf8_iter@1.0.4	X									X			
-uuid@1.18.1	X									X			
-version_check@0.9.5	X									X			
-want@0.3.1										X			
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
-wasip2@1.0.1+wasi-0.2.4	X	X								X			
-wasm-bindgen@0.2.105	X									X			
-wasm-bindgen-futures@0.4.55	X									X			
-wasm-bindgen-macro@0.2.105	X									X			
-wasm-bindgen-macro-support@0.2.105	X									X			
-wasm-bindgen-shared@0.2.105	X									X			
-wasm-streams@0.4.2	X									X			
-web-sys@0.3.82	X									X			
-web-time@1.1.0	X									X			
-webpki-roots@1.0.4							X						
-winapi@0.3.9	X									X			
-winapi-i686-pc-windows-gnu@0.4.0	X									X			
-winapi-x86_64-pc-windows-gnu@0.4.0	X									X			
-windows-core@0.62.2	X									X			
-windows-implement@0.60.2	X									X			
-windows-interface@0.59.3	X									X			
-windows-link@0.2.1	X									X			
-windows-result@0.4.1	X									X			
-windows-strings@0.5.1	X									X			
-windows-sys@0.52.0	X									X			
-windows-sys@0.59.0	X									X			
-windows-sys@0.60.2	X									X			
-windows-sys@0.61.2	X									X			
-windows-targets@0.52.6	X									X			
-windows-targets@0.53.5	X									X			
-windows_aarch64_gnullvm@0.52.6	X									X			
-windows_aarch64_gnullvm@0.53.1	X									X			
-windows_aarch64_msvc@0.52.6	X									X			
-windows_aarch64_msvc@0.53.1	X									X			
-windows_i686_gnu@0.52.6	X									X			
-windows_i686_gnu@0.53.1	X									X			
-windows_i686_gnullvm@0.52.6	X									X			
-windows_i686_gnullvm@0.53.1	X									X			
-windows_i686_msvc@0.52.6	X									X			
-windows_i686_msvc@0.53.1	X									X			
-windows_x86_64_gnu@0.52.6	X									X			
-windows_x86_64_gnu@0.53.1	X									X			
-windows_x86_64_gnullvm@0.52.6	X									X			
-windows_x86_64_gnullvm@0.53.1	X									X			
-windows_x86_64_msvc@0.52.6	X									X			
-windows_x86_64_msvc@0.53.1	X									X			
-wit-bindgen@0.46.0	X	X								X			
-writeable@0.6.2											X		
-yoke@0.8.1											X		
-yoke-derive@0.8.1											X		
-zerocopy@0.8.28	X		X							X			
-zerofrom@0.1.6											X		
-zerofrom-derive@0.1.6											X		
-zeroize@1.8.2	X									X			
-zerotrie@0.2.3											X		
-zerovec@0.11.5											X		
-zerovec-derive@0.11.2											X		
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib
+aes@0.8.4	X									X				
+allocator-api2@0.2.21	X									X				
+anyhow@1.0.102	X									X				
+async-trait@0.1.89	X									X				
+atomic-waker@1.1.2	X									X				
+autocfg@1.5.0	X									X				
+aws-lc-rs@1.16.3	X							X						
+aws-lc-sys@0.40.0	X			X				X		X	X			
+backon@1.6.0	X													
+base64@0.22.1	X									X				
+base64ct@1.8.3	X									X				
+bitflags@2.11.1	X									X				
+block-buffer@0.10.4	X									X				
+block-padding@0.3.3	X									X				
+bumpalo@3.20.2	X									X				
+bytes@1.11.1										X				
+cbc@0.1.2	X									X				
+cc@1.2.60	X									X				
+cesu8@1.1.0	X									X				
+cfg-if@1.0.4	X									X				
+cipher@0.4.4	X									X				
+cmake@0.1.58	X									X				
+combine@4.6.7										X				
+const-oid@0.9.6	X									X				
+const-random@0.1.18	X									X				
+const-random-macro@0.1.16	X									X				
+convert_case@0.8.0										X				
+core-foundation@0.10.1	X									X				
+core-foundation-sys@0.8.7	X									X				
+cpufeatures@0.2.17	X									X				
+crc32c@0.6.8	X									X				
+crossbeam-utils@0.8.21	X									X				
+crunchy@0.2.4										X				
+crypto-common@0.1.7	X									X				
+ctor@0.6.3	X									X				
+ctor-proc-macro@0.0.7	X									X				
+dashmap@6.1.0										X				
+der@0.7.10	X									X				
+deranged@0.5.8	X									X				
+digest@0.10.7	X									X				
+displaydoc@0.2.5	X									X				
+dlv-list@0.5.2	X									X				
+dtor@0.1.1	X									X				
+dtor-proc-macro@0.0.6	X									X				
+dunce@1.0.5	X					X					X			
+either@1.15.0	X									X				
+equivalent@1.0.2	X									X				
+errno@0.3.14	X									X				
+fastrand@2.4.1	X									X				
+find-msvc-tools@0.1.9	X									X				
+foldhash@0.2.0														X
+form_urlencoded@1.2.2	X									X				
+fs_extra@1.3.0										X				
+futures@0.3.32	X									X				
+futures-channel@0.3.32	X									X				
+futures-core@0.3.32	X									X				
+futures-executor@0.3.32	X									X				
+futures-io@0.3.32	X									X				
+futures-macro@0.3.32	X									X				
+futures-sink@0.3.32	X									X				
+futures-task@0.3.32	X									X				
+futures-timer@3.0.3	X									X				
+futures-util@0.3.32	X									X				
+generic-array@0.14.7										X				
+getrandom@0.2.17	X									X				
+getrandom@0.3.4	X									X				
+getrandom@0.4.2	X									X				
+ghac@0.2.0	X													
+gloo-timers@0.3.0	X									X				
+governor@0.10.4										X				
+hashbrown@0.14.5	X									X				
+hashbrown@0.16.1	X									X				
+hex@0.4.3	X									X				
+hmac@0.12.1	X									X				
+http@1.4.0	X									X				
+http-body@1.0.1										X				
+http-body-util@0.1.3										X				
+httparse@1.10.1	X									X				
+hyper@1.9.0										X				
+hyper-rustls@0.27.9	X							X		X				
+hyper-util@0.1.20										X				
+icu_collections@2.1.1												X		
+icu_locale_core@2.1.1												X		
+icu_normalizer@2.1.1												X		
+icu_normalizer_data@2.1.1												X		
+icu_properties@2.1.2												X		
+icu_properties_data@2.1.2												X		
+icu_provider@2.1.1												X		
+idna@1.1.0	X									X				
+idna_adapter@1.2.1	X									X				
+inout@0.1.4	X									X				
+ipnet@2.12.0	X									X				
+iri-string@0.7.12	X									X				
+itertools@0.14.0	X									X				
+itoa@1.0.18	X									X				
+jiff@0.2.23										X			X	
+jiff-tzdb@0.1.6										X			X	
+jiff-tzdb-platform@0.1.3										X			X	
+jni@0.21.1	X									X				
+jni-sys@0.3.1	X									X				
+jni-sys@0.4.1	X									X				
+jni-sys-macros@0.4.1	X									X				
+jobserver@0.1.34	X									X				
+js-sys@0.3.95	X									X				
+jsonwebtoken@10.3.0										X				
+lazy_static@1.5.0	X									X				
+libc@0.2.185	X									X				
+libloading@0.8.9								X						
+libm@0.2.16										X				
+linux-raw-sys@0.12.1	X	X								X				
+litemap@0.8.2												X		
+lock_api@0.4.14	X									X				
+log@0.4.29	X									X				
+md-5@0.10.6	X									X				
+mea@0.6.3	X													
+memchr@2.8.0										X			X	
+mio@1.2.0										X				
+napi@3.4.0										X				
+napi-build@2.2.4										X				
+napi-derive@3.3.0										X				
+napi-derive-backend@3.0.0										X				
+napi-sys@3.0.1										X				
+nohash-hasher@0.2.0	X									X				
+nonzero_ext@0.3.0	X													
+num-bigint@0.4.6	X									X				
+num-bigint-dig@0.8.6	X									X				
+num-conv@0.2.1	X									X				
+num-integer@0.1.46	X									X				
+num-iter@0.1.45	X									X				
+num-traits@0.2.19	X									X				
+once_cell@1.21.4	X									X				
+opendal@0.56.0	X													
+opendal-core@0.56.0	X													
+opendal-layer-concurrent-limit@0.56.0	X													
+opendal-layer-logging@0.56.0	X													
+opendal-layer-retry@0.56.0	X													
+opendal-layer-throttle@0.56.0	X													
+opendal-layer-timeout@0.56.0	X													
+opendal-nodejs@0.0.0	X													
+opendal-service-azblob@0.56.0	X													
+opendal-service-azdls@0.56.0	X													
+opendal-service-azure-common@0.56.0	X													
+opendal-service-cos@0.56.0	X													
+opendal-service-fs@0.56.0	X													
+opendal-service-gcs@0.56.0	X													
+opendal-service-ghac@0.56.0	X													
+opendal-service-http@0.56.0	X													
+opendal-service-ipmfs@0.56.0	X													
+opendal-service-obs@0.56.0	X													
+opendal-service-oss@0.56.0	X													
+opendal-service-s3@0.56.0	X													
+opendal-service-webdav@0.56.0	X													
+opendal-service-webhdfs@0.56.0	X													
+openssl-probe@0.2.1	X									X				
+ordered-multimap@0.7.3										X				
+parking_lot@0.12.5	X									X				
+parking_lot_core@0.9.12	X									X				
+pbkdf2@0.12.2	X									X				
+pem@3.0.6										X				
+pem-rfc7468@0.7.0	X									X				
+percent-encoding@2.3.2	X									X				
+pin-project-lite@0.2.17	X									X				
+pkcs1@0.7.5	X									X				
+pkcs5@0.7.1	X									X				
+pkcs8@0.10.2	X									X				
+portable-atomic@1.13.1	X									X				
+portable-atomic-util@0.2.6	X									X				
+potential_utf@0.1.5												X		
+powerfmt@0.2.0	X									X				
+ppv-lite86@0.2.21	X									X				
+proc-macro2@1.0.106	X									X				
+prost@0.13.5	X													
+prost-derive@0.13.5	X													
+quanta@0.12.6										X				
+quick-xml@0.38.4										X				
+quick-xml@0.39.2										X				
+quote@1.0.45	X									X				
+r-efi@5.3.0	X								X	X				
+r-efi@6.0.0	X								X	X				
+rand@0.8.5	X									X				
+rand@0.9.4	X									X				
+rand_chacha@0.3.1	X									X				
+rand_chacha@0.9.0	X									X				
+rand_core@0.6.4	X									X				
+rand_core@0.9.5	X									X				
+raw-cpuid@11.6.0										X				
+redox_syscall@0.5.18										X				
+reqsign-aliyun-oss@3.0.0	X													
+reqsign-aws-v4@3.0.0	X													
+reqsign-azure-storage@3.0.0	X													
+reqsign-core@3.0.0	X													
+reqsign-file-read-tokio@3.0.0	X													
+reqsign-google@3.0.0	X													
+reqsign-huaweicloud-obs@3.0.0	X													
+reqsign-tencent-cos@3.0.0	X													
+reqwest@0.13.2	X									X				
+rsa@0.9.10	X									X				
+rust-ini@0.21.3										X				
+rustc-hash@2.1.2	X									X				
+rustc_version@0.4.1	X									X				
+rustix@1.1.4	X	X								X				
+rustls@0.23.38	X							X		X				
+rustls-native-certs@0.8.3	X							X		X				
+rustls-pki-types@1.14.0	X									X				
+rustls-platform-verifier@0.6.2	X									X				
+rustls-platform-verifier-android@0.1.1	X									X				
+rustls-webpki@0.103.12								X						
+rustversion@1.0.22	X									X				
+ryu@1.0.23	X				X									
+salsa20@0.10.2	X									X				
+same-file@1.0.6										X			X	
+schannel@0.1.29										X				
+scopeguard@1.2.0	X									X				
+scrypt@0.11.0	X									X				
+security-framework@3.7.0	X									X				
+security-framework-sys@2.17.0	X									X				
+semver@1.0.28	X									X				
+serde@1.0.228	X									X				
+serde_core@1.0.228	X									X				
+serde_derive@1.0.228	X									X				
+serde_json@1.0.149	X									X				
+serde_urlencoded@0.7.1	X									X				
+sha1@0.10.6	X									X				
+sha2@0.10.9	X									X				
+shlex@1.3.0	X									X				
+signature@2.2.0	X									X				
+simple_asn1@0.6.4								X						
+slab@0.4.12										X				
+smallvec@1.15.1	X									X				
+socket2@0.6.3	X									X				
+spin@0.9.8										X				
+spinning_top@0.3.0	X									X				
+spki@0.7.3	X									X				
+stable_deref_trait@1.2.1	X									X				
+subtle@2.6.1				X										
+syn@2.0.117	X									X				
+sync_wrapper@1.0.2	X													
+synstructure@0.13.2										X				
+thiserror@1.0.69	X									X				
+thiserror@2.0.18	X									X				
+thiserror-impl@1.0.69	X									X				
+thiserror-impl@2.0.18	X									X				
+time@0.3.47	X									X				
+time-core@0.1.8	X									X				
+time-macros@0.2.27	X									X				
+tiny-keccak@2.0.2						X								
+tinystr@0.8.3												X		
+tokio@1.52.0										X				
+tokio-macros@2.7.0										X				
+tokio-rustls@0.26.4	X									X				
+tokio-util@0.7.18										X				
+tower@0.5.3										X				
+tower-http@0.6.8										X				
+tower-layer@0.3.3										X				
+tower-service@0.3.3										X				
+tracing@0.1.44										X				
+tracing-core@0.1.36										X				
+try-lock@0.2.5										X				
+typenum@1.19.0	X									X				
+unicode-ident@1.0.24	X									X		X		
+unicode-segmentation@1.13.2	X									X				
+untrusted@0.7.1								X						
+untrusted@0.9.0								X						
+url@2.5.8	X									X				
+utf8_iter@1.0.4	X									X				
+uuid@1.23.1	X									X				
+version_check@0.9.5	X									X				
+walkdir@2.5.0										X			X	
+want@0.3.1										X				
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X				
+wasip2@1.0.1+wasi-0.2.4	X	X								X				
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X				
+wasm-bindgen@0.2.118	X									X				
+wasm-bindgen-futures@0.4.68	X									X				
+wasm-bindgen-macro@0.2.118	X									X				
+wasm-bindgen-macro-support@0.2.118	X									X				
+wasm-bindgen-shared@0.2.118	X									X				
+wasm-streams@0.5.0	X									X				
+web-sys@0.3.95	X									X				
+web-time@1.1.0	X									X				
+webpki-root-certs@1.0.6							X							
+winapi@0.3.9	X									X				
+winapi-i686-pc-windows-gnu@0.4.0	X									X				
+winapi-util@0.1.11										X			X	
+winapi-x86_64-pc-windows-gnu@0.4.0	X									X				
+windows-link@0.2.1	X									X				
+windows-sys@0.45.0	X									X				
+windows-sys@0.61.2	X									X				
+windows-targets@0.42.2	X									X				
+windows_aarch64_gnullvm@0.42.2	X									X				
+windows_aarch64_msvc@0.42.2	X									X				
+windows_i686_gnu@0.42.2	X									X				
+windows_i686_msvc@0.42.2	X									X				
+windows_x86_64_gnu@0.42.2	X									X				
+windows_x86_64_gnullvm@0.42.2	X									X				
+windows_x86_64_msvc@0.42.2	X									X				
+wit-bindgen@0.46.0	X	X								X				
+wit-bindgen@0.51.0	X	X								X				
+writeable@0.6.3												X		
+xattr@1.6.1	X									X				
+yoke@0.8.2												X		
+yoke-derive@0.8.2												X		
+zerocopy@0.8.48	X		X							X				
+zerofrom@0.1.7												X		
+zerofrom-derive@0.1.7												X		
+zeroize@1.8.2	X									X				
+zerotrie@0.2.4												X		
+zerovec@0.11.6												X		
+zerovec-derive@0.11.3												X		
+zmij@1.0.21										X				

--- a/bindings/nodejs/generated.js
+++ b/bindings/nodejs/generated.js
@@ -99,8 +99,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-android-arm64')
         const bindingPackageVersion = require('@opendal/lib-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -115,8 +115,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-android-arm-eabi')
         const bindingPackageVersion = require('@opendal/lib-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -135,8 +135,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-x64-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-ia32-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-arm64-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@opendal/lib-darwin-universal')
       const bindingPackageVersion = require('@opendal/lib-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-darwin-x64')
         const bindingPackageVersion = require('@opendal/lib-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-darwin-arm64')
         const bindingPackageVersion = require('@opendal/lib-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-freebsd-x64')
         const bindingPackageVersion = require('@opendal/lib-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-freebsd-arm64')
         const bindingPackageVersion = require('@opendal/lib-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-x64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-x64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm-musleabihf')
           const bindingPackageVersion = require('@opendal/lib-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@opendal/lib-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-riscv64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-riscv64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -410,8 +410,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-linux-ppc64-gnu')
         const bindingPackageVersion = require('@opendal/lib-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -426,8 +426,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-linux-s390x-gnu')
         const bindingPackageVersion = require('@opendal/lib-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -446,8 +446,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-arm64')
         const bindingPackageVersion = require('@opendal/lib-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -462,8 +462,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-x64')
         const bindingPackageVersion = require('@opendal/lib-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -478,8 +478,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-arm')
         const bindingPackageVersion = require('@opendal/lib-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.49.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-arm64",
-  "version": "0.49.2",
+  "version": "0.49.3",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-x64",
-  "version": "0.49.2",
+  "version": "0.49.3",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-gnu",
-  "version": "0.49.2",
+  "version": "0.49.3",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-musl",
-  "version": "0.49.2",
+  "version": "0.49.3",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.49.2",
+  "version": "0.49.3",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/linux-x64-musl/package.json
+++ b/bindings/nodejs/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-musl",
-  "version": "0.49.2",
+  "version": "0.49.3",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-arm64-msvc",
-  "version": "0.49.2",
+  "version": "0.49.3",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.49.2",
+  "version": "0.49.3",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "Apache OpenDAL <dev@opendal.apache.org>",
-  "version": "0.49.2",
+  "version": "0.49.3",
   "license": "Apache-2.0",
   "main": "index.cjs",
   "module": "index.mjs",

--- a/bindings/ocaml/DEPENDENCIES.rust.tsv
+++ b/bindings/ocaml/DEPENDENCIES.rust.tsv
@@ -1,249 +1,290 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense
-aes@0.8.4	X									X		
-android_system_properties@0.1.5	X									X		
-anyhow@1.0.100	X									X		
-async-trait@0.1.89	X									X		
-atomic-waker@1.1.2	X									X		
-autocfg@1.5.0	X									X		
-backon@1.6.0	X											
-base64@0.22.1	X									X		
-base64ct@1.8.0	X									X		
-bitflags@2.10.0	X									X		
-block-buffer@0.10.4	X									X		
-block-padding@0.3.3	X									X		
-bumpalo@3.19.0	X									X		
-bytes@1.11.0										X		
-cbc@0.1.2	X									X		
-cc@1.2.47	X									X		
-cfg-if@1.0.4	X									X		
-chrono@0.4.42	X									X		
-cipher@0.4.4	X									X		
-const-oid@0.9.6	X									X		
-const-random@0.1.18	X									X		
-const-random-macro@0.1.16	X									X		
-core-foundation-sys@0.8.7	X									X		
-cpufeatures@0.2.17	X									X		
-crc32c@0.6.8	X									X		
-crunchy@0.2.4										X		
-crypto-common@0.1.7	X									X		
-cty@0.2.2	X									X		
-der@0.7.10	X									X		
-deranged@0.5.5	X									X		
-digest@0.10.7	X									X		
-displaydoc@0.2.5	X									X		
-dlv-list@0.5.2	X									X		
-either@1.15.0	X									X		
-fastrand@2.3.0	X									X		
-find-msvc-tools@0.1.5	X									X		
-fnv@1.0.7	X									X		
-form_urlencoded@1.2.2	X									X		
-futures@0.3.31	X									X		
-futures-channel@0.3.31	X									X		
-futures-core@0.3.31	X									X		
-futures-io@0.3.31	X									X		
-futures-macro@0.3.31	X									X		
-futures-sink@0.3.31	X									X		
-futures-task@0.3.31	X									X		
-futures-util@0.3.31	X									X		
-generic-array@0.14.7										X		
-getrandom@0.2.16	X									X		
-getrandom@0.3.4	X									X		
-ghac@0.2.0	X											
-gloo-timers@0.3.0	X									X		
-hashbrown@0.14.5	X									X		
-hex@0.4.3	X									X		
-hmac@0.12.1	X									X		
-home@0.5.11	X									X		
-http@1.3.1	X									X		
-http-body@1.0.1										X		
-http-body-util@0.1.3										X		
-httparse@1.10.1	X									X		
-hyper@1.8.1										X		
-hyper-rustls@0.27.7	X							X		X		
-hyper-util@0.1.18										X		
-iana-time-zone@0.1.64	X									X		
-iana-time-zone-haiku@0.1.2	X									X		
-icu_collections@2.1.1											X	
-icu_locale_core@2.1.1											X	
-icu_normalizer@2.1.1											X	
-icu_normalizer_data@2.1.1											X	
-icu_properties@2.1.1											X	
-icu_properties_data@2.1.1											X	
-icu_provider@2.1.1											X	
-idna@1.1.0	X									X		
-idna_adapter@1.2.1	X									X		
-inout@0.1.4	X									X		
-ipnet@2.11.0	X									X		
-iri-string@0.7.9	X									X		
-itertools@0.14.0	X									X		
-itoa@1.0.15	X									X		
-jiff@0.2.16										X		X
-jiff-tzdb@0.1.4										X		X
-jiff-tzdb-platform@0.1.3										X		X
-js-sys@0.3.82	X									X		
-jsonwebtoken@9.3.1										X		
-lazy_static@1.5.0	X									X		
-libc@0.2.177	X									X		
-libm@0.2.15										X		
-litemap@0.8.1											X	
-lock_api@0.4.14	X									X		
-log@0.4.28	X									X		
-md-5@0.10.6	X									X		
-memchr@2.7.6										X		X
-mio@1.1.0										X		
-num-bigint@0.4.6	X									X		
-num-bigint-dig@0.8.6	X									X		
-num-conv@0.1.0	X									X		
-num-integer@0.1.46	X									X		
-num-iter@0.1.45	X									X		
-num-traits@0.2.19	X									X		
-ocaml@1.3.0								X				
-ocaml-boxroot-sys@0.4.0										X		
-ocaml-build@1.0.0								X				
-ocaml-derive@1.0.0								X				
-ocaml-sys@0.26.0								X				
-once_cell@1.21.3	X									X		
-opendal@0.55.0	X											
-opendal-ocaml@0.0.0	X											
-ordered-multimap@0.7.3										X		
-parking_lot@0.12.5	X									X		
-parking_lot_core@0.9.12	X									X		
-pbkdf2@0.12.2	X									X		
-pem@3.0.6										X		
-pem-rfc7468@0.7.0	X									X		
-percent-encoding@2.3.2	X									X		
-pin-project-lite@0.2.16	X									X		
-pin-utils@0.1.0	X									X		
-pkcs1@0.7.5	X									X		
-pkcs5@0.7.1	X									X		
-pkcs8@0.10.2	X									X		
-portable-atomic@1.11.1	X									X		
-portable-atomic-util@0.2.4	X									X		
-potential_utf@0.1.4											X	
-powerfmt@0.2.0	X									X		
-ppv-lite86@0.2.21	X									X		
-proc-macro2@1.0.103	X									X		
-prost@0.13.5	X											
-prost-derive@0.13.5	X											
-quick-xml@0.38.4										X		
-quote@1.0.42	X									X		
-r-efi@5.3.0	X								X	X		
-rand@0.8.5	X									X		
-rand_chacha@0.3.1	X									X		
-rand_core@0.6.4	X									X		
-redox_syscall@0.5.18										X		
-reqsign@0.16.5	X											
-reqsign-aws-v4@2.0.1	X											
-reqsign-core@2.0.1	X											
-reqsign-file-read-tokio@2.0.1	X											
-reqsign-http-send-reqwest@2.0.1	X											
-reqwest@0.12.24	X									X		
-ring@0.17.14	X							X				
-rsa@0.9.9	X									X		
-rust-ini@0.21.3										X		
-rustc_version@0.4.1	X									X		
-rustls@0.23.35	X							X		X		
-rustls-pki-types@1.13.0	X									X		
-rustls-webpki@0.103.8								X				
-rustversion@1.0.22	X									X		
-ryu@1.0.20	X				X							
-salsa20@0.10.2	X									X		
-scopeguard@1.2.0	X									X		
-scrypt@0.11.0	X									X		
-semver@1.0.27	X									X		
-serde@1.0.228	X									X		
-serde_core@1.0.228	X									X		
-serde_derive@1.0.228	X									X		
-serde_json@1.0.145	X									X		
-serde_urlencoded@0.7.1	X									X		
-sha1@0.10.6	X									X		
-sha2@0.10.9	X									X		
-shlex@1.3.0	X									X		
-signal-hook-registry@1.4.6	X									X		
-signature@2.2.0	X									X		
-simple_asn1@0.6.3								X				
-slab@0.4.11										X		
-smallvec@1.15.1	X									X		
-socket2@0.6.1	X									X		
-spin@0.9.8										X		
-spki@0.7.3	X									X		
-stable_deref_trait@1.2.1	X									X		
-subtle@2.6.1				X								
-syn@2.0.110	X									X		
-sync_wrapper@1.0.2	X											
-synstructure@0.13.2										X		
-thiserror@2.0.17	X									X		
-thiserror-impl@2.0.17	X									X		
-time@0.3.44	X									X		
-time-core@0.1.6	X									X		
-time-macros@0.2.24	X									X		
-tiny-keccak@2.0.2						X						
-tinystr@0.8.2											X	
-tokio@1.48.0										X		
-tokio-macros@2.6.0										X		
-tokio-rustls@0.26.4	X									X		
-tokio-util@0.7.17										X		
-tower@0.5.2										X		
-tower-http@0.6.6										X		
-tower-layer@0.3.3										X		
-tower-service@0.3.3										X		
-tracing@0.1.41										X		
-tracing-core@0.1.34										X		
-try-lock@0.2.5										X		
-typenum@1.19.0	X									X		
-unicode-ident@1.0.22	X									X	X	
-untrusted@0.9.0								X				
-url@2.5.7	X									X		
-utf8_iter@1.0.4	X									X		
-uuid@1.18.1	X									X		
-version_check@0.9.5	X									X		
-want@0.3.1										X		
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X		
-wasip2@1.0.1+wasi-0.2.4	X	X								X		
-wasm-bindgen@0.2.105	X									X		
-wasm-bindgen-futures@0.4.55	X									X		
-wasm-bindgen-macro@0.2.105	X									X		
-wasm-bindgen-macro-support@0.2.105	X									X		
-wasm-bindgen-shared@0.2.105	X									X		
-wasm-streams@0.4.2	X									X		
-web-sys@0.3.82	X									X		
-webpki-roots@1.0.4							X					
-windows-core@0.62.2	X									X		
-windows-implement@0.60.2	X									X		
-windows-interface@0.59.3	X									X		
-windows-link@0.2.1	X									X		
-windows-result@0.4.1	X									X		
-windows-strings@0.5.1	X									X		
-windows-sys@0.52.0	X									X		
-windows-sys@0.59.0	X									X		
-windows-sys@0.60.2	X									X		
-windows-sys@0.61.2	X									X		
-windows-targets@0.52.6	X									X		
-windows-targets@0.53.5	X									X		
-windows_aarch64_gnullvm@0.52.6	X									X		
-windows_aarch64_gnullvm@0.53.1	X									X		
-windows_aarch64_msvc@0.52.6	X									X		
-windows_aarch64_msvc@0.53.1	X									X		
-windows_i686_gnu@0.52.6	X									X		
-windows_i686_gnu@0.53.1	X									X		
-windows_i686_gnullvm@0.52.6	X									X		
-windows_i686_gnullvm@0.53.1	X									X		
-windows_i686_msvc@0.52.6	X									X		
-windows_i686_msvc@0.53.1	X									X		
-windows_x86_64_gnu@0.52.6	X									X		
-windows_x86_64_gnu@0.53.1	X									X		
-windows_x86_64_gnullvm@0.52.6	X									X		
-windows_x86_64_gnullvm@0.53.1	X									X		
-windows_x86_64_msvc@0.52.6	X									X		
-windows_x86_64_msvc@0.53.1	X									X		
-wit-bindgen@0.46.0	X	X								X		
-writeable@0.6.2											X	
-yoke@0.8.1											X	
-yoke-derive@0.8.1											X	
-zerocopy@0.8.28	X		X							X		
-zerofrom@0.1.6											X	
-zerofrom-derive@0.1.6											X	
-zeroize@1.8.2	X									X		
-zerotrie@0.2.3											X	
-zerovec@0.11.5											X	
-zerovec-derive@0.11.2											X	
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
+aes@0.8.4	X									X			
+anyhow@1.0.102	X									X			
+async-trait@0.1.89	X									X			
+atomic-waker@1.1.2	X									X			
+autocfg@1.5.0	X									X			
+aws-lc-rs@1.16.3	X							X					
+aws-lc-sys@0.40.0	X			X				X		X	X		
+backon@1.6.0	X												
+base64@0.22.1	X									X			
+base64ct@1.8.3	X									X			
+bitflags@2.11.1	X									X			
+block-buffer@0.10.4	X									X			
+block-padding@0.3.3	X									X			
+bumpalo@3.20.2	X									X			
+bytes@1.11.1										X			
+cbc@0.1.2	X									X			
+cc@1.2.60	X									X			
+cesu8@1.1.0	X									X			
+cfg-if@1.0.4	X									X			
+cipher@0.4.4	X									X			
+cmake@0.1.58	X									X			
+combine@4.6.7										X			
+const-oid@0.9.6	X									X			
+const-random@0.1.18	X									X			
+const-random-macro@0.1.16	X									X			
+core-foundation@0.10.1	X									X			
+core-foundation-sys@0.8.7	X									X			
+cpufeatures@0.2.17	X									X			
+crc32c@0.6.8	X									X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7	X									X			
+ctor@0.6.3	X									X			
+ctor-proc-macro@0.0.7	X									X			
+cty@0.2.2	X									X			
+der@0.7.10	X									X			
+deranged@0.5.8	X									X			
+digest@0.10.7	X									X			
+displaydoc@0.2.5	X									X			
+dlv-list@0.5.2	X									X			
+dtor@0.1.1	X									X			
+dtor-proc-macro@0.0.6	X									X			
+dunce@1.0.5	X					X					X		
+either@1.15.0	X									X			
+errno@0.3.14	X									X			
+fastrand@2.4.1	X									X			
+find-msvc-tools@0.1.9	X									X			
+form_urlencoded@1.2.2	X									X			
+fs_extra@1.3.0										X			
+futures@0.3.32	X									X			
+futures-channel@0.3.32	X									X			
+futures-core@0.3.32	X									X			
+futures-executor@0.3.32	X									X			
+futures-io@0.3.32	X									X			
+futures-macro@0.3.32	X									X			
+futures-sink@0.3.32	X									X			
+futures-task@0.3.32	X									X			
+futures-util@0.3.32	X									X			
+generic-array@0.14.7										X			
+getrandom@0.2.17	X									X			
+getrandom@0.3.4	X									X			
+getrandom@0.4.2	X									X			
+ghac@0.2.0	X												
+gloo-timers@0.3.0	X									X			
+hashbrown@0.14.5	X									X			
+hex@0.4.3	X									X			
+hmac@0.12.1	X									X			
+http@1.4.0	X									X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1	X									X			
+hyper@1.9.0										X			
+hyper-rustls@0.27.9	X							X		X			
+hyper-util@0.1.20										X			
+icu_collections@2.1.1												X	
+icu_locale_core@2.1.1												X	
+icu_normalizer@2.1.1												X	
+icu_normalizer_data@2.1.1												X	
+icu_properties@2.1.2												X	
+icu_properties_data@2.1.2												X	
+icu_provider@2.1.1												X	
+idna@1.1.0	X									X			
+idna_adapter@1.2.1	X									X			
+inout@0.1.4	X									X			
+ipnet@2.12.0	X									X			
+iri-string@0.7.12	X									X			
+itertools@0.14.0	X									X			
+itoa@1.0.18	X									X			
+jiff@0.2.23										X			X
+jiff-tzdb@0.1.6										X			X
+jiff-tzdb-platform@0.1.3										X			X
+jni@0.21.1	X									X			
+jni-sys@0.3.1	X									X			
+jni-sys@0.4.1	X									X			
+jni-sys-macros@0.4.1	X									X			
+jobserver@0.1.34	X									X			
+js-sys@0.3.95	X									X			
+jsonwebtoken@10.3.0										X			
+lazy_static@1.5.0	X									X			
+libc@0.2.185	X									X			
+libm@0.2.16										X			
+linux-raw-sys@0.12.1	X	X								X			
+litemap@0.8.2												X	
+lock_api@0.4.14	X									X			
+log@0.4.29	X									X			
+md-5@0.10.6	X									X			
+mea@0.6.3	X												
+memchr@2.8.0										X			X
+mio@1.2.0										X			
+num-bigint@0.4.6	X									X			
+num-bigint-dig@0.8.6	X									X			
+num-conv@0.2.1	X									X			
+num-integer@0.1.46	X									X			
+num-iter@0.1.45	X									X			
+num-traits@0.2.19	X									X			
+ocaml@1.3.0								X					
+ocaml-boxroot-sys@0.4.0										X			
+ocaml-build@1.0.0								X					
+ocaml-derive@1.0.0								X					
+ocaml-sys@0.26.0								X					
+once_cell@1.21.4	X									X			
+opendal@0.56.0	X												
+opendal-core@0.56.0	X												
+opendal-layer-concurrent-limit@0.56.0	X												
+opendal-layer-logging@0.56.0	X												
+opendal-layer-retry@0.56.0	X												
+opendal-layer-timeout@0.56.0	X												
+opendal-ocaml@0.0.0	X												
+opendal-service-azblob@0.56.0	X												
+opendal-service-azdls@0.56.0	X												
+opendal-service-azfile@0.56.0	X												
+opendal-service-azure-common@0.56.0	X												
+opendal-service-cos@0.56.0	X												
+opendal-service-fs@0.56.0	X												
+opendal-service-gcs@0.56.0	X												
+opendal-service-ghac@0.56.0	X												
+opendal-service-http@0.56.0	X												
+opendal-service-ipmfs@0.56.0	X												
+opendal-service-obs@0.56.0	X												
+opendal-service-oss@0.56.0	X												
+opendal-service-s3@0.56.0	X												
+opendal-service-webdav@0.56.0	X												
+opendal-service-webhdfs@0.56.0	X												
+openssl-probe@0.2.1	X									X			
+ordered-multimap@0.7.3										X			
+parking_lot@0.12.5	X									X			
+parking_lot_core@0.9.12	X									X			
+pbkdf2@0.12.2	X									X			
+pem@3.0.6										X			
+pem-rfc7468@0.7.0	X									X			
+percent-encoding@2.3.2	X									X			
+pin-project-lite@0.2.17	X									X			
+pkcs1@0.7.5	X									X			
+pkcs5@0.7.1	X									X			
+pkcs8@0.10.2	X									X			
+portable-atomic@1.13.1	X									X			
+portable-atomic-util@0.2.6	X									X			
+potential_utf@0.1.5												X	
+powerfmt@0.2.0	X									X			
+ppv-lite86@0.2.21	X									X			
+proc-macro2@1.0.106	X									X			
+prost@0.13.5	X												
+prost-derive@0.13.5	X												
+quick-xml@0.38.4										X			
+quick-xml@0.39.2										X			
+quote@1.0.45	X									X			
+r-efi@5.3.0	X								X	X			
+r-efi@6.0.0	X								X	X			
+rand@0.8.5	X									X			
+rand_chacha@0.3.1	X									X			
+rand_core@0.6.4	X									X			
+redox_syscall@0.5.18										X			
+reqsign-aliyun-oss@3.0.0	X												
+reqsign-aws-v4@3.0.0	X												
+reqsign-azure-storage@3.0.0	X												
+reqsign-core@3.0.0	X												
+reqsign-file-read-tokio@3.0.0	X												
+reqsign-google@3.0.0	X												
+reqsign-huaweicloud-obs@3.0.0	X												
+reqsign-tencent-cos@3.0.0	X												
+reqwest@0.13.2	X									X			
+rsa@0.9.10	X									X			
+rust-ini@0.21.3										X			
+rustc_version@0.4.1	X									X			
+rustix@1.1.4	X	X								X			
+rustls@0.23.38	X							X		X			
+rustls-native-certs@0.8.3	X							X		X			
+rustls-pki-types@1.14.0	X									X			
+rustls-platform-verifier@0.6.2	X									X			
+rustls-platform-verifier-android@0.1.1	X									X			
+rustls-webpki@0.103.12								X					
+rustversion@1.0.22	X									X			
+ryu@1.0.23	X				X								
+salsa20@0.10.2	X									X			
+same-file@1.0.6										X			X
+schannel@0.1.29										X			
+scopeguard@1.2.0	X									X			
+scrypt@0.11.0	X									X			
+security-framework@3.7.0	X									X			
+security-framework-sys@2.17.0	X									X			
+semver@1.0.28	X									X			
+serde@1.0.228	X									X			
+serde_core@1.0.228	X									X			
+serde_derive@1.0.228	X									X			
+serde_json@1.0.149	X									X			
+serde_urlencoded@0.7.1	X									X			
+sha1@0.10.6	X									X			
+sha2@0.10.9	X									X			
+shlex@1.3.0	X									X			
+signal-hook-registry@1.4.8	X									X			
+signature@2.2.0	X									X			
+simple_asn1@0.6.4								X					
+slab@0.4.12										X			
+smallvec@1.15.1	X									X			
+socket2@0.6.3	X									X			
+spin@0.9.8										X			
+spki@0.7.3	X									X			
+stable_deref_trait@1.2.1	X									X			
+subtle@2.6.1				X									
+syn@2.0.117	X									X			
+sync_wrapper@1.0.2	X												
+synstructure@0.13.2										X			
+thiserror@1.0.69	X									X			
+thiserror@2.0.18	X									X			
+thiserror-impl@1.0.69	X									X			
+thiserror-impl@2.0.18	X									X			
+time@0.3.47	X									X			
+time-core@0.1.8	X									X			
+time-macros@0.2.27	X									X			
+tiny-keccak@2.0.2						X							
+tinystr@0.8.3												X	
+tokio@1.52.0										X			
+tokio-macros@2.7.0										X			
+tokio-rustls@0.26.4	X									X			
+tokio-util@0.7.18										X			
+tower@0.5.3										X			
+tower-http@0.6.8										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-core@0.1.36										X			
+try-lock@0.2.5										X			
+typenum@1.19.0	X									X			
+unicode-ident@1.0.24	X									X		X	
+untrusted@0.7.1								X					
+untrusted@0.9.0								X					
+url@2.5.8	X									X			
+utf8_iter@1.0.4	X									X			
+uuid@1.23.1	X									X			
+version_check@0.9.5	X									X			
+walkdir@2.5.0										X			X
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
+wasip2@1.0.1+wasi-0.2.4	X	X								X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
+wasm-bindgen@0.2.118	X									X			
+wasm-bindgen-futures@0.4.68	X									X			
+wasm-bindgen-macro@0.2.118	X									X			
+wasm-bindgen-macro-support@0.2.118	X									X			
+wasm-bindgen-shared@0.2.118	X									X			
+wasm-streams@0.5.0	X									X			
+web-sys@0.3.95	X									X			
+web-time@1.1.0	X									X			
+webpki-root-certs@1.0.6							X						
+winapi-util@0.1.11										X			X
+windows-link@0.2.1	X									X			
+windows-sys@0.45.0	X									X			
+windows-sys@0.61.2	X									X			
+windows-targets@0.42.2	X									X			
+windows_aarch64_gnullvm@0.42.2	X									X			
+windows_aarch64_msvc@0.42.2	X									X			
+windows_i686_gnu@0.42.2	X									X			
+windows_i686_msvc@0.42.2	X									X			
+windows_x86_64_gnu@0.42.2	X									X			
+windows_x86_64_gnullvm@0.42.2	X									X			
+windows_x86_64_msvc@0.42.2	X									X			
+wit-bindgen@0.46.0	X	X								X			
+wit-bindgen@0.51.0	X	X								X			
+writeable@0.6.3												X	
+xattr@1.6.1	X									X			
+yoke@0.8.2												X	
+yoke-derive@0.8.2												X	
+zerocopy@0.8.48	X		X							X			
+zerofrom@0.1.7												X	
+zerofrom-derive@0.1.7												X	
+zeroize@1.8.2	X									X			
+zerotrie@0.2.4												X	
+zerovec@0.11.6												X	
+zerovec-derive@0.11.3												X	
+zmij@1.0.21										X			

--- a/bindings/php/DEPENDENCIES.rust.tsv
+++ b/bindings/php/DEPENDENCIES.rust.tsv
@@ -1,314 +1,355 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X									X			
-aes@0.8.4		X									X			
-android_system_properties@0.1.5		X									X			
-anyhow@1.0.100		X									X			
-async-trait@0.1.89		X									X			
-atomic-waker@1.1.2		X									X			
-autocfg@1.5.0		X									X			
-backon@1.6.0		X												
-base64@0.22.1		X									X			
-base64ct@1.8.0		X									X			
-bindgen@0.68.1					X									
-bitflags@2.10.0		X									X			
-block-buffer@0.10.4		X									X			
-block-padding@0.3.3		X									X			
-bumpalo@3.19.0		X									X			
-bytecount@0.6.9		X									X			
-byteorder@1.5.0											X		X	
-bytes@1.11.0											X			
-bzip2@0.4.4		X									X			
-bzip2-sys@0.1.13+1.0.8		X									X			
-camino@1.2.1		X									X			
-cargo-platform@0.1.9		X									X			
-cargo_metadata@0.14.2											X			
-cbc@0.1.2		X									X			
-cc@1.2.47		X									X			
-cexpr@0.6.0		X									X			
-cfg-if@1.0.4		X									X			
-chrono@0.4.42		X									X			
-cipher@0.4.4		X									X			
-clang-sys@1.8.1		X												
-const-oid@0.9.6		X									X			
-const-random@0.1.18		X									X			
-const-random-macro@0.1.16		X									X			
-constant_time_eq@0.1.5							X							
-core-foundation@0.9.4		X									X			
-core-foundation-sys@0.8.7		X									X			
-cpufeatures@0.2.17		X									X			
-crc32c@0.6.8		X									X			
-crc32fast@1.5.0		X									X			
-crossbeam-utils@0.8.21		X									X			
-crunchy@0.2.4											X			
-crypto-common@0.1.7		X									X			
-darling@0.14.4											X			
-darling_core@0.14.4											X			
-darling_macro@0.14.4											X			
-der@0.7.10		X									X			
-deranged@0.5.5		X									X			
-digest@0.10.7		X									X			
-displaydoc@0.2.5		X									X			
-dlv-list@0.5.2		X									X			
-either@1.15.0		X									X			
-errno@0.3.14		X									X			
-error-chain@0.12.4		X									X			
-ext-php-rs@0.13.1		X									X			
-ext-php-rs-derive@0.10.2		X									X			
-fastrand@2.3.0		X									X			
-find-msvc-tools@0.1.5		X									X			
-flate2@1.1.5		X									X			
-fnv@1.0.7		X									X			
-foreign-types@0.3.2		X									X			
-foreign-types-shared@0.1.1		X									X			
-form_urlencoded@1.2.2		X									X			
-futures@0.3.31		X									X			
-futures-channel@0.3.31		X									X			
-futures-core@0.3.31		X									X			
-futures-io@0.3.31		X									X			
-futures-macro@0.3.31		X									X			
-futures-sink@0.3.31		X									X			
-futures-task@0.3.31		X									X			
-futures-util@0.3.31		X									X			
-generic-array@0.14.7											X			
-getrandom@0.2.16		X									X			
-getrandom@0.3.4		X									X			
-ghac@0.2.0		X												
-glob@0.3.3		X									X			
-gloo-timers@0.3.0		X									X			
-hashbrown@0.14.5		X									X			
-hex@0.4.3		X									X			
-hmac@0.12.1		X									X			
-home@0.5.11		X									X			
-http@1.3.1		X									X			
-http-body@1.0.1											X			
-http-body-util@0.1.3											X			
-httparse@1.10.1		X									X			
-hyper@1.8.1											X			
-hyper-rustls@0.27.7		X							X		X			
-hyper-util@0.1.18											X			
-iana-time-zone@0.1.64		X									X			
-iana-time-zone-haiku@0.1.2		X									X			
-icu_collections@2.1.1												X		
-icu_locale_core@2.1.1												X		
-icu_normalizer@2.1.1												X		
-icu_normalizer_data@2.1.1												X		
-icu_properties@2.1.1												X		
-icu_properties_data@2.1.1												X		
-icu_provider@2.1.1												X		
-ident_case@1.0.1		X									X			
-idna@1.1.0		X									X			
-idna_adapter@1.2.1		X									X			
-inout@0.1.4		X									X			
-ipnet@2.11.0		X									X			
-iri-string@0.7.9		X									X			
-itertools@0.14.0		X									X			
-itoa@1.0.15		X									X			
-jiff@0.2.16											X		X	
-jiff-tzdb@0.1.4											X		X	
-jiff-tzdb-platform@0.1.3											X		X	
-jobserver@0.1.34		X									X			
-js-sys@0.3.82		X									X			
-jsonwebtoken@9.3.1											X			
-lazy_static@1.5.0		X									X			
-lazycell@1.3.0		X									X			
-libc@0.2.177		X									X			
-libloading@0.8.9									X					
-libm@0.2.15											X			
-linux-raw-sys@0.11.0		X	X								X			
-linux-raw-sys@0.4.15		X	X								X			
-litemap@0.8.1												X		
-lock_api@0.4.14		X									X			
-log@0.4.28		X									X			
-md-5@0.10.6		X									X			
-memchr@2.7.6											X		X	
-minimal-lexical@0.2.1		X									X			
-miniz_oxide@0.8.9		X									X			X
-mio@1.1.0											X			
-native-tls@0.2.14		X									X			
-nom@7.1.3											X			
-num-bigint@0.4.6		X									X			
-num-bigint-dig@0.8.6		X									X			
-num-conv@0.1.0		X									X			
-num-integer@0.1.46		X									X			
-num-iter@0.1.45		X									X			
-num-traits@0.2.19		X									X			
-once_cell@1.21.3		X									X			
-opendal@0.55.0		X												
-opendal-php@0.0.0		X												
-openssl@0.10.75		X												
-openssl-macros@0.1.1		X									X			
-openssl-probe@0.1.6		X									X			
-openssl-sys@0.9.111											X			
-ordered-multimap@0.7.3											X			
-parking_lot@0.12.5		X									X			
-parking_lot_core@0.9.12		X									X			
-password-hash@0.4.2		X									X			
-pbkdf2@0.11.0		X									X			
-pbkdf2@0.12.2		X									X			
-peeking_take_while@0.1.2		X									X			
-pem@3.0.6											X			
-pem-rfc7468@0.7.0		X									X			
-percent-encoding@2.3.2		X									X			
-pin-project-lite@0.2.16		X									X			
-pin-utils@0.1.0		X									X			
-pkcs1@0.7.5		X									X			
-pkcs5@0.7.1		X									X			
-pkcs8@0.10.2		X									X			
-pkg-config@0.3.32		X									X			
-portable-atomic@1.11.1		X									X			
-portable-atomic-util@0.2.4		X									X			
-potential_utf@0.1.4												X		
-powerfmt@0.2.0		X									X			
-ppv-lite86@0.2.21		X									X			
-prettyplease@0.2.37		X									X			
-proc-macro2@1.0.103		X									X			
-prost@0.13.5		X												
-prost-derive@0.13.5		X												
-pulldown-cmark@0.9.6											X			
-quick-xml@0.38.4											X			
-quote@1.0.42		X									X			
-r-efi@5.3.0		X								X	X			
-rand@0.8.5		X									X			
-rand_chacha@0.3.1		X									X			
-rand_core@0.6.4		X									X			
-redox_syscall@0.5.18											X			
-regex@1.12.2		X									X			
-regex-automata@0.4.13		X									X			
-regex-syntax@0.8.8		X									X			
-reqsign@0.16.5		X												
-reqsign-aws-v4@2.0.1		X												
-reqsign-core@2.0.1		X												
-reqsign-file-read-tokio@2.0.1		X												
-reqsign-http-send-reqwest@2.0.1		X												
-reqwest@0.12.24		X									X			
-ring@0.17.14		X							X					
-rsa@0.9.9		X									X			
-rust-ini@0.21.3											X			
-rustc-hash@1.1.0		X									X			
-rustc_version@0.4.1		X									X			
-rustix@0.38.44		X	X								X			
-rustix@1.1.2		X	X								X			
-rustls@0.23.35		X							X		X			
-rustls-pki-types@1.13.0		X									X			
-rustls-webpki@0.103.8									X					
-rustversion@1.0.22		X									X			
-ryu@1.0.20		X				X								
-salsa20@0.10.2		X									X			
-same-file@1.0.6											X		X	
-schannel@0.1.28											X			
-scopeguard@1.2.0		X									X			
-scrypt@0.11.0		X									X			
-security-framework@2.11.1		X									X			
-security-framework-sys@2.15.0		X									X			
-semver@1.0.27		X									X			
-serde@1.0.228		X									X			
-serde_core@1.0.228		X									X			
-serde_derive@1.0.228		X									X			
-serde_json@1.0.145		X									X			
-serde_urlencoded@0.7.1		X									X			
-sha1@0.10.6		X									X			
-sha2@0.10.9		X									X			
-shlex@1.3.0		X									X			
-signal-hook-registry@1.4.6		X									X			
-signature@2.2.0		X									X			
-simd-adler32@0.3.7											X			
-simple_asn1@0.6.3									X					
-skeptic@0.13.7		X									X			
-slab@0.4.11											X			
-smallvec@1.15.1		X									X			
-socket2@0.6.1		X									X			
-spin@0.9.8											X			
-spki@0.7.3		X									X			
-stable_deref_trait@1.2.1		X									X			
-strsim@0.10.0											X			
-subtle@2.6.1					X									
-syn@1.0.109		X									X			
-syn@2.0.110		X									X			
-sync_wrapper@1.0.2		X												
-synstructure@0.13.2											X			
-tempfile@3.23.0		X									X			
-thiserror@2.0.17		X									X			
-thiserror-impl@2.0.17		X									X			
-time@0.3.44		X									X			
-time-core@0.1.6		X									X			
-time-macros@0.2.24		X									X			
-tiny-keccak@2.0.2							X							
-tinystr@0.8.2												X		
-tokio@1.48.0											X			
-tokio-macros@2.6.0											X			
-tokio-rustls@0.26.4		X									X			
-tokio-util@0.7.17											X			
-tower@0.5.2											X			
-tower-http@0.6.6											X			
-tower-layer@0.3.3											X			
-tower-service@0.3.3											X			
-tracing@0.1.41											X			
-tracing-core@0.1.34											X			
-try-lock@0.2.5											X			
-typenum@1.19.0		X									X			
-unicase@2.8.1		X									X			
-unicode-ident@1.0.22		X									X	X		
-untrusted@0.9.0									X					
-ureq@2.12.1		X									X			
-url@2.5.7		X									X			
-utf8_iter@1.0.4		X									X			
-uuid@1.18.1		X									X			
-vcpkg@0.2.15		X									X			
-version_check@0.9.5		X									X			
-walkdir@2.5.0											X		X	
-want@0.3.1											X			
-wasi@0.11.1+wasi-snapshot-preview1		X	X								X			
-wasip2@1.0.1+wasi-0.2.4		X	X								X			
-wasm-bindgen@0.2.105		X									X			
-wasm-bindgen-futures@0.4.55		X									X			
-wasm-bindgen-macro@0.2.105		X									X			
-wasm-bindgen-macro-support@0.2.105		X									X			
-wasm-bindgen-shared@0.2.105		X									X			
-wasm-streams@0.4.2		X									X			
-web-sys@0.3.82		X									X			
-webpki-roots@1.0.4								X						
-which@4.4.2											X			
-winapi-util@0.1.11											X		X	
-windows-core@0.62.2		X									X			
-windows-implement@0.60.2		X									X			
-windows-interface@0.59.3		X									X			
-windows-link@0.2.1		X									X			
-windows-result@0.4.1		X									X			
-windows-strings@0.5.1		X									X			
-windows-sys@0.52.0		X									X			
-windows-sys@0.59.0		X									X			
-windows-sys@0.60.2		X									X			
-windows-sys@0.61.2		X									X			
-windows-targets@0.52.6		X									X			
-windows-targets@0.53.5		X									X			
-windows_aarch64_gnullvm@0.52.6		X									X			
-windows_aarch64_gnullvm@0.53.1		X									X			
-windows_aarch64_msvc@0.52.6		X									X			
-windows_aarch64_msvc@0.53.1		X									X			
-windows_i686_gnu@0.52.6		X									X			
-windows_i686_gnu@0.53.1		X									X			
-windows_i686_gnullvm@0.52.6		X									X			
-windows_i686_gnullvm@0.53.1		X									X			
-windows_i686_msvc@0.52.6		X									X			
-windows_i686_msvc@0.53.1		X									X			
-windows_x86_64_gnu@0.52.6		X									X			
-windows_x86_64_gnu@0.53.1		X									X			
-windows_x86_64_gnullvm@0.52.6		X									X			
-windows_x86_64_gnullvm@0.53.1		X									X			
-windows_x86_64_msvc@0.52.6		X									X			
-windows_x86_64_msvc@0.53.1		X									X			
-wit-bindgen@0.46.0		X	X								X			
-writeable@0.6.2												X		
-yoke@0.8.1												X		
-yoke-derive@0.8.1												X		
-zerocopy@0.8.28		X		X							X			
-zerofrom@0.1.6												X		
-zerofrom-derive@0.1.6												X		
-zeroize@1.8.2		X									X			
-zerotrie@0.2.3												X		
-zerovec@0.11.5												X		
-zerovec-derive@0.11.2												X		
-zip@0.6.6											X			
-zstd@0.11.2+zstd.1.5.2											X			
-zstd-safe@5.0.2+zstd.1.5.2		X									X			
-zstd-sys@2.0.16+zstd.1.5.7		X									X			
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X				
+aes@0.8.4		X									X				
+anyhow@1.0.102		X									X				
+async-trait@0.1.89		X									X				
+atomic-waker@1.1.2		X									X				
+autocfg@1.5.0		X									X				
+aws-lc-rs@1.16.3		X							X						
+aws-lc-sys@0.40.0		X			X				X		X	X			
+backon@1.6.0		X													
+base64@0.22.1		X									X				
+base64ct@1.8.3		X									X				
+bindgen@0.68.1					X										
+bitflags@2.11.1		X									X				
+block-buffer@0.10.4		X									X				
+block-padding@0.3.3		X									X				
+bumpalo@3.20.2		X									X				
+bytecount@0.6.9		X									X				
+byteorder@1.5.0											X			X	
+bytes@1.11.1											X				
+bzip2@0.4.4		X									X				
+bzip2-sys@0.1.13+1.0.8		X									X				
+camino@1.2.2		X									X				
+cargo-platform@0.1.9		X									X				
+cargo_metadata@0.14.2											X				
+cbc@0.1.2		X									X				
+cc@1.2.60		X									X				
+cesu8@1.1.0		X									X				
+cexpr@0.6.0		X									X				
+cfg-if@1.0.4		X									X				
+cipher@0.4.4		X									X				
+clang-sys@1.8.1		X													
+cmake@0.1.58		X									X				
+combine@4.6.7											X				
+const-oid@0.9.6		X									X				
+const-random@0.1.18		X									X				
+const-random-macro@0.1.16		X									X				
+constant_time_eq@0.1.5							X								
+core-foundation@0.10.1		X									X				
+core-foundation-sys@0.8.7		X									X				
+cpufeatures@0.2.17		X									X				
+crc32c@0.6.8		X									X				
+crc32fast@1.5.0		X									X				
+crossbeam-utils@0.8.21		X									X				
+crunchy@0.2.4											X				
+crypto-common@0.1.7		X									X				
+ctor@0.6.3		X									X				
+ctor-proc-macro@0.0.7		X									X				
+darling@0.14.4											X				
+darling_core@0.14.4											X				
+darling_macro@0.14.4											X				
+der@0.7.10		X									X				
+deranged@0.5.8		X									X				
+digest@0.10.7		X									X				
+displaydoc@0.2.5		X									X				
+dlv-list@0.5.2		X									X				
+dtor@0.1.1		X									X				
+dtor-proc-macro@0.0.6		X									X				
+dunce@1.0.5		X					X					X			
+either@1.15.0		X									X				
+errno@0.3.14		X									X				
+error-chain@0.12.4		X									X				
+ext-php-rs@0.13.1		X									X				
+ext-php-rs-derive@0.10.2		X									X				
+fastrand@2.4.1		X									X				
+find-msvc-tools@0.1.9		X									X				
+flate2@1.1.9		X									X				
+fnv@1.0.7		X									X				
+foreign-types@0.3.2		X									X				
+foreign-types-shared@0.1.1		X									X				
+form_urlencoded@1.2.2		X									X				
+fs_extra@1.3.0											X				
+futures@0.3.32		X									X				
+futures-channel@0.3.32		X									X				
+futures-core@0.3.32		X									X				
+futures-executor@0.3.32		X									X				
+futures-io@0.3.32		X									X				
+futures-macro@0.3.32		X									X				
+futures-sink@0.3.32		X									X				
+futures-task@0.3.32		X									X				
+futures-util@0.3.32		X									X				
+generic-array@0.14.7											X				
+getrandom@0.2.17		X									X				
+getrandom@0.3.4		X									X				
+getrandom@0.4.2		X									X				
+ghac@0.2.0		X													
+glob@0.3.3		X									X				
+gloo-timers@0.3.0		X									X				
+hashbrown@0.14.5		X									X				
+hex@0.4.3		X									X				
+hmac@0.12.1		X									X				
+home@0.5.11		X									X				
+http@1.4.0		X									X				
+http-body@1.0.1											X				
+http-body-util@0.1.3											X				
+httparse@1.10.1		X									X				
+hyper@1.9.0											X				
+hyper-rustls@0.27.9		X							X		X				
+hyper-util@0.1.20											X				
+icu_collections@2.1.1													X		
+icu_locale_core@2.1.1													X		
+icu_normalizer@2.1.1													X		
+icu_normalizer_data@2.1.1													X		
+icu_properties@2.1.2													X		
+icu_properties_data@2.1.2													X		
+icu_provider@2.1.1													X		
+ident_case@1.0.1		X									X				
+idna@1.1.0		X									X				
+idna_adapter@1.2.1		X									X				
+inout@0.1.4		X									X				
+ipnet@2.12.0		X									X				
+iri-string@0.7.12		X									X				
+itertools@0.14.0		X									X				
+itoa@1.0.18		X									X				
+jiff@0.2.23											X			X	
+jiff-tzdb@0.1.6											X			X	
+jiff-tzdb-platform@0.1.3											X			X	
+jni@0.21.1		X									X				
+jni-sys@0.3.1		X									X				
+jni-sys@0.4.1		X									X				
+jni-sys-macros@0.4.1		X									X				
+jobserver@0.1.34		X									X				
+js-sys@0.3.95		X									X				
+jsonwebtoken@10.3.0											X				
+lazy_static@1.5.0		X									X				
+lazycell@1.3.0		X									X				
+libc@0.2.185		X									X				
+libloading@0.8.9									X						
+libm@0.2.16											X				
+linux-raw-sys@0.12.1		X	X								X				
+linux-raw-sys@0.4.15		X	X								X				
+litemap@0.8.2													X		
+lock_api@0.4.14		X									X				
+log@0.4.29		X									X				
+md-5@0.10.6		X									X				
+mea@0.6.3		X													
+memchr@2.8.0											X			X	
+minimal-lexical@0.2.1		X									X				
+miniz_oxide@0.8.9		X									X				X
+mio@1.2.0											X				
+native-tls@0.2.18		X									X				
+nom@7.1.3											X				
+num-bigint@0.4.6		X									X				
+num-bigint-dig@0.8.6		X									X				
+num-conv@0.2.1		X									X				
+num-integer@0.1.46		X									X				
+num-iter@0.1.45		X									X				
+num-traits@0.2.19		X									X				
+once_cell@1.21.4		X									X				
+opendal@0.56.0		X													
+opendal-core@0.56.0		X													
+opendal-layer-concurrent-limit@0.56.0		X													
+opendal-layer-logging@0.56.0		X													
+opendal-layer-retry@0.56.0		X													
+opendal-layer-timeout@0.56.0		X													
+opendal-php@0.0.0		X													
+opendal-service-azblob@0.56.0		X													
+opendal-service-azdls@0.56.0		X													
+opendal-service-azfile@0.56.0		X													
+opendal-service-azure-common@0.56.0		X													
+opendal-service-cos@0.56.0		X													
+opendal-service-fs@0.56.0		X													
+opendal-service-gcs@0.56.0		X													
+opendal-service-ghac@0.56.0		X													
+opendal-service-http@0.56.0		X													
+opendal-service-ipmfs@0.56.0		X													
+opendal-service-obs@0.56.0		X													
+opendal-service-oss@0.56.0		X													
+opendal-service-s3@0.56.0		X													
+opendal-service-webdav@0.56.0		X													
+opendal-service-webhdfs@0.56.0		X													
+openssl@0.10.77		X													
+openssl-macros@0.1.1		X									X				
+openssl-probe@0.2.1		X									X				
+openssl-sys@0.9.113											X				
+ordered-multimap@0.7.3											X				
+parking_lot@0.12.5		X									X				
+parking_lot_core@0.9.12		X									X				
+password-hash@0.4.2		X									X				
+pbkdf2@0.11.0		X									X				
+pbkdf2@0.12.2		X									X				
+peeking_take_while@0.1.2		X									X				
+pem@3.0.6											X				
+pem-rfc7468@0.7.0		X									X				
+percent-encoding@2.3.2		X									X				
+pin-project-lite@0.2.17		X									X				
+pkcs1@0.7.5		X									X				
+pkcs5@0.7.1		X									X				
+pkcs8@0.10.2		X									X				
+pkg-config@0.3.33		X									X				
+portable-atomic@1.13.1		X									X				
+portable-atomic-util@0.2.6		X									X				
+potential_utf@0.1.5													X		
+powerfmt@0.2.0		X									X				
+ppv-lite86@0.2.21		X									X				
+prettyplease@0.2.37		X									X				
+proc-macro2@1.0.106		X									X				
+prost@0.13.5		X													
+prost-derive@0.13.5		X													
+pulldown-cmark@0.9.6											X				
+quick-xml@0.38.4											X				
+quick-xml@0.39.2											X				
+quote@1.0.45		X									X				
+r-efi@5.3.0		X								X	X				
+r-efi@6.0.0		X								X	X				
+rand@0.8.5		X									X				
+rand_chacha@0.3.1		X									X				
+rand_core@0.6.4		X									X				
+redox_syscall@0.5.18											X				
+regex@1.12.3		X									X				
+regex-automata@0.4.14		X									X				
+regex-syntax@0.8.10		X									X				
+reqsign-aliyun-oss@3.0.0		X													
+reqsign-aws-v4@3.0.0		X													
+reqsign-azure-storage@3.0.0		X													
+reqsign-core@3.0.0		X													
+reqsign-file-read-tokio@3.0.0		X													
+reqsign-google@3.0.0		X													
+reqsign-huaweicloud-obs@3.0.0		X													
+reqsign-tencent-cos@3.0.0		X													
+reqwest@0.13.2		X									X				
+rsa@0.9.10		X									X				
+rust-ini@0.21.3											X				
+rustc-hash@1.1.0		X									X				
+rustc_version@0.4.1		X									X				
+rustix@0.38.44		X	X								X				
+rustix@1.1.4		X	X								X				
+rustls@0.23.38		X							X		X				
+rustls-native-certs@0.8.3		X							X		X				
+rustls-pki-types@1.14.0		X									X				
+rustls-platform-verifier@0.6.2		X									X				
+rustls-platform-verifier-android@0.1.1		X									X				
+rustls-webpki@0.103.12									X						
+rustversion@1.0.22		X									X				
+ryu@1.0.23		X				X									
+salsa20@0.10.2		X									X				
+same-file@1.0.6											X			X	
+schannel@0.1.29											X				
+scopeguard@1.2.0		X									X				
+scrypt@0.11.0		X									X				
+security-framework@3.7.0		X									X				
+security-framework-sys@2.17.0		X									X				
+semver@1.0.28		X									X				
+serde@1.0.228		X									X				
+serde_core@1.0.228		X									X				
+serde_derive@1.0.228		X									X				
+serde_json@1.0.149		X									X				
+serde_urlencoded@0.7.1		X									X				
+sha1@0.10.6		X									X				
+sha2@0.10.9		X									X				
+shlex@1.3.0		X									X				
+signal-hook-registry@1.4.8		X									X				
+signature@2.2.0		X									X				
+simd-adler32@0.3.9											X				
+simple_asn1@0.6.4									X						
+skeptic@0.13.7		X									X				
+slab@0.4.12											X				
+smallvec@1.15.1		X									X				
+socket2@0.6.3		X									X				
+spin@0.9.8											X				
+spki@0.7.3		X									X				
+stable_deref_trait@1.2.1		X									X				
+strsim@0.10.0											X				
+subtle@2.6.1					X										
+syn@1.0.109		X									X				
+syn@2.0.117		X									X				
+sync_wrapper@1.0.2		X													
+synstructure@0.13.2											X				
+tempfile@3.27.0		X									X				
+thiserror@1.0.69		X									X				
+thiserror@2.0.18		X									X				
+thiserror-impl@1.0.69		X									X				
+thiserror-impl@2.0.18		X									X				
+time@0.3.47		X									X				
+time-core@0.1.8		X									X				
+time-macros@0.2.27		X									X				
+tiny-keccak@2.0.2							X								
+tinystr@0.8.3													X		
+tokio@1.52.0											X				
+tokio-macros@2.7.0											X				
+tokio-rustls@0.26.4		X									X				
+tokio-util@0.7.18											X				
+tower@0.5.3											X				
+tower-http@0.6.8											X				
+tower-layer@0.3.3											X				
+tower-service@0.3.3											X				
+tracing@0.1.44											X				
+tracing-core@0.1.36											X				
+try-lock@0.2.5											X				
+typenum@1.19.0		X									X				
+unicase@2.9.0		X									X				
+unicode-ident@1.0.24		X									X		X		
+untrusted@0.7.1									X						
+untrusted@0.9.0									X						
+ureq@2.12.1		X									X				
+url@2.5.8		X									X				
+utf8_iter@1.0.4		X									X				
+uuid@1.23.1		X									X				
+vcpkg@0.2.15		X									X				
+version_check@0.9.5		X									X				
+walkdir@2.5.0											X			X	
+want@0.3.1											X				
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X				
+wasip2@1.0.1+wasi-0.2.4		X	X								X				
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X				
+wasm-bindgen@0.2.118		X									X				
+wasm-bindgen-futures@0.4.68		X									X				
+wasm-bindgen-macro@0.2.118		X									X				
+wasm-bindgen-macro-support@0.2.118		X									X				
+wasm-bindgen-shared@0.2.118		X									X				
+wasm-streams@0.5.0		X									X				
+web-sys@0.3.95		X									X				
+web-time@1.1.0		X									X				
+webpki-root-certs@1.0.6								X							
+which@4.4.2											X				
+winapi-util@0.1.11											X			X	
+windows-link@0.2.1		X									X				
+windows-sys@0.45.0		X									X				
+windows-sys@0.59.0		X									X				
+windows-sys@0.61.2		X									X				
+windows-targets@0.42.2		X									X				
+windows-targets@0.52.6		X									X				
+windows_aarch64_gnullvm@0.42.2		X									X				
+windows_aarch64_gnullvm@0.52.6		X									X				
+windows_aarch64_msvc@0.42.2		X									X				
+windows_aarch64_msvc@0.52.6		X									X				
+windows_i686_gnu@0.42.2		X									X				
+windows_i686_gnu@0.52.6		X									X				
+windows_i686_gnullvm@0.52.6		X									X				
+windows_i686_msvc@0.42.2		X									X				
+windows_i686_msvc@0.52.6		X									X				
+windows_x86_64_gnu@0.42.2		X									X				
+windows_x86_64_gnu@0.52.6		X									X				
+windows_x86_64_gnullvm@0.42.2		X									X				
+windows_x86_64_gnullvm@0.52.6		X									X				
+windows_x86_64_msvc@0.42.2		X									X				
+windows_x86_64_msvc@0.52.6		X									X				
+wit-bindgen@0.46.0		X	X								X				
+wit-bindgen@0.51.0		X	X								X				
+writeable@0.6.3													X		
+xattr@1.6.1		X									X				
+yoke@0.8.2													X		
+yoke-derive@0.8.2													X		
+zerocopy@0.8.48		X		X							X				
+zerofrom@0.1.7													X		
+zerofrom-derive@0.1.7													X		
+zeroize@1.8.2		X									X				
+zerotrie@0.2.4													X		
+zerovec@0.11.6													X		
+zerovec-derive@0.11.3													X		
+zip@0.6.6											X				
+zmij@1.0.21											X				
+zstd@0.11.2+zstd.1.5.2											X				
+zstd-safe@5.0.2+zstd.1.5.2		X									X				
+zstd-sys@2.0.16+zstd.1.5.7		X									X				

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.85"
-version = "0.47.0"
+version = "0.47.1"
 
 [features]
 default = [

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -1,308 +1,347 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	LGPL-3.0	MIT	Unicode-3.0	Unicode-DFS-2016	Unlicense
-aes@0.8.4	X										X			
-ahash@0.8.12	X										X			
-android_system_properties@0.1.5	X										X			
-anyhow@1.0.100	X										X			
-async-trait@0.1.89	X										X			
-atomic-waker@1.1.2	X										X			
-autocfg@1.5.0	X										X			
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unicode-DFS-2016	Unlicense
+aes@0.8.4	X									X				
+android_system_properties@0.1.5	X									X				
+anyhow@1.0.102	X									X				
+async-trait@0.1.89	X									X				
+atomic-waker@1.1.2	X									X				
+autocfg@1.5.0	X									X				
+aws-lc-rs@1.16.3	X							X						
+aws-lc-sys@0.40.0	X			X				X		X	X			
 backon@1.6.0	X													
-base64@0.22.1	X										X			
-base64ct@1.8.0	X										X			
-bitflags@2.10.0	X										X			
-block-buffer@0.10.4	X										X			
-block-padding@0.3.3	X										X			
-bumpalo@3.19.0	X										X			
-bytes@1.11.0											X			
-cbc@0.1.2	X										X			
-cc@1.2.47	X										X			
-cfg-if@1.0.4	X										X			
-chrono@0.4.42	X										X			
-cipher@0.4.4	X										X			
-const-oid@0.9.6	X										X			
-const-random@0.1.18	X										X			
-const-random-macro@0.1.16	X										X			
-core-foundation-sys@0.8.7	X										X			
-cpufeatures@0.2.17	X										X			
-crc32c@0.6.8	X										X			
-crunchy@0.2.4											X			
-crypto-common@0.1.7	X										X			
-der@0.7.10	X										X			
-deranged@0.5.5	X										X			
-derive_more@1.0.0											X			
-derive_more-impl@1.0.0											X			
-dict_derive@0.6.0	X													
-digest@0.10.7	X										X			
-displaydoc@0.2.5	X										X			
-dlv-list@0.5.2	X										X			
-either@1.15.0	X										X			
-equivalent@1.0.2	X										X			
-fastrand@2.3.0	X										X			
-find-msvc-tools@0.1.5	X										X			
-fnv@1.0.7	X										X			
-form_urlencoded@1.2.2	X										X			
-futures@0.3.31	X										X			
-futures-channel@0.3.31	X										X			
-futures-core@0.3.31	X										X			
-futures-executor@0.3.31	X										X			
-futures-io@0.3.31	X										X			
-futures-macro@0.3.31	X										X			
-futures-sink@0.3.31	X										X			
-futures-task@0.3.31	X										X			
-futures-util@0.3.31	X										X			
-generic-array@0.14.7											X			
-getopts@0.2.24	X										X			
-getrandom@0.2.16	X										X			
-getrandom@0.3.4	X										X			
+base64@0.22.1	X									X				
+base64ct@1.8.3	X									X				
+bitflags@2.11.1	X									X				
+block-buffer@0.10.4	X									X				
+block-padding@0.3.3	X									X				
+bumpalo@3.20.2	X									X				
+bytes@1.11.1										X				
+cbc@0.1.2	X									X				
+cc@1.2.60	X									X				
+cesu8@1.1.0	X									X				
+cfg-if@1.0.4	X									X				
+chrono@0.4.44	X									X				
+cipher@0.4.4	X									X				
+cmake@0.1.58	X									X				
+combine@4.6.7										X				
+const-oid@0.9.6	X									X				
+const-random@0.1.18	X									X				
+const-random-macro@0.1.16	X									X				
+core-foundation@0.10.1	X									X				
+core-foundation-sys@0.8.7	X									X				
+cpufeatures@0.2.17	X									X				
+crc32c@0.6.8	X									X				
+crunchy@0.2.4										X				
+crypto-common@0.1.7	X									X				
+ctor@0.6.3	X									X				
+ctor-proc-macro@0.0.7	X									X				
+der@0.7.10	X									X				
+deranged@0.5.8	X									X				
+digest@0.10.7	X									X				
+displaydoc@0.2.5	X									X				
+dlv-list@0.5.2	X									X				
+dtor@0.1.1	X									X				
+dtor-proc-macro@0.0.6	X									X				
+dunce@1.0.5	X					X					X			
+either@1.15.0	X									X				
+equivalent@1.0.2	X									X				
+errno@0.3.14	X									X				
+fastrand@2.4.1	X									X				
+find-msvc-tools@0.1.9	X									X				
+form_urlencoded@1.2.2	X									X				
+fs_extra@1.3.0										X				
+futures@0.3.32	X									X				
+futures-channel@0.3.32	X									X				
+futures-core@0.3.32	X									X				
+futures-executor@0.3.32	X									X				
+futures-io@0.3.32	X									X				
+futures-macro@0.3.32	X									X				
+futures-sink@0.3.32	X									X				
+futures-task@0.3.32	X									X				
+futures-util@0.3.32	X									X				
+generic-array@0.14.7										X				
+getopts@0.2.24	X									X				
+getrandom@0.2.17	X									X				
+getrandom@0.3.4	X									X				
+getrandom@0.4.2	X									X				
 ghac@0.2.0	X													
-gloo-timers@0.3.0	X										X			
-hashbrown@0.14.5	X										X			
-hashbrown@0.16.1	X										X			
-heck@0.5.0	X										X			
-hex@0.4.3	X										X			
-hmac@0.12.1	X										X			
-home@0.5.11	X										X			
-http@1.3.1	X										X			
-http-body@1.0.1											X			
-http-body-util@0.1.3											X			
-httparse@1.10.1	X										X			
-hyper@1.8.1											X			
-hyper-rustls@0.27.7	X							X			X			
-hyper-util@0.1.18											X			
-iana-time-zone@0.1.64	X										X			
-iana-time-zone-haiku@0.1.2	X										X			
+gloo-timers@0.3.0	X									X				
+hashbrown@0.14.5	X									X				
+hashbrown@0.17.0	X									X				
+heck@0.5.0	X									X				
+hex@0.4.3	X									X				
+hmac@0.12.1	X									X				
+http@1.4.0	X									X				
+http-body@1.0.1										X				
+http-body-util@0.1.3										X				
+httparse@1.10.1	X									X				
+hyper@1.9.0										X				
+hyper-rustls@0.27.9	X							X		X				
+hyper-util@0.1.20										X				
+iana-time-zone@0.1.65	X									X				
+iana-time-zone-haiku@0.1.2	X									X				
 icu_collections@2.1.1												X		
 icu_locale_core@2.1.1												X		
 icu_normalizer@2.1.1												X		
 icu_normalizer_data@2.1.1												X		
-icu_properties@2.1.1												X		
-icu_properties_data@2.1.1												X		
+icu_properties@2.1.2												X		
+icu_properties_data@2.1.2												X		
 icu_provider@2.1.1												X		
-idna@1.1.0	X										X			
-idna_adapter@1.2.1	X										X			
-indexmap@2.12.1	X										X			
-indoc@2.0.7	X										X			
-inout@0.1.4	X										X			
-inventory@0.3.21	X										X			
-ipnet@2.11.0	X										X			
-iri-string@0.7.9	X										X			
+idna@1.1.0	X									X				
+idna_adapter@1.2.1	X									X				
+indexmap@2.14.0	X									X				
+indoc@2.0.7	X									X				
+inout@0.1.4	X									X				
+inventory@0.3.24	X									X				
+ipnet@2.12.0	X									X				
+iri-string@0.7.12	X									X				
 is-macro@0.3.7	X													
-itertools@0.11.0	X										X			
-itertools@0.14.0	X										X			
-itoa@1.0.15	X										X			
-jiff@0.2.16											X			X
-jiff-tzdb@0.1.4											X			X
-jiff-tzdb-platform@0.1.3											X			X
-js-sys@0.3.82	X										X			
-jsonwebtoken@9.3.1											X			
-lalrpop-util@0.20.2	X										X			
-lazy_static@1.5.0	X										X			
-libc@0.2.177	X										X			
-libm@0.2.15											X			
-litemap@0.8.1												X		
-log@0.4.28	X										X			
-malachite@0.4.22										X				
-malachite-base@0.4.22										X				
-malachite-bigint@0.2.3										X				
-malachite-nz@0.4.22										X				
-malachite-q@0.4.22										X				
-maplit@1.0.2	X										X			
-matrixmultiply@0.3.10	X										X			
-md-5@0.10.6	X										X			
-memchr@2.7.6											X			X
-memoffset@0.9.1											X			
-mime@0.3.17	X										X			
-mime_guess@2.0.5											X			
-mio@1.1.0											X			
-ndarray@0.16.1	X										X			
-num-bigint@0.4.6	X										X			
-num-bigint-dig@0.8.6	X										X			
-num-complex@0.4.6	X										X			
-num-conv@0.1.0	X										X			
-num-integer@0.1.46	X										X			
-num-iter@0.1.45	X										X			
-num-traits@0.2.19	X										X			
-numpy@0.26.0			X											
-once_cell@1.21.3	X										X			
-opendal@0.55.0	X													
-opendal-python@0.47.0	X													
-ordered-float@5.1.0											X			
-ordered-multimap@0.7.3											X			
-paste@1.0.15	X										X			
-pbkdf2@0.12.2	X										X			
-pem@3.0.6											X			
-pem-rfc7468@0.7.0	X										X			
-percent-encoding@2.3.2	X										X			
-phf@0.11.3											X			
-phf_codegen@0.11.3											X			
-phf_generator@0.11.3											X			
-phf_shared@0.11.3											X			
-pin-project-lite@0.2.16	X										X			
-pin-utils@0.1.0	X										X			
-pkcs1@0.7.5	X										X			
-pkcs5@0.7.1	X										X			
-pkcs8@0.10.2	X										X			
-portable-atomic@1.11.1	X										X			
-portable-atomic-util@0.2.4	X										X			
-potential_utf@0.1.4												X		
-powerfmt@0.2.0	X										X			
-ppv-lite86@0.2.21	X										X			
-proc-macro2@1.0.103	X										X			
+itertools@0.11.0	X									X				
+itertools@0.14.0	X									X				
+itoa@1.0.18	X									X				
+jiff@0.2.23										X				X
+jiff-tzdb@0.1.6										X				X
+jiff-tzdb-platform@0.1.3										X				X
+jni@0.21.1	X									X				
+jni-sys@0.3.1	X									X				
+jni-sys@0.4.1	X									X				
+jni-sys-macros@0.4.1	X									X				
+jobserver@0.1.34	X									X				
+js-sys@0.3.95	X									X				
+jsonwebtoken@10.3.0										X				
+lalrpop-util@0.20.2	X									X				
+lazy_static@1.5.0	X									X				
+libc@0.2.185	X									X				
+libm@0.2.16										X				
+linux-raw-sys@0.12.1	X	X								X				
+litemap@0.8.2												X		
+log@0.4.29	X									X				
+maplit@1.0.2	X									X				
+matrixmultiply@0.3.10	X									X				
+md-5@0.10.6	X									X				
+mea@0.6.3	X													
+memchr@2.8.0										X				X
+memoffset@0.9.1										X				
+mime@0.3.17	X									X				
+mime_guess@2.0.5										X				
+mio@1.2.0										X				
+ndarray@0.17.2	X									X				
+num-bigint@0.4.6	X									X				
+num-bigint-dig@0.8.6	X									X				
+num-complex@0.4.6	X									X				
+num-conv@0.2.1	X									X				
+num-integer@0.1.46	X									X				
+num-iter@0.1.45	X									X				
+num-traits@0.2.19	X									X				
+numpy@0.27.1			X											
+once_cell@1.21.4	X									X				
+opendal@0.56.0	X													
+opendal-core@0.56.0	X													
+opendal-layer-concurrent-limit@0.56.0	X													
+opendal-layer-logging@0.56.0	X													
+opendal-layer-mime-guess@0.56.0	X													
+opendal-layer-retry@0.56.0	X													
+opendal-layer-timeout@0.56.0	X													
+opendal-python@0.47.1	X													
+opendal-service-azblob@0.56.0	X													
+opendal-service-azdls@0.56.0	X													
+opendal-service-azure-common@0.56.0	X													
+opendal-service-cos@0.56.0	X													
+opendal-service-fs@0.56.0	X													
+opendal-service-gcs@0.56.0	X													
+opendal-service-ghac@0.56.0	X													
+opendal-service-http@0.56.0	X													
+opendal-service-ipmfs@0.56.0	X													
+opendal-service-obs@0.56.0	X													
+opendal-service-oss@0.56.0	X													
+opendal-service-s3@0.56.0	X													
+opendal-service-webdav@0.56.0	X													
+opendal-service-webhdfs@0.56.0	X													
+openssl-probe@0.2.1	X									X				
+ordered-float@5.3.0										X				
+ordered-multimap@0.7.3										X				
+pbkdf2@0.12.2	X									X				
+pem@3.0.6										X				
+pem-rfc7468@0.7.0	X									X				
+percent-encoding@2.3.2	X									X				
+phf@0.11.3										X				
+phf_codegen@0.11.3										X				
+phf_generator@0.11.3										X				
+phf_shared@0.11.3										X				
+pin-project-lite@0.2.17	X									X				
+pkcs1@0.7.5	X									X				
+pkcs5@0.7.1	X									X				
+pkcs8@0.10.2	X									X				
+portable-atomic@1.13.1	X									X				
+portable-atomic-util@0.2.6	X									X				
+potential_utf@0.1.5												X		
+powerfmt@0.2.0	X									X				
+ppv-lite86@0.2.21	X									X				
+proc-macro2@1.0.106	X									X				
 prost@0.13.5	X													
 prost-derive@0.13.5	X													
-pyo3@0.26.0	X										X			
-pyo3-async-runtimes@0.26.0	X													
-pyo3-build-config@0.26.0	X										X			
-pyo3-ffi@0.26.0	X										X			
-pyo3-macros@0.26.0	X										X			
-pyo3-macros-backend@0.26.0	X										X			
-pyo3-stub-gen@0.17.1	X										X			
-pyo3-stub-gen-derive@0.17.1	X										X			
-python3-dll-a@0.2.14											X			
-quick-xml@0.38.4											X			
-quote@1.0.42	X										X			
-r-efi@5.3.0	X								X		X			
-rand@0.8.5	X										X			
-rand_chacha@0.3.1	X										X			
-rand_core@0.6.4	X										X			
-rawpointer@0.2.1	X										X			
-reqsign@0.16.5	X													
-reqsign-aws-v4@2.0.1	X													
-reqsign-core@2.0.1	X													
-reqsign-file-read-tokio@2.0.1	X													
-reqsign-http-send-reqwest@2.0.1	X													
-reqwest@0.12.24	X										X			
-ring@0.17.14	X							X						
-rsa@0.9.9	X										X			
-rust-ini@0.21.3											X			
-rustc-hash@1.1.0	X										X			
-rustc-hash@2.1.1	X										X			
-rustc_version@0.4.1	X										X			
-rustls@0.23.35	X							X			X			
-rustls-pki-types@1.13.0	X										X			
-rustls-webpki@0.103.8								X						
-rustpython-ast@0.4.0											X			
-rustpython-parser@0.4.0											X			
-rustpython-parser-core@0.4.0											X			
-rustpython-parser-vendored@0.4.0											X			
-rustversion@1.0.22	X										X			
-ryu@1.0.20	X				X									
-salsa20@0.10.2	X										X			
-scrypt@0.11.0	X										X			
-semver@1.0.27	X										X			
-serde@1.0.228	X										X			
-serde_core@1.0.228	X										X			
-serde_derive@1.0.228	X										X			
-serde_json@1.0.145	X										X			
-serde_spanned@1.0.3	X										X			
-serde_urlencoded@0.7.1	X										X			
-sha1@0.10.6	X										X			
-sha2@0.10.9	X										X			
-shlex@1.3.0	X										X			
-signature@2.2.0	X										X			
-simple_asn1@0.6.3								X						
-siphasher@1.0.1	X										X			
-slab@0.4.11											X			
-smallvec@1.15.1	X										X			
-socket2@0.6.1	X										X			
-spin@0.9.8											X			
-spki@0.7.3	X										X			
-stable_deref_trait@1.2.1	X										X			
-static_assertions@1.1.0	X										X			
+pyo3@0.27.2	X									X				
+pyo3-async-runtimes@0.27.0	X													
+pyo3-build-config@0.27.2	X									X				
+pyo3-ffi@0.27.2	X									X				
+pyo3-macros@0.27.2	X									X				
+pyo3-macros-backend@0.27.2	X									X				
+pyo3-stub-gen@0.17.2	X									X				
+pyo3-stub-gen-derive@0.17.2	X									X				
+python3-dll-a@0.2.15										X				
+quick-xml@0.38.4										X				
+quick-xml@0.39.2										X				
+quote@1.0.45	X									X				
+r-efi@5.3.0	X								X	X				
+r-efi@6.0.0	X								X	X				
+rand@0.8.5	X									X				
+rand_chacha@0.3.1	X									X				
+rand_core@0.6.4	X									X				
+rawpointer@0.2.1	X									X				
+reqsign-aliyun-oss@3.0.0	X													
+reqsign-aws-v4@3.0.0	X													
+reqsign-azure-storage@3.0.0	X													
+reqsign-core@3.0.0	X													
+reqsign-file-read-tokio@3.0.0	X													
+reqsign-google@3.0.0	X													
+reqsign-huaweicloud-obs@3.0.0	X													
+reqsign-tencent-cos@3.0.0	X													
+reqwest@0.13.2	X									X				
+rsa@0.9.10	X									X				
+rust-ini@0.21.3										X				
+rustc-hash@1.1.0	X									X				
+rustc-hash@2.1.2	X									X				
+rustc_version@0.4.1	X									X				
+rustix@1.1.4	X	X								X				
+rustls@0.23.38	X							X		X				
+rustls-native-certs@0.8.3	X							X		X				
+rustls-pki-types@1.14.0	X									X				
+rustls-platform-verifier@0.6.2	X									X				
+rustls-platform-verifier-android@0.1.1	X									X				
+rustls-webpki@0.103.12								X						
+rustpython-ast@0.4.0										X				
+rustpython-parser@0.4.0										X				
+rustpython-parser-core@0.4.0										X				
+rustpython-parser-vendored@0.4.0										X				
+rustversion@1.0.22	X									X				
+ryu@1.0.23	X				X									
+salsa20@0.10.2	X									X				
+same-file@1.0.6										X				X
+schannel@0.1.29										X				
+scrypt@0.11.0	X									X				
+security-framework@3.7.0	X									X				
+security-framework-sys@2.17.0	X									X				
+semver@1.0.28	X									X				
+serde@1.0.228	X									X				
+serde_core@1.0.228	X									X				
+serde_derive@1.0.228	X									X				
+serde_json@1.0.149	X									X				
+serde_spanned@1.1.1	X									X				
+serde_urlencoded@0.7.1	X									X				
+sha1@0.10.6	X									X				
+sha2@0.10.9	X									X				
+shlex@1.3.0	X									X				
+signature@2.2.0	X									X				
+simple_asn1@0.6.4								X						
+siphasher@1.0.2	X									X				
+slab@0.4.12										X				
+smallvec@1.15.1	X									X				
+socket2@0.6.3	X									X				
+spin@0.9.8										X				
+spki@0.7.3	X									X				
+stable_deref_trait@1.2.1	X									X				
+static_assertions@1.1.0	X									X				
 subtle@2.6.1				X										
-syn@1.0.109	X										X			
-syn@2.0.110	X										X			
+syn@2.0.117	X									X				
 sync_wrapper@1.0.2	X													
-synstructure@0.13.2											X			
-target-lexicon@0.13.3		X												
-thiserror@2.0.17	X										X			
-thiserror-impl@2.0.17	X										X			
-time@0.3.44	X										X			
-time-core@0.1.6	X										X			
-time-macros@0.2.24	X										X			
+synstructure@0.13.2										X				
+target-lexicon@0.13.5		X												
+thiserror@1.0.69	X									X				
+thiserror@2.0.18	X									X				
+thiserror-impl@1.0.69	X									X				
+thiserror-impl@2.0.18	X									X				
+time@0.3.47	X									X				
+time-core@0.1.8	X									X				
+time-macros@0.2.27	X									X				
 tiny-keccak@2.0.2						X								
-tinystr@0.8.2												X		
-tokio@1.48.0											X			
-tokio-rustls@0.26.4	X										X			
-tokio-util@0.7.17											X			
-toml@0.9.8	X										X			
-toml_datetime@0.7.3	X										X			
-toml_parser@1.0.4	X										X			
-toml_writer@1.0.4	X										X			
-tower@0.5.2											X			
-tower-http@0.6.6											X			
-tower-layer@0.3.3											X			
-tower-service@0.3.3											X			
-tracing@0.1.41											X			
-tracing-core@0.1.34											X			
-try-lock@0.2.5											X			
-typenum@1.19.0	X										X			
-unic-char-property@0.9.0	X										X			
-unic-char-range@0.9.0	X										X			
-unic-common@0.9.0	X										X			
-unic-emoji-char@0.9.0	X										X			
-unic-ucd-ident@0.9.0	X										X			
-unic-ucd-version@0.9.0	X										X			
-unicase@2.8.1	X										X			
-unicode-ident@1.0.22	X										X	X		
-unicode-width@0.2.2	X										X			
-unicode-xid@0.2.6	X										X			
-unicode_names2@1.3.0	X										X		X	
-unicode_names2_generator@1.3.0	X										X			
-unindent@0.2.4	X										X			
+tinystr@0.8.3												X		
+tokio@1.52.0										X				
+tokio-macros@2.7.0										X				
+tokio-rustls@0.26.4	X									X				
+tokio-util@0.7.18										X				
+toml@0.9.12+spec-1.1.0	X									X				
+toml_datetime@0.7.5+spec-1.1.0	X									X				
+toml_parser@1.1.2+spec-1.1.0	X									X				
+toml_writer@1.1.1+spec-1.1.0	X									X				
+tower@0.5.3										X				
+tower-http@0.6.8										X				
+tower-layer@0.3.3										X				
+tower-service@0.3.3										X				
+tracing@0.1.44										X				
+tracing-core@0.1.36										X				
+try-lock@0.2.5										X				
+typenum@1.19.0	X									X				
+unic-char-property@0.9.0	X									X				
+unic-char-range@0.9.0	X									X				
+unic-common@0.9.0	X									X				
+unic-emoji-char@0.9.0	X									X				
+unic-ucd-ident@0.9.0	X									X				
+unic-ucd-version@0.9.0	X									X				
+unicase@2.9.0	X									X				
+unicode-ident@1.0.24	X									X		X		
+unicode-width@0.2.2	X									X				
+unicode_names2@1.3.0	X									X			X	
+unicode_names2_generator@1.3.0	X									X				
+unindent@0.2.4	X									X				
+untrusted@0.7.1								X						
 untrusted@0.9.0								X						
-url@2.5.7	X										X			
-utf8_iter@1.0.4	X										X			
-uuid@1.18.1	X										X			
-version_check@0.9.5	X										X			
-want@0.3.1											X			
-wasi@0.11.1+wasi-snapshot-preview1	X	X									X			
-wasip2@1.0.1+wasi-0.2.4	X	X									X			
-wasm-bindgen@0.2.105	X										X			
-wasm-bindgen-futures@0.4.55	X										X			
-wasm-bindgen-macro@0.2.105	X										X			
-wasm-bindgen-macro-support@0.2.105	X										X			
-wasm-bindgen-shared@0.2.105	X										X			
-wasm-streams@0.4.2	X										X			
-web-sys@0.3.82	X										X			
-webpki-roots@1.0.4							X							
-windows-core@0.62.2	X										X			
-windows-implement@0.60.2	X										X			
-windows-interface@0.59.3	X										X			
-windows-link@0.2.1	X										X			
-windows-result@0.4.1	X										X			
-windows-strings@0.5.1	X										X			
-windows-sys@0.52.0	X										X			
-windows-sys@0.59.0	X										X			
-windows-sys@0.60.2	X										X			
-windows-sys@0.61.2	X										X			
-windows-targets@0.52.6	X										X			
-windows-targets@0.53.5	X										X			
-windows_aarch64_gnullvm@0.52.6	X										X			
-windows_aarch64_gnullvm@0.53.1	X										X			
-windows_aarch64_msvc@0.52.6	X										X			
-windows_aarch64_msvc@0.53.1	X										X			
-windows_i686_gnu@0.52.6	X										X			
-windows_i686_gnu@0.53.1	X										X			
-windows_i686_gnullvm@0.52.6	X										X			
-windows_i686_gnullvm@0.53.1	X										X			
-windows_i686_msvc@0.52.6	X										X			
-windows_i686_msvc@0.53.1	X										X			
-windows_x86_64_gnu@0.52.6	X										X			
-windows_x86_64_gnu@0.53.1	X										X			
-windows_x86_64_gnullvm@0.52.6	X										X			
-windows_x86_64_gnullvm@0.53.1	X										X			
-windows_x86_64_msvc@0.52.6	X										X			
-windows_x86_64_msvc@0.53.1	X										X			
-winnow@0.7.13											X			
-wit-bindgen@0.46.0	X	X									X			
-writeable@0.6.2												X		
-yoke@0.8.1												X		
-yoke-derive@0.8.1												X		
-zerocopy@0.8.28	X		X								X			
-zerofrom@0.1.6												X		
-zerofrom-derive@0.1.6												X		
-zeroize@1.8.2	X										X			
-zerotrie@0.2.3												X		
-zerovec@0.11.5												X		
-zerovec-derive@0.11.2												X		
+url@2.5.8	X									X				
+utf8_iter@1.0.4	X									X				
+uuid@1.23.1	X									X				
+version_check@0.9.5	X									X				
+walkdir@2.5.0										X				X
+want@0.3.1										X				
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X				
+wasip2@1.0.1+wasi-0.2.4	X	X								X				
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X				
+wasm-bindgen@0.2.118	X									X				
+wasm-bindgen-futures@0.4.68	X									X				
+wasm-bindgen-macro@0.2.118	X									X				
+wasm-bindgen-macro-support@0.2.118	X									X				
+wasm-bindgen-shared@0.2.118	X									X				
+wasm-streams@0.5.0	X									X				
+web-sys@0.3.95	X									X				
+web-time@1.1.0	X									X				
+webpki-root-certs@1.0.6							X							
+winapi-util@0.1.11										X				X
+windows-core@0.62.2	X									X				
+windows-implement@0.60.2	X									X				
+windows-interface@0.59.3	X									X				
+windows-link@0.2.1	X									X				
+windows-result@0.4.1	X									X				
+windows-strings@0.5.1	X									X				
+windows-sys@0.45.0	X									X				
+windows-sys@0.61.2	X									X				
+windows-targets@0.42.2	X									X				
+windows_aarch64_gnullvm@0.42.2	X									X				
+windows_aarch64_msvc@0.42.2	X									X				
+windows_i686_gnu@0.42.2	X									X				
+windows_i686_msvc@0.42.2	X									X				
+windows_x86_64_gnu@0.42.2	X									X				
+windows_x86_64_gnullvm@0.42.2	X									X				
+windows_x86_64_msvc@0.42.2	X									X				
+winnow@0.7.15										X				
+winnow@1.0.1										X				
+wit-bindgen@0.46.0	X	X								X				
+wit-bindgen@0.51.0	X	X								X				
+writeable@0.6.3												X		
+xattr@1.6.1	X									X				
+yoke@0.8.2												X		
+yoke-derive@0.8.2												X		
+zerocopy@0.8.48	X		X							X				
+zerofrom@0.1.7												X		
+zerofrom-derive@0.1.7												X		
+zeroize@1.8.2	X									X				
+zerotrie@0.2.4												X		
+zerovec@0.11.6												X		
+zerovec-derive@0.11.3												X		
+zmij@1.0.21										X				

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -1,284 +1,324 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense	Zlib
-aes@0.8.4	X									X			
-aho-corasick@1.1.4										X		X	
-allocator-api2@0.2.21	X									X			
-android_system_properties@0.1.5	X									X			
-anyhow@1.0.100	X									X			
-async-trait@0.1.89	X									X			
-atomic-waker@1.1.2	X									X			
-autocfg@1.5.0	X									X			
-backon@1.6.0	X												
-base64@0.22.1	X									X			
-base64ct@1.8.0	X									X			
-bindgen@0.69.5				X									
-bitflags@2.10.0	X									X			
-block-buffer@0.10.4	X									X			
-block-padding@0.3.3	X									X			
-bumpalo@3.19.0	X									X			
-bytes@1.11.0										X			
-cbc@0.1.2	X									X			
-cc@1.2.47	X									X			
-cexpr@0.6.0	X									X			
-cfg-if@1.0.4	X									X			
-chrono@0.4.42	X									X			
-cipher@0.4.4	X									X			
-clang-sys@1.8.1	X												
-const-oid@0.9.6	X									X			
-const-random@0.1.18	X									X			
-const-random-macro@0.1.16	X									X			
-core-foundation-sys@0.8.7	X									X			
-cpufeatures@0.2.17	X									X			
-crc32c@0.6.8	X									X			
-crossbeam-utils@0.8.21	X									X			
-crunchy@0.2.4										X			
-crypto-common@0.1.7	X									X			
-dashmap@6.1.0										X			
-der@0.7.10	X									X			
-deranged@0.5.5	X									X			
-digest@0.10.7	X									X			
-displaydoc@0.2.5	X									X			
-dlv-list@0.5.2	X									X			
-either@1.15.0	X									X			
-equivalent@1.0.2	X									X			
-fastrand@2.3.0	X									X			
-find-msvc-tools@0.1.5	X									X			
-fnv@1.0.7	X									X			
-foldhash@0.2.0													X
-form_urlencoded@1.2.2	X									X			
-futures@0.3.31	X									X			
-futures-channel@0.3.31	X									X			
-futures-core@0.3.31	X									X			
-futures-io@0.3.31	X									X			
-futures-macro@0.3.31	X									X			
-futures-sink@0.3.31	X									X			
-futures-task@0.3.31	X									X			
-futures-timer@3.0.3	X									X			
-futures-util@0.3.31	X									X			
-generic-array@0.14.7										X			
-getrandom@0.2.16	X									X			
-getrandom@0.3.4	X									X			
-ghac@0.2.0	X												
-glob@0.3.3	X									X			
-gloo-timers@0.3.0	X									X			
-governor@0.10.2										X			
-hashbrown@0.14.5	X									X			
-hashbrown@0.16.1	X									X			
-hex@0.4.3	X									X			
-hmac@0.12.1	X									X			
-home@0.5.11	X									X			
-http@1.3.1	X									X			
-http-body@1.0.1										X			
-http-body-util@0.1.3										X			
-httparse@1.10.1	X									X			
-hyper@1.8.1										X			
-hyper-rustls@0.27.7	X							X		X			
-hyper-util@0.1.18										X			
-iana-time-zone@0.1.64	X									X			
-iana-time-zone-haiku@0.1.2	X									X			
-icu_collections@2.1.1											X		
-icu_locale_core@2.1.1											X		
-icu_normalizer@2.1.1											X		
-icu_normalizer_data@2.1.1											X		
-icu_properties@2.1.1											X		
-icu_properties_data@2.1.1											X		
-icu_provider@2.1.1											X		
-idna@1.1.0	X									X			
-idna_adapter@1.2.1	X									X			
-inout@0.1.4	X									X			
-ipnet@2.11.0	X									X			
-iri-string@0.7.9	X									X			
-itertools@0.12.1	X									X			
-itertools@0.14.0	X									X			
-itoa@1.0.15	X									X			
-jiff@0.2.16										X		X	
-jiff-tzdb@0.1.4										X		X	
-jiff-tzdb-platform@0.1.3										X		X	
-js-sys@0.3.82	X									X			
-jsonwebtoken@9.3.1										X			
-lazy_static@1.5.0	X									X			
-lazycell@1.3.0	X									X			
-libc@0.2.177	X									X			
-libloading@0.8.9								X					
-libm@0.2.15										X			
-litemap@0.8.1											X		
-lock_api@0.4.14	X									X			
-log@0.4.28	X									X			
-magnus@0.8.2										X			
-magnus-macros@0.8.0										X			
-md-5@0.10.6	X									X			
-memchr@2.7.6										X		X	
-minimal-lexical@0.2.1	X									X			
-mio@1.1.0										X			
-nom@7.1.3										X			
-nonzero_ext@0.3.0	X												
-num-bigint@0.4.6	X									X			
-num-bigint-dig@0.8.6	X									X			
-num-conv@0.1.0	X									X			
-num-integer@0.1.46	X									X			
-num-iter@0.1.45	X									X			
-num-traits@0.2.19	X									X			
-once_cell@1.21.3	X									X			
-opendal@0.55.0	X												
-opendal-ruby@0.1.6-rc.2	X												
-ordered-multimap@0.7.3										X			
-parking_lot@0.12.5	X									X			
-parking_lot_core@0.9.12	X									X			
-pbkdf2@0.12.2	X									X			
-pem@3.0.6										X			
-pem-rfc7468@0.7.0	X									X			
-percent-encoding@2.3.2	X									X			
-pin-project-lite@0.2.16	X									X			
-pin-utils@0.1.0	X									X			
-pkcs1@0.7.5	X									X			
-pkcs5@0.7.1	X									X			
-pkcs8@0.10.2	X									X			
-portable-atomic@1.11.1	X									X			
-portable-atomic-util@0.2.4	X									X			
-potential_utf@0.1.4											X		
-powerfmt@0.2.0	X									X			
-ppv-lite86@0.2.21	X									X			
-proc-macro2@1.0.103	X									X			
-prost@0.13.5	X												
-prost-derive@0.13.5	X												
-quanta@0.12.6										X			
-quick-xml@0.38.4										X			
-quote@1.0.42	X									X			
-r-efi@5.3.0	X								X	X			
-rand@0.8.5	X									X			
-rand@0.9.2	X									X			
-rand_chacha@0.3.1	X									X			
-rand_chacha@0.9.0	X									X			
-rand_core@0.6.4	X									X			
-rand_core@0.9.3	X									X			
-raw-cpuid@11.6.0										X			
-rb-sys@0.9.117	X									X			
-rb-sys-build@0.9.117	X									X			
-rb-sys-env@0.1.2	X									X			
-rb-sys-env@0.2.2	X									X			
-redox_syscall@0.5.18										X			
-regex@1.12.2	X									X			
-regex-automata@0.4.13	X									X			
-regex-syntax@0.8.8	X									X			
-reqsign@0.16.5	X												
-reqsign-aws-v4@2.0.1	X												
-reqsign-core@2.0.1	X												
-reqsign-file-read-tokio@2.0.1	X												
-reqsign-http-send-reqwest@2.0.1	X												
-reqwest@0.12.24	X									X			
-ring@0.17.14	X							X					
-rsa@0.9.9	X									X			
-rust-ini@0.21.3										X			
-rustc-hash@1.1.0	X									X			
-rustc_version@0.4.1	X									X			
-rustls@0.23.35	X							X		X			
-rustls-pki-types@1.13.0	X									X			
-rustls-webpki@0.103.8								X					
-rustversion@1.0.22	X									X			
-ryu@1.0.20	X				X								
-salsa20@0.10.2	X									X			
-scopeguard@1.2.0	X									X			
-scrypt@0.11.0	X									X			
-semver@1.0.27	X									X			
-seq-macro@0.3.6	X									X			
-serde@1.0.228	X									X			
-serde_core@1.0.228	X									X			
-serde_derive@1.0.228	X									X			
-serde_json@1.0.145	X									X			
-serde_urlencoded@0.7.1	X									X			
-sha1@0.10.6	X									X			
-sha2@0.10.9	X									X			
-shell-words@1.1.0	X									X			
-shlex@1.3.0	X									X			
-signal-hook-registry@1.4.6	X									X			
-signature@2.2.0	X									X			
-simple_asn1@0.6.3								X					
-slab@0.4.11										X			
-smallvec@1.15.1	X									X			
-socket2@0.6.1	X									X			
-spin@0.9.8										X			
-spinning_top@0.3.0	X									X			
-spki@0.7.3	X									X			
-stable_deref_trait@1.2.1	X									X			
-subtle@2.6.1				X									
-syn@2.0.110	X									X			
-sync_wrapper@1.0.2	X												
-synstructure@0.13.2										X			
-thiserror@2.0.17	X									X			
-thiserror-impl@2.0.17	X									X			
-time@0.3.44	X									X			
-time-core@0.1.6	X									X			
-time-macros@0.2.24	X									X			
-tiny-keccak@2.0.2						X							
-tinystr@0.8.2											X		
-tokio@1.48.0										X			
-tokio-macros@2.6.0										X			
-tokio-rustls@0.26.4	X									X			
-tokio-util@0.7.17										X			
-tower@0.5.2										X			
-tower-http@0.6.6										X			
-tower-layer@0.3.3										X			
-tower-service@0.3.3										X			
-tracing@0.1.41										X			
-tracing-core@0.1.34										X			
-try-lock@0.2.5										X			
-typenum@1.19.0	X									X			
-unicode-ident@1.0.22	X									X	X		
-untrusted@0.9.0								X					
-url@2.5.7	X									X			
-utf8_iter@1.0.4	X									X			
-uuid@1.18.1	X									X			
-version_check@0.9.5	X									X			
-want@0.3.1										X			
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
-wasip2@1.0.1+wasi-0.2.4	X	X								X			
-wasm-bindgen@0.2.105	X									X			
-wasm-bindgen-futures@0.4.55	X									X			
-wasm-bindgen-macro@0.2.105	X									X			
-wasm-bindgen-macro-support@0.2.105	X									X			
-wasm-bindgen-shared@0.2.105	X									X			
-wasm-streams@0.4.2	X									X			
-web-sys@0.3.82	X									X			
-web-time@1.1.0	X									X			
-webpki-roots@1.0.4							X						
-winapi@0.3.9	X									X			
-winapi-i686-pc-windows-gnu@0.4.0	X									X			
-winapi-x86_64-pc-windows-gnu@0.4.0	X									X			
-windows-core@0.62.2	X									X			
-windows-implement@0.60.2	X									X			
-windows-interface@0.59.3	X									X			
-windows-link@0.2.1	X									X			
-windows-result@0.4.1	X									X			
-windows-strings@0.5.1	X									X			
-windows-sys@0.52.0	X									X			
-windows-sys@0.59.0	X									X			
-windows-sys@0.60.2	X									X			
-windows-sys@0.61.2	X									X			
-windows-targets@0.52.6	X									X			
-windows-targets@0.53.5	X									X			
-windows_aarch64_gnullvm@0.52.6	X									X			
-windows_aarch64_gnullvm@0.53.1	X									X			
-windows_aarch64_msvc@0.52.6	X									X			
-windows_aarch64_msvc@0.53.1	X									X			
-windows_i686_gnu@0.52.6	X									X			
-windows_i686_gnu@0.53.1	X									X			
-windows_i686_gnullvm@0.52.6	X									X			
-windows_i686_gnullvm@0.53.1	X									X			
-windows_i686_msvc@0.52.6	X									X			
-windows_i686_msvc@0.53.1	X									X			
-windows_x86_64_gnu@0.52.6	X									X			
-windows_x86_64_gnu@0.53.1	X									X			
-windows_x86_64_gnullvm@0.52.6	X									X			
-windows_x86_64_gnullvm@0.53.1	X									X			
-windows_x86_64_msvc@0.52.6	X									X			
-windows_x86_64_msvc@0.53.1	X									X			
-wit-bindgen@0.46.0	X	X								X			
-writeable@0.6.2											X		
-yoke@0.8.1											X		
-yoke-derive@0.8.1											X		
-zerocopy@0.8.28	X		X							X			
-zerofrom@0.1.6											X		
-zerofrom-derive@0.1.6											X		
-zeroize@1.8.2	X									X			
-zerotrie@0.2.3											X		
-zerovec@0.11.5											X		
-zerovec-derive@0.11.2											X		
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib
+aes@0.8.4	X									X				
+aho-corasick@1.1.4										X			X	
+allocator-api2@0.2.21	X									X				
+anyhow@1.0.102	X									X				
+async-trait@0.1.89	X									X				
+atomic-waker@1.1.2	X									X				
+autocfg@1.5.0	X									X				
+aws-lc-rs@1.16.3	X							X						
+aws-lc-sys@0.40.0	X			X				X		X	X			
+backon@1.6.0	X													
+base64@0.22.1	X									X				
+base64ct@1.8.3	X									X				
+bindgen@0.72.1				X										
+bitflags@2.11.1	X									X				
+block-buffer@0.10.4	X									X				
+block-padding@0.3.3	X									X				
+bumpalo@3.20.2	X									X				
+bytes@1.11.1										X				
+cbc@0.1.2	X									X				
+cc@1.2.60	X									X				
+cesu8@1.1.0	X									X				
+cexpr@0.6.0	X									X				
+cfg-if@1.0.4	X									X				
+cipher@0.4.4	X									X				
+clang-sys@1.8.1	X													
+cmake@0.1.58	X									X				
+combine@4.6.7										X				
+const-oid@0.9.6	X									X				
+const-random@0.1.18	X									X				
+const-random-macro@0.1.16	X									X				
+core-foundation@0.10.1	X									X				
+core-foundation-sys@0.8.7	X									X				
+cpufeatures@0.2.17	X									X				
+crc32c@0.6.8	X									X				
+crossbeam-utils@0.8.21	X									X				
+crunchy@0.2.4										X				
+crypto-common@0.1.7	X									X				
+ctor@0.6.3	X									X				
+ctor-proc-macro@0.0.7	X									X				
+dashmap@6.1.0										X				
+der@0.7.10	X									X				
+deranged@0.5.8	X									X				
+digest@0.10.7	X									X				
+displaydoc@0.2.5	X									X				
+dlv-list@0.5.2	X									X				
+dtor@0.1.1	X									X				
+dtor-proc-macro@0.0.6	X									X				
+dunce@1.0.5	X					X					X			
+either@1.15.0	X									X				
+equivalent@1.0.2	X									X				
+errno@0.3.14	X									X				
+fastrand@2.4.1	X									X				
+find-msvc-tools@0.1.9	X									X				
+foldhash@0.2.0														X
+form_urlencoded@1.2.2	X									X				
+fs_extra@1.3.0										X				
+futures@0.3.32	X									X				
+futures-channel@0.3.32	X									X				
+futures-core@0.3.32	X									X				
+futures-executor@0.3.32	X									X				
+futures-io@0.3.32	X									X				
+futures-macro@0.3.32	X									X				
+futures-sink@0.3.32	X									X				
+futures-task@0.3.32	X									X				
+futures-timer@3.0.3	X									X				
+futures-util@0.3.32	X									X				
+generic-array@0.14.7										X				
+getrandom@0.2.17	X									X				
+getrandom@0.3.4	X									X				
+getrandom@0.4.2	X									X				
+ghac@0.2.0	X													
+glob@0.3.3	X									X				
+gloo-timers@0.3.0	X									X				
+governor@0.10.4										X				
+hashbrown@0.14.5	X									X				
+hashbrown@0.16.1	X									X				
+hex@0.4.3	X									X				
+hmac@0.12.1	X									X				
+http@1.4.0	X									X				
+http-body@1.0.1										X				
+http-body-util@0.1.3										X				
+httparse@1.10.1	X									X				
+hyper@1.9.0										X				
+hyper-rustls@0.27.9	X							X		X				
+hyper-util@0.1.20										X				
+icu_collections@2.1.1												X		
+icu_locale_core@2.1.1												X		
+icu_normalizer@2.1.1												X		
+icu_normalizer_data@2.1.1												X		
+icu_properties@2.1.2												X		
+icu_properties_data@2.1.2												X		
+icu_provider@2.1.1												X		
+idna@1.1.0	X									X				
+idna_adapter@1.2.1	X									X				
+inout@0.1.4	X									X				
+ipnet@2.12.0	X									X				
+iri-string@0.7.12	X									X				
+itertools@0.13.0	X									X				
+itertools@0.14.0	X									X				
+itoa@1.0.18	X									X				
+jiff@0.2.23										X			X	
+jiff-tzdb@0.1.6										X			X	
+jiff-tzdb-platform@0.1.3										X			X	
+jni@0.21.1	X									X				
+jni-sys@0.3.1	X									X				
+jni-sys@0.4.1	X									X				
+jni-sys-macros@0.4.1	X									X				
+jobserver@0.1.34	X									X				
+js-sys@0.3.95	X									X				
+jsonwebtoken@10.3.0										X				
+lazy_static@1.5.0	X									X				
+libc@0.2.185	X									X				
+libloading@0.8.9								X						
+libm@0.2.16										X				
+linux-raw-sys@0.12.1	X	X								X				
+litemap@0.8.2												X		
+lock_api@0.4.14	X									X				
+log@0.4.29	X									X				
+magnus@0.8.2										X				
+magnus-macros@0.8.0										X				
+md-5@0.10.6	X									X				
+mea@0.6.3	X													
+memchr@2.8.0										X			X	
+minimal-lexical@0.2.1	X									X				
+mio@1.2.0										X				
+nom@7.1.3										X				
+nonzero_ext@0.3.0	X													
+num-bigint@0.4.6	X									X				
+num-bigint-dig@0.8.6	X									X				
+num-conv@0.2.1	X									X				
+num-integer@0.1.46	X									X				
+num-iter@0.1.45	X									X				
+num-traits@0.2.19	X									X				
+once_cell@1.21.4	X									X				
+opendal@0.56.0	X													
+opendal-core@0.56.0	X													
+opendal-layer-concurrent-limit@0.56.0	X													
+opendal-layer-logging@0.56.0	X													
+opendal-layer-retry@0.56.0	X													
+opendal-layer-throttle@0.56.0	X													
+opendal-layer-timeout@0.56.0	X													
+opendal-ruby@0.1.6-rc.2	X													
+opendal-service-azblob@0.56.0	X													
+opendal-service-azdls@0.56.0	X													
+opendal-service-azfile@0.56.0	X													
+opendal-service-azure-common@0.56.0	X													
+opendal-service-cos@0.56.0	X													
+opendal-service-fs@0.56.0	X													
+opendal-service-gcs@0.56.0	X													
+opendal-service-ghac@0.56.0	X													
+opendal-service-http@0.56.0	X													
+opendal-service-ipmfs@0.56.0	X													
+opendal-service-obs@0.56.0	X													
+opendal-service-oss@0.56.0	X													
+opendal-service-s3@0.56.0	X													
+opendal-service-webdav@0.56.0	X													
+opendal-service-webhdfs@0.56.0	X													
+openssl-probe@0.2.1	X									X				
+ordered-multimap@0.7.3										X				
+parking_lot@0.12.5	X									X				
+parking_lot_core@0.9.12	X									X				
+pbkdf2@0.12.2	X									X				
+pem@3.0.6										X				
+pem-rfc7468@0.7.0	X									X				
+percent-encoding@2.3.2	X									X				
+pin-project-lite@0.2.17	X									X				
+pkcs1@0.7.5	X									X				
+pkcs5@0.7.1	X									X				
+pkcs8@0.10.2	X									X				
+portable-atomic@1.13.1	X									X				
+portable-atomic-util@0.2.6	X									X				
+potential_utf@0.1.5												X		
+powerfmt@0.2.0	X									X				
+ppv-lite86@0.2.21	X									X				
+proc-macro2@1.0.106	X									X				
+prost@0.13.5	X													
+prost-derive@0.13.5	X													
+quanta@0.12.6										X				
+quick-xml@0.38.4										X				
+quick-xml@0.39.2										X				
+quote@1.0.45	X									X				
+r-efi@5.3.0	X								X	X				
+r-efi@6.0.0	X								X	X				
+rand@0.8.5	X									X				
+rand@0.9.4	X									X				
+rand_chacha@0.3.1	X									X				
+rand_chacha@0.9.0	X									X				
+rand_core@0.6.4	X									X				
+rand_core@0.9.5	X									X				
+raw-cpuid@11.6.0										X				
+rb-sys@0.9.126	X									X				
+rb-sys-build@0.9.126	X									X				
+rb-sys-env@0.1.2	X									X				
+rb-sys-env@0.2.3	X									X				
+redox_syscall@0.5.18										X				
+regex@1.12.3	X									X				
+regex-automata@0.4.14	X									X				
+regex-syntax@0.8.10	X									X				
+reqsign-aliyun-oss@3.0.0	X													
+reqsign-aws-v4@3.0.0	X													
+reqsign-azure-storage@3.0.0	X													
+reqsign-core@3.0.0	X													
+reqsign-file-read-tokio@3.0.0	X													
+reqsign-google@3.0.0	X													
+reqsign-huaweicloud-obs@3.0.0	X													
+reqsign-tencent-cos@3.0.0	X													
+reqwest@0.13.2	X									X				
+rsa@0.9.10	X									X				
+rust-ini@0.21.3										X				
+rustc-hash@2.1.2	X									X				
+rustc_version@0.4.1	X									X				
+rustix@1.1.4	X	X								X				
+rustls@0.23.38	X							X		X				
+rustls-native-certs@0.8.3	X							X		X				
+rustls-pki-types@1.14.0	X									X				
+rustls-platform-verifier@0.6.2	X									X				
+rustls-platform-verifier-android@0.1.1	X									X				
+rustls-webpki@0.103.12								X						
+rustversion@1.0.22	X									X				
+ryu@1.0.23	X				X									
+salsa20@0.10.2	X									X				
+same-file@1.0.6										X			X	
+schannel@0.1.29										X				
+scopeguard@1.2.0	X									X				
+scrypt@0.11.0	X									X				
+security-framework@3.7.0	X									X				
+security-framework-sys@2.17.0	X									X				
+semver@1.0.28	X									X				
+seq-macro@0.3.6	X									X				
+serde@1.0.228	X									X				
+serde_core@1.0.228	X									X				
+serde_derive@1.0.228	X									X				
+serde_json@1.0.149	X									X				
+serde_urlencoded@0.7.1	X									X				
+sha1@0.10.6	X									X				
+sha2@0.10.9	X									X				
+shell-words@1.1.1	X									X				
+shlex@1.3.0	X									X				
+signal-hook-registry@1.4.8	X									X				
+signature@2.2.0	X									X				
+simple_asn1@0.6.4								X						
+slab@0.4.12										X				
+smallvec@1.15.1	X									X				
+socket2@0.6.3	X									X				
+spin@0.9.8										X				
+spinning_top@0.3.0	X									X				
+spki@0.7.3	X									X				
+stable_deref_trait@1.2.1	X									X				
+subtle@2.6.1				X										
+syn@2.0.117	X									X				
+sync_wrapper@1.0.2	X													
+synstructure@0.13.2										X				
+thiserror@1.0.69	X									X				
+thiserror@2.0.18	X									X				
+thiserror-impl@1.0.69	X									X				
+thiserror-impl@2.0.18	X									X				
+time@0.3.47	X									X				
+time-core@0.1.8	X									X				
+time-macros@0.2.27	X									X				
+tiny-keccak@2.0.2						X								
+tinystr@0.8.3												X		
+tokio@1.52.0										X				
+tokio-macros@2.7.0										X				
+tokio-rustls@0.26.4	X									X				
+tokio-util@0.7.18										X				
+tower@0.5.3										X				
+tower-http@0.6.8										X				
+tower-layer@0.3.3										X				
+tower-service@0.3.3										X				
+tracing@0.1.44										X				
+tracing-core@0.1.36										X				
+try-lock@0.2.5										X				
+typenum@1.19.0	X									X				
+unicode-ident@1.0.24	X									X		X		
+untrusted@0.7.1								X						
+untrusted@0.9.0								X						
+url@2.5.8	X									X				
+utf8_iter@1.0.4	X									X				
+uuid@1.23.1	X									X				
+version_check@0.9.5	X									X				
+walkdir@2.5.0										X			X	
+want@0.3.1										X				
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X				
+wasip2@1.0.1+wasi-0.2.4	X	X								X				
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X				
+wasm-bindgen@0.2.118	X									X				
+wasm-bindgen-futures@0.4.68	X									X				
+wasm-bindgen-macro@0.2.118	X									X				
+wasm-bindgen-macro-support@0.2.118	X									X				
+wasm-bindgen-shared@0.2.118	X									X				
+wasm-streams@0.5.0	X									X				
+web-sys@0.3.95	X									X				
+web-time@1.1.0	X									X				
+webpki-root-certs@1.0.6							X							
+winapi@0.3.9	X									X				
+winapi-i686-pc-windows-gnu@0.4.0	X									X				
+winapi-util@0.1.11										X			X	
+winapi-x86_64-pc-windows-gnu@0.4.0	X									X				
+windows-link@0.2.1	X									X				
+windows-sys@0.45.0	X									X				
+windows-sys@0.61.2	X									X				
+windows-targets@0.42.2	X									X				
+windows_aarch64_gnullvm@0.42.2	X									X				
+windows_aarch64_msvc@0.42.2	X									X				
+windows_i686_gnu@0.42.2	X									X				
+windows_i686_msvc@0.42.2	X									X				
+windows_x86_64_gnu@0.42.2	X									X				
+windows_x86_64_gnullvm@0.42.2	X									X				
+windows_x86_64_msvc@0.42.2	X									X				
+wit-bindgen@0.46.0	X	X								X				
+wit-bindgen@0.51.0	X	X								X				
+writeable@0.6.3												X		
+xattr@1.6.1	X									X				
+yoke@0.8.2												X		
+yoke-derive@0.8.2												X		
+zerocopy@0.8.48	X		X							X				
+zerofrom@0.1.7												X		
+zerofrom-derive@0.1.7												X		
+zeroize@1.8.2	X									X				
+zerotrie@0.2.4												X		
+zerovec@0.11.6												X		
+zerovec-derive@0.11.3												X		
+zmij@1.0.21										X				

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_aws_s3_assume_role_with_web_identity"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "logforth",
  "opendal",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_file_write_on_full_disk"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal",
  "rand 0.8.5",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_s3_read_on_wasm"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal",
  "wasm-bindgen",
@@ -6061,7 +6061,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opendal"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-benchmark-vs-fs"
-version = "0.0.0"
+version = "0.56.0"
 dependencies = [
  "criterion",
  "opendal",
@@ -6183,7 +6183,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-benchmark-vs-s3"
-version = "0.0.0"
+version = "0.56.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -6198,7 +6198,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-core"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6229,7 +6229,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-basic"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6237,7 +6237,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-concurrent-upload"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6245,7 +6245,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-multipart-upload"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6253,7 +6253,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-fuzz"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -6265,7 +6265,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-async-backtrace"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "async-backtrace",
  "opendal-core",
@@ -6273,7 +6273,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-await-tree"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "await-tree",
  "futures",
@@ -6282,7 +6282,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-capability-check"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -6290,7 +6290,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-chaos"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal-core",
  "rand 0.8.5",
@@ -6298,7 +6298,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-concurrent-limit"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -6309,7 +6309,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-dtrace"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "opendal-core",
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-fastmetrics"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "fastmetrics",
  "log",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-fastrace"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6342,7 +6342,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-foyer"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bincode",
  "foyer",
@@ -6355,7 +6355,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-hotpath"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "futures",
  "hotpath",
@@ -6366,7 +6366,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-immutable-index"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "futures",
  "log",
@@ -6377,7 +6377,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-logging"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "log",
  "opendal-core",
@@ -6385,7 +6385,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-metrics"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "metrics",
  "opendal-core",
@@ -6394,7 +6394,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-mime-guess"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "futures",
  "mime_guess",
@@ -6404,7 +6404,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-observe-metrics-common"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -6413,7 +6413,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-otelmetrics"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal-core",
  "opendal-layer-observe-metrics-common",
@@ -6422,7 +6422,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-oteltrace"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal-core",
  "opentelemetry",
@@ -6430,7 +6430,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-prometheus"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "log",
  "opendal-core",
@@ -6441,7 +6441,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-prometheus-client"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "log",
  "opendal-core",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-retry"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "backon",
  "bytes",
@@ -6467,7 +6467,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-route"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "futures",
  "globset",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-tail-cut"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -6486,7 +6486,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-throttle"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "governor",
  "opendal-core",
@@ -6494,7 +6494,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-timeout"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "futures",
  "opendal-core",
@@ -6504,7 +6504,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-tracing"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6522,7 +6522,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-aliyun-drive"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6536,7 +6536,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-alluxio"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6549,7 +6549,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azblob"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6571,7 +6571,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azdls"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6589,7 +6589,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azfile"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6606,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azure-common"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "http 1.4.0",
  "opendal-core",
@@ -6614,7 +6614,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-b2"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6628,7 +6628,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cacache"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "cacache",
@@ -6639,7 +6639,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cloudflare-kv"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6650,7 +6650,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-compfs"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "compio",
@@ -6661,7 +6661,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cos"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6677,7 +6677,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-d1"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6689,7 +6689,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dashmap"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "dashmap 6.1.0",
  "log",
@@ -6700,7 +6700,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dbfs"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6714,7 +6714,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dropbox"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6727,7 +6727,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-etcd"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "etcd-client",
  "fastpool",
@@ -6738,7 +6738,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-foundationdb"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "foundationdb",
  "opendal-core",
@@ -6748,7 +6748,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-foyer"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "foyer",
  "log",
@@ -6762,7 +6762,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-fs"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "log",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ftp"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "fastpool",
@@ -6791,7 +6791,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6810,7 +6810,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gdrive"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6824,7 +6824,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ghac"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "ghac",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-github"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6857,7 +6857,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gridfs"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "futures",
  "mea",
@@ -6869,7 +6869,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hdfs"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "futures",
@@ -6882,7 +6882,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hdfs-native"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "futures",
@@ -6894,7 +6894,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hf"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "futures",
@@ -6911,7 +6911,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-http"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "http 1.4.0",
  "log",
@@ -6922,7 +6922,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ipfs"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6935,7 +6935,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ipmfs"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6948,7 +6948,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-koofr"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6962,7 +6962,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-lakefs"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6975,7 +6975,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-memcached"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "fastpool",
  "opendal-core",
@@ -6986,7 +6986,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mini-moka"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "log",
  "mini-moka",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-moka"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "log",
  "moka",
@@ -7007,7 +7007,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mongodb"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "mea",
@@ -7019,7 +7019,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-monoiofs"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "flume 0.12.0",
@@ -7032,7 +7032,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mysql"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7043,7 +7043,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-obs"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7059,7 +7059,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-onedrive"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7073,7 +7073,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-opfs"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "js-sys",
  "opendal-core",
@@ -7085,7 +7085,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-oss"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-pcloud"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7115,7 +7115,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-persy"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal-core",
  "persy",
@@ -7125,7 +7125,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-postgresql"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7136,7 +7136,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-redb"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal-core",
  "redb 2.6.3",
@@ -7146,7 +7146,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-redis"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "fastpool",
@@ -7159,7 +7159,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-rocksdb"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal-core",
  "rocksdb",
@@ -7169,7 +7169,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-s3"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7191,7 +7191,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-seafile"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7205,7 +7205,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sftp"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sled"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal-core",
  "serde",
@@ -7231,7 +7231,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sqlite"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-surrealdb"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7253,7 +7253,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-swift"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7273,7 +7273,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-tikv"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7284,7 +7284,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-tos"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "opendal-core",
  "serde",
@@ -7293,7 +7293,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-upyun"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7311,7 +7311,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-vercel-artifacts"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7325,7 +7325,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-vercel-blob"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7339,7 +7339,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webdav"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7354,7 +7354,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webhdfs"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7370,7 +7370,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-yandex-disk"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7384,7 +7384,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-testkit"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bytes",
  "dotenvy",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,7 +38,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.85"
-version = "0.55.0"
+version = "0.56.0"
 
 [workspace.dependencies]
 base64 = "0.22"
@@ -212,100 +212,100 @@ required-features = ["tests"]
 
 [dependencies]
 ctor = { workspace = true, optional = true }
-opendal-core = { path = "core", version = "0.55.0", default-features = false }
-opendal-layer-async-backtrace = { path = "layers/async-backtrace", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-await-tree = { path = "layers/await-tree", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-capability-check = { path = "layers/capability-check", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-chaos = { path = "layers/chaos", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-concurrent-limit = { path = "layers/concurrent-limit", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-fastmetrics = { path = "layers/fastmetrics", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-fastrace = { path = "layers/fastrace", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-foyer = { path = "layers/foyer", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-hotpath = { path = "layers/hotpath", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-immutable-index = { path = "layers/immutable-index", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-logging = { path = "layers/logging", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-metrics = { path = "layers/metrics", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-mime-guess = { path = "layers/mime-guess", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-observe-metrics-common = { path = "layers/observe-metrics-common", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-otelmetrics = { path = "layers/otelmetrics", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-oteltrace = { path = "layers/oteltrace", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-prometheus = { path = "layers/prometheus", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-prometheus-client = { path = "layers/prometheus-client", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-retry = { path = "layers/retry", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-route = { path = "layers/route", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-tail-cut = { path = "layers/tail-cut", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-throttle = { path = "layers/throttle", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-timeout = { path = "layers/timeout", version = "0.55.0", optional = true, default-features = false }
-opendal-layer-tracing = { path = "layers/tracing", version = "0.55.0", optional = true, default-features = false }
-opendal-service-aliyun-drive = { path = "services/aliyun-drive", version = "0.55.0", optional = true, default-features = false }
-opendal-service-alluxio = { path = "services/alluxio", version = "0.55.0", optional = true, default-features = false }
-opendal-service-azblob = { path = "services/azblob", version = "0.55.0", optional = true, default-features = false }
-opendal-service-azdls = { path = "services/azdls", version = "0.55.0", optional = true, default-features = false }
-opendal-service-azfile = { path = "services/azfile", version = "0.55.0", optional = true, default-features = false }
-opendal-service-b2 = { path = "services/b2", version = "0.55.0", optional = true, default-features = false }
-opendal-service-cacache = { path = "services/cacache", version = "0.55.0", optional = true, default-features = false }
-opendal-service-cloudflare-kv = { path = "services/cloudflare-kv", version = "0.55.0", optional = true, default-features = false }
-opendal-service-compfs = { path = "services/compfs", version = "0.55.0", optional = true, default-features = false }
-opendal-service-cos = { path = "services/cos", version = "0.55.0", optional = true, default-features = false }
-opendal-service-d1 = { path = "services/d1", version = "0.55.0", optional = true, default-features = false }
-opendal-service-dashmap = { path = "services/dashmap", version = "0.55.0", optional = true, default-features = false }
-opendal-service-dbfs = { path = "services/dbfs", version = "0.55.0", optional = true, default-features = false }
-opendal-service-dropbox = { path = "services/dropbox", version = "0.55.0", optional = true, default-features = false }
-opendal-service-etcd = { path = "services/etcd", version = "0.55.0", optional = true, default-features = false }
-opendal-service-foundationdb = { path = "services/foundationdb", version = "0.55.0", optional = true, default-features = false }
-opendal-service-foyer = { path = "services/foyer", version = "0.55.0", optional = true, default-features = false }
-opendal-service-fs = { path = "services/fs", version = "0.55.0", optional = true, default-features = false }
-opendal-service-ftp = { path = "services/ftp", version = "0.55.0", optional = true, default-features = false }
-opendal-service-gcs = { path = "services/gcs", version = "0.55.0", optional = true, default-features = false }
-opendal-service-gdrive = { path = "services/gdrive", version = "0.55.0", optional = true, default-features = false }
-opendal-service-ghac = { path = "services/ghac", version = "0.55.0", optional = true, default-features = false }
-opendal-service-github = { path = "services/github", version = "0.55.0", optional = true, default-features = false }
-opendal-service-gridfs = { path = "services/gridfs", version = "0.55.0", optional = true, default-features = false }
-opendal-service-hdfs = { path = "services/hdfs", version = "0.55.0", optional = true, default-features = false }
-opendal-service-hdfs-native = { path = "services/hdfs-native", version = "0.55.0", optional = true, default-features = false }
-opendal-service-hf = { path = "services/hf", version = "0.55.0", optional = true, default-features = false }
-opendal-service-http = { path = "services/http", version = "0.55.0", optional = true, default-features = false }
-opendal-service-ipfs = { path = "services/ipfs", version = "0.55.0", optional = true, default-features = false }
-opendal-service-ipmfs = { path = "services/ipmfs", version = "0.55.0", optional = true, default-features = false }
-opendal-service-koofr = { path = "services/koofr", version = "0.55.0", optional = true, default-features = false }
-opendal-service-lakefs = { path = "services/lakefs", version = "0.55.0", optional = true, default-features = false }
-opendal-service-memcached = { path = "services/memcached", version = "0.55.0", optional = true, default-features = false }
-opendal-service-mini-moka = { path = "services/mini_moka", version = "0.55.0", optional = true, default-features = false }
-opendal-service-moka = { path = "services/moka", version = "0.55.0", optional = true, default-features = false }
-opendal-service-mongodb = { path = "services/mongodb", version = "0.55.0", optional = true, default-features = false }
-opendal-service-monoiofs = { path = "services/monoiofs", version = "0.55.0", optional = true, default-features = false }
-opendal-service-mysql = { path = "services/mysql", version = "0.55.0", optional = true, default-features = false }
-opendal-service-obs = { path = "services/obs", version = "0.55.0", optional = true, default-features = false }
-opendal-service-onedrive = { path = "services/onedrive", version = "0.55.0", optional = true, default-features = false }
-opendal-service-oss = { path = "services/oss", version = "0.55.0", optional = true, default-features = false }
-opendal-service-pcloud = { path = "services/pcloud", version = "0.55.0", optional = true, default-features = false }
-opendal-service-persy = { path = "services/persy", version = "0.55.0", optional = true, default-features = false }
-opendal-service-postgresql = { path = "services/postgresql", version = "0.55.0", optional = true, default-features = false }
-opendal-service-redb = { path = "services/redb", version = "0.55.0", optional = true, default-features = false }
-opendal-service-redis = { path = "services/redis", version = "0.55.0", optional = true, default-features = false }
-opendal-service-rocksdb = { path = "services/rocksdb", version = "0.55.0", optional = true, default-features = false }
-opendal-service-s3 = { path = "services/s3", version = "0.55.0", optional = true, default-features = false }
-opendal-service-seafile = { path = "services/seafile", version = "0.55.0", optional = true, default-features = false }
-opendal-service-sftp = { path = "services/sftp", version = "0.55.0", optional = true, default-features = false }
-opendal-service-sled = { path = "services/sled", version = "0.55.0", optional = true, default-features = false }
-opendal-service-sqlite = { path = "services/sqlite", version = "0.55.0", optional = true, default-features = false }
-opendal-service-surrealdb = { path = "services/surrealdb", version = "0.55.0", optional = true, default-features = false }
-opendal-service-swift = { path = "services/swift", version = "0.55.0", optional = true, default-features = false }
-opendal-service-tikv = { path = "services/tikv", version = "0.55.0", optional = true, default-features = false }
-opendal-service-tos = { path = "services/tos", version = "0.55.0", optional = true, default-features = false }
-opendal-service-upyun = { path = "services/upyun", version = "0.55.0", optional = true, default-features = false }
-opendal-service-vercel-artifacts = { path = "services/vercel-artifacts", version = "0.55.0", optional = true, default-features = false }
-opendal-service-vercel-blob = { path = "services/vercel-blob", version = "0.55.0", optional = true, default-features = false }
-opendal-service-webdav = { path = "services/webdav", version = "0.55.0", optional = true, default-features = false }
-opendal-service-webhdfs = { path = "services/webhdfs", version = "0.55.0", optional = true, default-features = false }
-opendal-service-yandex-disk = { path = "services/yandex-disk", version = "0.55.0", optional = true, default-features = false }
-opendal-testkit = { path = "testkit", version = "0.55.0", optional = true }
+opendal-core = { path = "core", version = "0.56.0", default-features = false }
+opendal-layer-async-backtrace = { path = "layers/async-backtrace", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-await-tree = { path = "layers/await-tree", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-capability-check = { path = "layers/capability-check", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-chaos = { path = "layers/chaos", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-concurrent-limit = { path = "layers/concurrent-limit", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-fastmetrics = { path = "layers/fastmetrics", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-fastrace = { path = "layers/fastrace", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-foyer = { path = "layers/foyer", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-hotpath = { path = "layers/hotpath", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-immutable-index = { path = "layers/immutable-index", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-logging = { path = "layers/logging", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-metrics = { path = "layers/metrics", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-mime-guess = { path = "layers/mime-guess", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-observe-metrics-common = { path = "layers/observe-metrics-common", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-otelmetrics = { path = "layers/otelmetrics", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-oteltrace = { path = "layers/oteltrace", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-prometheus = { path = "layers/prometheus", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-prometheus-client = { path = "layers/prometheus-client", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-retry = { path = "layers/retry", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-route = { path = "layers/route", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-tail-cut = { path = "layers/tail-cut", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-throttle = { path = "layers/throttle", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-timeout = { path = "layers/timeout", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-tracing = { path = "layers/tracing", version = "0.56.0", optional = true, default-features = false }
+opendal-service-aliyun-drive = { path = "services/aliyun-drive", version = "0.56.0", optional = true, default-features = false }
+opendal-service-alluxio = { path = "services/alluxio", version = "0.56.0", optional = true, default-features = false }
+opendal-service-azblob = { path = "services/azblob", version = "0.56.0", optional = true, default-features = false }
+opendal-service-azdls = { path = "services/azdls", version = "0.56.0", optional = true, default-features = false }
+opendal-service-azfile = { path = "services/azfile", version = "0.56.0", optional = true, default-features = false }
+opendal-service-b2 = { path = "services/b2", version = "0.56.0", optional = true, default-features = false }
+opendal-service-cacache = { path = "services/cacache", version = "0.56.0", optional = true, default-features = false }
+opendal-service-cloudflare-kv = { path = "services/cloudflare-kv", version = "0.56.0", optional = true, default-features = false }
+opendal-service-compfs = { path = "services/compfs", version = "0.56.0", optional = true, default-features = false }
+opendal-service-cos = { path = "services/cos", version = "0.56.0", optional = true, default-features = false }
+opendal-service-d1 = { path = "services/d1", version = "0.56.0", optional = true, default-features = false }
+opendal-service-dashmap = { path = "services/dashmap", version = "0.56.0", optional = true, default-features = false }
+opendal-service-dbfs = { path = "services/dbfs", version = "0.56.0", optional = true, default-features = false }
+opendal-service-dropbox = { path = "services/dropbox", version = "0.56.0", optional = true, default-features = false }
+opendal-service-etcd = { path = "services/etcd", version = "0.56.0", optional = true, default-features = false }
+opendal-service-foundationdb = { path = "services/foundationdb", version = "0.56.0", optional = true, default-features = false }
+opendal-service-foyer = { path = "services/foyer", version = "0.56.0", optional = true, default-features = false }
+opendal-service-fs = { path = "services/fs", version = "0.56.0", optional = true, default-features = false }
+opendal-service-ftp = { path = "services/ftp", version = "0.56.0", optional = true, default-features = false }
+opendal-service-gcs = { path = "services/gcs", version = "0.56.0", optional = true, default-features = false }
+opendal-service-gdrive = { path = "services/gdrive", version = "0.56.0", optional = true, default-features = false }
+opendal-service-ghac = { path = "services/ghac", version = "0.56.0", optional = true, default-features = false }
+opendal-service-github = { path = "services/github", version = "0.56.0", optional = true, default-features = false }
+opendal-service-gridfs = { path = "services/gridfs", version = "0.56.0", optional = true, default-features = false }
+opendal-service-hdfs = { path = "services/hdfs", version = "0.56.0", optional = true, default-features = false }
+opendal-service-hdfs-native = { path = "services/hdfs-native", version = "0.56.0", optional = true, default-features = false }
+opendal-service-hf = { path = "services/hf", version = "0.56.0", optional = true, default-features = false }
+opendal-service-http = { path = "services/http", version = "0.56.0", optional = true, default-features = false }
+opendal-service-ipfs = { path = "services/ipfs", version = "0.56.0", optional = true, default-features = false }
+opendal-service-ipmfs = { path = "services/ipmfs", version = "0.56.0", optional = true, default-features = false }
+opendal-service-koofr = { path = "services/koofr", version = "0.56.0", optional = true, default-features = false }
+opendal-service-lakefs = { path = "services/lakefs", version = "0.56.0", optional = true, default-features = false }
+opendal-service-memcached = { path = "services/memcached", version = "0.56.0", optional = true, default-features = false }
+opendal-service-mini-moka = { path = "services/mini_moka", version = "0.56.0", optional = true, default-features = false }
+opendal-service-moka = { path = "services/moka", version = "0.56.0", optional = true, default-features = false }
+opendal-service-mongodb = { path = "services/mongodb", version = "0.56.0", optional = true, default-features = false }
+opendal-service-monoiofs = { path = "services/monoiofs", version = "0.56.0", optional = true, default-features = false }
+opendal-service-mysql = { path = "services/mysql", version = "0.56.0", optional = true, default-features = false }
+opendal-service-obs = { path = "services/obs", version = "0.56.0", optional = true, default-features = false }
+opendal-service-onedrive = { path = "services/onedrive", version = "0.56.0", optional = true, default-features = false }
+opendal-service-oss = { path = "services/oss", version = "0.56.0", optional = true, default-features = false }
+opendal-service-pcloud = { path = "services/pcloud", version = "0.56.0", optional = true, default-features = false }
+opendal-service-persy = { path = "services/persy", version = "0.56.0", optional = true, default-features = false }
+opendal-service-postgresql = { path = "services/postgresql", version = "0.56.0", optional = true, default-features = false }
+opendal-service-redb = { path = "services/redb", version = "0.56.0", optional = true, default-features = false }
+opendal-service-redis = { path = "services/redis", version = "0.56.0", optional = true, default-features = false }
+opendal-service-rocksdb = { path = "services/rocksdb", version = "0.56.0", optional = true, default-features = false }
+opendal-service-s3 = { path = "services/s3", version = "0.56.0", optional = true, default-features = false }
+opendal-service-seafile = { path = "services/seafile", version = "0.56.0", optional = true, default-features = false }
+opendal-service-sftp = { path = "services/sftp", version = "0.56.0", optional = true, default-features = false }
+opendal-service-sled = { path = "services/sled", version = "0.56.0", optional = true, default-features = false }
+opendal-service-sqlite = { path = "services/sqlite", version = "0.56.0", optional = true, default-features = false }
+opendal-service-surrealdb = { path = "services/surrealdb", version = "0.56.0", optional = true, default-features = false }
+opendal-service-swift = { path = "services/swift", version = "0.56.0", optional = true, default-features = false }
+opendal-service-tikv = { path = "services/tikv", version = "0.56.0", optional = true, default-features = false }
+opendal-service-tos = { path = "services/tos", version = "0.56.0", optional = true, default-features = false }
+opendal-service-upyun = { path = "services/upyun", version = "0.56.0", optional = true, default-features = false }
+opendal-service-vercel-artifacts = { path = "services/vercel-artifacts", version = "0.56.0", optional = true, default-features = false }
+opendal-service-vercel-blob = { path = "services/vercel-blob", version = "0.56.0", optional = true, default-features = false }
+opendal-service-webdav = { path = "services/webdav", version = "0.56.0", optional = true, default-features = false }
+opendal-service-webhdfs = { path = "services/webhdfs", version = "0.56.0", optional = true, default-features = false }
+opendal-service-yandex-disk = { path = "services/yandex-disk", version = "0.56.0", optional = true, default-features = false }
+opendal-testkit = { path = "testkit", version = "0.56.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-opendal-layer-dtrace = { path = "layers/dtrace", version = "0.55.0", optional = true, default-features = false }
+opendal-layer-dtrace = { path = "layers/dtrace", version = "0.56.0", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-opendal-service-opfs = { path = "services/opfs", version = "0.55.0", optional = true, default-features = false }
+opendal-service-opfs = { path = "services/opfs", version = "0.56.0", optional = true, default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -1,204 +1,245 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense
-android_system_properties@0.1.5	X									X		
-anyhow@1.0.100	X									X		
-async-trait@0.1.89	X									X		
-atomic-waker@1.1.2	X									X		
-autocfg@1.5.0	X									X		
-backon@1.6.0	X											
-base64@0.22.1	X									X		
-bitflags@2.10.0	X									X		
-block-buffer@0.10.4	X									X		
-bumpalo@3.19.0	X									X		
-bytes@1.11.0										X		
-cc@1.2.46	X									X		
-cfg-if@1.0.4	X									X		
-chrono@0.4.42	X									X		
-const-oid@0.9.6	X									X		
-const-random@0.1.18	X									X		
-const-random-macro@0.1.16	X									X		
-core-foundation-sys@0.8.7	X									X		
-cpufeatures@0.2.17	X									X		
-crc32c@0.6.8	X									X		
-crunchy@0.2.4										X		
-crypto-common@0.1.7	X									X		
-digest@0.10.7	X									X		
-displaydoc@0.2.5	X									X		
-dlv-list@0.5.2	X									X		
-dotenvy@0.15.7										X		
-equivalent@1.0.2	X									X		
-fastrand@2.3.0	X									X		
-find-msvc-tools@0.1.5	X									X		
-fnv@1.0.7	X									X		
-form_urlencoded@1.2.2	X									X		
-futures@0.3.31	X									X		
-futures-channel@0.3.31	X									X		
-futures-core@0.3.31	X									X		
-futures-io@0.3.31	X									X		
-futures-macro@0.3.31	X									X		
-futures-sink@0.3.31	X									X		
-futures-task@0.3.31	X									X		
-futures-util@0.3.31	X									X		
-generic-array@0.14.7										X		
-getrandom@0.2.16	X									X		
-getrandom@0.3.4	X									X		
-gloo-timers@0.3.0	X									X		
-h2@0.4.12										X		
-hashbrown@0.14.5	X									X		
-hashbrown@0.16.0	X									X		
-hex@0.4.3	X									X		
-hmac@0.12.1	X									X		
-home@0.5.11	X									X		
-http@1.3.1	X									X		
-http-body@1.0.1										X		
-http-body-util@0.1.3										X		
-httparse@1.10.1	X									X		
-hyper@1.8.1										X		
-hyper-rustls@0.27.7	X							X		X		
-hyper-util@0.1.18										X		
-iana-time-zone@0.1.64	X									X		
-iana-time-zone-haiku@0.1.2	X									X		
-icu_collections@2.1.1											X	
-icu_locale_core@2.1.1											X	
-icu_normalizer@2.1.1											X	
-icu_normalizer_data@2.1.1											X	
-icu_properties@2.1.1											X	
-icu_properties_data@2.1.1											X	
-icu_provider@2.1.1											X	
-idna@1.1.0	X									X		
-idna_adapter@1.2.1	X									X		
-indexmap@2.12.0	X									X		
-ipnet@2.11.0	X									X		
-iri-string@0.7.9	X									X		
-itoa@1.0.15	X									X		
-jiff@0.2.16										X		X
-jiff-tzdb@0.1.4										X		X
-jiff-tzdb-platform@0.1.3										X		X
-js-sys@0.3.82	X									X		
-libc@0.2.177	X									X		
-litemap@0.8.1											X	
-log@0.4.28	X									X		
-md-5@0.10.6	X									X		
-memchr@2.7.6										X		X
-mio@1.1.0										X		
-num-traits@0.2.19	X									X		
-once_cell@1.21.3	X									X		
-opendal@0.55.0	X											
-ordered-multimap@0.7.3										X		
-percent-encoding@2.3.2	X									X		
-pin-project-lite@0.2.16	X									X		
-pin-utils@0.1.0	X									X		
-portable-atomic@1.11.1	X									X		
-portable-atomic-util@0.2.4	X									X		
-potential_utf@0.1.4											X	
-ppv-lite86@0.2.21	X									X		
-proc-macro2@1.0.103	X									X		
-quick-xml@0.38.4										X		
-quote@1.0.42	X									X		
-r-efi@5.3.0	X								X	X		
-rand@0.8.5	X									X		
-rand_chacha@0.3.1	X									X		
-rand_core@0.6.4	X									X		
-reqsign@0.16.5	X											
-reqsign-aliyun-oss@2.0.2	X											
-reqsign-aws-v4@2.0.1	X											
-reqsign-core@2.0.2	X											
-reqsign-file-read-tokio@2.0.1	X											
-reqsign-http-send-reqwest@2.0.1	X											
-reqwest@0.12.24	X									X		
-ring@0.17.14	X							X				
-rust-ini@0.21.3										X		
-rustc_version@0.4.1	X									X		
-rustls@0.23.35	X							X		X		
-rustls-pki-types@1.13.0	X									X		
-rustls-webpki@0.103.8								X				
-rustversion@1.0.22	X									X		
-ryu@1.0.20	X				X							
-semver@1.0.27	X									X		
-serde@1.0.228	X									X		
-serde_core@1.0.228	X									X		
-serde_derive@1.0.228	X									X		
-serde_json@1.0.145	X									X		
-serde_urlencoded@0.7.1	X									X		
-sha1@0.10.6	X									X		
-sha2@0.10.9	X									X		
-shlex@1.3.0	X									X		
-slab@0.4.11										X		
-smallvec@1.15.1	X									X		
-socket2@0.6.1	X									X		
-stable_deref_trait@1.2.1	X									X		
-subtle@2.6.1				X								
-syn@2.0.110	X									X		
-sync_wrapper@1.0.2	X											
-synstructure@0.13.2										X		
-tiny-keccak@2.0.2						X						
-tinystr@0.8.2											X	
-tokio@1.48.0										X		
-tokio-macros@2.6.0										X		
-tokio-rustls@0.26.4	X									X		
-tokio-util@0.7.17										X		
-tower@0.5.2										X		
-tower-http@0.6.6										X		
-tower-layer@0.3.3										X		
-tower-service@0.3.3										X		
-tracing@0.1.41										X		
-tracing-attributes@0.1.30										X		
-tracing-core@0.1.34										X		
-try-lock@0.2.5										X		
-typenum@1.19.0	X									X		
-unicode-ident@1.0.22	X									X	X	
-untrusted@0.9.0								X				
-url@2.5.7	X									X		
-utf8_iter@1.0.4	X									X		
-uuid@1.18.1	X									X		
-version_check@0.9.5	X									X		
-want@0.3.1										X		
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X		
-wasip2@1.0.1+wasi-0.2.4	X	X								X		
-wasm-bindgen@0.2.105	X									X		
-wasm-bindgen-futures@0.4.55	X									X		
-wasm-bindgen-macro@0.2.105	X									X		
-wasm-bindgen-macro-support@0.2.105	X									X		
-wasm-bindgen-shared@0.2.105	X									X		
-wasm-streams@0.4.2	X									X		
-web-sys@0.3.82	X									X		
-webpki-roots@1.0.4							X					
-windows-core@0.62.2	X									X		
-windows-implement@0.60.2	X									X		
-windows-interface@0.59.3	X									X		
-windows-link@0.2.1	X									X		
-windows-result@0.4.1	X									X		
-windows-strings@0.5.1	X									X		
-windows-sys@0.52.0	X									X		
-windows-sys@0.59.0	X									X		
-windows-sys@0.60.2	X									X		
-windows-sys@0.61.2	X									X		
-windows-targets@0.52.6	X									X		
-windows-targets@0.53.5	X									X		
-windows_aarch64_gnullvm@0.52.6	X									X		
-windows_aarch64_gnullvm@0.53.1	X									X		
-windows_aarch64_msvc@0.52.6	X									X		
-windows_aarch64_msvc@0.53.1	X									X		
-windows_i686_gnu@0.52.6	X									X		
-windows_i686_gnu@0.53.1	X									X		
-windows_i686_gnullvm@0.52.6	X									X		
-windows_i686_gnullvm@0.53.1	X									X		
-windows_i686_msvc@0.52.6	X									X		
-windows_i686_msvc@0.53.1	X									X		
-windows_x86_64_gnu@0.52.6	X									X		
-windows_x86_64_gnu@0.53.1	X									X		
-windows_x86_64_gnullvm@0.52.6	X									X		
-windows_x86_64_gnullvm@0.53.1	X									X		
-windows_x86_64_msvc@0.52.6	X									X		
-windows_x86_64_msvc@0.53.1	X									X		
-wit-bindgen@0.46.0	X	X								X		
-writeable@0.6.2											X	
-yoke@0.8.1											X	
-yoke-derive@0.8.1											X	
-zerocopy@0.8.27	X		X							X		
-zerocopy-derive@0.8.27	X		X							X		
-zerofrom@0.1.6											X	
-zerofrom-derive@0.1.6											X	
-zeroize@1.8.2	X									X		
-zerotrie@0.2.3											X	
-zerovec@0.11.5											X	
-zerovec-derive@0.11.2											X	
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
+anyhow@1.0.102	X									X			
+atomic-waker@1.1.2	X									X			
+aws-lc-rs@1.16.2	X							X					
+aws-lc-sys@0.39.0	X			X				X		X	X		
+backon@1.6.0	X												
+base64@0.22.1	X									X			
+bitflags@2.11.0	X									X			
+block-buffer@0.10.4	X									X			
+bumpalo@3.20.2	X									X			
+bytes@1.11.1										X			
+cc@1.2.57	X									X			
+cesu8@1.1.0	X									X			
+cfg-if@1.0.4	X									X			
+cmake@0.1.57	X									X			
+combine@4.6.7										X			
+const-oid@0.9.6	X									X			
+const-random@0.1.18	X									X			
+const-random-macro@0.1.16	X									X			
+core-foundation@0.10.1	X									X			
+core-foundation@0.9.4	X									X			
+core-foundation-sys@0.8.7	X									X			
+cpufeatures@0.2.17	X									X			
+crc32c@0.6.8	X									X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7	X									X			
+ctor@0.6.3	X									X			
+ctor-proc-macro@0.0.7	X									X			
+digest@0.10.7	X									X			
+displaydoc@0.2.5	X									X			
+dlv-list@0.5.2	X									X			
+dotenvy@0.15.7										X			
+dtor@0.1.1	X									X			
+dtor-proc-macro@0.0.6	X									X			
+dunce@1.0.5	X					X					X		
+encoding_rs@0.8.35	X			X						X			
+equivalent@1.0.2	X									X			
+erased-serde@0.4.10	X									X			
+errno@0.3.14	X									X			
+fastrand@2.3.0	X									X			
+find-msvc-tools@0.1.9	X									X			
+fnv@1.0.7	X									X			
+form_urlencoded@1.2.2	X									X			
+fs_extra@1.3.0										X			
+futures@0.3.32	X									X			
+futures-channel@0.3.32	X									X			
+futures-core@0.3.32	X									X			
+futures-executor@0.3.32	X									X			
+futures-io@0.3.32	X									X			
+futures-macro@0.3.32	X									X			
+futures-sink@0.3.32	X									X			
+futures-task@0.3.32	X									X			
+futures-util@0.3.32	X									X			
+generic-array@0.14.7										X			
+getrandom@0.2.17	X									X			
+getrandom@0.3.4	X									X			
+getrandom@0.4.2	X									X			
+gloo-timers@0.3.0	X									X			
+h2@0.4.13										X			
+hashbrown@0.14.5	X									X			
+hashbrown@0.16.1	X									X			
+hex@0.4.3	X									X			
+hmac@0.12.1	X									X			
+http@1.4.0	X									X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1	X									X			
+hyper@1.8.1										X			
+hyper-rustls@0.27.7	X							X		X			
+hyper-util@0.1.20										X			
+icu_collections@2.1.1												X	
+icu_locale_core@2.1.1												X	
+icu_normalizer@2.1.1												X	
+icu_normalizer_data@2.1.1												X	
+icu_properties@2.1.2												X	
+icu_properties_data@2.1.2												X	
+icu_provider@2.1.1												X	
+idna@1.1.0	X									X			
+idna_adapter@1.2.1	X									X			
+indexmap@2.13.0	X									X			
+ipnet@2.12.0	X									X			
+iri-string@0.7.11	X									X			
+itoa@1.0.18	X									X			
+jiff@0.2.23										X			X
+jiff-tzdb@0.1.6										X			X
+jiff-tzdb-platform@0.1.3										X			X
+jni@0.21.1	X									X			
+jni-sys@0.3.1	X									X			
+jni-sys@0.4.1	X									X			
+jni-sys-macros@0.4.1	X									X			
+jobserver@0.1.34	X									X			
+js-sys@0.3.91	X									X			
+libc@0.2.183	X									X			
+linux-raw-sys@0.12.1	X	X								X			
+litemap@0.8.1												X	
+log@0.4.29	X									X			
+md-5@0.10.6	X									X			
+mea@0.6.3	X												
+memchr@2.8.0										X			X
+mime@0.3.17	X									X			
+mio@1.1.1										X			
+once_cell@1.21.4	X									X			
+opendal@0.56.0	X												
+opendal-core@0.56.0	X												
+opendal-layer-concurrent-limit@0.56.0	X												
+opendal-layer-logging@0.56.0	X												
+opendal-layer-retry@0.56.0	X												
+opendal-layer-timeout@0.56.0	X												
+opendal-service-fs@0.56.0	X												
+opendal-service-s3@0.56.0	X												
+opendal-testkit@0.56.0	X												
+openssl-probe@0.2.1	X									X			
+ordered-multimap@0.7.3										X			
+percent-encoding@2.3.2	X									X			
+pin-project-lite@0.2.17	X									X			
+pin-utils@0.1.0	X									X			
+portable-atomic@1.13.1	X									X			
+portable-atomic-util@0.2.6	X									X			
+potential_utf@0.1.4												X	
+ppv-lite86@0.2.21	X									X			
+proc-macro2@1.0.106	X									X			
+quick-xml@0.38.4										X			
+quick-xml@0.39.2										X			
+quote@1.0.45	X									X			
+r-efi@5.3.0	X								X	X			
+r-efi@6.0.0	X								X	X			
+rand@0.8.5	X									X			
+rand_chacha@0.3.1	X									X			
+rand_core@0.6.4	X									X			
+reqsign-aws-v4@3.0.0	X												
+reqsign-core@3.0.0	X												
+reqsign-file-read-tokio@3.0.0	X												
+reqwest@0.13.2	X									X			
+rust-ini@0.21.3										X			
+rustc_version@0.4.1	X									X			
+rustix@1.1.4	X	X								X			
+rustls@0.23.37	X							X		X			
+rustls-native-certs@0.8.3	X							X		X			
+rustls-pki-types@1.14.0	X									X			
+rustls-platform-verifier@0.6.2	X									X			
+rustls-platform-verifier-android@0.1.1	X									X			
+rustls-webpki@0.103.10								X					
+rustversion@1.0.22	X									X			
+ryu@1.0.23	X				X								
+same-file@1.0.6										X			X
+schannel@0.1.29										X			
+security-framework@3.7.0	X									X			
+security-framework-sys@2.17.0	X									X			
+semver@1.0.27	X									X			
+serde@1.0.228	X									X			
+serde_buf@0.1.2	X									X			
+serde_core@1.0.228	X									X			
+serde_derive@1.0.228	X									X			
+serde_fmt@1.1.0	X									X			
+serde_json@1.0.149	X									X			
+serde_urlencoded@0.7.1	X									X			
+sha1@0.10.6	X									X			
+sha2@0.10.9	X									X			
+shlex@1.3.0	X									X			
+slab@0.4.12										X			
+smallvec@1.15.1	X									X			
+socket2@0.6.3	X									X			
+stable_deref_trait@1.2.1	X									X			
+subtle@2.6.1				X									
+sval@2.17.0	X									X			
+sval_buffer@2.17.0	X									X			
+sval_dynamic@2.17.0	X									X			
+sval_fmt@2.17.0	X									X			
+sval_nested@2.17.0	X									X			
+sval_ref@2.17.0	X									X			
+sval_serde@2.17.0	X									X			
+syn@2.0.117	X									X			
+sync_wrapper@1.0.2	X												
+synstructure@0.13.2										X			
+system-configuration@0.7.0	X									X			
+system-configuration-sys@0.6.0	X									X			
+thiserror@1.0.69	X									X			
+thiserror-impl@1.0.69	X									X			
+tiny-keccak@2.0.2						X							
+tinystr@0.8.2												X	
+tokio@1.50.0										X			
+tokio-macros@2.6.1										X			
+tokio-rustls@0.26.4	X									X			
+tokio-util@0.7.18										X			
+tower@0.5.3										X			
+tower-http@0.6.8										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-core@0.1.36										X			
+try-lock@0.2.5										X			
+typeid@1.0.3	X									X			
+typenum@1.19.0	X									X			
+unicode-ident@1.0.24	X									X		X	
+untrusted@0.9.0								X					
+url@2.5.8	X									X			
+utf8_iter@1.0.4	X									X			
+uuid@1.22.0	X									X			
+value-bag@1.12.0	X									X			
+value-bag-serde1@1.12.0	X									X			
+value-bag-sval2@1.12.0	X									X			
+version_check@0.9.5	X									X			
+walkdir@2.5.0										X			X
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
+wasip2@1.0.1+wasi-0.2.4	X	X								X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
+wasm-bindgen@0.2.114	X									X			
+wasm-bindgen-futures@0.4.64	X									X			
+wasm-bindgen-macro@0.2.114	X									X			
+wasm-bindgen-macro-support@0.2.114	X									X			
+wasm-bindgen-shared@0.2.114	X									X			
+wasm-streams@0.5.0	X									X			
+web-sys@0.3.91	X									X			
+web-time@1.1.0	X									X			
+webpki-root-certs@1.0.6							X						
+winapi-util@0.1.11										X			X
+windows-link@0.2.1	X									X			
+windows-registry@0.6.1	X									X			
+windows-result@0.4.1	X									X			
+windows-strings@0.5.1	X									X			
+windows-sys@0.45.0	X									X			
+windows-sys@0.61.2	X									X			
+windows-targets@0.42.2	X									X			
+windows_aarch64_gnullvm@0.42.2	X									X			
+windows_aarch64_msvc@0.42.2	X									X			
+windows_i686_gnu@0.42.2	X									X			
+windows_i686_msvc@0.42.2	X									X			
+windows_x86_64_gnu@0.42.2	X									X			
+windows_x86_64_gnullvm@0.42.2	X									X			
+windows_x86_64_msvc@0.42.2	X									X			
+wit-bindgen@0.46.0	X	X								X			
+wit-bindgen@0.51.0	X	X								X			
+writeable@0.6.2												X	
+xattr@1.6.1	X									X			
+yoke@0.8.1												X	
+yoke-derive@0.8.1												X	
+zerocopy@0.8.47	X		X							X			
+zerofrom@0.1.6												X	
+zerofrom-derive@0.1.6												X	
+zeroize@1.8.2	X									X			
+zerotrie@0.2.3												X	
+zerovec@0.11.5												X	
+zerovec-derive@0.11.2												X	
+zmij@1.0.21										X			

--- a/core/benches/vs_fs/Cargo.toml
+++ b/core/benches/vs_fs/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "opendal-benchmark-vs-fs"
 publish = false
 rust-version = "1.85"
-version = "0.0.0"
+version = "0.56.0"
 
 [dependencies]
 criterion = { version = "0.7", features = ["async", "async_tokio"] }

--- a/core/benches/vs_s3/Cargo.toml
+++ b/core/benches/vs_s3/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "opendal-benchmark-vs-s3"
 publish = false
 rust-version = "1.85"
-version = "0.0.0"
+version = "0.56.0"
 
 [dependencies]
 aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }

--- a/core/core/src/docs/upgrade.md
+++ b/core/core/src/docs/upgrade.md
@@ -2,6 +2,24 @@
 
 ## Public API
 
+### Deprecated HTTP client builder hooks removed
+
+The long-deprecated `http_client` customization hooks on service builders have been removed. Configure custom HTTP behavior with the layered HTTP client APIs instead of mutating service builders directly.
+
+### `TimeoutLayer::with_speed` removed
+
+`TimeoutLayer::with_speed` has been removed after a deprecation cycle. Use `with_io_timeout` to enforce per-IO deadlines instead.
+
+## Raw API
+
+### Test helpers moved to `opendal_testkit`
+
+The old `opendal::raw::tests` module has been split into the standalone `opendal-testkit` crate. If you maintain out-of-tree services or integrations, replace imports from `opendal::raw::tests` with `opendal::tests` or depend on `opendal-testkit` directly.
+
+# Upgrade to v0.55
+
+## Public API
+
 ### Timestamp types now come from `jiff`
 
 All public metadata APIs that previously exposed `chrono::DateTime<Utc>` now use `jiff::Timestamp`. For example, `Metadata::last_modified()` and related setters return/accept `Timestamp` values (`core/src/types/metadata.rs`). Update downstream crates to depend on `jiff` if they manipulate these timestamps or convert them to other formats.
@@ -18,14 +36,6 @@ All public metadata APIs that previously exposed `chrono::DateTime<Utc>` now use
 
 `S3Builder` no longer exposes the deprecated `security_token()` helper. Use `session_token()` exclusively when configuring temporary credentials.
 
-### Deprecated HTTP client builder hooks removed
-
-The long-deprecated `http_client` customization hooks on service builders have been removed. Configure custom HTTP behavior with the layered HTTP client APIs instead of mutating service builders directly.
-
-### `TimeoutLayer::with_speed` removed
-
-`TimeoutLayer::with_speed` has been removed after a deprecation cycle. Use `with_io_timeout` to enforce per-IO deadlines instead.
-
 ### KV-style services no longer pretend to support `list`
 
 Services that never returned meaningful results for `Operator::list` (such as D1, FoundationDB, GridFS, Memcached, MongoDB, MySQL, Persy, PostgreSQL, Redb, Redis, SurrealDB, TiKV, etc.) now rely on the default `Unsupported` implementation. Those features will be implemented later.
@@ -35,10 +45,6 @@ Services that never returned meaningful results for `Operator::list` (such as D1
 ### Deprecated KV adapters removed
 
 The legacy `opendal::raw::adapters::{kv, typed_kv}` modules have been deleted. Services should directly implement `Access` instead of depending on the adapters. Remove the corresponding imports and shim layers from any out-of-tree services.
-
-### Test helpers moved to `opendal_testkit`
-
-The old `opendal::raw::tests` module has been split into the standalone `opendal-testkit` crate. If you maintain out-of-tree services or integrations, replace imports from `opendal::raw::tests` with `opendal::tests` or depend on `opendal-testkit` directly.
 
 # Upgrade to v0.54
 

--- a/core/core/src/docs/upgrade.md
+++ b/core/core/src/docs/upgrade.md
@@ -1,4 +1,4 @@
-# Upgrade to v0.55
+# Upgrade to v0.56
 
 ## Public API
 
@@ -18,6 +18,14 @@ All public metadata APIs that previously exposed `chrono::DateTime<Utc>` now use
 
 `S3Builder` no longer exposes the deprecated `security_token()` helper. Use `session_token()` exclusively when configuring temporary credentials.
 
+### Deprecated HTTP client builder hooks removed
+
+The long-deprecated `http_client` customization hooks on service builders have been removed. Configure custom HTTP behavior with the layered HTTP client APIs instead of mutating service builders directly.
+
+### `TimeoutLayer::with_speed` removed
+
+`TimeoutLayer::with_speed` has been removed after a deprecation cycle. Use `with_io_timeout` to enforce per-IO deadlines instead.
+
 ### KV-style services no longer pretend to support `list`
 
 Services that never returned meaningful results for `Operator::list` (such as D1, FoundationDB, GridFS, Memcached, MongoDB, MySQL, Persy, PostgreSQL, Redb, Redis, SurrealDB, TiKV, etc.) now rely on the default `Unsupported` implementation. Those features will be implemented later.
@@ -27,6 +35,10 @@ Services that never returned meaningful results for `Operator::list` (such as D1
 ### Deprecated KV adapters removed
 
 The legacy `opendal::raw::adapters::{kv, typed_kv}` modules have been deleted. Services should directly implement `Access` instead of depending on the adapters. Remove the corresponding imports and shim layers from any out-of-tree services.
+
+### Test helpers moved to `opendal_testkit`
+
+The old `opendal::raw::tests` module has been split into the standalone `opendal-testkit` crate. If you maintain out-of-tree services or integrations, replace imports from `opendal::raw::tests` with `opendal::tests` or depend on `opendal-testkit` directly.
 
 # Upgrade to v0.54
 

--- a/core/layers/async-backtrace/Cargo.toml
+++ b/core/layers/async-backtrace/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 async-backtrace = "0.2.6"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }

--- a/core/layers/await-tree/Cargo.toml
+++ b/core/layers/await-tree/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 await-tree = "0.3"
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }

--- a/core/layers/capability-check/Cargo.toml
+++ b/core/layers/capability-check/Cargo.toml
@@ -31,8 +31,8 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/chaos/Cargo.toml
+++ b/core/layers/chaos/Cargo.toml
@@ -31,8 +31,8 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 rand = { workspace = true }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }

--- a/core/layers/concurrent-limit/Cargo.toml
+++ b/core/layers/concurrent-limit/Cargo.toml
@@ -34,8 +34,8 @@ all-features = true
 futures = { workspace = true }
 http = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/core/layers/dtrace/Cargo.toml
+++ b/core/layers/dtrace/Cargo.toml
@@ -32,9 +32,9 @@ all-features = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 bytes = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 probe = "0.5.1"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/fastmetrics/Cargo.toml
+++ b/core/layers/fastmetrics/Cargo.toml
@@ -32,10 +32,10 @@ all-features = true
 
 [dependencies]
 fastmetrics = "0.7"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/fastrace/Cargo.toml
+++ b/core/layers/fastrace/Cargo.toml
@@ -32,12 +32,12 @@ all-features = true
 
 [dependencies]
 fastrace = "0.7.16"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0"
 dotenvy = "0.15"
 fastrace = { version = "0.7", features = ["enable"] }
 fastrace-jaeger = "0.7"
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/foyer/Cargo.toml
+++ b/core/layers/foyer/Cargo.toml
@@ -33,11 +33,11 @@ all-features = true
 [dependencies]
 bincode = "1"
 foyer = { version = "0.18", features = ["serde"] }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", features = [
+opendal-core = { path = "../../core", version = "0.56.0", features = [
   "services-memory",
 ] }
 size = "0.5"

--- a/core/layers/hotpath/Cargo.toml
+++ b/core/layers/hotpath/Cargo.toml
@@ -34,8 +34,8 @@ all-features = true
 futures = { workspace = true }
 hotpath = "0.9.2"
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/immutable-index/Cargo.toml
+++ b/core/layers/immutable-index/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
 log = { workspace = true }
 logforth = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/logging/Cargo.toml
+++ b/core/layers/logging/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }

--- a/core/layers/metrics/Cargo.toml
+++ b/core/layers/metrics/Cargo.toml
@@ -32,8 +32,8 @@ all-features = true
 
 [dependencies]
 metrics = "0.24"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }

--- a/core/layers/mime-guess/Cargo.toml
+++ b/core/layers/mime-guess/Cargo.toml
@@ -32,9 +32,9 @@ all-features = true
 
 [dependencies]
 mime_guess = "2.0.5"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/observe-metrics-common/Cargo.toml
+++ b/core/layers/observe-metrics-common/Cargo.toml
@@ -33,4 +33,4 @@ all-features = true
 [dependencies]
 futures = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }

--- a/core/layers/otelmetrics/Cargo.toml
+++ b/core/layers/otelmetrics/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.56.0" }
 opentelemetry = { version = "0.31.0", default-features = false, features = [
   "metrics",
 ] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }

--- a/core/layers/oteltrace/Cargo.toml
+++ b/core/layers/oteltrace/Cargo.toml
@@ -31,10 +31,10 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 opentelemetry = { version = "0.31.0", default-features = false, features = [
   "trace",
 ] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }

--- a/core/layers/prometheus-client/Cargo.toml
+++ b/core/layers/prometheus-client/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.56.0" }
 prometheus-client = { version = "0.24" }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/prometheus/Cargo.toml
+++ b/core/layers/prometheus/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.56.0" }
 prometheus = { version = "0.14", features = ["process"] }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/retry/Cargo.toml
+++ b/core/layers/retry/Cargo.toml
@@ -33,13 +33,13 @@ all-features = true
 [dependencies]
 backon = { version = "1.6", features = ["tokio-sleep"] }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
 bytes = { workspace = true }
 futures = { workspace = true }
 logforth = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0" }
-opendal-layer-logging = { path = "../logging", version = "0.55.0" }
-opendal-layer-timeout = { path = "../timeout", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-layer-logging = { path = "../logging", version = "0.56.0" }
+opendal-layer-timeout = { path = "../timeout", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/route/Cargo.toml
+++ b/core/layers/route/Cargo.toml
@@ -32,10 +32,10 @@ all-features = true
 
 [dependencies]
 globset = "0.4.15"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0" }
-opendal-service-fs = { path = "../../services/fs", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-service-fs = { path = "../../services/fs", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/tail-cut/Cargo.toml
+++ b/core/layers/tail-cut/Cargo.toml
@@ -31,9 +31,9 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/throttle/Cargo.toml
+++ b/core/layers/throttle/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 governor = "0.10.4"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }

--- a/core/layers/timeout/Cargo.toml
+++ b/core/layers/timeout/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0" }
-opendal-layer-retry = { path = "../retry", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-layer-retry = { path = "../retry", version = "0.56.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/tracing/Cargo.toml
+++ b/core/layers/tracing/Cargo.toml
@@ -33,13 +33,13 @@ all-features = true
 [dependencies]
 futures = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 tracing = "0.1"
 
 [dev-dependencies]
 anyhow = "1.0"
 dotenvy = "0.15"
-opendal-core = { path = "../../core", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0" }
 opentelemetry = { version = "0.31.0", default-features = false, features = [
   "trace",
 ] }

--- a/core/services/aliyun-drive/Cargo.toml
+++ b/core/services/aliyun-drive/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/alluxio/Cargo.toml
+++ b/core/services/alluxio/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/azblob/Cargo.toml
+++ b/core/services/azblob/Cargo.toml
@@ -35,8 +35,8 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
-opendal-service-azure-common = { path = "../azure-common", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-service-azure-common = { path = "../azure-common", version = "0.56.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/azdls/Cargo.toml
+++ b/core/services/azdls/Cargo.toml
@@ -34,8 +34,8 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
-opendal-service-azure-common = { path = "../azure-common", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-service-azure-common = { path = "../azure-common", version = "0.56.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/azfile/Cargo.toml
+++ b/core/services/azfile/Cargo.toml
@@ -34,8 +34,8 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
-opendal-service-azure-common = { path = "../azure-common", version = "0.55.0" }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-service-azure-common = { path = "../azure-common", version = "0.56.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/azure-common/Cargo.toml
+++ b/core/services/azure-common/Cargo.toml
@@ -32,4 +32,4 @@ all-features = true
 
 [dependencies]
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }

--- a/core/services/b2/Cargo.toml
+++ b/core/services/b2/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/cacache/Cargo.toml
+++ b/core/services/cacache/Cargo.toml
@@ -36,7 +36,7 @@ cacache = { version = "13.0", default-features = false, features = [
   "tokio-runtime",
   "mmap",
 ] }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/cloudflare-kv/Cargo.toml
+++ b/core/services/cloudflare-kv/Cargo.toml
@@ -33,6 +33,6 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/compfs/Cargo.toml
+++ b/core/services/compfs/Cargo.toml
@@ -38,7 +38,7 @@ compio = { version = "0.17.0", features = [
   "polling",
   "runtime",
 ] }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/cos/Cargo.toml
+++ b/core/services/cos/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-core = { version = "3.0.0", default-features = false }
 reqsign-file-read-tokio = { version = "3.0.0", default-features = false }

--- a/core/services/d1/Cargo.toml
+++ b/core/services/d1/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/dashmap/Cargo.toml
+++ b/core/services/dashmap/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 dashmap = "6"
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/dbfs/Cargo.toml
+++ b/core/services/dbfs/Cargo.toml
@@ -35,7 +35,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/dropbox/Cargo.toml
+++ b/core/services/dropbox/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/etcd/Cargo.toml
+++ b/core/services/etcd/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 etcd-client = { version = "0.17", features = ["tls"] }
 fastpool = "1.0.2"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["time"] }
 

--- a/core/services/foundationdb/Cargo.toml
+++ b/core/services/foundationdb/Cargo.toml
@@ -35,7 +35,7 @@ foundationdb = { version = "0.9.0", features = [
   "embedded-fdb-include",
   "fdb-7_3",
 ] }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/foyer/Cargo.toml
+++ b/core/services/foyer/Cargo.toml
@@ -33,12 +33,12 @@ all-features = true
 [dependencies]
 foyer = { version = "0.18", features = ["serde"] }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-opendal = { path = "../..", version = "0.55.0", features = ["services-memory"] }
-opendal-core = { path = "../../core", version = "0.55.0", features = [
+opendal = { path = "../..", version = "0.56.0", features = ["services-memory"] }
+opendal-core = { path = "../../core", version = "0.56.0", features = [
   "services-memory",
 ] }
 size = "0.5"

--- a/core/services/fs/Cargo.toml
+++ b/core/services/fs/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false, features = [
   "internal-tokio-rt",
 ] }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/ftp/Cargo.toml
+++ b/core/services/ftp/Cargo.toml
@@ -37,7 +37,7 @@ futures = { workspace = true, features = ["std", "async-await"] }
 futures-rustls = "0.26.0"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 rustls-native-certs = "0.8"
 serde = { workspace = true, features = ["derive"] }
 suppaftp = { version = "6.3.0", default-features = false, features = [

--- a/core/services/gcs/Cargo.toml
+++ b/core/services/gcs/Cargo.toml
@@ -35,7 +35,7 @@ async-trait = "0.1"
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 percent-encoding = "2.3"
 quick-xml = { workspace = true, features = ["serialize"] }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/gdrive/Cargo.toml
+++ b/core/services/gdrive/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false, features = [
   "internal-path-cache",
 ] }
 

--- a/core/services/ghac/Cargo.toml
+++ b/core/services/ghac/Cargo.toml
@@ -35,8 +35,8 @@ bytes = { workspace = true }
 ghac = { version = "0.2.0", default-features = false }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
-opendal-service-azblob = { path = "../azblob", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-service-azblob = { path = "../azblob", version = "0.56.0", default-features = false }
 prost = { version = "0.13", default-features = false }
 reqsign-azure-storage = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/github/Cargo.toml
+++ b/core/services/github/Cargo.toml
@@ -35,7 +35,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/gridfs/Cargo.toml
+++ b/core/services/gridfs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 futures = { workspace = true }
 mea = { workspace = true }
 mongodb = "3.3.0"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/hdfs-native/Cargo.toml
+++ b/core/services/hdfs-native/Cargo.toml
@@ -35,5 +35,5 @@ bytes = { workspace = true }
 futures = { workspace = true }
 hdfs-native = { version = "0.13" }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/hdfs/Cargo.toml
+++ b/core/services/hdfs/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 bytes = { workspace = true }
 futures = { workspace = true }

--- a/core/services/hf/Cargo.toml
+++ b/core/services/hf/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 hf-xet = "1.5.0"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 percent-encoding = "2"
 reqwest = { version = "0.13.2", default-features = false, features = [
   "rustls",
@@ -45,7 +45,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", features = [
+opendal-core = { path = "../../core", version = "0.56.0", features = [
   "reqwest-rustls-tls",
 ] }
 serde_json = { workspace = true }

--- a/core/services/http/Cargo.toml
+++ b/core/services/http/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2024"
 license = "Apache-2.0"
 name = "opendal-service-http"
 repository = "https://github.com/apache/opendal"
-version = "0.55.0"
+version = "0.56.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -29,9 +29,9 @@ all-features = true
 [dependencies]
 http = "1.1"
 log = "0.4"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread"] }

--- a/core/services/ipfs/Cargo.toml
+++ b/core/services/ipfs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 prost = "0.13"
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/ipmfs/Cargo.toml
+++ b/core/services/ipmfs/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/koofr/Cargo.toml
+++ b/core/services/koofr/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/lakefs/Cargo.toml
+++ b/core/services/lakefs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/memcached/Cargo.toml
+++ b/core/services/memcached/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 fastpool = "1.0.2"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["net", "io-util"] }
 url = { workspace = true }

--- a/core/services/mini_moka/Cargo.toml
+++ b/core/services/mini_moka/Cargo.toml
@@ -33,5 +33,5 @@ all-features = true
 [dependencies]
 log = { workspace = true }
 mini-moka = "0.10"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/moka/Cargo.toml
+++ b/core/services/moka/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 log = { workspace = true }
 moka = { version = "0.12", features = ["future", "sync"] }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/mongodb/Cargo.toml
+++ b/core/services/mongodb/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 mea = { workspace = true }
 mongodb = { version = "3.3.0" }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/monoiofs/Cargo.toml
+++ b/core/services/monoiofs/Cargo.toml
@@ -40,7 +40,7 @@ monoio = { version = "0.2.4", features = [
   "unlinkat",
   "renameat",
 ] }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/mysql/Cargo.toml
+++ b/core/services/mysql/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "mysql"] }
 

--- a/core/services/obs/Cargo.toml
+++ b/core/services/obs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-core = "3.0.0"
 reqsign-file-read-tokio = "3.0.0"

--- a/core/services/onedrive/Cargo.toml
+++ b/core/services/onedrive/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time"] }

--- a/core/services/opfs/Cargo.toml
+++ b/core/services/opfs/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.77"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.50"

--- a/core/services/oss/Cargo.toml
+++ b/core/services/oss/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-aliyun-oss = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/pcloud/Cargo.toml
+++ b/core/services/pcloud/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/persy/Cargo.toml
+++ b/core/services/persy/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 persy = "1.7.1"
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/postgresql/Cargo.toml
+++ b/core/services/postgresql/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "postgres"] }
 

--- a/core/services/redb/Cargo.toml
+++ b/core/services/redb/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 redb = { version = "2" }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/redis/Cargo.toml
+++ b/core/services/redis/Cargo.toml
@@ -39,7 +39,7 @@ rustls = ["redis/tokio-rustls-comp"]
 bytes = { workspace = true }
 fastpool = "1.0.2"
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 redis = { version = "1.0", features = [
   "cluster-async",
   "tokio-comp",

--- a/core/services/rocksdb/Cargo.toml
+++ b/core/services/rocksdb/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 rocksdb = { version = "0.21.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/s3/Cargo.toml
+++ b/core/services/s3/Cargo.toml
@@ -37,7 +37,7 @@ crc32c = "0.6.6"
 http = { workspace = true }
 log = { workspace = true }
 md-5 = "0.10"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-aws-v4 = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/seafile/Cargo.toml
+++ b/core/services/seafile/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/sftp/Cargo.toml
+++ b/core/services/sftp/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 bytes = { workspace = true }
 fastpool = "1.0.2"

--- a/core/services/sled/Cargo.toml
+++ b/core/services/sled/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sled = "0.34.7"
 

--- a/core/services/sqlite/Cargo.toml
+++ b/core/services/sqlite/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "sqlite"] }
 

--- a/core/services/surrealdb/Cargo.toml
+++ b/core/services/surrealdb/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 surrealdb = { version = "3", features = ["protocol-http"] }
 

--- a/core/services/swift/Cargo.toml
+++ b/core/services/swift/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 hmac = "0.12.1"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 percent-encoding = "2"
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/tikv/Cargo.toml
+++ b/core/services/tikv/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tikv-client = { version = "0.3.0", default-features = false }
 

--- a/core/services/tos/Cargo.toml
+++ b/core/services/tos/Cargo.toml
@@ -31,6 +31,6 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/upyun/Cargo.toml
+++ b/core/services/upyun/Cargo.toml
@@ -37,7 +37,7 @@ hmac = "0.12.1"
 http = { workspace = true }
 log = { workspace = true }
 md-5 = "0.10"
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/vercel-artifacts/Cargo.toml
+++ b/core/services/vercel-artifacts/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/vercel-blob/Cargo.toml
+++ b/core/services/vercel-blob/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/webdav/Cargo.toml
+++ b/core/services/webdav/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/webhdfs/Cargo.toml
+++ b/core/services/webhdfs/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/core/services/yandex-disk/Cargo.toml
+++ b/core/services/yandex-disk/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.55.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/testkit/Cargo.toml
+++ b/core/testkit/Cargo.toml
@@ -34,10 +34,10 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 dotenvy = "0.15"
-opendal-core = { path = "../core", version = "0.55.0", default-features = false }
-opendal-layer-logging = { path = "../layers/logging", version = "0.55.0", default-features = false }
-opendal-layer-retry = { path = "../layers/retry", version = "0.55.0", default-features = false }
-opendal-layer-timeout = { path = "../layers/timeout", version = "0.55.0", default-features = false }
+opendal-core = { path = "../core", version = "0.56.0", default-features = false }
+opendal-layer-logging = { path = "../layers/logging", version = "0.56.0", default-features = false }
+opendal-layer-retry = { path = "../layers/retry", version = "0.56.0", default-features = false }
+opendal-layer-timeout = { path = "../layers/timeout", version = "0.56.0", default-features = false }
 rand = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/dev/src/generate/python.rs
+++ b/dev/src/generate/python.rs
@@ -25,9 +25,9 @@ use std::path::PathBuf;
 fn enabled_service(srv: &str) -> bool {
     match srv {
         // not enabled in bindings/python/Cargo.toml
-        "etcd" | "foundationdb" | "hdfs" | "rocksdb" | "tikv" | "github"
-        | "cloudflare_kv" | "monoiofs" | "dbfs" | "surrealdb" | "d1" | "opfs" | "compfs"
-        | "lakefs" | "pcloud" | "vercel_blob" => false,
+        "etcd" | "foundationdb" | "hdfs" | "rocksdb" | "tikv" | "github" | "cloudflare_kv"
+        | "monoiofs" | "dbfs" | "surrealdb" | "d1" | "opfs" | "compfs" | "lakefs" | "pcloud"
+        | "vercel_blob" => false,
         _ => true,
     }
 }
@@ -184,7 +184,11 @@ pub fn format_text(text: &str, indent: usize, max_line_length: usize) -> String 
 }
 
 // Compose first line: param_name : type[, optional]
-pub fn make_pydoc_param_header(name: &str, ty: ViaDeserialize<ConfigType>, optional: bool) -> Result<String, minijinja::Error> {
+pub fn make_pydoc_param_header(
+    name: &str,
+    ty: ViaDeserialize<ConfigType>,
+    optional: bool,
+) -> Result<String, minijinja::Error> {
     let py_type = make_python_type(ty)?;
     let optional_str = if optional { ", optional" } else { "" };
     let first_line = format!("{} : {}{}", name, py_type, optional_str);
@@ -193,7 +197,10 @@ pub fn make_pydoc_param_header(name: &str, ty: ViaDeserialize<ConfigType>, optio
 }
 
 /// Generate a properly indented NumPy-style docstring line for a parameter
-pub fn make_pydoc_param(comments: &str, ty: ViaDeserialize<ConfigType>) -> Result<String, minijinja::Error> {
+pub fn make_pydoc_param(
+    comments: &str,
+    ty: ViaDeserialize<ConfigType>,
+) -> Result<String, minijinja::Error> {
     // Collect description parts
     let mut desc_parts = Vec::new();
     let comments = comments.trim();
@@ -215,7 +222,9 @@ pub fn make_pydoc_param(comments: &str, ty: ViaDeserialize<ConfigType>) -> Resul
         _ => {}
     }
 
-    Ok(format_text(&desc_parts.join(". "), 20, 72).trim_end().to_string())
+    Ok(format_text(&desc_parts.join(". "), 20, 72)
+        .trim_end()
+        .to_string())
 }
 
 fn make_python_type(ty: ViaDeserialize<ConfigType>) -> Result<String, minijinja::Error> {

--- a/dev/src/release/package.rs
+++ b/dev/src/release/package.rs
@@ -61,22 +61,22 @@ fn make_package(path: &str, version: &str, dependencies: Vec<Package>) -> Packag
 
 /// List all packages that are ready for release.
 pub fn all_packages() -> Vec<Package> {
-    let core = make_package("core", "0.55.0", vec![]);
+    let core = make_package("core", "0.56.0", vec![]);
 
     // Integrations
-    let dav_server = make_package("integrations/dav-server", "0.7.0", vec![core.clone()]);
-    let object_store = make_package("integrations/object_store", "0.55.0", vec![core.clone()]);
+    let dav_server = make_package("integrations/dav-server", "0.7.1", vec![core.clone()]);
+    let object_store = make_package("integrations/object_store", "0.56.0", vec![core.clone()]);
     let parquet = make_package("integrations/parquet", "0.8.0", vec![core.clone()]);
-    let unftp_sbe = make_package("integrations/unftp-sbe", "0.4.0", vec![core.clone()]);
+    let unftp_sbe = make_package("integrations/unftp-sbe", "0.4.1", vec![core.clone()]);
 
     // Binaries moved to separate repositories; no longer released from this repo
 
     // Bindings
-    let c = make_package("bindings/c", "0.46.4", vec![core.clone()]);
-    let cpp = make_package("bindings/cpp", "0.45.24", vec![core.clone()]);
-    let java = make_package("bindings/java", "0.48.2", vec![core.clone()]);
-    let nodejs = make_package("bindings/nodejs", "0.49.2", vec![core.clone()]);
-    let python = make_package("bindings/python", "0.47.0", vec![core.clone()]);
+    let c = make_package("bindings/c", "0.46.5", vec![core.clone()]);
+    let cpp = make_package("bindings/cpp", "0.45.25", vec![core.clone()]);
+    let java = make_package("bindings/java", "0.48.3", vec![core.clone()]);
+    let nodejs = make_package("bindings/nodejs", "0.49.3", vec![core.clone()]);
+    let python = make_package("bindings/python", "0.47.1", vec![core.clone()]);
 
     vec![
         core,
@@ -121,17 +121,21 @@ pub fn update_package_version(package: &Package) -> bool {
 }
 
 fn update_cargo_version(path: &Path, version: &Version, dependencies: &[Package]) -> bool {
-    let path = path.join("Cargo.toml");
-    let manifest = std::fs::read_to_string(&path).unwrap();
+    let manifest_path = path.join("Cargo.toml");
+    let manifest = std::fs::read_to_string(&manifest_path).unwrap();
     let mut manifest = DocumentMut::from_str(manifest.as_str()).unwrap();
-    let mut updated = update_manifest_version(&mut manifest, version, &path);
+    let mut updated = update_manifest_version(&mut manifest, version, &manifest_path);
 
     for dependency in dependencies {
-        updated |= update_dependency_version(&mut manifest, dependency);
+        updated |= update_dependency_version(&mut manifest, path, dependency);
     }
 
     if updated {
-        std::fs::write(&path, manifest.to_string()).unwrap();
+        std::fs::write(&manifest_path, manifest.to_string()).unwrap();
+    }
+
+    if is_core_workspace_root(path) {
+        updated |= sync_workspace_internal_dependency_versions(path, version);
     }
 
     updated
@@ -181,16 +185,26 @@ fn update_manifest_version(manifest: &mut DocumentMut, version: &Version, path: 
     panic!("missing version for package: {}", path.display());
 }
 
-fn update_dependency_version(manifest: &mut DocumentMut, dependency: &Package) -> bool {
+fn update_dependency_version(
+    manifest: &mut DocumentMut,
+    manifest_dir: &Path,
+    dependency: &Package,
+) -> bool {
     let Some(crate_name) = dependency.crate_name() else {
         return false;
     };
 
-    update_dependency_version_in_table(manifest.as_table_mut(), crate_name, dependency)
+    update_dependency_version_in_table(
+        manifest.as_table_mut(),
+        manifest_dir,
+        crate_name,
+        dependency,
+    )
 }
 
 fn update_dependency_version_in_table(
     table: &mut dyn TableLike,
+    manifest_dir: &Path,
     crate_name: &str,
     dependency: &Package,
 ) -> bool {
@@ -201,7 +215,12 @@ fn update_dependency_version_in_table(
             continue;
         };
 
-        updated |= update_dependency_version_in_dependencies(dependencies, crate_name, dependency);
+        updated |= update_dependency_version_in_dependencies(
+            dependencies,
+            manifest_dir,
+            crate_name,
+            dependency,
+        );
     }
 
     let Some(targets) = table.get_mut("target").and_then(Item::as_table_like_mut) else {
@@ -212,7 +231,7 @@ fn update_dependency_version_in_table(
         let Some(target) = target.as_table_like_mut() else {
             continue;
         };
-        updated |= update_dependency_version_in_table(target, crate_name, dependency);
+        updated |= update_dependency_version_in_table(target, manifest_dir, crate_name, dependency);
     }
 
     updated
@@ -220,6 +239,7 @@ fn update_dependency_version_in_table(
 
 fn update_dependency_version_in_dependencies(
     dependencies: &mut dyn TableLike,
+    manifest_dir: &Path,
     crate_name: &str,
     dependency: &Package,
 ) -> bool {
@@ -229,9 +249,12 @@ fn update_dependency_version_in_dependencies(
     let Some(entry) = entry.as_table_like_mut() else {
         return false;
     };
-    let Some("../../core") = entry.get("path").and_then(Item::as_str) else {
+    let Some(path) = entry.get("path").and_then(Item::as_str) else {
         return false;
     };
+    if !path_points_to(manifest_dir, path, &dependency.path) {
+        return false;
+    }
     let Some(value) = entry.get_mut("version") else {
         return false;
     };
@@ -254,6 +277,176 @@ fn update_dependency_version_in_dependencies(
         crate_name, old_version, dependency.version
     );
     true
+}
+
+fn is_core_workspace_root(path: &Path) -> bool {
+    path == workspace_dir().join("core")
+}
+
+fn sync_workspace_internal_dependency_versions(workspace_root: &Path, version: &Version) -> bool {
+    let workspace_root = normalize_path(workspace_root);
+    let mut updated = false;
+
+    for entry in ignore::Walk::new(&workspace_root) {
+        let entry = entry.unwrap();
+        if entry.file_name() != "Cargo.toml" {
+            continue;
+        }
+
+        let manifest_path = entry.path();
+        let manifest_dir = manifest_path.parent().unwrap();
+        let manifest = std::fs::read_to_string(manifest_path).unwrap();
+        let mut manifest = DocumentMut::from_str(&manifest).unwrap();
+
+        let mut manifest_updated = sync_workspace_internal_dependency_versions_in_table(
+            manifest.as_table_mut(),
+            manifest_dir,
+            &workspace_root,
+            version,
+        );
+        manifest_updated |= sync_workspace_package_version(&mut manifest, version);
+        if manifest_updated {
+            std::fs::write(manifest_path, manifest.to_string()).unwrap();
+            updated = true;
+        }
+    }
+
+    updated
+}
+
+fn sync_workspace_package_version(manifest: &mut DocumentMut, version: &Version) -> bool {
+    let Some(package) = manifest.get("package").and_then(Item::as_table_like) else {
+        return false;
+    };
+    let Some(name) = package.get("name").and_then(Item::as_str) else {
+        return false;
+    };
+    if !name.starts_with("opendal") {
+        return false;
+    }
+    let Some(old_version) = manifest["package"]["version"]
+        .as_str()
+        .map(Version::parse)
+        .transpose()
+        .unwrap()
+    else {
+        return false;
+    };
+    if &old_version == version {
+        return false;
+    }
+
+    manifest["package"]["version"] = toml_edit::value(version.to_string());
+    true
+}
+
+fn sync_workspace_internal_dependency_versions_in_table(
+    table: &mut dyn TableLike,
+    manifest_dir: &Path,
+    workspace_root: &Path,
+    version: &Version,
+) -> bool {
+    let mut updated = false;
+
+    for table_name in ["dependencies", "dev-dependencies", "build-dependencies"] {
+        let Some(dependencies) = table.get_mut(table_name).and_then(Item::as_table_like_mut) else {
+            continue;
+        };
+
+        updated |= sync_workspace_internal_dependency_versions_in_dependencies(
+            dependencies,
+            manifest_dir,
+            workspace_root,
+            version,
+        );
+    }
+
+    let Some(targets) = table.get_mut("target").and_then(Item::as_table_like_mut) else {
+        return updated;
+    };
+
+    for (_, target) in targets.iter_mut() {
+        let Some(target) = target.as_table_like_mut() else {
+            continue;
+        };
+        updated |= sync_workspace_internal_dependency_versions_in_table(
+            target,
+            manifest_dir,
+            workspace_root,
+            version,
+        );
+    }
+
+    updated
+}
+
+fn sync_workspace_internal_dependency_versions_in_dependencies(
+    dependencies: &mut dyn TableLike,
+    manifest_dir: &Path,
+    workspace_root: &Path,
+    version: &Version,
+) -> bool {
+    let mut updated = false;
+
+    for (_, dependency) in dependencies.iter_mut() {
+        let Some(dependency) = dependency.as_table_like_mut() else {
+            continue;
+        };
+        let Some(path) = dependency.get("path").and_then(Item::as_str) else {
+            continue;
+        };
+        if !path_points_into(manifest_dir, path, workspace_root) {
+            continue;
+        }
+        let Some(value) = dependency.get_mut("version") else {
+            continue;
+        };
+
+        let old_version = match value.as_str() {
+            Some(version) => match Version::parse(version) {
+                Ok(version) => version,
+                Err(_) => continue,
+            },
+            None => continue,
+        };
+
+        if &old_version == version {
+            continue;
+        }
+
+        *value = toml_edit::value(version.to_string());
+        updated = true;
+    }
+
+    updated
+}
+
+fn path_points_to(manifest_dir: &Path, raw_path: &str, expected: &Path) -> bool {
+    normalize_path(&manifest_dir.join(raw_path)) == normalize_path(expected)
+}
+
+fn path_points_into(manifest_dir: &Path, raw_path: &str, workspace_root: &Path) -> bool {
+    normalize_path(&manifest_dir.join(raw_path)).starts_with(workspace_root)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| lexical_normalize(path))
+}
+
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+
+    normalized
 }
 
 impl Package {
@@ -406,7 +599,7 @@ opendal = { version = "0.55.0", path = "../core" }
 
         let dependency = Package {
             name: "core".to_string(),
-            path: PathBuf::from("core"),
+            path: dir.join("../../core"),
             version: Version::parse("0.56.0").unwrap(),
             dependencies: vec![],
         };
@@ -441,6 +634,66 @@ opendal = { version = "0.55.0", path = "../core" }
             manifest["target"]["cfg(windows)"]["dependencies"]["opendal"]["version"].as_str(),
             Some("0.55.0")
         );
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn sync_workspace_internal_dependency_versions_updates_workspace_path_dependencies() {
+        let dir = temp_test_dir("workspace-sync");
+        let crate_dir = dir.join("crate-a");
+        let dep_dir = dir.join("dep-b");
+        std::fs::create_dir_all(&crate_dir).unwrap();
+        std::fs::create_dir_all(&dep_dir).unwrap();
+
+        std::fs::write(
+            dir.join("Cargo.toml"),
+            r#"[workspace]
+members = ["crate-a", "dep-b"]
+
+[workspace.package]
+version = "0.56.0"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            crate_dir.join("Cargo.toml"),
+            r#"[package]
+name = "crate-a"
+version = "0.56.0"
+
+[dependencies]
+dep-b = { path = "../dep-b", version = "0.55.0" }
+serde = "1"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dep_dir.join("Cargo.toml"),
+            r#"[package]
+name = "dep-b"
+version = "0.56.0"
+"#,
+        )
+        .unwrap();
+
+        let updated = sync_workspace_internal_dependency_versions(
+            dir.as_path(),
+            &Version::parse("0.56.0").unwrap(),
+        );
+        assert!(updated);
+
+        let manifest = std::fs::read_to_string(crate_dir.join("Cargo.toml")).unwrap();
+        let manifest = DocumentMut::from_str(&manifest).unwrap();
+        assert_eq!(
+            manifest["dependencies"]["dep-b"]["version"].as_str(),
+            Some("0.56.0")
+        );
+        assert_eq!(manifest["dependencies"]["serde"].as_str(), Some("1"));
+
+        let dep_manifest = std::fs::read_to_string(dep_dir.join("Cargo.toml")).unwrap();
+        let dep_manifest = DocumentMut::from_str(&dep_manifest).unwrap();
+        assert_eq!(dep_manifest["package"]["version"].as_str(), Some("0.56.0"));
 
         std::fs::remove_dir_all(dir).unwrap();
     }

--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 description = "Use OpenDAL as a backend to access data in various service with WebDAV protocol"
 name = "dav-server-opendalfs"
-version = "0.7.0"
+version = "0.7.1"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2024"
@@ -32,10 +32,10 @@ anyhow = "1"
 bytes = { version = "1.4.0" }
 dav-server = { version = "0.8.0" }
 futures = "0.3"
-opendal = { version = "0.55.0", path = "../../core" }
+opendal = { version = "0.56.0", path = "../../core" }
 
 [dev-dependencies]
-opendal = { version = "0.55.0", path = "../../core", features = [
+opendal = { version = "0.56.0", path = "../../core", features = [
   "services-fs",
 ] }
 tokio = { version = "1.27", features = ["macros", "rt-multi-thread", "io-std"] }

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -1,208 +1,241 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MPL-2.0	Unicode-3.0	Unlicense	Zlib
-aho-corasick@1.1.4								X			X	
-allocator-api2@0.2.21	X							X				
-anyhow@1.0.100	X							X				
-atomic-waker@1.1.2	X							X				
-backon@1.6.0	X											
-base64@0.22.1	X							X				
-bitflags@2.10.0	X							X				
-block-buffer@0.10.4	X							X				
-bumpalo@3.19.0	X							X				
-bytes@1.11.0								X				
-cc@1.2.47	X							X				
-cfg-if@1.0.4	X							X				
-cpufeatures@0.2.17	X							X				
-crypto-common@0.1.7	X							X				
-dav-server@0.8.0	X											
-dav-server-opendalfs@0.7.0	X											
-deranged@0.5.5	X							X				
-derivative@2.2.0	X							X				
-digest@0.10.7	X							X				
-displaydoc@0.2.5	X							X				
-dyn-clone@1.0.20	X							X				
-equivalent@1.0.2	X							X				
-errno@0.3.14	X							X				
-fastrand@2.3.0	X							X				
-find-msvc-tools@0.1.5	X							X				
-fnv@1.0.7	X							X				
-foldhash@0.1.5												X
-form_urlencoded@1.2.2	X							X				
-futures@0.3.31	X							X				
-futures-channel@0.3.31	X							X				
-futures-core@0.3.31	X							X				
-futures-executor@0.3.31	X							X				
-futures-io@0.3.31	X							X				
-futures-macro@0.3.31	X							X				
-futures-sink@0.3.31	X							X				
-futures-task@0.3.31	X							X				
-futures-util@0.3.31	X							X				
-generic-array@0.14.7								X				
-getrandom@0.2.16	X							X				
-getrandom@0.3.4	X							X				
-gloo-timers@0.3.0	X							X				
-hashbrown@0.15.5	X							X				
-headers@0.4.1								X				
-headers-core@0.3.0								X				
-htmlescape@0.3.1	X							X	X			
-http@1.3.1	X							X				
-http-body@1.0.1								X				
-http-body-util@0.1.3								X				
-httparse@1.10.1	X							X				
-httpdate@1.0.3	X							X				
-hyper@1.8.1								X				
-hyper-rustls@0.27.7	X					X		X				
-hyper-util@0.1.18								X				
-icu_collections@2.1.1										X		
-icu_locale_core@2.1.1										X		
-icu_normalizer@2.1.1										X		
-icu_normalizer_data@2.1.1										X		
-icu_properties@2.1.1										X		
-icu_properties_data@2.1.1										X		
-icu_provider@2.1.1										X		
-idna@1.1.0	X							X				
-idna_adapter@1.2.1	X							X				
-ipnet@2.11.0	X							X				
-iri-string@0.7.9	X							X				
-itoa@1.0.15	X							X				
-jiff@0.2.16								X			X	
-jiff-tzdb@0.1.4								X			X	
-jiff-tzdb-platform@0.1.3								X			X	
-js-sys@0.3.82	X							X				
-lazy_static@1.5.0	X							X				
-libc@0.2.177	X							X				
-linux-raw-sys@0.11.0	X	X						X				
-litemap@0.8.1										X		
-lock_api@0.4.14	X							X				
-log@0.4.28	X							X				
-lru@0.14.0								X				
-md-5@0.10.6	X							X				
-memchr@2.7.6								X			X	
-mime@0.3.17	X							X				
-mime_guess@2.0.5								X				
-mio@1.1.0								X				
-num-conv@0.1.0	X							X				
-once_cell@1.21.3	X							X				
-opendal@0.55.0	X											
-parking_lot@0.12.5	X							X				
-parking_lot_core@0.9.12	X							X				
-percent-encoding@2.3.2	X							X				
-pin-project@1.1.10	X							X				
-pin-project-internal@1.1.10	X							X				
-pin-project-lite@0.2.16	X							X				
-pin-utils@0.1.0	X							X				
-portable-atomic@1.11.1	X							X				
-portable-atomic-util@0.2.4	X							X				
-potential_utf@0.1.4										X		
-powerfmt@0.2.0	X							X				
-proc-macro2@1.0.103	X							X				
-quick-xml@0.38.4								X				
-quote@1.0.42	X							X				
-r-efi@5.3.0	X						X	X				
-redox_syscall@0.5.18								X				
-reflink-copy@0.1.28	X							X				
-regex@1.12.2	X							X				
-regex-automata@0.4.13	X							X				
-regex-syntax@0.8.8	X							X				
-reqwest@0.12.24	X							X				
-ring@0.17.14	X					X						
-rustix@1.1.2	X	X						X				
-rustls@0.23.35	X					X		X				
-rustls-pki-types@1.13.0	X							X				
-rustls-webpki@0.103.8						X						
-rustversion@1.0.22	X							X				
-ryu@1.0.20	X			X								
-scopeguard@1.2.0	X							X				
-serde@1.0.228	X							X				
-serde_core@1.0.228	X							X				
-serde_derive@1.0.228	X							X				
-serde_json@1.0.145	X							X				
-serde_urlencoded@0.7.1	X							X				
-sha1@0.10.6	X							X				
-shlex@1.3.0	X							X				
-slab@0.4.11								X				
-smallvec@1.15.1	X							X				
-socket2@0.6.1	X							X				
-stable_deref_trait@1.2.1	X							X				
-subtle@2.6.1			X									
-syn@1.0.109	X							X				
-syn@2.0.110	X							X				
-sync_wrapper@1.0.2	X											
-synstructure@0.13.2								X				
-time@0.3.44	X							X				
-time-core@0.1.6	X							X				
-time-macros@0.2.24	X							X				
-tinystr@0.8.2										X		
-tokio@1.48.0								X				
-tokio-macros@2.6.0								X				
-tokio-rustls@0.26.4	X							X				
-tokio-util@0.7.17								X				
-tower@0.5.2								X				
-tower-http@0.6.6								X				
-tower-layer@0.3.3								X				
-tower-service@0.3.3								X				
-tracing@0.1.41								X				
-tracing-core@0.1.34								X				
-try-lock@0.2.5								X				
-typenum@1.19.0	X							X				
-unicase@2.8.1	X							X				
-unicode-ident@1.0.22	X							X		X		
-untrusted@0.9.0						X						
-url@2.5.7	X							X				
-utf8_iter@1.0.4	X							X				
-uuid@1.18.1	X							X				
-version_check@0.9.5	X							X				
-want@0.3.1								X				
-wasi@0.11.1+wasi-snapshot-preview1	X	X						X				
-wasip2@1.0.1+wasi-0.2.4	X	X						X				
-wasm-bindgen@0.2.105	X							X				
-wasm-bindgen-futures@0.4.55	X							X				
-wasm-bindgen-macro@0.2.105	X							X				
-wasm-bindgen-macro-support@0.2.105	X							X				
-wasm-bindgen-shared@0.2.105	X							X				
-wasm-streams@0.4.2	X							X				
-web-sys@0.3.82	X							X				
-webpki-roots@1.0.4					X							
-windows@0.62.2	X							X				
-windows-collections@0.3.2	X							X				
-windows-core@0.62.2	X							X				
-windows-future@0.3.2	X							X				
-windows-implement@0.60.2	X							X				
-windows-interface@0.59.3	X							X				
-windows-link@0.2.1	X							X				
-windows-numerics@0.3.1	X							X				
-windows-result@0.4.1	X							X				
-windows-strings@0.5.1	X							X				
-windows-sys@0.52.0	X							X				
-windows-sys@0.60.2	X							X				
-windows-sys@0.61.2	X							X				
-windows-targets@0.52.6	X							X				
-windows-targets@0.53.5	X							X				
-windows-threading@0.2.1	X							X				
-windows_aarch64_gnullvm@0.52.6	X							X				
-windows_aarch64_gnullvm@0.53.1	X							X				
-windows_aarch64_msvc@0.52.6	X							X				
-windows_aarch64_msvc@0.53.1	X							X				
-windows_i686_gnu@0.52.6	X							X				
-windows_i686_gnu@0.53.1	X							X				
-windows_i686_gnullvm@0.52.6	X							X				
-windows_i686_gnullvm@0.53.1	X							X				
-windows_i686_msvc@0.52.6	X							X				
-windows_i686_msvc@0.53.1	X							X				
-windows_x86_64_gnu@0.52.6	X							X				
-windows_x86_64_gnu@0.53.1	X							X				
-windows_x86_64_gnullvm@0.52.6	X							X				
-windows_x86_64_gnullvm@0.53.1	X							X				
-windows_x86_64_msvc@0.52.6	X							X				
-windows_x86_64_msvc@0.53.1	X							X				
-wit-bindgen@0.46.0	X	X						X				
-writeable@0.6.2										X		
-xml-rs@0.8.28								X				
-xmltree@0.11.0								X				
-yoke@0.8.1										X		
-yoke-derive@0.8.1										X		
-zerofrom@0.1.6										X		
-zerofrom-derive@0.1.6										X		
-zeroize@1.8.2	X							X				
-zerotrie@0.2.3										X		
-zerovec@0.11.5										X		
-zerovec-derive@0.11.2										X		
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib
+aho-corasick@1.1.4								X				X	
+allocator-api2@0.2.21	X							X					
+anyhow@1.0.102	X							X					
+atomic-waker@1.1.2	X							X					
+aws-lc-rs@1.16.3	X					X							
+aws-lc-sys@0.40.0	X		X			X		X	X				
+backon@1.6.0	X												
+base64@0.22.1	X							X					
+bitflags@2.11.1	X							X					
+block-buffer@0.10.4	X							X					
+bumpalo@3.20.2	X							X					
+bytes@1.11.1								X					
+cc@1.2.60	X							X					
+cesu8@1.1.0	X							X					
+cfg-if@1.0.4	X							X					
+cmake@0.1.58	X							X					
+combine@4.6.7								X					
+const-oid@0.9.6	X							X					
+core-foundation@0.10.1	X							X					
+core-foundation-sys@0.8.7	X							X					
+cpufeatures@0.2.17	X							X					
+crypto-common@0.1.7	X							X					
+ctor@0.6.3	X							X					
+ctor-proc-macro@0.0.7	X							X					
+dav-server@0.8.0	X												
+dav-server-opendalfs@0.7.1	X												
+deranged@0.5.8	X							X					
+derivative@2.2.0	X							X					
+digest@0.10.7	X							X					
+displaydoc@0.2.5	X							X					
+dtor@0.1.1	X							X					
+dtor-proc-macro@0.0.6	X							X					
+dunce@1.0.5	X			X					X				
+dyn-clone@1.0.20	X							X					
+equivalent@1.0.2	X							X					
+errno@0.3.14	X							X					
+fastrand@2.4.1	X							X					
+find-msvc-tools@0.1.9	X							X					
+foldhash@0.1.5													X
+form_urlencoded@1.2.2	X							X					
+fs_extra@1.3.0								X					
+futures@0.3.32	X							X					
+futures-channel@0.3.32	X							X					
+futures-core@0.3.32	X							X					
+futures-executor@0.3.32	X							X					
+futures-io@0.3.32	X							X					
+futures-macro@0.3.32	X							X					
+futures-sink@0.3.32	X							X					
+futures-task@0.3.32	X							X					
+futures-util@0.3.32	X							X					
+generic-array@0.14.7								X					
+getrandom@0.3.4	X							X					
+getrandom@0.4.2	X							X					
+gloo-timers@0.3.0	X							X					
+hashbrown@0.15.5	X							X					
+headers@0.4.1								X					
+headers-core@0.3.0								X					
+hex@0.4.3	X							X					
+hmac@0.12.1	X							X					
+htmlescape@0.3.1	X							X		X			
+http@1.4.0	X							X					
+http-body@1.0.1								X					
+http-body-util@0.1.3								X					
+httparse@1.10.1	X							X					
+httpdate@1.0.3	X							X					
+hyper@1.9.0								X					
+hyper-rustls@0.27.9	X					X		X					
+hyper-util@0.1.20								X					
+icu_collections@2.1.1											X		
+icu_locale_core@2.1.1											X		
+icu_normalizer@2.1.1											X		
+icu_normalizer_data@2.1.1											X		
+icu_properties@2.1.2											X		
+icu_properties_data@2.1.2											X		
+icu_provider@2.1.1											X		
+idna@1.1.0	X							X					
+idna_adapter@1.2.1	X							X					
+ipnet@2.12.0	X							X					
+iri-string@0.7.12	X							X					
+itoa@1.0.18	X							X					
+jiff@0.2.23								X				X	
+jiff-tzdb@0.1.6								X				X	
+jiff-tzdb-platform@0.1.3								X				X	
+jni@0.21.1	X							X					
+jni-sys@0.3.1	X							X					
+jni-sys@0.4.1	X							X					
+jni-sys-macros@0.4.1	X							X					
+jobserver@0.1.34	X							X					
+js-sys@0.3.95	X							X					
+lazy_static@1.5.0	X							X					
+libc@0.2.185	X							X					
+linux-raw-sys@0.12.1	X	X						X					
+litemap@0.8.2											X		
+lock_api@0.4.14	X							X					
+log@0.4.29	X							X					
+lru@0.14.0								X					
+md-5@0.10.6	X							X					
+mea@0.6.3	X												
+memchr@2.8.0								X				X	
+mime@0.3.17	X							X					
+mime_guess@2.0.5								X					
+mio@1.2.0								X					
+num-conv@0.1.0	X							X					
+once_cell@1.21.4	X							X					
+opendal@0.56.0	X												
+opendal-core@0.56.0	X												
+opendal-layer-concurrent-limit@0.56.0	X												
+opendal-layer-logging@0.56.0	X												
+opendal-layer-retry@0.56.0	X												
+opendal-layer-timeout@0.56.0	X												
+opendal-service-fs@0.56.0	X												
+openssl-probe@0.2.1	X							X					
+parking_lot@0.12.5	X							X					
+parking_lot_core@0.9.12	X							X					
+percent-encoding@2.3.2	X							X					
+pin-project@1.1.11	X							X					
+pin-project-internal@1.1.11	X							X					
+pin-project-lite@0.2.17	X							X					
+pin-utils@0.1.0	X							X					
+portable-atomic@1.13.1	X							X					
+portable-atomic-util@0.2.6	X							X					
+potential_utf@0.1.5											X		
+powerfmt@0.2.0	X							X					
+proc-macro2@1.0.106	X							X					
+quick-xml@0.38.4								X					
+quote@1.0.45	X							X					
+r-efi@5.3.0	X						X	X					
+r-efi@6.0.0	X						X	X					
+redox_syscall@0.5.18								X					
+reflink-copy@0.1.29	X							X					
+regex@1.12.3	X							X					
+regex-automata@0.4.14	X							X					
+regex-syntax@0.8.10	X							X					
+reqsign-core@3.0.0	X												
+reqwest@0.13.2	X							X					
+rustix@1.1.4	X	X						X					
+rustls@0.23.38	X					X		X					
+rustls-native-certs@0.8.3	X					X		X					
+rustls-pki-types@1.14.0	X							X					
+rustls-platform-verifier@0.6.2	X							X					
+rustls-platform-verifier-android@0.1.1	X							X					
+rustls-webpki@0.103.12						X							
+rustversion@1.0.22	X							X					
+same-file@1.0.6								X				X	
+schannel@0.1.29								X					
+scopeguard@1.2.0	X							X					
+security-framework@3.7.0	X							X					
+security-framework-sys@2.17.0	X							X					
+serde@1.0.228	X							X					
+serde_core@1.0.228	X							X					
+serde_derive@1.0.228	X							X					
+serde_json@1.0.149	X							X					
+sha1@0.10.6	X							X					
+sha2@0.10.9	X							X					
+shlex@1.3.0	X							X					
+slab@0.4.12								X					
+smallvec@1.15.1	X							X					
+socket2@0.6.3	X							X					
+stable_deref_trait@1.2.1	X							X					
+subtle@2.6.1			X										
+syn@1.0.109	X							X					
+syn@2.0.117	X							X					
+sync_wrapper@1.0.2	X												
+synstructure@0.13.2								X					
+thiserror@1.0.69	X							X					
+thiserror-impl@1.0.69	X							X					
+time@0.3.45	X							X					
+time-core@0.1.7	X							X					
+time-macros@0.2.25	X							X					
+tinystr@0.8.3											X		
+tokio@1.52.0								X					
+tokio-macros@2.7.0								X					
+tokio-rustls@0.26.4	X							X					
+tokio-util@0.7.18								X					
+tower@0.5.3								X					
+tower-http@0.6.8								X					
+tower-layer@0.3.3								X					
+tower-service@0.3.3								X					
+tracing@0.1.44								X					
+tracing-core@0.1.36								X					
+try-lock@0.2.5								X					
+typenum@1.19.0	X							X					
+unicase@2.9.0	X							X					
+unicode-ident@1.0.24	X							X			X		
+untrusted@0.9.0						X							
+url@2.5.8	X							X					
+utf8_iter@1.0.4	X							X					
+uuid@1.23.1	X							X					
+version_check@0.9.5	X							X					
+walkdir@2.5.0								X				X	
+want@0.3.1								X					
+wasi@0.11.1+wasi-snapshot-preview1	X	X						X					
+wasip2@1.0.1+wasi-0.2.4	X	X						X					
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X						X					
+wasm-bindgen@0.2.118	X							X					
+wasm-bindgen-futures@0.4.68	X							X					
+wasm-bindgen-macro@0.2.118	X							X					
+wasm-bindgen-macro-support@0.2.118	X							X					
+wasm-bindgen-shared@0.2.118	X							X					
+wasm-streams@0.5.0	X							X					
+web-sys@0.3.95	X							X					
+web-time@1.1.0	X							X					
+webpki-root-certs@1.0.6					X								
+winapi-util@0.1.11								X				X	
+windows@0.62.2	X							X					
+windows-collections@0.3.2	X							X					
+windows-core@0.62.2	X							X					
+windows-future@0.3.2	X							X					
+windows-implement@0.60.2	X							X					
+windows-interface@0.59.3	X							X					
+windows-link@0.2.1	X							X					
+windows-numerics@0.3.1	X							X					
+windows-result@0.4.1	X							X					
+windows-strings@0.5.1	X							X					
+windows-sys@0.45.0	X							X					
+windows-sys@0.61.2	X							X					
+windows-targets@0.42.2	X							X					
+windows-threading@0.2.1	X							X					
+windows_aarch64_gnullvm@0.42.2	X							X					
+windows_aarch64_msvc@0.42.2	X							X					
+windows_i686_gnu@0.42.2	X							X					
+windows_i686_msvc@0.42.2	X							X					
+windows_x86_64_gnu@0.42.2	X							X					
+windows_x86_64_gnullvm@0.42.2	X							X					
+windows_x86_64_msvc@0.42.2	X							X					
+wit-bindgen@0.46.0	X	X						X					
+wit-bindgen@0.51.0	X	X						X					
+writeable@0.6.3											X		
+xattr@1.6.1	X							X					
+xml-rs@0.8.28								X					
+xmltree@0.11.0								X					
+yoke@0.8.2											X		
+yoke-derive@0.8.2											X		
+zerofrom@0.1.7											X		
+zerofrom-derive@0.1.7											X		
+zeroize@1.8.2	X							X					
+zerotrie@0.2.4											X		
+zerovec@0.11.6											X		
+zerovec-derive@0.11.3											X		
+zmij@1.0.21								X					

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.85"
-version = "0.55.0"
+version = "0.56.0"
 
 [features]
 send_wrapper = ["dep:send_wrapper"]
@@ -43,7 +43,7 @@ chrono = { version = "0.4.42", features = ["std", "clock"] }
 futures = "0.3"
 mea = "0.6"
 object_store = "0.13.1"
-opendal = { version = "0.55.0", path = "../../core", default-features = false }
+opendal = { version = "0.56.0", path = "../../core", default-features = false }
 pin-project = "1.1"
 send_wrapper = { version = "0.6", features = ["futures"], optional = true }
 tokio = { version = "1", default-features = false }
@@ -52,7 +52,7 @@ tokio = { version = "1", default-features = false }
 anyhow = "1.0.86"
 datafusion = "53.0.0"
 libtest-mimic = "0.8.1"
-opendal = { version = "0.55.0", path = "../../core", features = [
+opendal = { version = "0.56.0", path = "../../core", features = [
   "services-fs",
   "services-memory",
   "services-s3",

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -1,222 +1,246 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense
-ahash@0.8.12	X									X		
-allocator-api2@0.2.21	X									X		
-android_system_properties@0.1.5	X									X		
-anyhow@1.0.100	X									X		
-async-trait@0.1.89	X									X		
-atomic-waker@1.1.2	X									X		
-autocfg@1.5.0	X									X		
-backon@1.6.0	X											
-base64@0.22.1	X									X		
-bitflags@2.10.0	X									X		
-block-buffer@0.10.4	X									X		
-bumpalo@3.19.0	X									X		
-bytes@1.11.0										X		
-cc@1.2.47	X									X		
-cfg-if@1.0.4	X									X		
-chrono@0.4.42	X									X		
-const-oid@0.9.6	X									X		
-const-random@0.1.18	X									X		
-const-random-macro@0.1.16	X									X		
-core-foundation-sys@0.8.7	X									X		
-cpufeatures@0.2.17	X									X		
-crc32c@0.6.8	X									X		
-crunchy@0.2.4										X		
-crypto-common@0.1.7	X									X		
-digest@0.10.7	X									X		
-displaydoc@0.2.5	X									X		
-dlv-list@0.5.2	X									X		
-dotenvy@0.15.7										X		
-either@1.15.0	X									X		
-fastrand@2.3.0	X									X		
-find-msvc-tools@0.1.5	X									X		
-fnv@1.0.7	X									X		
-form_urlencoded@1.2.2	X									X		
-futures@0.3.31	X									X		
-futures-channel@0.3.31	X									X		
-futures-core@0.3.31	X									X		
-futures-executor@0.3.31	X									X		
-futures-io@0.3.31	X									X		
-futures-macro@0.3.31	X									X		
-futures-sink@0.3.31	X									X		
-futures-task@0.3.31	X									X		
-futures-util@0.3.31	X									X		
-generic-array@0.14.7										X		
-getrandom@0.2.16	X									X		
-getrandom@0.3.4	X									X		
-gloo-timers@0.3.0	X									X		
-hashbrown@0.14.5	X									X		
-hex@0.4.3	X									X		
-hmac@0.12.1	X									X		
-home@0.5.11	X									X		
-http@1.3.1	X									X		
-http-body@1.0.1										X		
-http-body-util@0.1.3										X		
-httparse@1.10.1	X									X		
-humantime@2.3.0	X									X		
-hyper@1.8.1										X		
-hyper-rustls@0.27.7	X							X		X		
-hyper-util@0.1.18										X		
-iana-time-zone@0.1.64	X									X		
-iana-time-zone-haiku@0.1.2	X									X		
-icu_collections@2.1.1											X	
-icu_locale_core@2.1.1											X	
-icu_normalizer@2.1.1											X	
-icu_normalizer_data@2.1.1											X	
-icu_properties@2.1.1											X	
-icu_properties_data@2.1.1											X	
-icu_provider@2.1.1											X	
-idna@1.1.0	X									X		
-idna_adapter@1.2.1	X									X		
-ipnet@2.11.0	X									X		
-iri-string@0.7.9	X									X		
-itertools@0.14.0	X									X		
-itoa@1.0.15	X									X		
-jiff@0.2.16										X		X
-jiff-tzdb@0.1.4										X		X
-jiff-tzdb-platform@0.1.3										X		X
-jobserver@0.1.34	X									X		
-js-sys@0.3.82	X									X		
-libc@0.2.177	X									X		
-libm@0.2.15										X		
-litemap@0.8.1											X	
-lock_api@0.4.14	X									X		
-log@0.4.28	X									X		
-md-5@0.10.6	X									X		
-memchr@2.7.6										X		X
-mio@1.1.0										X		
-num-traits@0.2.19	X									X		
-object_store@0.12.4	X									X		
-object_store_opendal@0.55.0	X											
-once_cell@1.21.3	X									X		
-opendal@0.55.0	X											
-ordered-multimap@0.7.3										X		
-parking_lot@0.12.5	X									X		
-parking_lot_core@0.9.12	X									X		
-percent-encoding@2.3.2	X									X		
-pin-project@1.1.10	X									X		
-pin-project-internal@1.1.10	X									X		
-pin-project-lite@0.2.16	X									X		
-pin-utils@0.1.0	X									X		
-portable-atomic@1.11.1	X									X		
-portable-atomic-util@0.2.4	X									X		
-potential_utf@0.1.4											X	
-ppv-lite86@0.2.21	X									X		
-proc-macro2@1.0.103	X									X		
-quick-xml@0.38.4										X		
-quote@1.0.42	X									X		
-r-efi@5.3.0	X								X	X		
-rand@0.8.5	X									X		
-rand_chacha@0.3.1	X									X		
-rand_core@0.6.4	X									X		
-redox_syscall@0.5.18										X		
-reqsign@0.16.5	X											
-reqsign-aws-v4@2.0.1	X											
-reqsign-core@2.0.1	X											
-reqsign-file-read-tokio@2.0.1	X											
-reqsign-http-send-reqwest@2.0.1	X											
-reqwest@0.12.24	X									X		
-ring@0.17.14	X							X				
-rust-ini@0.21.3										X		
-rustc_version@0.4.1	X									X		
-rustls@0.23.35	X							X		X		
-rustls-pki-types@1.13.0	X									X		
-rustls-webpki@0.103.8								X				
-rustversion@1.0.22	X									X		
-ryu@1.0.20	X				X							
-same-file@1.0.6										X		X
-scopeguard@1.2.0	X									X		
-semver@1.0.27	X									X		
-serde@1.0.228	X									X		
-serde_core@1.0.228	X									X		
-serde_derive@1.0.228	X									X		
-serde_json@1.0.145	X									X		
-serde_urlencoded@0.7.1	X									X		
-sha1@0.10.6	X									X		
-sha2@0.10.9	X									X		
-shlex@1.3.0	X									X		
-slab@0.4.11										X		
-smallvec@1.15.1	X									X		
-socket2@0.6.1	X									X		
-stable_deref_trait@1.2.1	X									X		
-subtle@2.6.1				X								
-syn@2.0.110	X									X		
-sync_wrapper@1.0.2	X											
-synstructure@0.13.2										X		
-thiserror@2.0.17	X									X		
-thiserror-impl@2.0.17	X									X		
-tiny-keccak@2.0.2						X						
-tinystr@0.8.2											X	
-tokio@1.48.0										X		
-tokio-macros@2.6.0										X		
-tokio-rustls@0.26.4	X									X		
-tokio-util@0.7.17										X		
-tower@0.5.2										X		
-tower-http@0.6.6										X		
-tower-layer@0.3.3										X		
-tower-service@0.3.3										X		
-tracing@0.1.41										X		
-tracing-attributes@0.1.30										X		
-tracing-core@0.1.34										X		
-try-lock@0.2.5										X		
-typenum@1.19.0	X									X		
-unicode-ident@1.0.22	X									X	X	
-untrusted@0.9.0								X				
-url@2.5.7	X									X		
-utf8_iter@1.0.4	X									X		
-uuid@1.18.1	X									X		
-version_check@0.9.5	X									X		
-walkdir@2.5.0										X		X
-want@0.3.1										X		
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X		
-wasip2@1.0.1+wasi-0.2.4	X	X								X		
-wasm-bindgen@0.2.105	X									X		
-wasm-bindgen-futures@0.4.55	X									X		
-wasm-bindgen-macro@0.2.105	X									X		
-wasm-bindgen-macro-support@0.2.105	X									X		
-wasm-bindgen-shared@0.2.105	X									X		
-wasm-streams@0.4.2	X									X		
-web-sys@0.3.82	X									X		
-web-time@1.1.0	X									X		
-webpki-roots@1.0.4							X					
-winapi-util@0.1.11										X		X
-windows-core@0.62.2	X									X		
-windows-implement@0.60.2	X									X		
-windows-interface@0.59.3	X									X		
-windows-link@0.2.1	X									X		
-windows-result@0.4.1	X									X		
-windows-strings@0.5.1	X									X		
-windows-sys@0.52.0	X									X		
-windows-sys@0.59.0	X									X		
-windows-sys@0.60.2	X									X		
-windows-sys@0.61.2	X									X		
-windows-targets@0.52.6	X									X		
-windows-targets@0.53.5	X									X		
-windows_aarch64_gnullvm@0.52.6	X									X		
-windows_aarch64_gnullvm@0.53.1	X									X		
-windows_aarch64_msvc@0.52.6	X									X		
-windows_aarch64_msvc@0.53.1	X									X		
-windows_i686_gnu@0.52.6	X									X		
-windows_i686_gnu@0.53.1	X									X		
-windows_i686_gnullvm@0.52.6	X									X		
-windows_i686_gnullvm@0.53.1	X									X		
-windows_i686_msvc@0.52.6	X									X		
-windows_i686_msvc@0.53.1	X									X		
-windows_x86_64_gnu@0.52.6	X									X		
-windows_x86_64_gnu@0.53.1	X									X		
-windows_x86_64_gnullvm@0.52.6	X									X		
-windows_x86_64_gnullvm@0.53.1	X									X		
-windows_x86_64_msvc@0.52.6	X									X		
-windows_x86_64_msvc@0.53.1	X									X		
-wit-bindgen@0.46.0	X	X								X		
-writeable@0.6.2											X	
-yoke@0.8.1											X	
-yoke-derive@0.8.1											X	
-zerocopy@0.8.28	X		X							X		
-zerocopy-derive@0.8.28	X		X							X		
-zerofrom@0.1.6											X	
-zerofrom-derive@0.1.6											X	
-zeroize@1.8.2	X									X		
-zerotrie@0.2.3											X	
-zerovec@0.11.5											X	
-zerovec-derive@0.11.2											X	
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
+android_system_properties@0.1.5	X									X			
+anyhow@1.0.102	X									X			
+async-trait@0.1.89	X									X			
+atomic-waker@1.1.2	X									X			
+autocfg@1.5.0	X									X			
+aws-lc-rs@1.16.3	X							X					
+aws-lc-sys@0.40.0	X			X				X		X	X		
+backon@1.6.0	X												
+base64@0.22.1	X									X			
+bitflags@2.11.1	X									X			
+block-buffer@0.10.4	X									X			
+bumpalo@3.20.2	X									X			
+bytes@1.11.1										X			
+cc@1.2.60	X									X			
+cesu8@1.1.0	X									X			
+cfg-if@1.0.4	X									X			
+chrono@0.4.44	X									X			
+cmake@0.1.58	X									X			
+combine@4.6.7										X			
+const-oid@0.9.6	X									X			
+const-random@0.1.18	X									X			
+const-random-macro@0.1.16	X									X			
+core-foundation@0.10.1	X									X			
+core-foundation-sys@0.8.7	X									X			
+cpufeatures@0.2.17	X									X			
+crc32c@0.6.8	X									X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7	X									X			
+ctor@0.6.3	X									X			
+ctor-proc-macro@0.0.7	X									X			
+digest@0.10.7	X									X			
+displaydoc@0.2.5	X									X			
+dlv-list@0.5.2	X									X			
+dotenvy@0.15.7										X			
+dtor@0.1.1	X									X			
+dtor-proc-macro@0.0.6	X									X			
+dunce@1.0.5	X					X					X		
+either@1.15.0	X									X			
+errno@0.3.14	X									X			
+fastrand@2.4.1	X									X			
+find-msvc-tools@0.1.9	X									X			
+form_urlencoded@1.2.2	X									X			
+fs_extra@1.3.0										X			
+futures@0.3.32	X									X			
+futures-channel@0.3.32	X									X			
+futures-core@0.3.32	X									X			
+futures-executor@0.3.32	X									X			
+futures-io@0.3.32	X									X			
+futures-macro@0.3.32	X									X			
+futures-sink@0.3.32	X									X			
+futures-task@0.3.32	X									X			
+futures-util@0.3.32	X									X			
+generic-array@0.14.7										X			
+getrandom@0.2.17	X									X			
+getrandom@0.3.4	X									X			
+getrandom@0.4.2	X									X			
+gloo-timers@0.3.0	X									X			
+hashbrown@0.14.5	X									X			
+hex@0.4.3	X									X			
+hmac@0.12.1	X									X			
+http@1.4.0	X									X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1	X									X			
+humantime@2.3.0	X									X			
+hyper@1.9.0										X			
+hyper-rustls@0.27.9	X							X		X			
+hyper-util@0.1.20										X			
+iana-time-zone@0.1.65	X									X			
+iana-time-zone-haiku@0.1.2	X									X			
+icu_collections@2.1.1												X	
+icu_locale_core@2.1.1												X	
+icu_normalizer@2.1.1												X	
+icu_normalizer_data@2.1.1												X	
+icu_properties@2.1.2												X	
+icu_properties_data@2.1.2												X	
+icu_provider@2.1.1												X	
+idna@1.1.0	X									X			
+idna_adapter@1.2.1	X									X			
+ipnet@2.12.0	X									X			
+iri-string@0.7.12	X									X			
+itertools@0.14.0	X									X			
+itoa@1.0.18	X									X			
+jiff@0.2.23										X			X
+jiff-tzdb@0.1.6										X			X
+jiff-tzdb-platform@0.1.3										X			X
+jni@0.21.1	X									X			
+jni-sys@0.3.1	X									X			
+jni-sys@0.4.1	X									X			
+jni-sys-macros@0.4.1	X									X			
+jobserver@0.1.34	X									X			
+js-sys@0.3.95	X									X			
+libc@0.2.185	X									X			
+libm@0.2.16										X			
+linux-raw-sys@0.12.1	X	X								X			
+litemap@0.8.2												X	
+lock_api@0.4.14	X									X			
+log@0.4.29	X									X			
+md-5@0.10.6	X									X			
+mea@0.6.3	X												
+memchr@2.8.0										X			X
+mio@1.2.0										X			
+num-traits@0.2.19	X									X			
+object_store@0.13.2	X									X			
+object_store_opendal@0.56.0	X												
+once_cell@1.21.4	X									X			
+opendal@0.56.0	X												
+opendal-core@0.56.0	X												
+opendal-layer-concurrent-limit@0.56.0	X												
+opendal-layer-logging@0.56.0	X												
+opendal-layer-retry@0.56.0	X												
+opendal-layer-timeout@0.56.0	X												
+opendal-service-fs@0.56.0	X												
+opendal-service-s3@0.56.0	X												
+opendal-testkit@0.56.0	X												
+openssl-probe@0.2.1	X									X			
+ordered-multimap@0.7.3										X			
+parking_lot@0.12.5	X									X			
+parking_lot_core@0.9.12	X									X			
+percent-encoding@2.3.2	X									X			
+pin-project@1.1.11	X									X			
+pin-project-internal@1.1.11	X									X			
+pin-project-lite@0.2.17	X									X			
+portable-atomic@1.13.1	X									X			
+portable-atomic-util@0.2.6	X									X			
+potential_utf@0.1.5												X	
+ppv-lite86@0.2.21	X									X			
+proc-macro2@1.0.106	X									X			
+quick-xml@0.38.4										X			
+quick-xml@0.39.2										X			
+quote@1.0.45	X									X			
+r-efi@5.3.0	X								X	X			
+r-efi@6.0.0	X								X	X			
+rand@0.8.5	X									X			
+rand_chacha@0.3.1	X									X			
+rand_core@0.6.4	X									X			
+redox_syscall@0.5.18										X			
+reqsign-aws-v4@3.0.0	X												
+reqsign-core@3.0.0	X												
+reqsign-file-read-tokio@3.0.0	X												
+reqwest@0.13.2	X									X			
+rust-ini@0.21.3										X			
+rustc_version@0.4.1	X									X			
+rustix@1.1.4	X	X								X			
+rustls@0.23.38	X							X		X			
+rustls-native-certs@0.8.3	X							X		X			
+rustls-pki-types@1.14.0	X									X			
+rustls-platform-verifier@0.6.2	X									X			
+rustls-platform-verifier-android@0.1.1	X									X			
+rustls-webpki@0.103.12								X					
+rustversion@1.0.22	X									X			
+ryu@1.0.23	X				X								
+same-file@1.0.6										X			X
+schannel@0.1.29										X			
+scopeguard@1.2.0	X									X			
+security-framework@3.7.0	X									X			
+security-framework-sys@2.17.0	X									X			
+semver@1.0.28	X									X			
+serde@1.0.228	X									X			
+serde_core@1.0.228	X									X			
+serde_derive@1.0.228	X									X			
+serde_json@1.0.149	X									X			
+serde_urlencoded@0.7.1	X									X			
+sha1@0.10.6	X									X			
+sha2@0.10.9	X									X			
+shlex@1.3.0	X									X			
+slab@0.4.12										X			
+smallvec@1.15.1	X									X			
+socket2@0.6.3	X									X			
+stable_deref_trait@1.2.1	X									X			
+subtle@2.6.1				X									
+syn@2.0.117	X									X			
+sync_wrapper@1.0.2	X												
+synstructure@0.13.2										X			
+thiserror@1.0.69	X									X			
+thiserror@2.0.18	X									X			
+thiserror-impl@1.0.69	X									X			
+thiserror-impl@2.0.18	X									X			
+tiny-keccak@2.0.2						X							
+tinystr@0.8.3												X	
+tokio@1.52.0										X			
+tokio-macros@2.7.0										X			
+tokio-rustls@0.26.4	X									X			
+tokio-util@0.7.18										X			
+tower@0.5.3										X			
+tower-http@0.6.8										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-attributes@0.1.31										X			
+tracing-core@0.1.36										X			
+try-lock@0.2.5										X			
+typenum@1.19.0	X									X			
+unicode-ident@1.0.24	X									X		X	
+untrusted@0.9.0								X					
+url@2.5.8	X									X			
+utf8_iter@1.0.4	X									X			
+uuid@1.23.1	X									X			
+version_check@0.9.5	X									X			
+walkdir@2.5.0										X			X
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
+wasip2@1.0.1+wasi-0.2.4	X	X								X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
+wasm-bindgen@0.2.118	X									X			
+wasm-bindgen-futures@0.4.68	X									X			
+wasm-bindgen-macro@0.2.118	X									X			
+wasm-bindgen-macro-support@0.2.118	X									X			
+wasm-bindgen-shared@0.2.118	X									X			
+wasm-streams@0.5.0	X									X			
+web-sys@0.3.95	X									X			
+web-time@1.1.0	X									X			
+webpki-root-certs@1.0.6							X						
+winapi-util@0.1.11										X			X
+windows-core@0.62.2	X									X			
+windows-implement@0.60.2	X									X			
+windows-interface@0.59.3	X									X			
+windows-link@0.2.1	X									X			
+windows-result@0.4.1	X									X			
+windows-strings@0.5.1	X									X			
+windows-sys@0.45.0	X									X			
+windows-sys@0.61.2	X									X			
+windows-targets@0.42.2	X									X			
+windows_aarch64_gnullvm@0.42.2	X									X			
+windows_aarch64_msvc@0.42.2	X									X			
+windows_i686_gnu@0.42.2	X									X			
+windows_i686_msvc@0.42.2	X									X			
+windows_x86_64_gnu@0.42.2	X									X			
+windows_x86_64_gnullvm@0.42.2	X									X			
+windows_x86_64_msvc@0.42.2	X									X			
+wit-bindgen@0.46.0	X	X								X			
+wit-bindgen@0.51.0	X	X								X			
+writeable@0.6.3												X	
+xattr@1.6.1	X									X			
+yoke@0.8.2												X	
+yoke-derive@0.8.2												X	
+zerocopy@0.8.48	X		X							X			
+zerocopy-derive@0.8.48	X		X							X			
+zerofrom@0.1.7												X	
+zerofrom-derive@0.1.7												X	
+zeroize@1.8.2	X									X			
+zerotrie@0.2.4												X	
+zerovec@0.11.6												X	
+zerovec-derive@0.11.3												X	
+zmij@1.0.21										X			

--- a/integrations/parquet/Cargo.toml
+++ b/integrations/parquet/Cargo.toml
@@ -31,7 +31,7 @@ version = "0.8.0"
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
-opendal = { version = "0.55.0", path = "../../core" }
+opendal = { version = "0.56.0", path = "../../core" }
 parquet = { version = "58.0", default-features = false, features = [
   "async",
   "arrow",
@@ -39,7 +39,7 @@ parquet = { version = "58.0", default-features = false, features = [
 
 [dev-dependencies]
 arrow = { version = "58.0" }
-opendal = { version = "0.55.0", path = "../../core", features = [
+opendal = { version = "0.56.0", path = "../../core", features = [
   "services-memory",
   "services-s3",
 ] }

--- a/integrations/parquet/DEPENDENCIES.rust.tsv
+++ b/integrations/parquet/DEPENDENCIES.rust.tsv
@@ -1,227 +1,242 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	Unicode-3.0	Unlicense
-ahash@0.8.12	X									X		
-android_system_properties@0.1.5	X									X		
-anyhow@1.0.100	X									X		
-arrow-array@54.3.1	X											
-arrow-buffer@54.3.1	X											
-arrow-cast@54.3.1	X											
-arrow-data@54.3.1	X											
-arrow-ipc@54.3.1	X											
-arrow-schema@54.3.1	X											
-arrow-select@54.3.1	X											
-async-trait@0.1.89	X									X		
-atoi@2.0.0										X		
-atomic-waker@1.1.2	X									X		
-autocfg@1.5.0	X									X		
-backon@1.6.0	X											
-base64@0.22.1	X									X		
-bitflags@1.3.2	X									X		
-bitflags@2.10.0	X									X		
-block-buffer@0.10.4	X									X		
-bumpalo@3.19.0	X									X		
-byteorder@1.5.0										X		X
-bytes@1.11.0										X		
-cc@1.2.47	X									X		
-cfg-if@1.0.4	X									X		
-chrono@0.4.42	X									X		
-const-oid@0.9.6	X									X		
-const-random@0.1.18	X									X		
-const-random-macro@0.1.16	X									X		
-core-foundation-sys@0.8.7	X									X		
-cpufeatures@0.2.17	X									X		
-crc32c@0.6.8	X									X		
-crunchy@0.2.4										X		
-crypto-common@0.1.7	X									X		
-digest@0.10.7	X									X		
-displaydoc@0.2.5	X									X		
-dlv-list@0.5.2	X									X		
-fastrand@2.3.0	X									X		
-find-msvc-tools@0.1.5	X									X		
-flatbuffers@24.12.23	X											
-fnv@1.0.7	X									X		
-form_urlencoded@1.2.2	X									X		
-futures@0.3.31	X									X		
-futures-channel@0.3.31	X									X		
-futures-core@0.3.31	X									X		
-futures-executor@0.3.31	X									X		
-futures-io@0.3.31	X									X		
-futures-macro@0.3.31	X									X		
-futures-sink@0.3.31	X									X		
-futures-task@0.3.31	X									X		
-futures-util@0.3.31	X									X		
-generic-array@0.14.7										X		
-getrandom@0.2.16	X									X		
-getrandom@0.3.4	X									X		
-gloo-timers@0.3.0	X									X		
-half@2.7.1	X									X		
-hashbrown@0.14.5	X									X		
-hashbrown@0.15.5	X									X		
-hex@0.4.3	X									X		
-hmac@0.12.1	X									X		
-http@1.3.1	X									X		
-http-body@1.0.1										X		
-http-body-util@0.1.3										X		
-httparse@1.10.1	X									X		
-hyper@1.8.1										X		
-hyper-rustls@0.27.7	X							X		X		
-hyper-util@0.1.18										X		
-iana-time-zone@0.1.64	X									X		
-iana-time-zone-haiku@0.1.2	X									X		
-icu_collections@2.1.1											X	
-icu_locale_core@2.1.1											X	
-icu_normalizer@2.1.1											X	
-icu_normalizer_data@2.1.1											X	
-icu_properties@2.1.1											X	
-icu_properties_data@2.1.1											X	
-icu_provider@2.1.1											X	
-idna@1.1.0	X									X		
-idna_adapter@1.2.1	X									X		
-integer-encoding@3.0.4										X		
-ipnet@2.11.0	X									X		
-iri-string@0.7.9	X									X		
-itoa@1.0.15	X									X		
-jiff@0.2.16										X		X
-jiff-tzdb@0.1.4										X		X
-jiff-tzdb-platform@0.1.3										X		X
-js-sys@0.3.82	X									X		
-lexical-core@1.0.6	X									X		
-lexical-parse-float@1.0.6	X									X		
-lexical-parse-integer@1.0.6	X									X		
-lexical-util@1.0.7	X									X		
-lexical-write-float@1.0.6	X									X		
-lexical-write-integer@1.0.6	X									X		
-libc@0.2.177	X									X		
-libm@0.2.15										X		
-litemap@0.8.1											X	
-log@0.4.28	X									X		
-md-5@0.10.6	X									X		
-memchr@2.7.6										X		X
-mio@1.1.0										X		
-num@0.4.3	X									X		
-num-bigint@0.4.6	X									X		
-num-complex@0.4.6	X									X		
-num-integer@0.1.46	X									X		
-num-iter@0.1.45	X									X		
-num-rational@0.4.2	X									X		
-num-traits@0.2.19	X									X		
-once_cell@1.21.3	X									X		
-opendal@0.55.0	X											
-ordered-float@2.10.1										X		
-ordered-multimap@0.7.3										X		
-parquet@54.3.1	X											
-parquet_opendal@0.7.0	X											
-paste@1.0.15	X									X		
-percent-encoding@2.3.2	X									X		
-pin-project-lite@0.2.16	X									X		
-pin-utils@0.1.0	X									X		
-portable-atomic@1.11.1	X									X		
-portable-atomic-util@0.2.4	X									X		
-potential_utf@0.1.4											X	
-proc-macro2@1.0.103	X									X		
-quick-xml@0.38.4										X		
-quote@1.0.42	X									X		
-r-efi@5.3.0	X								X	X		
-reqsign-aws-v4@2.0.1	X											
-reqsign-core@2.0.1	X											
-reqsign-file-read-tokio@2.0.1	X											
-reqsign-http-send-reqwest@2.0.1	X											
-reqwest@0.12.24	X									X		
-ring@0.17.14	X							X				
-rust-ini@0.21.3										X		
-rustc_version@0.4.1	X									X		
-rustls@0.23.35	X							X		X		
-rustls-pki-types@1.13.0	X									X		
-rustls-webpki@0.103.8								X				
-rustversion@1.0.22	X									X		
-ryu@1.0.20	X				X							
-semver@1.0.27	X									X		
-seq-macro@0.3.6	X									X		
-serde@1.0.228	X									X		
-serde_core@1.0.228	X									X		
-serde_derive@1.0.228	X									X		
-serde_json@1.0.145	X									X		
-serde_urlencoded@0.7.1	X									X		
-sha1@0.10.6	X									X		
-sha2@0.10.9	X									X		
-shlex@1.3.0	X									X		
-slab@0.4.11										X		
-smallvec@1.15.1	X									X		
-socket2@0.6.1	X									X		
-stable_deref_trait@1.2.1	X									X		
-static_assertions@1.1.0	X									X		
-subtle@2.6.1				X								
-syn@2.0.110	X									X		
-sync_wrapper@1.0.2	X											
-synstructure@0.13.2										X		
-thrift@0.17.0	X											
-tiny-keccak@2.0.2						X						
-tinystr@0.8.2											X	
-tokio@1.48.0										X		
-tokio-macros@2.6.0										X		
-tokio-rustls@0.26.4	X									X		
-tokio-util@0.7.17										X		
-tower@0.5.2										X		
-tower-http@0.6.6										X		
-tower-layer@0.3.3										X		
-tower-service@0.3.3										X		
-tracing@0.1.41										X		
-tracing-core@0.1.34										X		
-try-lock@0.2.5										X		
-twox-hash@1.6.3										X		
-typenum@1.19.0	X									X		
-unicode-ident@1.0.22	X									X	X	
-untrusted@0.9.0								X				
-url@2.5.7	X									X		
-utf8_iter@1.0.4	X									X		
-uuid@1.18.1	X									X		
-version_check@0.9.5	X									X		
-want@0.3.1										X		
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X		
-wasip2@1.0.1+wasi-0.2.4	X	X								X		
-wasm-bindgen@0.2.105	X									X		
-wasm-bindgen-futures@0.4.55	X									X		
-wasm-bindgen-macro@0.2.105	X									X		
-wasm-bindgen-macro-support@0.2.105	X									X		
-wasm-bindgen-shared@0.2.105	X									X		
-wasm-streams@0.4.2	X									X		
-web-sys@0.3.82	X									X		
-webpki-roots@1.0.4							X					
-windows-core@0.62.2	X									X		
-windows-implement@0.60.2	X									X		
-windows-interface@0.59.3	X									X		
-windows-link@0.2.1	X									X		
-windows-result@0.4.1	X									X		
-windows-strings@0.5.1	X									X		
-windows-sys@0.52.0	X									X		
-windows-sys@0.60.2	X									X		
-windows-sys@0.61.2	X									X		
-windows-targets@0.52.6	X									X		
-windows-targets@0.53.5	X									X		
-windows_aarch64_gnullvm@0.52.6	X									X		
-windows_aarch64_gnullvm@0.53.1	X									X		
-windows_aarch64_msvc@0.52.6	X									X		
-windows_aarch64_msvc@0.53.1	X									X		
-windows_i686_gnu@0.52.6	X									X		
-windows_i686_gnu@0.53.1	X									X		
-windows_i686_gnullvm@0.52.6	X									X		
-windows_i686_gnullvm@0.53.1	X									X		
-windows_i686_msvc@0.52.6	X									X		
-windows_i686_msvc@0.53.1	X									X		
-windows_x86_64_gnu@0.52.6	X									X		
-windows_x86_64_gnu@0.53.1	X									X		
-windows_x86_64_gnullvm@0.52.6	X									X		
-windows_x86_64_gnullvm@0.53.1	X									X		
-windows_x86_64_msvc@0.52.6	X									X		
-windows_x86_64_msvc@0.53.1	X									X		
-wit-bindgen@0.46.0	X	X								X		
-writeable@0.6.2											X	
-yoke@0.8.1											X	
-yoke-derive@0.8.1											X	
-zerocopy@0.8.28	X		X							X		
-zerocopy-derive@0.8.28	X		X							X		
-zerofrom@0.1.6											X	
-zerofrom-derive@0.1.6											X	
-zeroize@1.8.2	X									X		
-zerotrie@0.2.3											X	
-zerovec@0.11.5											X	
-zerovec-derive@0.11.2											X	
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
+ahash@0.8.12	X									X			
+android_system_properties@0.1.5	X									X			
+anyhow@1.0.102	X									X			
+arrow-array@58.1.0	X												
+arrow-buffer@58.1.0	X												
+arrow-data@58.1.0	X												
+arrow-ipc@58.1.0	X												
+arrow-schema@58.1.0	X												
+arrow-select@58.1.0	X												
+async-trait@0.1.89	X									X			
+atomic-waker@1.1.2	X									X			
+autocfg@1.5.0	X									X			
+aws-lc-rs@1.16.3	X							X					
+aws-lc-sys@0.40.0	X			X				X		X	X		
+backon@1.6.0	X												
+base64@0.22.1	X									X			
+bitflags@2.11.1	X									X			
+block-buffer@0.10.4	X									X			
+bumpalo@3.20.2	X									X			
+byteorder@1.5.0										X			X
+bytes@1.11.1										X			
+cc@1.2.60	X									X			
+cesu8@1.1.0	X									X			
+cfg-if@1.0.4	X									X			
+chrono@0.4.44	X									X			
+cmake@0.1.58	X									X			
+combine@4.6.7										X			
+const-oid@0.9.6	X									X			
+const-random@0.1.18	X									X			
+const-random-macro@0.1.16	X									X			
+core-foundation@0.10.1	X									X			
+core-foundation-sys@0.8.7	X									X			
+cpufeatures@0.2.17	X									X			
+crc32c@0.6.8	X									X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7	X									X			
+ctor@0.6.3	X									X			
+ctor-proc-macro@0.0.7	X									X			
+digest@0.10.7	X									X			
+displaydoc@0.2.5	X									X			
+dlv-list@0.5.2	X									X			
+dtor@0.1.1	X									X			
+dtor-proc-macro@0.0.6	X									X			
+dunce@1.0.5	X					X					X		
+fastrand@2.4.1	X									X			
+find-msvc-tools@0.1.9	X									X			
+flatbuffers@25.12.19	X												
+form_urlencoded@1.2.2	X									X			
+fs_extra@1.3.0										X			
+futures@0.3.32	X									X			
+futures-channel@0.3.32	X									X			
+futures-core@0.3.32	X									X			
+futures-executor@0.3.32	X									X			
+futures-io@0.3.32	X									X			
+futures-macro@0.3.32	X									X			
+futures-sink@0.3.32	X									X			
+futures-task@0.3.32	X									X			
+futures-util@0.3.32	X									X			
+generic-array@0.14.7										X			
+getrandom@0.2.17	X									X			
+getrandom@0.3.4	X									X			
+getrandom@0.4.2	X									X			
+gloo-timers@0.3.0	X									X			
+half@2.7.1	X									X			
+hashbrown@0.14.5	X									X			
+hashbrown@0.16.1	X									X			
+hex@0.4.3	X									X			
+hmac@0.12.1	X									X			
+http@1.4.0	X									X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1	X									X			
+hyper@1.9.0										X			
+hyper-rustls@0.27.9	X							X		X			
+hyper-util@0.1.20										X			
+iana-time-zone@0.1.65	X									X			
+iana-time-zone-haiku@0.1.2	X									X			
+icu_collections@2.1.1												X	
+icu_locale_core@2.1.1												X	
+icu_normalizer@2.1.1												X	
+icu_normalizer_data@2.1.1												X	
+icu_properties@2.1.2												X	
+icu_properties_data@2.1.2												X	
+icu_provider@2.1.1												X	
+idna@1.1.0	X									X			
+idna_adapter@1.2.1	X									X			
+integer-encoding@3.0.4										X			
+ipnet@2.12.0	X									X			
+iri-string@0.7.12	X									X			
+itoa@1.0.18	X									X			
+jiff@0.2.23										X			X
+jiff-tzdb@0.1.6										X			X
+jiff-tzdb-platform@0.1.3										X			X
+jni@0.21.1	X									X			
+jni-sys@0.3.1	X									X			
+jni-sys@0.4.1	X									X			
+jni-sys-macros@0.4.1	X									X			
+jobserver@0.1.34	X									X			
+js-sys@0.3.95	X									X			
+libc@0.2.185	X									X			
+libm@0.2.16										X			
+litemap@0.8.2												X	
+log@0.4.29	X									X			
+md-5@0.10.6	X									X			
+mea@0.6.3	X												
+memchr@2.8.0										X			X
+mio@1.2.0										X			
+num-bigint@0.4.6	X									X			
+num-complex@0.4.6	X									X			
+num-integer@0.1.46	X									X			
+num-traits@0.2.19	X									X			
+once_cell@1.21.4	X									X			
+opendal@0.56.0	X												
+opendal-core@0.56.0	X												
+opendal-layer-concurrent-limit@0.56.0	X												
+opendal-layer-logging@0.56.0	X												
+opendal-layer-retry@0.56.0	X												
+opendal-layer-timeout@0.56.0	X												
+opendal-service-s3@0.56.0	X												
+openssl-probe@0.2.1	X									X			
+ordered-float@2.10.1										X			
+ordered-multimap@0.7.3										X			
+parquet@58.1.0	X												
+parquet_opendal@0.8.0	X												
+paste@1.0.15	X									X			
+percent-encoding@2.3.2	X									X			
+pin-project-lite@0.2.17	X									X			
+portable-atomic@1.13.1	X									X			
+portable-atomic-util@0.2.6	X									X			
+potential_utf@0.1.5												X	
+proc-macro2@1.0.106	X									X			
+quick-xml@0.38.4										X			
+quick-xml@0.39.2										X			
+quote@1.0.45	X									X			
+r-efi@5.3.0	X								X	X			
+r-efi@6.0.0	X								X	X			
+reqsign-aws-v4@3.0.0	X												
+reqsign-core@3.0.0	X												
+reqsign-file-read-tokio@3.0.0	X												
+reqwest@0.13.2	X									X			
+rust-ini@0.21.3										X			
+rustc_version@0.4.1	X									X			
+rustls@0.23.38	X							X		X			
+rustls-native-certs@0.8.3	X							X		X			
+rustls-pki-types@1.14.0	X									X			
+rustls-platform-verifier@0.6.2	X									X			
+rustls-platform-verifier-android@0.1.1	X									X			
+rustls-webpki@0.103.12								X					
+rustversion@1.0.22	X									X			
+ryu@1.0.23	X				X								
+same-file@1.0.6										X			X
+schannel@0.1.29										X			
+security-framework@3.7.0	X									X			
+security-framework-sys@2.17.0	X									X			
+semver@1.0.28	X									X			
+seq-macro@0.3.6	X									X			
+serde@1.0.228	X									X			
+serde_core@1.0.228	X									X			
+serde_derive@1.0.228	X									X			
+serde_json@1.0.149	X									X			
+serde_urlencoded@0.7.1	X									X			
+sha1@0.10.6	X									X			
+sha2@0.10.9	X									X			
+shlex@1.3.0	X									X			
+slab@0.4.12										X			
+smallvec@1.15.1	X									X			
+socket2@0.6.3	X									X			
+stable_deref_trait@1.2.1	X									X			
+subtle@2.6.1				X									
+syn@2.0.117	X									X			
+sync_wrapper@1.0.2	X												
+synstructure@0.13.2										X			
+thiserror@1.0.69	X									X			
+thiserror-impl@1.0.69	X									X			
+thrift@0.17.0	X												
+tiny-keccak@2.0.2						X							
+tinystr@0.8.3												X	
+tokio@1.52.0										X			
+tokio-macros@2.7.0										X			
+tokio-rustls@0.26.4	X									X			
+tokio-util@0.7.18										X			
+tower@0.5.3										X			
+tower-http@0.6.8										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-core@0.1.36										X			
+try-lock@0.2.5										X			
+twox-hash@2.1.2										X			
+typenum@1.19.0	X									X			
+unicode-ident@1.0.24	X									X		X	
+untrusted@0.9.0								X					
+url@2.5.8	X									X			
+utf8_iter@1.0.4	X									X			
+uuid@1.23.1	X									X			
+version_check@0.9.5	X									X			
+walkdir@2.5.0										X			X
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
+wasip2@1.0.1+wasi-0.2.4	X	X								X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
+wasm-bindgen@0.2.118	X									X			
+wasm-bindgen-futures@0.4.68	X									X			
+wasm-bindgen-macro@0.2.118	X									X			
+wasm-bindgen-macro-support@0.2.118	X									X			
+wasm-bindgen-shared@0.2.118	X									X			
+wasm-streams@0.5.0	X									X			
+web-sys@0.3.95	X									X			
+web-time@1.1.0	X									X			
+webpki-root-certs@1.0.6							X						
+winapi-util@0.1.11										X			X
+windows-core@0.62.2	X									X			
+windows-implement@0.60.2	X									X			
+windows-interface@0.59.3	X									X			
+windows-link@0.2.1	X									X			
+windows-result@0.4.1	X									X			
+windows-strings@0.5.1	X									X			
+windows-sys@0.45.0	X									X			
+windows-sys@0.61.2	X									X			
+windows-targets@0.42.2	X									X			
+windows_aarch64_gnullvm@0.42.2	X									X			
+windows_aarch64_msvc@0.42.2	X									X			
+windows_i686_gnu@0.42.2	X									X			
+windows_i686_msvc@0.42.2	X									X			
+windows_x86_64_gnu@0.42.2	X									X			
+windows_x86_64_gnullvm@0.42.2	X									X			
+windows_x86_64_msvc@0.42.2	X									X			
+wit-bindgen@0.46.0	X	X								X			
+wit-bindgen@0.51.0	X	X								X			
+writeable@0.6.3												X	
+yoke@0.8.2												X	
+yoke-derive@0.8.2												X	
+zerocopy@0.8.48	X		X							X			
+zerocopy-derive@0.8.48	X		X							X			
+zerofrom@0.1.7												X	
+zerofrom-derive@0.1.7												X	
+zeroize@1.8.2	X									X			
+zerotrie@0.2.4												X	
+zerovec@0.11.6												X	
+zerovec-derive@0.11.3												X	
+zmij@1.0.21										X			

--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -24,11 +24,11 @@ license = "Apache-2.0"
 name = "unftp-sbe-opendal"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.85"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 async-trait = "0.1.88"
-opendal = { version = "0.55.0", path = "../../core" }
+opendal = { version = "0.56.0", path = "../../core" }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.7.11", features = ["compat"] }
 unftp-core = "0.1.0"
@@ -36,7 +36,7 @@ unftp-core = "0.1.0"
 [dev-dependencies]
 anyhow = "1"
 libunftp = "0.23.0"
-opendal = { version = "0.55.0", path = "../../core", features = [
+opendal = { version = "0.56.0", path = "../../core", features = [
   "services-s3",
 ] }
 tokio = { version = "1.38.0", default-features = false, features = [

--- a/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
+++ b/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
@@ -1,248 +1,247 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	OpenSSL	Unicode-3.0	Unlicense
-android_system_properties@0.1.5	X								X					
-anyhow@1.0.100	X								X					
-arc-swap@1.7.1	X								X					
-asn1-rs@0.7.1	X								X					
-asn1-rs-derive@0.6.0	X								X					
-asn1-rs-impl@0.2.0	X								X					
-async-trait@0.1.89	X								X					
-atomic-waker@1.1.2	X								X					
-autocfg@1.5.0	X								X					
-aws-lc-rs@1.15.1	X						X							
-aws-lc-sys@0.34.0	X						X					X		
-backon@1.6.0	X													
-base64@0.22.1	X								X					
-bitflags@2.10.0	X								X					
-block-buffer@0.10.4	X								X					
-bumpalo@3.19.0	X								X					
-bytes@1.11.0									X					
-cc@1.2.47	X								X					
-cfg-if@1.0.4	X								X					
-cfg_aliases@0.2.1									X					
-chrono@0.4.42	X								X					
-cmake@0.1.54	X								X					
-const-oid@0.9.6	X								X					
-const-random@0.1.18	X								X					
-const-random-macro@0.1.16	X								X					
-core-foundation-sys@0.8.7	X								X					
-cpufeatures@0.2.17	X								X					
-crc32c@0.6.8	X								X					
-crossbeam-channel@0.5.15	X								X					
-crossbeam-epoch@0.9.18	X								X					
-crossbeam-utils@0.8.21	X								X					
-crunchy@0.2.4									X					
-crypto-common@0.1.7	X								X					
-dashmap@6.1.0									X					
-data-encoding@2.9.0									X					
-der-parser@10.0.0	X								X					
-deranged@0.5.5	X								X					
-derive_more@2.0.1									X					
-derive_more-impl@2.0.1									X					
-digest@0.10.7	X								X					
-displaydoc@0.2.5	X								X					
-dlv-list@0.5.2	X								X					
-doc-comment@0.3.4									X					
-dunce@1.0.5	X				X					X				
-equivalent@1.0.2	X								X					
-erased-serde@0.3.31	X								X					
-fastrand@2.3.0	X								X					
-find-msvc-tools@0.1.5	X								X					
-fnv@1.0.7	X								X					
-form_urlencoded@1.2.2	X								X					
-fs_extra@1.3.0									X					
-futures@0.3.31	X								X					
-futures-channel@0.3.31	X								X					
-futures-core@0.3.31	X								X					
-futures-io@0.3.31	X								X					
-futures-macro@0.3.31	X								X					
-futures-sink@0.3.31	X								X					
-futures-task@0.3.31	X								X					
-futures-util@0.3.31	X								X					
-generic-array@0.14.7									X					
-getrandom@0.2.16	X								X					
-getrandom@0.3.4	X								X					
-gloo-timers@0.3.0	X								X					
-hashbrown@0.14.5	X								X					
-hex@0.4.3	X								X					
-hmac@0.12.1	X								X					
-http@1.3.1	X								X					
-http-body@1.0.1									X					
-http-body-util@0.1.3									X					
-httparse@1.10.1	X								X					
-hyper@1.8.1									X					
-hyper-rustls@0.27.7	X						X		X					
-hyper-util@0.1.18									X					
-iana-time-zone@0.1.64	X								X					
-iana-time-zone-haiku@0.1.2	X								X					
-icu_collections@2.1.1													X	
-icu_locale_core@2.1.1													X	
-icu_normalizer@2.1.1													X	
-icu_normalizer_data@2.1.1													X	
-icu_properties@2.1.1													X	
-icu_properties_data@2.1.1													X	
-icu_provider@2.1.1													X	
-idna@1.1.0	X								X					
-idna_adapter@1.2.1	X								X					
-ipnet@2.11.0	X								X					
-iri-string@0.7.9	X								X					
-itoa@1.0.15	X								X					
-jiff@0.2.16									X					X
-jiff-tzdb@0.1.4									X					X
-jiff-tzdb-platform@0.1.3									X					X
-jobserver@0.1.34	X								X					
-js-sys@0.3.82	X								X					
-lazy_static@1.5.0	X								X					
-libc@0.2.177	X								X					
-libunftp@0.21.0	X													
-litemap@0.8.1													X	
-lock_api@0.4.14	X								X					
-log@0.4.28	X								X					
-md-5@0.10.6	X								X					
-memchr@2.7.6									X					X
-minimal-lexical@0.2.1	X								X					
-mio@1.1.0									X					
-moka@0.12.11	X								X					
-nix@0.29.0									X					
-nom@7.1.3									X					
-num-bigint@0.4.6	X								X					
-num-conv@0.1.0	X								X					
-num-integer@0.1.46	X								X					
-num-traits@0.2.19	X								X					
-oid-registry@0.8.1	X								X					
-once_cell@1.21.3	X								X					
-opendal@0.55.0	X													
-ordered-multimap@0.7.3									X					
-parking_lot@0.12.5	X								X					
-parking_lot_core@0.9.12	X								X					
-percent-encoding@2.3.2	X								X					
-pin-project-lite@0.2.16	X								X					
-pin-utils@0.1.0	X								X					
-portable-atomic@1.11.1	X								X					
-portable-atomic-util@0.2.4	X								X					
-potential_utf@0.1.4													X	
-powerfmt@0.2.0	X								X					
-proc-macro2@1.0.103	X								X					
-prometheus@0.14.0	X													
-proxy-protocol@0.5.0	X								X					
-quick-xml@0.38.4									X					
-quote@1.0.42	X								X					
-r-efi@5.3.0	X							X	X					
-redox_syscall@0.5.18									X					
-reqsign-aws-v4@2.0.1	X													
-reqsign-core@2.0.1	X													
-reqsign-file-read-tokio@2.0.1	X													
-reqsign-http-send-reqwest@2.0.1	X													
-reqwest@0.12.24	X								X					
-ring@0.17.14	X						X							
-rust-ini@0.21.3									X					
-rustc_version@0.4.1	X								X					
-rusticata-macros@4.1.0	X								X					
-rustls@0.23.35	X						X		X					
-rustls-pemfile@2.2.0	X						X		X					
-rustls-pki-types@1.13.0	X								X					
-rustls-webpki@0.103.8							X							
-rustversion@1.0.22	X								X					
-ryu@1.0.20	X			X										
-scopeguard@1.2.0	X								X					
-semver@1.0.27	X								X					
-serde@1.0.228	X								X					
-serde_core@1.0.228	X								X					
-serde_derive@1.0.228	X								X					
-serde_json@1.0.145	X								X					
-serde_urlencoded@0.7.1	X								X					
-sha1@0.10.6	X								X					
-sha2@0.10.9	X								X					
-shlex@1.3.0	X								X					
-signal-hook-registry@1.4.6	X								X					
-slab@0.4.11									X					
-slog@2.8.2	X								X		X			
-slog-scope@4.4.0	X								X		X			
-slog-stdlog@4.1.1	X								X		X			
-smallvec@1.15.1	X								X					
-snafu@0.6.10	X								X					
-snafu-derive@0.6.10	X								X					
-socket2@0.6.1	X								X					
-stable_deref_trait@1.2.1	X								X					
-subtle@2.6.1			X											
-syn@1.0.109	X								X					
-syn@2.0.110	X								X					
-sync_wrapper@1.0.2	X													
-synstructure@0.13.2									X					
-tagptr@0.2.0	X								X					
-thiserror@2.0.17	X								X					
-thiserror-impl@2.0.17	X								X					
-time@0.3.44	X								X					
-time-core@0.1.6	X								X					
-time-macros@0.2.24	X								X					
-tiny-keccak@2.0.2					X									
-tinystr@0.8.2													X	
-tokio@1.48.0									X					
-tokio-macros@2.6.0									X					
-tokio-rustls@0.26.4	X								X					
-tokio-util@0.7.17									X					
-tower@0.5.2									X					
-tower-http@0.6.6									X					
-tower-layer@0.3.3									X					
-tower-service@0.3.3									X					
-tracing@0.1.41									X					
-tracing-attributes@0.1.30									X					
-tracing-core@0.1.34									X					
-try-lock@0.2.5									X					
-typenum@1.19.0	X								X					
-unftp-sbe-opendal@0.4.0	X													
-unicode-ident@1.0.22	X								X				X	
-unicode-xid@0.2.6	X								X					
-untrusted@0.9.0							X							
-url@2.5.7	X								X					
-utf8_iter@1.0.4	X								X					
-uuid@1.18.1	X								X					
-version_check@0.9.5	X								X					
-want@0.3.1									X					
-wasi@0.11.1+wasi-snapshot-preview1	X	X							X					
-wasip2@1.0.1+wasi-0.2.4	X	X							X					
-wasm-bindgen@0.2.105	X								X					
-wasm-bindgen-futures@0.4.55	X								X					
-wasm-bindgen-macro@0.2.105	X								X					
-wasm-bindgen-macro-support@0.2.105	X								X					
-wasm-bindgen-shared@0.2.105	X								X					
-wasm-streams@0.4.2	X								X					
-web-sys@0.3.82	X								X					
-webpki-roots@1.0.4						X								
-windows-core@0.62.2	X								X					
-windows-implement@0.60.2	X								X					
-windows-interface@0.59.3	X								X					
-windows-link@0.2.1	X								X					
-windows-result@0.4.1	X								X					
-windows-strings@0.5.1	X								X					
-windows-sys@0.52.0	X								X					
-windows-sys@0.60.2	X								X					
-windows-sys@0.61.2	X								X					
-windows-targets@0.52.6	X								X					
-windows-targets@0.53.5	X								X					
-windows_aarch64_gnullvm@0.52.6	X								X					
-windows_aarch64_gnullvm@0.53.1	X								X					
-windows_aarch64_msvc@0.52.6	X								X					
-windows_aarch64_msvc@0.53.1	X								X					
-windows_i686_gnu@0.52.6	X								X					
-windows_i686_gnu@0.53.1	X								X					
-windows_i686_gnullvm@0.52.6	X								X					
-windows_i686_gnullvm@0.53.1	X								X					
-windows_i686_msvc@0.52.6	X								X					
-windows_i686_msvc@0.53.1	X								X					
-windows_x86_64_gnu@0.52.6	X								X					
-windows_x86_64_gnu@0.53.1	X								X					
-windows_x86_64_gnullvm@0.52.6	X								X					
-windows_x86_64_gnullvm@0.53.1	X								X					
-windows_x86_64_msvc@0.52.6	X								X					
-windows_x86_64_msvc@0.53.1	X								X					
-wit-bindgen@0.46.0	X	X							X					
-writeable@0.6.2													X	
-x509-parser@0.17.0	X								X					
-yoke@0.8.1													X	
-yoke-derive@0.8.1													X	
-zerofrom@0.1.6													X	
-zerofrom-derive@0.1.6													X	
-zeroize@1.8.2	X								X					
-zerotrie@0.2.3													X	
-zerovec@0.11.5													X	
-zerovec-derive@0.11.2													X	
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
+android_system_properties@0.1.5	X								X			
+anyhow@1.0.102	X								X			
+asn1-rs@0.7.1	X								X			
+asn1-rs-derive@0.6.0	X								X			
+asn1-rs-impl@0.2.0	X								X			
+async-trait@0.1.89	X								X			
+atomic-waker@1.1.2	X								X			
+autocfg@1.5.0	X								X			
+aws-lc-rs@1.16.3	X						X					
+aws-lc-sys@0.40.0	X		X				X		X	X		
+backon@1.6.0	X											
+base64@0.22.1	X								X			
+bitflags@2.11.1	X								X			
+block-buffer@0.10.4	X								X			
+bumpalo@3.20.2	X								X			
+bytes@1.11.1									X			
+cc@1.2.60	X								X			
+cesu8@1.1.0	X								X			
+cfg-if@1.0.4	X								X			
+chrono@0.4.44	X								X			
+cmake@0.1.58	X								X			
+combine@4.6.7									X			
+const-oid@0.9.6	X								X			
+const-random@0.1.18	X								X			
+const-random-macro@0.1.16	X								X			
+convert_case@0.10.0									X			
+core-foundation@0.10.1	X								X			
+core-foundation-sys@0.8.7	X								X			
+cpufeatures@0.2.17	X								X			
+crc32c@0.6.8	X								X			
+crunchy@0.2.4									X			
+crypto-common@0.1.7	X								X			
+ctor@0.6.3	X								X			
+ctor-proc-macro@0.0.7	X								X			
+data-encoding@2.10.0									X			
+der-parser@10.0.0	X								X			
+deranged@0.5.8	X								X			
+derive_more@2.1.1									X			
+derive_more-impl@2.1.1									X			
+digest@0.10.7	X								X			
+displaydoc@0.2.5	X								X			
+dlv-list@0.5.2	X								X			
+dtor@0.1.1	X								X			
+dtor-proc-macro@0.0.6	X								X			
+dunce@1.0.5	X				X					X		
+errno@0.3.14	X								X			
+fastrand@2.4.1	X								X			
+find-msvc-tools@0.1.9	X								X			
+form_urlencoded@1.2.2	X								X			
+fs_extra@1.3.0									X			
+futures@0.3.32	X								X			
+futures-channel@0.3.32	X								X			
+futures-core@0.3.32	X								X			
+futures-executor@0.3.32	X								X			
+futures-io@0.3.32	X								X			
+futures-macro@0.3.32	X								X			
+futures-sink@0.3.32	X								X			
+futures-task@0.3.32	X								X			
+futures-util@0.3.32	X								X			
+generic-array@0.14.7									X			
+getrandom@0.2.17	X								X			
+getrandom@0.3.4	X								X			
+getrandom@0.4.2	X								X			
+gloo-timers@0.3.0	X								X			
+hashbrown@0.14.5	X								X			
+hex@0.4.3	X								X			
+hmac@0.12.1	X								X			
+http@1.4.0	X								X			
+http-body@1.0.1									X			
+http-body-util@0.1.3									X			
+httparse@1.10.1	X								X			
+hyper@1.9.0									X			
+hyper-rustls@0.27.9	X						X		X			
+hyper-util@0.1.20									X			
+iana-time-zone@0.1.65	X								X			
+iana-time-zone-haiku@0.1.2	X								X			
+icu_collections@2.1.1											X	
+icu_locale_core@2.1.1											X	
+icu_normalizer@2.1.1											X	
+icu_normalizer_data@2.1.1											X	
+icu_properties@2.1.2											X	
+icu_properties_data@2.1.2											X	
+icu_provider@2.1.1											X	
+idna@1.1.0	X								X			
+idna_adapter@1.2.1	X								X			
+ipnet@2.12.0	X								X			
+iri-string@0.7.12	X								X			
+itoa@1.0.18	X								X			
+jiff@0.2.23									X			X
+jiff-tzdb@0.1.6									X			X
+jiff-tzdb-platform@0.1.3									X			X
+jni@0.21.1	X								X			
+jni-sys@0.3.1	X								X			
+jni-sys@0.4.1	X								X			
+jni-sys-macros@0.4.1	X								X			
+jobserver@0.1.34	X								X			
+js-sys@0.3.95	X								X			
+lazy_static@1.5.0	X								X			
+libc@0.2.185	X								X			
+litemap@0.8.2											X	
+log@0.4.29	X								X			
+md-5@0.10.6	X								X			
+mea@0.6.3	X											
+memchr@2.8.0									X			X
+minimal-lexical@0.2.1	X								X			
+mio@1.2.0									X			
+nom@7.1.3									X			
+num-bigint@0.4.6	X								X			
+num-conv@0.1.0	X								X			
+num-integer@0.1.46	X								X			
+num-traits@0.2.19	X								X			
+oid-registry@0.8.1	X								X			
+once_cell@1.21.4	X								X			
+opendal@0.56.0	X											
+opendal-core@0.56.0	X											
+opendal-layer-concurrent-limit@0.56.0	X											
+opendal-layer-logging@0.56.0	X											
+opendal-layer-retry@0.56.0	X											
+opendal-layer-timeout@0.56.0	X											
+opendal-service-s3@0.56.0	X											
+openssl-probe@0.2.1	X								X			
+ordered-multimap@0.7.3									X			
+percent-encoding@2.3.2	X								X			
+pin-project-lite@0.2.17	X								X			
+portable-atomic@1.13.1	X								X			
+portable-atomic-util@0.2.6	X								X			
+potential_utf@0.1.5											X	
+powerfmt@0.2.0	X								X			
+proc-macro2@1.0.106	X								X			
+quick-xml@0.38.4									X			
+quick-xml@0.39.2									X			
+quote@1.0.45	X								X			
+r-efi@5.3.0	X							X	X			
+r-efi@6.0.0	X							X	X			
+reqsign-aws-v4@3.0.0	X											
+reqsign-core@3.0.0	X											
+reqsign-file-read-tokio@3.0.0	X											
+reqwest@0.13.2	X								X			
+rust-ini@0.21.3									X			
+rustc_version@0.4.1	X								X			
+rusticata-macros@4.1.0	X								X			
+rustls@0.23.38	X						X		X			
+rustls-native-certs@0.8.3	X						X		X			
+rustls-pki-types@1.14.0	X								X			
+rustls-platform-verifier@0.6.2	X								X			
+rustls-platform-verifier-android@0.1.1	X								X			
+rustls-webpki@0.103.12							X					
+rustversion@1.0.22	X								X			
+ryu@1.0.23	X			X								
+same-file@1.0.6									X			X
+schannel@0.1.29									X			
+security-framework@3.7.0	X								X			
+security-framework-sys@2.17.0	X								X			
+semver@1.0.28	X								X			
+serde@1.0.228	X								X			
+serde_core@1.0.228	X								X			
+serde_derive@1.0.228	X								X			
+serde_json@1.0.149	X								X			
+serde_urlencoded@0.7.1	X								X			
+sha1@0.10.6	X								X			
+sha2@0.10.9	X								X			
+shlex@1.3.0	X								X			
+signal-hook-registry@1.4.8	X								X			
+slab@0.4.12									X			
+smallvec@1.15.1	X								X			
+socket2@0.6.3	X								X			
+stable_deref_trait@1.2.1	X								X			
+subtle@2.6.1			X									
+syn@2.0.117	X								X			
+sync_wrapper@1.0.2	X											
+synstructure@0.13.2									X			
+thiserror@1.0.69	X								X			
+thiserror@2.0.18	X								X			
+thiserror-impl@1.0.69	X								X			
+thiserror-impl@2.0.18	X								X			
+time@0.3.45	X								X			
+time-core@0.1.7	X								X			
+time-macros@0.2.25	X								X			
+tiny-keccak@2.0.2					X							
+tinystr@0.8.3											X	
+tokio@1.52.0									X			
+tokio-macros@2.7.0									X			
+tokio-rustls@0.26.4	X								X			
+tokio-util@0.7.18									X			
+tower@0.5.3									X			
+tower-http@0.6.8									X			
+tower-layer@0.3.3									X			
+tower-service@0.3.3									X			
+tracing@0.1.44									X			
+tracing-core@0.1.36									X			
+try-lock@0.2.5									X			
+typenum@1.19.0	X								X			
+unftp-core@0.1.0	X											
+unftp-sbe-opendal@0.4.1	X											
+unicode-ident@1.0.24	X								X		X	
+unicode-segmentation@1.13.2	X								X			
+unicode-xid@0.2.6	X								X			
+untrusted@0.9.0							X					
+url@2.5.8	X								X			
+utf8_iter@1.0.4	X								X			
+uuid@1.23.1	X								X			
+version_check@0.9.5	X								X			
+walkdir@2.5.0									X			X
+want@0.3.1									X			
+wasi@0.11.1+wasi-snapshot-preview1	X	X							X			
+wasip2@1.0.1+wasi-0.2.4	X	X							X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X							X			
+wasm-bindgen@0.2.118	X								X			
+wasm-bindgen-futures@0.4.68	X								X			
+wasm-bindgen-macro@0.2.118	X								X			
+wasm-bindgen-macro-support@0.2.118	X								X			
+wasm-bindgen-shared@0.2.118	X								X			
+wasm-streams@0.5.0	X								X			
+web-sys@0.3.95	X								X			
+web-time@1.1.0	X								X			
+webpki-root-certs@1.0.6						X						
+winapi-util@0.1.11									X			X
+windows-core@0.62.2	X								X			
+windows-implement@0.60.2	X								X			
+windows-interface@0.59.3	X								X			
+windows-link@0.2.1	X								X			
+windows-result@0.4.1	X								X			
+windows-strings@0.5.1	X								X			
+windows-sys@0.45.0	X								X			
+windows-sys@0.61.2	X								X			
+windows-targets@0.42.2	X								X			
+windows_aarch64_gnullvm@0.42.2	X								X			
+windows_aarch64_msvc@0.42.2	X								X			
+windows_i686_gnu@0.42.2	X								X			
+windows_i686_msvc@0.42.2	X								X			
+windows_x86_64_gnu@0.42.2	X								X			
+windows_x86_64_gnullvm@0.42.2	X								X			
+windows_x86_64_msvc@0.42.2	X								X			
+wit-bindgen@0.46.0	X	X							X			
+wit-bindgen@0.51.0	X	X							X			
+writeable@0.6.3											X	
+x509-parser@0.18.1	X								X			
+yoke@0.8.2											X	
+yoke-derive@0.8.2											X	
+zerofrom@0.1.7											X	
+zerofrom-derive@0.1.7											X	
+zeroize@1.8.2	X								X			
+zerotrie@0.2.4											X	
+zerovec@0.11.6											X	
+zerovec-derive@0.11.3											X	
+zmij@1.0.21									X			

--- a/website/community/release/release.md
+++ b/website/community/release/release.md
@@ -92,7 +92,7 @@ Run `just update-version` to bump the version in the project.
 ### Update docs
 
 - Update `CHANGELOG.md`, refer to [Generate Release Note](reference/generate_release_note.md) for more information.
-- Update `core/src/docs/upgrade.md` if there are breaking changes in `core`
+- Update `core/core/src/docs/upgrade.md` if there are breaking changes in `core`
 - Make sure every released bindings' `upgrade.md` has been updated.
     - java: `bindings/java/upgrade.md`
     - node.js: `bindings/nodejs/upgrade.md`
@@ -123,6 +123,7 @@ Pushing an RC tag to GitHub will trigger the tag-based release workflows. In the
 After pushing the tag, check the GitHub action status to make sure the RC workflows finished successfully.
 
 - Rust packages: [Release Rust Packages](https://github.com/apache/opendal/actions/workflows/release_rust.yml)
+- Python: [Release Python Binding](https://github.com/apache/opendal/actions/workflows/release_python.yml)
 - Java: [Bindings Java CI](https://github.com/apache/opendal/actions/workflows/ci_bindings_java.yml) and [Bindings Java Release](https://github.com/apache/opendal/actions/workflows/release_java.yml)
 - Node.js: [Bindings Node.js CI](https://github.com/apache/opendal/actions/workflows/ci_bindings_nodejs.yml) and [Release NodeJS Binding](https://github.com/apache/opendal/actions/workflows/release_nodejs.yml)
 - Docs: [Docs](https://github.com/apache/opendal/actions/workflows/docs.yml)


### PR DESCRIPTION
# Which issue does this PR close?

N/A. This PR prepares the v0.56.0 release.

# Rationale for this change

The release preparation work had drifted in a few places: version synchronization was incomplete across the core workspace, the release docs referenced the wrong upgrade path, and the changelog plus upgrade notes had not been brought up to date for v0.56.0. This change prepares the release end to end and fixes the tooling gap so future release bumps update the workspace consistently.

# What changes are included in this PR?

This updates release-managed versions across core, bindings, and integrations, regenerates dependency manifests, refreshes the v0.56.0 changelog and upgrade notes, and corrects the release documentation checklist. It also fixes `dev/src/release/package.rs` so `just update-version` syncs internal workspace package versions and path dependency constraints instead of leaving part of the core workspace behind.

Validation used for this release prep: `cargo test --manifest-path dev/Cargo.toml`, `cargo fmt --check --manifest-path dev/Cargo.toml`, `cargo metadata --manifest-path core/Cargo.toml --no-deps`, and `cargo check --manifest-path core/Cargo.toml --workspace`.

# Are there any user-facing changes?

Yes. The v0.56.0 release metadata, changelog, and upgrade documentation are updated, and the release tooling now keeps internal workspace versions in sync during future version bumps.

# AI Usage Statement

AI-assisted: GPT-5 was used to help prepare the release changes and documentation updates.
