### PR TITLE
chore(deps): upgrade rand to 0.10.1

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2899,7 +2899,7 @@ name = "edge_test_file_write_on_full_disk"
 version = "0.56.0"
 dependencies = [
  "opendal",
- "rand 0.8.6",
+ "rand 0.10.1",
  "tokio",
 ]
 
@@ -6462,7 +6462,7 @@ dependencies = [
  "opendal-service-webhdfs",
  "opendal-service-yandex-disk",
  "opendal-testkit",
- "rand 0.8.6",
+ "rand 0.10.1",
  "reqwest",
  "sha2 0.11.0",
  "size",
@@ -6476,7 +6476,7 @@ version = "0.56.0"
 dependencies = [
  "criterion",
  "opendal",
- "rand 0.8.6",
+ "rand 0.10.1",
  "tokio",
  "uuid",
 ]
@@ -6492,7 +6492,7 @@ dependencies = [
  "dotenvy",
  "logforth",
  "opendal",
- "rand 0.8.6",
+ "rand 0.10.1",
  "tokio",
 ]
 
@@ -6515,7 +6515,7 @@ dependencies = [
  "percent-encoding",
  "pretty_assertions",
  "quick-xml",
- "rand 0.8.6",
+ "rand 0.10.1",
  "reqsign-core",
  "reqwest",
  "serde",
@@ -6593,7 +6593,7 @@ name = "opendal-layer-chaos"
 version = "0.56.0"
 dependencies = [
  "opendal-core",
- "rand 0.8.6",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -6956,7 +6956,7 @@ dependencies = [
  "bytes",
  "compio",
  "opendal-core",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
 ]
 
@@ -7707,7 +7707,7 @@ dependencies = [
  "opendal-layer-logging",
  "opendal-layer-retry",
  "opendal-layer-timeout",
- "rand 0.8.6",
+ "rand 0.10.1",
  "sha2 0.11.0",
  "tokio",
  "uuid",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -50,7 +50,7 @@ log = { version = "0.4.29" }
 logforth = { version = "0.29.1", features = ["starter-log"] }
 mea = "0.6"
 quick-xml = { version = "0.39.3", default-features = false }
-rand = "0.8"
+rand = "0.10.1"
 serde = { version = "1", default-features = false }
 serde_json = "1"
 sha2 = "0.11.0"

--- a/core/benches/ops/read.rs
+++ b/core/benches/ops/read.rs
@@ -19,7 +19,6 @@ use divan::Bencher;
 use divan::counter::BytesCount;
 use opendal::tests::TEST_RUNTIME;
 use opendal::tests::init_test_service;
-use rand::prelude::*;
 use rand::rng;
 use size::Size;
 

--- a/core/benches/ops/read.rs
+++ b/core/benches/ops/read.rs
@@ -20,6 +20,7 @@ use divan::counter::BytesCount;
 use opendal::tests::TEST_RUNTIME;
 use opendal::tests::init_test_service;
 use rand::prelude::*;
+use rand::rng;
 use size::Size;
 
 use super::utils::*;
@@ -35,7 +36,7 @@ use super::utils::*;
 )]
 fn whole(b: Bencher, size: Size) {
     let op = init_test_service().unwrap().unwrap();
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let content = gen_bytes(&mut rng, size.bytes() as usize);
     let path = uuid::Uuid::new_v4().to_string();
     let _temp_data = TempData::generate(op.clone(), &path, content.clone());
@@ -57,7 +58,7 @@ mod concurrent {
     )]
     fn baseline(b: Bencher) {
         let op = init_test_service().unwrap().unwrap();
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let content = gen_bytes(&mut rng, 1024 * 1024 * 1024);
         let path = uuid::Uuid::new_v4().to_string();
         let _temp_data = TempData::generate(op.clone(), &path, content.clone());
@@ -78,7 +79,7 @@ mod concurrent {
     )]
     fn concurrent(b: Bencher, concurrent: usize) {
         let op = init_test_service().unwrap().unwrap();
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let content = gen_bytes(&mut rng, 1024 * 1024 * 1024);
         let path = uuid::Uuid::new_v4().to_string();
         let _temp_data = TempData::generate(op.clone(), &path, content.clone());

--- a/core/benches/ops/write.rs
+++ b/core/benches/ops/write.rs
@@ -19,7 +19,6 @@ use divan::Bencher;
 use divan::counter::BytesCount;
 use opendal::tests::TEST_RUNTIME;
 use opendal::tests::init_test_service;
-use rand::prelude::*;
 use rand::rng;
 use size::Size;
 

--- a/core/benches/ops/write.rs
+++ b/core/benches/ops/write.rs
@@ -20,6 +20,7 @@ use divan::counter::BytesCount;
 use opendal::tests::TEST_RUNTIME;
 use opendal::tests::init_test_service;
 use rand::prelude::*;
+use rand::rng;
 use size::Size;
 
 use super::utils::*;
@@ -40,7 +41,7 @@ fn whole(b: Bencher, size: Size) {
 
     b.counter(BytesCount::from(size.bytes() as u64))
         .with_inputs(|| {
-            let mut rng = thread_rng();
+            let mut rng = rng();
             gen_bytes(&mut rng, size.bytes() as usize)
         })
         .bench_values(|content| {
@@ -65,7 +66,7 @@ mod concurrent {
         let op = init_test_service().unwrap().unwrap();
         let path = uuid::Uuid::new_v4().to_string();
         let _temp_data = TempData::existing(op.clone(), &path);
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let content = gen_bytes(&mut rng, SIZE);
 
         b.counter(BytesCount::from(SIZE)).bench(|| {
@@ -86,7 +87,7 @@ mod concurrent {
         let op = init_test_service().unwrap().unwrap();
         let path = uuid::Uuid::new_v4().to_string();
         let _temp_data = TempData::existing(op.clone(), &path);
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let content = gen_bytes(&mut rng, SIZE);
 
         b.counter(BytesCount::from(SIZE)).bench(|| {

--- a/core/benches/vs_fs/src/main.rs
+++ b/core/benches/vs_fs/src/main.rs
@@ -21,6 +21,7 @@ use opendal::blocking;
 use opendal::options;
 use opendal::services;
 use rand::prelude::*;
+use rand::rng;
 
 fn main() {
     let mut c = Criterion::default().configure_from_args();
@@ -71,7 +72,7 @@ fn bench_vs_fs(c: &mut Criterion) {
 }
 
 fn prepare() -> String {
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let mut content = vec![0; 16 * 1024 * 1024];
     rng.fill_bytes(&mut content);
 

--- a/core/benches/vs_s3/src/main.rs
+++ b/core/benches/vs_s3/src/main.rs
@@ -25,6 +25,7 @@ use opendal::Operator;
 use opendal::services;
 use opendal::tests::TEST_RUNTIME;
 use rand::prelude::*;
+use rand::rng;
 use tokio::io::AsyncReadExt;
 
 fn main() {
@@ -115,7 +116,7 @@ fn bench_read(c: &mut Criterion, op: Operator, s3_client: aws_sdk_s3::Client, bu
 }
 
 async fn prepare(op: &Operator) {
-    let mut rng = thread_rng();
+    let mut rng = rng();
     let mut content = vec![0; 16 * 1024 * 1024];
     rng.fill_bytes(&mut content);
 

--- a/core/core/src/raw/futures_util.rs
+++ b/core/core/src/raw/futures_util.rs
@@ -319,7 +319,7 @@ impl<I: Send + 'static, O: Send + 'static> ConcurrentTasks<I, O> {
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
-    use rand::Rng;
+    use rand::{Rng, RngExt};
     use tokio::time::sleep;
 
     use super::*;
@@ -334,7 +334,7 @@ mod tests {
                 sleep(dur).await;
 
                 // 5% rate to fail.
-                if rand::thread_rng().gen_range(0..100) > 90 {
+                if rand::rng().random_range(0..100) > 90 {
                     return (
                         (i, dur),
                         Err(Error::new(ErrorKind::Unexpected, "I'm lucky").set_temporary()),
@@ -348,7 +348,7 @@ mod tests {
 
         for i in 0..10240 {
             // Sleep up to 10ms
-            let dur = Duration::from_millis(rand::thread_rng().gen_range(0..10));
+            let dur = Duration::from_millis(rand::rng().random_range(0..10));
             loop {
                 let res = tasks.execute((i, dur)).await;
                 if res.is_ok() {

--- a/core/core/src/raw/futures_util.rs
+++ b/core/core/src/raw/futures_util.rs
@@ -319,7 +319,7 @@ impl<I: Send + 'static, O: Send + 'static> ConcurrentTasks<I, O> {
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
-    use rand::{Rng, RngExt};
+    use rand::RngExt;
     use tokio::time::sleep;
 
     use super::*;

--- a/core/core/src/raw/oio/write/block_write.rs
+++ b/core/core/src/raw/oio/write/block_write.rs
@@ -247,9 +247,7 @@ mod tests {
     use std::sync::Mutex;
 
     use pretty_assertions::assert_eq;
-    use rand::Rng;
-    use rand::RngCore;
-    use rand::thread_rng;
+    use rand::{Rng, RngExt, rng};
     use tokio::time::sleep;
 
     use super::*;
@@ -277,7 +275,7 @@ mod tests {
         async fn write_once(&self, size: u64, body: Buffer) -> Result<Metadata> {
             sleep(Duration::from_nanos(50)).await;
 
-            if thread_rng().gen_bool(1.0 / 10.0) {
+            if rng().random_bool(1.0 / 10.0) {
                 return Err(
                     Error::new(ErrorKind::Unexpected, "I'm a crazy monkey!").set_temporary()
                 );
@@ -294,7 +292,7 @@ mod tests {
             sleep(Duration::from_millis(50)).await;
 
             // We will have 10% percent rate for write part to fail.
-            if thread_rng().gen_bool(1.0 / 10.0) {
+            if rng().random_bool(1.0 / 10.0) {
                 return Err(
                     Error::new(ErrorKind::Unexpected, "I'm a crazy monkey!").set_temporary()
                 );
@@ -325,14 +323,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_block_writer_with_concurrent_errors() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         let mut w = BlockWriter::new(Arc::default(), TestWrite::new(), 8);
         let mut total_size = 0u64;
         let mut expected_content = Vec::new();
 
         for _ in 0..1000 {
-            let size = rng.gen_range(1..1024);
+            let size = rng.random_range(1..1024);
             total_size += size as u64;
 
             let mut bs = vec![0; size];
@@ -368,12 +366,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_block_writer_with_retry_when_write_once_error() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         for _ in 1..100 {
             let mut w = BlockWriter::new(Arc::default(), TestWrite::new(), 8);
 
-            let size = rng.gen_range(1..1024);
+            let size = rng.random_range(1..1024);
             let mut bs = vec![0; size];
             rng.fill_bytes(&mut bs);
 

--- a/core/core/src/raw/oio/write/multipart_write.rs
+++ b/core/core/src/raw/oio/write/multipart_write.rs
@@ -311,9 +311,7 @@ where
 mod tests {
     use mea::mutex::Mutex;
     use pretty_assertions::assert_eq;
-    use rand::Rng;
-    use rand::RngCore;
-    use rand::thread_rng;
+    use rand::{Rng, RngExt, rng};
     use tokio::time::sleep;
     use tokio::time::timeout;
 
@@ -344,7 +342,7 @@ mod tests {
         async fn write_once(&self, size: u64, body: Buffer) -> Result<Metadata> {
             sleep(Duration::from_nanos(50)).await;
 
-            if thread_rng().gen_bool(1.0 / 10.0) {
+            if rng().random_bool(1.0 / 10.0) {
                 return Err(
                     Error::new(ErrorKind::Unexpected, "I'm a crazy monkey!").set_temporary()
                 );
@@ -377,7 +375,7 @@ mod tests {
             sleep(Duration::from_nanos(50)).await;
 
             // We will have 10% percent rate for write part to fail.
-            if thread_rng().gen_bool(1.0 / 10.0) {
+            if rng().random_bool(1.0 / 10.0) {
                 return Err(
                     Error::new(ErrorKind::Unexpected, "I'm a crazy monkey!").set_temporary()
                 );
@@ -435,14 +433,14 @@ mod tests {
         }
 
         fn timeout(&self) -> Option<BoxedStaticFuture<()>> {
-            let time = thread_rng().gen_range(0..100);
+            let time = rng().random_range(0..100);
             Some(Box::pin(tokio::time::sleep(Duration::from_nanos(time))))
         }
     }
 
     #[tokio::test]
     async fn test_multipart_upload_writer_with_concurrent_errors() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         let info = Arc::new(AccessorInfo::default());
         info.update_executor(|_| Executor::with(TimeoutExecutor::new()));
@@ -451,7 +449,7 @@ mod tests {
         let mut total_size = 0u64;
 
         for _ in 0..1000 {
-            let size = rng.gen_range(1..1024);
+            let size = rng.random_range(1..1024);
             total_size += size as u64;
 
             let mut bs = vec![0; size];
@@ -488,11 +486,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_multipart_writer_with_retry_when_write_once_error() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         for _ in 0..100 {
             let mut w = MultipartWriter::new(Arc::default(), TestWrite::new(), 200);
-            let size = rng.gen_range(1..1024);
+            let size = rng.random_range(1..1024);
             let mut bs = vec![0; size];
             rng.fill_bytes(&mut bs);
 

--- a/core/core/src/raw/oio/write/position_write.rs
+++ b/core/core/src/raw/oio/write/position_write.rs
@@ -177,9 +177,7 @@ mod tests {
     use std::sync::Mutex;
 
     use pretty_assertions::assert_eq;
-    use rand::Rng;
-    use rand::RngCore;
-    use rand::thread_rng;
+    use rand::{Rng, RngExt, rng};
     use tokio::time::sleep;
 
     use super::*;
@@ -207,7 +205,7 @@ mod tests {
             sleep(Duration::from_millis(50)).await;
 
             // We will have 10% percent rate for write part to fail.
-            if thread_rng().gen_bool(1.0 / 10.0) {
+            if rng().random_bool(1.0 / 10.0) {
                 return Err(
                     Error::new(ErrorKind::Unexpected, "I'm a crazy monkey!").set_temporary()
                 );
@@ -239,13 +237,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_position_writer_with_concurrent_errors() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         let mut w = PositionWriter::new(Arc::default(), TestWrite::new(), 200);
         let mut total_size = 0u64;
 
         for _ in 0..1000 {
-            let size = rng.gen_range(1..1024);
+            let size = rng.random_range(1..1024);
             total_size += size as u64;
 
             let mut bs = vec![0; size];

--- a/core/core/src/types/buffer.rs
+++ b/core/core/src/types/buffer.rs
@@ -750,6 +750,7 @@ mod tests {
 
     use pretty_assertions::assert_eq;
     use rand::prelude::*;
+    use rand::rng;
 
     use super::*;
 
@@ -900,11 +901,11 @@ mod tests {
     /// - Total size of this buffer.
     /// - Total content of this buffer.
     fn setup_buffer() -> (Buffer, usize, Bytes) {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         let bs = (0..100)
             .map(|_| {
-                let len = rng.gen_range(1..100);
+                let len = rng.random_range(1..100);
                 let mut buf = vec![0; len];
                 rng.fill(&mut buf[..]);
                 Bytes::from(buf)
@@ -920,7 +921,7 @@ mod tests {
 
     #[test]
     fn fuzz_buffer_advance() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         let (mut buf, total_size, total_content) = setup_buffer();
         assert_eq!(buf.remaining(), total_size);
@@ -932,7 +933,7 @@ mod tests {
         while !buf.is_empty() && times > 0 {
             times -= 1;
 
-            let cnt = rng.gen_range(0..total_size - cur);
+            let cnt = rng.random_range(0..total_size - cur);
             cur += cnt;
             buf.advance(cnt);
 
@@ -943,7 +944,7 @@ mod tests {
 
     #[test]
     fn fuzz_buffer_iter() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         let (mut buf, total_size, total_content) = setup_buffer();
         assert_eq!(buf.remaining(), total_size);
@@ -951,7 +952,7 @@ mod tests {
 
         let mut cur = 0;
         while buf.is_empty() {
-            let cnt = rng.gen_range(0..total_size - cur);
+            let cnt = rng.random_range(0..total_size - cur);
             cur += cnt;
             buf.advance(cnt);
 
@@ -972,7 +973,7 @@ mod tests {
 
     #[test]
     fn fuzz_buffer_truncate() {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         let (mut buf, total_size, total_content) = setup_buffer();
         assert_eq!(buf.remaining(), total_size);
@@ -980,7 +981,7 @@ mod tests {
 
         let mut cur = 0;
         while buf.is_empty() {
-            let cnt = rng.gen_range(0..total_size - cur);
+            let cnt = rng.random_range(0..total_size - cur);
             cur += cnt;
             buf.advance(cnt);
 
@@ -988,7 +989,7 @@ mod tests {
             assert_eq!(buf.remaining(), total_size - cur);
             assert_eq!(buf.to_bytes(), total_content.slice(cur..));
 
-            let truncate_size = rng.gen_range(0..total_size - cur);
+            let truncate_size = rng.random_range(0..total_size - cur);
             buf.truncate(truncate_size);
 
             // After truncate

--- a/core/core/src/types/context/write.rs
+++ b/core/core/src/types/context/write.rs
@@ -215,9 +215,7 @@ mod tests {
     use logforth::layout::TextLayout;
     use mea::mutex::Mutex;
     use pretty_assertions::assert_eq;
-    use rand::Rng;
-    use rand::RngCore;
-    use rand::thread_rng;
+    use rand::{Rng, RngExt, rng};
     use sha2::Digest;
     use sha2::Sha256;
 
@@ -275,7 +273,7 @@ mod tests {
     async fn test_exact_buf_writer_short_write() -> Result<()> {
         setup();
 
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut expected = vec![0; 5];
         rng.fill_bytes(&mut expected);
 
@@ -317,7 +315,7 @@ mod tests {
             false,
         );
 
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut expected = vec![0; 15];
         rng.fill_bytes(&mut expected);
 
@@ -348,7 +346,7 @@ mod tests {
             false,
         );
 
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut expected = vec![];
 
         let mut new_content = |size| {
@@ -391,7 +389,7 @@ mod tests {
             false,
         );
 
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut expected = vec![];
 
         let mut new_content = |size| {
@@ -426,11 +424,11 @@ mod tests {
     async fn test_fuzz_exact_buf_writer() -> Result<()> {
         setup();
 
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut expected = vec![];
 
         let buf = Arc::new(Mutex::new(vec![]));
-        let buffer_size = rng.gen_range(1..10);
+        let buffer_size = rng.random_range(1..10);
         let mut writer = WriteGenerator::new(
             Box::new(MockWriter {
                 buf: buf.clone(),
@@ -442,7 +440,7 @@ mod tests {
         debug!("test_fuzz_exact_buf_writer: buffer size: {buffer_size}");
 
         for _ in 0..1000 {
-            let size = rng.gen_range(1..20);
+            let size = rng.random_range(1..20);
             debug!("test_fuzz_exact_buf_writer: write size: {size}");
             let mut content = vec![0; size];
             rng.fill_bytes(&mut content);
@@ -486,7 +484,7 @@ mod tests {
             true, // exact mode
         );
 
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut expected = vec![0; large_buffer_size];
         rng.fill_bytes(&mut expected);
 

--- a/core/core/src/types/read/reader.rs
+++ b/core/core/src/types/read/reader.rs
@@ -433,9 +433,7 @@ impl Reader {
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use rand::Rng;
-    use rand::RngCore;
-    use rand::rngs::ThreadRng;
+    use rand::{Rng, RngExt};
 
     use super::*;
     use crate::Operator;
@@ -460,16 +458,16 @@ mod tests {
     }
 
     fn gen_random_bytes() -> Vec<u8> {
-        let mut rng = ThreadRng::default();
+        let mut rng = rand::rng();
         // Generate size between 1B..16MB.
-        let size = rng.gen_range(1..16 * 1024 * 1024);
+        let size = rng.random_range(1..16 * 1024 * 1024);
         let mut content = vec![0; size];
         rng.fill_bytes(&mut content);
         content
     }
 
     fn gen_fixed_bytes(size: usize) -> Vec<u8> {
-        let mut rng = ThreadRng::default();
+        let mut rng = rand::rng();
         let mut content = vec![0; size];
         rng.fill_bytes(&mut content);
         content

--- a/core/core/src/types/write/writer.rs
+++ b/core/core/src/types/write/writer.rs
@@ -380,17 +380,15 @@ impl Writer {
 #[cfg(test)]
 mod tests {
     use bytes::{Buf, Bytes};
-    use rand::Rng;
-    use rand::RngCore;
-    use rand::rngs::ThreadRng;
+    use rand::{Rng, RngExt};
 
     use crate::Operator;
     use crate::services;
 
     fn gen_random_bytes() -> Vec<u8> {
-        let mut rng = ThreadRng::default();
+        let mut rng = rand::rng();
         // Generate size between 1B..16MB.
-        let size = rng.gen_range(1..16 * 1024 * 1024);
+        let size = rng.random_range(1..16 * 1024 * 1024);
         let mut content = vec![0; size];
         rng.fill_bytes(&mut content);
         content

--- a/core/edge/file_write_on_full_disk/src/main.rs
+++ b/core/edge/file_write_on_full_disk/src/main.rs
@@ -21,6 +21,7 @@ use opendal::Operator;
 use opendal::Result;
 use opendal::services::Fs;
 use rand::prelude::*;
+use rand::rng;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -28,9 +29,9 @@ async fn main() -> Result<()> {
         Fs::default().root(&env::var("OPENDAL_FS_ROOT").expect("root must be set for this test"));
     let op = Operator::new(builder)?.finish();
 
-    let size = thread_rng().gen_range(512 * 1024 + 1..4 * 1024 * 1024);
+    let size = rng().random_range(512 * 1024 + 1..4 * 1024 * 1024);
     let mut bs = vec![0; size];
-    thread_rng().fill_bytes(&mut bs);
+    rng().fill_bytes(&mut bs);
 
     let result = op.write("/test", bs).await;
     // Write file with size > 512KB should fail

--- a/core/layers/chaos/src/lib.rs
+++ b/core/layers/chaos/src/lib.rs
@@ -86,7 +86,7 @@ impl<A: Access> Layer<A> for ChaosLayer {
     fn layer(&self, inner: A) -> Self::LayeredAccess {
         ChaosAccessor {
             inner,
-            rng: StdRng::from_entropy(),
+            rng: Arc::new(Mutex::new(rand::make_rng())),
             error_ratio: self.error_ratio,
         }
     }
@@ -96,7 +96,7 @@ impl<A: Access> Layer<A> for ChaosLayer {
 #[derive(Debug)]
 pub struct ChaosAccessor<A> {
     inner: A,
-    rng: StdRng,
+    rng: Arc<Mutex<StdRng>>,
 
     error_ratio: f64,
 }
@@ -113,10 +113,12 @@ impl<A: Access> LayeredAccess for ChaosAccessor<A> {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        self.inner
-            .read(path, args)
-            .await
-            .map(|(rp, r)| (rp, ChaosReader::new(r, self.rng.clone(), self.error_ratio)))
+        self.inner.read(path, args).await.map(|(rp, r)| {
+            (
+                rp,
+                ChaosReader::new(r, Arc::clone(&self.rng), self.error_ratio),
+            )
+        })
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
@@ -141,10 +143,10 @@ pub struct ChaosReader<R> {
 }
 
 impl<R> ChaosReader<R> {
-    fn new(inner: R, rng: StdRng, error_ratio: f64) -> Self {
+    fn new(inner: R, rng: Arc<Mutex<StdRng>>, error_ratio: f64) -> Self {
         Self {
             inner,
-            rng: Arc::new(Mutex::new(rng)),
+            rng,
             error_ratio,
         }
     }
@@ -152,8 +154,8 @@ impl<R> ChaosReader<R> {
     /// If I feel lucky, we can return the correct response. Otherwise,
     /// we need to generate an error.
     fn i_feel_lucky(&self) -> bool {
-        let point = self.rng.lock().unwrap().gen_range(0..100);
-        point >= (self.error_ratio * 100.0) as i32
+        let point: u32 = self.rng.lock().unwrap().random_range(0..100);
+        point >= (self.error_ratio * 100.0) as u32
     }
 
     fn unexpected_eof() -> Error {

--- a/core/services/compfs/src/core.rs
+++ b/core/services/compfs/src/core.rs
@@ -97,17 +97,16 @@ impl CompfsCore {
 #[cfg(test)]
 mod tests {
     use bytes::Bytes;
-    use rand::Rng;
-    use rand::thread_rng;
+    use rand::{RngExt, rng};
 
     use super::*;
 
     fn setup_buffer() -> (CompfsBuffer, usize, Bytes) {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         let bs = (0..100)
             .map(|_| {
-                let len = rng.gen_range(1..100);
+                let len = rng.random_range(1..100);
                 let mut buf = vec![0; len];
                 rng.fill(&mut buf[..]);
                 Bytes::from(buf)

--- a/core/testkit/src/read.rs
+++ b/core/testkit/src/read.rs
@@ -17,7 +17,7 @@
 
 use bytes::Bytes;
 use opendal_core::*;
-use rand::RngCore;
+use rand::Rng;
 use rand::rng;
 
 use crate::utils::sha256_digest;

--- a/core/testkit/src/read.rs
+++ b/core/testkit/src/read.rs
@@ -18,7 +18,7 @@
 use bytes::Bytes;
 use opendal_core::*;
 use rand::RngCore;
-use rand::thread_rng;
+use rand::rng;
 
 use crate::utils::sha256_digest;
 
@@ -45,7 +45,7 @@ impl ReadChecker {
     /// It's by design that we use a random generator to generate the raw data. The content of data
     /// is not important, we only care about the correctness of the read process.
     pub fn new(size: usize) -> Self {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let mut data = vec![0; size];
         rng.fill_bytes(&mut data);
 

--- a/core/testkit/src/write.rs
+++ b/core/testkit/src/write.rs
@@ -18,7 +18,7 @@
 use bytes::Bytes;
 use bytes::BytesMut;
 use rand::RngCore;
-use rand::thread_rng;
+use rand::rng;
 
 use crate::utils::sha256_digest;
 
@@ -42,7 +42,7 @@ pub struct WriteChecker {
 impl WriteChecker {
     /// Create a new WriteChecker with given size.
     pub fn new(size: Vec<usize>) -> Self {
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         let mut chunks = Vec::with_capacity(size.len());
 

--- a/core/testkit/src/write.rs
+++ b/core/testkit/src/write.rs
@@ -17,7 +17,7 @@
 
 use bytes::Bytes;
 use bytes::BytesMut;
-use rand::RngCore;
+use rand::Rng;
 use rand::rng;
 
 use crate::utils::sha256_digest;

--- a/core/tests/behavior/utils.rs
+++ b/core/tests/behavior/utils.rs
@@ -24,8 +24,9 @@ use libtest_mimic::Trial;
 use opendal::raw::*;
 use opendal::tests::TEST_RUNTIME;
 use opendal::*;
-use rand::distributions::uniform::SampleRange;
+use rand::distr::uniform::SampleRange;
 use rand::prelude::*;
+use rand::rng;
 use sha2::Digest;
 use sha2::Sha256;
 
@@ -41,9 +42,9 @@ pub fn sha256_digest(data: impl AsRef<[u8]>) -> String {
 }
 
 pub fn gen_bytes_with_range(range: impl SampleRange<usize>) -> (Vec<u8>, usize) {
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
-    let size = rng.gen_range(range);
+    let size = rng.random_range(range);
     let mut content = vec![0; size];
     rng.fill_bytes(&mut content);
 
@@ -62,11 +63,11 @@ pub fn gen_fixed_bytes(size: usize) -> Vec<u8> {
 }
 
 pub fn gen_offset_length(size: usize) -> (u64, u64) {
-    let mut rng = thread_rng();
+    let mut rng = rng();
 
     // Make sure at least one byte is read.
-    let offset = rng.gen_range(0..size - 1);
-    let length = rng.gen_range(1..(size - offset));
+    let offset = rng.random_range(0..size - 1);
+    let length = rng.random_range(1..(size - offset));
 
     (offset as u64, length as u64)
 }
@@ -171,9 +172,9 @@ impl Fixture {
         let path = path.into();
         self.paths.lock().unwrap().push(path.clone());
 
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
-        let size = rng.gen_range(range);
+        let size = rng.random_range(range);
         let mut content = vec![0; size];
         rng.fill_bytes(&mut content);
 

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -58,7 +58,7 @@ opendal = { version = "0.56.0", path = "../../core", features = [
   "services-s3",
   "tests",
 ] }
-rand = "0.8.5"
+rand = "0.10.1"
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread"] }
 url = "2.5.2"
 uuid = "1.11.0"

--- a/integrations/object_store/src/store.rs
+++ b/integrations/object_store/src/store.rs
@@ -714,6 +714,7 @@ mod tests {
     use object_store::{ObjectStore, ObjectStoreExt, WriteMultipart};
     use opendal::services;
     use rand::prelude::*;
+    use rand::rng;
     use std::sync::Arc;
 
     use super::*;
@@ -765,7 +766,7 @@ mod tests {
         let op = Operator::new(services::Memory::default()).unwrap().finish();
         let object_store: Arc<dyn ObjectStore> = Arc::new(OpendalStore::new(op));
 
-        let mut rng = thread_rng();
+        let mut rng = rng();
 
         // Case complete
         let path: Path = "data/test_complete.txt".into();
@@ -774,9 +775,9 @@ mod tests {
         let mut write = WriteMultipart::new(upload);
 
         let mut all_bytes = vec![];
-        let round = rng.gen_range(1..=1024);
+        let round = rng.random_range(1..=1024);
         for _ in 0..round {
-            let size = rng.gen_range(1..=1024);
+            let size = rng.random_range(1..=1024);
             let mut bytes = vec![0; size];
             rng.fill_bytes(&mut bytes);
 

--- a/integrations/parquet/Cargo.toml
+++ b/integrations/parquet/Cargo.toml
@@ -43,7 +43,7 @@ opendal = { version = "0.56.0", path = "../../core", features = [
   "services-memory",
   "services-s3",
 ] }
-rand = "0.8.5"
+rand = "0.10.1"
 tokio = { version = "1", features = ["fs", "macros", "rt-multi-thread"] }
 
 [[example]]

--- a/integrations/parquet/src/async_reader.rs
+++ b/integrations/parquet/src/async_reader.rs
@@ -171,7 +171,7 @@ impl AsyncFileReader for AsyncReader {
 mod tests {
     use futures::StreamExt;
     use opendal::{Operator, services};
-    use rand::{Rng, distributions::Alphanumeric};
+    use rand::{RngExt, distr::Alphanumeric};
 
     use crate::{AsyncReader, AsyncWriter, async_reader::PREFETCH_FOOTER_SIZE};
     use std::sync::Arc;
@@ -208,7 +208,7 @@ mod tests {
     }
 
     fn gen_fixed_string(size: usize) -> String {
-        rand::thread_rng()
+        rand::rng()
             .sample_iter(&Alphanumeric)
             .take(size)
             .map(char::from)


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

This upgrades OpenDAL's direct Rust `rand` dependencies from `0.8`/`0.8.5` to `0.10.1` while keeping older transitive `rand` versions where required by dependencies.

# What changes are included in this PR?

The workspace dependency, object_store integration dev dependency, and parquet integration dev dependency now use `rand 0.10.1`. Direct call sites were updated for the 0.10 API changes, including `rng()`, `RngExt::random_range`, `RngExt::random_bool`, and `rand::distr`.

# Are there any user-facing changes?

No.

# AI Usage Statement

Prepared with automated assistance.
