### PR TITLE
refactor(services/hdfs): deprecate append option

### DIFF
--- a/.github/services/hdfs/hdfs_cluster/action.yml
+++ b/.github/services/hdfs/hdfs_cluster/action.yml
@@ -35,5 +35,4 @@ runs:
         cat << EOF >> $GITHUB_ENV
         OPENDAL_HDFS_ROOT=/tmp/opendal/
         OPENDAL_HDFS_NAME_NODE=hdfs://localhost:8020
-        OPENDAL_HDFS_ENABLE_APPEND=true
         EOF

--- a/.github/services/hdfs/hdfs_cluster_with_atomic_write_dir/action.yml
+++ b/.github/services/hdfs/hdfs_cluster_with_atomic_write_dir/action.yml
@@ -36,5 +36,5 @@ runs:
         OPENDAL_HDFS_ROOT=/tmp/opendal/
         OPENDAL_HDFS_ATOMIC_WRITE_DIR=/tmp/atomic_write_dir/opendal/
         OPENDAL_HDFS_NAME_NODE=hdfs://localhost:8020
-        OPENDAL_HDFS_ENABLE_APPEND=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_can_append=false
         EOF

--- a/.github/services/hdfs/hdfs_default/action.yml
+++ b/.github/services/hdfs/hdfs_default/action.yml
@@ -31,5 +31,5 @@ runs:
         cat << EOF >> $GITHUB_ENV
         OPENDAL_HDFS_ROOT=/tmp/opendal/
         OPENDAL_HDFS_NAME_NODE=default
-        OPENDAL_HDFS_ENABLE_APPEND=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_can_append=false
         EOF

--- a/.github/services/hdfs/hdfs_default_gcs/action.yml
+++ b/.github/services/hdfs/hdfs_default_gcs/action.yml
@@ -54,7 +54,7 @@ runs:
         LD_LIBRARY_PATH=${JAVA_HOME}/lib/server:${HADOOP_HOME}/lib/native
         OPENDAL_HDFS_ROOT=${OPENDAL_GCS_ROOT}
         OPENDAL_HDFS_NAME_NODE=gs://${OPENDAL_GCS_BUCKET}
-        OPENDAL_HDFS_ENABLE_APPEND=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_can_append=false
         EOF
 
         mkdir -p /tmp/hdfs

--- a/.github/services/hdfs/hdfs_default_on_azurite_azblob/action.yml
+++ b/.github/services/hdfs/hdfs_default_on_azurite_azblob/action.yml
@@ -67,5 +67,5 @@ runs:
         LD_LIBRARY_PATH=${JAVA_HOME}/lib/server:${HADOOP_HOME}/lib/native
         OPENDAL_HDFS_ROOT=${OPENDAL_AZBLOB_ROOT}
         OPENDAL_HDFS_NAME_NODE=wasb://${OPENDAL_AZBLOB_CONTAINER}@${OPENDAL_AZBLOB_ACCOUNT_NAME}.blob.core.windows.net
-        OPENDAL_HDFS_ENABLE_APPEND=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_can_append=false
         EOF

--- a/.github/services/hdfs/hdfs_default_on_minio_s3/action.yml
+++ b/.github/services/hdfs/hdfs_default_on_minio_s3/action.yml
@@ -64,5 +64,5 @@ runs:
         CLASSPATH=${CLASSPATH}
         LD_LIBRARY_PATH=${JAVA_HOME}/lib/server:${HADOOP_HOME}/lib/native
         OPENDAL_HDFS_NAME_NODE=s3a://test
-        OPENDAL_HDFS_ENABLE_APPEND=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_can_append=false
         EOF

--- a/.github/services/hdfs/hdfs_default_with_atomic_write_dir/action.yml
+++ b/.github/services/hdfs/hdfs_default_with_atomic_write_dir/action.yml
@@ -32,5 +32,5 @@ runs:
         OPENDAL_HDFS_ROOT=/tmp/opendal/
         OPENDAL_HDFS_ATOMIC_WRITE_DIR=/tmp/atomic_write_dir/opendal/
         OPENDAL_HDFS_NAME_NODE=default
-        OPENDAL_HDFS_ENABLE_APPEND=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_can_append=false
         EOF

--- a/.github/services/hdfs_native/hdfs_native_cluster/action.yml
+++ b/.github/services/hdfs_native/hdfs_native_cluster/action.yml
@@ -31,5 +31,4 @@ runs:
         cat << EOF >> $GITHUB_ENV
         OPENDAL_HDFS_NATIVE_ROOT=/tmp/opendal/
         OPENDAL_HDFS_NATIVE_NAME_NODE=hdfs://localhost:8020
-        OPENDAL_HDFS_NATIVE_ENABLE_APPEND=true
         EOF

--- a/bindings/dotnet/OpenDAL/ServiceConfig/HdfsNativeServiceConfig.cs
+++ b/bindings/dotnet/OpenDAL/ServiceConfig/HdfsNativeServiceConfig.cs
@@ -29,7 +29,7 @@ namespace OpenDAL.ServiceConfig
     public sealed class HdfsNativeServiceConfig : IServiceConfig
     {
         /// <summary>
-        /// enable the append capacity
+        /// Deprecated: HDFS Native append capability is enabled by default.
         /// </summary>
         public bool? EnableAppend { get; init; }
         /// <summary>

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -1497,7 +1497,9 @@ public interface ServiceConfig {
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     class HdfsNative implements ServiceConfig {
         /**
-         * <p>enable the append capacity</p>
+         * <p>Deprecated: HDFS Native append capability is enabled by default.</p>
+         *
+         * @deprecated HDFS Native append capability is enabled by default and this option is no longer needed.
          */
         public final Boolean enableAppend;
         /**

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -1380,7 +1380,7 @@ class AsyncOperator:
         Parameters
         ----------
         enable_append : builtins.bool, optional
-            enable the append capacity
+            Deprecated: HDFS Native append capability is enabled by default.
         name_node : builtins.str, optional
             name_node of this backend
         options : builtins.dict, optional
@@ -3981,7 +3981,7 @@ class Operator:
         Parameters
         ----------
         enable_append : builtins.bool, optional
-            enable the append capacity
+            Deprecated: HDFS Native append capability is enabled by default.
         name_node : builtins.str, optional
             name_node of this backend
         options : builtins.dict, optional

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -1144,7 +1144,8 @@ submit! {
                 Parameters
                 ----------
                 enable_append : builtins.bool, optional
-                    enable the append capacity
+                    Deprecated: HDFS Native append capability is enabled
+                    by default.
                 name_node : builtins.str, optional
                     name_node of this backend
                 options : builtins.dict, optional
@@ -3823,7 +3824,8 @@ submit! {
                 Parameters
                 ----------
                 enable_append : builtins.bool, optional
-                    enable the append capacity
+                    Deprecated: HDFS Native append capability is enabled
+                    by default.
                 name_node : builtins.str, optional
                     name_node of this backend
                 options : builtins.dict, optional

--- a/core/services/hdfs-native/src/backend.rs
+++ b/core/services/hdfs-native/src/backend.rs
@@ -72,11 +72,12 @@ impl HdfsNativeBuilder {
         self
     }
 
-    /// Enable append capacity of this backend.
-    ///
-    /// This should be disabled when HDFS runs in non-distributed mode.
-    pub fn enable_append(mut self, enable_append: bool) -> Self {
-        self.config.enable_append = enable_append;
+    /// Deprecated: HDFS Native append capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "HDFS Native append capability is enabled by default and this option is no longer needed."
+    )]
+    pub fn enable_append(self, _enable_append: bool) -> Self {
         self
     }
 
@@ -130,7 +131,7 @@ impl Builder for HdfsNativeBuilder {
                             read: true,
 
                             write: true,
-                            write_can_append: self.config.enable_append,
+                            write_can_append: true,
 
                             create_dir: true,
                             delete: true,
@@ -148,7 +149,6 @@ impl Builder for HdfsNativeBuilder {
                 },
                 root,
                 client: Arc::new(client),
-                enable_append: self.config.enable_append,
             }),
         })
     }

--- a/core/services/hdfs-native/src/config.rs
+++ b/core/services/hdfs-native/src/config.rs
@@ -37,7 +37,11 @@ pub struct HdfsNativeConfig {
     pub root: Option<String>,
     /// name_node of this backend
     pub name_node: Option<String>,
-    /// enable the append capacity
+    /// Deprecated: HDFS Native append capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "HDFS Native append capability is enabled by default and this option is no longer needed."
+    )]
     pub enable_append: bool,
     /// other options for hdfs client
     pub options: Option<HashMap<String, String>>,
@@ -48,7 +52,6 @@ impl Debug for HdfsNativeConfig {
         f.debug_struct("HdfsNativeConfig")
             .field("root", &self.root)
             .field("name_node", &self.name_node)
-            .field("enable_append", &self.enable_append)
             .field("options", &self.options)
             .finish_non_exhaustive()
     }
@@ -72,6 +75,7 @@ impl opendal_core::Configurator for HdfsNativeConfig {
         Self::from_iter(map)
     }
 
+    #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
         HdfsNativeBuilder { config: self }
     }

--- a/core/services/hdfs-native/src/core.rs
+++ b/core/services/hdfs-native/src/core.rs
@@ -31,14 +31,12 @@ pub struct HdfsNativeCore {
     pub info: Arc<AccessorInfo>,
     pub root: String,
     pub client: Arc<hdfs_native::Client>,
-    pub enable_append: bool,
 }
 
 impl Debug for HdfsNativeCore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HdfsNativeCore")
             .field("root", &self.root)
-            .field("enable_append", &self.enable_append)
             .finish_non_exhaustive()
     }
 }
@@ -116,7 +114,6 @@ impl HdfsNativeCore {
 
         let f = if target_exists {
             if args.append() {
-                assert!(self.enable_append, "append is not enabled");
                 self.client
                     .append(&target_path)
                     .await

--- a/core/services/hdfs-native/src/docs.md
+++ b/core/services/hdfs-native/src/docs.md
@@ -19,4 +19,4 @@ This service can be used to:
 
 - `root`: Set the work dir for backend.
 - `name_node`: Set the name node for backend.
-- `enable_append`: enable the append capacity. Default is false.
+- `enable_append`: Deprecated. HDFS Native append capability is enabled by default and this option is no longer needed.

--- a/core/services/hdfs/src/backend.rs
+++ b/core/services/hdfs/src/backend.rs
@@ -82,11 +82,12 @@ impl HdfsBuilder {
         self
     }
 
-    /// Enable append capacity of this backend.
-    ///
-    /// This should be disabled when HDFS runs in non-distributed mode.
-    pub fn enable_append(mut self, enable_append: bool) -> Self {
-        self.config.enable_append = enable_append;
+    /// Deprecated: HDFS append capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "HDFS append capability is enabled by default and this option is no longer needed."
+    )]
+    pub fn enable_append(self, _enable_append: bool) -> Self {
         self
     }
 
@@ -165,7 +166,7 @@ impl Builder for HdfsBuilder {
                             read: true,
 
                             write: true,
-                            write_can_append: self.config.enable_append,
+                            write_can_append: true,
 
                             create_dir: true,
                             delete: true,

--- a/core/services/hdfs/src/config.rs
+++ b/core/services/hdfs/src/config.rs
@@ -37,7 +37,11 @@ pub struct HdfsConfig {
     pub kerberos_ticket_cache_path: Option<String>,
     /// user of this backend
     pub user: Option<String>,
-    /// enable the append capacity
+    /// Deprecated: HDFS append capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "HDFS append capability is enabled by default and this option is no longer needed."
+    )]
     pub enable_append: bool,
     /// atomic_write_dir of this backend
     pub atomic_write_dir: Option<String>,
@@ -53,7 +57,6 @@ impl Debug for HdfsConfig {
                 &self.kerberos_ticket_cache_path,
             )
             .field("user", &self.user)
-            .field("enable_append", &self.enable_append)
             .field("atomic_write_dir", &self.atomic_write_dir)
             .finish_non_exhaustive()
     }
@@ -77,6 +80,7 @@ impl opendal_core::Configurator for HdfsConfig {
         Self::from_iter(map)
     }
 
+    #[allow(deprecated)]
     fn into_builder(self) -> Self::Builder {
         HdfsBuilder { config: self }
     }

--- a/core/services/hdfs/src/docs.md
+++ b/core/services/hdfs/src/docs.md
@@ -28,7 +28,7 @@ HDFS support needs to enable feature `services-hdfs`.
 - `name_node`: Set the name node for backend.
 - `kerberos_ticket_cache_path`: Set the kerberos ticket cache path for backend, this should be gotten by `klist` after `kinit`
 - `user`: Set the user for backend
-- `enable_append`: enable the append capacity. Default is false. 
+- `enable_append`: Deprecated. HDFS append capability is enabled by default and this option is no longer needed.
 
 Refer to [`HdfsBuilder`]'s public API docs for more information.
 
@@ -113,19 +113,14 @@ use opendal_service_hdfs::Hdfs;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create fs backend builder.
-    let mut builder = Hdfs::default()
+    let builder = Hdfs::default()
         // Set the name node for hdfs.
         // If the string starts with a protocol type such as file://, hdfs://, or gs://, this protocol type will be used.
         .name_node("hdfs://127.0.0.1:9000")
         // Set the root for hdfs, all operations will happen under this root.
         //
         // NOTE: the root must be absolute path.
-        .root("/tmp")
-        
-        // Enable the append capacity for hdfs. 
-        // 
-        // Note: HDFS run in non-distributed mode doesn't support append.
-        .enable_append(true);
+        .root("/tmp");
 
     // `Accessor` provides the low level APIs, we will use `Operator` normally.
     let op: Operator = Operator::new(builder)?.finish();


### PR DESCRIPTION
# Which issue does this PR close?

Refs #6708.

# Rationale for this change

HDFS append is a native write capability that only affects explicit append requests. Regular writes do not use the append path, so service config should not hide this capability for test selection.

# What changes are included in this PR?

This PR enables `write_can_append` by default for HDFS and HDFS Native, keeps `enable_append` as a deprecated no-op compatibility option, and removes the HDFS Native runtime append gate so backend/client errors surface naturally. HDFS fixtures that previously disabled append through service config now use `OPENDAL_TEST_CAPABILITY_OVERRIDES=write_can_append=false`.

# Are there any user-facing changes?

`enable_append` is deprecated because HDFS append capability is enabled by default. Deployments that do not support append will only see backend/client errors when callers explicitly request append.

# AI Usage Statement

N/A.
