### PR TITLE
fix(binding/go): correct entry free ffi signature

### DIFF
--- a/bindings/c/tests/test_suites_list.cpp
+++ b/bindings/c/tests/test_suites_list.cpp
@@ -335,7 +335,7 @@ void test_entry_metadata(opendal_test_context* ctx)
         }
 
         opendal_metadata_free(meta);
-        free(path);
+        opendal_string_free(path);
         opendal_entry_free(next_result.entry);
     }
 

--- a/bindings/go/lister.go
+++ b/bindings/go/lister.go
@@ -359,7 +359,7 @@ var ffiListerNext = newFFI(ffiOpts{
 
 var ffiEntryFree = newFFI(ffiOpts{
 	sym:    "opendal_entry_free",
-	rType:  &ffi.TypePointer,
+	rType:  &ffi.TypeVoid,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
 }, func(ctx context.Context, ffiCall ffiCall) func(e *opendalEntry) {
 	return func(e *opendalEntry) {

--- a/bindings/go/string_ownership_test.go
+++ b/bindings/go/string_ownership_test.go
@@ -23,7 +23,15 @@ import (
 	"context"
 	"testing"
 	"unsafe"
+
+	"github.com/jupiterrider/ffi"
 )
+
+func TestEntryFreeUsesVoidReturnType(t *testing.T) {
+	if ffiEntryFree.opts.rType != &ffi.TypeVoid {
+		t.Fatalf("ffiEntryFree return type = %v, want void", ffiEntryFree.opts.rType)
+	}
+}
 
 func TestCopyCStringAndFreeNil(t *testing.T) {
 	var freed int


### PR DESCRIPTION
# Which issue does this PR close?

None. Follow-up to the failed Go azfile behavior job in https://github.com/apache/opendal/actions/runs/25996329416/job/76411435154.

# Rationale for this change

The Go azfile behavior test completed all `TestBehavior` subtests successfully, then crashed during `TestMain` cleanup while closing the operator. The crash was caused by an FFI ABI mismatch: the Go binding declared `opendal_entry_free` as returning a pointer even though the C binding exposes it as a `void` function.

# What changes are included in this PR?

This PR fixes the Go FFI return type for `opendal_entry_free` and adds a small regression test for the binding signature. It also updates the C list metadata test to release OpenDAL-owned strings with `opendal_string_free` instead of raw `free`.

# Are there any user-facing changes?

No API changes. This fixes undefined behavior in binding cleanup paths.

# AI Usage Statement

This PR was prepared with ChatGPT (GPT-5) assistance for CI log inspection and patch preparation.
