### PR TITLE
feat(bindings/python): expose stat_with_if_modified_since, stat_with_if_unmodified_since, stat_with_version in Capability

### DIFF
--- a/bindings/python/src/capability.rs
+++ b/bindings/python/src/capability.rs
@@ -34,6 +34,12 @@ pub struct Capability {
     pub stat_with_if_match: bool,
     /// If operator supports stat with if none match.
     pub stat_with_if_none_match: bool,
+    /// If operator supports stat with if modified since.
+    pub stat_with_if_modified_since: bool,
+    /// If operator supports stat with if unmodified since.
+    pub stat_with_if_unmodified_since: bool,
+    /// If operator supports stat with version.
+    pub stat_with_version: bool,
 
     /// If the operator supports read operations.
     pub read: bool,
@@ -133,6 +139,9 @@ impl Capability {
             stat: capability.stat,
             stat_with_if_match: capability.stat_with_if_match,
             stat_with_if_none_match: capability.stat_with_if_none_match,
+            stat_with_if_modified_since: capability.stat_with_if_modified_since,
+            stat_with_if_unmodified_since: capability.stat_with_if_unmodified_since,
+            stat_with_version: capability.stat_with_version,
             read: capability.read,
             read_with_if_match: capability.read_with_if_match,
             read_with_if_none_match: capability.read_with_if_none_match,

--- a/bindings/python/tests/test_stat_capability.py
+++ b/bindings/python/tests/test_stat_capability.py
@@ -20,7 +20,7 @@ import opendal
 
 def test_stat_capability_fields_exist():
     op = opendal.Operator("memory")
-    cap = op.capability
+    cap = op.capability()
 
     assert isinstance(cap.stat_with_if_modified_since, bool)
     assert isinstance(cap.stat_with_if_unmodified_since, bool)

--- a/bindings/python/tests/test_stat_capability.py
+++ b/bindings/python/tests/test_stat_capability.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import opendal
+
+
+def test_stat_capability_fields_exist():
+    op = opendal.Operator("memory")
+    cap = op.capability
+
+    assert isinstance(cap.stat_with_if_modified_since, bool)
+    assert isinstance(cap.stat_with_if_unmodified_since, bool)
+    assert isinstance(cap.stat_with_version, bool)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Python's `Capability` class was missing three stat-related flags that exist in Rust core's `Capability` struct: `stat_with_if_modified_since`, `stat_with_if_unmodified_since`, and `stat_with_version`. Without these, Python callers cannot check whether a backend supports conditional stat operations before attempting them.

# What changes are included in this PR?

- `capability.rs`: add three new boolean fields to `Capability` struct and map them in `Capability::new()`
- `tests/test_stat_capability.py`: smoke test verifying the fields are accessible and boolean from Python

# Are there any user-facing changes?

Yes — Python callers can now read `capability.stat_with_if_modified_since`, `capability.stat_with_if_unmodified_since`, and `capability.stat_with_version` from `Operator.capability()`.

# AI Usage Statement

This PR was prepared with assistance from Claude (claude-sonnet-4-6) as part of a staging regression run. All changes were reviewed before pushing.