### PR TITLE
chore(integrations/dav-server): upgrade dav-server to 0.11.0

### DIFF
--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -30,7 +30,7 @@ rust-version = "1.85"
 [dependencies]
 anyhow = "1"
 bytes = { version = "1.4.0" }
-dav-server = { version = "0.8.0" }
+dav-server = { version = "0.11.0" }
 futures = "0.3"
 opendal = { version = "0.56.0", path = "../../core" }
 

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -1,8 +1,9 @@
 crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib
-aho-corasick@1.1.4								X				X	
 allocator-api2@0.2.21	X							X					
+android_system_properties@0.1.5	X							X					
 anyhow@1.0.102	X							X					
 atomic-waker@1.1.2	X							X					
+autocfg@1.5.0	X							X					
 aws-lc-rs@1.16.3	X					X							
 aws-lc-sys@0.40.0	X		X			X		X	X				
 backon@1.6.0	X												
@@ -11,9 +12,9 @@ bitflags@2.11.1	X							X
 block-buffer@0.10.4	X							X					
 bumpalo@3.20.2	X							X					
 bytes@1.11.1								X					
-cc@1.2.60	X							X					
-cesu8@1.1.0	X							X					
+cc@1.2.62	X							X					
 cfg-if@1.0.4	X							X					
+chrono@0.4.44	X							X					
 cmake@0.1.58	X							X					
 combine@4.6.7								X					
 const-oid@0.9.6	X							X					
@@ -21,23 +22,19 @@ core-foundation@0.10.1	X							X
 core-foundation-sys@0.8.7	X							X					
 cpufeatures@0.2.17	X							X					
 crypto-common@0.1.7	X							X					
-ctor@0.6.3	X							X					
-ctor-proc-macro@0.0.7	X							X					
-dav-server@0.8.0	X												
+ctor@1.0.4	X							X					
+dav-server@0.11.0	X												
 dav-server-opendalfs@0.7.1	X												
-deranged@0.5.8	X							X					
-derivative@2.2.0	X							X					
+derive-where@1.6.1	X							X					
 digest@0.10.7	X							X					
 displaydoc@0.2.5	X							X					
-dtor@0.1.1	X							X					
-dtor-proc-macro@0.0.6	X							X					
 dunce@1.0.5	X			X					X				
 dyn-clone@1.0.20	X							X					
 equivalent@1.0.2	X							X					
 errno@0.3.14	X							X					
 fastrand@2.4.1	X							X					
 find-msvc-tools@0.1.9	X							X					
-foldhash@0.1.5													X
+foldhash@0.2.0													X
 form_urlencoded@1.2.2	X							X					
 fs_extra@1.3.0								X					
 futures@0.3.32	X							X					
@@ -53,7 +50,7 @@ generic-array@0.14.7								X
 getrandom@0.3.4	X							X					
 getrandom@0.4.2	X							X					
 gloo-timers@0.3.0	X							X					
-hashbrown@0.15.5	X							X					
+hashbrown@0.16.1	X							X					
 headers@0.4.1								X					
 headers-core@0.3.0								X					
 hex@0.4.3	X							X					
@@ -67,6 +64,8 @@ httpdate@1.0.3	X							X
 hyper@1.9.0								X					
 hyper-rustls@0.27.9	X					X		X					
 hyper-util@0.1.20								X					
+iana-time-zone@0.1.65	X							X					
+iana-time-zone-haiku@0.1.2	X							X					
 icu_collections@2.1.1											X		
 icu_locale_core@2.1.1											X		
 icu_normalizer@2.1.1											X		
@@ -77,31 +76,31 @@ icu_provider@2.1.1											X
 idna@1.1.0	X							X					
 idna_adapter@1.2.1	X							X					
 ipnet@2.12.0	X							X					
-iri-string@0.7.12	X							X					
 itoa@1.0.18	X							X					
-jiff@0.2.23								X				X	
+jiff@0.2.24								X				X	
 jiff-tzdb@0.1.6								X				X	
 jiff-tzdb-platform@0.1.3								X				X	
-jni@0.21.1	X							X					
-jni-sys@0.3.1	X							X					
+jni@0.22.4	X							X					
+jni-macros@0.22.4	X							X					
 jni-sys@0.4.1	X							X					
 jni-sys-macros@0.4.1	X							X					
 jobserver@0.1.34	X							X					
-js-sys@0.3.95	X							X					
-lazy_static@1.5.0	X							X					
-libc@0.2.185	X							X					
+js-sys@0.3.98	X							X					
+libc@0.2.186	X							X					
+link-section@0.16.0	X							X					
+linktime-proc-macro@0.1.0	X							X					
 linux-raw-sys@0.12.1	X	X						X					
 litemap@0.8.2											X		
 lock_api@0.4.14	X							X					
 log@0.4.29	X							X					
-lru@0.14.0								X					
+lru@0.16.4								X					
 md-5@0.10.6	X							X					
 mea@0.6.3	X												
 memchr@2.8.0								X				X	
 mime@0.3.17	X							X					
 mime_guess@2.0.5								X					
 mio@1.2.0								X					
-num-conv@0.1.0	X							X					
+num-traits@0.2.19	X							X					
 once_cell@1.21.4	X							X					
 opendal@0.56.0	X												
 opendal-core@0.56.0	X												
@@ -114,39 +113,34 @@ openssl-probe@0.2.1	X							X
 parking_lot@0.12.5	X							X					
 parking_lot_core@0.9.12	X							X					
 percent-encoding@2.3.2	X							X					
-pin-project@1.1.11	X							X					
-pin-project-internal@1.1.11	X							X					
 pin-project-lite@0.2.17	X							X					
-pin-utils@0.1.0	X							X					
 portable-atomic@1.13.1	X							X					
-portable-atomic-util@0.2.6	X							X					
+portable-atomic-util@0.2.7	X							X					
 potential_utf@0.1.5											X		
-powerfmt@0.2.0	X							X					
 proc-macro2@1.0.106	X							X					
-quick-xml@0.38.4								X					
+quick-xml@0.39.4								X					
 quote@1.0.45	X							X					
 r-efi@5.3.0	X						X	X					
 r-efi@6.0.0	X						X	X					
 redox_syscall@0.5.18								X					
 reflink-copy@0.1.29	X							X					
-regex@1.12.3	X							X					
-regex-automata@0.4.14	X							X					
-regex-syntax@0.8.10	X							X					
 reqsign-core@3.0.0	X												
-reqwest@0.13.2	X							X					
+reqwest@0.13.3	X							X					
+rustc_version@0.4.1	X							X					
 rustix@1.1.4	X	X						X					
-rustls@0.23.38	X					X		X					
+rustls@0.23.40	X					X		X					
 rustls-native-certs@0.8.3	X					X		X					
-rustls-pki-types@1.14.0	X							X					
-rustls-platform-verifier@0.6.2	X							X					
+rustls-pki-types@1.14.1	X							X					
+rustls-platform-verifier@0.7.0	X							X					
 rustls-platform-verifier-android@0.1.1	X							X					
-rustls-webpki@0.103.12						X							
+rustls-webpki@0.103.13						X							
 rustversion@1.0.22	X							X					
 same-file@1.0.6								X				X	
 schannel@0.1.29								X					
 scopeguard@1.2.0	X							X					
 security-framework@3.7.0	X							X					
 security-framework-sys@2.17.0	X							X					
+semver@1.0.28	X							X					
 serde@1.0.228	X							X					
 serde_core@1.0.228	X							X					
 serde_derive@1.0.228	X							X					
@@ -154,33 +148,31 @@ serde_json@1.0.149	X							X
 sha1@0.10.6	X							X					
 sha2@0.10.9	X							X					
 shlex@1.3.0	X							X					
+simd_cesu8@1.1.1	X							X					
+simdutf8@0.1.5	X							X					
 slab@0.4.12								X					
 smallvec@1.15.1	X							X					
 socket2@0.6.3	X							X					
 stable_deref_trait@1.2.1	X							X					
 subtle@2.6.1			X										
-syn@1.0.109	X							X					
 syn@2.0.117	X							X					
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2								X					
-thiserror@1.0.69	X							X					
-thiserror-impl@1.0.69	X							X					
-time@0.3.45	X							X					
-time-core@0.1.7	X							X					
-time-macros@0.2.25	X							X					
+thiserror@2.0.18	X							X					
+thiserror-impl@2.0.18	X							X					
 tinystr@0.8.3											X		
-tokio@1.52.0								X					
+tokio@1.52.3								X					
 tokio-macros@2.7.0								X					
 tokio-rustls@0.26.4	X							X					
 tokio-util@0.7.18								X					
 tower@0.5.3								X					
-tower-http@0.6.8								X					
+tower-http@0.6.10								X					
 tower-layer@0.3.3								X					
 tower-service@0.3.3								X					
 tracing@0.1.44								X					
 tracing-core@0.1.36								X					
 try-lock@0.2.5								X					
-typenum@1.19.0	X							X					
+typenum@1.20.0	X							X					
 unicase@2.9.0	X							X					
 unicode-ident@1.0.24	X							X			X		
 untrusted@0.9.0						X							
@@ -193,15 +185,15 @@ want@0.3.1								X
 wasi@0.11.1+wasi-snapshot-preview1	X	X						X					
 wasip2@1.0.1+wasi-0.2.4	X	X						X					
 wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X						X					
-wasm-bindgen@0.2.118	X							X					
-wasm-bindgen-futures@0.4.68	X							X					
-wasm-bindgen-macro@0.2.118	X							X					
-wasm-bindgen-macro-support@0.2.118	X							X					
-wasm-bindgen-shared@0.2.118	X							X					
+wasm-bindgen@0.2.121	X							X					
+wasm-bindgen-futures@0.4.71	X							X					
+wasm-bindgen-macro@0.2.121	X							X					
+wasm-bindgen-macro-support@0.2.121	X							X					
+wasm-bindgen-shared@0.2.121	X							X					
 wasm-streams@0.5.0	X							X					
-web-sys@0.3.95	X							X					
+web-sys@0.3.98	X							X					
 web-time@1.1.0	X							X					
-webpki-root-certs@1.0.6					X								
+webpki-root-certs@1.0.7					X								
 winapi-util@0.1.11								X				X	
 windows@0.62.2	X							X					
 windows-collections@0.3.2	X							X					
@@ -213,23 +205,15 @@ windows-link@0.2.1	X							X
 windows-numerics@0.3.1	X							X					
 windows-result@0.4.1	X							X					
 windows-strings@0.5.1	X							X					
-windows-sys@0.45.0	X							X					
 windows-sys@0.61.2	X							X					
-windows-targets@0.42.2	X							X					
 windows-threading@0.2.1	X							X					
-windows_aarch64_gnullvm@0.42.2	X							X					
-windows_aarch64_msvc@0.42.2	X							X					
-windows_i686_gnu@0.42.2	X							X					
-windows_i686_msvc@0.42.2	X							X					
-windows_x86_64_gnu@0.42.2	X							X					
-windows_x86_64_gnullvm@0.42.2	X							X					
-windows_x86_64_msvc@0.42.2	X							X					
 wit-bindgen@0.46.0	X	X						X					
 wit-bindgen@0.51.0	X	X						X					
 writeable@0.6.3											X		
 xattr@1.6.1	X							X					
-xml-rs@0.8.28								X					
-xmltree@0.11.0								X					
+xml@1.3.0								X					
+xml-rs@1.0.0								X					
+xmltree@0.12.0								X					
 yoke@0.8.2											X		
 yoke-derive@0.8.2											X		
 zerofrom@0.1.7											X		


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

This updates the dav-server integration to use dav-server 0.11.0 so the integration stays current with the upstream WebDAV server crate.

# What changes are included in this PR?

The dav-server integration manifest now depends on dav-server 0.11.0. The Rust dependency license inventory for this integration has been regenerated from the updated dependency graph.

# Are there any user-facing changes?

No user-facing behavior changes are expected.

# AI Usage Statement

N/A.
