### PR TITLE
test(bindings/python): add focused behavior tests for write conditional options

### DIFF
--- a/bindings/python/tests/test_write_conditional.py
+++ b/bindings/python/tests/test_write_conditional.py
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from uuid import uuid4
+
+import pytest
+
+
+@pytest.mark.need_capability("write")
+def test_write_accepts_if_match_param(service_name, operator, async_operator):
+    path = f"test_write_if_match_{uuid4()}.txt"
+    operator.write(path, b"test content", if_match="etag123")
+
+
+@pytest.mark.need_capability("write")
+def test_write_accepts_if_none_match_param(service_name, operator, async_operator):
+    path = f"test_write_if_none_match_{uuid4()}.txt"
+    operator.write(path, b"test content", if_none_match="etag456")
+
+
+@pytest.mark.need_capability("write")
+def test_write_accepts_if_not_exists_param(service_name, operator, async_operator):
+    path = f"test_write_if_not_exists_{uuid4()}.txt"
+    operator.write(path, b"test content", if_not_exists=True)
+
+
+@pytest.mark.need_capability("write")
+def test_write_default_params_unchanged(service_name, operator, async_operator):
+    path = f"test_write_default_{uuid4()}.txt"
+    operator.write(path, b"test content")
+
+
+@pytest.mark.need_capability("write")
+@pytest.mark.asyncio
+async def test_async_write_accepts_if_match_param(service_name, operator, async_operator):
+    path = f"test_async_write_if_match_{uuid4()}.txt"
+    await async_operator.write(path, b"test content", if_match="etag123")
+
+
+@pytest.mark.need_capability("write")
+@pytest.mark.asyncio
+async def test_async_write_accepts_if_none_match_param(service_name, operator, async_operator):
+    path = f"test_async_write_if_none_match_{uuid4()}.txt"
+    await async_operator.write(path, b"test content", if_none_match="etag456")
+
+
+@pytest.mark.need_capability("write")
+@pytest.mark.asyncio
+async def test_async_write_accepts_if_not_exists_param(service_name, operator, async_operator):
+    path = f"test_async_write_if_not_exists_{uuid4()}.txt"
+    await async_operator.write(path, b"test content", if_not_exists=True)

--- a/bindings/python/tests/test_write_conditional.py
+++ b/bindings/python/tests/test_write_conditional.py
@@ -20,20 +20,24 @@ from uuid import uuid4
 import pytest
 
 
-@pytest.mark.need_capability("write")
+@pytest.mark.need_capability("write", "write_with_if_match")
 def test_write_accepts_if_match_param(service_name, operator, async_operator):
     path = f"test_write_if_match_{uuid4()}.txt"
     operator.write(path, b"test content", if_match="etag123")
 
 
-@pytest.mark.need_capability("write")
-def test_write_accepts_if_none_match_param(service_name, operator, async_operator):
+@pytest.mark.need_capability("write", "write_with_if_none_match")
+def test_write_accepts_if_none_match_param(
+    service_name, operator, async_operator
+):
     path = f"test_write_if_none_match_{uuid4()}.txt"
     operator.write(path, b"test content", if_none_match="etag456")
 
 
-@pytest.mark.need_capability("write")
-def test_write_accepts_if_not_exists_param(service_name, operator, async_operator):
+@pytest.mark.need_capability("write", "write_with_if_not_exists")
+def test_write_accepts_if_not_exists_param(
+    service_name, operator, async_operator
+):
     path = f"test_write_if_not_exists_{uuid4()}.txt"
     operator.write(path, b"test content", if_not_exists=True)
 
@@ -44,22 +48,28 @@ def test_write_default_params_unchanged(service_name, operator, async_operator):
     operator.write(path, b"test content")
 
 
-@pytest.mark.need_capability("write")
+@pytest.mark.need_capability("write", "write_with_if_match")
 @pytest.mark.asyncio
-async def test_async_write_accepts_if_match_param(service_name, operator, async_operator):
+async def test_async_write_accepts_if_match_param(
+    service_name, operator, async_operator
+):
     path = f"test_async_write_if_match_{uuid4()}.txt"
     await async_operator.write(path, b"test content", if_match="etag123")
 
 
-@pytest.mark.need_capability("write")
+@pytest.mark.need_capability("write", "write_with_if_none_match")
 @pytest.mark.asyncio
-async def test_async_write_accepts_if_none_match_param(service_name, operator, async_operator):
+async def test_async_write_accepts_if_none_match_param(
+    service_name, operator, async_operator
+):
     path = f"test_async_write_if_none_match_{uuid4()}.txt"
     await async_operator.write(path, b"test content", if_none_match="etag456")
 
 
-@pytest.mark.need_capability("write")
+@pytest.mark.need_capability("write", "write_with_if_not_exists")
 @pytest.mark.asyncio
-async def test_async_write_accepts_if_not_exists_param(service_name, operator, async_operator):
+async def test_async_write_accepts_if_not_exists_param(
+    service_name, operator, async_operator
+):
     path = f"test_async_write_if_not_exists_{uuid4()}.txt"
     await async_operator.write(path, b"test content", if_not_exists=True)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Python's `write()` method exposes `if_match`, `if_none_match`, and `if_not_exists` options, but there were no dedicated behavior tests for these parameters. This PR adds focused smoke tests to verify the parameters are accepted and dispatched correctly.

# What changes are included in this PR?

- `tests/test_write_conditional.py`: 7 new tests covering sync and async `write()` with `if_match`, `if_none_match`, `if_not_exists`, and default (no-options) invocations. Each conditional test gates on the specific capability flag (`write_with_if_match`, `write_with_if_none_match`, `write_with_if_not_exists`).

# Are there any user-facing changes?

No — test-only change.

# AI Usage Statement

This PR was prepared with assistance from Claude (claude-sonnet-4-6) as part of a staging regression run. All changes were reviewed before pushing.