### PR TITLE
ci: Add TOS behavior test setup

### DIFF
--- a/.github/scripts/test_behavior/plan.py
+++ b/.github/scripts/test_behavior/plan.py
@@ -285,6 +285,13 @@ def generate_language_binding_cases(
             "rocksdb",
         ]]
 
+    # Remove invalid cases for go.
+    if language == "go":
+        cases = [v for v in cases if v["service"] not in [
+            # opendal-go-services doesn't provide TOS yet.
+            "tos",
+        ]]
+
     if os.getenv("GITHUB_IS_PUSH") == "true":
         return cases
 

--- a/.github/services/tos/tos/action.yml
+++ b/.github/services/tos/tos/action.yml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: tos
+description: "Behavior test for Volcengine TOS"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup
+      uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3.2.1
+      with:
+        export-env: true
+      env:
+        OPENDAL_TOS_ROOT: op://services/tos/root
+        OPENDAL_TOS_BUCKET: op://services/tos/bucket
+        OPENDAL_TOS_ENDPOINT: op://services/tos/endpoint
+        OPENDAL_TOS_ACCESS_KEY_ID: op://services/tos/access_key_id
+        OPENDAL_TOS_SECRET_ACCESS_KEY: op://services/tos/secret_access_key
+        OPENDAL_TOS_REGION: op://services/tos/region

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -56,6 +56,7 @@ opendal = { version = ">=0", path = "../../core", features = [
   "services-obs",
   "services-oss",
   "services-s3",
+  "services-tos",
   "services-webdav",
   "services-webhdfs",
   "services-aliyun-drive",

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -57,6 +57,7 @@ opendal = { version = ">=0", path = "../../core", default-features = false, feat
   "services-obs",
   "services-oss",
   "services-s3",
+  "services-tos",
   "services-webdav",
   "services-webhdfs",
   "services-aliyun-drive",

--- a/bindings/java/src/utility.rs
+++ b/bindings/java/src/utility.rs
@@ -84,6 +84,7 @@ fn intern_load_enabled_services(env: &mut JNIEnv) -> Result<jobjectArray> {
         opendal::services::SQLITE_SCHEME,
         opendal::services::SWIFT_SCHEME,
         opendal::services::TIKV_SCHEME,
+        opendal::services::TOS_SCHEME,
         opendal::services::UPYUN_SCHEME,
         opendal::services::VERCEL_ARTIFACTS_SCHEME,
         opendal::services::WEBDAV_SCHEME,

--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -77,6 +77,7 @@ services-all = [
   # "services-rocksdb",
   "services-sled",
   "services-swift",
+  "services-tos",
   # FIXME this service need protoc
   # "services-tikv",
   "services-vercel-artifacts",
@@ -145,6 +146,7 @@ services-sled = ["opendal/services-sled"]
 services-sqlite = ["opendal/services-sqlite"]
 services-swift = ["opendal/services-swift"]
 services-tikv = ["opendal/services-tikv"]
+services-tos = ["opendal/services-tos"]
 services-upyun = ["opendal/services-upyun"]
 services-vercel-artifacts = ["opendal/services-vercel-artifacts"]
 services-yandex-disk = ["opendal/services-yandex-disk"]

--- a/bindings/python/tests/test_write_conditional.py
+++ b/bindings/python/tests/test_write_conditional.py
@@ -20,10 +20,14 @@ from uuid import uuid4
 import pytest
 
 
-@pytest.mark.need_capability("write", "write_with_if_match")
+@pytest.mark.need_capability("write", "stat", "write_with_if_match")
 def test_write_accepts_if_match_param(service_name, operator, async_operator):
     path = f"test_write_if_match_{uuid4()}.txt"
-    operator.write(path, b"test content", if_match="etag123")
+    operator.write(path, b"initial content")
+    etag = operator.stat(path).etag
+    if etag is None:
+        pytest.skip("backend does not return etag")
+    operator.write(path, b"test content", if_match=etag)
 
 
 @pytest.mark.need_capability("write", "write_with_if_none_match")
@@ -44,13 +48,17 @@ def test_write_default_params_unchanged(service_name, operator, async_operator):
     operator.write(path, b"test content")
 
 
-@pytest.mark.need_capability("write", "write_with_if_match")
+@pytest.mark.need_capability("write", "stat", "write_with_if_match")
 @pytest.mark.asyncio
 async def test_async_write_accepts_if_match_param(
     service_name, operator, async_operator
 ):
     path = f"test_async_write_if_match_{uuid4()}.txt"
-    await async_operator.write(path, b"test content", if_match="etag123")
+    await async_operator.write(path, b"initial content")
+    meta = await async_operator.stat(path)
+    if meta.etag is None:
+        pytest.skip("backend does not return etag")
+    await async_operator.write(path, b"test content", if_match=meta.etag)
 
 
 @pytest.mark.need_capability("write", "write_with_if_none_match")

--- a/core/services/tos/src/backend.rs
+++ b/core/services/tos/src/backend.rs
@@ -155,7 +155,7 @@ impl Builder for TosBuilder {
 
         let endpoint = config.endpoint.clone().unwrap();
         let bucket = config.bucket.clone();
-        let root = config.root.clone().unwrap_or_else(|| "/".to_string());
+        let root = normalize_root(&config.root.clone().unwrap_or_default());
 
         let ctx = Context::new()
             .with_file_read(TokioFileRead)


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

TOS now has credentials available in 1Password, so we can run its behavior tests in GitHub Actions like other externally backed services.

# What changes are included in this PR?

This PR adds a TOS service setup action backed by 1Password secrets, enables TOS in Java, .NET, and NodeJS binding builds, and updates the behavior-test planner to skip TOS for Go until `opendal-go-services` provides a TOS package.

# Are there any user-facing changes?

No.

# AI Usage Statement

N/A.
