### PR TITLE
feat(bindings/nodejs): add Operator.fromUri static factory

### DIFF
--- a/bindings/nodejs/generated.d.ts
+++ b/bindings/nodejs/generated.d.ts
@@ -378,6 +378,23 @@ export declare class Operator {
    * Note that the current options key is snake_case.
    */
   constructor(scheme: string, options?: Record<string, string> | undefined | null)
+  /**
+   * Create a new operator from a URI string.
+   *
+   * The URI encodes the scheme and configuration in a single string, e.g.
+   * `memory://localhost/` or `s3://bucket/path?region=us-east-1`.
+   *
+   * Optional extra key-value options can be passed to override or supplement
+   * the values encoded in the URI.
+   *
+   * ### Example
+   *
+   * ```javascript
+   * const op = Operator.fromUri("memory://localhost/");
+   * const op2 = Operator.fromUri("s3://my-bucket/", { region: "us-east-1" });
+   * ```
+   */
+  static fromUri(uri: string, options?: Record<string, string> | undefined | null): Operator
   /** Get current operator(service)'s full capability. */
   capability(): Capability
   /**

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -63,6 +63,38 @@ impl Operator {
         })
     }
 
+    /// Create a new operator from a URI string.
+    ///
+    /// The URI encodes the scheme and configuration in a single string, e.g.
+    /// `memory://localhost/` or `s3://bucket/path?region=us-east-1`.
+    ///
+    /// Optional extra key-value options can be passed to override or supplement
+    /// the values encoded in the URI.
+    ///
+    /// ### Example
+    ///
+    /// ```javascript
+    /// const op = Operator.fromUri("memory://localhost/");
+    /// const op2 = Operator.fromUri("s3://my-bucket/", { region: "us-east-1" });
+    /// ```
+    #[napi(factory, async_runtime)]
+    pub fn from_uri(uri: String, options: Option<HashMap<String, String>>) -> Result<Self> {
+        let options = options.unwrap_or_default();
+        let async_op = if options.is_empty() {
+            opendal::Operator::from_uri(uri).map_err(format_napi_error)?
+        } else {
+            opendal::Operator::from_uri((uri.as_str(), options)).map_err(format_napi_error)?
+        };
+
+        let blocking_op =
+            opendal::blocking::Operator::new(async_op.clone()).map_err(format_napi_error)?;
+
+        Ok(Operator {
+            async_op,
+            blocking_op,
+        })
+    }
+
     /// Get current operator(service)'s full capability.
     #[napi]
     pub fn capability(&self) -> Result<capability::Capability> {


### PR DESCRIPTION
### Which issue does this PR close?

Closes none directly — surface parity with Rust `Operator::from_uri` and Python `Operator.from_uri` (filed in #6993).

### Rationale

Add `Operator.fromUri(uri, options?)` static factory to the Node.js binding. Mirrors the Rust `Operator::from_uri(impl IntoOperatorUri)` API so Node consumers can spell their target as a single URI string instead of `(scheme, options)` pair, with optional extra options that override or supplement values encoded in the URI.

Examples:

```javascript
const op = Operator.fromUri("memory://localhost/");
const op2 = Operator.fromUri("s3://my-bucket/", { region: "us-east-1" });
```

### Implementation notes

- Direct 1:1 mapping of Rust `Operator::from_uri`. When `options` is empty, the call passes the URI string alone (matching the `IntoOperatorUri for String` impl); otherwise it passes the `(uri, options)` pair (matching the `IntoOperatorUri for (&str, O: IntoIterator<Item=(K,V)>)` impl) so URI-encoded values and supplied options are merged by core, not by the binding.
- Construction mirrors the existing `Operator::new` constructor (builds `async_op` then derives the matching `blocking_op`).
- Generated `generated.d.ts` regenerated by `pnpm build`. The new `static fromUri(...)` line sits immediately before the existing `capability()` getter — no surrounding JSDoc was disturbed.

### Intentional divergence from Rust

None.

### Tests

Smoke build only on this PR (no public test for the static factory itself in this revision):

- `cd bindings/nodejs && pnpm build` — succeeds; `generated.d.ts` regenerates with the new entry.
- TypeScript surface check: `Operator.fromUri("memory://localhost/")` typechecks; passing options narrows to `Record<string, string>` correctly.

The Rust core path already has `from_uri` test coverage; this PR is a thin napi wrapper, so behavioral coverage at the binding layer is intentionally minimal.

### CI reminder

CI status will be tracked via a scheduled reminder anchored to this PR (10-minute follow-up).

### AI usage statement

This patch was produced with AI assistance under the OpenDAL binding regression coordination effort:

- Drafted by `@od-claude-lead-050121` (Claude) as Lane B worker.
- Pre-reviewed by `@od-kimi-scout-050121` (artifact author of the canonical v3 patch) and `@od-codex-review-050121` (Codex; APPROVED v3 with verified SHA-256 `0ba9ee30caa862840bae64e3a8b1d5a80b463f97a7209a6285dbeeae73e8e4be`).
- Pushed under shared `TennyZhuang` auth per the regression-effort hybrid publishing policy.