### PR TITLE
refactor(services/azblob): deprecate batch option

### DIFF
--- a/bindings/dotnet/OpenDAL/ServiceConfig/AzblobServiceConfig.cs
+++ b/bindings/dotnet/OpenDAL/ServiceConfig/AzblobServiceConfig.cs
@@ -37,7 +37,7 @@ namespace OpenDAL.ServiceConfig
         /// </summary>
         public string? AccountName { get; init; }
         /// <summary>
-        /// The maximum batch operations of Azblob service backend.
+        /// Deprecated: Azblob delete batch capability is enabled by default with Azure Blob's 256-operation batch limit.
         /// </summary>
         public long? BatchMaxOperations { get; init; }
         /// <summary>

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -173,7 +173,9 @@ public interface ServiceConfig {
          */
         public final String accountName;
         /**
-         * <p>The maximum batch operations of Azblob service backend.</p>
+         * <p>Deprecated: Azblob delete batch capability is enabled by default with Azure Blob's 256-operation batch limit.</p>
+         *
+         * @deprecated Azblob delete batch capability is enabled by default with Azure Blob's 256-operation batch limit. Use CapabilityOverrideLayer to override delete_max_size for specific endpoints.
          */
         public final Long batchMaxOperations;
         /**

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -697,8 +697,9 @@ class AsyncOperator:
         account_name : builtins.str, optional
             The account name of Azblob service backend.
         batch_max_operations : builtins.int, optional
-            The maximum batch operations of Azblob service
-            backend.
+            Deprecated: Azblob delete batch capability is
+            enabled by default with Azure Blob's 256-operation
+            batch limit.
         container : builtins.str
             The container name of Azblob service backend.
         encryption_algorithm : builtins.str, optional
@@ -3298,8 +3299,9 @@ class Operator:
         account_name : builtins.str, optional
             The account name of Azblob service backend.
         batch_max_operations : builtins.int, optional
-            The maximum batch operations of Azblob service
-            backend.
+            Deprecated: Azblob delete batch capability is
+            enabled by default with Azure Blob's 256-operation
+            batch limit.
         container : builtins.str
             The container name of Azblob service backend.
         encryption_algorithm : builtins.str, optional

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -308,8 +308,9 @@ submit! {
                 account_name : builtins.str, optional
                     The account name of Azblob service backend.
                 batch_max_operations : builtins.int, optional
-                    The maximum batch operations of Azblob service
-                    backend.
+                    Deprecated: Azblob delete batch capability is
+                    enabled by default with Azure Blob's 256-operation
+                    batch limit.
                 container : builtins.str
                     The container name of Azblob service backend.
                 encryption_algorithm : builtins.str, optional
@@ -2987,8 +2988,9 @@ submit! {
                 account_name : builtins.str, optional
                     The account name of Azblob service backend.
                 batch_max_operations : builtins.int, optional
-                    The maximum batch operations of Azblob service
-                    backend.
+                    Deprecated: Azblob delete batch capability is
+                    enabled by default with Azure Blob's 256-operation
+                    batch limit.
                 container : builtins.str
                     The container name of Azblob service backend.
                 encryption_algorithm : builtins.str, optional

--- a/core/services/azblob/src/backend.rs
+++ b/core/services/azblob/src/backend.rs
@@ -237,10 +237,12 @@ impl AzblobBuilder {
         self
     }
 
-    /// Set maximum batch operations of this backend.
-    pub fn batch_max_operations(mut self, batch_max_operations: usize) -> Self {
-        self.config.batch_max_operations = Some(batch_max_operations);
-
+    /// Deprecated: Azblob delete batch capability is enabled by default with Azure Blob's 256-operation batch limit.
+    #[deprecated(
+        since = "0.57.0",
+        note = "Azblob delete batch capability is enabled by default with Azure Blob's 256-operation batch limit and this option is no longer needed."
+    )]
+    pub fn batch_max_operations(self, _batch_max_operations: usize) -> Self {
         self
     }
 

--- a/core/services/azblob/src/config.rs
+++ b/core/services/azblob/src/config.rs
@@ -74,7 +74,11 @@ pub struct AzblobConfig {
     )]
     pub sas_token: Option<String>,
 
-    /// The maximum batch operations of Azblob service backend.
+    /// Deprecated: Azblob delete batch capability is enabled by default with Azure Blob's 256-operation batch limit.
+    #[deprecated(
+        since = "0.57.0",
+        note = "Azblob delete batch capability is enabled by default with Azure Blob's 256-operation batch limit. Use CapabilityOverrideLayer to override delete_max_size for specific endpoints."
+    )]
     pub batch_max_operations: Option<usize>,
 
     /// Skip signature will skip loading credentials and signing requests.

--- a/core/services/azblob/src/docs.md
+++ b/core/services/azblob/src/docs.md
@@ -19,6 +19,7 @@ This service can be used to:
 - `endpoint`: Set the endpoint for backend.
 - `account_name`: Set the account_name for backend.
 - `account_key`: Set the account_key for backend.
+- `batch_max_operations`: Deprecated. Azblob delete batch capability is enabled by default with Azure Blob's 256-operation batch limit and this option is no longer needed.
 
 Refer to public API docs for more information.
 


### PR DESCRIPTION
# Which issue does this PR close?

Refs #6708.

# Rationale for this change

Azblob's `batch_max_operations` config is only stored in config today; it does not affect the backend's native delete batch capability. The service declares `delete_max_size` from Azure Blob's fixed 256-operation batch limit, and the delete path already reads the final capability from `full_capability()`, so endpoint-specific test adjustments should be handled through `CapabilityOverrideLayer` instead of a service config option.

# What changes are included in this PR?

This deprecates `batch_max_operations` as a no-op compatibility shim for Azblob and updates the service docs plus generated Java/Python/.NET config docs to describe the default delete batch capability.

# Are there any user-facing changes?

The deprecated `batch_max_operations` option no longer changes Azblob behavior. Azblob delete batch capability remains enabled by default with Azure Blob's 256-operation batch limit.

# AI Usage Statement

N/A.
