### PR TITLE
Fix root and FTP temp path normalization

### DIFF
--- a/core/core/src/raw/path.rs
+++ b/core/core/src/raw/path.rs
@@ -134,6 +134,7 @@ pub fn normalize_path(path: &str) -> String {
 /// Finally, we will get path like `/path/to/root/`.
 pub fn normalize_root(v: &str) -> String {
     let mut v = v
+        .trim()
         .split('/')
         .filter(|v| !v.is_empty())
         .collect::<Vec<&str>>()
@@ -303,6 +304,7 @@ mod tests {
             ("abs file path with extra /", "///abc/def", "/abc/def/"),
             ("abs dir path with extra /", "///abc/def/", "/abc/def/"),
             ("dir path contains ///", "abc///def///", "/abc/def/"),
+            ("dir path with whitespace", "  abc/def/  ", "/abc/def/"),
         ];
 
         for (name, input, expect) in cases {

--- a/core/services/ftp/src/backend.rs
+++ b/core/services/ftp/src/backend.rs
@@ -278,7 +278,7 @@ impl Access for FtpBackend {
             }
         }
 
-        let tmp_path = (!op.append()).then_some(build_tmp_path_of(path));
+        let tmp_path = (!op.append()).then_some(build_ftp_tmp_path(path));
         let w = FtpWriter::new(ftp_stream, path.to_string(), tmp_path);
 
         Ok((RpWrite::new(), w))
@@ -332,9 +332,20 @@ impl FtpBackend {
     }
 }
 
+fn build_ftp_tmp_path(path: &str) -> String {
+    let parent = get_parent(path);
+    let tmp_name = build_tmp_path_of(path);
+
+    if parent == "/" {
+        tmp_name
+    } else {
+        format!("{parent}{tmp_name}")
+    }
+}
+
 #[cfg(test)]
 mod build_test {
-    use super::FtpBuilder;
+    use super::{FtpBuilder, build_ftp_tmp_path};
     use crate::FtpConfig;
     use opendal_core::*;
 
@@ -395,5 +406,31 @@ mod build_test {
         assert_eq!(cfg.endpoint.as_deref(), Some("ftp://example.com"));
         assert_eq!(cfg.user.as_deref(), Some("alice"));
         assert_eq!(cfg.password.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn test_build_ftp_tmp_path() {
+        let cases = vec![
+            ("root file", "example.txt", "example.txt."),
+            ("nested file", "folder/example.txt", "folder/example.txt."),
+            (
+                "deep nested file",
+                "folder/sub/example.txt",
+                "folder/sub/example.txt.",
+            ),
+        ];
+
+        for (name, path, expect_starts_with) in cases {
+            let actual = build_ftp_tmp_path(path);
+            assert!(
+                actual.starts_with(expect_starts_with),
+                "{name}: got `{actual}`, but expect `{expect_starts_with}`"
+            );
+            assert_eq!(
+                actual.len(),
+                expect_starts_with.len() + 8,
+                "{name}: got `{actual}`, but expect `{expect_starts_with}`"
+            );
+        }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

N/A. Rust-core correctness follow-up from the staging regression.

# Rationale for this change

Two path-normalization edge cases were found while validating Rust-core behavior:

- Root normalization should apply the same surrounding-whitespace normalization as other path normalization helpers.
- FTP atomic write temporary paths should be built in the same parent directory as the target path, rather than at the backend root, so nested writes do not produce misplaced temporary objects before rename.

# What changes are included in this PR?

- Normalize surrounding whitespace in `normalize_root` before processing the root.
- Build FTP temporary paths relative to the target path parent.
- Add focused unit coverage for the path helper and FTP backend construction behavior.

Validation:

```text
git diff --name-status origin/main...HEAD
M core/core/src/raw/path.rs
M core/services/ftp/src/backend.rs

cargo fmt --check
cargo test -p opendal-core raw::path::tests
cargo test -p opendal-service-ftp build_test
```

# Are there any user-facing changes?

No API change. Root and FTP temporary-path handling are corrected for edge cases.

# AI Usage Statement

This PR was prepared with AI assistance from OpenAI Codex (GPT-5), supervised by @TennyZhuang in the staging regression workflow.
