### PR TITLE
feat(services/azblob): support skip_signature

### DIFF
--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -173,6 +173,11 @@ public interface ServiceConfig {
          */
         public final String accountName;
         /**
+         * <p>Allow anonymous will allow opendal to send request without signing
+         * when credential is not loaded.</p>
+         */
+        public final Boolean allowAnonymous;
+        /**
          * <p>The maximum batch operations of Azblob service backend.</p>
          */
         public final Long batchMaxOperations;
@@ -224,6 +229,9 @@ public interface ServiceConfig {
             }
             if (accountName != null) {
                 map.put("account_name", accountName);
+            }
+            if (allowAnonymous != null) {
+                map.put("allow_anonymous", String.valueOf(allowAnonymous));
             }
             if (batchMaxOperations != null) {
                 map.put("batch_max_operations", String.valueOf(batchMaxOperations));

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -173,11 +173,6 @@ public interface ServiceConfig {
          */
         public final String accountName;
         /**
-         * <p>Allow anonymous will allow opendal to send request without signing
-         * when credential is not loaded.</p>
-         */
-        public final Boolean allowAnonymous;
-        /**
          * <p>The maximum batch operations of Azblob service backend.</p>
          */
         public final Long batchMaxOperations;
@@ -215,6 +210,12 @@ public interface ServiceConfig {
          * <p>The sas token of Azblob service backend.</p>
          */
         public final String sasToken;
+        /**
+         * <p>Skip signature will skip loading credentials and signing requests.</p>
+         * <p>This is useful for accessing public Azure containers without
+         * credentials.</p>
+         */
+        public final Boolean skipSignature;
 
         @Override
         public String scheme() {
@@ -229,9 +230,6 @@ public interface ServiceConfig {
             }
             if (accountName != null) {
                 map.put("account_name", accountName);
-            }
-            if (allowAnonymous != null) {
-                map.put("allow_anonymous", String.valueOf(allowAnonymous));
             }
             if (batchMaxOperations != null) {
                 map.put("batch_max_operations", String.valueOf(batchMaxOperations));
@@ -254,6 +252,9 @@ public interface ServiceConfig {
             }
             if (sasToken != null) {
                 map.put("sas_token", sasToken);
+            }
+            if (skipSignature != null) {
+                map.put("skip_signature", String.valueOf(skipSignature));
             }
             return map;
         }

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -212,8 +212,6 @@ public interface ServiceConfig {
         public final String sasToken;
         /**
          * <p>Skip signature will skip loading credentials and signing requests.</p>
-         * <p>This is useful for accessing public Azure containers without
-         * credentials.</p>
          */
         public final Boolean skipSignature;
 

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -288,6 +288,7 @@ submit! {
                 *,
                 account_key: builtins.str = ...,
                 account_name: builtins.str = ...,
+                allow_anonymous: builtins.bool = ...,
                 batch_max_operations: builtins.int = ...,
                 container: builtins.str,
                 encryption_algorithm: builtins.str = ...,
@@ -306,6 +307,9 @@ submit! {
                     The account key of Azblob service backend.
                 account_name : builtins.str, optional
                     The account name of Azblob service backend.
+                allow_anonymous : builtins.bool, optional
+                    Allow anonymous will allow opendal to send request
+                    without signing when credential is not loaded.
                 batch_max_operations : builtins.int, optional
                     The maximum batch operations of Azblob service
                     backend.
@@ -2971,6 +2975,7 @@ submit! {
                 *,
                 account_key: builtins.str = ...,
                 account_name: builtins.str = ...,
+                allow_anonymous: builtins.bool = ...,
                 batch_max_operations: builtins.int = ...,
                 container: builtins.str,
                 encryption_algorithm: builtins.str = ...,
@@ -2989,6 +2994,9 @@ submit! {
                     The account key of Azblob service backend.
                 account_name : builtins.str, optional
                     The account name of Azblob service backend.
+                allow_anonymous : builtins.bool, optional
+                    Allow anonymous will allow opendal to send request
+                    without signing when credential is not loaded.
                 batch_max_operations : builtins.int, optional
                     The maximum batch operations of Azblob service
                     backend.

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -288,7 +288,6 @@ submit! {
                 *,
                 account_key: builtins.str = ...,
                 account_name: builtins.str = ...,
-                allow_anonymous: builtins.bool = ...,
                 batch_max_operations: builtins.int = ...,
                 container: builtins.str,
                 encryption_algorithm: builtins.str = ...,
@@ -297,6 +296,7 @@ submit! {
                 endpoint: builtins.str = ...,
                 root: builtins.str = ...,
                 sas_token: builtins.str = ...,
+                skip_signature: builtins.bool = ...,
             ) -> typing.Self:
                 r"""
                 Create a new `Operator` for `azblob` service.
@@ -307,9 +307,6 @@ submit! {
                     The account key of Azblob service backend.
                 account_name : builtins.str, optional
                     The account name of Azblob service backend.
-                allow_anonymous : builtins.bool, optional
-                    Allow anonymous will allow opendal to send request
-                    without signing when credential is not loaded.
                 batch_max_operations : builtins.int, optional
                     The maximum batch operations of Azblob service
                     backend.
@@ -332,6 +329,11 @@ submit! {
                     All operations will happen under this root.
                 sas_token : builtins.str, optional
                     The sas token of Azblob service backend.
+                skip_signature : builtins.bool, optional
+                    Skip signature will skip loading credentials and
+                    signing requests.
+                    This is useful for accessing public Azure containers
+                    without credentials.
                 Returns
                 -------
                 Operator
@@ -2975,7 +2977,6 @@ submit! {
                 *,
                 account_key: builtins.str = ...,
                 account_name: builtins.str = ...,
-                allow_anonymous: builtins.bool = ...,
                 batch_max_operations: builtins.int = ...,
                 container: builtins.str,
                 encryption_algorithm: builtins.str = ...,
@@ -2984,6 +2985,7 @@ submit! {
                 endpoint: builtins.str = ...,
                 root: builtins.str = ...,
                 sas_token: builtins.str = ...,
+                skip_signature: builtins.bool = ...,
             ) -> typing.Self:
                 r"""
                 Create a new `AsyncOperator` for `azblob` service.
@@ -2994,9 +2996,6 @@ submit! {
                     The account key of Azblob service backend.
                 account_name : builtins.str, optional
                     The account name of Azblob service backend.
-                allow_anonymous : builtins.bool, optional
-                    Allow anonymous will allow opendal to send request
-                    without signing when credential is not loaded.
                 batch_max_operations : builtins.int, optional
                     The maximum batch operations of Azblob service
                     backend.
@@ -3019,6 +3018,11 @@ submit! {
                     All operations will happen under this root.
                 sas_token : builtins.str, optional
                     The sas token of Azblob service backend.
+                skip_signature : builtins.bool, optional
+                    Skip signature will skip loading credentials and
+                    signing requests.
+                    This is useful for accessing public Azure containers
+                    without credentials.
                 Returns
                 -------
                 AsyncOperator

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -332,8 +332,6 @@ submit! {
                 skip_signature : builtins.bool, optional
                     Skip signature will skip loading credentials and
                     signing requests.
-                    This is useful for accessing public Azure containers
-                    without credentials.
                 Returns
                 -------
                 Operator
@@ -3021,8 +3019,6 @@ submit! {
                 skip_signature : builtins.bool, optional
                     Skip signature will skip loading credentials and
                     signing requests.
-                    This is useful for accessing public Azure containers
-                    without credentials.
                 Returns
                 -------
                 AsyncOperator

--- a/core/services/azblob/src/backend.rs
+++ b/core/services/azblob/src/backend.rs
@@ -244,10 +244,9 @@ impl AzblobBuilder {
         self
     }
 
-    /// Allow anonymous will allow opendal to send request without signing
-    /// when credential is not loaded.
-    pub fn allow_anonymous(mut self) -> Self {
-        self.config.allow_anonymous = true;
+    /// Skip signature will skip loading credentials and signing requests.
+    pub fn skip_signature(mut self) -> Self {
+        self.config.skip_signature = true;
         self
     }
 
@@ -462,7 +461,7 @@ impl Builder for AzblobBuilder {
                 encryption_key_sha256,
                 encryption_algorithm,
                 container: self.config.container.clone(),
-                allow_anonymous: self.config.allow_anonymous,
+                skip_signature: self.config.skip_signature,
                 signer,
             }),
         })

--- a/core/services/azblob/src/backend.rs
+++ b/core/services/azblob/src/backend.rs
@@ -244,6 +244,13 @@ impl AzblobBuilder {
         self
     }
 
+    /// Allow anonymous will allow opendal to send request without signing
+    /// when credential is not loaded.
+    pub fn allow_anonymous(mut self) -> Self {
+        self.config.allow_anonymous = true;
+        self
+    }
+
     /// from_connection_string will make a builder from connection string
     ///
     /// connection string looks like:
@@ -455,7 +462,7 @@ impl Builder for AzblobBuilder {
                 encryption_key_sha256,
                 encryption_algorithm,
                 container: self.config.container.clone(),
-
+                allow_anonymous: self.config.allow_anonymous,
                 signer,
             }),
         })

--- a/core/services/azblob/src/config.rs
+++ b/core/services/azblob/src/config.rs
@@ -76,6 +76,10 @@ pub struct AzblobConfig {
 
     /// The maximum batch operations of Azblob service backend.
     pub batch_max_operations: Option<usize>,
+
+    /// Allow anonymous will allow opendal to send request without signing
+    /// when credential is not loaded.
+    pub allow_anonymous: bool,
 }
 
 impl Debug for AzblobConfig {

--- a/core/services/azblob/src/config.rs
+++ b/core/services/azblob/src/config.rs
@@ -79,6 +79,7 @@ pub struct AzblobConfig {
 
     /// Allow anonymous will allow opendal to send request without signing
     /// when credential is not loaded.
+    #[serde(default)]
     pub allow_anonymous: bool,
 }
 

--- a/core/services/azblob/src/config.rs
+++ b/core/services/azblob/src/config.rs
@@ -77,10 +77,9 @@ pub struct AzblobConfig {
     /// The maximum batch operations of Azblob service backend.
     pub batch_max_operations: Option<usize>,
 
-    /// Allow anonymous will allow opendal to send request without signing
-    /// when credential is not loaded.
+    /// Skip signature will skip loading credentials and signing requests.
     #[serde(default)]
-    pub allow_anonymous: bool,
+    pub skip_signature: bool,
 }
 
 impl Debug for AzblobConfig {

--- a/core/services/azblob/src/core.rs
+++ b/core/services/azblob/src/core.rs
@@ -68,7 +68,7 @@ pub struct AzblobCore {
     pub encryption_key: Option<HeaderValue>,
     pub encryption_key_sha256: Option<HeaderValue>,
     pub encryption_algorithm: Option<HeaderValue>,
-    pub allow_anonymous: bool,
+    pub skip_signature: bool,
     pub signer: Signer<Credential>,
 }
 
@@ -84,7 +84,7 @@ impl Debug for AzblobCore {
 
 impl AzblobCore {
     pub async fn sign_query<T>(&self, req: Request<T>) -> Result<Request<T>> {
-        if self.allow_anonymous {
+        if self.skip_signature {
             return Ok(req);
         }
 
@@ -112,8 +112,8 @@ impl AzblobCore {
             HeaderValue::from_static("2022-11-02"),
         );
 
-        // x-ms-version must be set even for anonymous requests.
-        if self.allow_anonymous {
+        // x-ms-version must be set even when signing is skipped.
+        if self.skip_signature {
             return Ok(Request::from_parts(parts, body));
         }
 
@@ -126,7 +126,7 @@ impl AzblobCore {
     }
 
     async fn batch_sign<T>(&self, req: Request<T>) -> Result<Request<T>> {
-        if self.allow_anonymous {
+        if self.skip_signature {
             return Ok(req);
         }
 

--- a/core/services/azblob/src/core.rs
+++ b/core/services/azblob/src/core.rs
@@ -68,6 +68,7 @@ pub struct AzblobCore {
     pub encryption_key: Option<HeaderValue>,
     pub encryption_key_sha256: Option<HeaderValue>,
     pub encryption_algorithm: Option<HeaderValue>,
+    pub allow_anonymous: bool,
     pub signer: Signer<Credential>,
 }
 
@@ -83,6 +84,10 @@ impl Debug for AzblobCore {
 
 impl AzblobCore {
     pub async fn sign_query<T>(&self, req: Request<T>) -> Result<Request<T>> {
+        if self.allow_anonymous {
+            return Ok(req);
+        }
+
         let (mut parts, body) = req.into_parts();
 
         self.signer
@@ -107,6 +112,11 @@ impl AzblobCore {
             HeaderValue::from_static("2022-11-02"),
         );
 
+        // x-ms-version must be set even for anonymous requests.
+        if self.allow_anonymous {
+            return Ok(Request::from_parts(parts, body));
+        }
+
         self.signer
             .sign(&mut parts, None)
             .await
@@ -116,6 +126,10 @@ impl AzblobCore {
     }
 
     async fn batch_sign<T>(&self, req: Request<T>) -> Result<Request<T>> {
+        if self.allow_anonymous {
+            return Ok(req);
+        }
+
         let (mut parts, body) = req.into_parts();
 
         self.signer

--- a/core/services/ghac/src/writer.rs
+++ b/core/services/ghac/src/writer.rs
@@ -122,6 +122,7 @@ impl GhacWriter {
                     encryption_key: None,
                     encryption_key_sha256: None,
                     encryption_algorithm: None,
+                    allow_anonymous: false,
                     signer,
                 });
                 let w = AzblobWriter::new(azure_core, OpWrite::default(), path.to_string());

--- a/core/services/ghac/src/writer.rs
+++ b/core/services/ghac/src/writer.rs
@@ -122,7 +122,7 @@ impl GhacWriter {
                     encryption_key: None,
                     encryption_key_sha256: None,
                     encryption_algorithm: None,
-                    allow_anonymous: false,
+                    skip_signature: false,
                     signer,
                 });
                 let w = AzblobWriter::new(azure_core, OpWrite::default(), path.to_string());


### PR DESCRIPTION
# Which issue does this PR close?
Closes #7404.

# Rationale for this change
Azure Blob Storage supports anonymous public read access on containers, but `opendal-service-azblob` always signs requests and rejects setups with no credentials.

# What changes are included in this PR?
- Add `allow_anonymous: bool` field to `AzblobConfig`.
- Add `AzblobBuilder::allow_anonymous` builder method.
- Short-circuit `AzblobCore::sign_query` / `sign` / `batch_sign` to skip signing when set; `sign` still injects `x-ms-version` since Azure requires it regardless of auth.

# Are there any user-facing changes?
Yes — a new public config field and a new builder method. Not a breaking change: the field defaults to `false`, which preserves current behavior.

# AI Usage Statement
AI-assisted implementation.