### PR TITLE
feat(metrics): add operation label to a few backends [1/N]

### DIFF
--- a/core/services/azfile/src/core.rs
+++ b/core/services/azfile/src/core.rs
@@ -101,7 +101,9 @@ impl AzfileCore {
             req = req.header(RANGE, range.to_header());
         }
 
-        let req = req.extension(Operation::Read);
+        let req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("GetFile"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
         let req = self.sign(req).await?;
@@ -150,7 +152,9 @@ impl AzfileCore {
             }
         }
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("CreateFile"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
         let req = self.sign(req).await?;
@@ -186,7 +190,9 @@ impl AzfileCore {
             BytesRange::from(position..position + size).to_header(),
         );
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("PutRange"));
 
         let req = req.body(body).map_err(new_request_build_error)?;
         let req = self.sign(req).await?;
@@ -204,7 +210,9 @@ impl AzfileCore {
 
         let req = Request::head(&url);
 
-        let req = req.extension(Operation::Stat);
+        let req = req
+            .extension(Operation::Stat)
+            .extension(ServiceOperation("GetFileProperties"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
         let req = self.sign(req).await?;
@@ -223,7 +231,9 @@ impl AzfileCore {
 
         let req = Request::head(&url);
 
-        let req = req.extension(Operation::Stat);
+        let req = req
+            .extension(Operation::Stat)
+            .extension(ServiceOperation("GetDirectoryProperties"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
         let req = self.sign(req).await?;
@@ -275,7 +285,9 @@ impl AzfileCore {
 
         req = req.header(X_MS_FILE_RENAME_REPLACE_IF_EXISTS, "true");
 
-        let req = req.extension(Operation::Rename);
+        let req = req
+            .extension(Operation::Rename)
+            .extension(ServiceOperation("Rename"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
         let req = self.sign(req).await?;
@@ -298,7 +310,9 @@ impl AzfileCore {
 
         req = req.header(CONTENT_LENGTH, 0);
 
-        let req = req.extension(Operation::CreateDir);
+        let req = req
+            .extension(Operation::CreateDir)
+            .extension(ServiceOperation("CreateDirectory"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
         let req = self.sign(req).await?;
@@ -319,7 +333,9 @@ impl AzfileCore {
 
         let req = Request::delete(&url);
 
-        let req = req.extension(Operation::Delete);
+        let req = req
+            .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteFile"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
         let req = self.sign(req).await?;
@@ -340,7 +356,9 @@ impl AzfileCore {
 
         let req = Request::delete(&url);
 
-        let req = req.extension(Operation::Delete);
+        let req = req
+            .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteDirectory"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
         let req = self.sign(req).await?;
@@ -379,7 +397,9 @@ impl AzfileCore {
 
         let req = Request::get(url.finish());
 
-        let req = req.extension(Operation::List);
+        let req = req
+            .extension(Operation::List)
+            .extension(ServiceOperation("ListDirectoriesAndFiles"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
         let req = self.sign(req).await?;

--- a/core/services/cos/src/core.rs
+++ b/core/services/cos/src/core.rs
@@ -149,7 +149,9 @@ impl CosCore {
             req = req.header(IF_UNMODIFIED_SINCE, if_unmodified_since.format_http_date());
         }
 
-        let req = req.extension(Operation::Read);
+        let req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("GetObject"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -201,7 +203,9 @@ impl CosCore {
             }
         }
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("PutObject"));
 
         let req = req.body(body).map_err(new_request_build_error)?;
 
@@ -242,7 +246,9 @@ impl CosCore {
             req = req.header(IF_NONE_MATCH, if_none_match);
         }
 
-        let req = req.extension(Operation::Stat);
+        let req = req
+            .extension(Operation::Stat)
+            .extension(ServiceOperation("HeadObject"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -268,7 +274,9 @@ impl CosCore {
 
         let req = Request::delete(&url);
 
-        let req = req.extension(Operation::Delete);
+        let req = req
+            .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteObject"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
         let req = self.sign(req).await?;
@@ -308,7 +316,9 @@ impl CosCore {
             req = req.header(CACHE_CONTROL, cache_control)
         }
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("AppendObject"));
 
         let req = req.body(body).map_err(new_request_build_error)?;
         Ok(req)
@@ -328,6 +338,7 @@ impl CosCore {
 
         let mut req = Request::put(&url)
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyObject"))
             .header("x-cos-copy-source", &source);
 
         // For a bucket which has never enabled versioning, x-cos-forbid-overwrite
@@ -371,6 +382,7 @@ impl CosCore {
 
         let req = Request::get(url.finish())
             .extension(Operation::List)
+            .extension(ServiceOperation("ListObjects"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -409,7 +421,9 @@ impl CosCore {
             }
         }
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("InitiateMultipartUpload"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
         let req = self.sign(req).await?;
@@ -438,7 +452,9 @@ impl CosCore {
         let mut req = Request::put(&url);
         req = req.header(CONTENT_LENGTH, size);
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("UploadPart"));
 
         // Set body
         let req = req.body(body).map_err(new_request_build_error)?;
@@ -471,7 +487,9 @@ impl CosCore {
         // Set content-type to `application/xml` to avoid mixed with form post.
         let req = req.header(CONTENT_TYPE, "application/xml");
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("CompleteMultipartUpload"));
 
         let req = req
             .body(Buffer::from(Bytes::from(content)))
@@ -499,6 +517,7 @@ impl CosCore {
 
         let req = Request::delete(&url)
             .extension(Operation::Delete)
+            .extension(ServiceOperation("AbortMultipartUpload"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
         let req = self.sign(req).await?;
@@ -536,6 +555,7 @@ impl CosCore {
 
         let req = Request::get(url.finish())
             .extension(Operation::List)
+            .extension(ServiceOperation("ListObjectVersions"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 

--- a/core/services/obs/src/core.rs
+++ b/core/services/obs/src/core.rs
@@ -127,6 +127,7 @@ impl ObsCore {
 
         let req = req
             .extension(Operation::Read)
+            .extension(ServiceOperation("GetObject"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -166,6 +167,7 @@ impl ObsCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("PutObject"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -200,6 +202,7 @@ impl ObsCore {
 
         let req = req
             .extension(Operation::Stat)
+            .extension(ServiceOperation("HeadObject"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -215,6 +218,7 @@ impl ObsCore {
 
         let req = req
             .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteObject"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -257,6 +261,7 @@ impl ObsCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("AppendObject"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -272,6 +277,7 @@ impl ObsCore {
 
         let req = Request::put(&url)
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyObject"))
             .header("x-obs-copy-source", &source)
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
@@ -306,6 +312,7 @@ impl ObsCore {
 
         let req = Request::get(url.finish())
             .extension(Operation::List)
+            .extension(ServiceOperation("ListObjects"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -329,6 +336,7 @@ impl ObsCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("InitiateMultipartUpload"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -362,6 +370,7 @@ impl ObsCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("UploadPart"))
             // Set body
             .body(body)
             .map_err(new_request_build_error)?;
@@ -398,6 +407,7 @@ impl ObsCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("CompleteMultipartUpload"))
             .body(Buffer::from(Bytes::from(content)))
             .map_err(new_request_build_error)?;
 
@@ -422,6 +432,7 @@ impl ObsCore {
 
         let req = Request::delete(&url)
             .extension(Operation::Write)
+            .extension(ServiceOperation("AbortMultipartUpload"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 

--- a/core/services/tos/src/core.rs
+++ b/core/services/tos/src/core.rs
@@ -239,7 +239,9 @@ impl TosCore {
             );
         }
 
-        req = req.extension(Operation::Read);
+        req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("GetObject"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -276,7 +278,9 @@ impl TosCore {
 
         req = self.insert_metadata_headers(req, size, args);
 
-        req = req.extension(Operation::Write);
+        req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("PutObject"));
 
         let req = req.body(body).map_err(new_request_build_error)?;
 
@@ -348,7 +352,9 @@ impl TosCore {
             );
         }
 
-        req = req.extension(Operation::Stat);
+        req = req
+            .extension(Operation::Stat)
+            .extension(ServiceOperation("HeadObject"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -388,6 +394,7 @@ impl TosCore {
 
         let req = req
             .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteObject"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -417,7 +424,9 @@ impl TosCore {
         req = req.header(CONTENT_TYPE, "application/json");
         req = req.header("CONTENT-MD5", format_content_md5(content.as_bytes()));
 
-        req = req.extension(Operation::Delete);
+        req = req
+            .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteMultipleObjects"));
 
         let req = req
             .body(Buffer::from(content))


### PR DESCRIPTION
# Rationale for this change

Followup PR for https://github.com/apache/opendal/pull/7407, which adds service operation label to a few storage backends.
I tried to include more backends but the change is too large, would prefer to do in batches.

# What changes are included in this PR?

This PR adds service operation in the request extension, which will be picked up at metrics layer and set as label.

# Are there any user-facing changes?

No

# AI Usage Statement

Opus 4.7 made all the code change and me doing eyeball checking.