### PR TITLE
build(deps): upgrade hotpath to 0.16.0

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -4321,18 +4321,18 @@ dependencies = [
 
 [[package]]
 name = "hotpath"
-version = "0.9.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3554f9fc054c95f68e9f31196ca3aa77c6ce299f2e5877788e68168d01b7cfab"
+checksum = "0482d7c2c47acfec79b90e55188e8b86c66fd9d541335eac3ce3f73055984643"
 dependencies = [
  "hotpath-macros",
 ]
 
 [[package]]
 name = "hotpath-macros"
-version = "0.9.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8cf5fa828dd9b99de52bb85f9027c0d5205971cb3c45842b4bf6d7c7f6c679"
+checksum = "a0a541a2ab3263fcf42ff399ec68ddd458f4883aa656c6229f59092f94058eb2"
 
 [[package]]
 name = "html5ever"

--- a/core/layers/hotpath/Cargo.toml
+++ b/core/layers/hotpath/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 futures = { workspace = true }
-hotpath = "0.9.2"
+hotpath = "0.16.0"
 http = { workspace = true }
 opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 

--- a/core/layers/hotpath/src/lib.rs
+++ b/core/layers/hotpath/src/lib.rs
@@ -26,7 +26,6 @@ use std::task::Poll;
 
 use futures::Stream;
 use futures::StreamExt;
-use hotpath::MeasurementGuard;
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -55,7 +54,7 @@ const LABEL_HTTP_BODY_POLL: &str = "opendal.http.body.poll";
 /// # Notes
 ///
 /// When `hotpath` profiling is enabled, initialize a guard via
-/// [`hotpath::FunctionsGuardBuilder`] or `#[hotpath::main]` before running
+/// [`hotpath::HotpathGuardBuilder`] or `#[hotpath::main]` before running
 /// operations. Otherwise, hotpath will panic on the first measurement.
 ///
 /// # Examples
@@ -68,7 +67,7 @@ const LABEL_HTTP_BODY_POLL: &str = "opendal.http.body.poll";
 /// #
 /// # #[tokio::main]
 /// # async fn main() -> Result<()> {
-/// let _guard = hotpath::FunctionsGuardBuilder::new("opendal").build();
+/// let _guard = hotpath::HotpathGuardBuilder::new("opendal").build();
 /// let op = Operator::new(services::Memory::default())?
 ///     .layer(HotpathLayer::new())
 ///     .finish();
@@ -120,52 +119,44 @@ impl<A: Access> LayeredAccess for HotpathAccessor<A> {
     }
 
     async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        let _guard = MeasurementGuard::build(LABEL_CREATE_DIR, false, true);
-        self.inner.create_dir(path, args).await
+        hotpath::measure_async(LABEL_CREATE_DIR, self.inner.create_dir(path, args)).await
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let _guard = MeasurementGuard::build(LABEL_READ, false, true);
-        let (rp, reader) = self.inner.read(path, args).await?;
+        let (rp, reader) = hotpath::measure_async(LABEL_READ, self.inner.read(path, args)).await?;
         Ok((rp, HotpathWrapper::new(reader)))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        let _guard = MeasurementGuard::build(LABEL_WRITE, false, true);
-        let (rp, writer) = self.inner.write(path, args).await?;
+        let (rp, writer) =
+            hotpath::measure_async(LABEL_WRITE, self.inner.write(path, args)).await?;
         Ok((rp, HotpathWrapper::new(writer)))
     }
 
     async fn copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
-        let _guard = MeasurementGuard::build(LABEL_COPY, false, true);
-        self.inner.copy(from, to, args).await
+        hotpath::measure_async(LABEL_COPY, self.inner.copy(from, to, args)).await
     }
 
     async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
-        let _guard = MeasurementGuard::build(LABEL_RENAME, false, true);
-        self.inner.rename(from, to, args).await
+        hotpath::measure_async(LABEL_RENAME, self.inner.rename(from, to, args)).await
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        let _guard = MeasurementGuard::build(LABEL_STAT, false, true);
-        self.inner.stat(path, args).await
+        hotpath::measure_async(LABEL_STAT, self.inner.stat(path, args)).await
     }
 
     async fn delete(&self) -> Result<(RpDelete, Self::Deleter)> {
-        let _guard = MeasurementGuard::build(LABEL_DELETE, false, true);
-        let (rp, deleter) = self.inner.delete().await?;
+        let (rp, deleter) = hotpath::measure_async(LABEL_DELETE, self.inner.delete()).await?;
         Ok((rp, HotpathWrapper::new(deleter)))
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
-        let _guard = MeasurementGuard::build(LABEL_LIST, false, true);
-        let (rp, lister) = self.inner.list(path, args).await?;
+        let (rp, lister) = hotpath::measure_async(LABEL_LIST, self.inner.list(path, args)).await?;
         Ok((rp, HotpathWrapper::new(lister)))
     }
 
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
-        let _guard = MeasurementGuard::build(LABEL_PRESIGN, false, true);
-        self.inner.presign(path, args).await
+        hotpath::measure_async(LABEL_PRESIGN, self.inner.presign(path, args)).await
     }
 }
 
@@ -182,44 +173,37 @@ impl<R> HotpathWrapper<R> {
 
 impl<R: oio::Read> oio::Read for HotpathWrapper<R> {
     async fn read(&mut self) -> Result<Buffer> {
-        let _guard = MeasurementGuard::build(LABEL_READER_READ, false, true);
-        self.inner.read().await
+        hotpath::measure_async(LABEL_READER_READ, self.inner.read()).await
     }
 }
 
 impl<R: oio::Write> oio::Write for HotpathWrapper<R> {
     async fn write(&mut self, bs: Buffer) -> Result<()> {
-        let _guard = MeasurementGuard::build(LABEL_WRITER_WRITE, false, true);
-        self.inner.write(bs).await
+        hotpath::measure_async(LABEL_WRITER_WRITE, self.inner.write(bs)).await
     }
 
     async fn close(&mut self) -> Result<Metadata> {
-        let _guard = MeasurementGuard::build(LABEL_WRITER_CLOSE, false, true);
-        self.inner.close().await
+        hotpath::measure_async(LABEL_WRITER_CLOSE, self.inner.close()).await
     }
 
     async fn abort(&mut self) -> Result<()> {
-        let _guard = MeasurementGuard::build(LABEL_WRITER_ABORT, false, true);
-        self.inner.abort().await
+        hotpath::measure_async(LABEL_WRITER_ABORT, self.inner.abort()).await
     }
 }
 
 impl<R: oio::List> oio::List for HotpathWrapper<R> {
     async fn next(&mut self) -> Result<Option<oio::Entry>> {
-        let _guard = MeasurementGuard::build(LABEL_LISTER_NEXT, false, true);
-        self.inner.next().await
+        hotpath::measure_async(LABEL_LISTER_NEXT, self.inner.next()).await
     }
 }
 
 impl<R: oio::Delete> oio::Delete for HotpathWrapper<R> {
     async fn delete(&mut self, path: &str, args: OpDelete) -> Result<()> {
-        let _guard = MeasurementGuard::build(LABEL_DELETER_DELETE, false, true);
-        self.inner.delete(path, args).await
+        hotpath::measure_async(LABEL_DELETER_DELETE, self.inner.delete(path, args)).await
     }
 
     async fn close(&mut self) -> Result<()> {
-        let _guard = MeasurementGuard::build(LABEL_DELETER_CLOSE, false, true);
-        self.inner.close().await
+        hotpath::measure_async(LABEL_DELETER_CLOSE, self.inner.close()).await
     }
 }
 
@@ -229,8 +213,7 @@ struct HotpathHttpFetcher {
 
 impl HttpFetch for HotpathHttpFetcher {
     async fn fetch(&self, req: http::Request<Buffer>) -> Result<http::Response<HttpBody>> {
-        let _guard = MeasurementGuard::build(LABEL_HTTP_FETCH, false, true);
-        let resp = self.inner.fetch(req).await?;
+        let resp = hotpath::measure_async(LABEL_HTTP_FETCH, self.inner.fetch(req)).await?;
         let (parts, body) = resp.into_parts();
         let body = body.map_inner(|stream| Box::new(HotpathStream { inner: stream }));
         Ok(http::Response::from_parts(parts, body))
@@ -248,7 +231,7 @@ where
     type Item = Result<Buffer>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let _guard = MeasurementGuard::build(LABEL_HTTP_BODY_POLL, false, true);
-        self.inner.poll_next_unpin(cx)
+        let _label = LABEL_HTTP_BODY_POLL;
+        hotpath::measure_block!(_label, self.inner.poll_next_unpin(cx))
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

This upgrades the Rust `hotpath` dependency used by `opendal-layer-hotpath` from the 0.9 line to 0.16.0.

# What changes are included in this PR?

The hotpath layer now uses the 0.16 public measurement APIs (`measure_async` and `measure_block!`) instead of the removed `MeasurementGuard::build(..., is_async)` API. The crate documentation example is updated to use `HotpathGuardBuilder`, and `core/Cargo.lock` is refreshed for `hotpath` and `hotpath-macros` 0.16.0.

# Are there any user-facing changes?

No public OpenDAL API changes.

# AI Usage Statement

Assisted by an AI coding tool.
