### PR TITLE
refactor(services/oss): complete capability override migration

### DIFF
--- a/.github/services/oss/oss/action.yml
+++ b/.github/services/oss/oss/action.yml
@@ -30,3 +30,8 @@ runs:
         OPENDAL_OSS_ENDPOINT: op://services/oss/endpoint
         OPENDAL_OSS_ACCESS_KEY_ID: op://services/oss/access_key_id
         OPENDAL_OSS_ACCESS_KEY_SECRET: op://services/oss/access_key_secret
+
+    - name: Add extra settings
+      shell: bash
+      run: |
+        echo "OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false" >> $GITHUB_ENV

--- a/.github/services/oss/oss_with_versioning/action.yml
+++ b/.github/services/oss/oss_with_versioning/action.yml
@@ -30,8 +30,3 @@ runs:
         OPENDAL_OSS_ENDPOINT: op://services/oss/endpoint
         OPENDAL_OSS_ACCESS_KEY_ID: op://services/oss/access_key_id
         OPENDAL_OSS_ACCESS_KEY_SECRET: op://services/oss/access_key_secret
-
-    - name: Add extra settings
-      shell: bash
-      run: |
-        echo "OPENDAL_OSS_ENABLE_VERSIONING=true" >> $GITHUB_ENV

--- a/.github/services/oss/oss_with_versioning/action.yml
+++ b/.github/services/oss/oss_with_versioning/action.yml
@@ -30,3 +30,8 @@ runs:
         OPENDAL_OSS_ENDPOINT: op://services/oss/endpoint
         OPENDAL_OSS_ACCESS_KEY_ID: op://services/oss/access_key_id
         OPENDAL_OSS_ACCESS_KEY_SECRET: op://services/oss/access_key_secret
+
+    - name: Add extra settings
+      shell: bash
+      run: |
+        echo "OPENDAL_TEST_CAPABILITY_OVERRIDES=write_with_if_not_exists=false" >> $GITHUB_ENV

--- a/bindings/dotnet/OpenDAL/ServiceConfig/OssServiceConfig.cs
+++ b/bindings/dotnet/OpenDAL/ServiceConfig/OssServiceConfig.cs
@@ -45,7 +45,7 @@ namespace OpenDAL.ServiceConfig
         /// </summary>
         public bool? AllowAnonymous { get; init; }
         /// <summary>
-        /// The size of max batch operations.
+        /// Deprecated: OSS delete batch capability is enabled by default.
         /// </summary>
         public long? BatchMaxOperations { get; init; }
         /// <summary>
@@ -53,11 +53,11 @@ namespace OpenDAL.ServiceConfig
         /// </summary>
         public string? Bucket { get; init; }
         /// <summary>
-        /// The size of max delete operations.
+        /// Deprecated: OSS delete batch capability is enabled by default.
         /// </summary>
         public long? DeleteMaxSize { get; init; }
         /// <summary>
-        /// is bucket versioning enabled for this bucket
+        /// Deprecated: OSS versioning capability is enabled by default.
         /// </summary>
         public bool? EnableVersioning { get; init; }
         /// <summary>

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -2376,9 +2376,9 @@ public interface ServiceConfig {
          */
         public final Boolean allowAnonymous;
         /**
-         * <p>The size of max batch operations.</p>
+         * <p>Deprecated: OSS delete batch capability is enabled by default.</p>
          *
-         * @deprecated Please use `delete_max_size` instead of `batch_max_operations`
+         * @deprecated OSS delete batch capability is enabled by default. Use CapabilityOverrideLayer to override delete_max_size for specific endpoints.
          */
         public final Long batchMaxOperations;
         /**
@@ -2386,11 +2386,15 @@ public interface ServiceConfig {
          */
         public final @NonNull String bucket;
         /**
-         * <p>The size of max delete operations.</p>
+         * <p>Deprecated: OSS delete batch capability is enabled by default.</p>
+         *
+         * @deprecated OSS delete batch capability is enabled by default. Use CapabilityOverrideLayer to override delete_max_size for specific endpoints.
          */
         public final Long deleteMaxSize;
         /**
-         * <p>is bucket versioning enabled for this bucket</p>
+         * <p>Deprecated: OSS versioning capability is enabled by default.</p>
+         *
+         * @deprecated OSS versioning capability is enabled by default and this option is no longer needed.
          */
         public final Boolean enableVersioning;
         /**

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -1889,13 +1889,16 @@ class AsyncOperator:
         allow_anonymous : builtins.bool, optional
             Allow anonymous for oss.
         batch_max_operations : builtins.int, optional
-            The size of max batch operations.
+            Deprecated: OSS delete batch capability is enabled by
+            default.
         bucket : builtins.str
             Bucket for oss.
         delete_max_size : builtins.int, optional
-            The size of max delete operations.
+            Deprecated: OSS delete batch capability is enabled by
+            default.
         enable_versioning : builtins.bool, optional
-            is bucket versioning enabled for this bucket
+            Deprecated: OSS versioning capability is enabled by
+            default.
         endpoint : builtins.str, optional
             Endpoint for oss.
         oidc_provider_arn : builtins.str, optional
@@ -4491,13 +4494,16 @@ class Operator:
         allow_anonymous : builtins.bool, optional
             Allow anonymous for oss.
         batch_max_operations : builtins.int, optional
-            The size of max batch operations.
+            Deprecated: OSS delete batch capability is enabled by
+            default.
         bucket : builtins.str
             Bucket for oss.
         delete_max_size : builtins.int, optional
-            The size of max delete operations.
+            Deprecated: OSS delete batch capability is enabled by
+            default.
         enable_versioning : builtins.bool, optional
-            is bucket versioning enabled for this bucket
+            Deprecated: OSS versioning capability is enabled by
+            default.
         endpoint : builtins.str, optional
             Endpoint for oss.
         oidc_provider_arn : builtins.str, optional

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -1779,13 +1779,16 @@ submit! {
                 allow_anonymous : builtins.bool, optional
                     Allow anonymous for oss.
                 batch_max_operations : builtins.int, optional
-                    The size of max batch operations.
+                    Deprecated: OSS delete batch capability is enabled
+                    by default.
                 bucket : builtins.str
                     Bucket for oss.
                 delete_max_size : builtins.int, optional
-                    The size of max delete operations.
+                    Deprecated: OSS delete batch capability is enabled
+                    by default.
                 enable_versioning : builtins.bool, optional
-                    is bucket versioning enabled for this bucket
+                    Deprecated: OSS versioning capability is enabled by
+                    default.
                 endpoint : builtins.str, optional
                     Endpoint for oss.
                 oidc_provider_arn : builtins.str, optional
@@ -4459,13 +4462,16 @@ submit! {
                 allow_anonymous : builtins.bool, optional
                     Allow anonymous for oss.
                 batch_max_operations : builtins.int, optional
-                    The size of max batch operations.
+                    Deprecated: OSS delete batch capability is enabled
+                    by default.
                 bucket : builtins.str
                     Bucket for oss.
                 delete_max_size : builtins.int, optional
-                    The size of max delete operations.
+                    Deprecated: OSS delete batch capability is enabled
+                    by default.
                 enable_versioning : builtins.bool, optional
-                    is bucket versioning enabled for this bucket
+                    Deprecated: OSS versioning capability is enabled by
+                    default.
                 endpoint : builtins.str, optional
                     Endpoint for oss.
                 oidc_provider_arn : builtins.str, optional

--- a/core/services/oss/src/backend.rs
+++ b/core/services/oss/src/backend.rs
@@ -111,10 +111,12 @@ impl OssBuilder {
         self
     }
 
-    /// Set bucket versioning status for this backend
-    pub fn enable_versioning(mut self, enabled: bool) -> Self {
-        self.config.enable_versioning = enabled;
-
+    /// Deprecated: OSS versioning capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "OSS versioning capability is enabled by default and this option is no longer needed."
+    )]
+    pub fn enable_versioning(self, _enabled: bool) -> Self {
         self
     }
 
@@ -287,21 +289,21 @@ impl OssBuilder {
         self
     }
 
-    /// Set maximum batch operations of this backend.
+    /// Deprecated: OSS delete batch capability is enabled by default.
     #[deprecated(
-        since = "0.52.0",
-        note = "Please use `delete_max_size` instead of `batch_max_operations`"
+        since = "0.57.0",
+        note = "OSS delete batch capability is enabled by default and this option is no longer needed."
     )]
-    pub fn batch_max_operations(mut self, delete_max_size: usize) -> Self {
-        self.config.delete_max_size = Some(delete_max_size);
-
+    pub fn batch_max_operations(self, _delete_max_size: usize) -> Self {
         self
     }
 
-    /// Set maximum delete operations of this backend.
-    pub fn delete_max_size(mut self, delete_max_size: usize) -> Self {
-        self.config.delete_max_size = Some(delete_max_size);
-
+    /// Deprecated: OSS delete batch capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "OSS delete batch capability is enabled by default and this option is no longer needed."
+    )]
+    pub fn delete_max_size(self, _delete_max_size: usize) -> Self {
         self
     }
 
@@ -501,11 +503,6 @@ impl Builder for OssBuilder {
         let request_signer = RequestSigner::new(bucket);
         let signer = Signer::new(ctx, provider, request_signer);
 
-        let delete_max_size = self
-            .config
-            .delete_max_size
-            .unwrap_or(DEFAULT_BATCH_MAX_OPERATIONS);
-
         Ok(OssBackend {
             core: Arc::new(OssCore {
                 info: {
@@ -516,13 +513,13 @@ impl Builder for OssBuilder {
                             stat: true,
                             stat_with_if_match: true,
                             stat_with_if_none_match: true,
-                            stat_with_version: self.config.enable_versioning,
+                            stat_with_version: true,
 
                             read: true,
 
                             read_with_if_match: true,
                             read_with_if_none_match: true,
-                            read_with_version: self.config.enable_versioning,
+                            read_with_version: true,
                             read_with_if_modified_since: true,
                             read_with_if_unmodified_since: true,
 
@@ -533,8 +530,7 @@ impl Builder for OssBuilder {
                             write_with_cache_control: true,
                             write_with_content_type: true,
                             write_with_content_disposition: true,
-                            // TODO: set this to false while version has been enabled.
-                            write_with_if_not_exists: !self.config.enable_versioning,
+                            write_with_if_not_exists: true,
 
                             // The min multipart size of OSS is 100 KiB.
                             //
@@ -551,8 +547,8 @@ impl Builder for OssBuilder {
                             write_with_user_metadata: true,
 
                             delete: true,
-                            delete_with_version: self.config.enable_versioning,
-                            delete_max_size: Some(delete_max_size),
+                            delete_with_version: true,
+                            delete_max_size: Some(DEFAULT_BATCH_MAX_OPERATIONS),
 
                             copy: true,
 
@@ -560,8 +556,8 @@ impl Builder for OssBuilder {
                             list_with_limit: true,
                             list_with_start_after: true,
                             list_with_recursive: true,
-                            list_with_versions: self.config.enable_versioning,
-                            list_with_deleted: self.config.enable_versioning,
+                            list_with_versions: true,
+                            list_with_deleted: true,
 
                             presign: true,
                             presign_stat: true,

--- a/core/services/oss/src/config.rs
+++ b/core/services/oss/src/config.rs
@@ -43,7 +43,11 @@ pub struct OssConfig {
     /// Pre sign addressing style for oss.
     pub presign_addressing_style: Option<String>,
 
-    /// is bucket versioning enabled for this bucket
+    /// Deprecated: OSS versioning capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "OSS versioning capability is enabled by default and this option is no longer needed."
+    )]
     pub enable_versioning: bool,
 
     // OSS features
@@ -70,13 +74,17 @@ pub struct OssConfig {
     /// - this field if it's `is_some`
     /// - env value: `ALIBABA_CLOUD_SECURITY_TOKEN`
     pub security_token: Option<String>,
-    /// The size of max batch operations.
+    /// Deprecated: OSS delete batch capability is enabled by default.
     #[deprecated(
-        since = "0.52.0",
-        note = "Please use `delete_max_size` instead of `batch_max_operations`"
+        since = "0.57.0",
+        note = "OSS delete batch capability is enabled by default. Use CapabilityOverrideLayer to override delete_max_size for specific endpoints."
     )]
     pub batch_max_operations: Option<usize>,
-    /// The size of max delete operations.
+    /// Deprecated: OSS delete batch capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "OSS delete batch capability is enabled by default. Use CapabilityOverrideLayer to override delete_max_size for specific endpoints."
+    )]
     pub delete_max_size: Option<usize>,
     /// If `role_arn` is set, we will use already known config as source
     /// credential to assume role with `role_arn`.

--- a/core/services/oss/src/docs.md
+++ b/core/services/oss/src/docs.md
@@ -25,6 +25,9 @@ This service can be used to:
 - `role_arn`: Set the role of backend.
 - `oidc_token`: Set the oidc_token for backend.
 - `allow_anonymous`: Set the backend access OSS in anonymous way.
+- `enable_versioning`: Deprecated. OSS versioning capability is enabled by default and this option is no longer needed.
+- `batch_max_operations`: Deprecated. OSS delete batch capability is enabled by default and this option is no longer needed.
+- `delete_max_size`: Deprecated. OSS delete batch capability is enabled by default and this option is no longer needed.
 
 Refer to [`OssBuilder`]'s public API docs for more information.
 


### PR DESCRIPTION
# Which issue does this PR close?

Refs #6708.

# Rationale for this change

OSS still had service config values that only changed declared capabilities. After #7520, those test/setup differences should be expressed through capability overrides instead of OSS-specific config.

# What changes are included in this PR?

This PR deprecates the remaining OSS capability-only config values as no-op compatibility shims, declares OSS versioning and delete batch capabilities directly, and migrates the non-versioned OSS behavior setup to `OPENDAL_TEST_CAPABILITY_OVERRIDES`. It also treats `write_with_if_not_exists` as an OSS native capability regardless of bucket versioning, and updates generated binding docs.

# Are there any user-facing changes?

`enable_versioning`, `batch_max_operations`, and `delete_max_size` are now deprecated for OSS and no longer change OSS's native capability declaration. OSS setups with narrower capability support should override the operator capability instead.

# AI Usage Statement

N/A.
