### PR TITLE
fix(core): refresh tos lockfile entry

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -7604,7 +7604,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opendal-core",
- "quick-xml 0.38.4",
+ "quick-xml",
  "reqsign-core",
  "reqsign-file-read-tokio",
  "reqsign-volcengine-tos",


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

Main Core CI fails because `core/Cargo.lock` still refers to `quick-xml 0.38.4` in the `opendal-service-tos` dependency list, while the workspace now resolves `quick-xml` to `0.39.3`. With `--locked`, Cargo refuses to rewrite the stale lockfile entry.

# What changes are included in this PR?

Refresh the TOS lockfile dependency entry so locked builds can use the existing resolved `quick-xml` package.

# Are there any user-facing changes?

No.

# AI Usage Statement

N/A.
