### PR TITLE
fix(ci): disable WebDAV metadata test for Nextcloud and OwnCloud

### DIFF
--- a/.github/services/webdav/nextcloud/action.yml
+++ b/.github/services/webdav/nextcloud/action.yml
@@ -32,4 +32,5 @@ runs:
         OPENDAL_WEBDAV_ENDPOINT=http://127.0.0.1:8080/remote.php/webdav/
         OPENDAL_WEBDAV_USERNAME=admin
         OPENDAL_WEBDAV_PASSWORD=admin
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_with_user_metadata=false
         EOF

--- a/.github/services/webdav/owncloud/action.yml
+++ b/.github/services/webdav/owncloud/action.yml
@@ -32,4 +32,5 @@ runs:
         OPENDAL_WEBDAV_ENDPOINT=http://127.0.0.1:8080/remote.php/webdav/
         OPENDAL_WEBDAV_USERNAME=admin
         OPENDAL_WEBDAV_PASSWORD=admin
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_with_user_metadata=false
         EOF


### PR DESCRIPTION
# Which issue does this PR close?

Part of #6708.

# Rationale for this change

The main branch Behavior Test currently fails for WebDAV Nextcloud and OwnCloud after #7562 enabled `write_with_user_metadata` by default for WebDAV. Both fixtures complete the write successfully, but the metadata is not preserved, so `behavior::test_write_with_user_metadata` fails with `meta data must exist`.

# What changes are included in this PR?

This PR adds `OPENDAL_TEST_CAPABILITY_OVERRIDES=write_with_user_metadata=false` to the Nextcloud and OwnCloud WebDAV behavior fixtures, matching the existing overrides for other WebDAV fixtures that do not support custom user metadata.

# Are there any user-facing changes?

No.

# AI Usage Statement

N/A.
