### PR TITLE
feat(bindings/nodejs): expose presignDelete capability

### DIFF
--- a/bindings/nodejs/generated.d.ts
+++ b/bindings/nodejs/generated.d.ts
@@ -201,6 +201,8 @@ export declare class Capability {
   get presignStat(): boolean
   /** If operator supports presign write. */
   get presignWrite(): boolean
+  /** If operator supports presign delete. */
+  get presignDelete(): boolean
   /** If operator supports shared. */
   get shared(): boolean
 }

--- a/bindings/nodejs/src/capability.rs
+++ b/bindings/nodejs/src/capability.rs
@@ -329,6 +329,12 @@ impl Capability {
         self.0.presign_write
     }
 
+    /// If operator supports presign delete.
+    #[napi(getter)]
+    pub fn presign_delete(&self) -> bool {
+        self.0.presign_delete
+    }
+
     /// If operator supports shared.
     #[napi(getter)]
     pub fn shared(&self) -> bool {


### PR DESCRIPTION
# Which issue does this PR close?

N/A — small Node.js binding capability-surface parity patch following Rust core and existing sibling presign capability getters.

# Rationale for this change

Rust core exposes `Capability.presign_delete`, but the Node.js binding `Capability` wrapper currently exposes only `presign`, `presignRead`, `presignStat`, and `presignWrite`. This leaves Node.js users unable to inspect delete-presign support even when the underlying capability is available.

Prior-art / duplicate check:
- GitHub searches found no open PR or issue for Node.js `Capability.presignDelete` / `presign_delete` capability exposure.
- Independent scout pre-review confirmed the gap and API shape against `apache/opendal:main`.

# What changes are included in this PR?

- Add `presignDelete` getter to the Node.js `Capability` napi wrapper.
- Add the generated TypeScript declaration `get presignDelete(): boolean`.

Patch scope is intentionally limited to:
- `bindings/nodejs/src/capability.rs`
- `bindings/nodejs/generated.d.ts`

# Are there any user-facing changes?

Yes. Node.js users can now read `operator.capability().presignDelete` to check whether the operator supports presigned delete.

There are no breaking changes.

Validation:

```text
pnpm install --frozen-lockfile
pnpm build
```

`pnpm build` passed with the release profile. A focused runtime smoke check verified that `presignDelete` exists on the `Capability` prototype, returns a boolean, returns `false` for the memory service, and leaves sibling `presignWrite` as a boolean.

# AI Usage Statement

This PR was prepared by the Slock agent `@od-codex-review-050121` using OpenAI Codex as part of the OpenDAL binding regression run. It was pre-reviewed by Slock agents `@od-claude-lead-050121` for design/API readiness and `@od-kimi-scout-050121` for duplicate/API-surface sanity before publication.
