### PR TITLE
feat(bindings/nodejs): add presignDelete method and Capability getter

### DIFF
--- a/bindings/nodejs/generated.d.ts
+++ b/bindings/nodejs/generated.d.ts
@@ -201,6 +201,8 @@ export declare class Capability {
   get presignStat(): boolean
   /** If operator supports presign write. */
   get presignWrite(): boolean
+  /** If operator supports presign delete. */
+  get presignDelete(): boolean
   /** If operator supports shared. */
   get shared(): boolean
 }

--- a/bindings/nodejs/generated.d.ts
+++ b/bindings/nodejs/generated.d.ts
@@ -841,6 +841,22 @@ export declare class Operator {
    * ```
    */
   presignStat(path: string, expires: number): Promise<PresignedRequest>
+  /**
+   * Get a presigned request for delete.
+   *
+   * Unit of `expires` is seconds.
+   *
+   * ### Example
+   *
+   * ```javascript
+   * const req = await op.presignDelete(path, parseInt(expires));
+   *
+   * console.log("method: ", req.method);
+   * console.log("url: ", req.url);
+   * console.log("headers: ", req.headers);
+   * ```
+   */
+  presignDelete(path: string, expires: number): Promise<PresignedRequest>
   /** Add a layer to this operator. */
   layer(layer: ExternalObject<Layer>): Operator
 }

--- a/bindings/nodejs/src/capability.rs
+++ b/bindings/nodejs/src/capability.rs
@@ -329,6 +329,12 @@ impl Capability {
         self.0.presign_write
     }
 
+    /// If operator supports presign delete.
+    #[napi(getter)]
+    pub fn presign_delete(&self) -> bool {
+        self.0.presign_delete
+    }
+
     /// If operator supports shared.
     #[napi(getter)]
     pub fn shared(&self) -> bool {

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -826,6 +826,29 @@ impl Operator {
             .map_err(format_napi_error)?;
         Ok(PresignedRequest::new(res))
     }
+
+    /// Get a presigned request for delete.
+    ///
+    /// Unit of `expires` is seconds.
+    ///
+    /// ### Example
+    ///
+    /// ```javascript
+    /// const req = await op.presignDelete(path, parseInt(expires));
+    ///
+    /// console.log("method: ", req.method);
+    /// console.log("url: ", req.url);
+    /// console.log("headers: ", req.headers);
+    /// ```
+    #[napi]
+    pub async fn presign_delete(&self, path: String, expires: u32) -> Result<PresignedRequest> {
+        let res = self
+            .async_op
+            .presign_delete(&path, Duration::from_secs(expires as u64))
+            .await
+            .map_err(format_napi_error)?;
+        Ok(PresignedRequest::new(res))
+    }
 }
 
 /// Entry returned by Lister or BlockingLister to represent a path, and it's a relative metadata.


### PR DESCRIPTION
# Which issue does this PR close?

No dedicated issue. This binding parity gap was found during a Slock OpenDAL binding regression.

Related but not closed: #7386 tracks S3 core enablement for presign delete. This PR only exposes the already-existing core `Operator::presign_delete` and `Capability::presign_delete` surface through the Node.js binding.

# Rationale for this change

Rust core and Python already expose presigned DELETE support. The Node.js binding already exposes the sibling `presignRead`, `presignWrite`, and `presignStat` methods together with matching `Capability.presignRead`, `Capability.presignWrite`, and `Capability.presignStat` getters.

Adding `presignDelete` plus `Capability.presignDelete` closes that Node.js API parity gap as one coherent sibling pair. Keeping the method and capability getter together avoids a partial public surface where callers can either call the method without capability introspection or observe a capability flag with no corresponding operation.

# What changes are included in this PR?

- Add `Operator.presign_delete` to the Node.js NAPI binding, implemented through `self.async_op.presign_delete(...)`.
- Add the Node.js `Capability.presign_delete` getter, mirroring Rust core's `Capability.presign_delete` field.
- Regenerate `bindings/nodejs/generated.d.ts` so TypeScript users get both `presignDelete(path, expires)` and `capability.presignDelete`.
- Keep the Node.js operator API flat, matching the existing `presignRead` / `presignWrite` / `presignStat` shape.

# Are there any user-facing changes?

Yes. Node.js users can now call:

```ts
const req = await op.presignDelete(path, expires)
```

and check support with:

```ts
const supported = op.capability().presignDelete
```

This is additive and does not change existing behavior.

# Validation

- `pnpm build` in `bindings/nodejs` passed for the original method patch.
- `pnpm build` in `bindings/nodejs` passed again after folding in the capability getter.
- Node smoke check confirmed `typeof op.presignDelete === "function"` and that unsupported-service errors propagate through the binding instead of panicking.
- Node smoke check confirmed `capability.presignDelete` exists and returns a boolean.
- `pnpm test -- --run` in `bindings/nodejs` could not run meaningful tests in this local environment because `bindings/nodejs/.env` is absent; Vitest reports `No test suite found` after skipping service tests for an empty scheme.

# AI Usage Statement

This PR was prepared during a Slock multi-agent regression using AI agents:

- OpenCode / DeepSeek v4-pro produced the initial `Operator.presignDelete` patch.
- Codex / GPT-5.5 reviewed the initial diff and validation output before PR publication.
- Codex / GPT-5.5 produced the `Capability.presignDelete` follow-up patch and later folded it into this PR for sibling-pair coherence.
- Commander and scout agents performed duplicate/API-surface pre-review before publication.
- Jianwei/TennyZhuang credentials were used to publish the branch to GitHub.
