### PR TITLE
chore(services/ftp): Upgrade suppaftp to 8.0.3

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -10709,9 +10709,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suppaftp"
-version = "6.3.0"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d869e942cc5f349ad91645925a9e6b570f62c4c170ad1c7b92b867bd16bd54"
+checksum = "4275c142b5be3af2eeadd70dd368caf3b65546c8af1035839372dd7a1436127d"
 dependencies = [
  "async-std",
  "async-trait",
@@ -10721,7 +10721,6 @@ dependencies = [
  "lazy-regex",
  "log",
  "pin-project",
- "rustls 0.23.40",
  "rustls-pki-types",
  "thiserror 2.0.18",
 ]

--- a/core/services/ftp/Cargo.toml
+++ b/core/services/ftp/Cargo.toml
@@ -40,10 +40,8 @@ log = { workspace = true }
 opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 rustls-native-certs = "0.8"
 serde = { workspace = true, features = ["derive"] }
-suppaftp = { version = "6.3.0", default-features = false, features = [
-  "async-secure",
-  "rustls",
-  "async-rustls",
+suppaftp = { version = "8.0.3", default-features = false, features = [
+  "async-std-rustls-ring",
 ] }
 tokio = { workspace = true, features = ["macros", "time"] }
 

--- a/core/services/ftp/src/core.rs
+++ b/core/services/ftp/src/core.rs
@@ -19,12 +19,13 @@ use std::sync::Arc;
 
 use fastpool::{ManageObject, ObjectStatus, bounded};
 use futures_rustls::TlsConnector;
-use suppaftp::AsyncRustlsConnector;
-use suppaftp::AsyncRustlsFtpStream;
+use futures_rustls::rustls::ClientConfig;
+use futures_rustls::rustls::RootCertStore;
 use suppaftp::FtpError;
-use suppaftp::ImplAsyncFtpStream;
 use suppaftp::Status;
-use suppaftp::rustls::ClientConfig;
+use suppaftp::async_std::AsyncRustlsConnector;
+use suppaftp::async_std::AsyncRustlsFtpStream;
+use suppaftp::async_std::ImplAsyncFtpStream;
 use suppaftp::types::FileType;
 
 use super::err::format_ftp_error;
@@ -78,7 +79,7 @@ impl ManageObject for Manager {
         let stream = ImplAsyncFtpStream::connect(&self.endpoint).await?;
         // switch to secure mode if ssl/tls is on.
         let mut ftp_stream = if self.enable_secure {
-            let mut root_store = suppaftp::rustls::RootCertStore::empty();
+            let mut root_store = RootCertStore::empty();
             for cert in
                 rustls_native_certs::load_native_certs().expect("could not load platform certs")
             {


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

This updates the FTP service's `suppaftp` dependency from 6.3.0 to 8.0.3.

`suppaftp` 8 split the async Rustls feature by runtime and crypto provider, so this PR switches the FTP service to the equivalent `async-std-rustls-ring` feature while keeping the existing futures-based FTP data stream integration.

# What changes are included in this PR?

- Update `suppaftp` to 8.0.3 in `opendal-service-ftp`.
- Refresh `core/Cargo.lock`.
- Adjust FTP TLS imports to use the async-std exports and `futures_rustls` Rustls types required by the new feature layout.

# Are there any user-facing changes?

No public OpenDAL API changes are expected.

# AI Usage Statement

This PR was prepared with AI assistance.
