### PR TITLE
build(deps): upgrade etcd-client to 0.18.0

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2949,9 +2949,9 @@ checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
 
 [[package]]
 name = "etcd-client"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acfe553027cd07fc5fafa81a84f19a7a87eaffaccd2162b6db05e8d6ce98084"
+checksum = "5ed900ba953ca6bf1fadb75e0c6b73d8463b9e2bb6bdb7b4573e8e7295852fbe"
 dependencies = [
  "http 1.4.0",
  "prost 0.14.3",

--- a/core/services/etcd/Cargo.toml
+++ b/core/services/etcd/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-etcd-client = { version = "0.17", features = ["tls"] }
+etcd-client = { version = "0.18.0", features = ["tls"] }
 fastpool = "1.0.2"
 opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

Upgrade the etcd service dependency to `etcd-client` 0.18.0 so OpenDAL tracks the current crate release.

# What changes are included in this PR?

This PR updates `opendal-service-etcd`'s direct dependency from `etcd-client` 0.17 to 0.18.0 and refreshes `core/Cargo.lock`. No source changes were required for the new API surface.

# Are there any user-facing changes?

No.

# AI Usage Statement

AI-assisted.
