### PR TITLE
fix(services/azdls): return user metadata from stat

### DIFF
--- a/core/services/azdls/src/core.rs
+++ b/core/services/azdls/src/core.rs
@@ -298,7 +298,7 @@ impl AzdlsCore {
             .to_string();
 
         let url = format!(
-            "{}/{}/{}?action=getStatus",
+            "{}/{}/{}",
             self.endpoint,
             self.filesystem,
             percent_encode_path(&p)


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

`azdls` recently enabled `write_with_user_metadata`, but `stat` still used `action=getStatus` when fetching path properties. Azure Data Lake Storage Gen2 only returns system-defined properties for `getStatus`, so `x-ms-properties` was omitted and the behavior tests observed missing user metadata after write.

# What changes are included in this PR?

This PR changes `azdls` stat to call the default Get Properties API instead of Get Status, allowing Azure to return both system and user-defined properties.

# Are there any user-facing changes?

No API changes. `azdls` now correctly returns user metadata from `stat` after writes that set user metadata.

# AI Usage Statement

This PR was prepared with AI assistance.
