### PR TITLE
deps(services/rocksdb): upgrade rocksdb to 0.24.0

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -55,7 +55,7 @@ runs:
     - name: Setup Linux
       if: runner.os == 'Linux'
       shell: bash
-      run: sudo apt-get install libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
+      run: sudo apt-get install libclang-dev libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
 
     - name: Setup Protoc
       if: inputs.need-protoc == 'true'

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -162,7 +162,7 @@ runs:
       if: runner.os == 'Linux' && inputs.need-rocksdb == 'true'
       with:
         path: /tmp/rocksdb
-        key: r2-rocksdb-10.4.2
+        key: r3-rocksdb-10.4.2-${{ runner.os }}-${{ runner.arch }}
 
     - name: Build rocksdb if not cached
       if: steps.cache-rocksdb.outputs.cache-hit != 'true' && runner.os == 'Linux' && inputs.need-rocksdb == 'true'

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -162,7 +162,7 @@ runs:
       if: runner.os == 'Linux' && inputs.need-rocksdb == 'true'
       with:
         path: /tmp/rocksdb
-        key: r2-rocksdb-8.1.1
+        key: r2-rocksdb-10.4.2
 
     - name: Build rocksdb if not cached
       if: steps.cache-rocksdb.outputs.cache-hit != 'true' && runner.os == 'Linux' && inputs.need-rocksdb == 'true'
@@ -171,9 +171,9 @@ runs:
         set -e
 
         cd /tmp
-        curl https://github.com/facebook/rocksdb/archive/refs/tags/v8.1.1.tar.gz -L -o rocksdb.tar.gz
+        curl https://github.com/facebook/rocksdb/archive/refs/tags/v10.4.2.tar.gz -L -o rocksdb.tar.gz
         tar -xzf rocksdb.tar.gz
-        cd rocksdb-8.1.1
+        cd rocksdb-10.4.2
 
         mkdir /tmp/rocksdb
         cmake -DCMAKE_INSTALL_PREFIX=/tmp/rocksdb -DPORTABLE=1
@@ -181,7 +181,7 @@ runs:
         make install
 
         cd ..
-        rm -rf /tmp/rocksdb-8.1.1
+        rm -rf /tmp/rocksdb-10.4.2
 
     - name: Cache foundationdb
       id: cache-foundationdb

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1153,27 +1153,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.65.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -5123,12 +5102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5199,14 +5172,13 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.11.0+8.1.1"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
- "bindgen 0.65.1",
+ "bindgen 0.72.1",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
 ]
@@ -7984,12 +7956,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9470,9 +9436,9 @@ checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
 
 [[package]]
 name = "rocksdb"
-version = "0.21.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/core/services/rocksdb/Cargo.toml
+++ b/core/services/rocksdb/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
-rocksdb = { version = "0.21.0", default-features = false }
+rocksdb = { version = "0.24.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

Upgrade the Rust `rocksdb` crate used by `opendal-service-rocksdb` from `0.21.0` to `0.24.0`.

The new crate release depends on `librocksdb-sys 0.17.3+10.4.2`, so the GitHub Actions setup now builds RocksDB `10.4.2` and uses cache key `r2-rocksdb-10.4.2` instead of the previous RocksDB `8.1.1` cache.

# What changes are included in this PR?

- Upgrade `rocksdb` to `0.24.0` and refresh `core/Cargo.lock`.
- Update the shared setup action's RocksDB tarball URL, extracted directory name, cleanup path, and cache key from `8.1.1` to `10.4.2`.

# Are there any user-facing changes?

No public API or behavior changes are intended.

# AI Usage Statement

N/A.
