### PR TITLE
fix(chaos): fix cases when error ratio = 1

### DIFF
--- a/core/layers/chaos/src/lib.rs
+++ b/core/layers/chaos/src/lib.rs
@@ -152,7 +152,7 @@ impl<R> ChaosReader<R> {
     /// If I feel lucky, we can return the correct response. Otherwise,
     /// we need to generate an error.
     fn i_feel_lucky(&self) -> bool {
-        let point = self.rng.lock().unwrap().gen_range(0..=100);
+        let point = self.rng.lock().unwrap().gen_range(0..100);
         point >= (self.error_ratio * 100.0) as i32
     }
 


### PR DESCRIPTION
# Rationale for this change

With the current implementation, point could be 100 which returns true even if error ration assigned 1 (always failure).

# What changes are included in this PR?

Random range should include 100 possible values instead of 101.

# Are there any user-facing changes?

No

# AI Usage Statement

Opus 4.6 found the bug when it was generating failure tests.