### PR TITLE
fix(s3): add missing if-none-match request field

### DIFF
--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -318,6 +318,10 @@ impl S3Core {
             req = req.header(IF_MATCH, if_match);
         }
 
+        if let Some(if_none_match) = args.if_none_match() {
+            req = req.header(IF_NONE_MATCH, if_none_match);
+        }
+
         if args.if_not_exists() {
             req = req.header(IF_NONE_MATCH, "*");
         }
@@ -926,6 +930,9 @@ impl S3Core {
         // Set conditional write headers.
         if let Some(if_match) = args.if_match() {
             req = req.header(IF_MATCH, if_match);
+        }
+        if let Some(if_none_match) = args.if_none_match() {
+            req = req.header(IF_NONE_MATCH, if_none_match);
         }
         if args.if_not_exists() {
             req = req.header(IF_NONE_MATCH, "*");


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7419

# Rationale for this change

All request field in the S3 request should be supported.

# What changes are included in this PR?

This PR adds missing if-none-match field in S3 requests.

# Are there any user-facing changes?

No.

# AI Usage Statement

Cursor helped me auto-complete code.