### PR TITLE
ci: follow redirects when downloading minio mc

### DIFF
--- a/.github/services/s3/minio_s3_with_anonymous/action.yml
+++ b/.github/services/s3/minio_s3_with_anonymous/action.yml
@@ -35,7 +35,7 @@ runs:
       run: |
         aws --endpoint-url http://127.0.0.1:9000/ s3 mb s3://test
 
-        curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
+        curl -fL --retry 3 -o mc https://dl.min.io/client/mc/release/linux-amd64/mc
         chmod +x mc
         ./mc alias set local http://127.0.0.1:9000/ minioadmin minioadmin
         ./mc anonymous set public local/test


### PR DESCRIPTION
## Summary
- follow redirects while downloading the MinIO `mc` client in the anonymous S3 behavior-test setup
- fail fast on HTTP errors and retry transient download failures

## Root cause
The `minio_s3_with_anonymous` setup currently runs:

```bash
curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
```

That endpoint responds with HTTP 302 and `content-length: 141`. Without `-L`, curl saves the HTML redirect body as `mc`, so the workflow later fails before tests start with:

```text
./mc: line 1: a: No such file or directory
```

This exact failure appeared across several unrelated staging PRs in `core / ubuntu-latest / s3 / minio_s3_with_anonymous`.

## Tests
- `curl -sS -D - https://dl.min.io/client/mc/release/linux-amd64/mc -o /tmp/opendal-mc-check.bin` reproduces the 302 + 141-byte body
- `curl -fsSL --retry 3 -o /tmp/opendal-mc-followed https://dl.min.io/client/mc/release/linux-amd64/mc` downloads a 30,535,864-byte ELF binary
- `ruby -e 'require "yaml"; YAML.load_file(".github/services/s3/minio_s3_with_anonymous/action.yml")'`
