### PR TITLE
refactor(services/obs): deprecate versioning option

### DIFF
--- a/bindings/dotnet/OpenDAL/ServiceConfig/ObsServiceConfig.cs
+++ b/bindings/dotnet/OpenDAL/ServiceConfig/ObsServiceConfig.cs
@@ -37,7 +37,7 @@ namespace OpenDAL.ServiceConfig
         /// </summary>
         public string? Bucket { get; init; }
         /// <summary>
-        /// Is bucket versioning enabled for this bucket
+        /// Deprecated: OBS versioning capability is not controlled by service config.
         /// </summary>
         public bool? EnableVersioning { get; init; }
         /// <summary>

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -2211,7 +2211,9 @@ public interface ServiceConfig {
          */
         public final String bucket;
         /**
-         * <p>Is bucket versioning enabled for this bucket</p>
+         * <p>Deprecated: OBS versioning capability is not controlled by service config.</p>
+         *
+         * @deprecated OBS versioning capability is not controlled by this option and this option is no longer needed.
          */
         public final Boolean enableVersioning;
         /**

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -1792,7 +1792,8 @@ class AsyncOperator:
         bucket : builtins.str, optional
             Bucket for obs.
         enable_versioning : builtins.bool, optional
-            Is bucket versioning enabled for this bucket
+            Deprecated: OBS versioning capability is not controlled by
+            service config.
         endpoint : builtins.str, optional
             Endpoint for obs.
         root : builtins.str, optional
@@ -4393,7 +4394,8 @@ class Operator:
         bucket : builtins.str, optional
             Bucket for obs.
         enable_versioning : builtins.bool, optional
-            Is bucket versioning enabled for this bucket
+            Deprecated: OBS versioning capability is not controlled by
+            service config.
         endpoint : builtins.str, optional
             Endpoint for obs.
         root : builtins.str, optional

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -1664,7 +1664,8 @@ submit! {
                 bucket : builtins.str, optional
                     Bucket for obs.
                 enable_versioning : builtins.bool, optional
-                    Is bucket versioning enabled for this bucket
+                    Deprecated: OBS versioning capability is not
+                    controlled by service config.
                 endpoint : builtins.str, optional
                     Endpoint for obs.
                 root : builtins.str, optional
@@ -4343,7 +4344,8 @@ submit! {
                 bucket : builtins.str, optional
                     Bucket for obs.
                 enable_versioning : builtins.bool, optional
-                    Is bucket versioning enabled for this bucket
+                    Deprecated: OBS versioning capability is not
+                    controlled by service config.
                 endpoint : builtins.str, optional
                     Endpoint for obs.
                 root : builtins.str, optional

--- a/core/services/obs/src/backend.rs
+++ b/core/services/obs/src/backend.rs
@@ -121,10 +121,12 @@ impl ObsBuilder {
         self
     }
 
-    /// Set bucket versioning status for this backend
-    pub fn enable_versioning(mut self, enabled: bool) -> Self {
-        self.config.enable_versioning = enabled;
-
+    /// Deprecated: OBS versioning capability is not controlled by service config.
+    #[deprecated(
+        since = "0.57.0",
+        note = "OBS versioning capability is not controlled by this option and this option is no longer needed."
+    )]
+    pub fn enable_versioning(self, _enabled: bool) -> Self {
         self
     }
 }

--- a/core/services/obs/src/config.rs
+++ b/core/services/obs/src/config.rs
@@ -37,7 +37,11 @@ pub struct ObsConfig {
     pub secret_access_key: Option<String>,
     /// Bucket for obs.
     pub bucket: Option<String>,
-    /// Is bucket versioning enabled for this bucket
+    /// Deprecated: OBS versioning capability is not controlled by service config.
+    #[deprecated(
+        since = "0.57.0",
+        note = "OBS versioning capability is not controlled by this option and this option is no longer needed."
+    )]
     pub enable_versioning: bool,
 }
 
@@ -47,7 +51,6 @@ impl Debug for ObsConfig {
             .field("root", &self.root)
             .field("endpoint", &self.endpoint)
             .field("bucket", &self.bucket)
-            .field("enable_versioning", &self.enable_versioning)
             .finish_non_exhaustive()
     }
 }

--- a/core/services/obs/src/docs.md
+++ b/core/services/obs/src/docs.md
@@ -19,6 +19,7 @@ This service can be used to:
 - `endpoint`: Customizable endpoint setting
 - `access_key_id`: Set the access_key_id for backend.
 - `secret_access_key`: Set the secret_access_key for backend.
+- `enable_versioning`: Deprecated. OBS versioning capability is not controlled by this option and this option is no longer needed.
 
 You can refer to [`ObsBuilder`]'s docs for more information
 


### PR DESCRIPTION
# Which issue does this PR close?

Refs #6708.

# Rationale for this change

OBS `enable_versioning` is exposed as a service option, but the OBS backend does not use it when declaring capabilities or building requests. Keeping it as a service-level toggle is misleading because OBS versioned operations are not controlled by this config value.

# What changes are included in this PR?

This PR deprecates the OBS `enable_versioning` builder/config option and makes the builder method a no-op. It also removes the deprecated field from debug output and updates the OBS docs plus generated Java/Python/.NET service config docs.

# Are there any user-facing changes?

`enable_versioning` for OBS is now documented as deprecated. Runtime behavior is unchanged.

# AI Usage Statement

N/A.
