### PR TITLE
ci: drop skipStagingRepositoryClose for smoother staging

### DIFF
--- a/.github/workflows/release_java.yml
+++ b/.github/workflows/release_java.yml
@@ -169,7 +169,6 @@ jobs:
         run: |
           ./mvnw org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged \
             -DaltStagingDirectory=$LOCAL_STAGING_DIR \
-            -DskipStagingRepositoryClose=true \
             -DserverId=apache.releases.https \
             -DnexusUrl=https://repository.apache.org
         env:


### PR DESCRIPTION
This closes https://github.com/apache/opendal/issues/7435

Reference for further context - https://github.com/sonatype/nexus-maven-plugins/tree/main/staging/maven-plugin#plugin-flags