### PR TITLE
fix(binding/go): keep service library loaded

### DIFF
--- a/bindings/go/ffi.go
+++ b/bindings/go/ffi.go
@@ -22,6 +22,7 @@ package opendal
 import (
 	"context"
 	"errors"
+	"sync"
 	"unsafe"
 
 	"github.com/jupiterrider/ffi"
@@ -84,8 +85,29 @@ func (f *FFI[T]) withFFI(ctx context.Context, lib uintptr) (context.Context, err
 
 var withFFIs []contextWithFFI
 
-func newContext(path string) (ctx context.Context, cancel context.CancelFunc, err error) {
+var (
+	libraryMu sync.Mutex
+	libraries = map[string]uintptr{}
+)
+
+func loadSharedLibrary(path string) (uintptr, error) {
+	libraryMu.Lock()
+	defer libraryMu.Unlock()
+
+	if lib, ok := libraries[path]; ok {
+		return lib, nil
+	}
+
 	lib, err := LoadLibrary(path)
+	if err != nil {
+		return 0, err
+	}
+	libraries[path] = lib
+	return lib, nil
+}
+
+func newContext(path string) (ctx context.Context, cancel context.CancelFunc, err error) {
+	lib, err := loadSharedLibrary(path)
 	if err != nil {
 		return
 	}
@@ -96,9 +118,10 @@ func newContext(path string) (ctx context.Context, cancel context.CancelFunc, er
 			return
 		}
 	}
-	cancel = func() {
-		_ = FreeLibrary(lib)
-	}
+	// Keep the library loaded for the process lifetime. The context stores libffi
+	// call targets into this library, so unloading it during operator cleanup can
+	// leave Go frames returning into unmapped code.
+	cancel = func() {}
 
 	return
 }


### PR DESCRIPTION
# Which issue does this PR close?

None. Follow-up to #7538 after the main behavior run still crashed in Go binding cleanup: https://github.com/apache/opendal/actions/runs/25997664484/job/76414938891.

# Rationale for this change

The failing Go behavior jobs completed their subtests, then crashed while closing the operator. #7538 fixed one incorrect FFI return type, but the remaining failure points at the dynamic library unload path: `Operator.Close` calls the context cancel function, which unloads the service library while Go-side libffi call targets and Rust-side static runtime state can still reference code from that library.

Unloading a dynamically generated service library during normal operator cleanup is unsafe for this binding model. The operator itself still needs to be freed, but the library should stay loaded for the process lifetime.

# What changes are included in this PR?

This PR caches loaded service libraries by path and reuses the same handle across operators. The per-operator cancel function no longer unloads the library; `Operator.Close` still releases the underlying Rust operator via `opendal_operator_free`.

# Are there any user-facing changes?

No API changes. This avoids cleanup-time crashes in Go behavior tests and keeps service libraries process-scoped after first use.

# AI Usage Statement

This PR was prepared with ChatGPT (GPT-5) assistance for CI log inspection and patch preparation.
