### PR TITLE
chore(deps): upgrade criterion to 0.8.2

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -56,6 +56,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2037,10 +2046,11 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
@@ -2049,6 +2059,7 @@ dependencies = [
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
@@ -2061,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -7824,6 +7835,16 @@ dependencies = [
  "elliptic-curve 0.13.8",
  "primeorder",
  "sha2",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/core/benches/vs_fs/Cargo.toml
+++ b/core/benches/vs_fs/Cargo.toml
@@ -21,12 +21,12 @@ edition = "2024"
 license = "Apache-2.0"
 name = "opendal-benchmark-vs-fs"
 publish = false
-rust-version = "1.85"
+rust-version = "1.86"
 version = "0.56.0"
 
 [dependencies]
-criterion = { version = "0.7", features = ["async", "async_tokio"] }
-opendal = { path = "../..", features = ["blocking", "tests"] }
+criterion = { version = "0.8.2", features = ["async", "async_tokio"] }
+opendal = { path = "../..", features = ["blocking", "services-fs", "tests"] }
 rand = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 uuid = { workspace = true, features = ["v4"] }

--- a/core/benches/vs_s3/Cargo.toml
+++ b/core/benches/vs_s3/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2024"
 license = "Apache-2.0"
 name = "opendal-benchmark-vs-s3"
 publish = false
-rust-version = "1.85"
+rust-version = "1.86"
 version = "0.56.0"
 
 [dependencies]
@@ -30,9 +30,9 @@ aws-credential-types = { version = "1.2.8", features = [
   "hardcoded-credentials",
 ] }
 aws-sdk-s3 = "1.91.0"
-criterion = { version = "0.7", features = ["async", "async_tokio"] }
+criterion = { version = "0.8.2", features = ["async", "async_tokio"] }
 dotenvy = "0.15"
 logforth = { workspace = true }
-opendal = { path = "../..", features = ["tests"] }
+opendal = { path = "../..", features = ["services-s3", "tests"] }
 rand = { workspace = true }
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

This upgrades the Rust benchmark dependency `criterion` from `0.7` to `0.8.2` for the OpenDAL benchmark crates.

# What changes are included in this PR?

The benchmark manifests now depend on `criterion 0.8.2`, and the lockfile has been refreshed accordingly. The benchmark crates also declare the required OpenDAL service features and Rust 1.86, which is required by `criterion 0.8.2`.

# Are there any user-facing changes?

No user-facing changes.

# AI Usage Statement

This PR was prepared with AI assistance.
