### PR TITLE
feat(azure): Add operation label to azure operations

### DIFF
--- a/core/services/azblob/src/core.rs
+++ b/core/services/azblob/src/core.rs
@@ -215,6 +215,7 @@ impl AzblobCore {
 
         let req = req
             .extension(Operation::Read)
+            .extension(ServiceOperation("GetBlob"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -280,6 +281,7 @@ impl AzblobCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("PutBlob"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -343,6 +345,7 @@ impl AzblobCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("PutBlob"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -388,6 +391,7 @@ impl AzblobCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("AppendBlock"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -441,6 +445,7 @@ impl AzblobCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("PutBlock"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -491,6 +496,7 @@ impl AzblobCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("PutBlockList"))
             .body(Buffer::from(Bytes::from(content)))
             .map_err(new_request_build_error)?;
 
@@ -524,6 +530,7 @@ impl AzblobCore {
 
         let req = req
             .extension(Operation::Stat)
+            .extension(ServiceOperation("GetBlobProperties"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -544,6 +551,7 @@ impl AzblobCore {
         Request::delete(self.build_path_url(path))
             .header(CONTENT_LENGTH, 0)
             .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteBlob"))
             .body(Buffer::new())
             .map_err(new_request_build_error)
     }
@@ -574,6 +582,7 @@ impl AzblobCore {
 
         let req = req
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyBlob"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -608,6 +617,7 @@ impl AzblobCore {
 
         let req = Request::get(url.finish())
             .extension(Operation::List)
+            .extension(ServiceOperation("ListBlobs"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -632,7 +642,9 @@ impl AzblobCore {
             );
         }
 
-        let req = Request::post(url);
+        let req = Request::post(url)
+            .extension(Operation::Delete)
+            .extension(ServiceOperation("BatchDeleteBlobs"));
         let req = multipart.apply(req)?;
         let req = self.sign(req).await?;
         self.send(req).await

--- a/core/services/azdls/src/core.rs
+++ b/core/services/azdls/src/core.rs
@@ -110,6 +110,7 @@ impl AzdlsCore {
 
         let req = req
             .extension(Operation::Read)
+            .extension(ServiceOperation("ReadFile"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -163,9 +164,15 @@ impl AzdlsCore {
         } else {
             Operation::Write
         };
+        let service_operation = if resource == DIRECTORY {
+            ServiceOperation("CreateDirectory")
+        } else {
+            ServiceOperation("CreateFile")
+        };
 
         let req = req
             .extension(operation)
+            .extension(service_operation)
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -190,6 +197,7 @@ impl AzdlsCore {
             .header(X_MS_RENAME_SOURCE, source_path)
             .header(CONTENT_LENGTH, 0)
             .extension(Operation::Rename)
+            .extension(ServiceOperation("RenamePath"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -232,6 +240,7 @@ impl AzdlsCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("AppendData"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -263,6 +272,7 @@ impl AzdlsCore {
         let req = Request::patch(&url)
             .header(CONTENT_LENGTH, 0)
             .extension(Operation::Write)
+            .extension(ServiceOperation("FlushData"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -286,6 +296,7 @@ impl AzdlsCore {
 
         let req = req
             .extension(Operation::Stat)
+            .extension(ServiceOperation("GetPathProperties"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -350,6 +361,7 @@ impl AzdlsCore {
 
         let req = Request::delete(&url)
             .extension(Operation::Delete)
+            .extension(ServiceOperation("DeletePath"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -384,6 +396,7 @@ impl AzdlsCore {
 
             let req = Request::delete(url.finish())
                 .extension(Operation::Delete)
+                .extension(ServiceOperation("RecursiveDeletePath"))
                 .body(Buffer::new())
                 .map_err(new_request_build_error)?;
 
@@ -436,6 +449,7 @@ impl AzdlsCore {
 
         let req = Request::get(url.finish())
             .extension(Operation::List)
+            .extension(ServiceOperation("ListPaths"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 


### PR DESCRIPTION
# Rationale for this change

Followup PR for https://github.com/apache/opendal/pull/7407, which adds service operation label to azure operations.

# What changes are included in this PR?

This PR adds service operation in the azure request extension, which will be picked up at metrics layer and set as label.

# Are there any user-facing changes?

No

# AI Usage Statement

GPT-5.5 made all the code change.
