### PR TITLE
feat(services/s3): Rename allow_anonymous to skip_signature

### DIFF
--- a/bindings/dotnet/OpenDAL/ServiceConfig/S3ServiceConfig.cs
+++ b/bindings/dotnet/OpenDAL/ServiceConfig/S3ServiceConfig.cs
@@ -37,6 +37,11 @@ namespace OpenDAL.ServiceConfig
         /// </summary>
         public bool? SkipSignature { get; init; }
         /// <summary>
+        /// Allow anonymous will allow opendal to send request without signing when credential is not loaded.
+        /// </summary>
+        [System.Obsolete("Please use SkipSignature instead of AllowAnonymous")]
+        public bool? AllowAnonymous { get; init; }
+        /// <summary>
         /// Set maximum batch operations of this backend. Some compatible services have a limit on the number of operations in a batch request. For example, R2 could return Internal Error while batch delete 1000 files. Please tune this value based on services' document.
         /// </summary>
         public long? BatchMaxOperations { get; init; }
@@ -158,6 +163,12 @@ namespace OpenDAL.ServiceConfig
             {
                 map["skip_signature"] = Utilities.ToOptionString(SkipSignature);
             }
+#pragma warning disable CS0618
+            if (AllowAnonymous is not null)
+            {
+                map["allow_anonymous"] = Utilities.ToOptionString(AllowAnonymous);
+            }
+#pragma warning restore CS0618
             if (BatchMaxOperations is not null)
             {
                 map["batch_max_operations"] = Utilities.ToOptionString(BatchMaxOperations);

--- a/bindings/dotnet/OpenDAL/ServiceConfig/S3ServiceConfig.cs
+++ b/bindings/dotnet/OpenDAL/ServiceConfig/S3ServiceConfig.cs
@@ -33,9 +33,9 @@ namespace OpenDAL.ServiceConfig
         /// </summary>
         public string? AccessKeyId { get; init; }
         /// <summary>
-        /// Allow anonymous will allow opendal to send request without signing when credential is not loaded.
+        /// Skip signature will skip loading credentials and signing requests.
         /// </summary>
-        public bool? AllowAnonymous { get; init; }
+        public bool? SkipSignature { get; init; }
         /// <summary>
         /// Set maximum batch operations of this backend. Some compatible services have a limit on the number of operations in a batch request. For example, R2 could return Internal Error while batch delete 1000 files. Please tune this value based on services' document.
         /// </summary>
@@ -154,9 +154,9 @@ namespace OpenDAL.ServiceConfig
             {
                 map["access_key_id"] = Utilities.ToOptionString(AccessKeyId);
             }
-            if (AllowAnonymous is not null)
+            if (SkipSignature is not null)
             {
-                map["allow_anonymous"] = Utilities.ToOptionString(AllowAnonymous);
+                map["skip_signature"] = Utilities.ToOptionString(SkipSignature);
             }
             if (BatchMaxOperations is not null)
             {

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -2823,11 +2823,6 @@ public interface ServiceConfig {
          */
         public final String accessKeyId;
         /**
-         * <p>Allow anonymous will allow opendal to send request without signing
-         * when credential is not loaded.</p>
-         */
-        public final Boolean allowAnonymous;
-        /**
          * <p>assume_role_duration_seconds for this backend.</p>
          */
         public final Integer assumeRoleDurationSeconds;
@@ -3040,6 +3035,10 @@ public interface ServiceConfig {
          * by hand.</p>
          */
         public final String sessionToken;
+        /**
+         * <p>Skip signature will skip loading credentials and signing requests.</p>
+         */
+        public final Boolean skipSignature;
 
         @Override
         public String scheme() {
@@ -3051,9 +3050,6 @@ public interface ServiceConfig {
             final HashMap<String, String> map = new HashMap<>();
             if (accessKeyId != null) {
                 map.put("access_key_id", accessKeyId);
-            }
-            if (allowAnonymous != null) {
-                map.put("allow_anonymous", String.valueOf(allowAnonymous));
             }
             if (assumeRoleDurationSeconds != null) {
                 map.put("assume_role_duration_seconds", String.valueOf(assumeRoleDurationSeconds));
@@ -3142,6 +3138,9 @@ public interface ServiceConfig {
             }
             if (sessionToken != null) {
                 map.put("session_token", sessionToken);
+            }
+            if (skipSignature != null) {
+                map.put("skip_signature", String.valueOf(skipSignature));
             }
             return map;
         }

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -2823,6 +2823,13 @@ public interface ServiceConfig {
          */
         public final String accessKeyId;
         /**
+         * <p>Allow anonymous will allow opendal to send request without signing
+         * when credential is not loaded.</p>
+         *
+         * @deprecated Please use `skip_signature` instead of `allow_anonymous`
+         */
+        public final Boolean allowAnonymous;
+        /**
          * <p>assume_role_duration_seconds for this backend.</p>
          */
         public final Integer assumeRoleDurationSeconds;
@@ -3050,6 +3057,9 @@ public interface ServiceConfig {
             final HashMap<String, String> map = new HashMap<>();
             if (accessKeyId != null) {
                 map.put("access_key_id", accessKeyId);
+            }
+            if (allowAnonymous != null) {
+                map.put("allow_anonymous", String.valueOf(allowAnonymous));
             }
             if (assumeRoleDurationSeconds != null) {
                 map.put("assume_role_duration_seconds", String.valueOf(assumeRoleDurationSeconds));

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -685,6 +685,7 @@ class AsyncOperator:
         endpoint: builtins.str = ...,
         root: builtins.str = ...,
         sas_token: builtins.str = ...,
+        skip_signature: builtins.bool = ...,
     ) -> typing.Self:
         r"""
         Create a new `AsyncOperator` for `azblob` service.
@@ -717,6 +718,9 @@ class AsyncOperator:
             All operations will happen under this root.
         sas_token : builtins.str, optional
             The sas token of Azblob service backend.
+        skip_signature : builtins.bool, optional
+            Skip signature will skip loading credentials and
+            signing requests.
 
         Returns
         -------
@@ -2095,7 +2099,6 @@ class AsyncOperator:
         /,
         *,
         access_key_id: builtins.str = ...,
-        allow_anonymous: builtins.bool = ...,
         assume_role_duration_seconds: builtins.int = ...,
         assume_role_session_tags: builtins.dict = ...,
         batch_max_operations: builtins.int = ...,
@@ -2126,6 +2129,7 @@ class AsyncOperator:
         server_side_encryption_customer_key: builtins.str = ...,
         server_side_encryption_customer_key_md5: builtins.str = ...,
         session_token: builtins.str = ...,
+        skip_signature: builtins.bool = ...,
     ) -> typing.Self:
         r"""
         Create a new `AsyncOperator` for `s3` service.
@@ -2137,9 +2141,6 @@ class AsyncOperator:
             - If access_key_id is set, we will take user's input
             first.
             - If not, we will try to load it from environment.
-        allow_anonymous : builtins.bool, optional
-            Allow anonymous will allow opendal to send request
-            without signing when credential is not loaded.
         assume_role_duration_seconds : builtins.int, optional
             assume_role_duration_seconds for this backend.
         assume_role_session_tags : builtins.dict, optional
@@ -2299,6 +2300,9 @@ class AsyncOperator:
             session_token (aka, security token) of this backend.
             This token will expire after sometime, it's
             recommended to set session_token by hand.
+        skip_signature : builtins.bool, optional
+            Skip signature will skip loading credentials and
+            signing requests.
 
         Returns
         -------
@@ -3289,6 +3293,7 @@ class Operator:
         endpoint: builtins.str = ...,
         root: builtins.str = ...,
         sas_token: builtins.str = ...,
+        skip_signature: builtins.bool = ...,
     ) -> typing.Self:
         r"""
         Create a new `Operator` for `azblob` service.
@@ -3321,6 +3326,9 @@ class Operator:
             All operations will happen under this root.
         sas_token : builtins.str, optional
             The sas token of Azblob service backend.
+        skip_signature : builtins.bool, optional
+            Skip signature will skip loading credentials and
+            signing requests.
 
         Returns
         -------
@@ -4699,7 +4707,6 @@ class Operator:
         /,
         *,
         access_key_id: builtins.str = ...,
-        allow_anonymous: builtins.bool = ...,
         assume_role_duration_seconds: builtins.int = ...,
         assume_role_session_tags: builtins.dict = ...,
         batch_max_operations: builtins.int = ...,
@@ -4730,6 +4737,7 @@ class Operator:
         server_side_encryption_customer_key: builtins.str = ...,
         server_side_encryption_customer_key_md5: builtins.str = ...,
         session_token: builtins.str = ...,
+        skip_signature: builtins.bool = ...,
     ) -> typing.Self:
         r"""
         Create a new `Operator` for `s3` service.
@@ -4741,9 +4749,6 @@ class Operator:
             - If access_key_id is set, we will take user's input
             first.
             - If not, we will try to load it from environment.
-        allow_anonymous : builtins.bool, optional
-            Allow anonymous will allow opendal to send request
-            without signing when credential is not loaded.
         assume_role_duration_seconds : builtins.int, optional
             assume_role_duration_seconds for this backend.
         assume_role_session_tags : builtins.dict, optional
@@ -4903,6 +4908,9 @@ class Operator:
             session_token (aka, security token) of this backend.
             This token will expire after sometime, it's
             recommended to set session_token by hand.
+        skip_signature : builtins.bool, optional
+            Skip signature will skip loading credentials and
+            signing requests.
 
         Returns
         -------

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -2099,6 +2099,7 @@ class AsyncOperator:
         /,
         *,
         access_key_id: builtins.str = ...,
+        allow_anonymous: builtins.bool = ...,
         assume_role_duration_seconds: builtins.int = ...,
         assume_role_session_tags: builtins.dict = ...,
         batch_max_operations: builtins.int = ...,
@@ -2141,6 +2142,9 @@ class AsyncOperator:
             - If access_key_id is set, we will take user's input
             first.
             - If not, we will try to load it from environment.
+        allow_anonymous : builtins.bool, optional
+            Allow anonymous will allow opendal to send request
+            without signing when credential is not loaded.
         assume_role_duration_seconds : builtins.int, optional
             assume_role_duration_seconds for this backend.
         assume_role_session_tags : builtins.dict, optional
@@ -4707,6 +4711,7 @@ class Operator:
         /,
         *,
         access_key_id: builtins.str = ...,
+        allow_anonymous: builtins.bool = ...,
         assume_role_duration_seconds: builtins.int = ...,
         assume_role_session_tags: builtins.dict = ...,
         batch_max_operations: builtins.int = ...,
@@ -4749,6 +4754,9 @@ class Operator:
             - If access_key_id is set, we will take user's input
             first.
             - If not, we will try to load it from environment.
+        allow_anonymous : builtins.bool, optional
+            Allow anonymous will allow opendal to send request
+            without signing when credential is not loaded.
         assume_role_duration_seconds : builtins.int, optional
             assume_role_duration_seconds for this backend.
         assume_role_session_tags : builtins.dict, optional

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -2034,7 +2034,6 @@ submit! {
                 /,
                 *,
                 access_key_id: builtins.str = ...,
-                allow_anonymous: builtins.bool = ...,
                 assume_role_duration_seconds: builtins.int = ...,
                 assume_role_session_tags: builtins.dict = ...,
                 batch_max_operations: builtins.int = ...,
@@ -2065,6 +2064,7 @@ submit! {
                 server_side_encryption_customer_key: builtins.str = ...,
                 server_side_encryption_customer_key_md5: builtins.str = ...,
                 session_token: builtins.str = ...,
+                skip_signature: builtins.bool = ...,
             ) -> typing.Self:
                 r"""
                 Create a new `Operator` for `s3` service.
@@ -2076,9 +2076,6 @@ submit! {
                     - If access_key_id is set, we will take user's input
                     first.
                     - If not, we will try to load it from environment.
-                allow_anonymous : builtins.bool, optional
-                    Allow anonymous will allow opendal to send request
-                    without signing when credential is not loaded.
                 assume_role_duration_seconds : builtins.int, optional
                     assume_role_duration_seconds for this backend.
                 assume_role_session_tags : builtins.dict, optional
@@ -2238,6 +2235,9 @@ submit! {
                     session_token (aka, security token) of this backend.
                     This token will expire after sometime, it's
                     recommended to set session_token by hand.
+                skip_signature : builtins.bool, optional
+                    Skip signature will skip loading credentials and
+                    signing requests.
                 Returns
                 -------
                 Operator
@@ -4721,7 +4721,6 @@ submit! {
                 /,
                 *,
                 access_key_id: builtins.str = ...,
-                allow_anonymous: builtins.bool = ...,
                 assume_role_duration_seconds: builtins.int = ...,
                 assume_role_session_tags: builtins.dict = ...,
                 batch_max_operations: builtins.int = ...,
@@ -4752,6 +4751,7 @@ submit! {
                 server_side_encryption_customer_key: builtins.str = ...,
                 server_side_encryption_customer_key_md5: builtins.str = ...,
                 session_token: builtins.str = ...,
+                skip_signature: builtins.bool = ...,
             ) -> typing.Self:
                 r"""
                 Create a new `AsyncOperator` for `s3` service.
@@ -4763,9 +4763,6 @@ submit! {
                     - If access_key_id is set, we will take user's input
                     first.
                     - If not, we will try to load it from environment.
-                allow_anonymous : builtins.bool, optional
-                    Allow anonymous will allow opendal to send request
-                    without signing when credential is not loaded.
                 assume_role_duration_seconds : builtins.int, optional
                     assume_role_duration_seconds for this backend.
                 assume_role_session_tags : builtins.dict, optional
@@ -4925,6 +4922,9 @@ submit! {
                     session_token (aka, security token) of this backend.
                     This token will expire after sometime, it's
                     recommended to set session_token by hand.
+                skip_signature : builtins.bool, optional
+                    Skip signature will skip loading credentials and
+                    signing requests.
                 Returns
                 -------
                 AsyncOperator

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -2034,6 +2034,7 @@ submit! {
                 /,
                 *,
                 access_key_id: builtins.str = ...,
+                allow_anonymous: builtins.bool = ...,
                 assume_role_duration_seconds: builtins.int = ...,
                 assume_role_session_tags: builtins.dict = ...,
                 batch_max_operations: builtins.int = ...,
@@ -2076,6 +2077,9 @@ submit! {
                     - If access_key_id is set, we will take user's input
                     first.
                     - If not, we will try to load it from environment.
+                allow_anonymous : builtins.bool, optional
+                    Allow anonymous will allow opendal to send request
+                    without signing when credential is not loaded.
                 assume_role_duration_seconds : builtins.int, optional
                     assume_role_duration_seconds for this backend.
                 assume_role_session_tags : builtins.dict, optional
@@ -4721,6 +4725,7 @@ submit! {
                 /,
                 *,
                 access_key_id: builtins.str = ...,
+                allow_anonymous: builtins.bool = ...,
                 assume_role_duration_seconds: builtins.int = ...,
                 assume_role_session_tags: builtins.dict = ...,
                 batch_max_operations: builtins.int = ...,
@@ -4763,6 +4768,9 @@ submit! {
                     - If access_key_id is set, we will take user's input
                     first.
                     - If not, we will try to load it from environment.
+                allow_anonymous : builtins.bool, optional
+                    Allow anonymous will allow opendal to send request
+                    without signing when credential is not loaded.
                 assume_role_duration_seconds : builtins.int, optional
                     assume_role_duration_seconds for this backend.
                 assume_role_session_tags : builtins.dict, optional

--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -429,11 +429,20 @@ impl S3Builder {
         self
     }
 
+    /// Skip signature will skip loading credentials and signing requests.
+    pub fn skip_signature(mut self) -> Self {
+        self.config.skip_signature = true;
+        self
+    }
+
     /// Allow anonymous will allow opendal to send request without signing
     /// when credential is not loaded.
-    pub fn allow_anonymous(mut self) -> Self {
-        self.config.allow_anonymous = true;
-        self
+    #[deprecated(
+        since = "0.57.0",
+        note = "Please use `skip_signature` instead of `allow_anonymous`"
+    )]
+    pub fn allow_anonymous(self) -> Self {
+        self.skip_signature()
     }
 
     /// Enable virtual host style so that opendal will send API requests
@@ -977,7 +986,7 @@ impl Builder for S3Builder {
                 server_side_encryption_customer_key,
                 server_side_encryption_customer_key_md5,
                 default_storage_class,
-                allow_anonymous: config.allow_anonymous,
+                skip_signature: config.skip_signature,
                 disable_list_objects_v2: config.disable_list_objects_v2,
                 enable_request_payer: config.enable_request_payer,
                 signer,
@@ -1280,7 +1289,7 @@ mod tests {
         let backend = S3Builder::default()
             .bucket("test")
             .region("us-east-1")
-            .allow_anonymous()
+            .skip_signature()
             .disable_config_load()
             .disable_ec2_metadata()
             .build()

--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -717,6 +717,11 @@ impl Builder for S3Builder {
             credential_providers,
         } = self;
 
+        #[allow(deprecated)]
+        if config.allow_anonymous {
+            config.skip_signature = true;
+        }
+
         let root = normalize_root(&config.root.clone().unwrap_or_default());
         debug!("backend use root {}", &root);
 

--- a/core/services/s3/src/config.rs
+++ b/core/services/s3/src/config.rs
@@ -121,8 +121,14 @@ pub struct S3Config {
     /// to load credential from ec2 metadata, a.k.a., IMDSv2
     pub disable_ec2_metadata: bool,
     /// Skip signature will skip loading credentials and signing requests.
-    #[serde(alias = "allow_anonymous")]
     pub skip_signature: bool,
+    /// Allow anonymous will allow opendal to send request without signing
+    /// when credential is not loaded.
+    #[deprecated(
+        since = "0.57.0",
+        note = "Please use `skip_signature` instead of `allow_anonymous`"
+    )]
+    pub allow_anonymous: bool,
     /// server_side_encryption for this backend.
     ///
     /// Available values: `AES256`, `aws:kms`.

--- a/core/services/s3/src/config.rs
+++ b/core/services/s3/src/config.rs
@@ -120,9 +120,9 @@ pub struct S3Config {
     /// This option is used to disable the default behavior of opendal
     /// to load credential from ec2 metadata, a.k.a., IMDSv2
     pub disable_ec2_metadata: bool,
-    /// Allow anonymous will allow opendal to send request without signing
-    /// when credential is not loaded.
-    pub allow_anonymous: bool,
+    /// Skip signature will skip loading credentials and signing requests.
+    #[serde(alias = "allow_anonymous")]
+    pub skip_signature: bool,
     /// server_side_encryption for this backend.
     ///
     /// Available values: `AES256`, `aws:kms`.

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -96,7 +96,7 @@ pub struct S3Core {
     pub server_side_encryption_customer_key: Option<HeaderValue>,
     pub server_side_encryption_customer_key_md5: Option<HeaderValue>,
     pub default_storage_class: Option<HeaderValue>,
-    pub allow_anonymous: bool,
+    pub skip_signature: bool,
     pub disable_list_objects_v2: bool,
     pub enable_request_payer: bool,
     pub default_acl: Option<String>,
@@ -117,8 +117,7 @@ impl Debug for S3Core {
 
 impl S3Core {
     pub async fn sign_query<T>(&self, req: Request<T>, duration: Duration) -> Result<Request<T>> {
-        // Skip signing for anonymous access
-        if self.allow_anonymous {
+        if self.skip_signature {
             return Ok(req);
         }
 
@@ -142,8 +141,7 @@ impl S3Core {
     }
 
     pub async fn send(&self, req: Request<Buffer>) -> Result<Response<Buffer>> {
-        // Skip signing for anonymous access
-        if self.allow_anonymous {
+        if self.skip_signature {
             return self.info.http_client().send(req).await;
         }
 
@@ -169,8 +167,7 @@ impl S3Core {
     }
 
     pub async fn fetch(&self, req: Request<Buffer>) -> Result<Response<HttpBody>> {
-        // Skip signing for anonymous access
-        if self.allow_anonymous {
+        if self.skip_signature {
             return self.info.http_client().fetch(req).await;
         }
 

--- a/integrations/object_store/src/amazon_s3.rs
+++ b/integrations/object_store/src/amazon_s3.rs
@@ -66,7 +66,7 @@ impl OpendalStore {
                     source: Box::new(err),
                 })?;
             if r {
-                s3 = s3.allow_anonymous();
+                s3 = s3.skip_signature();
             }
         }
 


### PR DESCRIPTION
# Which issue does this PR close?
Refs #7537. 

# Rationale for this change
`allow_anonymous` on S3 services is misleading — the implementation unconditionally skips credential loading and request signing rather than falling back from a failed credential load. Rename it to `skip_signature` to describe the actual behavior, aligning with `object_store::AmazonS3Builder::with_skip_signature`.

# What changes are included in this PR?
- Rename `S3Config::allow_anonymous` to `skip_signature`, with `#[serde(alias = "allow_anonymous")]` so the old config key still deserializes.
- Add `S3Builder::skip_signature()`; keep `S3Builder::allow_anonymous()` as a `#[deprecated]` wrapper.
- Rename the short-circuit field in `S3Core` and update `sign_query` / `send` / `fetch`.
- Update `object_store_opendal` integration to map `SkipSignature` to `s3.skip_signature()`.
- Update .NET S3 service config (`AllowAnonymous` → `SkipSignature`).
- Regenerate Java + Python bindings 
# Are there any user-facing changes?
Yes, but not breaking

# AI Usage Statement
AI-assisted implementation.