### PR TITLE
feat(core): expose metadata access for raw list entries

### DIFF
--- a/core/core/src/raw/oio/entry.rs
+++ b/core/core/src/raw/oio/entry.rs
@@ -88,12 +88,17 @@ impl Entry {
     }
 
     /// Get metadata of entry.
-    pub(crate) fn metadata(&self) -> &Metadata {
+    pub fn metadata(&self) -> &Metadata {
         &self.meta
     }
 
     /// Get mutable metadata of entry.
-    pub(crate) fn metadata_mut(&mut self) -> &mut Metadata {
+    pub fn metadata_mut(&mut self) -> &mut Metadata {
         &mut self.meta
+    }
+
+    /// Consume this entry to get its path and metadata.
+    pub fn into_parts(self) -> (String, Metadata) {
+        (self.path, self.meta)
     }
 }


### PR DESCRIPTION
Expose `oio::Entry::metadata`, `metadata_mut`, and `into_parts` so layers can inspect or rewrite list entry metadata without issuing extra stat requests.

# Which issue does this PR close?

Closes #7484
<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

# Are there any user-facing changes?

No breaking changes, no changes for end users, only to layer developers.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

None
<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
