### PR TITLE
fix(services): redact credentials in debug output

### DIFF
--- a/core/services/dbfs/src/core.rs
+++ b/core/services/dbfs/src/core.rs
@@ -42,7 +42,7 @@ impl Debug for DbfsCore {
         f.debug_struct("DbfsCore")
             .field("root", &self.root)
             .field("endpoint", &self.endpoint)
-            .field("token", &self.token)
+            .field("token", &"<redacted>")
             .finish_non_exhaustive()
     }
 }

--- a/core/services/lakefs/src/core.rs
+++ b/core/services/lakefs/src/core.rs
@@ -41,7 +41,7 @@ impl Debug for LakefsCore {
         f.debug_struct("LakefsCore")
             .field("endpoint", &self.endpoint)
             .field("username", &self.username)
-            .field("password", &self.password)
+            .field("password", &"<redacted>")
             .field("root", &self.root)
             .field("repository", &self.repository)
             .field("branch", &self.branch)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7522 

# Rationale for this change

`LakefsCore::fmt` currently prints `password`, and `DbfsCore::fmt` prints `token`. Since `LakefsBackend` and `DbfsBackend` derive `Debug`, formatting these backends with `{:?}` can expose credentials in logs.

Debug output should not leak sensitive credentials.

# What changes are included in this PR?

This PR redacts sensitive fields in debug output:

- Redact `LakefsCore.password`.
- Redact `DbfsCore.token`.

# Are there any user-facing changes?

No public API changes.

The only user-facing behavior change is that debug output now shows `<redacted>` instead of the actual credential value.

# AI Usage Statement

This PR was prepared with assistance from OpenAI Codex.
