### PR TITLE
test(bindings/python): add focused behavior tests for stat conditional options

### DIFF
--- a/bindings/python/src/capability.rs
+++ b/bindings/python/src/capability.rs
@@ -34,6 +34,8 @@ pub struct Capability {
     pub stat_with_if_match: bool,
     /// If operator supports stat with if none match.
     pub stat_with_if_none_match: bool,
+    /// If operator supports stat with version.
+    pub stat_with_version: bool,
 
     /// If the operator supports read operations.
     pub read: bool,
@@ -133,6 +135,7 @@ impl Capability {
             stat: capability.stat,
             stat_with_if_match: capability.stat_with_if_match,
             stat_with_if_none_match: capability.stat_with_if_none_match,
+            stat_with_version: capability.stat_with_version,
             read: capability.read,
             read_with_if_match: capability.read_with_if_match,
             read_with_if_none_match: capability.read_with_if_none_match,

--- a/bindings/python/tests/test_stat_conditional.py
+++ b/bindings/python/tests/test_stat_conditional.py
@@ -20,21 +20,23 @@ from uuid import uuid4
 import pytest
 
 
-@pytest.mark.need_capability("write", "stat")
+@pytest.mark.need_capability("write", "stat", "stat_with_if_match")
 def test_stat_accepts_if_match_param(service_name, operator, async_operator):
     path = f"test_stat_if_match_{uuid4()}.txt"
     operator.write(path, b"test content")
     operator.stat(path, if_match="etag123")
 
 
-@pytest.mark.need_capability("write", "stat")
-def test_stat_accepts_if_none_match_param(service_name, operator, async_operator):
+@pytest.mark.need_capability("write", "stat", "stat_with_if_none_match")
+def test_stat_accepts_if_none_match_param(
+    service_name, operator, async_operator
+):
     path = f"test_stat_if_none_match_{uuid4()}.txt"
     operator.write(path, b"test content")
     operator.stat(path, if_none_match="etag456")
 
 
-@pytest.mark.need_capability("write", "stat")
+@pytest.mark.need_capability("write", "stat", "stat_with_version")
 def test_stat_accepts_version_param(service_name, operator, async_operator):
     path = f"test_stat_version_{uuid4()}.txt"
     operator.write(path, b"test content")
@@ -49,25 +51,31 @@ def test_stat_default_params_unchanged(service_name, operator, async_operator):
     assert meta.content_length == len(b"test content")
 
 
-@pytest.mark.need_capability("write", "stat")
+@pytest.mark.need_capability("write", "stat", "stat_with_if_match")
 @pytest.mark.asyncio
-async def test_async_stat_accepts_if_match_param(service_name, operator, async_operator):
+async def test_async_stat_accepts_if_match_param(
+    service_name, operator, async_operator
+):
     path = f"test_async_stat_if_match_{uuid4()}.txt"
     await async_operator.write(path, b"test content")
     await async_operator.stat(path, if_match="etag123")
 
 
-@pytest.mark.need_capability("write", "stat")
+@pytest.mark.need_capability("write", "stat", "stat_with_if_none_match")
 @pytest.mark.asyncio
-async def test_async_stat_accepts_if_none_match_param(service_name, operator, async_operator):
+async def test_async_stat_accepts_if_none_match_param(
+    service_name, operator, async_operator
+):
     path = f"test_async_stat_if_none_match_{uuid4()}.txt"
     await async_operator.write(path, b"test content")
     await async_operator.stat(path, if_none_match="etag456")
 
 
-@pytest.mark.need_capability("write", "stat")
+@pytest.mark.need_capability("write", "stat", "stat_with_version")
 @pytest.mark.asyncio
-async def test_async_stat_accepts_version_param(service_name, operator, async_operator):
+async def test_async_stat_accepts_version_param(
+    service_name, operator, async_operator
+):
     path = f"test_async_stat_version_{uuid4()}.txt"
     await async_operator.write(path, b"test content")
     await async_operator.stat(path, version="v1")

--- a/bindings/python/tests/test_stat_conditional.py
+++ b/bindings/python/tests/test_stat_conditional.py
@@ -24,7 +24,11 @@ import pytest
 def test_stat_accepts_if_match_param(service_name, operator, async_operator):
     path = f"test_stat_if_match_{uuid4()}.txt"
     operator.write(path, b"test content")
-    operator.stat(path, if_match="etag123")
+    meta = operator.stat(path)
+    etag = meta.etag
+    if etag is None:
+        pytest.skip("backend does not return etag")
+    operator.stat(path, if_match=etag)
 
 
 @pytest.mark.need_capability("write", "stat", "stat_with_if_none_match")
@@ -58,7 +62,11 @@ async def test_async_stat_accepts_if_match_param(
 ):
     path = f"test_async_stat_if_match_{uuid4()}.txt"
     await async_operator.write(path, b"test content")
-    await async_operator.stat(path, if_match="etag123")
+    meta = await async_operator.stat(path)
+    etag = meta.etag
+    if etag is None:
+        pytest.skip("backend does not return etag")
+    await async_operator.stat(path, if_match=etag)
 
 
 @pytest.mark.need_capability("write", "stat", "stat_with_if_none_match")

--- a/bindings/python/tests/test_stat_conditional.py
+++ b/bindings/python/tests/test_stat_conditional.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from uuid import uuid4
+
+import pytest
+
+
+@pytest.mark.need_capability("write", "stat")
+def test_stat_accepts_if_match_param(service_name, operator, async_operator):
+    path = f"test_stat_if_match_{uuid4()}.txt"
+    operator.write(path, b"test content")
+    operator.stat(path, if_match="etag123")
+
+
+@pytest.mark.need_capability("write", "stat")
+def test_stat_accepts_if_none_match_param(service_name, operator, async_operator):
+    path = f"test_stat_if_none_match_{uuid4()}.txt"
+    operator.write(path, b"test content")
+    operator.stat(path, if_none_match="etag456")
+
+
+@pytest.mark.need_capability("write", "stat")
+def test_stat_accepts_version_param(service_name, operator, async_operator):
+    path = f"test_stat_version_{uuid4()}.txt"
+    operator.write(path, b"test content")
+    operator.stat(path, version="v1")
+
+
+@pytest.mark.need_capability("write", "stat")
+def test_stat_default_params_unchanged(service_name, operator, async_operator):
+    path = f"test_stat_default_{uuid4()}.txt"
+    operator.write(path, b"test content")
+    meta = operator.stat(path)
+    assert meta.content_length == len(b"test content")
+
+
+@pytest.mark.need_capability("write", "stat")
+@pytest.mark.asyncio
+async def test_async_stat_accepts_if_match_param(service_name, operator, async_operator):
+    path = f"test_async_stat_if_match_{uuid4()}.txt"
+    await async_operator.write(path, b"test content")
+    await async_operator.stat(path, if_match="etag123")
+
+
+@pytest.mark.need_capability("write", "stat")
+@pytest.mark.asyncio
+async def test_async_stat_accepts_if_none_match_param(service_name, operator, async_operator):
+    path = f"test_async_stat_if_none_match_{uuid4()}.txt"
+    await async_operator.write(path, b"test content")
+    await async_operator.stat(path, if_none_match="etag456")
+
+
+@pytest.mark.need_capability("write", "stat")
+@pytest.mark.asyncio
+async def test_async_stat_accepts_version_param(service_name, operator, async_operator):
+    path = f"test_async_stat_version_{uuid4()}.txt"
+    await async_operator.write(path, b"test content")
+    await async_operator.stat(path, version="v1")


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Python's `stat()` method exposes `if_match`, `if_none_match`, and `version` options, but there were no dedicated behavior tests for these parameters. This PR adds focused smoke tests and also adds the missing `stat_with_version` field to `Capability` so the capability gate works correctly.

# What changes are included in this PR?

- `capability.rs`: add `stat_with_version` field to `Capability` struct (makes this PR self-contained)
- `tests/test_stat_conditional.py`: 7 tests covering sync and async `stat()` with `if_match`, `if_none_match`, `version`, and default invocations. `if_match` tests fetch the real etag from the backend and skip if none is returned.

# Are there any user-facing changes?

Yes — Python callers can now read `capability.stat_with_version` from `Operator.capability()`.

# AI Usage Statement

This PR was prepared with assistance from Claude (claude-sonnet-4-6) as part of a staging regression run. All changes were reviewed before pushing.