### PR TITLE
feat(services/oss): Rename allow_anonymous to skip_signature

### DIFF
--- a/bindings/dotnet/OpenDAL/ServiceConfig/OssServiceConfig.cs
+++ b/bindings/dotnet/OpenDAL/ServiceConfig/OssServiceConfig.cs
@@ -41,8 +41,13 @@ namespace OpenDAL.ServiceConfig
         /// </summary>
         public string? AddressingStyle { get; init; }
         /// <summary>
+        /// Skip signature will skip loading credentials and signing requests.
+        /// </summary>
+        public bool? SkipSignature { get; init; }
+        /// <summary>
         /// Allow anonymous for oss.
         /// </summary>
+        [System.Obsolete("Please use SkipSignature instead of AllowAnonymous")]
         public bool? AllowAnonymous { get; init; }
         /// <summary>
         /// Deprecated: OSS delete batch capability is enabled by default.
@@ -126,10 +131,16 @@ namespace OpenDAL.ServiceConfig
             {
                 map["addressing_style"] = Utilities.ToOptionString(AddressingStyle);
             }
+            if (SkipSignature is not null)
+            {
+                map["skip_signature"] = Utilities.ToOptionString(SkipSignature);
+            }
+#pragma warning disable CS0618
             if (AllowAnonymous is not null)
             {
                 map["allow_anonymous"] = Utilities.ToOptionString(AllowAnonymous);
             }
+#pragma warning restore CS0618
             if (BatchMaxOperations is not null)
             {
                 map["batch_max_operations"] = Utilities.ToOptionString(BatchMaxOperations);

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -2375,6 +2375,8 @@ public interface ServiceConfig {
         public final String addressingStyle;
         /**
          * <p>Allow anonymous for oss.</p>
+         *
+         * @deprecated Please use `skip_signature` instead of `allow_anonymous`
          */
         public final Boolean allowAnonymous;
         /**
@@ -2461,6 +2463,10 @@ public interface ServiceConfig {
          */
         public final String serverSideEncryptionKeyId;
         /**
+         * <p>Skip signature will skip loading credentials and signing requests.</p>
+         */
+        public final Boolean skipSignature;
+        /**
          * <p><code>sts_endpoint</code> will be loaded from</p>
          * <ul>
          * <li>this field if it's <code>is_some</code></li>
@@ -2531,6 +2537,9 @@ public interface ServiceConfig {
             }
             if (serverSideEncryptionKeyId != null) {
                 map.put("server_side_encryption_key_id", serverSideEncryptionKeyId);
+            }
+            if (skipSignature != null) {
+                map.put("skip_signature", String.valueOf(skipSignature));
             }
             if (stsEndpoint != null) {
                 map.put("sts_endpoint", stsEndpoint);

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -1870,6 +1870,7 @@ class AsyncOperator:
         security_token: builtins.str = ...,
         server_side_encryption: builtins.str = ...,
         server_side_encryption_key_id: builtins.str = ...,
+        skip_signature: builtins.bool = ...,
         sts_endpoint: builtins.str = ...,
     ) -> typing.Self:
         r"""
@@ -1890,13 +1891,13 @@ class AsyncOperator:
         allow_anonymous : builtins.bool, optional
             Allow anonymous for oss.
         batch_max_operations : builtins.int, optional
-            Deprecated: OSS delete batch capability is enabled by
-            default.
+            Deprecated: OSS delete batch capability is enabled
+            by default.
         bucket : builtins.str
             Bucket for oss.
         delete_max_size : builtins.int, optional
-            Deprecated: OSS delete batch capability is enabled by
-            default.
+            Deprecated: OSS delete batch capability is enabled
+            by default.
         enable_versioning : builtins.bool, optional
             Deprecated: OSS versioning capability is enabled by
             default.
@@ -1932,6 +1933,9 @@ class AsyncOperator:
             Server side encryption for oss.
         server_side_encryption_key_id : builtins.str, optional
             Server side encryption key id for oss.
+        skip_signature : builtins.bool, optional
+            Skip signature will skip loading credentials and
+            signing requests.
         sts_endpoint : builtins.str, optional
             `sts_endpoint` will be loaded from - this field if
             it's `is_some` - env value:
@@ -2199,15 +2203,14 @@ class AsyncOperator:
             Deprecated: S3 stat override capabilities are
             enabled by default.
         disable_write_with_if_match : builtins.bool, optional
-            Disable write with if match so that opendal will not
-            send write request with if match headers.
-            For example, Ceph RADOS S3 doesn't support write
-            with if matched.
+            Deprecated: S3 write with If-Match capability is
+            enabled by default.
         enable_request_payer : builtins.bool, optional
             Indicates whether the client agrees to pay for the
             requests made to the S3 bucket.
         enable_versioning : builtins.bool, optional
-            is bucket versioning enabled for this bucket
+            Deprecated: S3 versioning capability is enabled by
+            default.
         enable_virtual_host_style : builtins.bool, optional
             Enable virtual host style so that opendal will send
             API requests in virtual host style instead of path
@@ -2217,8 +2220,8 @@ class AsyncOperator:
             Enabled, opendal will send API to
             `https://bucket_name.s3.us-east-1.amazonaws.com`
         enable_write_with_append : builtins.bool, optional
-            Enable write with append so that opendal will send
-            write request with append headers.
+            Deprecated: S3 append capability is enabled by
+            default.
         endpoint : builtins.str, optional
             endpoint of this backend.
             Endpoint must be full uri, e.g.
@@ -4476,6 +4479,7 @@ class Operator:
         security_token: builtins.str = ...,
         server_side_encryption: builtins.str = ...,
         server_side_encryption_key_id: builtins.str = ...,
+        skip_signature: builtins.bool = ...,
         sts_endpoint: builtins.str = ...,
     ) -> typing.Self:
         r"""
@@ -4496,13 +4500,13 @@ class Operator:
         allow_anonymous : builtins.bool, optional
             Allow anonymous for oss.
         batch_max_operations : builtins.int, optional
-            Deprecated: OSS delete batch capability is enabled by
-            default.
+            Deprecated: OSS delete batch capability is enabled
+            by default.
         bucket : builtins.str
             Bucket for oss.
         delete_max_size : builtins.int, optional
-            Deprecated: OSS delete batch capability is enabled by
-            default.
+            Deprecated: OSS delete batch capability is enabled
+            by default.
         enable_versioning : builtins.bool, optional
             Deprecated: OSS versioning capability is enabled by
             default.
@@ -4538,6 +4542,9 @@ class Operator:
             Server side encryption for oss.
         server_side_encryption_key_id : builtins.str, optional
             Server side encryption key id for oss.
+        skip_signature : builtins.bool, optional
+            Skip signature will skip loading credentials and
+            signing requests.
         sts_endpoint : builtins.str, optional
             `sts_endpoint` will be loaded from - this field if
             it's `is_some` - env value:
@@ -4805,15 +4812,14 @@ class Operator:
             Deprecated: S3 stat override capabilities are
             enabled by default.
         disable_write_with_if_match : builtins.bool, optional
-            Disable write with if match so that opendal will not
-            send write request with if match headers.
-            For example, Ceph RADOS S3 doesn't support write
-            with if matched.
+            Deprecated: S3 write with If-Match capability is
+            enabled by default.
         enable_request_payer : builtins.bool, optional
             Indicates whether the client agrees to pay for the
             requests made to the S3 bucket.
         enable_versioning : builtins.bool, optional
-            is bucket versioning enabled for this bucket
+            Deprecated: S3 versioning capability is enabled by
+            default.
         enable_virtual_host_style : builtins.bool, optional
             Enable virtual host style so that opendal will send
             API requests in virtual host style instead of path
@@ -4823,8 +4829,8 @@ class Operator:
             Enabled, opendal will send API to
             `https://bucket_name.s3.us-east-1.amazonaws.com`
         enable_write_with_append : builtins.bool, optional
-            Enable write with append so that opendal will send
-            write request with append headers.
+            Deprecated: S3 append capability is enabled by
+            default.
         endpoint : builtins.str, optional
             endpoint of this backend.
             Endpoint must be full uri, e.g.

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -1760,6 +1760,7 @@ submit! {
                 security_token: builtins.str = ...,
                 server_side_encryption: builtins.str = ...,
                 server_side_encryption_key_id: builtins.str = ...,
+                skip_signature: builtins.bool = ...,
                 sts_endpoint: builtins.str = ...,
             ) -> typing.Self:
                 r"""
@@ -1822,6 +1823,9 @@ submit! {
                     Server side encryption for oss.
                 server_side_encryption_key_id : builtins.str, optional
                     Server side encryption key id for oss.
+                skip_signature : builtins.bool, optional
+                    Skip signature will skip loading credentials and
+                    signing requests.
                 sts_endpoint : builtins.str, optional
                     `sts_endpoint` will be loaded from - this field if
                     it's `is_some` - env value:
@@ -4444,6 +4448,7 @@ submit! {
                 security_token: builtins.str = ...,
                 server_side_encryption: builtins.str = ...,
                 server_side_encryption_key_id: builtins.str = ...,
+                skip_signature: builtins.bool = ...,
                 sts_endpoint: builtins.str = ...,
             ) -> typing.Self:
                 r"""
@@ -4506,6 +4511,9 @@ submit! {
                     Server side encryption for oss.
                 server_side_encryption_key_id : builtins.str, optional
                     Server side encryption key id for oss.
+                skip_signature : builtins.bool, optional
+                    Skip signature will skip loading credentials and
+                    signing requests.
                 sts_endpoint : builtins.str, optional
                     `sts_endpoint` will be loaded from - this field if
                     it's `is_some` - env value:

--- a/core/services/oss/src/backend.rs
+++ b/core/services/oss/src/backend.rs
@@ -307,11 +307,20 @@ impl OssBuilder {
         self
     }
 
+    /// Skip signature will skip loading credentials and signing requests.
+    pub fn skip_signature(mut self) -> Self {
+        self.config.skip_signature = true;
+        self
+    }
+
     /// Allow anonymous will allow opendal to send request without signing
     /// when credential is not loaded.
-    pub fn allow_anonymous(mut self) -> Self {
-        self.config.allow_anonymous = true;
-        self
+    #[deprecated(
+        since = "0.57.0",
+        note = "Please use `skip_signature` instead of `allow_anonymous`"
+    )]
+    pub fn allow_anonymous(self) -> Self {
+        self.skip_signature()
     }
 
     /// Set role_arn for this backend.
@@ -392,6 +401,9 @@ impl Builder for OssBuilder {
 
     fn build(self) -> Result<impl Access> {
         debug!("backend build started: {:?}", &self);
+
+        #[allow(deprecated)]
+        let skip_signature = self.config.skip_signature || self.config.allow_anonymous;
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
         debug!("backend use root {}", &root);
@@ -576,7 +588,7 @@ impl Builder for OssBuilder {
                 endpoint,
                 host,
                 presign_endpoint,
-                allow_anonymous: self.config.allow_anonymous,
+                skip_signature,
                 signer,
                 server_side_encryption,
                 server_side_encryption_key_id,

--- a/core/services/oss/src/config.rs
+++ b/core/services/oss/src/config.rs
@@ -55,7 +55,13 @@ pub struct OssConfig {
     pub server_side_encryption: Option<String>,
     /// Server side encryption key id for oss.
     pub server_side_encryption_key_id: Option<String>,
+    /// Skip signature will skip loading credentials and signing requests.
+    pub skip_signature: bool,
     /// Allow anonymous for oss.
+    #[deprecated(
+        since = "0.57.0",
+        note = "Please use `skip_signature` instead of `allow_anonymous`"
+    )]
     pub allow_anonymous: bool,
 
     // authenticate options
@@ -117,7 +123,7 @@ impl Debug for OssConfig {
             .field("root", &self.root)
             .field("bucket", &self.bucket)
             .field("endpoint", &self.endpoint)
-            .field("allow_anonymous", &self.allow_anonymous)
+            .field("skip_signature", &self.skip_signature)
             .finish_non_exhaustive()
     }
 }

--- a/core/services/oss/src/core.rs
+++ b/core/services/oss/src/core.rs
@@ -70,7 +70,7 @@ pub struct OssCore {
     pub host: String,
     pub endpoint: String,
     pub presign_endpoint: String,
-    pub allow_anonymous: bool,
+    pub skip_signature: bool,
 
     pub server_side_encryption: Option<HeaderValue>,
     pub server_side_encryption_key_id: Option<HeaderValue>,
@@ -91,8 +91,7 @@ impl Debug for OssCore {
 
 impl OssCore {
     pub async fn sign<T>(&self, req: Request<T>) -> Result<Request<T>> {
-        // Skip signing for anonymous access.
-        if self.allow_anonymous {
+        if self.skip_signature {
             return Ok(req);
         }
 
@@ -107,8 +106,7 @@ impl OssCore {
     }
 
     pub async fn sign_query<T>(&self, req: Request<T>, duration: Duration) -> Result<Request<T>> {
-        // Skip signing for anonymous access.
-        if self.allow_anonymous {
+        if self.skip_signature {
             return Ok(req);
         }
 

--- a/core/services/oss/src/docs.md
+++ b/core/services/oss/src/docs.md
@@ -24,7 +24,8 @@ This service can be used to:
 - `access_key_secret`: Set the access_key_secret for backend.
 - `role_arn`: Set the role of backend.
 - `oidc_token`: Set the oidc_token for backend.
-- `allow_anonymous`: Set the backend access OSS in anonymous way.
+- `skip_signature`: Skip loading credentials and signing requests.
+- `allow_anonymous`: Deprecated. Use `skip_signature` instead.
 - `enable_versioning`: Deprecated. OSS versioning capability is enabled by default and this option is no longer needed.
 - `batch_max_operations`: Deprecated. OSS delete batch capability is enabled by default and this option is no longer needed.
 - `delete_max_size`: Deprecated. OSS delete batch capability is enabled by default and this option is no longer needed.


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #7537.

## Rationale for this change

 This PR renames `allow_anonymous` to `skip_signature` for OSS, matching the naming used by `object_store` and aligning with the S3 rename in #7544.

## What changes are included in this PR?

- Add `OssBuilder::skip_signature` and `OssConfig::skip_signature`.
- Deprecate `OssBuilder::allow_anonymous` and `OssConfig::allow_anonymous`;
  both keep working and are merged into `skip_signature` at build time.
- Update `.NET` / Java / Python bindings accordingly (old field kept, new
  field added, old marked deprecated).
- Update `docs.md` to reference the new option.

## Are there any user-facing changes?
No breaking changes. `allow_anonymous` still works but emits a deprecation warning suggesting `skip_signature`.