### PR TITLE
feat(bindings/python): expose list_with_versions and list_with_deleted in Capability

### DIFF
--- a/bindings/python/python/opendal/capability.pyi
+++ b/bindings/python/python/opendal/capability.pyi
@@ -152,6 +152,12 @@ class Capability:
     def list_with_recursive(self) -> builtins.bool:
         r"""If backend supports list without delimiter."""
     @property
+    def list_with_versions(self) -> builtins.bool:
+        r"""If backend supports list with versions."""
+    @property
+    def list_with_deleted(self) -> builtins.bool:
+        r"""If backend supports list with deleted."""
+    @property
     def presign(self) -> builtins.bool:
         r"""If operator supports presign."""
     @property

--- a/bindings/python/src/capability.rs
+++ b/bindings/python/src/capability.rs
@@ -111,6 +111,10 @@ pub struct Capability {
     pub list_with_start_after: bool,
     /// If backend supports list without delimiter.
     pub list_with_recursive: bool,
+    /// If backend supports list with versions.
+    pub list_with_versions: bool,
+    /// If backend supports list with deleted.
+    pub list_with_deleted: bool,
 
     /// If operator supports presign.
     pub presign: bool,
@@ -166,6 +170,8 @@ impl Capability {
             list_with_limit: capability.list_with_limit,
             list_with_start_after: capability.list_with_start_after,
             list_with_recursive: capability.list_with_recursive,
+            list_with_versions: capability.list_with_versions,
+            list_with_deleted: capability.list_with_deleted,
             presign: capability.presign,
             presign_read: capability.presign_read,
             presign_stat: capability.presign_stat,

--- a/bindings/python/tests/test_capability.py
+++ b/bindings/python/tests/test_capability.py
@@ -24,6 +24,16 @@ def test_capability(service_name, operator):
     assert cap.read is not None
 
 
+def test_capability_list_flags(service_name, operator):
+    cap = operator.capability()
+    assert cap is not None
+    assert cap.list_with_limit is not None
+    assert cap.list_with_start_after is not None
+    assert cap.list_with_recursive is not None
+    assert cap.list_with_versions is not None
+    assert cap.list_with_deleted is not None
+
+
 def test_capability_exception(service_name, operator):
     cap = operator.capability()
     assert cap is not None


### PR DESCRIPTION
The Rust core already supports `list_with_versions` and `list_with_deleted` capabilities, but the Python binding `Capability` struct did not expose them.

This PR:
- Adds `list_with_versions` and `list_with_deleted` fields to Python `Capability`
- Updates `capability.pyi` type stubs
- Adds capability tests for the new list flags

Diff summary:
```
M	bindings/python/python/opendal/capability.pyi
M	bindings/python/src/capability.rs
M	bindings/python/tests/test_capability.py
```