### PR TITLE
fix(core): preserve spaces during path normalization

### DIFF
--- a/core/core/src/raw/path.rs
+++ b/core/core/src/raw/path.rs
@@ -90,14 +90,12 @@ pub fn build_rel_path(root: &str, path: &str) -> String {
 ///
 /// # Normalize Rules
 ///
-/// - All whitespace will be trimmed: ` abc/def ` => `abc/def`
 /// - All leading / will be trimmed: `///abc` => `abc`
 /// - Internal // will be replaced by /: `abc///def` => `abc/def`
 /// - Empty path will be `/`: `` => `/`
 pub fn normalize_path(path: &str) -> String {
-    // - all whitespace has been trimmed.
     // - all leading `/` has been trimmed.
-    let path = path.trim().trim_start_matches('/');
+    let path = path.trim_start_matches('/');
 
     // Fast line for empty path.
     if path.is_empty() {
@@ -284,7 +282,17 @@ mod tests {
             ("abs dir path with extra /", "///abc/def/", "abc/def/"),
             ("file path contains ///", "abc///def", "abc/def"),
             ("dir path contains ///", "abc///def///", "abc/def/"),
-            ("file with whitespace", "abc/def   ", "abc/def"),
+            ("file with trailing whitespace", "abc/def   ", "abc/def   "),
+            (
+                "file with surrounding whitespace",
+                "  abc/def   ",
+                "  abc/def   ",
+            ),
+            (
+                "abs file with trailing whitespace",
+                "/abc/def   ",
+                "abc/def   ",
+            ),
         ];
 
         for (name, input, expect) in cases {


### PR DESCRIPTION
## Summary
- stop trimming whitespace in `normalize_path` so object names can preserve leading and trailing spaces
- keep the existing leading-slash and repeated-slash normalization behavior
- add focused path normalization cases for trailing and surrounding spaces

Fixes #6577.

## Tests
- `cargo fmt --check`
- `cargo test -p opendal-core raw::path::tests::test_normalize_path`
- `cargo clippy -p opendal-core --all-targets -- -D warnings`
