### PR TITLE
docs(sftp): correct key description to private key

### DIFF
--- a/core/services/sftp/src/docs.md
+++ b/core/services/sftp/src/docs.md
@@ -17,11 +17,11 @@ This service can be used to:
 - `endpoint`: Set the endpoint for connection. The format is same as `openssh`, using either `[user@]hostname` or `ssh://[user@]hostname[:port]`. A username or port that is specified in the endpoint overrides the one set in the builder (but does not change the builder).
 - `root`: Set the work directory for backend. It uses the default directory set by the remote `sftp-server` as default
 - `user`: Set the login user
-- `key`: Set the public key for login
+- `key`: Set the file path to the private key for authentication
 - `known_hosts_strategy`: Set the strategy for known hosts, default to `Strict`
 - `enable_copy`: Set whether the remote server has copy-file extension
 
-For security reasons, it doesn't support password login, you can use public key or ssh-copy-id instead.
+For security reasons, it doesn't support password login. Use SSH key-based authentication (e.g., configure your public key on the server via `ssh-copy-id` and provide the private key here).
 
 You can refer to [`SftpBuilder`]'s docs for more information
 


### PR DESCRIPTION
Update SFTP service docs to reflect that the `key` field expects a private key. SSH authentication uses a private key on the client, while public keys are stored on the server.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7491.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The current documentation incorrectly refers to the key as a public key, which can be misleading. This change corrects the description to match SSH authentication behavior.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Update `key` description from "public key" to "private key"
- Clarify wording around SSH key-based authentication

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

N/A

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->

N/A
