### PR TITLE
feat(services/s3): support configuring assume role duration_seconds

### DIFF
--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -198,6 +198,12 @@ impl S3Builder {
         self
     }
 
+    /// Set assume_role_duration_seconds for this backend.
+    pub fn assume_role_duration_seconds(mut self, v: u32) -> Self {
+        self.config.assume_role_duration_seconds = Some(v);
+        self
+    }
+
     /// Set default storage_class for this backend.
     ///
     /// Available values:
@@ -849,6 +855,9 @@ impl Builder for S3Builder {
             if let Some(role_session_name) = &config.role_session_name {
                 assume_role_provider =
                     assume_role_provider.with_role_session_name(role_session_name.clone());
+            }
+            if let Some(duration_seconds) = config.assume_role_duration_seconds {
+                assume_role_provider = assume_role_provider.with_duration_seconds(duration_seconds);
             }
             provider = ProvideCredentialChain::new().push(assume_role_provider);
         }

--- a/core/services/s3/src/config.rs
+++ b/core/services/s3/src/config.rs
@@ -102,6 +102,8 @@ pub struct S3Config {
     pub external_id: Option<String>,
     /// role_session_name for this backend.
     pub role_session_name: Option<String>,
+    /// assume_role_duration_seconds for this backend.
+    pub assume_role_duration_seconds: Option<u32>,
     /// Disable config load so that opendal will not load config from
     /// environment.
     ///


### PR DESCRIPTION
# Which issue does this PR close?
Closes #4976.

# Rationale for this change
AWS STS AssumeRole defaults to a 1-hour session duration.
Upstream `reqsign-aws-v4` v3.0.0 already exposes `AssumeRoleCredentialProvider::with_duration_seconds(u32)`, so this PR is purely a config exposure on the OpenDAL side.

# What changes are included in this PR?
- Add `assume_role_duration_seconds: Option<u32>` field to `S3Config`.
- Add `S3Builder::assume_role_duration_seconds` builder method.
- Pass the value through in `S3Builder::build`, mirroring the existing `external_id` / `role_session_name` wiring.

# Are there any user-facing changes?
Yes — a new public config field and a new builder method. Not a breaking change: the field is `Option<u32>` defaulting to `None`, which preserves current behavior.

# AI Usage Statement
AI-assisted implementation.