### PR TITLE
fix: address clippy lints on Rust 1.95

### DIFF
--- a/core/core/src/types/read/reader.rs
+++ b/core/core/src/types/read/reader.rs
@@ -194,7 +194,7 @@ impl Reader {
         let gap = self.ctx.options().gap().unwrap_or(1024 * 1024) as u64;
         // We don't care about the order of range with same start, they
         // will be merged in the next step.
-        ranges.sort_unstable_by(|a, b| a.start.cmp(&b.start));
+        ranges.sort_unstable_by_key(|a| a.start);
 
         // We know that this vector will have at most element
         let mut merged = Vec::with_capacity(ranges.len());

--- a/core/services/webdav/src/core.rs
+++ b/core/services/webdav/src/core.rs
@@ -609,27 +609,23 @@ pub fn parse_user_metadata_from_xml(xml: &str, namespace_uri: &str) -> HashMap<S
                     }
                 }
             }
-            Ok(Event::Text(ref e)) => {
-                if current_prop_key.is_some() {
-                    // Text content - add directly (no escaping needed)
-                    let text_str = String::from_utf8_lossy(e.as_ref());
-                    current_prop_value.push_str(&text_str);
-                }
+            Ok(Event::Text(ref e)) if current_prop_key.is_some() => {
+                // Text content - add directly (no escaping needed)
+                let text_str = String::from_utf8_lossy(e.as_ref());
+                current_prop_value.push_str(&text_str);
             }
-            Ok(Event::GeneralRef(ref e)) => {
-                if current_prop_key.is_some() {
-                    // Handle XML entity references (e.g., &lt; &gt; &amp; &quot; &apos;)
-                    let entity_name = String::from_utf8_lossy(e.as_ref());
-                    let decoded = match entity_name.as_ref() {
-                        "lt" => "<",
-                        "gt" => ">",
-                        "amp" => "&",
-                        "quot" => "\"",
-                        "apos" => "'",
-                        _ => "", // Unknown entity, skip
-                    };
-                    current_prop_value.push_str(decoded);
-                }
+            Ok(Event::GeneralRef(ref e)) if current_prop_key.is_some() => {
+                // Handle XML entity references (e.g., &lt; &gt; &amp; &quot; &apos;)
+                let entity_name = String::from_utf8_lossy(e.as_ref());
+                let decoded = match entity_name.as_ref() {
+                    "lt" => "<",
+                    "gt" => ">",
+                    "amp" => "&",
+                    "quot" => "\"",
+                    "apos" => "'",
+                    _ => "", // Unknown entity, skip
+                };
+                current_prop_value.push_str(decoded);
             }
             Ok(Event::End(ref e)) => {
                 let name = String::from_utf8_lossy(e.name().as_ref()).to_string();
@@ -682,11 +678,9 @@ pub fn check_proppatch_response(xml: &str) -> Result<()> {
                     status_text.clear();
                 }
             }
-            Ok(Event::Text(ref e)) => {
-                if in_status {
-                    let text_str = String::from_utf8_lossy(e.as_ref());
-                    status_text.push_str(&text_str);
-                }
+            Ok(Event::Text(ref e)) if in_status => {
+                let text_str = String::from_utf8_lossy(e.as_ref());
+                status_text.push_str(&text_str);
             }
             Ok(Event::End(ref e)) => {
                 let name = String::from_utf8_lossy(e.name().as_ref()).to_lowercase();

--- a/dev/src/generate/python.rs
+++ b/dev/src/generate/python.rs
@@ -121,12 +121,10 @@ pub fn format_text(text: &str, indent: usize, max_line_length: usize) -> String 
 
     for (i, &ch) in chars.iter().enumerate() {
         match ch {
-            '.' | '!' | '?' => {
+            '.' | '!' | '?' if i + 1 < chars.len() && chars[i + 1].is_whitespace() => {
                 // Sentence end
-                if i + 1 < chars.len() && chars[i + 1].is_whitespace() {
-                    segments.push(&text[start..=i]);
-                    start = i + 1;
-                }
+                segments.push(&text[start..=i]);
+                start = i + 1;
             }
             '\n' => {
                 if i > start {

--- a/integrations/object_store/src/store.rs
+++ b/integrations/object_store/src/store.rs
@@ -662,7 +662,7 @@ impl MultipartUpload for OpendalMultipartUpload {
 
             let mut writer = writer.lock().await;
             let result = writer
-                .write(Buffer::from_iter(data.into_iter()))
+                .write(Buffer::from_iter(data))
                 .await
                 .map_err(|err| format_object_store_error(err, location.as_ref()));
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

Rust 1.95 introduces additional clippy diagnostics that fail the repository's `-D warnings` checks. This change updates the affected call sites in `core`, `services/webdav`, and `integrations/object_store` without changing behavior.

# What changes are included in this PR?

The patch replaces a sort closure with `sort_unstable_by_key`, removes a redundant `into_iter()` when constructing a `Buffer`, and rewrites a few guarded WebDAV XML parsing arms into guarded match arms to satisfy the new clippy rules.

# Are there any user-facing changes?

No user-facing behavior changes. This keeps the clippy checks green on the latest stable Rust toolchain.

# AI Usage Statement

Prepared with OpenAI GPT-5.
