### PR TITLE
ci: Add ASF allowlist check

### DIFF
--- a/.github/workflows/asf_allowlist_check.yml
+++ b/.github/workflows/asf_allowlist_check.yml
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: ASF Allowlist Check
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  asf-allowlist-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: apache/infrastructure-actions/allowlist-check@main
+        with:
+          scan-glob: ".github/**/*.y*ml"


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

ASF GitHub Actions policy failures can surface as startup failures with little useful job output. Adding the ASF allowlist check makes workflow allowlist violations visible during PR review before they reach `main`.

# What changes are included in this PR?

This adds a dedicated `ASF Allowlist Check` workflow for `.github/**` changes. It runs `apache/infrastructure-actions/allowlist-check@main` against `.github/**/*.y*ml`, covering both workflow files and composite action YAML files.

# Are there any user-facing changes?

No.

# AI Usage Statement

This PR was prepared with AI assistance.
