### PR TITLE
ci(bindings/dotnet): drive releases via workflow_dispatch with previe…

### DIFF
--- a/.github/workflows/release_dotnet.yml
+++ b/.github/workflows/release_dotnet.yml
@@ -18,9 +18,6 @@
 name: Release Dotnet Binding
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
     branches:
       - main
@@ -30,11 +27,15 @@ on:
       - "bindings/dotnet/OpenDAL/OpenDAL.csproj"
   workflow_dispatch:
     inputs:
-      dotnet_publish:
-        description: "Publish OpenDAL .NET package to nuget.org"
+      release_type:
+        description: "Release type"
         required: true
-        type: boolean
-        default: false
+        type: choice
+        default: none
+        options:
+          - none
+          - preview
+          - rc
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -121,28 +122,22 @@ jobs:
           cp target/release-assets/libopendal_dotnet.so OpenDAL/runtimes/linux-x64/native/
           cp target/release-assets/libopendal_dotnet.dylib OpenDAL/runtimes/osx-arm64/native/
 
-      - name: Determine package version
+      - name: Determine version suffix
         id: version
         shell: bash
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF_NAME#v}"
-            if [[ "${VERSION}" != *-* ]]; then
-              VERSION="${VERSION}-rc"
-            fi
-            echo "PACKAGE_VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
-          fi
+          case "${{ inputs.release_type }}" in
+            rc)
+              SUFFIX="rc"
+              ;;
+            *)
+              SUFFIX="preview.${GITHUB_RUN_NUMBER}"
+              ;;
+          esac
+          echo "VERSION_SUFFIX=${SUFFIX}" >> "$GITHUB_OUTPUT"
 
       - name: Pack OpenDAL
-        shell: bash
-        env:
-          PKG_VERSION: ${{ steps.version.outputs.PACKAGE_VERSION }}
-        run: |
-          PACK_CMD="dotnet pack OpenDAL/OpenDAL.csproj -c Release -o artifacts/package"
-          if [[ -n "${PKG_VERSION}" ]]; then
-            PACK_CMD="${PACK_CMD} /p:PackageVersion=${PKG_VERSION}"
-          fi
-          ${PACK_CMD}
+        run: dotnet pack OpenDAL/OpenDAL.csproj -c Release -o artifacts/package --version-suffix "${{ steps.version.outputs.VERSION_SUFFIX }}"
 
       - name: Upload NuGet package
         uses: actions/upload-artifact@v6
@@ -153,7 +148,7 @@ jobs:
 
   publish:
     name: Publish
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.dotnet_publish) }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.release_type != 'none' }}
     runs-on: ubuntu-latest
     needs:
       - package

--- a/bindings/dotnet/OpenDAL/OpenDAL.csproj
+++ b/bindings/dotnet/OpenDAL/OpenDAL.csproj
@@ -4,9 +4,6 @@
         <Title>Apache OpenDAL .NET</Title>
         <PackageId>Apache.OpenDAL</PackageId>
         <Description>The official .NET binding for Apache OpenDAL™</Description>
-        <Version>0.1.0</Version>
-        <AssemblyVersion>$(Version)</AssemblyVersion>
-        <FileVersion>$(Version)</FileVersion>
         <VersionPrefix>0.1.0</VersionPrefix>
         <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
         <FileVersion>$(VersionPrefix)</FileVersion>

--- a/bindings/dotnet/OpenDAL/OpenDAL.csproj
+++ b/bindings/dotnet/OpenDAL/OpenDAL.csproj
@@ -7,6 +7,9 @@
         <Version>0.1.0</Version>
         <AssemblyVersion>$(Version)</AssemblyVersion>
         <FileVersion>$(Version)</FileVersion>
+        <VersionPrefix>0.1.0</VersionPrefix>
+        <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
+        <FileVersion>$(VersionPrefix)</FileVersion>
         <Authors>Apache OpenDAL™</Authors>
         <Company>Apache Software Foundation</Company>
         <Copyright>$(Company)</Copyright>


### PR DESCRIPTION
# Rationale for this change

The initial `release_dotnet.yml` used a shared `v*` tag trigger, which would fire on core and other bindings' tags as well.
Since NuGet packages cannot be deleted (only unlisted) and NuGet has no staging repository, any accidental publish is irreversible.

After discussion with a maintainer, releases are driven entirely via `workflow_dispatch` — every publish is an explicit, intentional action.

# What changes are included in this PR?

- Remove the `push: tags:` trigger.
- Replace the `dotnet_publish` boolean with a `release_type` choice input (`none` / `preview` / `rc`).
- Switch `.csproj` from `<Version>` to `<VersionPrefix>` and use `dotnet pack --version-suffix` to assemble the final version.

| `release_type` | Version | Publishes to |
|----------------|---------|--------------|
| `none` (default) | `{VersionPrefix}-preview.{run_number}` | GitHub Actions artifact only (dry run) |
| `preview` | `{VersionPrefix}-preview.{run_number}` | nuget.org |
| `rc` | `{VersionPrefix}-rc` | nuget.org |

# Are there any user-facing changes?

No.

# AI Usage Statement

This PR was developed with assistance from Claude (Anthropic) for research and drafting.
