### PR TITLE
feat(binding/c): extract metadata from list entry

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -1542,6 +1542,14 @@ char *opendal_entry_path(const struct opendal_entry *self);
 char *opendal_entry_name(const struct opendal_entry *self);
 
 /**
+ * \brief Return the metadata associated with this entry.
+ *
+ * The returned metadata is heap-allocated and must be freed
+ * by the caller via opendal_metadata_free().
+ */
+struct opendal_metadata *opendal_entry_metadata(const struct opendal_entry *self);
+
+/**
  * \brief Frees the heap memory used by the opendal_list_entry
  */
 void opendal_entry_free(struct opendal_entry *ptr);

--- a/bindings/c/src/entry.rs
+++ b/bindings/c/src/entry.rs
@@ -20,6 +20,8 @@ use std::os::raw::c_char;
 
 use ::opendal as core;
 
+use super::opendal_metadata;
+
 /// \brief opendal_list_entry is the entry under a path, which is listed from the opendal_lister
 ///
 /// For examples, please see the comment section of opendal_operator_list()
@@ -73,6 +75,16 @@ impl opendal_entry {
         let s = self.deref().name();
         let c_str = CString::new(s).unwrap();
         c_str.into_raw()
+    }
+
+    /// \brief Return the metadata associated with this entry.
+    ///
+    /// The returned metadata is heap-allocated and must be freed
+    /// by the caller via opendal_metadata_free().
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_entry_metadata(&self) -> *mut opendal_metadata {
+        let metadata = self.deref().metadata().clone();
+        Box::into_raw(Box::new(opendal_metadata::new(metadata)))
     }
 
     /// \brief Frees the heap memory used by the opendal_list_entry

--- a/bindings/c/tests/test_suites_list.cpp
+++ b/bindings/c/tests/test_suites_list.cpp
@@ -282,12 +282,79 @@ void test_entry_name_path(opendal_test_context* ctx)
     opendal_operator_delete(ctx->config->operator_instance, dir_path);
 }
 
+// Test: Entry metadata from lister
+void test_entry_metadata(opendal_test_context* ctx)
+{
+    const char* dir_path = "test_entry_meta/";
+    const char* file_path = "test_entry_meta/file.txt";
+    const char* content_str = "hello, metadata!";
+    const size_t content_len = strlen(content_str);
+
+    // Create directory and file
+    opendal_error* error = opendal_operator_create_dir(ctx->config->operator_instance, dir_path);
+    OPENDAL_ASSERT_NO_ERROR(error, "Create dir should succeed");
+
+    opendal_bytes data;
+    data.data = (uint8_t*)content_str;
+    data.len = content_len;
+    data.capacity = content_len;
+    error = opendal_operator_write(ctx->config->operator_instance, file_path, &data);
+    OPENDAL_ASSERT_NO_ERROR(error, "Write should succeed");
+
+    // List directory
+    opendal_result_list list_result = opendal_operator_list(ctx->config->operator_instance, dir_path);
+    OPENDAL_ASSERT_NO_ERROR(list_result.error, "List operation should succeed");
+
+    bool found_file = false;
+    bool found_dir = false;
+    while (true) {
+        opendal_result_lister_next next_result = opendal_lister_next(list_result.lister);
+        if (next_result.error) {
+            OPENDAL_ASSERT_NO_ERROR(next_result.error, "Lister next should not fail");
+            break;
+        }
+
+        if (!next_result.entry) {
+            break;
+        }
+
+        char* path = opendal_entry_path(next_result.entry);
+        opendal_metadata* meta = opendal_entry_metadata(next_result.entry);
+        OPENDAL_ASSERT_NOT_NULL(meta, "Entry metadata should not be null");
+
+        if (strcmp(path, file_path) == 0) {
+            found_file = true;
+            OPENDAL_ASSERT(opendal_metadata_is_file(meta), "File entry should be a file");
+            OPENDAL_ASSERT(!opendal_metadata_is_dir(meta), "File entry should not be a dir");
+            OPENDAL_ASSERT_EQ((long)content_len, (long)opendal_metadata_content_length(meta),
+                "Content length should match written data");
+        } else if (strcmp(path, dir_path) == 0) {
+            found_dir = true;
+            OPENDAL_ASSERT(opendal_metadata_is_dir(meta), "Dir entry should be a dir");
+            OPENDAL_ASSERT(!opendal_metadata_is_file(meta), "Dir entry should not be a file");
+        }
+
+        opendal_metadata_free(meta);
+        free(path);
+        opendal_entry_free(next_result.entry);
+    }
+
+    OPENDAL_ASSERT(found_file, "Should have found the test file");
+
+    // Cleanup
+    opendal_lister_free(list_result.lister);
+    opendal_operator_delete(ctx->config->operator_instance, file_path);
+    opendal_operator_delete(ctx->config->operator_instance, dir_path);
+}
+
 // Define the list test suite
 opendal_test_case list_tests[] = {
     { "list_basic", test_list_basic, make_capability_write_create_dir_list() },
     { "list_empty_dir", test_list_empty_dir, make_capability_create_dir_list() },
     { "list_nested", test_list_nested, make_capability_write_create_dir_list() },
     { "entry_name_path", test_entry_name_path,
+        make_capability_write_create_dir_list() },
+    { "entry_metadata", test_entry_metadata,
         make_capability_write_create_dir_list() },
 };
 


### PR DESCRIPTION
# Rationale for this change

I'm trying to integrate opendal into kuberay history server, thus cleaning up blocker items for golang binding.

# What changes are included in this PR?

This PR implements the metadata extraction from list entries.

# Are there any user-facing changes?

Yes, no API added.

# AI Usage Statement

Opus 4.7 made all the code change for me, I eyeball-checked the code and looks fine.