### PR TITLE
ci: install wasm-pack from official installer

### DIFF
--- a/.github/workflows/test_edge.yml
+++ b/.github/workflows/test_edge.yml
@@ -90,9 +90,11 @@ jobs:
           cp -r chromedriver-linux64 /tmp/chrome/chromedriver
 
       - name: Setup wasm-pack
-        uses: taiki-e/install-action@v2
-        with:
-          tool: wasm-pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://wasm-bindgen.github.io/wasm-pack/installer/init.sh | bash
+          wasm-pack --version
 
       - name: Setup MinIO Server
         shell: bash


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

The Edge Test workflow currently installs wasm-pack through taiki-e/install-action. It resolves wasm-pack to v0.14.0 but attempts to download the asset from drager/wasm-pack, where the release asset returns 404.

The official wasm-pack installer downloads from wasm-bindgen/wasm-pack, where the v0.14.0 release assets are available.

# What changes are included in this PR?

Install wasm-pack through the official wasm-pack installer in the edge test workflow and print the installed version as a setup check.

# Are there any user-facing changes?

No.

# AI Usage Statement

AI assistance was used to prepare this PR.
