### PR TITLE
ci: skip dotnet publish for rc tags

### DIFF
--- a/.github/workflows/release_dotnet.yml
+++ b/.github/workflows/release_dotnet.yml
@@ -153,7 +153,7 @@ jobs:
 
   publish:
     name: Publish
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.dotnet_publish) }}
+    if: ${{ (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')) || (github.event_name == 'workflow_dispatch' && inputs.dotnet_publish) }}
     runs-on: ubuntu-latest
     needs:
       - package


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

The v0.56.0-rc.4 tag build showed that the .NET release workflow still tries to publish to NuGet for RC tags. RC tag builds should validate and package artifacts, but publishing to NuGet should only happen for final release tags or explicit manual publish runs.

# What changes are included in this PR?

This PR gates the .NET publish job so prerelease tags such as `v0.56.0-rc.4` skip NuGet publishing while final `v*` tags and `workflow_dispatch` publish runs keep the existing publish path.

# Are there any user-facing changes?

No.

# AI Usage Statement

Assisted.
