### PR TITLE
ci: fix release workflows for actions allowlist

### DIFF
--- a/.github/workflows/ci_bindings_zig.yml
+++ b/.github/workflows/ci_bindings_zig.yml
@@ -49,10 +49,10 @@ jobs:
         shell: bash
         run: |
           ZIG_VERSION=0.14.0
-          case "$(uname -s)-$(uname -m)" in
-            Linux-x86_64) ZIG_TARGET=x86_64-linux ;;
+          case "${RUNNER_OS}-${RUNNER_ARCH}" in
+            Linux-X64) ZIG_TARGET=linux-x86_64 ;;
             *)
-              echo "unsupported host for Zig: $(uname -s)-$(uname -m)" >&2
+              echo "unsupported host for Zig: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
               exit 1
               ;;
           esac

--- a/.github/workflows/ci_bindings_zig.yml
+++ b/.github/workflows/ci_bindings_zig.yml
@@ -45,9 +45,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: mlugg/setup-zig@fa65c4058643678a4e4a9a60513944a7d8d35440 # v2.1.0
-        with:
-          version: 0.14.0
+      - name: Setup Zig
+        shell: bash
+        run: |
+          ZIG_VERSION=0.14.0
+          case "$(uname -s)-$(uname -m)" in
+            Linux-x86_64) ZIG_TARGET=x86_64-linux ;;
+            *)
+              echo "unsupported host for Zig: $(uname -s)-$(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+          ZIG_HOME="${RUNNER_TOOL_CACHE}/zig/${ZIG_VERSION}"
+          mkdir -p "${ZIG_HOME}"
+          curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_TARGET}-${ZIG_VERSION}.tar.xz" \
+            | tar -xJ --strip-components=1 -C "${ZIG_HOME}"
+          echo "${ZIG_HOME}" >> "${GITHUB_PATH}"
 
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -629,16 +629,22 @@ jobs:
           OPENDAL_WEBSITE_NOT_LATEST: true
 
       - name: Deploy to nightlies for tagged version
-        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
         if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}
-        with:
-          switches: -avzr
-          path: website/build/
-          remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/opendal/opendal-docs-release-${{ github.ref_name }}/
-          remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
-          remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
-          remote_user: ${{ secrets.NIGHTLIES_RSYNC_USER }}
-          remote_key: ${{ secrets.NIGHTLIES_RSYNC_KEY }}
+        shell: bash
+        env:
+          NIGHTLIES_RSYNC_HOST: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
+          NIGHTLIES_RSYNC_KEY: ${{ secrets.NIGHTLIES_RSYNC_KEY }}
+          NIGHTLIES_RSYNC_PATH: ${{ secrets.NIGHTLIES_RSYNC_PATH }}
+          NIGHTLIES_RSYNC_PORT: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
+          NIGHTLIES_RSYNC_USER: ${{ secrets.NIGHTLIES_RSYNC_USER }}
+        run: |
+          mkdir -p "${HOME}/.ssh"
+          printf '%s' "${NIGHTLIES_RSYNC_KEY}" > "${HOME}/.ssh/nightlies_rsync"
+          chmod 0600 "${HOME}/.ssh/nightlies_rsync"
+          rsync -avzr \
+            -e "ssh -i ${HOME}/.ssh/nightlies_rsync -p ${NIGHTLIES_RSYNC_PORT} -o StrictHostKeyChecking=no" \
+            website/build/ \
+            "${NIGHTLIES_RSYNC_USER}@${NIGHTLIES_RSYNC_HOST}:${NIGHTLIES_RSYNC_PATH}/opendal/opendal-docs-release-${{ github.ref_name }}/"
 
       - name: Clear build
         run: rm -rf ./website/build
@@ -650,13 +656,19 @@ jobs:
           OPENDAL_WEBSITE_BASE_URL: /opendal/opendal-docs-stable/
 
       - name: Deploy to nightlies for stable version
-        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
         if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}
-        with:
-          switches: -avzr --delete
-          path: website/build/
-          remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/opendal/opendal-docs-stable/
-          remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
-          remote_port: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
-          remote_user: ${{ secrets.NIGHTLIES_RSYNC_USER }}
-          remote_key: ${{ secrets.NIGHTLIES_RSYNC_KEY }}
+        shell: bash
+        env:
+          NIGHTLIES_RSYNC_HOST: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
+          NIGHTLIES_RSYNC_KEY: ${{ secrets.NIGHTLIES_RSYNC_KEY }}
+          NIGHTLIES_RSYNC_PATH: ${{ secrets.NIGHTLIES_RSYNC_PATH }}
+          NIGHTLIES_RSYNC_PORT: ${{ secrets.NIGHTLIES_RSYNC_PORT }}
+          NIGHTLIES_RSYNC_USER: ${{ secrets.NIGHTLIES_RSYNC_USER }}
+        run: |
+          mkdir -p "${HOME}/.ssh"
+          printf '%s' "${NIGHTLIES_RSYNC_KEY}" > "${HOME}/.ssh/nightlies_rsync"
+          chmod 0600 "${HOME}/.ssh/nightlies_rsync"
+          rsync -avzr --delete \
+            -e "ssh -i ${HOME}/.ssh/nightlies_rsync -p ${NIGHTLIES_RSYNC_PORT} -o StrictHostKeyChecking=no" \
+            website/build/ \
+            "${NIGHTLIES_RSYNC_USER}@${NIGHTLIES_RSYNC_HOST}:${NIGHTLIES_RSYNC_PATH}/opendal/opendal-docs-stable/"

--- a/.github/workflows/release_dotnet.yml
+++ b/.github/workflows/release_dotnet.yml
@@ -175,10 +175,27 @@ jobs:
           path: bindings/dotnet/artifacts/package
 
       - name: NuGet login
-        uses: NuGet/login@v1
         id: login
-        with:
-          user: Apache.OpenDAL
+        shell: bash
+        env:
+          NUGET_USERNAME: Apache.OpenDAL
+        run: |
+          oidc_token="$(curl -fsSL \
+            -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https%3A%2F%2Fwww.nuget.org" \
+            | python3 -c 'import json, sys; print(json.load(sys.stdin)["value"])')"
+          echo "::add-mask::${oidc_token}"
+
+          request_body="$(python3 -c 'import json, os; print(json.dumps({"username": os.environ["NUGET_USERNAME"], "tokenType": "ApiKey"}))')"
+          api_key="$(curl -fsSL \
+            -X POST https://www.nuget.org/api/v2/token \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H "User-Agent: apache-opendal-release" \
+            --data "${request_body}" \
+            | python3 -c 'import json, sys; print(json.load(sys.stdin)["apiKey"])')"
+          echo "::add-mask::${api_key}"
+          echo "NUGET_API_KEY=${api_key}" >> "${GITHUB_OUTPUT}"
 
       - name: Publish package
         run: dotnet nuget push bindings/dotnet/artifacts/package/*.nupkg --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/release_java.yml
+++ b/.github/workflows/release_java.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: apache/opendal
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
       - name: Set up JDK 8
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/release_nodejs.yml
+++ b/.github/workflows/release_nodejs.yml
@@ -63,24 +63,27 @@ jobs:
             target: x86_64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             features: services-all
-            build: pnpm build:ci --use-napi-cross && pnpm build:header
+            build: pnpm build:ci && pnpm build:header
           - os: linux
             host: ubuntu-latest
             target: x86_64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             features: services-all
+            zig: true
             build: pnpm build:ci -x && pnpm build:header
           - os: linux
             host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
             features: services-all
-            build: TARGET_CC=clang pnpm build:ci --use-napi-cross && pnpm build:header
+            zig: true
+            build: pnpm build:ci -x && pnpm build:header
           - os: linux
             host: ubuntu-latest
             target: aarch64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             features: services-all
+            zig: true
             build: pnpm build:ci -x && pnpm build:header
           - os: windows
             host: windows-latest
@@ -119,14 +122,14 @@ jobs:
           rustup default stable
           rustup target add ${{ matrix.settings.target }}
       - name: Setup Zig
-        if: ${{ contains(matrix.settings.target, 'musl') }}
+        if: ${{ matrix.settings.zig }}
         shell: bash
         run: |
           ZIG_VERSION=0.14.0
-          case "$(uname -s)-$(uname -m)" in
-            Linux-x86_64) ZIG_TARGET=x86_64-linux ;;
+          case "${RUNNER_OS}-${RUNNER_ARCH}" in
+            Linux-X64) ZIG_TARGET=linux-x86_64 ;;
             *)
-              echo "unsupported host for Zig: $(uname -s)-$(uname -m)" >&2
+              echo "unsupported host for Zig: ${RUNNER_OS}-${RUNNER_ARCH}" >&2
               exit 1
               ;;
           esac
@@ -137,7 +140,7 @@ jobs:
           echo "${ZIG_HOME}" >> "${GITHUB_PATH}"
       - name: Install cargo-zigbuild
         uses: taiki-e/install-action@v2
-        if: ${{ contains(matrix.settings.target, 'musl') }}
+        if: ${{ matrix.settings.zig }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/release_nodejs.yml
+++ b/.github/workflows/release_nodejs.yml
@@ -113,14 +113,28 @@ jobs:
           cache: pnpm
           cache-dependency-path: "bindings/nodejs/pnpm-lock.yaml"
       - name: Install
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          targets: ${{ matrix.settings.target }}
-      - uses: mlugg/setup-zig@fa65c4058643678a4e4a9a60513944a7d8d35440 # v2.1.0
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add ${{ matrix.settings.target }}
+      - name: Setup Zig
         if: ${{ contains(matrix.settings.target, 'musl') }}
-        with:
-          version: 0.14.0
+        shell: bash
+        run: |
+          ZIG_VERSION=0.14.0
+          case "$(uname -s)-$(uname -m)" in
+            Linux-x86_64) ZIG_TARGET=x86_64-linux ;;
+            *)
+              echo "unsupported host for Zig: $(uname -s)-$(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+          ZIG_HOME="${RUNNER_TOOL_CACHE}/zig/${ZIG_VERSION}"
+          mkdir -p "${ZIG_HOME}"
+          curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_TARGET}-${ZIG_VERSION}.tar.xz" \
+            | tar -xJ --strip-components=1 -C "${ZIG_HOME}"
+          echo "${ZIG_HOME}" >> "${GITHUB_PATH}"
       - name: Install cargo-zigbuild
         uses: taiki-e/install-action@v2
         if: ${{ contains(matrix.settings.target, 'musl') }}
@@ -128,10 +142,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           tool: cargo-zigbuild
-      - name: Setup toolchain
-        run: ${{ matrix.settings.setup }}
-        if: ${{ matrix.settings.setup }}
-        shell: bash
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Set Build ENV

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -123,16 +123,20 @@ jobs:
           pattern: wheels-*
           merge-multiple: true
           path: bindings/python/dist
+      - name: Setup uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-') }}
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-          packages-dir: bindings/python/dist
+        run: |
+          uv publish \
+            --trusted-publishing automatic \
+            --publish-url https://test.pypi.org/legacy/ \
+            --check-url https://test.pypi.org/simple/opendal/ \
+            bindings/python/dist/*
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-') }}
-        with:
-          skip-existing: true
-          packages-dir: bindings/python/dist
+        run: |
+          uv publish \
+            --trusted-publishing automatic \
+            --check-url https://pypi.org/simple/opendal/ \
+            bindings/python/dist/*

--- a/.github/workflows/release_ruby.yml
+++ b/.github/workflows/release_ruby.yml
@@ -112,9 +112,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.rust_target }}
+      - name: Setup Rust toolchain
+        shell: bash
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup target add ${{ matrix.rust_target }}
 
       - name: Setup Ruby and install dependencies
         uses: ruby/setup-ruby@v1
@@ -156,7 +159,7 @@ jobs:
     #     (github.event_name == 'workflow_dispatch' && contains(needs.build.outputs.version, 'rc'))
 
     # Don't start publish until we are ready
-    if: false
+    if: ${{ vars.RUBY_RELEASE_ENABLED == 'true' }}
     needs: [build, build-native]
     runs-on: ubuntu-latest
 
@@ -264,7 +267,34 @@ jobs:
           EOF
 
       - name: Configure trusted publishing credentials
-        uses: rubygems/configure-rubygems-credentials@v1.0.0
+        shell: bash
+        run: |
+          oidc_token="$(curl -fsSL \
+            -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=rubygems.org" \
+            | ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("value")')"
+          echo "::add-mask::${oidc_token}"
+
+          api_key="$(curl -fsSL \
+            -X POST https://rubygems.org/api/v1/oidc/trusted_publisher/exchange_token \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -H "User-Agent: apache-opendal-release" \
+            --data "{\"jwt\":\"${oidc_token}\"}" \
+            | ruby -rjson -e 'puts JSON.parse(STDIN.read).fetch("rubygems_api_key")')"
+          echo "::add-mask::${api_key}"
+
+          mkdir -p "${HOME}/.gem"
+          {
+            echo "---"
+            echo ":rubygems_api_key: ${api_key}"
+          } > "${HOME}/.gem/credentials"
+          chmod 0600 "${HOME}/.gem/credentials"
+          {
+            echo "RUBYGEMS_API_KEY=${api_key}"
+            echo "BUNDLE_GEM__PUSH_KEY=${api_key}"
+            echo "GEM_HOST_API_KEY=${api_key}"
+          } >> "${GITHUB_ENV}"
 
       - name: Release gem
         run: bundle exec rake release


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

The `v0.56.0-rc.3` tag triggered several workflow `startup_failure`s because Apache's GitHub Actions policy blocks external actions that are not owned by GitHub, the enterprise, or explicitly allowed.

The blocked actions included Python, Node.js, .NET, Ruby, Docs, and Zig release/CI paths. These failures happen before jobs start, so rerunning the workflows cannot repair the release candidate.

# What changes are included in this PR?

This PR replaces blocked third-party actions with allowed alternatives or shell commands:

- Use the already allowed pinned `astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78` plus `uv publish` for Python trusted publishing.
- Use `rustup` directly instead of `dtolnay/rust-toolchain@stable`.
- Download Zig 0.14.0 directly from ziglang.org instead of `mlugg/setup-zig`.
- Exchange GitHub OIDC tokens with NuGet/RubyGems directly instead of using blocked publishing credential actions.
- Use native `rsync` for docs nightlies deployment instead of `burnett01/rsync-deployments`.
- Fix `release_java.yml` to checkout `github.ref` instead of the undefined `inputs.ref`.

# Are there any user-facing changes?

No. This only changes release and CI workflow implementation.

# AI Usage Statement

AI assistance was used to investigate the workflow startup failures and prepare this release workflow fix.
