### PR TITLE
ci(bindings/ocaml): avoid unnecessary dune cache install

### DIFF
--- a/.github/actions/setup-ocaml/action.yaml
+++ b/.github/actions/setup-ocaml/action.yaml
@@ -22,6 +22,10 @@ inputs:
     description: "Enable the automation feature for opam depext."
   need-pin:
     description: "Enable the automation feature for opam pin."
+    default: "false"
+  need-dune-cache:
+    description: "Enable Dune build caching in ocaml/setup-ocaml."
+    default: "false"
 
 runs:
   using: "composite"
@@ -30,8 +34,8 @@ runs:
       uses: ocaml/setup-ocaml@v3
       with:
         ocaml-compiler: 4.14
-        opam-pin: ${{inputs.need-pin == true}}
-        dune-cache: true
+        opam-pin: ${{ inputs.need-pin }}
+        dune-cache: ${{ inputs.need-dune-cache }}
 
     - name: Set Opam env
       shell: bash


### PR DESCRIPTION
# Which issue does this PR close?

N/A. CI follow-up for #7455 after the main merge run failed in the OCaml `build` job.

# Rationale for this change

#7455 fixed the previous `ocaml/setup-ocaml@v2` setup failure (`Could not retrieve the opam release matching the version constraint`) by upgrading to `setup-ocaml@v3`.

The main branch run after merge exposed a different failure in `Bindings OCaml CI / build`: `setup-ocaml@v3` installed `dune` only because the shared wrapper unconditionally sets `dune-cache: true`, and that package fetch hit an HTTP 502:

```text
[ERROR] Failed to get sources of dune.3.22.2: HTTP error code 502
```

That `build` job only runs `cargo clippy` in `bindings/ocaml`, so it doesn't need Dune or Dune caching during setup. Avoiding that unnecessary install removes a flaky external fetch point from the build job.

The same log also showed `need-pin: true` becoming `opam-pin: false`, because the composite action compared string inputs to boolean `true`. This PR passes the input through directly.

# What changes are included in this PR?

- Add a `need-dune-cache` input to `.github/actions/setup-ocaml/action.yaml`, defaulting to `false`.
- Pass `need-pin` directly to `opam-pin` instead of using a string-vs-boolean comparison.
- Leave existing workflow call sites unchanged, so the OCaml build job no longer triggers `setup-ocaml`'s automatic Dune install.

Validation:

```text
git diff --name-status origin/main...HEAD
M .github/actions/setup-ocaml/action.yaml

ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' \
  .github/actions/setup-ocaml/action.yaml \
  .github/workflows/ci_bindings_ocaml.yml \
  .github/workflows/docs.yml
```

# Are there any user-facing changes?

No. CI-only harness change.

# AI Usage Statement

This PR was prepared with AI assistance from OpenAI Codex (GPT-5), supervised by @TennyZhuang in the staging regression workflow.
