### PR TITLE
feat(services/tos): Add native copy support

### DIFF
--- a/core/services/tos/src/backend.rs
+++ b/core/services/tos/src/backend.rs
@@ -205,6 +205,8 @@ impl Builder for TosBuilder {
                     delete_max_size: Some(1000),
                     delete_with_version: config.enable_versioning,
 
+                    copy: true,
+
                     list: true,
                     list_with_limit: true,
                     list_with_start_after: true,
@@ -340,5 +342,20 @@ impl Access for TosBackend {
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
         let lister = TosLister::new(self.core.clone(), path, args);
         Ok((RpList::default(), oio::PageLister::new(lister)))
+    }
+
+    async fn copy(
+        &self,
+        from: &str,
+        to: &str,
+        args: OpCopy,
+        _opts: OpCopier,
+    ) -> Result<(RpCopy, Self::Copier)> {
+        let resp = self.core.tos_copy_object(from, to, &args).await?;
+
+        match resp.status() {
+            StatusCode::OK => Ok((RpCopy::default(), ())),
+            _ => Err(parse_error(resp)),
+        }
     }
 }

--- a/core/services/tos/src/core.rs
+++ b/core/services/tos/src/core.rs
@@ -33,6 +33,9 @@ use opendal_core::raw::*;
 use opendal_core::*;
 
 pub mod constants {
+    pub const X_TOS_ACL: &str = "x-tos-acl";
+    pub const X_TOS_COPY_SOURCE: &str = "x-tos-copy-source";
+
     pub const X_TOS_STORAGE_CLASS: &str = "x-tos-storage-class";
 
     pub const X_TOS_META_PREFIX: &str = "x-tos-meta-";
@@ -421,6 +424,39 @@ impl TosCore {
 
         let req = req
             .body(Buffer::from(content))
+            .map_err(new_request_build_error)?;
+
+        self.send(req).await
+    }
+
+    pub async fn tos_copy_object(
+        &self,
+        from: &str,
+        to: &str,
+        args: &OpCopy,
+    ) -> Result<Response<Buffer>> {
+        let source = build_abs_path(&self.root, from);
+        let target = build_abs_path(&self.root, to);
+
+        let url = format!(
+            "https://{}.{}/{}",
+            self.bucket,
+            self.endpoint_domain,
+            percent_encode_path(&target)
+        );
+        let source = format!("/{}/{}", self.bucket, percent_encode_path(&source));
+
+        let mut req = Request::put(&url)
+            .header(constants::X_TOS_COPY_SOURCE, source)
+            .header(constants::X_TOS_ACL, "default");
+
+        if args.if_not_exists() {
+            req = req.header(http::header::IF_NONE_MATCH, "*");
+        }
+
+        let req = req
+            .extension(Operation::Copy)
+            .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
         self.send(req).await

--- a/core/services/tos/src/error.rs
+++ b/core/services/tos/src/error.rs
@@ -50,10 +50,9 @@ pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
         _ => (ErrorKind::Unexpected, false),
     };
 
-    let body_content = bs.chunk();
-    let (message, tos_err) = de::from_reader::<_, TosError>(body_content.reader())
+    let (message, tos_err) = parse_tos_error(&bs)
         .map(|tos_err| (format!("{tos_err:?}"), Some(tos_err)))
-        .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
+        .unwrap_or_else(|| (String::from_utf8_lossy(&bs).into_owned(), None));
 
     if let Some(tos_err) = tos_err {
         (kind, retryable) =
@@ -71,12 +70,19 @@ pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     err
 }
 
+fn parse_tos_error(bs: &bytes::Bytes) -> Option<TosError> {
+    de::from_reader::<_, TosError>(bs.chunk().reader())
+        .or_else(|_| serde_json::from_slice::<TosError>(bs))
+        .ok()
+}
+
 /// Returns the `Error kind` of this code and whether the error is retryable.
 /// TOS error codes: https://www.volcengine.com/docs/6349/74874
 pub fn parse_tos_error_code(code: &str) -> Option<(ErrorKind, bool)> {
     match code {
         "NoSuchBucket" => Some((ErrorKind::ConfigInvalid, false)),
         "NoSuchKey" => Some((ErrorKind::NotFound, false)),
+        "DuplicateObject" => Some((ErrorKind::ConditionNotMatch, false)),
         "RequestTimeout" => Some((ErrorKind::Unexpected, true)),
         "InternalError" => Some((ErrorKind::Unexpected, true)),
         "OperationAborted" => Some((ErrorKind::Unexpected, true)),
@@ -114,6 +120,19 @@ mod tests {
         assert_eq!(out.message, "The resource you requested does not exist");
         assert_eq!(out.resource, "/mybucket/myfoto.jpg");
         assert_eq!(out.request_id, "4442587FB7D0A2F9");
+    }
+
+    #[test]
+    fn test_parse_json_error() {
+        let bs = bytes::Bytes::from(
+            r#"{"Code":"DuplicateObject","RequestId":"request-id","Message":"The object already exists."}"#,
+        );
+
+        let out = parse_tos_error(&bs).expect("must success");
+
+        assert_eq!(out.code, "DuplicateObject");
+        assert_eq!(out.message, "The object already exists.");
+        assert_eq!(out.request_id, "request-id");
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

Part of #7152.

# Rationale for this change

TOS supports server-side object copy. OpenDAL should expose it through native `copy`.

# What changes are included in this PR?

- Enable TOS native `copy` capability.
- Add TOS `CopyObject` request construction with `x-tos-copy-source`.
- Set copied objects to inherit bucket ACL via `x-tos-acl: default`.

# Are there any user-facing changes?

TOS now supports native `Operator::copy`.

# AI Usage Statement

This PR was implemented with Codex.
