### PR TITLE
deps: Upgrade foyer to 0.22.3

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -7738,12 +7738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "panic-message"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384e52fd8fbd4cbe3c317e8216260c21a0f9134de108cea8a4dd4e7e152c472d"
-
-[[package]]
 name = "papaya"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -460,18 +460,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "auto_enums"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65398a2893f41bce5c9259f6e1a4f03fbae40637c1bdc755b4f387f48c613b03"
-dependencies = [
- "derive_utils",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,7 +1620,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
  "terminal_size",
 ]
 
@@ -2283,16 +2271,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
@@ -2313,20 +2291,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
@@ -2335,7 +2299,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.117",
 ]
 
@@ -2349,19 +2313,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2559,17 +2512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_utils"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362f47930db19fe7735f527e6595e4900316b893ebf6d48ad3d31be928d57dd6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "des"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,12 +2637,6 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dtoa"
@@ -3328,40 +3264,39 @@ dependencies = [
 
 [[package]]
 name = "foyer"
-version = "0.18.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642093b1a72c4a0ef89862484d669a353e732974781bb9c49a979526d1e30edc"
+checksum = "3b0abc0b87814989efa711f9becd9f26969820e2d3905db27d10969c4bd45890"
 dependencies = [
+ "anyhow",
  "equivalent",
  "foyer-common",
  "foyer-memory",
  "foyer-storage",
- "madsim-tokio",
+ "foyer-tokio",
+ "futures-util",
+ "mea",
  "mixtrics",
  "pin-project",
  "serde",
- "thiserror 2.0.18",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-common"
-version = "0.18.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db9c0e4648b13e9216d785b308d43751ca975301aeb83e607ec630b6f956944"
+checksum = "a3db80d5dece93adb7ad709c84578794724a9cba342a7e566c3551c7ec626789"
 dependencies = [
+ "anyhow",
  "bincode",
  "bytes",
  "cfg-if 1.0.4",
- "itertools 0.14.0",
- "madsim-tokio",
+ "foyer-tokio",
  "mixtrics",
  "parking_lot 0.12.5",
  "pin-project",
  "serde",
- "thiserror 2.0.18",
- "tokio",
  "twox-hash",
 ]
 
@@ -3376,60 +3311,69 @@ dependencies = [
 
 [[package]]
 name = "foyer-memory"
-version = "0.18.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "040dc38acbfca8f1def26bbbd9e9199090884aabb15de99f7bf4060be66ff608"
+checksum = "db907f40a527ca2aa2f40a5f68b32ea58aa70f050cd233518e9ffd402cfba6ce"
 dependencies = [
- "arc-swap",
+ "anyhow",
  "bitflags 2.11.1",
  "cmsketch",
  "equivalent",
  "foyer-common",
  "foyer-intrusive-collections",
- "hashbrown 0.15.5",
+ "foyer-tokio",
+ "futures-util",
+ "hashbrown 0.16.1",
  "itertools 0.14.0",
- "madsim-tokio",
+ "mea",
  "mixtrics",
  "parking_lot 0.12.5",
+ "paste",
  "pin-project",
  "serde",
- "thiserror 2.0.18",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-storage"
-version = "0.18.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a77ed888da490e997da6d6d62fcbce3f202ccf28be098c4ea595ca046fc4a9"
+checksum = "1983f1db3d0710e9c9d5fc116d9202dccd41a2d1e032572224f1aff5520aa958"
 dependencies = [
  "allocator-api2",
  "anyhow",
- "auto_enums",
  "bytes",
+ "core_affinity",
  "equivalent",
- "flume 0.11.1",
+ "fastant",
  "foyer-common",
  "foyer-memory",
+ "foyer-tokio",
  "fs4",
  "futures-core",
  "futures-util",
+ "hashbrown 0.16.1",
+ "io-uring 0.7.12",
  "itertools 0.14.0",
  "libc",
  "lz4",
- "madsim-tokio",
- "ordered_hash_map",
+ "mea",
  "parking_lot 0.12.5",
- "paste",
  "pin-project",
  "rand 0.9.4",
  "serde",
- "thiserror 2.0.18",
- "tokio",
  "tracing",
  "twox-hash",
  "zstd",
+]
+
+[[package]]
+name = "foyer-tokio"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6577b05a7ffad0db555aedf00bfe52af818220fc4c1c3a7a12520896fc38627"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]
@@ -4037,15 +3981,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.12",
 ]
 
 [[package]]
@@ -5478,61 +5413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "madsim"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18351aac4194337d6ea9ffbd25b3d1540ecc0754142af1bff5ba7392d1f6f771"
-dependencies = [
- "ahash 0.8.12",
- "async-channel 2.5.0",
- "async-stream",
- "async-task",
- "bincode",
- "bytes",
- "downcast-rs",
- "errno",
- "futures-util",
- "lazy_static",
- "libc",
- "madsim-macros",
- "naive-timer",
- "panic-message",
- "rand 0.8.6",
- "rand_xoshiro",
- "rustversion",
- "serde",
- "spin",
- "tokio",
- "tokio-util",
- "toml",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "madsim-macros"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d248e97b1a48826a12c3828d921e8548e714394bf17274dd0a93910dc946e1"
-dependencies = [
- "darling 0.14.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "madsim-tokio"
-version = "0.2.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3eb2acc57c82d21d699119b859e2df70a91dbdb84734885a1e72be83bdecb5"
-dependencies = [
- "madsim",
- "spin",
- "tokio",
-]
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5845,7 +5725,7 @@ dependencies = [
  "sha2",
  "socket2 0.6.3",
  "stringprep",
- "strsim 0.11.1",
+ "strsim",
  "take_mut",
  "thiserror 2.0.18",
  "tokio",
@@ -5913,12 +5793,6 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
-name = "naive-timer"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034a0ad7deebf0c2abcf2435950a6666c3c15ea9d8fad0c0f48efa8a7f843fed"
 
 [[package]]
 name = "nanorand"
@@ -7794,15 +7668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered_hash_map"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e5f22bf6dd04abd854a8874247813a8fa2c8c1260eba6fbb150270ce7c176"
-dependencies = [
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8943,15 +8808,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rapidhash"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10086,15 +9942,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10722,12 +10569,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -10882,7 +10723,7 @@ dependencies = [
  "sha1",
  "sha2",
  "storekey",
- "strsim 0.11.1",
+ "strsim",
  "subtle",
  "surrealdb-protocol",
  "surrealdb-types",
@@ -11532,30 +11373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap 2.14.0",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11571,9 +11388,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -11582,14 +11399,8 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -13047,12 +12858,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"

--- a/core/layers/foyer/Cargo.toml
+++ b/core/layers/foyer/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 bincode = "1"
-foyer = { version = "0.18", features = ["serde"] }
+foyer = { version = "0.22.3", features = ["serde"] }
 opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/layers/foyer/src/deleter.rs
+++ b/core/layers/foyer/src/deleter.rs
@@ -52,8 +52,16 @@ impl<A: Access> oio::Delete for Deleter<A> {
     }
 
     async fn close(&mut self) -> Result<()> {
-        for key in &self.keys {
-            self.inner.cache.remove(key);
+        {
+            let mut deleted_keys = self
+                .inner
+                .deleted_keys
+                .lock()
+                .expect("deleted keys lock poisoned");
+            for key in &self.keys {
+                self.inner.cache.remove(key);
+                deleted_keys.insert(key.clone());
+            }
         }
         self.deleter.close().await
     }

--- a/core/layers/foyer/src/error.rs
+++ b/core/layers/foyer/src/error.rs
@@ -20,22 +20,44 @@ use foyer::Error as FoyerError;
 use opendal_core::Error;
 use opendal_core::ErrorKind;
 
-/// Custom error type for when fetched data exceeds size limit.
 #[derive(Debug)]
-pub(crate) struct FetchSizeTooLarge;
+pub(crate) enum FetchError {
+    SizeTooLarge,
+    Source { kind: ErrorKind, message: String },
+}
 
-impl std::fmt::Display for FetchSizeTooLarge {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "fetched data size exceeds size limit")
+impl FetchError {
+    pub(crate) fn from_error(err: Error) -> Self {
+        Self::Source {
+            kind: err.kind(),
+            message: err.to_string(),
+        }
     }
 }
 
-impl std::error::Error for FetchSizeTooLarge {}
+impl std::fmt::Display for FetchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SizeTooLarge => write!(f, "fetched data size exceeds size limit"),
+            Self::Source { message, .. } => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for FetchError {}
 
 pub(crate) fn extract_err(e: FoyerError) -> Error {
-    let e = match e.downcast::<Error>() {
-        Ok(e) => return e,
-        Err(e) => e,
-    };
-    Error::new(ErrorKind::Unexpected, e.to_string())
+    if let Some(e) = e.downcast_ref::<Error>() {
+        return Error::new(e.kind(), e.to_string());
+    }
+    if let Some(e) = e.downcast_ref::<FetchError>() {
+        return match e {
+            FetchError::SizeTooLarge => Error::new(
+                ErrorKind::Unexpected,
+                "fetched data size exceeds size limit",
+            ),
+            FetchError::Source { kind, message } => Error::new(*kind, message.clone()),
+        };
+    }
+    Error::new(ErrorKind::Unexpected, "foyer operation failed").set_source(e)
 }

--- a/core/layers/foyer/src/full.rs
+++ b/core/layers/foyer/src/full.rs
@@ -17,9 +17,8 @@
 
 use std::sync::Arc;
 
-use foyer::Error as FoyerError;
-
 use opendal_core::Buffer;
+use opendal_core::Error;
 use opendal_core::Result;
 use opendal_core::raw::Access;
 use opendal_core::raw::BytesContentRange;
@@ -32,7 +31,7 @@ use opendal_core::raw::oio::Read;
 use crate::FoyerKey;
 use crate::FoyerValue;
 use crate::Inner;
-use crate::error::{FetchSizeTooLarge, extract_err};
+use crate::error::{FetchError, extract_err};
 
 pub struct FullReader<A: Access> {
     inner: Arc<Inner<A>>,
@@ -59,54 +58,65 @@ impl<A: Access> FullReader<A> {
             (start, end)
         };
 
-        // Use fetch to read data from cache or fallback to remote. fetch() can automatically
+        // Use get_or_fetch to read data from cache or fallback to remote. It can automatically
         // handle the thundering herd problem by ensuring only one request is made for a given
         // key.
         //
         // Please note that we only cache the object if it's smaller than size_limit. And we'll
         // fetch the ENTIRE object from remote to put it into cache, then slice it to the requested
         // range.
+        let key = FoyerKey {
+            path: path_str.clone(),
+            version: version.clone(),
+        };
+
+        if self
+            .inner
+            .deleted_keys
+            .lock()
+            .expect("deleted keys lock poisoned")
+            .contains(&key)
+        {
+            let (rp, mut reader) = self.inner.accessor.read(path, original_args).await?;
+            let buffer = reader.read_all().await?;
+            return Ok((rp, buffer));
+        }
+
         let result = self
             .inner
             .cache
-            .fetch(
-                FoyerKey {
-                    path: path_str.clone(),
-                    version: version.clone(),
-                },
-                || {
-                    let inner = self.inner.clone();
-                    let size_limit = self.size_limit.clone();
-                    let path_clone = path_str.clone();
-                    async move {
-                        // read the metadata first, if it's too large, do not cache
-                        let metadata = inner
-                            .accessor
-                            .stat(&path_clone, OpStat::default())
-                            .await
-                            .map_err(FoyerError::other)?
-                            .into_metadata();
+            .get_or_fetch(&key, || {
+                let inner = self.inner.clone();
+                let size_limit = self.size_limit.clone();
+                let path_clone = path_str.clone();
+                async move {
+                    // read the metadata first, if it's too large, do not cache
+                    let metadata = inner
+                        .accessor
+                        .stat(&path_clone, OpStat::default())
+                        .await
+                        .map_err(FetchError::from_error)?
+                        .into_metadata();
 
-                        let size = metadata.content_length() as usize;
-                        if !size_limit.contains(&size) {
-                            return Err(FoyerError::other(FetchSizeTooLarge));
-                        }
-
-                        // fetch the ENTIRE object from remote.
-                        let (_, mut reader) = inner
-                            .accessor
-                            .read(
-                                &path_clone,
-                                OpRead::default().with_range(BytesRange::new(0, None)),
-                            )
-                            .await
-                            .map_err(FoyerError::other)?;
-                        let buffer = reader.read_all().await.map_err(FoyerError::other)?;
-
-                        Ok(FoyerValue(buffer))
+                    let size = metadata.content_length() as usize;
+                    if !size_limit.contains(&size) {
+                        return Err(FetchError::SizeTooLarge);
                     }
-                },
-            )
+
+                    // fetch the ENTIRE object from remote.
+                    let (_, mut reader) = inner
+                        .accessor
+                        .read(
+                            &path_clone,
+                            OpRead::default().with_range(BytesRange::new(0, None)),
+                        )
+                        .await
+                        .map_err(FetchError::from_error)?;
+                    let buffer = reader.read_all().await.map_err(FetchError::from_error)?;
+
+                    Ok(FoyerValue(buffer))
+                }
+            })
             .await;
 
         // If got entry from cache, slice it to the requested range. If it's larger than size_limit,
@@ -123,13 +133,16 @@ impl<A: Access> FullReader<A> {
                     .with_range(Some(range));
                 Ok((rp, buffer))
             }
-            Err(e) => match e.downcast::<FetchSizeTooLarge>() {
-                Ok(_) => {
+            Err(e) => match e.downcast_ref::<FetchError>() {
+                Some(FetchError::SizeTooLarge) => {
                     let (rp, mut reader) = self.inner.accessor.read(path, original_args).await?;
                     let buffer = reader.read_all().await?;
                     Ok((rp, buffer))
                 }
-                Err(e) => Err(extract_err(e)),
+                Some(FetchError::Source { kind, message }) => {
+                    Err(Error::new(*kind, message.clone()))
+                }
+                None => Err(extract_err(e)),
             },
         }
     }

--- a/core/layers/foyer/src/lib.rs
+++ b/core/layers/foyer/src/lib.rs
@@ -21,12 +21,13 @@ mod full;
 mod writer;
 
 use std::{
+    collections::HashSet,
     future::Future,
     ops::{Bound, Deref, Range, RangeBounds},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
-use foyer::{Code, CodeError, HybridCache};
+use foyer::{Code, HybridCache, Result as FoyerResult};
 
 use opendal_core::raw::*;
 use opendal_core::*;
@@ -61,14 +62,14 @@ impl Deref for FoyerValue {
 }
 
 impl Code for FoyerValue {
-    fn encode(&self, writer: &mut impl std::io::Write) -> std::result::Result<(), CodeError> {
+    fn encode(&self, writer: &mut impl std::io::Write) -> FoyerResult<()> {
         let len = self.0.len() as u64;
         writer.write_all(&len.to_le_bytes())?;
         std::io::copy(&mut self.0.clone(), writer)?;
         Ok(())
     }
 
-    fn decode(reader: &mut impl std::io::Read) -> std::result::Result<Self, CodeError>
+    fn decode(reader: &mut impl std::io::Read) -> FoyerResult<Self>
     where
         Self: Sized,
     {
@@ -98,13 +99,13 @@ impl Code for FoyerValue {
 /// ```no_run
 /// use opendal_core::{Operator, services::Memory};
 /// use opendal_layer_foyer::FoyerLayer;
-/// use foyer::{HybridCacheBuilder, Engine};
+/// use foyer::HybridCacheBuilder;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let cache = HybridCacheBuilder::new()
 ///     .memory(64 * 1024 * 1024) // 64MB memory cache
 ///     .with_shards(4)
-///     .storage(Engine::Large(Default::default()))
+///     .storage()
 ///     .build()
 ///     .await?;
 ///
@@ -162,6 +163,7 @@ impl<A: Access> Layer<A> for FoyerLayer {
                 accessor,
                 cache,
                 size_limit: self.size_limit.clone(),
+                deleted_keys: Mutex::new(HashSet::new()),
             }),
         }
     }
@@ -172,6 +174,7 @@ pub(crate) struct Inner<A: Access> {
     pub(crate) accessor: A,
     pub(crate) cache: HybridCache<FoyerKey, FoyerValue>,
     pub(crate) size_limit: Range<usize>,
+    pub(crate) deleted_keys: Mutex<HashSet<FoyerKey>>,
 }
 
 #[derive(Debug)]
@@ -232,8 +235,8 @@ impl<A: Access> LayeredAccess for FoyerAccessor<A> {
 #[cfg(test)]
 mod tests {
     use foyer::{
-        DirectFsDeviceOptions, Engine, Error as FoyerError, HybridCacheBuilder, LargeEngineOptions,
-        RecoverMode,
+        BlockEngineConfig, DeviceBuilder, Error as FoyerError, ErrorKind as FoyerErrorKind,
+        FsDeviceBuilder, HybridCacheBuilder, RecoverMode,
     };
     use opendal_core::{Operator, services::Memory};
     use size::consts::MiB;
@@ -258,11 +261,15 @@ mod tests {
         let cache = HybridCacheBuilder::new()
             .memory(10)
             .with_shards(1)
-            .storage(Engine::Large(LargeEngineOptions::new()))
-            .with_device_options(
-                DirectFsDeviceOptions::new(dir.path())
-                    .with_capacity(16 * MiB as usize)
-                    .with_file_size(MiB as usize),
+            .storage()
+            .with_engine_config(
+                BlockEngineConfig::new(
+                    FsDeviceBuilder::new(dir.path())
+                        .with_capacity(16 * MiB as usize)
+                        .build()
+                        .unwrap(),
+                )
+                .with_block_size(MiB as usize),
             )
             .with_recover_mode(RecoverMode::None)
             .build()
@@ -313,11 +320,15 @@ mod tests {
         let cache = HybridCacheBuilder::new()
             .memory(1024 * 1024)
             .with_shards(1)
-            .storage(Engine::Large(LargeEngineOptions::new()))
-            .with_device_options(
-                DirectFsDeviceOptions::new(dir.path())
-                    .with_capacity(16 * MiB as usize)
-                    .with_file_size(MiB as usize),
+            .storage()
+            .with_engine_config(
+                BlockEngineConfig::new(
+                    FsDeviceBuilder::new(dir.path())
+                        .with_capacity(16 * MiB as usize)
+                        .build()
+                        .unwrap(),
+                )
+                .with_block_size(MiB as usize),
             )
             .with_recover_mode(RecoverMode::None)
             .build()
@@ -372,7 +383,7 @@ mod tests {
     #[test]
     fn test_error() {
         let e = Error::new(ErrorKind::NotFound, "not found");
-        let fe = FoyerError::other(e);
+        let fe = FoyerError::new(FoyerErrorKind::External, "external error").with_source(e);
         let oe = extract_err(fe);
         assert_eq!(oe.kind(), ErrorKind::NotFound);
     }

--- a/core/layers/foyer/src/writer.rs
+++ b/core/layers/foyer/src/writer.rs
@@ -70,13 +70,16 @@ impl<A: Access> oio::Write for Writer<A> {
         let buffer = self.buf.clone().collect();
         let metadata = self.w.close().await?;
         if !self.skip_cache {
-            self.inner.cache.insert(
-                FoyerKey {
-                    path: self.path.clone(),
-                    version: metadata.version().map(|v| v.to_string()),
-                },
-                FoyerValue(buffer),
-            );
+            let key = FoyerKey {
+                path: self.path.clone(),
+                version: metadata.version().map(|v| v.to_string()),
+            };
+            self.inner.cache.insert(key.clone(), FoyerValue(buffer));
+            self.inner
+                .deleted_keys
+                .lock()
+                .expect("deleted keys lock poisoned")
+                .remove(&key);
         }
         Ok(metadata)
     }

--- a/core/services/foyer/Cargo.toml
+++ b/core/services/foyer/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-foyer = { version = "0.18", features = ["serde"] }
+foyer = { version = "0.22.3", features = ["serde"] }
 log = { workspace = true }
 opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/foyer/src/backend.rs
+++ b/core/services/foyer/src/backend.rs
@@ -84,12 +84,12 @@ impl FoyerBuilder {
     ///
     /// ```no_run
     /// use opendal_service_foyer::Foyer;
-    /// use foyer::{HybridCacheBuilder, Engine};
+    /// use foyer::HybridCacheBuilder;
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let cache = HybridCacheBuilder::new()
     ///     .memory(64 * 1024 * 1024)
-    ///     .storage(Engine::Large(Default::default()))
+    ///     .storage()
     ///     .build()
     ///     .await?;
     ///

--- a/core/services/foyer/src/core.rs
+++ b/core/services/foyer/src/core.rs
@@ -15,15 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-use foyer::DirectFsDeviceOptions;
-use foyer::Engine;
+use foyer::BlockEngineConfig;
+use foyer::DeviceBuilder;
+use foyer::FsDeviceBuilder;
 use foyer::HybridCache;
 use foyer::HybridCacheBuilder;
-use foyer::LargeEngineOptions;
 use foyer::RecoverMode;
 
 use opendal_core::Buffer;
@@ -42,6 +43,7 @@ use super::FoyerValue;
 pub struct FoyerCore {
     /// OnceLock for lazy cache initialization.
     cache: std::sync::OnceLock<Arc<HybridCache<FoyerKey, FoyerValue>>>,
+    deleted_keys: Arc<Mutex<HashSet<FoyerKey>>>,
     /// Config
     config: FoyerConfig,
 }
@@ -80,6 +82,7 @@ impl FoyerCore {
     pub fn new(config: FoyerConfig) -> Self {
         Self {
             cache: std::sync::OnceLock::new(),
+            deleted_keys: Arc::new(Mutex::new(HashSet::new())),
             config,
         }
     }
@@ -107,35 +110,41 @@ impl FoyerCore {
         let mut builder = HybridCacheBuilder::new()
             .memory(memory)
             .with_shards(shards)
-            .storage(Engine::Large(LargeEngineOptions::new()))
+            .storage()
             .with_recover_mode(recover_mode);
 
         // Configure disk storage if disk_path is provided
         if let Some(ref disk_path) = self.config.disk_path {
             let path = PathBuf::from(disk_path);
 
-            let mut device_options = DirectFsDeviceOptions::new(path);
+            let mut device = FsDeviceBuilder::new(path);
 
             if let Some(capacity) = self.config.disk_capacity {
-                device_options = device_options.with_capacity(capacity);
+                device = device.with_capacity(capacity);
             }
 
-            let file_size = self
+            let block_size = self
                 .config
                 .disk_file_size
                 .unwrap_or(FOYER_DEFAULT_DISK_FILE_SIZE);
-            device_options = device_options.with_file_size(file_size);
+            let device = device.build().map_err(|e| {
+                Error::new(ErrorKind::Unexpected, "failed to build foyer cache device")
+                    .set_source(e)
+            })?;
 
-            builder = builder.with_device_options(device_options);
+            builder = builder
+                .with_engine_config(BlockEngineConfig::new(device).with_block_size(block_size));
         }
 
         let cache = Arc::new(builder.build().await.map_err(|e| {
             Error::new(ErrorKind::Unexpected, "failed to build foyer cache").set_source(e)
         })?);
 
-        self.cache
-            .set(cache.clone())
-            .map_err(|_| Error::new(ErrorKind::Unexpected, "failed to initialize foyer cache"))?;
+        if self.cache.set(cache.clone()).is_err() {
+            return self.cache.get().cloned().ok_or_else(|| {
+                Error::new(ErrorKind::Unexpected, "failed to initialize foyer cache")
+            });
+        }
 
         Ok(cache)
     }
@@ -149,6 +158,14 @@ impl FoyerCore {
         let foyer_key = FoyerKey {
             path: key.to_string(),
         };
+        if self
+            .deleted_keys
+            .lock()
+            .expect("deleted keys lock poisoned")
+            .contains(&foyer_key)
+        {
+            return Ok(None);
+        }
 
         match cache.get(&foyer_key).await {
             Ok(Some(entry)) => Ok(Some(entry.value().0.clone())),
@@ -159,20 +176,27 @@ impl FoyerCore {
 
     pub async fn insert(&self, key: &str, value: Buffer) -> Result<()> {
         let cache = self.get_cache().await?;
-        cache.insert(
-            FoyerKey {
-                path: key.to_string(),
-            },
-            FoyerValue(value),
-        );
+        let key = FoyerKey {
+            path: key.to_string(),
+        };
+        cache.insert(key.clone(), FoyerValue(value));
+        self.deleted_keys
+            .lock()
+            .expect("deleted keys lock poisoned")
+            .remove(&key);
         Ok(())
     }
 
     pub async fn remove(&self, key: &str) -> Result<()> {
         let cache = self.get_cache().await?;
-        cache.remove(&FoyerKey {
+        let key = FoyerKey {
             path: key.to_string(),
-        });
+        };
+        cache.remove(&key);
+        self.deleted_keys
+            .lock()
+            .expect("deleted keys lock poisoned")
+            .insert(key);
         Ok(())
     }
 }

--- a/core/services/foyer/src/docs.md
+++ b/core/services/foyer/src/docs.md
@@ -44,14 +44,18 @@ use opendal::Operator;
 use opendal_service_foyer::Foyer;
 use opendal_service_foyer::FoyerKey;
 use opendal_service_foyer::FoyerValue;
-use foyer::{HybridCacheBuilder, Engine};
+use foyer::{BlockEngineConfig, DeviceBuilder, FsDeviceBuilder, HybridCacheBuilder};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a foyer HybridCache with full control
+    let device = FsDeviceBuilder::new("/tmp/foyer")
+        .with_capacity(1024 * 1024 * 1024)
+        .build()?;
     let cache = HybridCacheBuilder::new()
         .memory(64 * 1024 * 1024) // 64MB memory cache
-        .storage(Engine::Large(Default::default()))
+        .storage()
+        .with_engine_config(BlockEngineConfig::new(device))
         .build()
         .await?;
 

--- a/core/services/foyer/src/lib.rs
+++ b/core/services/foyer/src/lib.rs
@@ -36,7 +36,7 @@ mod writer;
 use std::ops::Deref;
 
 use foyer::Code;
-use foyer::CodeError;
+use foyer::Result as FoyerResult;
 
 use opendal_core::Buffer;
 
@@ -68,14 +68,14 @@ impl Deref for FoyerValue {
 }
 
 impl Code for FoyerValue {
-    fn encode(&self, writer: &mut impl std::io::Write) -> std::result::Result<(), CodeError> {
+    fn encode(&self, writer: &mut impl std::io::Write) -> FoyerResult<()> {
         let len = self.0.len() as u64;
         writer.write_all(&len.to_le_bytes())?;
         std::io::copy(&mut self.0.clone(), writer)?;
         Ok(())
     }
 
-    fn decode(reader: &mut impl std::io::Read) -> std::result::Result<Self, CodeError>
+    fn decode(reader: &mut impl std::io::Read) -> FoyerResult<Self>
     where
         Self: Sized,
     {
@@ -100,7 +100,7 @@ pub fn register_foyer_service(registry: &opendal_core::OperatorRegistry) {
 #[cfg(test)]
 mod tests {
     use foyer::{
-        DirectFsDeviceOptions, Engine, HybridCacheBuilder, LargeEngineOptions, RecoverMode,
+        BlockEngineConfig, DeviceBuilder, FsDeviceBuilder, HybridCacheBuilder, RecoverMode,
     };
     use opendal_core::Operator;
     use size::consts::MiB;
@@ -122,11 +122,15 @@ mod tests {
         let cache = HybridCacheBuilder::new()
             .memory(10)
             .with_shards(1)
-            .storage(Engine::Large(LargeEngineOptions::new()))
-            .with_device_options(
-                DirectFsDeviceOptions::new(dir.path())
-                    .with_capacity(16 * MiB as usize)
-                    .with_file_size(MiB as usize),
+            .storage()
+            .with_engine_config(
+                BlockEngineConfig::new(
+                    FsDeviceBuilder::new(dir.path())
+                        .with_capacity(16 * MiB as usize)
+                        .build()
+                        .unwrap(),
+                )
+                .with_block_size(MiB as usize),
             )
             .with_recover_mode(RecoverMode::None)
             .build()
@@ -171,11 +175,15 @@ mod tests {
         let cache = HybridCacheBuilder::new()
             .memory(1024 * 1024)
             .with_shards(1)
-            .storage(Engine::Large(LargeEngineOptions::new()))
-            .with_device_options(
-                DirectFsDeviceOptions::new(dir.path())
-                    .with_capacity(16 * MiB as usize)
-                    .with_file_size(MiB as usize),
+            .storage()
+            .with_engine_config(
+                BlockEngineConfig::new(
+                    FsDeviceBuilder::new(dir.path())
+                        .with_capacity(16 * MiB as usize)
+                        .build()
+                        .unwrap(),
+                )
+                .with_block_size(MiB as usize),
             )
             .with_recover_mode(RecoverMode::None)
             .build()


### PR DESCRIPTION
# Which issue does this PR close?

No issue.

# Rationale for this change

This upgrades the Rust foyer dependency used by the foyer layer and service from 0.18 to 0.22.3.

# What changes are included in this PR?

The foyer layer and service now use the 0.22 hybrid cache APIs, including `get_or_fetch`, `BlockEngineConfig`, and `FsDeviceBuilder`. The change also preserves delete semantics under foyer 0.22 by tracking locally invalidated keys and fixes lazy cache initialization races by reusing the cache initialized by a concurrent caller.

# Are there any user-facing changes?

No public OpenDAL API changes. The foyer dependency is upgraded and existing foyer layer/service behavior is preserved.

# AI Usage Statement

N/A
