### PR TITLE
feat(fs): copy with metadata

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -7016,6 +7016,7 @@ dependencies = [
  "log",
  "opendal-core",
  "serde",
+ "tempfile",
  "tokio",
  "xattr",
 ]

--- a/core/services/fs/Cargo.toml
+++ b/core/services/fs/Cargo.toml
@@ -41,3 +41,7 @@ tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 
 [target.'cfg(unix)'.dependencies]
 xattr = "1"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/fs/src/core.rs
+++ b/core/services/fs/src/core.rs
@@ -359,7 +359,7 @@ mod tests {
         let src_path = root.join(src);
         let dst_path = root.join(dst);
 
-        tokio::fs::write(&src_path, b"payload").await.unwrap();
+        tokio::fs::File::create(&src_path).await.unwrap();
 
         let mut meta = HashMap::new();
         meta.insert("key".to_string(), "preserved123".to_string());

--- a/core/services/fs/src/core.rs
+++ b/core/services/fs/src/core.rs
@@ -224,7 +224,20 @@ impl FsCore {
             .ensure_write_abs_path(&self.root, to.trim_end_matches('/'))
             .await?;
 
-        tokio::fs::copy(from, to).await.map_err(new_std_io_error)?;
+        tokio::fs::copy(&from, &to)
+            .await
+            .map_err(new_std_io_error)?;
+
+        // only *nix supports `write_with_user_metadata`
+        #[cfg(unix)]
+        {
+            if let Ok(user_meta) = Self::get_user_metadata(&from) {
+                if !user_meta.is_empty() {
+                    Self::set_user_metadata(&to, &user_meta)?;
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -321,3 +334,40 @@ mod error {
 }
 
 pub(super) use error::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_fs_copy_preserves_user_metadata() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let root = temp_dir.path().to_path_buf();
+
+        let core = FsCore {
+            info: ServiceInfo::with_scheme("fs"),
+            capability: Capability::default(),
+            root: root.clone(),
+            atomic_write_dir: None,
+            buf_pool: oio::PooledBuf::new(1),
+        };
+
+        let src = "src_meta.txt";
+        let dst = "dst_meta.txt";
+
+        let src_path = root.join(src);
+        let dst_path = root.join(dst);
+
+        tokio::fs::write(&src_path, b"payload").await.unwrap();
+
+        let mut meta = HashMap::new();
+        meta.insert("key".to_string(), "preserved123".to_string());
+        FsCore::set_user_metadata(&src_path, &meta).unwrap();
+
+        core.fs_copy(src, dst).await.unwrap();
+
+        let got = FsCore::get_user_metadata(&dst_path).unwrap();
+        assert_eq!(got.get("key").map(String::as_str), Some("preserved123"));
+    }
+}

--- a/core/services/fs/src/core.rs
+++ b/core/services/fs/src/core.rs
@@ -341,17 +341,11 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn test_fs_copy_preserves_user_metadata() {
-        let temp_dir = tempfile::TempDir::new().unwrap();
-        let root = temp_dir.path().to_path_buf();
+    async fn test_fs_backend_copy_preserves_user_metadata() {
+        use opendal_core::Operator;
 
-        let core = FsCore {
-            info: ServiceInfo::with_scheme("fs"),
-            capability: Capability::default(),
-            root: root.clone(),
-            atomic_write_dir: None,
-            buf_pool: oio::PooledBuf::new(1),
-        };
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let root = temp_dir.path();
 
         let src = "src_meta.txt";
         let dst = "dst_meta.txt";
@@ -359,13 +353,14 @@ mod tests {
         let src_path = root.join(src);
         let dst_path = root.join(dst);
 
-        tokio::fs::File::create(&src_path).await.unwrap();
+        std::fs::File::create(&src_path).unwrap();
 
         let mut meta = HashMap::new();
         meta.insert("key".to_string(), "preserved123".to_string());
         FsCore::set_user_metadata(&src_path, &meta).unwrap();
 
-        core.fs_copy(src, dst).await.unwrap();
+        let op = Operator::new(crate::Fs::default().root(root.to_str().unwrap())).unwrap();
+        op.copy(src, dst).await.unwrap();
 
         let got = FsCore::get_user_metadata(&dst_path).unwrap();
         assert_eq!(got.get("key").map(String::as_str), Some("preserved123"));


### PR DESCRIPTION
# Rationale for this change

Currently, copy behavior is inconsistent across multiple platforms: on macos user metadata is copied over, but left on linux.

Verification script
```rust
#[tokio::test]
    async fn fs_copy_does_not_preserve_user_metadata_on_linux() {
        let temp_dir = tempfile::tempdir().expect("create temp dir");
        let root = temp_dir.path().to_string_lossy().to_string();

        let backend = FsBuilder::default()
            .root(&root)
            .build()
            .expect("build fs backend");

        let src = "src.txt";
        let dst = "dst.txt";

        let src_abs = temp_dir.path().join(src);
        std::fs::write(&src_abs, b"hello world").expect("write src");

        // Set a `user.foo` xattr directly on the source file. Some
        // filesystems (e.g. tmpfs mounted with `nouser_xattr`) reject this;
        // in that case skip the test instead of failing, since we cannot
        // observe the behavior we want to verify.
        if let Err(e) = xattr::set(&src_abs, "user.foo", b"bar") {
            // ENOTSUP == EOPNOTSUPP == 95 on Linux, mirroring the check in
            // `FsCore::get_user_metadata`.
            if e.kind() == std::io::ErrorKind::Unsupported || e.raw_os_error() == Some(95) {
                eprintln!("skipping fs_copy xattr test: xattr unsupported on {root}");
                return;
            }
            panic!("failed to set xattr on source: {e}");
        }

        // Sanity check: the source file now reports the user metadata via
        // the public stat API, which reads xattrs under the hood.
        let src_meta = backend.stat(src, OpStat::default()).await.expect("stat src");
        let src_user_md: HashMap<String, String> = src_meta
            .into_metadata()
            .user_metadata()
            .cloned()
            .unwrap_or_default();
        assert_eq!(
            src_user_md.get("foo").map(String::as_str),
            Some("bar"),
            "source file should expose its user metadata via stat",
        );

        backend
            .copy(src, dst, OpCopy::default(), OpCopier::default())
            .await
            .expect("copy");

        let dst_abs = temp_dir.path().join(dst);
        assert!(dst_abs.exists(), "destination file should exist after copy");
        assert_eq!(
            std::fs::read(&dst_abs).expect("read dst"),
            b"hello world".as_slice(),
            "file content should be copied verbatim",
        );

        // The actual behavior under test: user metadata is lost on copy.
        let dst_meta = backend.stat(dst, OpStat::default()).await.expect("stat dst");
        let dst_user_md = dst_meta
            .into_metadata()
            .user_metadata()
            .cloned()
            .unwrap_or_default();
        assert!(
            dst_user_md.is_empty(),
            "fs_copy must NOT preserve user metadata on Linux, but got {dst_user_md:?}",
        );

        // Cross-check at the raw xattr layer to rule out a stat-layer bug.
        let raw_dst_attrs: Vec<_> = xattr::list(&dst_abs)
            .expect("list dst xattrs")
            .filter(|name| name.to_string_lossy().starts_with("user."))
            .collect();
        assert!(
            raw_dst_attrs.is_empty(),
            "destination file should have no `user.*` xattrs after fs_copy, got {raw_dst_attrs:?}",
        );
    }
```

# What changes are included in this PR?

This PR explicitly copies user metadata on unix platform.

# Are there any user-facing changes?

No.

# AI Usage Statement

Gpt-5.5 helped me made the code change, I did the review.