### PR TITLE
ci: fix main workflow failures

### DIFF
--- a/.github/actions/test_behavior_binding_java/action.yaml
+++ b/.github/actions/test_behavior_binding_java/action.yaml
@@ -41,7 +41,7 @@ runs:
           - name: Run Test Binding Java
             shell: bash
             working-directory: bindings/java
-            run: ./mvnw test -Dtest="behavior.*Test"
+            run: mvn -B -ntp test -Dtest="behavior.*Test"
             env:
               OPENDAL_TEST: ${{ inputs.service }}
         EOF

--- a/.github/services/aliyun_drive/aliyun_drive/disable_action.yml
+++ b/.github/services/aliyun_drive/aliyun_drive/disable_action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/azblob/azure_azblob/action.yml
+++ b/.github/services/azblob/azure_azblob/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/azdls/azdls/action.yml
+++ b/.github/services/azdls/azdls/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/azfile/azfile/action.yml
+++ b/.github/services/azfile/azfile/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/b2/b2/action.yml
+++ b/.github/services/b2/b2/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/cos/cos/action.yml
+++ b/.github/services/cos/cos/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/dropbox/dropbox/disable_action.yml
+++ b/.github/services/dropbox/dropbox/disable_action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup credentials
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/gcs/gcs/action.yml
+++ b/.github/services/gcs/gcs/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/gcs/gcs_with_default_storage_class/action.yml
+++ b/.github/services/gcs/gcs_with_default_storage_class/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/gdrive/gdrive/action.yml
+++ b/.github/services/gdrive/gdrive/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/hdfs/hdfs_default_gcs/action.yml
+++ b/.github/services/hdfs/hdfs_default_gcs/action.yml
@@ -27,7 +27,7 @@ runs:
         distribution: zulu
         java-version: 11
     - name: Load secrets
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/hf/hf_bucket/action.yml
+++ b/.github/services/hf/hf_bucket/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/hf/hf_dataset/action.yml
+++ b/.github/services/hf/hf_dataset/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/koofr/koofr/disable_action.yml
+++ b/.github/services/koofr/koofr/disable_action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/oss/oss/action.yml
+++ b/.github/services/oss/oss/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/oss/oss_with_versioning/action.yml
+++ b/.github/services/oss/oss_with_versioning/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3/action.yml
+++ b/.github/services/s3/aws_s3/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3_with_list_objects_v1/action.yml
+++ b/.github/services/s3/aws_s3_with_list_objects_v1/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3_with_sse_c/action.yml
+++ b/.github/services/s3/aws_s3_with_sse_c/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3_with_versioning/action.yml
+++ b/.github/services/s3/aws_s3_with_versioning/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/s3/aws_s3_with_virtual_host/action.yml
+++ b/.github/services/s3/aws_s3_with_virtual_host/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/services/s3/r2/disabled_action.yml
+++ b/.github/services/s3/r2/disabled_action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup
-      uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
       with:
         export-env: true
       env:

--- a/.github/workflows/ci_bindings_haskell.yml
+++ b/.github/workflows/ci_bindings_haskell.yml
@@ -126,7 +126,7 @@ jobs:
 #          name: bindings-haskell-sdist
 #      - name: Load secret
 #        id: op-load-secret
-#        uses: 1password/load-secrets-action@13f58eec611f8e5db52ec16247f58c508398f3e6 # v3
+#        uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
 #        with:
 #          export-env: true
 #        env:

--- a/.github/workflows/ci_bindings_ocaml.yml
+++ b/.github/workflows/ci_bindings_ocaml.yml
@@ -58,15 +58,6 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v6
 
-      - name: Cache OPAM dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.opam
-          key: ${{ runner.os }}-opam-${{ hashFiles('bindings/ocaml/dune-project') }}
-          restore-keys: |
-            ${{ runner.os }}-opam-
-            ${{ runner.os }}-opam-doc-
-
       - name: Setup OCaml toolchain
         uses: ./.github/actions/setup-ocaml
         with:

--- a/.github/workflows/discussion-thread-link.yml
+++ b/.github/workflows/discussion-thread-link.yml
@@ -259,11 +259,23 @@ jobs:
                   }
                 }
               `;
-              await github.graphql(mutation, {
-                discussionId: discussion.node_id,
-                body: newBody,
-              });
-              core.info('Updated discussion via GraphQL');
+              try {
+                await github.graphql(mutation, {
+                  discussionId: discussion.node_id,
+                  body: newBody,
+                });
+                core.info('Updated discussion via GraphQL');
+              } catch (error) {
+                const message = error && error.message ? error.message : String(error);
+                if (message.includes('Resource not accessible by integration')) {
+                  core.warning(
+                    `Unable to update discussion with the default integration token. ` +
+                    `Computed thread URL: ${threadUrl}`
+                  );
+                  return;
+                }
+                throw error;
+              }
             }
 
             core.info(`Appended ${threadUrl}`);

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -317,15 +317,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Cache OPAM dependencies
-        uses: actions/cache@v5
-        with:
-          path: ~/.opam
-          key: ${{ runner.os }}-opam-doc-${{ hashFiles('bindings/ocaml/dune-project') }}
-          restore-keys: |
-            ${{ runner.os }}-opam-doc-
-            ${{ runner.os }}-opam-
-
       - name: Cache Dune build artifacts
         uses: actions/cache@v5
         with:

--- a/.github/workflows/test_behavior_binding_java.yml
+++ b/.github/workflows/test_behavior_binding_java.yml
@@ -53,6 +53,13 @@ jobs:
           echo "OP_CONNECT_HOST=${{ secrets.OP_CONNECT_HOST }}" >> "$GITHUB_ENV"
           echo "OP_CONNECT_TOKEN=${{ secrets.OP_CONNECT_TOKEN }}" >> "$GITHUB_ENV"
 
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 25
+          cache: 'maven'
+
       - name: Test Core
         uses: ./.github/actions/test_behavior_binding_java
         with:

--- a/bindings/python/tests/test_stat_conditional.py
+++ b/bindings/python/tests/test_stat_conditional.py
@@ -44,7 +44,10 @@ def test_stat_accepts_if_none_match_param(
 def test_stat_accepts_version_param(service_name, operator, async_operator):
     path = f"test_stat_version_{uuid4()}.txt"
     operator.write(path, b"test content")
-    operator.stat(path, version="v1")
+    meta = operator.stat(path)
+    if meta.version is None:
+        pytest.skip("backend does not return version")
+    operator.stat(path, version=meta.version)
 
 
 @pytest.mark.need_capability("write", "stat")
@@ -86,4 +89,7 @@ async def test_async_stat_accepts_version_param(
 ):
     path = f"test_async_stat_version_{uuid4()}.txt"
     await async_operator.write(path, b"test content")
-    await async_operator.stat(path, version="v1")
+    meta = await async_operator.stat(path)
+    if meta.version is None:
+        pytest.skip("backend does not return version")
+    await async_operator.stat(path, version=meta.version)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7475.

# Rationale for this change

Recent `main` CI failures are caused by CI workflow issues and behavior-test setup assumptions: external service setup jobs use a 1Password action SHA that is not allowed by the repository policy, OCaml jobs restore a stale `~/.opam` cache before `ocaml/setup-ocaml`, the discussion thread linker fails the whole workflow when the default integration token cannot update a discussion body, Python version stat tests use a fabricated version ID, and Java behavior tests run without an explicit Java/Maven setup.

# What changes are included in this PR?

This updates all 1Password secret-loading action references to an allowed v3.2.1 pin, removes the manual `~/.opam` cache restore from OCaml CI and docs, downgrades the discussion update permission failure to a warning while still logging the computed mailing-list thread URL, updates Python stat version tests to use the actual backend-returned version ID, and sets up JDK 25 for Java behavior tests while using Maven directly for the behavior matrix.

# Are there any user-facing changes?

No.

# AI Usage Statement

AI tools assisted with investigation and implementation.
