### PR TITLE
feat(services/s3): support configuring assume role session tags

### DIFF
--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -204,6 +204,12 @@ impl S3Builder {
         self
     }
 
+    /// Set assume_role_session_tags for this backend.
+    pub fn assume_role_session_tags(mut self, tags: HashMap<String, String>) -> Self {
+        self.config.assume_role_session_tags = Some(tags);
+        self
+    }
+
     /// Set default storage_class for this backend.
     ///
     /// Available values:
@@ -858,6 +864,10 @@ impl Builder for S3Builder {
             }
             if let Some(duration_seconds) = config.assume_role_duration_seconds {
                 assume_role_provider = assume_role_provider.with_duration_seconds(duration_seconds);
+            }
+            if let Some(tags) = &config.assume_role_session_tags {
+                assume_role_provider = assume_role_provider
+                    .with_tags(tags.iter().map(|(k, v)| (k.clone(), v.clone())).collect());
             }
             provider = ProvideCredentialChain::new().push(assume_role_provider);
         }

--- a/core/services/s3/src/config.rs
+++ b/core/services/s3/src/config.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 
 use opendal_core::Configurator;
@@ -104,6 +105,8 @@ pub struct S3Config {
     pub role_session_name: Option<String>,
     /// assume_role_duration_seconds for this backend.
     pub assume_role_duration_seconds: Option<u32>,
+    /// assume_role_session_tags for this backend.
+    pub assume_role_session_tags: Option<HashMap<String, String>>,
     /// Disable config load so that opendal will not load config from
     /// environment.
     ///


### PR DESCRIPTION
# Which issue does this PR close?
Closes #4975.

# Rationale for this change
AWS STS AssumeRole supports passing session tags for downstream attribute-based access control (ABAC) and audit purposes.
Upstream `reqsign-aws-v4` v3.0.0 already exposes `AssumeRoleCredentialProvider::with_tags(Vec<(String, String)>)`, so this PR is purely a config exposure on the OpenDAL side, mirroring #7495.

# What changes are included in this PR?
- Add `assume_role_session_tags: Option<HashMap<String, String>>` field to `S3Config`.
- Add `S3Builder::assume_role_session_tags` builder method.
- Pass the value through in `S3Builder::build`, mirroring the existing `assume_role_duration_seconds` wiring.

# Are there any user-facing changes?
Yes — a new public config field and a new builder method. Not a breaking change: the field is `Option<HashMap<String, String>>` defaulting to `None`, which preserves current behavior.

# AI Usage Statement
AI-assisted implementation.