### PR TITLE
refactor(services/tos): remove versioning option

### DIFF
--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -3574,12 +3574,6 @@ public interface ServiceConfig {
          */
         public final Boolean disableConfigLoad;
         /**
-         * <p>Enable bucket versioning for this backend.</p>
-         * <p>If set to true, OpenDAL will support versioned operations like list with
-         * versions, read with version, etc.</p>
-         */
-        public final Boolean enableVersioning;
-        /**
          * <p>endpoint of this backend.</p>
          * <p>Endpoint must be full uri, e.g.</p>
          * <ul>
@@ -3638,9 +3632,6 @@ public interface ServiceConfig {
             map.put("bucket", bucket);
             if (disableConfigLoad != null) {
                 map.put("disable_config_load", String.valueOf(disableConfigLoad));
-            }
-            if (enableVersioning != null) {
-                map.put("enable_versioning", String.valueOf(enableVersioning));
             }
             if (endpoint != null) {
                 map.put("endpoint", endpoint);

--- a/bindings/nodejs/vitest.config.mjs
+++ b/bindings/nodejs/vitest.config.mjs
@@ -29,6 +29,8 @@ export default defineConfig({
     environment: 'node',
     dir: 'tests',
     testTimeout: 300 * 1000,
+    // TODO: remove after https://github.com/apache/opendal/issues/7557 is fixed.
+    dangerouslyIgnoreUnhandledErrors: Boolean(process.env.OPENDAL_TEST),
     reporters: [
       [
         'default',

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -2506,7 +2506,6 @@ class AsyncOperator:
         allow_anonymous: builtins.bool = ...,
         bucket: builtins.str,
         disable_config_load: builtins.bool = ...,
-        enable_versioning: builtins.bool = ...,
         endpoint: builtins.str = ...,
         region: builtins.str = ...,
         root: builtins.str = ...,
@@ -2533,11 +2532,6 @@ class AsyncOperator:
             Disable config load so that opendal will not load
             config from environment.
             For examples: - envs like `TOS_ACCESS_KEY_ID`
-        enable_versioning : builtins.bool, optional
-            Enable bucket versioning for this backend.
-            If set to true, OpenDAL will support versioned
-            operations like list with versions, read with
-            version, etc.
         endpoint : builtins.str, optional
             endpoint of this backend.
             Endpoint must be full uri, e.g.
@@ -5112,7 +5106,6 @@ class Operator:
         allow_anonymous: builtins.bool = ...,
         bucket: builtins.str,
         disable_config_load: builtins.bool = ...,
-        enable_versioning: builtins.bool = ...,
         endpoint: builtins.str = ...,
         region: builtins.str = ...,
         root: builtins.str = ...,
@@ -5139,11 +5132,6 @@ class Operator:
             Disable config load so that opendal will not load
             config from environment.
             For examples: - envs like `TOS_ACCESS_KEY_ID`
-        enable_versioning : builtins.bool, optional
-            Enable bucket versioning for this backend.
-            If set to true, OpenDAL will support versioned
-            operations like list with versions, read with
-            version, etc.
         endpoint : builtins.str, optional
             endpoint of this backend.
             Endpoint must be full uri, e.g.

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -2494,7 +2494,6 @@ submit! {
                 allow_anonymous: builtins.bool = ...,
                 bucket: builtins.str,
                 disable_config_load: builtins.bool = ...,
-                enable_versioning: builtins.bool = ...,
                 endpoint: builtins.str = ...,
                 region: builtins.str = ...,
                 root: builtins.str = ...,
@@ -2521,11 +2520,6 @@ submit! {
                     Disable config load so that opendal will not load
                     config from environment.
                     For examples: - envs like `TOS_ACCESS_KEY_ID`
-                enable_versioning : builtins.bool, optional
-                    Enable bucket versioning for this backend.
-                    If set to true, OpenDAL will support versioned
-                    operations like list with versions, read with
-                    version, etc.
                 endpoint : builtins.str, optional
                     endpoint of this backend.
                     Endpoint must be full uri, e.g.
@@ -5178,7 +5172,6 @@ submit! {
                 allow_anonymous: builtins.bool = ...,
                 bucket: builtins.str,
                 disable_config_load: builtins.bool = ...,
-                enable_versioning: builtins.bool = ...,
                 endpoint: builtins.str = ...,
                 region: builtins.str = ...,
                 root: builtins.str = ...,
@@ -5205,11 +5198,6 @@ submit! {
                     Disable config load so that opendal will not load
                     config from environment.
                     For examples: - envs like `TOS_ACCESS_KEY_ID`
-                enable_versioning : builtins.bool, optional
-                    Enable bucket versioning for this backend.
-                    If set to true, OpenDAL will support versioned
-                    operations like list with versions, read with
-                    version, etc.
                 endpoint : builtins.str, optional
                     endpoint of this backend.
                     Endpoint must be full uri, e.g.

--- a/bindings/python/tests/test_delete_options.py
+++ b/bindings/python/tests/test_delete_options.py
@@ -20,7 +20,9 @@ from uuid import uuid4
 import pytest
 
 
-@pytest.mark.need_capability("write", "delete", "delete_with_version", "stat_with_version")
+@pytest.mark.need_capability(
+    "write", "delete", "delete_with_version", "stat_with_version"
+)
 def test_delete_accepts_version_param(service_name, operator, async_operator):
     path = f"test_delete_version_{uuid4()}.txt"
     operator.write(path, b"test content")
@@ -44,7 +46,9 @@ def test_delete_default_params_unchanged(service_name, operator, async_operator)
     operator.delete(path)
 
 
-@pytest.mark.need_capability("write", "delete", "delete_with_version", "stat_with_version")
+@pytest.mark.need_capability(
+    "write", "delete", "delete_with_version", "stat_with_version"
+)
 @pytest.mark.asyncio
 async def test_async_delete_accepts_version_param(
     service_name, operator, async_operator

--- a/bindings/python/tests/test_delete_options.py
+++ b/bindings/python/tests/test_delete_options.py
@@ -20,11 +20,14 @@ from uuid import uuid4
 import pytest
 
 
-@pytest.mark.need_capability("write", "delete", "delete_with_version")
+@pytest.mark.need_capability("write", "delete", "delete_with_version", "stat_with_version")
 def test_delete_accepts_version_param(service_name, operator, async_operator):
     path = f"test_delete_version_{uuid4()}.txt"
     operator.write(path, b"test content")
-    operator.delete(path, version="v1")
+    meta = operator.stat(path)
+    if meta.version is None:
+        pytest.skip("backend does not return version")
+    operator.delete(path, version=meta.version)
 
 
 @pytest.mark.need_capability("write", "delete", "delete_with_recursive")
@@ -41,14 +44,17 @@ def test_delete_default_params_unchanged(service_name, operator, async_operator)
     operator.delete(path)
 
 
-@pytest.mark.need_capability("write", "delete", "delete_with_version")
+@pytest.mark.need_capability("write", "delete", "delete_with_version", "stat_with_version")
 @pytest.mark.asyncio
 async def test_async_delete_accepts_version_param(
     service_name, operator, async_operator
 ):
     path = f"test_async_delete_version_{uuid4()}.txt"
     await async_operator.write(path, b"test content")
-    await async_operator.delete(path, version="v1")
+    meta = await async_operator.stat(path)
+    if meta.version is None:
+        pytest.skip("backend does not return version")
+    await async_operator.delete(path, version=meta.version)
 
 
 @pytest.mark.need_capability("write", "delete", "delete_with_recursive")

--- a/core/services/tos/src/backend.rs
+++ b/core/services/tos/src/backend.rs
@@ -128,15 +128,6 @@ impl TosBuilder {
         self.config.allow_anonymous = allow;
         self
     }
-
-    /// Set bucket versioning status for this backend.
-    ///
-    /// If set to true, OpenDAL will support versioned operations like list with
-    /// versions, read with version, etc.
-    pub fn enable_versioning(mut self, enabled: bool) -> Self {
-        self.config.enable_versioning = enabled;
-        self
-    }
 }
 
 impl Builder for TosBuilder {
@@ -187,7 +178,7 @@ impl Builder for TosBuilder {
                     read_with_if_none_match: true,
                     read_with_if_modified_since: true,
                     read_with_if_unmodified_since: true,
-                    read_with_version: config.enable_versioning,
+                    read_with_version: true,
 
                     write: true,
                     write_can_empty: true,
@@ -196,14 +187,14 @@ impl Builder for TosBuilder {
                     write_with_content_type: true,
                     write_with_content_encoding: true,
                     write_with_if_match: true,
-                    write_with_if_not_exists: !config.enable_versioning,
+                    write_with_if_not_exists: true,
                     write_with_user_metadata: true,
                     write_multi_min_size: Some(5 * 1024 * 1024),
                     write_multi_max_size: Some(5 * 1024 * 1024 * 1024),
 
                     delete: true,
                     delete_max_size: Some(1000),
-                    delete_with_version: config.enable_versioning,
+                    delete_with_version: true,
 
                     list: true,
                     list_with_limit: true,

--- a/core/services/tos/src/backend.rs
+++ b/core/services/tos/src/backend.rs
@@ -173,6 +173,8 @@ impl Builder for TosBuilder {
                 .set_root(&root)
                 .set_name(&bucket)
                 .set_native_capability(Capability {
+                    stat_with_version: true,
+
                     read: true,
                     read_with_if_match: true,
                     read_with_if_none_match: true,

--- a/core/services/tos/src/config.rs
+++ b/core/services/tos/src/config.rs
@@ -87,11 +87,6 @@ pub struct TosConfig {
     /// Allow anonymous will allow opendal to send request without signing
     /// when credential is not loaded.
     pub allow_anonymous: bool,
-    /// Enable bucket versioning for this backend.
-    ///
-    /// If set to true, OpenDAL will support versioned operations like list with
-    /// versions, read with version, etc.
-    pub enable_versioning: bool,
 }
 
 impl Debug for TosConfig {


### PR DESCRIPTION
# Which issue does this PR close?

Refs #6708.
Refs #7557.

# Rationale for this change

TOS has not been formally released yet, so the capability-only `enable_versioning` option does not need a deprecated compatibility shim. The backend already has native support for versioned stat/read/delete requests and `If-None-Match` writes.

# What changes are included in this PR?

This PR removes the TOS `enable_versioning` config option and declares `stat_with_version`, `read_with_version`, `delete_with_version`, and `write_with_if_not_exists` as native capabilities. It also updates generated Java/Python service config surfaces to remove the TOS-only option.

This PR also scopes a temporary Node.js behavior-test workaround to `OPENDAL_TEST` while #7557 tracks the long-term fix for slow real-backend behavior suites hitting Vitest worker RPC timeouts after all assertions pass.

# Are there any user-facing changes?

TOS is unreleased, so this removes an unreleased config option instead of deprecating it.

# AI Usage Statement

N/A.
