### PR TITLE
feat(services/cos): support copy_with_if_not_exists via x-cos-forbid-…

### DIFF
--- a/core/services/cos/src/backend.rs
+++ b/core/services/cos/src/backend.rs
@@ -246,6 +246,8 @@ impl Builder for CosBuilder {
                             write_with_content_disposition: true,
                             // Cos doesn't support forbid overwrite while version has been enabled.
                             write_with_if_not_exists: !self.config.enable_versioning,
+                            // Same as write: forbid-overwrite only works when versioning is disabled.
+                            copy_with_if_not_exists: !self.config.enable_versioning,
                             // The min multipart size of COS is 1 MiB.
                             //
                             // ref: <https://www.tencentcloud.com/document/product/436/14112>
@@ -392,8 +394,8 @@ impl Access for CosBackend {
         Ok((RpList::default(), l))
     }
 
-    async fn copy(&self, from: &str, to: &str, _args: OpCopy) -> Result<RpCopy> {
-        let resp = self.core.cos_copy_object(from, to).await?;
+    async fn copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
+        let resp = self.core.cos_copy_object(from, to, &args).await?;
 
         let status = resp.status();
 

--- a/core/services/cos/src/core.rs
+++ b/core/services/cos/src/core.rs
@@ -314,18 +314,31 @@ impl CosCore {
         Ok(req)
     }
 
-    pub async fn cos_copy_object(&self, from: &str, to: &str) -> Result<Response<Buffer>> {
+    pub async fn cos_copy_object(
+        &self,
+        from: &str,
+        to: &str,
+        args: &OpCopy,
+    ) -> Result<Response<Buffer>> {
         let source = build_abs_path(&self.root, from);
         let target = build_abs_path(&self.root, to);
 
         let source = format!("/{}/{}", self.bucket, percent_encode_path(&source));
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&target));
 
-        let req = Request::put(&url)
+        let mut req = Request::put(&url)
             .extension(Operation::Copy)
-            .header("x-cos-copy-source", &source)
-            .body(Buffer::new())
-            .map_err(new_request_build_error)?;
+            .header("x-cos-copy-source", &source);
+
+        // For a bucket which has never enabled versioning, x-cos-forbid-overwrite
+        // tells COS to reject the copy when the destination object already exists.
+        //
+        // ref: https://www.tencentcloud.com/document/product/436/10881
+        if args.if_not_exists() {
+            req = req.header("x-cos-forbid-overwrite", "true");
+        }
+
+        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
         let req = self.sign(req).await?;
 


### PR DESCRIPTION
…overwrite

Currently the COS backend declares write_with_if_not_exists but the COPY path silently drops OpCopy.if_not_exists: the copy() impl annotates the arg as `_args`, and cos_copy_object() does not even take an OpCopy.

This is observable when frameworks such as object_store use the default rename_if_not_exists implementation (copy_if_not_exists + delete) for commit-style atomicity (Lance, Iceberg, Delta, etc.). Without the x-cos-forbid-overwrite header, concurrent committers all win the COPY and silently overwrite each others manifests.

Changes:
* backend.rs: declare copy_with_if_not_exists capability (gated on enable_versioning, mirroring write_with_if_not_exists).
* backend.rs: stop dropping OpCopy and forward it to the core.
* core.rs: cos_copy_object now accepts &OpCopy and emits x-cos-forbid-overwrite: true when args.if_not_exists() is set.

Tested:
* cargo check / cargo test --lib -p opendal-service-cos pass.
* End-to-end verified against ap-guangzhou COS using the patched build: single-writer T1/T2 scenarios behave correctly (200 / 409 FileAlreadyExists). Highly-concurrent races on the same fresh key still show non-atomic behavior on the server side, but that is a separate server-level issue and out of scope for this PR.

Refs: https://www.tencentcloud.com/document/product/436/7749

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
