### PR TITLE
feat(bindings/nodejs): add Entry.name getter

### DIFF
--- a/bindings/nodejs/generated.d.ts
+++ b/bindings/nodejs/generated.d.ts
@@ -268,6 +268,8 @@ export declare class ConcurrentLimitLayer {
 export declare class Entry {
   /** Return the path of this entry. */
   path(): string
+  /** Return the name of this entry. */
+  name(): string
   /** Return the metadata of this entry. */
   metadata(): Metadata
 }

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -840,6 +840,12 @@ impl Entry {
         self.0.path().to_string()
     }
 
+    /// Return the name of this entry.
+    #[napi]
+    pub fn name(&self) -> String {
+        self.0.name().to_string()
+    }
+
     /// Return the metadata of this entry.
     #[napi]
     pub fn metadata(&self) -> Metadata {


### PR DESCRIPTION
## Which issue does this PR close?

No dedicated issue. This is a small Node.js binding parity patch found during the OpenDAL binding regression.

## Rationale for this change

Rust core exposes `Entry::name()` and the Python binding exposes `Entry.name`, but the Node.js binding only exposed `Entry.path()` and `Entry.metadata()`.

Adding `Entry.name()` lets Node.js users get the last path segment directly without parsing the full path themselves.

## What changes are included in this PR?

- Add `Entry.name()` in `bindings/nodejs/src/lib.rs`.
- Regenerate `bindings/nodejs/generated.d.ts` to expose `name(): string`.
- No options, no async variants, no behavior changes to existing APIs.

## Are there any user-facing changes?

Yes. `Entry` instances returned by listers now expose:

```ts
entry.name(): string
```

## Intentional divergence from Rust

None. This is a direct passthrough of Rust core `Entry::name()`.

## Validation

Internal agent-to-agent pre-review used the required patch artifact flow before PR publication:

- Patch v1 artifact: `856675db-8aa0-4802-ac15-ad608e31ea27`, SHA-256 `bdfa658679e741957aa11e36d1e6b156f9525dcbc51e1c115ff0edbb0fcd7254`.
- Patch v2 artifact: `c8dde254-c5ff-4ecc-8ae9-71ebb86dfac8`, SHA-256 `cdc9fa553421cadf13352eceba00f21233a71b2e21550a2305e0fcb787745bed`.
- Codex pre-review verified checksum, clean apply to `origin/main`, `git diff --check`, exact 2-file scope, API placement, and generated declaration.
- Commander pre-review verified Rust source parity, Python parity, placement, JSDoc, scope, and no divergence.

Reported local validation from the handoff:

- `pnpm install --frozen-lockfile` succeeded with no lockfile changes.
- `pnpm build` in `bindings/nodejs` passed.
- Runtime smoke with the memory service confirmed `entry.path()` and `entry.name()` both returned `test.txt` for a listed file.
- `git diff --check` / `git show --check HEAD` passed.

GitHub CI after PR open:

- `Bindings NodeJS CI / test` passed.
- Node docs/check jobs passed. Some behavior-test service matrix failures are the same repository CI infra/service allowlist failures seen on adjacent Node PRs, not specific to this 2-file binding patch.

## AI Usage Statement

This patch was produced by an AI agent during an OpenDAL binding regression effort. It was reviewed by separate AI reviewer/commander agents through Slock before publication. The PR body was corrected after publication to remove an accidentally pasted local `pnpm` error from the original validation text.
