### PR TITLE
refactor(services/cos): complete capability override migration

### DIFF
--- a/.github/services/cos/cos/action.yml
+++ b/.github/services/cos/cos/action.yml
@@ -34,4 +34,4 @@ runs:
     - name: Add extra settings
       shell: bash
       run: |
-        echo "OPENDAL_COS_ENABLE_VERSIONING=true" >> $GITHUB_ENV
+        echo "OPENDAL_TEST_CAPABILITY_OVERRIDES=write_with_if_not_exists=false,copy_with_if_not_exists=false" >> $GITHUB_ENV

--- a/bindings/dotnet/OpenDAL/ServiceConfig/CosServiceConfig.cs
+++ b/bindings/dotnet/OpenDAL/ServiceConfig/CosServiceConfig.cs
@@ -37,7 +37,7 @@ namespace OpenDAL.ServiceConfig
         /// </summary>
         public bool? DisableConfigLoad { get; init; }
         /// <summary>
-        /// is bucket versioning enabled for this bucket
+        /// Deprecated: COS versioning capability is enabled by default.
         /// </summary>
         public bool? EnableVersioning { get; init; }
         /// <summary>

--- a/bindings/go/operator_info.go
+++ b/bindings/go/operator_info.go
@@ -228,7 +228,7 @@ func (c *Capability) Shared() bool {
 }
 
 func (c *Capability) Blocking() bool {
-	return c.inner.blocking == 1
+	return true
 }
 
 var ffiOperatorInfoNew = newFFI(ffiOpts{

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -180,7 +180,6 @@ var (
 			&ffi.TypeUint8,   // presign_write
 			&ffi.TypeUint8,   // presign_delete
 			&ffi.TypeUint8,   // shared
-			&ffi.TypeUint8,   // blocking
 			nil,
 		}[0],
 	}
@@ -220,7 +219,6 @@ type opendalCapability struct {
 	presignWrite                       uint8
 	presignDelete                      uint8
 	shared                             uint8
-	blocking                           uint8
 }
 
 type resultOperatorNew struct {

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -629,7 +629,9 @@ public interface ServiceConfig {
          */
         public final Boolean disableConfigLoad;
         /**
-         * <p>is bucket versioning enabled for this bucket</p>
+         * <p>Deprecated: COS versioning capability is enabled by default.</p>
+         *
+         * @deprecated COS versioning capability is enabled by default and this option is no longer needed.
          */
         public final Boolean enableVersioning;
         /**

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -953,7 +953,8 @@ class AsyncOperator:
             Disable config load so that opendal will not load
             config from
         enable_versioning : builtins.bool, optional
-            is bucket versioning enabled for this bucket
+            Deprecated: COS versioning capability is enabled by
+            default.
         endpoint : builtins.str, optional
             Endpoint of this backend.
         root : builtins.str, optional
@@ -3558,7 +3559,8 @@ class Operator:
             Disable config load so that opendal will not load
             config from
         enable_versioning : builtins.bool, optional
-            is bucket versioning enabled for this bucket
+            Deprecated: COS versioning capability is enabled by
+            default.
         endpoint : builtins.str, optional
             Endpoint of this backend.
         root : builtins.str, optional

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -618,7 +618,8 @@ submit! {
                     Disable config load so that opendal will not load
                     config from
                 enable_versioning : builtins.bool, optional
-                    is bucket versioning enabled for this bucket
+                    Deprecated: COS versioning capability is enabled by
+                    default.
                 endpoint : builtins.str, optional
                     Endpoint of this backend.
                 root : builtins.str, optional
@@ -3301,7 +3302,8 @@ submit! {
                     Disable config load so that opendal will not load
                     config from
                 enable_versioning : builtins.bool, optional
-                    is bucket versioning enabled for this bucket
+                    Deprecated: COS versioning capability is enabled by
+                    default.
                 endpoint : builtins.str, optional
                     Endpoint of this backend.
                 root : builtins.str, optional

--- a/core/services/cos/src/backend.rs
+++ b/core/services/cos/src/backend.rs
@@ -120,10 +120,12 @@ impl CosBuilder {
         self
     }
 
-    /// Set bucket versioning status for this backend
-    pub fn enable_versioning(mut self, enabled: bool) -> Self {
-        self.config.enable_versioning = enabled;
-
+    /// Deprecated: COS versioning capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "COS versioning capability is enabled by default and this option is no longer needed."
+    )]
+    pub fn enable_versioning(self, _enabled: bool) -> Self {
         self
     }
 
@@ -227,7 +229,7 @@ impl Builder for CosBuilder {
                             stat: true,
                             stat_with_if_match: true,
                             stat_with_if_none_match: true,
-                            stat_with_version: self.config.enable_versioning,
+                            stat_with_version: true,
 
                             read: true,
 
@@ -235,7 +237,7 @@ impl Builder for CosBuilder {
                             read_with_if_none_match: true,
                             read_with_if_modified_since: true,
                             read_with_if_unmodified_since: true,
-                            read_with_version: self.config.enable_versioning,
+                            read_with_version: true,
 
                             write: true,
                             write_can_empty: true,
@@ -244,10 +246,8 @@ impl Builder for CosBuilder {
                             write_with_content_type: true,
                             write_with_cache_control: true,
                             write_with_content_disposition: true,
-                            // Cos doesn't support forbid overwrite while version has been enabled.
-                            write_with_if_not_exists: !self.config.enable_versioning,
-                            // Same as write: forbid-overwrite only works when versioning is disabled.
-                            copy_with_if_not_exists: !self.config.enable_versioning,
+                            write_with_if_not_exists: true,
+                            copy_with_if_not_exists: true,
                             // The min multipart size of COS is 1 MiB.
                             //
                             // ref: <https://www.tencentcloud.com/document/product/436/14112>
@@ -263,13 +263,13 @@ impl Builder for CosBuilder {
                             write_with_user_metadata: true,
 
                             delete: true,
-                            delete_with_version: self.config.enable_versioning,
+                            delete_with_version: true,
                             copy: true,
 
                             list: true,
                             list_with_recursive: true,
-                            list_with_versions: self.config.enable_versioning,
-                            list_with_deleted: self.config.enable_versioning,
+                            list_with_versions: true,
+                            list_with_deleted: true,
 
                             presign: true,
                             presign_stat: true,

--- a/core/services/cos/src/config.rs
+++ b/core/services/cos/src/config.rs
@@ -40,7 +40,11 @@ pub struct CosConfig {
     pub secret_key: Option<String>,
     /// Bucket of this backend.
     pub bucket: Option<String>,
-    /// is bucket versioning enabled for this bucket
+    /// Deprecated: COS versioning capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "COS versioning capability is enabled by default and this option is no longer needed."
+    )]
     pub enable_versioning: bool,
     /// Disable config load so that opendal will not load config from
     pub disable_config_load: bool,
@@ -52,7 +56,6 @@ impl Debug for CosConfig {
             .field("root", &self.root)
             .field("endpoint", &self.endpoint)
             .field("bucket", &self.bucket)
-            .field("enable_versioning", &self.enable_versioning)
             .field("disable_config_load", &self.disable_config_load)
             .finish_non_exhaustive()
     }

--- a/core/services/cos/src/docs.md
+++ b/core/services/cos/src/docs.md
@@ -19,6 +19,7 @@ This service can be used to:
 - `endpoint`: Customizable endpoint setting
 - `access_key_id`: Set the access_key_id for backend.
 - `secret_access_key`: Set the secret_access_key for backend.
+- `enable_versioning`: Deprecated. COS versioning capability is enabled by default and this option is no longer needed.
 
 You can refer to [`CosBuilder`]'s docs for more information
 


### PR DESCRIPTION
# Which issue does this PR close?

Refs #6708.

# Rationale for this change

COS still had a service config value that only changed declared capabilities. After #7520, those test/setup differences should be expressed through capability overrides instead of COS-specific config.

# What changes are included in this PR?

This PR deprecates `enable_versioning` as a no-op compatibility shim, declares COS versioning capabilities directly, and migrates the COS behavior setup to `OPENDAL_TEST_CAPABILITY_OVERRIDES`. The COS test setup also disables `write_with_if_not_exists` and `copy_with_if_not_exists` because `x-cos-forbid-overwrite` only works for buckets that have never enabled versioning.

It also aligns the Go binding's capability FFI layout with the C `opendal_capability` struct. Go kept a stale extra `blocking` field, which made `Info().GetFullCapability()` decode a different struct shape than the C ABI returns and could crash behavior tests.

# Are there any user-facing changes?

`enable_versioning` is now deprecated for COS and no longer changes COS's native capability declaration. COS setups with narrower capability support should override the operator capability instead.

# AI Usage Statement

N/A.
