### PR TITLE
feat(services/oss): support ECS RAM role credentials

### DIFF
--- a/core/services/oss/src/backend.rs
+++ b/core/services/oss/src/backend.rs
@@ -23,6 +23,7 @@ use http::StatusCode;
 use http::Uri;
 use log::debug;
 use reqsign_aliyun_oss::AssumeRoleWithOidcCredentialProvider;
+use reqsign_aliyun_oss::EcsRamRoleCredentialProvider;
 use reqsign_aliyun_oss::EnvCredentialProvider;
 use reqsign_aliyun_oss::RequestSigner;
 use reqsign_aliyun_oss::StaticCredentialProvider;
@@ -485,6 +486,7 @@ impl Builder for OssBuilder {
 
         let mut provider = ProvideCredentialChain::new()
             .push(EnvCredentialProvider::new())
+            .push(EcsRamRoleCredentialProvider::new())
             .push(assume_role);
 
         if let (Some(ak), Some(sk)) = (&self.config.access_key_id, &self.config.access_key_secret) {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

https://github.com/apache/opendal-reqsign/discussions/742

# Rationale for this change

OSS currently supports loading credentials from environment variables, static access keys, and OIDC assume-role flow. However, it doesn't include ECS RAM role credentials in the default credential chain.
This makes OSS fail to authenticate in Alibaba Cloud ECS environments where credentials are expected to come from the instance RAM role.
# What changes are included in this PR?

Add `EcsRamRoleCredentialProvider` into OSS's default credential provider chain.
With this change, OSS now resolves credentials in the following order:
1. Static access key and secret configured explicitly
2. Environment-based credentials
3. ECS RAM role credentials
4. OIDC assume-role credentials

# Are there any user-facing changes?

Yes. OSS can now authenticate with ECS RAM role credentials automatically when running inside supported Alibaba Cloud ECS environments, without requiring users to provide access key credentials explicitly.

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
