### PR TITLE
chore(deps): upgrade foundationdb to 0.10.0

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -189,7 +189,7 @@ runs:
       if: runner.os == 'Linux' && inputs.need-foundationdb == 'true'
       with:
         path: /etc/foundationdb
-        key: r0-foundationdb-7.1.17
+        key: r0-foundationdb-7.3.69
 
     - name: Build foundationdb if not cached
       if: steps.cache-foundationdb.outputs.cache-hit != 'true' && runner.os == 'Linux' && inputs.need-foundationdb == 'true'
@@ -199,10 +199,10 @@ runs:
 
         cd /tmp
 
-        curl https://github.com/apple/foundationdb/releases/download/7.1.17/foundationdb-clients_7.1.17-1_amd64.deb -L -o foundationdb-clients_7.1.17-1_amd64.deb
-        curl https://github.com/apple/foundationdb/releases/download/7.1.17/foundationdb-server_7.1.17-1_amd64.deb -L -o foundationdb-server_7.1.17-1_amd64.deb
+        curl https://github.com/apple/foundationdb/releases/download/7.3.69/foundationdb-clients_7.3.69-1_amd64.deb -L -o foundationdb-clients_7.3.69-1_amd64.deb
+        curl https://github.com/apple/foundationdb/releases/download/7.3.69/foundationdb-server_7.3.69-1_amd64.deb -L -o foundationdb-server_7.3.69-1_amd64.deb
 
-        sudo dpkg -i foundationdb-clients_7.1.17-1_amd64.deb foundationdb-server_7.1.17-1_amd64.deb
+        sudo dpkg -i foundationdb-clients_7.3.69-1_amd64.deb foundationdb-server_7.3.69-1_amd64.deb
 
-        rm foundationdb-clients_7.1.17-1_amd64.deb
-        rm foundationdb-server_7.1.17-1_amd64.deb
+        rm foundationdb-clients_7.3.69-1_amd64.deb
+        rm foundationdb-server_7.3.69-1_amd64.deb

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1159,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.11.1",
  "cexpr",
@@ -1172,7 +1172,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.2",
  "shlex",
  "syn 2.0.117",
 ]
@@ -3239,9 +3239,9 @@ dependencies = [
 
 [[package]]
 name = "foundationdb"
-version = "0.9.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514aeffe12bbcf2f64a746793cc1c2602006c705d3fc6285df024303d008cccf"
+checksum = "310c638e34e54f56daa986ed6c8dadecf4e4825245b73e577feb25c808222ae8"
 dependencies = [
  "async-recursion 1.1.1",
  "async-trait",
@@ -3250,8 +3250,7 @@ dependencies = [
  "foundationdb-sys",
  "foundationdb-tuple",
  "futures",
- "memchr",
- "rand 0.8.6",
+ "rand 0.9.4",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -3261,18 +3260,18 @@ dependencies = [
 
 [[package]]
 name = "foundationdb-gen"
-version = "0.9.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9d854866df33e1f4099769e2b9fa8bf8cf3bca707029ae6298d0e61bcae358"
+checksum = "b749fc82bb7576794d4679f166a5cfa0a856122e05635437f7231e5e679fa2f6"
 dependencies = [
  "xml-rs",
 ]
 
 [[package]]
 name = "foundationdb-macros"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be610412e5a92d89855fb15b099a57792b7dbdcf8ac74c5a0e24d9b7b1b6f7f"
+checksum = "c4ca5370149145ec3741cd7e82832f17f893b9421ee4e484d9511c6702bd9911"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3282,19 +3281,19 @@ dependencies = [
 
 [[package]]
 name = "foundationdb-sys"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bae14dba30b8dcc4905a9189ebb18bc9db9744ef0ad8f2b94ef00d21e176964"
+checksum = "c0f3f231ff5b8465063b2bf8af3b975222b4fa3cc8c07b43d01fe8e0ae15c9dd"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen 0.72.1",
  "libc",
 ]
 
 [[package]]
 name = "foundationdb-tuple"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1832c1fbe592de718893f7c3b48179a47757f8974d1498fece997454c2b0fa"
+checksum = "a8cd42c159de9b90a91efc0ce350e3142099571ef498e7fa1a1dcc1d1eeccd9d"
 dependencies = [
  "memchr",
  "uuid",
@@ -13276,10 +13275,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "xml-rs"
-version = "0.8.28"
+name = "xml"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
+
+[[package]]
+name = "xml-rs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a56132a0d6ecbe77352edc10232f788fc4ceefefff4cab784a98e0e16b6b51"
+dependencies = [
+ "xml",
+]
 
 [[package]]
 name = "xmlparser"

--- a/core/services/foundationdb/Cargo.toml
+++ b/core/services/foundationdb/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-foundationdb = { version = "0.9.0", features = [
+foundationdb = { version = "0.10.0", features = [
   "embedded-fdb-include",
   "fdb-7_3",
 ] }


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

This upgrades the Rust FoundationDB client crate to 0.10.0 for the OpenDAL FoundationDB service.

The existing service uses the `fdb-7_3` crate feature, which selects FoundationDB API version 730. The GitHub Actions setup was still installing and caching FoundationDB 7.1.17, so this PR also updates the external FoundationDB deb packages and cache key to 7.3.69 to avoid reusing an incompatible cached setup.

# What changes are included in this PR?

The `opendal-service-foundationdb` dependency now requires `foundationdb = 0.10.0`, and `core/Cargo.lock` is refreshed for the corresponding FoundationDB crate family updates.

The setup action now installs FoundationDB 7.3.69 clients/server packages and uses `r0-foundationdb-7.3.69` as the cache key.

# Are there any user-facing changes?

No user-facing API changes.

# AI Usage Statement

AI-assisted.
