### PR TITLE
fix(core): validate range bounds to prevent underflow

### DIFF
--- a/core/core/src/raw/http_util/bytes_content_range.rs
+++ b/core/core/src/raw/http_util/bytes_content_range.rs
@@ -75,7 +75,11 @@ impl BytesContentRange {
     /// Get the length that specified by this BytesContentRange, return `None` if range is not known.
     pub fn len(&self) -> Option<u64> {
         if let (Some(start), Some(end)) = (self.0, self.1) {
-            Some(end - start + 1)
+            if end < start {
+                Some(0)
+            } else {
+                Some(end - start + 1)
+            }
         } else {
             None
         }
@@ -163,6 +167,14 @@ impl FromStr for BytesContentRange {
         }
         let start: u64 = v[0].parse().map_err(parse_int_error)?;
         let end: u64 = v[1].parse().map_err(parse_int_error)?;
+        if end < start {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "header content range is invalid: end is less than start",
+            )
+            .with_operation("BytesContentRange::from_str")
+            .with_context("value", value));
+        }
         let mut bcr = BytesContentRange::default().with_range(start, end);
 
         // Handle size part first.
@@ -235,5 +247,25 @@ mod tests {
             .with_range(0, 1023)
             .with_size(1024);
         assert_eq!(h.to_header(), "bytes 0-1023/1024");
+    }
+
+    #[test]
+    fn test_bytes_content_range_from_str_invalid_end_less_than_start() {
+        let cases = vec!["bytes 100-50/*", "bytes 10-9/100", "bytes 1-0/100"];
+
+        for input in cases {
+            let result: Result<BytesContentRange> = input.parse();
+            assert!(
+                result.is_err(),
+                "expected error for invalid content range {input}, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_bytes_content_range_len_no_underflow() {
+        // len() should not underflow when end < start.
+        let bcr = BytesContentRange::default().with_range(100, 50);
+        assert_eq!(bcr.len(), Some(0));
     }
 }

--- a/core/core/src/raw/http_util/bytes_range.rs
+++ b/core/core/src/raw/http_util/bytes_range.rs
@@ -175,6 +175,14 @@ impl FromStr for BytesRange {
             // <range-start>-<range-end>
             let start: u64 = v[0].parse().map_err(parse_int_error)?;
             let end: u64 = v[1].parse().map_err(parse_int_error)?;
+            if end < start {
+                return Err(Error::new(
+                    ErrorKind::Unexpected,
+                    "header range is invalid: end is less than start",
+                )
+                .with_operation("BytesRange::from_str")
+                .with_context("value", value));
+            }
             Ok(BytesRange::new(start, Some(end - start + 1)))
         }
     }
@@ -187,12 +195,12 @@ where
     fn from(range: T) -> Self {
         let offset = match range.start_bound().cloned() {
             Bound::Included(n) => n,
-            Bound::Excluded(n) => n + 1,
+            Bound::Excluded(n) => n.saturating_add(1),
             Bound::Unbounded => 0,
         };
         let size = match range.end_bound().cloned() {
-            Bound::Included(n) => Some(n + 1 - offset),
-            Bound::Excluded(n) => Some(n - offset),
+            Bound::Included(n) => Some(n.saturating_add(1).saturating_sub(offset)),
+            Bound::Excluded(n) => Some(n.saturating_sub(offset)),
             Bound::Unbounded => None,
         };
 
@@ -269,5 +277,51 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_bytes_range_from_str_invalid_end_less_than_start() {
+        let cases = vec!["bytes=100-50", "bytes=10-9", "bytes=1-0"];
+
+        for input in cases {
+            let result: Result<BytesRange> = input.parse();
+            assert!(
+                result.is_err(),
+                "expected error for invalid range {input}, got {result:?}"
+            );
+        }
+    }
+
+    #[allow(clippy::reversed_empty_ranges)]
+    #[test]
+    fn test_bytes_range_from_range_bounds_underflow() {
+        // Invalid ranges where end < start should produce zero-size ranges
+        // rather than underflowing.
+        assert_eq!(BytesRange::new(100, Some(0)), BytesRange::from(100..50));
+        assert_eq!(BytesRange::new(10, Some(0)), BytesRange::from(10..=5));
+        assert_eq!(BytesRange::new(5, Some(0)), BytesRange::from(5..0));
+        assert_eq!(BytesRange::new(5, Some(0)), BytesRange::from(5..=0));
+    }
+
+    #[test]
+    fn test_bytes_range_from_range_bounds_u64_max() {
+        // Boundary cases near u64::MAX must not overflow.
+        assert_eq!(
+            BytesRange::new(0, Some(u64::MAX)),
+            BytesRange::from(..=u64::MAX)
+        );
+        assert_eq!(
+            BytesRange::new(0, Some(u64::MAX)),
+            BytesRange::from(..u64::MAX)
+        );
+        assert_eq!(
+            BytesRange::new(1, Some(u64::MAX.saturating_sub(1))),
+            BytesRange::from(1..=u64::MAX)
+        );
+        // Excluded start at u64::MAX must not overflow.
+        assert_eq!(
+            BytesRange::new(u64::MAX, None),
+            BytesRange::from((u64::MAX)..)
+        );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7337.

# Rationale for this change

Range parsing and range-bound conversion should not underflow when callers pass inverted bounds such as `bytes=100-50` or Rust ranges whose computed end is less than the start. Those invalid inputs should be rejected or handled without arithmetic overflow.

# What changes are included in this PR?

- Reject HTTP `Range` headers where `end < start`.
- Reject `Content-Range` headers where `end < start`.
- Use saturating arithmetic in `BytesRange::from<RangeBounds>` for boundary cases including `u64::MAX`.
- Add focused tests for invalid headers, inverted bounds, and boundary conversions.

Validation:

```text
git diff --name-status origin/main...HEAD
M core/core/src/raw/http_util/bytes_content_range.rs
M core/core/src/raw/http_util/bytes_range.rs

cargo fmt --check
cargo test --lib raw::http_util
cargo clippy -p opendal-core --all-targets -- -D warnings
```

# Are there any user-facing changes?

Invalid range input is now rejected instead of silently producing underflowed bounds.

# AI Usage Statement

This PR was prepared with AI assistance from OpenAI Codex (GPT-5), supervised by @TennyZhuang in the staging regression workflow.
