### PR TITLE
fix(core): prevent integer overflow in parse_into_range for u64::MAX bounds

### DIFF
--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -78,12 +78,22 @@ impl ReadContext {
     ) -> Result<Range<u64>> {
         let start = match range.start_bound() {
             Bound::Included(v) => *v,
-            Bound::Excluded(v) => v + 1,
+            Bound::Excluded(v) => v.checked_add(1).ok_or_else(|| {
+                Error::new(
+                    ErrorKind::RangeNotSatisfied,
+                    "range start overflow: excluded bound at u64::MAX cannot be incremented",
+                )
+            })?,
             Bound::Unbounded => 0,
         };
 
         let end = match range.end_bound() {
-            Bound::Included(v) => v + 1,
+            Bound::Included(v) => v.checked_add(1).ok_or_else(|| {
+                Error::new(
+                    ErrorKind::RangeNotSatisfied,
+                    "range end overflow: inclusive bound at u64::MAX cannot be incremented",
+                )
+            })?,
             Bound::Excluded(v) => *v,
             Bound::Unbounded => {
                 let mut op_stat = OpStat::new();
@@ -225,6 +235,39 @@ mod tests {
         }
 
         pretty_assertions::assert_eq!(readers.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_parse_into_range_inclusive_end_u64_max() -> Result<()> {
+        let op = Operator::via_iter(services::MEMORY_SCHEME, [])?;
+        op.write("test", Buffer::from(Bytes::new())).await?;
+
+        let acc = op.into_inner();
+        let ctx = ReadContext::new(acc, "test".to_string(), OpRead::new(), OpReader::new());
+
+        let result = ctx.parse_into_range(..=u64::MAX).await;
+        assert!(result.is_err(), "..=u64::MAX should return error, not overflow");
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::RangeNotSatisfied);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_parse_into_range_excluded_start_u64_max() -> Result<()> {
+        let op = Operator::via_iter(services::MEMORY_SCHEME, [])?;
+        op.write("test", Buffer::from(Bytes::new())).await?;
+
+        let acc = op.into_inner();
+        let ctx = ReadContext::new(acc, "test".to_string(), OpRead::new(), OpReader::new());
+
+        let result = ctx
+            .parse_into_range((Bound::Excluded(u64::MAX), Bound::Unbounded))
+            .await;
+        assert!(
+            result.is_err(),
+            "Excluded(u64::MAX) start should return error, not overflow"
+        );
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::RangeNotSatisfied);
         Ok(())
     }
 }

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -247,7 +247,10 @@ mod tests {
         let ctx = ReadContext::new(acc, "test".to_string(), OpRead::new(), OpReader::new());
 
         let result = ctx.parse_into_range(..=u64::MAX).await;
-        assert!(result.is_err(), "..=u64::MAX should return error, not overflow");
+        assert!(
+            result.is_err(),
+            "..=u64::MAX should return error, not overflow"
+        );
         assert_eq!(result.unwrap_err().kind(), ErrorKind::RangeNotSatisfied);
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

N/A — discovered via code review of boundary edge cases.

# Rationale for this change

`ReadContext::parse_into_range` converts `RangeBounds<u64>` into `Range<u64>` by adding 1 for `Bound::Excluded` start and `Bound::Included` end. When the bound value is `u64::MAX`, this causes:
- **Debug builds**: panic due to integer overflow
- **Release builds**: silent wraparound to 0, producing an incorrect range

Both outcomes are wrong. Users can trigger this with ranges like `..=u64::MAX` or `(Bound::Excluded(u64::MAX), Bound::Unbounded)`.

# What changes are included in this PR?

- Replace `v + 1` with `v.checked_add(1)` for both `Bound::Excluded` start and `Bound::Included` end in `parse_into_range`
- Return `ErrorKind::RangeNotSatisfied` on overflow instead of panicking or wrapping
- Add two deterministic tests covering the `u64::MAX` edge cases

# Are there any user-facing changes?

Ranges that previously caused a panic (debug) or silent incorrect behavior (release) now return a clear `RangeNotSatisfied` error.

# AI Usage Statement

This PR was authored with assistance from Claude (Anthropic), used for code review, bug identification, fix implementation, and test writing.