### PR TITLE
refactor(services/webdav): deprecate capability toggles

### DIFF
--- a/.github/services/webdav/0_nginx/action.yml
+++ b/.github/services/webdav/0_nginx/action.yml
@@ -30,4 +30,5 @@ runs:
       run: |
         cat << EOF >> $GITHUB_ENV
         OPENDAL_WEBDAV_ENDPOINT=http://127.0.0.1:8080
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_with_user_metadata=false
         EOF

--- a/.github/services/webdav/jfrog/disabled_action.yml
+++ b/.github/services/webdav/jfrog/disabled_action.yml
@@ -33,6 +33,6 @@ runs:
         OPENDAL_WEBDAV_ENDPOINT=http://127.0.0.1:8081/artifactory/example-repo-local
         OPENDAL_WEBDAV_USERNAME=admin
         OPENDAL_WEBDAV_PASSWORD=password
-        OPENDAL_WEBDAV_DISABLE_COPY=true
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=copy=false,write_with_user_metadata=false
         RUST_TEST_THREADS=1
         EOF

--- a/.github/services/webdav/nginx_with_empty_password/action.yml
+++ b/.github/services/webdav/nginx_with_empty_password/action.yml
@@ -31,4 +31,5 @@ runs:
         cat << EOF >> $GITHUB_ENV
         OPENDAL_WEBDAV_ENDPOINT=http://127.0.0.1:8080
         OPENDAL_WEBDAV_USERNAME=foo
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_with_user_metadata=false
         EOF

--- a/.github/services/webdav/nginx_with_password/action.yml
+++ b/.github/services/webdav/nginx_with_password/action.yml
@@ -32,4 +32,5 @@ runs:
         OPENDAL_WEBDAV_ENDPOINT=http://127.0.0.1:8080
         OPENDAL_WEBDAV_USERNAME=bar
         OPENDAL_WEBDAV_PASSWORD=bar
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_with_user_metadata=false
         EOF

--- a/.github/services/webdav/nginx_with_redirect/action.yml
+++ b/.github/services/webdav/nginx_with_redirect/action.yml
@@ -30,4 +30,5 @@ runs:
       run: |
         cat << EOF >> $GITHUB_ENV
         OPENDAL_WEBDAV_ENDPOINT=http://127.0.0.1:8081
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_with_user_metadata=false
         EOF

--- a/bindings/dotnet/OpenDAL/ServiceConfig/WebdavServiceConfig.cs
+++ b/bindings/dotnet/OpenDAL/ServiceConfig/WebdavServiceConfig.cs
@@ -29,7 +29,7 @@ namespace OpenDAL.ServiceConfig
     public sealed class WebdavServiceConfig : IServiceConfig
     {
         /// <summary>
-        /// WebDAV Service doesn't support copy.
+        /// Deprecated: WebDAV copy capability is enabled by default.
         /// </summary>
         public bool? DisableCopy { get; init; }
         /// <summary>

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -3795,7 +3795,9 @@ public interface ServiceConfig {
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     class Webdav implements ServiceConfig {
         /**
-         * <p>WebDAV Service doesn't support copy.</p>
+         * <p>Deprecated: WebDAV copy capability is enabled by default.</p>
+         *
+         * @deprecated WebDAV copy capability is enabled by default and this option is no longer needed.
          */
         public final Boolean disableCopy;
         /**
@@ -3809,11 +3811,9 @@ public interface ServiceConfig {
          */
         public final Boolean disableCreateDir;
         /**
-         * <p>Enable user metadata support via WebDAV PROPPATCH.</p>
-         * <p>This feature requires the WebDAV server to support RFC4918 PROPPATCH method.
-         * Not all WebDAV servers support this (e.g., nginx's basic WebDAV module doesn't).
-         * Only enable this if your server supports PROPPATCH (e.g., Apache mod_dav, Nextcloud).</p>
-         * <p>Default: false</p>
+         * <p>Deprecated: WebDAV user metadata capability is enabled by default.</p>
+         *
+         * @deprecated WebDAV user metadata capability is enabled by default. Use CapabilityOverrideLayer to override write_with_user_metadata for endpoints without PROPPATCH support.
          */
         public final Boolean enableUserMetadata;
         /**

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -2683,7 +2683,8 @@ class AsyncOperator:
         Parameters
         ----------
         disable_copy : builtins.bool, optional
-            WebDAV Service doesn't support copy.
+            Deprecated: WebDAV copy capability is enabled by
+            default.
         disable_create_dir : builtins.bool, optional
             Disable automatic parent directory creation before
             write operations.
@@ -2698,14 +2699,8 @@ class AsyncOperator:
             files directly.
             Default: false
         enable_user_metadata : builtins.bool, optional
-            Enable user metadata support via WebDAV PROPPATCH.
-            This feature requires the WebDAV server to support
-            RFC4918 PROPPATCH method.
-            Not all WebDAV servers support this (e.g., nginx's
-            basic WebDAV module doesn't).
-            Only enable this if your server supports PROPPATCH
-            (e.g., Apache mod_dav, Nextcloud).
-            Default: false
+            Deprecated: WebDAV user metadata capability is
+            enabled by default.
         endpoint : builtins.str, optional
             endpoint of this backend
         password : builtins.str, optional
@@ -5284,7 +5279,8 @@ class Operator:
         Parameters
         ----------
         disable_copy : builtins.bool, optional
-            WebDAV Service doesn't support copy.
+            Deprecated: WebDAV copy capability is enabled by
+            default.
         disable_create_dir : builtins.bool, optional
             Disable automatic parent directory creation before
             write operations.
@@ -5299,14 +5295,8 @@ class Operator:
             files directly.
             Default: false
         enable_user_metadata : builtins.bool, optional
-            Enable user metadata support via WebDAV PROPPATCH.
-            This feature requires the WebDAV server to support
-            RFC4918 PROPPATCH method.
-            Not all WebDAV servers support this (e.g., nginx's
-            basic WebDAV module doesn't).
-            Only enable this if your server supports PROPPATCH
-            (e.g., Apache mod_dav, Nextcloud).
-            Default: false
+            Deprecated: WebDAV user metadata capability is
+            enabled by default.
         endpoint : builtins.str, optional
             endpoint of this backend
         password : builtins.str, optional

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -2705,7 +2705,8 @@ submit! {
                 Parameters
                 ----------
                 disable_copy : builtins.bool, optional
-                    WebDAV Service doesn't support copy.
+                    Deprecated: WebDAV copy capability is enabled by
+                    default.
                 disable_create_dir : builtins.bool, optional
                     Disable automatic parent directory creation before
                     write operations.
@@ -2720,14 +2721,8 @@ submit! {
                     files directly.
                     Default: false
                 enable_user_metadata : builtins.bool, optional
-                    Enable user metadata support via WebDAV PROPPATCH.
-                    This feature requires the WebDAV server to support
-                    RFC4918 PROPPATCH method.
-                    Not all WebDAV servers support this (e.g., nginx's
-                    basic WebDAV module doesn't).
-                    Only enable this if your server supports PROPPATCH
-                    (e.g., Apache mod_dav, Nextcloud).
-                    Default: false
+                    Deprecated: WebDAV user metadata capability is
+                    enabled by default.
                 endpoint : builtins.str, optional
                     endpoint of this backend
                 password : builtins.str, optional
@@ -5384,7 +5379,8 @@ submit! {
                 Parameters
                 ----------
                 disable_copy : builtins.bool, optional
-                    WebDAV Service doesn't support copy.
+                    Deprecated: WebDAV copy capability is enabled by
+                    default.
                 disable_create_dir : builtins.bool, optional
                     Disable automatic parent directory creation before
                     write operations.
@@ -5399,14 +5395,8 @@ submit! {
                     files directly.
                     Default: false
                 enable_user_metadata : builtins.bool, optional
-                    Enable user metadata support via WebDAV PROPPATCH.
-                    This feature requires the WebDAV server to support
-                    RFC4918 PROPPATCH method.
-                    Not all WebDAV servers support this (e.g., nginx's
-                    basic WebDAV module doesn't).
-                    Only enable this if your server supports PROPPATCH
-                    (e.g., Apache mod_dav, Nextcloud).
-                    Default: false
+                    Deprecated: WebDAV user metadata capability is
+                    enabled by default.
                 endpoint : builtins.str, optional
                     endpoint of this backend
                 password : builtins.str, optional

--- a/core/services/webdav/src/backend.rs
+++ b/core/services/webdav/src/backend.rs
@@ -119,15 +119,12 @@ impl WebdavBuilder {
         self
     }
 
-    /// Enable user metadata support via WebDAV PROPPATCH.
-    ///
-    /// This feature requires the WebDAV server to support RFC4918 PROPPATCH method.
-    /// Not all WebDAV servers support this (e.g., nginx's basic WebDAV module doesn't).
-    /// Only enable this if your server supports PROPPATCH (e.g., Apache mod_dav, Nextcloud).
-    ///
-    /// Default: false
-    pub fn enable_user_metadata(mut self, enable: bool) -> Self {
-        self.config.enable_user_metadata = enable;
+    /// Deprecated: WebDAV user metadata capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "WebDAV user metadata capability is enabled by default. Use CapabilityOverrideLayer to override write_with_user_metadata for endpoints without PROPPATCH support."
+    )]
+    pub fn enable_user_metadata(self, _enable: bool) -> Self {
         self
     }
 
@@ -208,12 +205,12 @@ impl Builder for WebdavBuilder {
 
                         write: true,
                         write_can_empty: true,
-                        write_with_user_metadata: self.config.enable_user_metadata,
+                        write_with_user_metadata: true,
 
                         create_dir: true,
                         delete: true,
 
-                        copy: !self.config.disable_copy,
+                        copy: true,
 
                         rename: true,
 

--- a/core/services/webdav/src/config.rs
+++ b/core/services/webdav/src/config.rs
@@ -37,7 +37,11 @@ pub struct WebdavConfig {
     pub token: Option<String>,
     /// root of this backend
     pub root: Option<String>,
-    /// WebDAV Service doesn't support copy.
+    /// Deprecated: WebDAV copy capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "WebDAV copy capability is enabled by default and this option is no longer needed."
+    )]
     pub disable_copy: bool,
     /// Disable automatic parent directory creation before write operations.
     ///
@@ -50,13 +54,11 @@ pub struct WebdavConfig {
     ///
     /// Default: false
     pub disable_create_dir: bool,
-    /// Enable user metadata support via WebDAV PROPPATCH.
-    ///
-    /// This feature requires the WebDAV server to support RFC4918 PROPPATCH method.
-    /// Not all WebDAV servers support this (e.g., nginx's basic WebDAV module doesn't).
-    /// Only enable this if your server supports PROPPATCH (e.g., Apache mod_dav, Nextcloud).
-    ///
-    /// Default: false
+    /// Deprecated: WebDAV user metadata capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "WebDAV user metadata capability is enabled by default. Use CapabilityOverrideLayer to override write_with_user_metadata for endpoints without PROPPATCH support."
+    )]
     pub enable_user_metadata: bool,
     /// The XML namespace prefix for user metadata properties.
     ///
@@ -81,9 +83,7 @@ impl Debug for WebdavConfig {
             .field("endpoint", &self.endpoint)
             .field("username", &self.username)
             .field("root", &self.root)
-            .field("disable_copy", &self.disable_copy)
             .field("disable_create_dir", &self.disable_create_dir)
-            .field("enable_user_metadata", &self.enable_user_metadata)
             .field("user_metadata_prefix", &self.user_metadata_prefix)
             .field("user_metadata_uri", &self.user_metadata_uri)
             .finish_non_exhaustive()
@@ -146,7 +146,8 @@ mod tests {
     }
 
     #[test]
-    fn from_uri_propagates_disable_copy() {
+    #[allow(deprecated)]
+    fn from_uri_accepts_deprecated_disable_copy() {
         let uri = OperatorUri::new(
             "webdav://dav.example.com",
             vec![("disable_copy".to_string(), "true".to_string())],

--- a/core/services/webdav/src/docs.md
+++ b/core/services/webdav/src/docs.md
@@ -21,6 +21,8 @@ Users can use `webdav` to connect those services.
 
 - `endpoint`: set the endpoint for webdav
 - `root`: Set the work directory for backend
+- `disable_copy`: Deprecated. WebDAV copy capability is enabled by default and this option is no longer needed.
+- `enable_user_metadata`: Deprecated. WebDAV user metadata capability is enabled by default. Use `CapabilityOverrideLayer` to override `write_with_user_metadata` for endpoints without PROPPATCH support.
 
 You can refer to [`WebdavBuilder`]'s docs for more information
 


### PR DESCRIPTION
# Which issue does this PR close?

Refs #6708.

# Rationale for this change

`disable_copy` and `enable_user_metadata` were service config options used to hide implemented WebDAV capabilities from behavior tests. RFC-6707 moves endpoint-specific test selection to capability overrides instead, so WebDAV should report its implemented native capabilities by default.

# What changes are included in this PR?

This PR deprecates the WebDAV copy and user metadata toggles as compatibility shims, enables `copy` and `write_with_user_metadata` by default, and migrates WebDAV CI setups that do not support PROPPATCH or COPY to `OPENDAL_TEST_CAPABILITY_OVERRIDES`. The user metadata namespace and URI options remain unchanged because they are real request-construction settings for PROPPATCH/PROPFIND.

# Are there any user-facing changes?

`disable_copy` and `enable_user_metadata` are deprecated and no longer affect WebDAV capabilities. Endpoints without PROPPATCH support should disable `write_with_user_metadata` through `CapabilityOverrideLayer` or `OPENDAL_TEST_CAPABILITY_OVERRIDES` in tests.

# AI Usage Statement

N/A.
