### PR TITLE
chore(deps): upgrade RustCrypto digest crates

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -609,14 +609,14 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -703,13 +703,13 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "p256 0.11.1",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "tracing",
@@ -740,10 +740,10 @@ dependencies = [
  "hex",
  "http 0.2.12",
  "http-body 0.4.6",
- "md-5",
+ "md-5 0.10.6",
  "pin-project-lite",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -1210,7 +1210,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1234,6 +1234,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1419,7 +1428,7 @@ version = "13.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c5063741c7b2e260bbede781cf4679632dd90e2718e99f7715e46824b65670b"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "either",
  "futures",
  "hex",
@@ -1430,8 +1439,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "ssri",
  "tempfile",
  "thiserror 1.0.69",
@@ -1583,7 +1592,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1647,6 +1656,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "cmsketch"
@@ -1870,6 +1885,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2005,7 +2026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rand 0.9.4",
  "regex",
  "rustversion",
@@ -2159,6 +2180,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,6 +2268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,7 +2285,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -2408,7 +2447,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -2418,7 +2457,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -2579,10 +2618,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -2756,7 +2807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.10",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
  "signature 2.2.0",
@@ -2782,7 +2833,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2846,7 +2897,7 @@ dependencies = [
  "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
- "digest",
+ "digest 0.10.7",
  "ff 0.12.1",
  "generic-array 0.14.7",
  "group 0.12.1",
@@ -2865,7 +2916,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct 0.2.0",
  "crypto-bigint 0.5.5",
- "digest",
+ "digest 0.10.7",
  "ff 0.13.1",
  "generic-array 0.14.7",
  "group 0.13.0",
@@ -4086,11 +4137,11 @@ dependencies = [
  "futures",
  "g2p",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "libc",
  "libloading 0.9.0",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "num-traits",
  "once_cell",
  "prost 0.14.3",
@@ -4142,7 +4193,7 @@ dependencies = [
  "http 1.4.0",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -4287,7 +4338,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -4296,7 +4347,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4417,6 +4477,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -5024,7 +5093,7 @@ dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256 0.13.2",
  "p384",
@@ -5033,7 +5102,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature 2.2.0",
  "simple_asn1",
 ]
@@ -5578,7 +5647,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if 1.0.4",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if 1.0.4",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5791,9 +5870,9 @@ dependencies = [
  "hex",
  "hickory-proto",
  "hickory-resolver",
- "hmac",
+ "hmac 0.12.1",
  "macro_magic",
- "md-5",
+ "md-5 0.10.6",
  "mongocrypt",
  "mongodb-internal-macros",
  "pbkdf2",
@@ -5805,8 +5884,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_with",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "socket2 0.6.3",
  "stringprep",
  "strsim 0.11.1",
@@ -6291,7 +6370,7 @@ dependencies = [
  "opendal-testkit",
  "rand 0.8.6",
  "reqwest",
- "sha2",
+ "sha2 0.11.0",
  "size",
  "tokio",
  "uuid",
@@ -6336,7 +6415,7 @@ dependencies = [
  "jiff",
  "log",
  "logforth",
- "md-5",
+ "md-5 0.11.0",
  "mea",
  "moka",
  "percent-encoding",
@@ -6347,7 +6426,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tokio",
  "url",
  "uuid",
@@ -6692,7 +6771,7 @@ dependencies = [
  "reqsign-file-read-tokio",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tokio",
  "uuid",
 ]
@@ -6965,7 +7044,7 @@ dependencies = [
  "reqsign-core",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tokio",
 ]
 
@@ -7318,7 +7397,7 @@ dependencies = [
  "crc32c",
  "http 1.4.0",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "opendal-core",
  "pretty_assertions",
  "quick-xml",
@@ -7399,7 +7478,7 @@ version = "0.56.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "hmac",
+ "hmac 0.13.0",
  "http 1.4.0",
  "log",
  "opendal-core",
@@ -7407,8 +7486,8 @@ dependencies = [
  "quick-xml",
  "serde",
  "serde_json",
- "sha1",
- "sha2",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "tokio",
  "uuid",
 ]
@@ -7439,15 +7518,15 @@ version = "0.56.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "hmac",
+ "hmac 0.13.0",
  "http 1.4.0",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "opendal-core",
  "quick-xml",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.11.0",
  "tokio",
 ]
 
@@ -7535,7 +7614,7 @@ dependencies = [
  "opendal-layer-retry",
  "opendal-layer-timeout",
  "rand 0.8.6",
- "sha2",
+ "sha2 0.11.0",
  "tokio",
  "uuid",
 ]
@@ -7799,7 +7878,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -7811,7 +7890,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -7823,7 +7902,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -7925,10 +8004,10 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
  "password-hash",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8167,7 +8246,7 @@ dependencies = [
  "der 0.7.10",
  "pbkdf2",
  "scrypt",
- "sha2",
+ "sha2 0.10.9",
  "spki 0.7.3",
 ]
 
@@ -9144,7 +9223,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -9166,7 +9245,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -9181,13 +9260,13 @@ dependencies = [
  "form_urlencoded",
  "futures",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 1.4.0",
  "jiff",
  "log",
  "percent-encoding",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "windows-sys 0.61.2",
 ]
 
@@ -9218,7 +9297,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
 ]
 
@@ -9348,7 +9427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -9358,7 +9437,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -9447,15 +9526,15 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -9847,7 +9926,7 @@ dependencies = [
  "password-hash",
  "pbkdf2",
  "salsa20",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -10090,7 +10169,7 @@ checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -10101,7 +10180,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -10118,8 +10208,19 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
  "sha2-asm",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -10185,7 +10286,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -10195,7 +10296,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -10400,7 +10501,7 @@ dependencies = [
  "rustls 0.23.40",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -10438,7 +10539,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -10460,7 +10561,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -10470,18 +10571,18 @@ dependencies = [
  "generic-array 0.14.7",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
  "rand 0.8.6",
  "rsa",
  "serde",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -10508,17 +10609,17 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -10578,12 +10679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7a2b3c2bc9693bcb40870c4e9b5bf0d79f9cb46273321bf855ec513e919082"
 dependencies = [
  "base64 0.21.7",
- "digest",
+ "digest 0.10.7",
  "hex",
  "miette",
  "serde",
  "sha-1",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "xxhash-rust",
 ]
@@ -10801,7 +10902,7 @@ dependencies = [
  "ipnet",
  "jsonwebtoken",
  "lexicmp",
- "md-5",
+ "md-5 0.10.6",
  "mime",
  "ndarray",
  "ndarray-stats",
@@ -10828,8 +10929,8 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "storekey",
  "strsim 0.11.1",
  "subtle",
@@ -11923,7 +12024,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls 0.23.40",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "url",
  "utf-8",
@@ -13222,7 +13323,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -53,7 +53,7 @@ quick-xml = { version = "0.39.3", default-features = false }
 rand = "0.8"
 serde = { version = "1", default-features = false }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11.0"
 tokio = { version = "1.48", default-features = false }
 url = "2.5"
 uuid = { version = "1", default-features = false }

--- a/core/core/Cargo.toml
+++ b/core/core/Cargo.toml
@@ -71,7 +71,7 @@ http = { workspace = true }
 http-body = "1"
 jiff = { version = "0.2.17", features = ["serde"] }
 log = { workspace = true }
-md-5 = "0.10"
+md-5 = "0.11.0"
 mea = { workspace = true }
 percent-encoding = "2"
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/core/src/types/context/write.rs
+++ b/core/core/src/types/context/write.rs
@@ -224,6 +224,17 @@ mod tests {
     use super::*;
     use crate::raw::oio::Write;
 
+    fn sha256_digest(data: impl AsRef<[u8]>) -> String {
+        use std::fmt::Write;
+
+        let digest = Sha256::digest(data);
+        let mut output = String::with_capacity(digest.len() * 2);
+        for byte in digest {
+            write!(&mut output, "{byte:02x}").expect("writing to String must succeed");
+        }
+        output
+    }
+
     struct MockWriter {
         buf: Arc<Mutex<Vec<u8>>>,
         write_sizes: Arc<Mutex<Vec<usize>>>,
@@ -288,10 +299,7 @@ mod tests {
 
         let buf = buf.lock().await;
         assert_eq!(buf.len(), expected.len());
-        assert_eq!(
-            format!("{:x}", Sha256::digest(&*buf)),
-            format!("{:x}", Sha256::digest(&expected))
-        );
+        assert_eq!(sha256_digest(&*buf), sha256_digest(&expected));
         Ok(())
     }
 
@@ -322,10 +330,7 @@ mod tests {
 
         let buf = buf.lock().await;
         assert_eq!(buf.len(), expected.len());
-        assert_eq!(
-            format!("{:x}", Sha256::digest(&*buf)),
-            format!("{:x}", Sha256::digest(&expected))
-        );
+        assert_eq!(sha256_digest(&*buf), sha256_digest(&expected));
         Ok(())
     }
 
@@ -368,10 +373,7 @@ mod tests {
 
         let buf = buf.lock().await;
         assert_eq!(buf.len(), expected.len());
-        assert_eq!(
-            format!("{:x}", Sha256::digest(&*buf)),
-            format!("{:x}", Sha256::digest(&expected))
-        );
+        assert_eq!(sha256_digest(&*buf), sha256_digest(&expected));
         Ok(())
     }
 
@@ -416,10 +418,7 @@ mod tests {
 
         let buf = buf.lock().await;
         assert_eq!(buf.len(), expected.len());
-        assert_eq!(
-            format!("{:x}", Sha256::digest(&*buf)),
-            format!("{:x}", Sha256::digest(&expected))
-        );
+        assert_eq!(sha256_digest(&*buf), sha256_digest(&expected));
         Ok(())
     }
 
@@ -460,10 +459,7 @@ mod tests {
 
         let buf = buf.lock().await;
         assert_eq!(buf.len(), expected.len());
-        assert_eq!(
-            format!("{:x}", Sha256::digest(&*buf)),
-            format!("{:x}", Sha256::digest(&expected))
-        );
+        assert_eq!(sha256_digest(&*buf), sha256_digest(&expected));
         Ok(())
     }
 
@@ -508,10 +504,7 @@ mod tests {
         // Verify all data was written
         let buf = buf.lock().await;
         assert_eq!(buf.len(), expected.len());
-        assert_eq!(
-            format!("{:x}", Sha256::digest(&*buf)),
-            format!("{:x}", Sha256::digest(&expected))
-        );
+        assert_eq!(sha256_digest(&*buf), sha256_digest(&expected));
 
         // Verify that writes were split into chunks (except possibly the last one)
         let write_sizes = write_sizes.lock().await;

--- a/core/services/ghac/src/backend.rs
+++ b/core/services/ghac/src/backend.rs
@@ -138,7 +138,7 @@ impl Builder for GhacBuilder {
         // ghac requires to use hex digest of Sha256 as version.
         if matches!(service_version, GhacVersion::V2) {
             let hash = sha2::Sha256::digest(&version);
-            version = format!("{hash:x}");
+            version = format_digest_hex(hash);
         }
 
         let cache_url = self
@@ -190,6 +190,17 @@ impl Builder for GhacBuilder {
             core: Arc::new(core),
         })
     }
+}
+
+fn format_digest_hex(digest: impl AsRef<[u8]>) -> String {
+    use std::fmt::Write;
+
+    let digest = digest.as_ref();
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut output, "{byte:02x}").expect("writing to String must succeed");
+    }
+    output
 }
 
 /// Backend for github action cache services.

--- a/core/services/s3/Cargo.toml
+++ b/core/services/s3/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 crc32c = "0.6.6"
 http = { workspace = true }
 log = { workspace = true }
-md-5 = "0.10"
+md-5 = "0.11.0"
 opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-aws-v4 = { version = "3.0.0", default-features = false }

--- a/core/services/swift/Cargo.toml
+++ b/core/services/swift/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 base64 = { workspace = true }
 bytes = { workspace = true }
-hmac = "0.12.1"
+hmac = "0.13.0"
 http = { workspace = true }
 log = { workspace = true }
 opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
@@ -41,7 +41,7 @@ percent-encoding = "2"
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sha1 = "0.10.6"
+sha1 = "0.11.0"
 sha2 = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 

--- a/core/services/swift/src/core.rs
+++ b/core/services/swift/src/core.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use std::time::SystemTime;
 
 use hmac::Hmac;
+use hmac::KeyInit;
 use hmac::Mac;
 use http::Method;
 use http::Request;

--- a/core/services/upyun/Cargo.toml
+++ b/core/services/upyun/Cargo.toml
@@ -33,15 +33,15 @@ all-features = true
 [dependencies]
 base64 = { workspace = true }
 bytes = { workspace = true }
-hmac = "0.12.1"
+hmac = "0.13.0"
 http = { workspace = true }
 log = { workspace = true }
-md-5 = "0.10"
+md-5 = "0.11.0"
 opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sha1 = "0.10.6"
+sha1 = "0.11.0"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/upyun/src/core.rs
+++ b/core/services/upyun/src/core.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use base64::Engine;
 use hmac::Hmac;
+use hmac::KeyInit;
 use hmac::Mac;
 use http::HeaderMap;
 use http::Request;
@@ -499,7 +500,18 @@ pub fn format_md5(bs: &[u8]) -> String {
     let mut hasher = md5::Md5::new();
     hasher.update(bs);
 
-    format!("{:x}", hasher.finalize())
+    format_digest_hex(hasher.finalize())
+}
+
+fn format_digest_hex(digest: impl AsRef<[u8]>) -> String {
+    use std::fmt::Write;
+
+    let digest = digest.as_ref();
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut output, "{byte:02x}").expect("writing to String must succeed");
+    }
+    output
 }
 
 #[derive(Debug, Deserialize)]

--- a/core/testkit/src/read.rs
+++ b/core/testkit/src/read.rs
@@ -19,8 +19,8 @@ use bytes::Bytes;
 use opendal_core::*;
 use rand::RngCore;
 use rand::thread_rng;
-use sha2::Digest;
-use sha2::Sha256;
+
+use crate::utils::sha256_digest;
 
 /// ReadAction represents a read action.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -93,8 +93,8 @@ impl ReadChecker {
 
         // Check the read result
         assert_eq!(
-            format!("{:x}", Sha256::digest(output)),
-            format!("{:x}", Sha256::digest(expected)),
+            sha256_digest(output),
+            sha256_digest(expected),
             "check read failed: output bs is different with expected bs",
         );
     }

--- a/core/testkit/src/utils.rs
+++ b/core/testkit/src/utils.rs
@@ -24,6 +24,19 @@ use opendal_core::Result;
 use opendal_layer_logging::LoggingLayer;
 use opendal_layer_retry::RetryLayer;
 use opendal_layer_timeout::TimeoutLayer;
+use sha2::Digest;
+use sha2::Sha256;
+
+pub(crate) fn sha256_digest(data: impl AsRef<[u8]>) -> String {
+    use std::fmt::Write;
+
+    let digest = Sha256::digest(data);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut output, "{byte:02x}").expect("writing to String must succeed");
+    }
+    output
+}
 
 /// TEST_RUNTIME is the runtime used for running tests.
 pub static TEST_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {

--- a/core/testkit/src/write.rs
+++ b/core/testkit/src/write.rs
@@ -19,8 +19,8 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use rand::RngCore;
 use rand::thread_rng;
-use sha2::Digest;
-use sha2::Sha256;
+
+use crate::utils::sha256_digest;
 
 /// WriteAction represents a read action.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -71,8 +71,8 @@ impl WriteChecker {
     /// Check the correctness of the write process.
     pub fn check(&self, actual: &[u8]) {
         assert_eq!(
-            format!("{:x}", Sha256::digest(actual)),
-            format!("{:x}", Sha256::digest(&self.data)),
+            sha256_digest(actual),
+            sha256_digest(&self.data),
             "check failed: result is not expected"
         )
     }

--- a/core/tests/behavior/async_copy.rs
+++ b/core/tests/behavior/async_copy.rs
@@ -16,8 +16,6 @@
 // under the License.
 
 use anyhow::Result;
-use sha2::Digest;
-use sha2::Sha256;
 
 use crate::*;
 
@@ -64,8 +62,8 @@ pub async fn test_copy_file_with_ascii_name(op: Operator) -> Result<()> {
         .expect("read must succeed")
         .to_bytes();
     assert_eq!(
-        format!("{:x}", Sha256::digest(target_content)),
-        format!("{:x}", Sha256::digest(&source_content)),
+        sha256_digest(target_content),
+        sha256_digest(&source_content),
     );
 
     op.delete(&source_path).await.expect("delete must succeed");
@@ -94,8 +92,8 @@ pub async fn test_copy_file_with_non_ascii_name(op: Operator) -> Result<()> {
         .expect("read must succeed")
         .to_bytes();
     assert_eq!(
-        format!("{:x}", Sha256::digest(target_content)),
-        format!("{:x}", Sha256::digest(&source_content)),
+        sha256_digest(target_content),
+        sha256_digest(&source_content),
     );
 
     op.delete(source_path).await.expect("delete must succeed");
@@ -200,8 +198,8 @@ pub async fn test_copy_nested(op: Operator) -> Result<()> {
         .expect("read must succeed")
         .to_bytes();
     assert_eq!(
-        format!("{:x}", Sha256::digest(target_content)),
-        format!("{:x}", Sha256::digest(&source_content)),
+        sha256_digest(target_content),
+        sha256_digest(&source_content),
     );
 
     op.delete(&source_path).await.expect("delete must succeed");
@@ -230,8 +228,8 @@ pub async fn test_copy_overwrite(op: Operator) -> Result<()> {
         .expect("read must succeed")
         .to_bytes();
     assert_eq!(
-        format!("{:x}", Sha256::digest(target_content)),
-        format!("{:x}", Sha256::digest(&source_content)),
+        sha256_digest(target_content),
+        sha256_digest(&source_content),
     );
 
     op.delete(&source_path).await.expect("delete must succeed");
@@ -263,8 +261,8 @@ pub async fn test_copy_with_if_not_exists_to_new_file(op: Operator) -> Result<()
         .expect("read must succeed")
         .to_bytes();
     assert_eq!(
-        format!("{:x}", Sha256::digest(target_content)),
-        format!("{:x}", Sha256::digest(&source_content)),
+        sha256_digest(target_content),
+        sha256_digest(&source_content),
     );
 
     op.delete(&source_path).await.expect("delete must succeed");
@@ -305,8 +303,8 @@ pub async fn test_copy_with_if_not_exists_to_existing_file(op: Operator) -> Resu
         .expect("read must succeed")
         .to_bytes();
     assert_eq!(
-        format!("{:x}", Sha256::digest(current_content)),
-        format!("{:x}", Sha256::digest(&target_content)),
+        sha256_digest(current_content),
+        sha256_digest(&target_content),
     );
 
     op.delete(&source_path).await.expect("delete must succeed");

--- a/core/tests/behavior/async_presign.rs
+++ b/core/tests/behavior/async_presign.rs
@@ -23,8 +23,6 @@ use http::header;
 use log::debug;
 use opendal::raw;
 use reqwest::Url;
-use sha2::Digest;
-use sha2::Sha256;
 
 use crate::*;
 
@@ -130,11 +128,7 @@ pub async fn test_presign_read(op: Operator) -> Result<()> {
 
     let bs = resp.bytes().await.expect("read response must succeed");
     assert_eq!(size, bs.len(), "read size");
-    assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
-        format!("{:x}", Sha256::digest(&content)),
-        "read content"
-    );
+    assert_eq!(sha256_digest(&bs), sha256_digest(&content), "read content");
 
     op.delete(&path).await.expect("delete must succeed");
     Ok(())

--- a/core/tests/behavior/async_read.rs
+++ b/core/tests/behavior/async_read.rs
@@ -22,8 +22,6 @@ use futures::AsyncReadExt;
 use futures::TryStreamExt;
 use http::StatusCode;
 use reqwest::Url;
-use sha2::Digest;
-use sha2::Sha256;
 use tokio::time::sleep;
 
 use crate::*;
@@ -82,11 +80,7 @@ pub async fn test_read_full(op: Operator) -> anyhow::Result<()> {
 
     let bs = op.read(&path).await?.to_bytes();
     assert_eq!(size, bs.len(), "read size");
-    assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
-        format!("{:x}", Sha256::digest(&content)),
-        "read content"
-    );
+    assert_eq!(sha256_digest(&bs), sha256_digest(&content), "read content");
 
     Ok(())
 }
@@ -107,11 +101,8 @@ pub async fn test_read_range(op: Operator) -> anyhow::Result<()> {
         .to_bytes();
     assert_eq!(bs.len() as u64, length, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
-        format!(
-            "{:x}",
-            Sha256::digest(&content[offset as usize..(offset + length) as usize])
-        ),
+        sha256_digest(&bs),
+        sha256_digest(&content[offset as usize..(offset + length) as usize]),
         "read content"
     );
 
@@ -129,11 +120,7 @@ pub async fn test_reader(op: Operator) -> anyhow::Result<()> {
     // Reader.
     let bs = op.reader(&path).await?.read(..).await?.to_bytes();
     assert_eq!(size, bs.len(), "read size");
-    assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
-        format!("{:x}", Sha256::digest(&content)),
-        "read content"
-    );
+    assert_eq!(sha256_digest(&bs), sha256_digest(&content), "read content");
 
     // Bytes Stream
     let bs = op
@@ -147,11 +134,7 @@ pub async fn test_reader(op: Operator) -> anyhow::Result<()> {
         })
         .await?;
     assert_eq!(size, bs.len(), "read size");
-    assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
-        format!("{:x}", Sha256::digest(&content)),
-        "read content"
-    );
+    assert_eq!(sha256_digest(&bs), sha256_digest(&content), "read content");
 
     // Futures Reader
     let mut futures_reader = op
@@ -162,11 +145,7 @@ pub async fn test_reader(op: Operator) -> anyhow::Result<()> {
     let mut bs = Vec::new();
     futures_reader.read_to_end(&mut bs).await?;
     assert_eq!(size, bs.len(), "read size");
-    assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
-        format!("{:x}", Sha256::digest(&content)),
-        "read content"
-    );
+    assert_eq!(sha256_digest(&bs), sha256_digest(&content), "read content");
 
     Ok(())
 }
@@ -392,11 +371,7 @@ pub async fn test_read_with_special_chars(op: Operator) -> anyhow::Result<()> {
 
     let bs = op.read(&path).await?.to_bytes();
     assert_eq!(size, bs.len(), "read size");
-    assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
-        format!("{:x}", Sha256::digest(&content)),
-        "read content"
-    );
+    assert_eq!(sha256_digest(&bs), sha256_digest(&content), "read content");
 
     Ok(())
 }
@@ -610,7 +585,7 @@ pub async fn test_read_only_read_full(op: Operator) -> anyhow::Result<()> {
     let bs = op.read("normal_file.txt").await?.to_bytes();
     assert_eq!(bs.len(), 30482, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
+        sha256_digest(&bs),
         "943048ba817cdcd786db07d1f42d5500da7d10541c2f9353352cd2d3f66617e5",
         "read content"
     );
@@ -626,7 +601,7 @@ pub async fn test_read_only_read_full_with_special_chars(op: Operator) -> anyhow
         .to_bytes();
     assert_eq!(bs.len(), 30482, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
+        sha256_digest(&bs),
         "943048ba817cdcd786db07d1f42d5500da7d10541c2f9353352cd2d3f66617e5",
         "read content"
     );
@@ -643,7 +618,7 @@ pub async fn test_read_only_read_with_range(op: Operator) -> anyhow::Result<()> 
         .to_bytes();
     assert_eq!(bs.len(), 1024, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
+        sha256_digest(&bs),
         "330c6d57fdc1119d6021b37714ca5ad0ede12edd484f66be799a5cff59667034",
         "read content"
     );
@@ -697,7 +672,7 @@ pub async fn test_reader_only_read_with_if_match(op: Operator) -> anyhow::Result
 
     assert_eq!(bs.len(), 30482, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
+        sha256_digest(&bs),
         "943048ba817cdcd786db07d1f42d5500da7d10541c2f9353352cd2d3f66617e5",
         "read content"
     );
@@ -727,7 +702,7 @@ pub async fn test_read_only_read_with_if_match(op: Operator) -> anyhow::Result<(
         .to_bytes();
     assert_eq!(bs.len(), 30482, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
+        sha256_digest(&bs),
         "943048ba817cdcd786db07d1f42d5500da7d10541c2f9353352cd2d3f66617e5",
         "read content"
     );
@@ -759,7 +734,7 @@ pub async fn test_reader_only_read_with_if_none_match(op: Operator) -> anyhow::R
 
     assert_eq!(bs.len(), 30482, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
+        sha256_digest(&bs),
         "943048ba817cdcd786db07d1f42d5500da7d10541c2f9353352cd2d3f66617e5",
         "read content"
     );
@@ -792,7 +767,7 @@ pub async fn test_read_only_read_with_if_none_match(op: Operator) -> anyhow::Res
         .to_bytes();
     assert_eq!(bs.len(), 30482, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
+        sha256_digest(&bs),
         "943048ba817cdcd786db07d1f42d5500da7d10541c2f9353352cd2d3f66617e5",
         "read content"
     );

--- a/core/tests/behavior/async_rename.rs
+++ b/core/tests/behavior/async_rename.rs
@@ -16,8 +16,6 @@
 // under the License.
 
 use anyhow::Result;
-use sha2::Digest;
-use sha2::Sha256;
 
 use crate::*;
 
@@ -58,8 +56,8 @@ pub async fn test_rename_file(op: Operator) -> Result<()> {
         .expect("read must succeed")
         .to_bytes();
     assert_eq!(
-        format!("{:x}", Sha256::digest(target_content)),
-        format!("{:x}", Sha256::digest(&source_content)),
+        sha256_digest(target_content),
+        sha256_digest(&source_content),
     );
 
     op.delete(&source_path).await.expect("delete must succeed");
@@ -167,8 +165,8 @@ pub async fn test_rename_nested(op: Operator) -> Result<()> {
         .expect("read must succeed")
         .to_bytes();
     assert_eq!(
-        format!("{:x}", Sha256::digest(target_content)),
-        format!("{:x}", Sha256::digest(&source_content)),
+        sha256_digest(target_content),
+        sha256_digest(&source_content),
     );
 
     op.delete(&source_path).await.expect("delete must succeed");
@@ -200,8 +198,8 @@ pub async fn test_rename_overwrite(op: Operator) -> Result<()> {
         .expect("read must succeed")
         .to_bytes();
     assert_eq!(
-        format!("{:x}", Sha256::digest(target_content)),
-        format!("{:x}", Sha256::digest(&source_content)),
+        sha256_digest(target_content),
+        sha256_digest(&source_content),
     );
 
     op.delete(&source_path).await.expect("delete must succeed");

--- a/core/tests/behavior/async_write.rs
+++ b/core/tests/behavior/async_write.rs
@@ -25,8 +25,6 @@ use futures::StreamExt;
 use futures::io::BufReader;
 use futures::io::Cursor;
 use futures::stream;
-use sha2::Digest;
-use sha2::Sha256;
 
 use crate::*;
 
@@ -338,13 +336,13 @@ pub async fn test_writer_write(op: Operator) -> Result<()> {
     let bs = op.read(&path).await?.to_bytes();
     assert_eq!(bs.len(), size * 2, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs[..size])),
-        format!("{:x}", Sha256::digest(content_a)),
+        sha256_digest(&bs[..size]),
+        sha256_digest(content_a),
         "read content a"
     );
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs[size..])),
-        format!("{:x}", Sha256::digest(content_b)),
+        sha256_digest(&bs[size..]),
+        sha256_digest(content_b),
         "read content b"
     );
 
@@ -375,21 +373,18 @@ pub async fn test_writer_write_with_concurrent(op: Operator) -> Result<()> {
     let bs = op.read(&path).await?.to_bytes();
     assert_eq!(bs.len(), size_a + size_b + size_c, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs[..size_a])),
-        format!("{:x}", Sha256::digest(content_a)),
+        sha256_digest(&bs[..size_a]),
+        sha256_digest(content_a),
         "read content a"
     );
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs[size_a..size_a + size_b])),
-        format!("{:x}", Sha256::digest(content_b)),
+        sha256_digest(&bs[size_a..size_a + size_b]),
+        sha256_digest(content_b),
         "read content b"
     );
     assert_eq!(
-        format!(
-            "{:x}",
-            Sha256::digest(&bs[size_a + size_b..size_a + size_b + size_c])
-        ),
-        format!("{:x}", Sha256::digest(content_c)),
+        sha256_digest(&bs[size_a + size_b..size_a + size_b + size_c]),
+        sha256_digest(content_c),
         "read content b"
     );
 
@@ -427,13 +422,13 @@ pub async fn test_writer_sink(op: Operator) -> Result<()> {
     let bs = op.read(&path).await?.to_bytes();
     assert_eq!(bs.len(), size * 2, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs[..size])),
-        format!("{:x}", Sha256::digest(content_a)),
+        sha256_digest(&bs[..size]),
+        sha256_digest(content_a),
         "read content a"
     );
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs[size..])),
-        format!("{:x}", Sha256::digest(content_b)),
+        sha256_digest(&bs[size..]),
+        sha256_digest(content_b),
         "read content b"
     );
 
@@ -472,13 +467,13 @@ pub async fn test_writer_sink_with_concurrent(op: Operator) -> Result<()> {
     let bs = op.read(&path).await?.to_bytes();
     assert_eq!(bs.len(), size * 2, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs[..size])),
-        format!("{:x}", Sha256::digest(content_a)),
+        sha256_digest(&bs[..size]),
+        sha256_digest(content_a),
         "read content a"
     );
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs[size..])),
-        format!("{:x}", Sha256::digest(content_b)),
+        sha256_digest(&bs[size..]),
+        sha256_digest(content_b),
         "read content b"
     );
 
@@ -512,8 +507,8 @@ pub async fn test_writer_futures_copy(op: Operator) -> Result<()> {
     let bs = op.read(&path).await?.to_bytes();
     assert_eq!(bs.len(), size, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs[..size])),
-        format!("{:x}", Sha256::digest(content)),
+        sha256_digest(&bs[..size]),
+        sha256_digest(content),
         "read content"
     );
 
@@ -548,8 +543,8 @@ pub async fn test_writer_futures_copy_with_concurrent(op: Operator) -> Result<()
     let bs = op.read(&path).await?.to_bytes();
     assert_eq!(bs.len(), size, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs[..size])),
-        format!("{:x}", Sha256::digest(content)),
+        sha256_digest(&bs[..size]),
+        sha256_digest(content),
         "read content"
     );
 
@@ -683,8 +678,8 @@ pub async fn test_writer_with_append(op: Operator) -> Result<()> {
     let bs = op.read(&path).await?.to_bytes();
     assert_eq!(bs.len(), size, "read size");
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs[..size])),
-        format!("{:x}", Sha256::digest(content)),
+        sha256_digest(&bs[..size]),
+        sha256_digest(content),
         "read content"
     );
 
@@ -706,8 +701,8 @@ pub async fn test_writer_write_with_overwrite(op: Operator) -> Result<()> {
     op.write(&path, content_one.clone()).await?;
     let bs = op.read(&path).await?.to_bytes();
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
-        format!("{:x}", Sha256::digest(&content_one)),
+        sha256_digest(&bs),
+        sha256_digest(&content_one),
         "read content_one"
     );
     op.write(&path, content_two.clone())
@@ -715,13 +710,13 @@ pub async fn test_writer_write_with_overwrite(op: Operator) -> Result<()> {
         .expect("write overwrite must succeed");
     let bs = op.read(&path).await?.to_bytes();
     assert_ne!(
-        format!("{:x}", Sha256::digest(&bs)),
-        format!("{:x}", Sha256::digest(&content_one)),
+        sha256_digest(&bs),
+        sha256_digest(&content_one),
         "content_one must be overwrote"
     );
     assert_eq!(
-        format!("{:x}", Sha256::digest(&bs)),
-        format!("{:x}", Sha256::digest(&content_two)),
+        sha256_digest(&bs),
+        sha256_digest(&content_two),
         "read content_two"
     );
 
@@ -819,9 +814,9 @@ pub async fn test_writer_write_non_contiguous_data(op: Operator) -> Result<()> {
     let path = TEST_FIXTURE.new_file_path();
     let size = 1024 * 1024; // write file with 1 MiB
     let content_a = gen_fixed_bytes(size);
-    let digest_a = Sha256::digest(&content_a);
+    let digest_a = sha256_digest(&content_a);
     let content_b = gen_fixed_bytes(size);
-    let digest_b = Sha256::digest(&content_b);
+    let digest_b = sha256_digest(&content_b);
 
     let mut w = op.writer(&path).await?;
     w.write(vec![Bytes::from(content_a), Bytes::from(content_b)])
@@ -833,16 +828,8 @@ pub async fn test_writer_write_non_contiguous_data(op: Operator) -> Result<()> {
 
     let bs = op.read(&path).await?.to_bytes();
     assert_eq!(bs.len(), size * 2, "read size");
-    assert_eq!(
-        format!("{:x}", Sha256::digest(&bs[..size])),
-        format!("{:x}", digest_a),
-        "read content a"
-    );
-    assert_eq!(
-        format!("{:x}", Sha256::digest(&bs[size..])),
-        format!("{:x}", digest_b),
-        "read content b"
-    );
+    assert_eq!(sha256_digest(&bs[..size]), digest_a, "read content a");
+    assert_eq!(sha256_digest(&bs[size..]), digest_b, "read content b");
 
     Ok(())
 }

--- a/core/tests/behavior/utils.rs
+++ b/core/tests/behavior/utils.rs
@@ -26,6 +26,19 @@ use opendal::tests::TEST_RUNTIME;
 use opendal::*;
 use rand::distributions::uniform::SampleRange;
 use rand::prelude::*;
+use sha2::Digest;
+use sha2::Sha256;
+
+pub fn sha256_digest(data: impl AsRef<[u8]>) -> String {
+    use std::fmt::Write;
+
+    let digest = Sha256::digest(data);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut output, "{byte:02x}").expect("writing to String must succeed");
+    }
+    output
+}
 
 pub fn gen_bytes_with_range(range: impl SampleRange<usize>) -> (Vec<u8>, usize) {
     let mut rng = thread_rng();

--- a/dev/Cargo.lock
+++ b/dev/Cargo.lock
@@ -80,11 +80,11 @@ checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -159,10 +159,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -203,12 +209,11 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -219,11 +224,12 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -290,16 +296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "globset"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +319,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "ignore"
@@ -757,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -902,9 +907,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-id"
@@ -960,12 +965,6 @@ dependencies = [
  "sval_ref",
  "sval_serde",
 ]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/dev/Cargo.toml
+++ b/dev/Cargo.toml
@@ -41,7 +41,7 @@ regex = { version = "1.11.1" }
 semver = { version = "1.0.25" }
 serde = { version = "1.0.216", features = ["derive"] }
 serde_json = { version = "1.0.138", features = ["preserve_order"] }
-sha2 = { version = "0.10.8" }
+sha2 = { version = "0.11.0" }
 syn = { version = "2.0.91", features = ["visit", "full", "extra-traits"] }
 tar = { version = "0.4.43" }
 toml_edit = { version = "0.22.23", features = ["serde"] }

--- a/dev/src/release/mod.rs
+++ b/dev/src/release/mod.rs
@@ -20,6 +20,7 @@ use flate2::Compression;
 use flate2::write::GzEncoder;
 use sha2::{Digest, Sha512};
 use std::io::BufReader;
+use std::io::Read;
 
 mod package;
 
@@ -102,9 +103,16 @@ fn archive_and_checksum(package: &package::Package, files: &[&str]) -> anyhow::R
         let tarball = std::fs::File::open(&tarball)?;
         let mut reader = BufReader::new(tarball);
         let mut hasher = Sha512::new();
-        std::io::copy(&mut reader, &mut hasher)?;
+        let mut buf = [0; 8 * 1024];
+        loop {
+            let n = reader.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buf[..n]);
+        }
         let digest = hasher.finalize();
-        let checksum_lines = format!("{digest:x}  {filename}");
+        let checksum_lines = format!("{}  {filename}", format_digest_hex(digest));
 
         let checksum = workspace_dir()
             .join("dist")
@@ -113,4 +121,15 @@ fn archive_and_checksum(package: &package::Package, files: &[&str]) -> anyhow::R
     }
 
     Ok(())
+}
+
+fn format_digest_hex(digest: impl AsRef<[u8]>) -> String {
+    use std::fmt::Write;
+
+    let digest = digest.as_ref();
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut output, "{byte:02x}").expect("writing to String must succeed");
+    }
+    output
 }


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

This upgrades OpenDAL's direct RustCrypto digest/hash dependencies to the current digest 0.11 family, including md-5 0.11, hmac 0.13, sha1 0.11, and sha2 0.11.

# What changes are included in this PR?

Direct Rust/Cargo dependencies are updated across core, affected services, testkit, and dev tooling. The code is adjusted for the hmac 0.13 KeyInit import, explicit hex encoding for digest outputs, and the dev release checksum path now feeds Sha512 via Digest::update.

# Are there any user-facing changes?

No.

# AI Usage Statement

N/A.
