### PR TITLE
refactor(services/onedrive): deprecate versioning option

### DIFF
--- a/bindings/dotnet/OpenDAL/ServiceConfig/OnedriveServiceConfig.cs
+++ b/bindings/dotnet/OpenDAL/ServiceConfig/OnedriveServiceConfig.cs
@@ -41,7 +41,7 @@ namespace OpenDAL.ServiceConfig
         /// </summary>
         public string? ClientSecret { get; init; }
         /// <summary>
-        /// Enabling version support
+        /// Deprecated: OneDrive versioning capability is enabled by default.
         /// </summary>
         public bool? EnableVersioning { get; init; }
         /// <summary>

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -2277,7 +2277,9 @@ public interface ServiceConfig {
          */
         public final String clientSecret;
         /**
-         * <p>Enabling version support</p>
+         * <p>Deprecated: OneDrive versioning capability is enabled by default.</p>
+         *
+         * @deprecated OneDrive versioning capability is enabled by default and this option is no longer needed.
          */
         public final Boolean enableVersioning;
         /**

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -1832,7 +1832,8 @@ class AsyncOperator:
             Microsoft Graph API Application client secret that
             is in the Azure's app registration portal
         enable_versioning : builtins.bool, optional
-            Enabling version support
+            Deprecated: OneDrive versioning capability is
+            enabled by default.
         refresh_token : builtins.str, optional
             Microsoft Graph API (also OneDrive API) refresh
             token
@@ -4432,7 +4433,8 @@ class Operator:
             Microsoft Graph API Application client secret that
             is in the Azure's app registration portal
         enable_versioning : builtins.bool, optional
-            Enabling version support
+            Deprecated: OneDrive versioning capability is
+            enabled by default.
         refresh_token : builtins.str, optional
             Microsoft Graph API (also OneDrive API) refresh
             token

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -1713,7 +1713,8 @@ submit! {
                     Microsoft Graph API Application client secret that
                     is in the Azure's app registration portal
                 enable_versioning : builtins.bool, optional
-                    Enabling version support
+                    Deprecated: OneDrive versioning capability is
+                    enabled by default.
                 refresh_token : builtins.str, optional
                     Microsoft Graph API (also OneDrive API) refresh
                     token
@@ -4391,7 +4392,8 @@ submit! {
                     Microsoft Graph API Application client secret that
                     is in the Azure's app registration portal
                 enable_versioning : builtins.bool, optional
-                    Enabling version support
+                    Deprecated: OneDrive versioning capability is
+                    enabled by default.
                 refresh_token : builtins.str, optional
                     Microsoft Graph API (also OneDrive API) refresh
                     token

--- a/core/services/onedrive/src/builder.rs
+++ b/core/services/onedrive/src/builder.rs
@@ -99,9 +99,12 @@ impl OnedriveBuilder {
         self
     }
 
-    /// Enable versioning support for OneDrive
-    pub fn enable_versioning(mut self, enabled: bool) -> Self {
-        self.config.enable_versioning = enabled;
+    /// Deprecated: OneDrive versioning capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "OneDrive versioning capability is enabled by default and this option is no longer needed."
+    )]
+    pub fn enable_versioning(self, _enabled: bool) -> Self {
         self
     }
 }
@@ -132,14 +135,14 @@ impl Builder for OnedriveBuilder {
 
                 stat: true,
                 stat_with_if_none_match: true,
-                stat_with_version: self.config.enable_versioning,
+                stat_with_version: true,
 
                 delete: true,
                 create_dir: true,
 
                 list: true,
                 list_with_limit: true,
-                list_with_versions: self.config.enable_versioning,
+                list_with_versions: true,
 
                 shared: true,
 

--- a/core/services/onedrive/src/config.rs
+++ b/core/services/onedrive/src/config.rs
@@ -38,7 +38,11 @@ pub struct OnedriveConfig {
     pub client_id: Option<String>,
     /// Microsoft Graph API Application client secret that is in the Azure's app registration portal
     pub client_secret: Option<String>,
-    /// Enabling version support
+    /// Deprecated: OneDrive versioning capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "OneDrive versioning capability is enabled by default and this option is no longer needed."
+    )]
     pub enable_versioning: bool,
 }
 
@@ -46,7 +50,6 @@ impl Debug for OnedriveConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("OnedriveConfig")
             .field("root", &self.root)
-            .field("enable_versioning", &self.enable_versioning)
             .finish_non_exhaustive()
     }
 }

--- a/core/services/onedrive/src/docs.md
+++ b/core/services/onedrive/src/docs.md
@@ -47,7 +47,7 @@ You should consider [`RetryLayer`] and monitor your operations carefully.
 - `client_id`: Set the client ID for a Microsoft Graph API application (available though Azure's registration portal)
 - `client_secret`: Set the client secret for a Microsoft Graph API application
 - `root`: Set the work directory for OneDrive backend
-- `enable_versioning`: Enable versioning support for OneDrive items
+- `enable_versioning`: Deprecated. OneDrive versioning capability is enabled by default and this option is no longer needed.
 
 The configuration for tokens is one of the following:
 


### PR DESCRIPTION
# Which issue does this PR close?

Refs #6708.

# Rationale for this change

OneDrive versioned stat/list support is a real backend capability. The existing `enable_versioning` option only controls the advertised capability surface, so it should no longer be required to enable behavior tests or user-visible capability discovery.

# What changes are included in this PR?

This PR enables OneDrive `stat_with_version` and `list_with_versions` capabilities by default, and deprecates `enable_versioning` as a no-op compatibility shim. It also updates service docs and generated binding config docs to mark the option as deprecated.

# Are there any user-facing changes?

`enable_versioning` is deprecated for OneDrive and no longer changes capability reporting. OneDrive versioning capability is enabled by default.

# AI Usage Statement

N/A.
