### PR TITLE
feat(services/tos): Rename allow_anonymous to skip_signature

### DIFF
--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -3565,6 +3565,8 @@ public interface ServiceConfig {
         /**
          * <p>Allow anonymous will allow opendal to send request without signing
          * when credential is not loaded.</p>
+         *
+         * @deprecated Please use `skip_signature` instead of `allow_anonymous`
          */
         public final Boolean allowAnonymous;
         /**
@@ -3622,6 +3624,10 @@ public interface ServiceConfig {
          * by hand.</p>
          */
         public final String securityToken;
+        /**
+         * <p>Skip signature will skip loading credentials and signing requests.</p>
+         */
+        public final Boolean skipSignature;
 
         @Override
         public String scheme() {
@@ -3655,6 +3661,9 @@ public interface ServiceConfig {
             }
             if (securityToken != null) {
                 map.put("security_token", securityToken);
+            }
+            if (skipSignature != null) {
+                map.put("skip_signature", String.valueOf(skipSignature));
             }
             return map;
         }

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -3563,13 +3563,6 @@ public interface ServiceConfig {
          */
         public final String accessKeyId;
         /**
-         * <p>Allow anonymous will allow opendal to send request without signing
-         * when credential is not loaded.</p>
-         *
-         * @deprecated Please use `skip_signature` instead of `allow_anonymous`
-         */
-        public final Boolean allowAnonymous;
-        /**
          * <p>bucket name of this backend.</p>
          * <p>required.</p>
          */
@@ -3639,9 +3632,6 @@ public interface ServiceConfig {
             final HashMap<String, String> map = new HashMap<>();
             if (accessKeyId != null) {
                 map.put("access_key_id", accessKeyId);
-            }
-            if (allowAnonymous != null) {
-                map.put("allow_anonymous", String.valueOf(allowAnonymous));
             }
             map.put("bucket", bucket);
             if (disableConfigLoad != null) {

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -1381,7 +1381,8 @@ class AsyncOperator:
         Parameters
         ----------
         enable_append : builtins.bool, optional
-            Deprecated: HDFS Native append capability is enabled by default.
+            Deprecated: HDFS Native append capability is enabled
+            by default.
         name_node : builtins.str, optional
             name_node of this backend
         options : builtins.dict, optional
@@ -1793,8 +1794,8 @@ class AsyncOperator:
         bucket : builtins.str, optional
             Bucket for obs.
         enable_versioning : builtins.bool, optional
-            Deprecated: OBS versioning capability is not controlled by
-            service config.
+            Deprecated: OBS versioning capability is not
+            controlled by service config.
         endpoint : builtins.str, optional
             Endpoint for obs.
         root : builtins.str, optional
@@ -1893,13 +1894,13 @@ class AsyncOperator:
         allow_anonymous : builtins.bool, optional
             Allow anonymous for oss.
         batch_max_operations : builtins.int, optional
-            Deprecated: OSS delete batch capability is enabled by
-            default.
+            Deprecated: OSS delete batch capability is enabled
+            by default.
         bucket : builtins.str
             Bucket for oss.
         delete_max_size : builtins.int, optional
-            Deprecated: OSS delete batch capability is enabled by
-            default.
+            Deprecated: OSS delete batch capability is enabled
+            by default.
         enable_versioning : builtins.bool, optional
             Deprecated: OSS versioning capability is enabled by
             default.
@@ -2202,15 +2203,14 @@ class AsyncOperator:
             Deprecated: S3 stat override capabilities are
             enabled by default.
         disable_write_with_if_match : builtins.bool, optional
-            Disable write with if match so that opendal will not
-            send write request with if match headers.
-            For example, Ceph RADOS S3 doesn't support write
-            with if matched.
+            Deprecated: S3 write with If-Match capability is
+            enabled by default.
         enable_request_payer : builtins.bool, optional
             Indicates whether the client agrees to pay for the
             requests made to the S3 bucket.
         enable_versioning : builtins.bool, optional
-            is bucket versioning enabled for this bucket
+            Deprecated: S3 versioning capability is enabled by
+            default.
         enable_virtual_host_style : builtins.bool, optional
             Enable virtual host style so that opendal will send
             API requests in virtual host style instead of path
@@ -2220,8 +2220,8 @@ class AsyncOperator:
             Enabled, opendal will send API to
             `https://bucket_name.s3.us-east-1.amazonaws.com`
         enable_write_with_append : builtins.bool, optional
-            Enable write with append so that opendal will send
-            write request with append headers.
+            Deprecated: S3 append capability is enabled by
+            default.
         endpoint : builtins.str, optional
             endpoint of this backend.
             Endpoint must be full uri, e.g.
@@ -2514,6 +2514,7 @@ class AsyncOperator:
         root: builtins.str = ...,
         secret_access_key: builtins.str = ...,
         security_token: builtins.str = ...,
+        skip_signature: builtins.bool = ...,
     ) -> typing.Self:
         r"""
         Create a new `AsyncOperator` for `tos` service.
@@ -2563,6 +2564,9 @@ class AsyncOperator:
             security_token of this backend.
             This token will expire after sometime, it's
             recommended to set security_token by hand.
+        skip_signature : builtins.bool, optional
+            Skip signature will skip loading credentials and
+            signing requests.
 
         Returns
         -------
@@ -3979,7 +3983,8 @@ class Operator:
         Parameters
         ----------
         enable_append : builtins.bool, optional
-            Deprecated: HDFS Native append capability is enabled by default.
+            Deprecated: HDFS Native append capability is enabled
+            by default.
         name_node : builtins.str, optional
             name_node of this backend
         options : builtins.dict, optional
@@ -4391,8 +4396,8 @@ class Operator:
         bucket : builtins.str, optional
             Bucket for obs.
         enable_versioning : builtins.bool, optional
-            Deprecated: OBS versioning capability is not controlled by
-            service config.
+            Deprecated: OBS versioning capability is not
+            controlled by service config.
         endpoint : builtins.str, optional
             Endpoint for obs.
         root : builtins.str, optional
@@ -4491,13 +4496,13 @@ class Operator:
         allow_anonymous : builtins.bool, optional
             Allow anonymous for oss.
         batch_max_operations : builtins.int, optional
-            Deprecated: OSS delete batch capability is enabled by
-            default.
+            Deprecated: OSS delete batch capability is enabled
+            by default.
         bucket : builtins.str
             Bucket for oss.
         delete_max_size : builtins.int, optional
-            Deprecated: OSS delete batch capability is enabled by
-            default.
+            Deprecated: OSS delete batch capability is enabled
+            by default.
         enable_versioning : builtins.bool, optional
             Deprecated: OSS versioning capability is enabled by
             default.
@@ -4800,15 +4805,14 @@ class Operator:
             Deprecated: S3 stat override capabilities are
             enabled by default.
         disable_write_with_if_match : builtins.bool, optional
-            Disable write with if match so that opendal will not
-            send write request with if match headers.
-            For example, Ceph RADOS S3 doesn't support write
-            with if matched.
+            Deprecated: S3 write with If-Match capability is
+            enabled by default.
         enable_request_payer : builtins.bool, optional
             Indicates whether the client agrees to pay for the
             requests made to the S3 bucket.
         enable_versioning : builtins.bool, optional
-            is bucket versioning enabled for this bucket
+            Deprecated: S3 versioning capability is enabled by
+            default.
         enable_virtual_host_style : builtins.bool, optional
             Enable virtual host style so that opendal will send
             API requests in virtual host style instead of path
@@ -4818,8 +4822,8 @@ class Operator:
             Enabled, opendal will send API to
             `https://bucket_name.s3.us-east-1.amazonaws.com`
         enable_write_with_append : builtins.bool, optional
-            Enable write with append so that opendal will send
-            write request with append headers.
+            Deprecated: S3 append capability is enabled by
+            default.
         endpoint : builtins.str, optional
             endpoint of this backend.
             Endpoint must be full uri, e.g.
@@ -5112,6 +5116,7 @@ class Operator:
         root: builtins.str = ...,
         secret_access_key: builtins.str = ...,
         security_token: builtins.str = ...,
+        skip_signature: builtins.bool = ...,
     ) -> typing.Self:
         r"""
         Create a new `Operator` for `tos` service.
@@ -5161,6 +5166,9 @@ class Operator:
             security_token of this backend.
             This token will expire after sometime, it's
             recommended to set security_token by hand.
+        skip_signature : builtins.bool, optional
+            Skip signature will skip loading credentials and
+            signing requests.
 
         Returns
         -------

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -2506,7 +2506,6 @@ class AsyncOperator:
         /,
         *,
         access_key_id: builtins.str = ...,
-        allow_anonymous: builtins.bool = ...,
         bucket: builtins.str,
         disable_config_load: builtins.bool = ...,
         endpoint: builtins.str = ...,
@@ -2526,9 +2525,6 @@ class AsyncOperator:
             - If access_key_id is set, we will take user's input
             first.
             - If not, we will try to load it from environment.
-        allow_anonymous : builtins.bool, optional
-            Allow anonymous will allow opendal to send request
-            without signing when credential is not loaded.
         bucket : builtins.str
             bucket name of this backend.
             required.
@@ -5108,7 +5104,6 @@ class Operator:
         /,
         *,
         access_key_id: builtins.str = ...,
-        allow_anonymous: builtins.bool = ...,
         bucket: builtins.str,
         disable_config_load: builtins.bool = ...,
         endpoint: builtins.str = ...,
@@ -5128,9 +5123,6 @@ class Operator:
             - If access_key_id is set, we will take user's input
             first.
             - If not, we will try to load it from environment.
-        allow_anonymous : builtins.bool, optional
-            Allow anonymous will allow opendal to send request
-            without signing when credential is not loaded.
         bucket : builtins.str
             bucket name of this backend.
             required.

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -2503,6 +2503,7 @@ submit! {
                 root: builtins.str = ...,
                 secret_access_key: builtins.str = ...,
                 security_token: builtins.str = ...,
+                skip_signature: builtins.bool = ...,
             ) -> typing.Self:
                 r"""
                 Create a new `Operator` for `tos` service.
@@ -2552,6 +2553,9 @@ submit! {
                     security_token of this backend.
                     This token will expire after sometime, it's
                     recommended to set security_token by hand.
+                skip_signature : builtins.bool, optional
+                    Skip signature will skip loading credentials and
+                    signing requests.
                 Returns
                 -------
                 Operator
@@ -5180,6 +5184,7 @@ submit! {
                 root: builtins.str = ...,
                 secret_access_key: builtins.str = ...,
                 security_token: builtins.str = ...,
+                skip_signature: builtins.bool = ...,
             ) -> typing.Self:
                 r"""
                 Create a new `AsyncOperator` for `tos` service.
@@ -5229,6 +5234,9 @@ submit! {
                     security_token of this backend.
                     This token will expire after sometime, it's
                     recommended to set security_token by hand.
+                skip_signature : builtins.bool, optional
+                    Skip signature will skip loading credentials and
+                    signing requests.
                 Returns
                 -------
                 AsyncOperator

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -2495,7 +2495,6 @@ submit! {
                 /,
                 *,
                 access_key_id: builtins.str = ...,
-                allow_anonymous: builtins.bool = ...,
                 bucket: builtins.str,
                 disable_config_load: builtins.bool = ...,
                 endpoint: builtins.str = ...,
@@ -2515,9 +2514,6 @@ submit! {
                     - If access_key_id is set, we will take user's input
                     first.
                     - If not, we will try to load it from environment.
-                allow_anonymous : builtins.bool, optional
-                    Allow anonymous will allow opendal to send request
-                    without signing when credential is not loaded.
                 bucket : builtins.str
                     bucket name of this backend.
                     required.
@@ -5176,7 +5172,6 @@ submit! {
                 /,
                 *,
                 access_key_id: builtins.str = ...,
-                allow_anonymous: builtins.bool = ...,
                 bucket: builtins.str,
                 disable_config_load: builtins.bool = ...,
                 endpoint: builtins.str = ...,
@@ -5196,9 +5191,6 @@ submit! {
                     - If access_key_id is set, we will take user's input
                     first.
                     - If not, we will try to load it from environment.
-                allow_anonymous : builtins.bool, optional
-                    Allow anonymous will allow opendal to send request
-                    without signing when credential is not loaded.
                 bucket : builtins.str
                     bucket name of this backend.
                     required.

--- a/core/services/tos/src/backend.rs
+++ b/core/services/tos/src/backend.rs
@@ -127,17 +127,6 @@ impl TosBuilder {
         self.config.skip_signature = true;
         self
     }
-
-    /// Allow anonymous will allow opendal to send request without signing
-    /// when credential is not loaded.
-    #[deprecated(
-        since = "0.57.0",
-        note = "Please use `skip_signature` instead of `allow_anonymous`"
-    )]
-    pub fn allow_anonymous(mut self, allow: bool) -> Self {
-        self.config.skip_signature = allow;
-        self
-    }
 }
 
 impl Builder for TosBuilder {
@@ -145,12 +134,6 @@ impl Builder for TosBuilder {
 
     fn build(self) -> Result<impl Access> {
         let mut config = self.config;
-
-        #[allow(deprecated)]
-        if config.allow_anonymous {
-            config.skip_signature = true;
-        }
-
         let region = config
             .region
             .clone()

--- a/core/services/tos/src/backend.rs
+++ b/core/services/tos/src/backend.rs
@@ -122,10 +122,20 @@ impl TosBuilder {
         self
     }
 
+    /// Skip signature will skip loading credentials and signing requests.
+    pub fn skip_signature(mut self) -> Self {
+        self.config.skip_signature = true;
+        self
+    }
+
     /// Allow anonymous will allow opendal to send request without signing
     /// when credential is not loaded.
+    #[deprecated(
+        since = "0.57.0",
+        note = "Please use `skip_signature` instead of `allow_anonymous`"
+    )]
     pub fn allow_anonymous(mut self, allow: bool) -> Self {
-        self.config.allow_anonymous = allow;
+        self.config.skip_signature = allow;
         self
     }
 }
@@ -135,6 +145,12 @@ impl Builder for TosBuilder {
 
     fn build(self) -> Result<impl Access> {
         let mut config = self.config;
+
+        #[allow(deprecated)]
+        if config.allow_anonymous {
+            config.skip_signature = true;
+        }
+
         let region = config
             .region
             .clone()
@@ -229,7 +245,7 @@ impl Builder for TosBuilder {
             endpoint_domain: endpoint_domain.to_string(),
             root,
             default_storage_class: None,
-            allow_anonymous: config.allow_anonymous,
+            skip_signature: config.skip_signature,
             signer,
         };
 

--- a/core/services/tos/src/config.rs
+++ b/core/services/tos/src/config.rs
@@ -84,8 +84,14 @@ pub struct TosConfig {
     /// For examples:
     /// - envs like `TOS_ACCESS_KEY_ID`
     pub disable_config_load: bool,
+    /// Skip signature will skip loading credentials and signing requests.
+    pub skip_signature: bool,
     /// Allow anonymous will allow opendal to send request without signing
     /// when credential is not loaded.
+    #[deprecated(
+        since = "0.57.0",
+        note = "Please use `skip_signature` instead of `allow_anonymous`"
+    )]
     pub allow_anonymous: bool,
 }
 

--- a/core/services/tos/src/config.rs
+++ b/core/services/tos/src/config.rs
@@ -86,13 +86,6 @@ pub struct TosConfig {
     pub disable_config_load: bool,
     /// Skip signature will skip loading credentials and signing requests.
     pub skip_signature: bool,
-    /// Allow anonymous will allow opendal to send request without signing
-    /// when credential is not loaded.
-    #[deprecated(
-        since = "0.57.0",
-        note = "Please use `skip_signature` instead of `allow_anonymous`"
-    )]
-    pub allow_anonymous: bool,
 }
 
 impl Debug for TosConfig {

--- a/core/services/tos/src/core.rs
+++ b/core/services/tos/src/core.rs
@@ -57,7 +57,7 @@ pub struct TosCore {
     pub endpoint_domain: String, // endpoint domain without scheme, e.g. tos-cn-beijing.volces.com
     pub root: String,
     pub default_storage_class: Option<String>,
-    pub allow_anonymous: bool,
+    pub skip_signature: bool,
 
     pub signer: Signer<Credential>,
 }
@@ -74,7 +74,7 @@ impl Debug for TosCore {
 
 impl TosCore {
     pub async fn send(&self, req: Request<Buffer>) -> Result<Response<Buffer>> {
-        if self.allow_anonymous {
+        if self.skip_signature {
             return self.info.http_client().send(req).await;
         }
 
@@ -94,7 +94,7 @@ impl TosCore {
     }
 
     pub async fn fetch(&self, req: Request<Buffer>) -> Result<Response<HttpBody>> {
-        if self.allow_anonymous {
+        if self.skip_signature {
             return self.info.http_client().fetch(req).await;
         }
 


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #7537.

## Rationale for this change

 This PR renames `allow_anonymous` to `skip_signature` 
## What changes are included in this PR?

- Add `TosBuilder::skip_signature` and `TosConfig::skip_signature`.
- Deprecate `TosBuilder::allow_anonymous(bool)` and`TosConfig::allow_anonymous`; both keep working and are merged into `skip_signature` at build time.
- Update Java / Python bindings accordingly (old field kept, new field added, old marked deprecated).

## Are there any user-facing changes?

No breaking changes. `allow_anonymous` still works but emits a deprecation
warning suggesting `skip_signature`.