### PR TITLE
feat(services/gcs): Rename allow_anonymous to skip_signature

### DIFF
--- a/bindings/dotnet/OpenDAL/ServiceConfig/GcsServiceConfig.cs
+++ b/bindings/dotnet/OpenDAL/ServiceConfig/GcsServiceConfig.cs
@@ -29,8 +29,13 @@ namespace OpenDAL.ServiceConfig
     public sealed class GcsServiceConfig : IServiceConfig
     {
         /// <summary>
+        /// Skip signature will skip loading credentials and signing requests.
+        /// </summary>
+        public bool? SkipSignature { get; init; }
+        /// <summary>
         /// Allow opendal to send requests without signing when credentials are not loaded.
         /// </summary>
+        [System.Obsolete("Please use SkipSignature instead of AllowAnonymous")]
         public bool? AllowAnonymous { get; init; }
         /// <summary>
         /// bucket name
@@ -86,10 +91,16 @@ namespace OpenDAL.ServiceConfig
         public IReadOnlyDictionary<string, string> ToOptions()
         {
             var map = new Dictionary<string, string>();
+            if (SkipSignature is not null)
+            {
+                map["skip_signature"] = Utilities.ToOptionString(SkipSignature);
+            }
+#pragma warning disable CS0618
             if (AllowAnonymous is not null)
             {
                 map["allow_anonymous"] = Utilities.ToOptionString(AllowAnonymous);
             }
+#pragma warning restore CS0618
             if (Bucket is not null)
             {
                 map["bucket"] = Utilities.ToOptionString(Bucket);

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -1088,6 +1088,8 @@ public interface ServiceConfig {
         /**
          * <p>Allow opendal to send requests without signing when credentials are not
          * loaded.</p>
+         *
+         * @deprecated Please use `skip_signature` instead of `allow_anonymous`
          */
         public final Boolean allowAnonymous;
         /**
@@ -1137,6 +1139,10 @@ public interface ServiceConfig {
          */
         public final String serviceAccount;
         /**
+         * <p>Skip signature will skip loading credentials and signing requests.</p>
+         */
+        public final Boolean skipSignature;
+        /**
          * <p>A Google Cloud OAuth2 token.</p>
          * <p>Takes precedence over <code>credential</code> and <code>credential_path</code>.</p>
          */
@@ -1183,6 +1189,9 @@ public interface ServiceConfig {
             }
             if (serviceAccount != null) {
                 map.put("service_account", serviceAccount);
+            }
+            if (skipSignature != null) {
+                map.put("skip_signature", String.valueOf(skipSignature));
             }
             if (token != null) {
                 map.put("token", token);

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -1151,6 +1151,7 @@ class AsyncOperator:
         root: builtins.str = ...,
         scope: builtins.str = ...,
         service_account: builtins.str = ...,
+        skip_signature: builtins.bool = ...,
         token: builtins.str = ...,
     ) -> typing.Self:
         r"""
@@ -1187,6 +1188,9 @@ class AsyncOperator:
             Scope for gcs.
         service_account : builtins.str, optional
             Service Account for gcs.
+        skip_signature : builtins.bool, optional
+            Skip signature will skip loading credentials and
+            signing requests.
         token : builtins.str, optional
             A Google Cloud OAuth2 token.
             Takes precedence over `credential` and
@@ -1381,7 +1385,8 @@ class AsyncOperator:
         Parameters
         ----------
         enable_append : builtins.bool, optional
-            Deprecated: HDFS Native append capability is enabled by default.
+            Deprecated: HDFS Native append capability is enabled
+            by default.
         name_node : builtins.str, optional
             name_node of this backend
         options : builtins.dict, optional
@@ -1793,8 +1798,8 @@ class AsyncOperator:
         bucket : builtins.str, optional
             Bucket for obs.
         enable_versioning : builtins.bool, optional
-            Deprecated: OBS versioning capability is not controlled by
-            service config.
+            Deprecated: OBS versioning capability is not
+            controlled by service config.
         endpoint : builtins.str, optional
             Endpoint for obs.
         root : builtins.str, optional
@@ -3752,6 +3757,7 @@ class Operator:
         root: builtins.str = ...,
         scope: builtins.str = ...,
         service_account: builtins.str = ...,
+        skip_signature: builtins.bool = ...,
         token: builtins.str = ...,
     ) -> typing.Self:
         r"""
@@ -3788,6 +3794,9 @@ class Operator:
             Scope for gcs.
         service_account : builtins.str, optional
             Service Account for gcs.
+        skip_signature : builtins.bool, optional
+            Skip signature will skip loading credentials and
+            signing requests.
         token : builtins.str, optional
             A Google Cloud OAuth2 token.
             Takes precedence over `credential` and
@@ -3982,7 +3991,8 @@ class Operator:
         Parameters
         ----------
         enable_append : builtins.bool, optional
-            Deprecated: HDFS Native append capability is enabled by default.
+            Deprecated: HDFS Native append capability is enabled
+            by default.
         name_node : builtins.str, optional
             name_node of this backend
         options : builtins.dict, optional
@@ -4394,8 +4404,8 @@ class Operator:
         bucket : builtins.str, optional
             Bucket for obs.
         enable_versioning : builtins.bool, optional
-            Deprecated: OBS versioning capability is not controlled by
-            service config.
+            Deprecated: OBS versioning capability is not
+            controlled by service config.
         endpoint : builtins.str, optional
             Endpoint for obs.
         root : builtins.str, optional

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -870,6 +870,7 @@ submit! {
                 root: builtins.str = ...,
                 scope: builtins.str = ...,
                 service_account: builtins.str = ...,
+                skip_signature: builtins.bool = ...,
                 token: builtins.str = ...,
             ) -> typing.Self:
                 r"""
@@ -906,6 +907,9 @@ submit! {
                     Scope for gcs.
                 service_account : builtins.str, optional
                     Service Account for gcs.
+                skip_signature : builtins.bool, optional
+                    Skip signature will skip loading credentials and
+                    signing requests.
                 token : builtins.str, optional
                     A Google Cloud OAuth2 token.
                     Takes precedence over `credential` and
@@ -3551,6 +3555,7 @@ submit! {
                 root: builtins.str = ...,
                 scope: builtins.str = ...,
                 service_account: builtins.str = ...,
+                skip_signature: builtins.bool = ...,
                 token: builtins.str = ...,
             ) -> typing.Self:
                 r"""
@@ -3587,6 +3592,9 @@ submit! {
                     Scope for gcs.
                 service_account : builtins.str, optional
                     Service Account for gcs.
+                skip_signature : builtins.bool, optional
+                    Skip signature will skip loading credentials and
+                    signing requests.
                 token : builtins.str, optional
                     A Google Cloud OAuth2 token.
                     Takes precedence over `credential` and

--- a/core/services/gcs/src/backend.rs
+++ b/core/services/gcs/src/backend.rs
@@ -220,13 +220,22 @@ impl GcsBuilder {
         self
     }
 
-    /// Allow anonymous requests.
+    /// Skip signature will skip loading credentials and signing requests.
     ///
     /// This is typically used for buckets which are open to the public or GCS
     /// storage emulators.
-    pub fn allow_anonymous(mut self) -> Self {
-        self.config.allow_anonymous = true;
+    pub fn skip_signature(mut self) -> Self {
+        self.config.skip_signature = true;
         self
+    }
+
+    /// Allow anonymous requests.
+    #[deprecated(
+        since = "0.57.0",
+        note = "Please use `skip_signature` instead of `allow_anonymous`"
+    )]
+    pub fn allow_anonymous(self) -> Self {
+        self.skip_signature()
     }
 }
 
@@ -235,6 +244,9 @@ impl Builder for GcsBuilder {
 
     fn build(self) -> Result<impl Access> {
         debug!("backend build started: {self:?}");
+
+        #[allow(deprecated)]
+        let skip_signature = self.config.skip_signature || self.config.allow_anonymous;
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
         debug!("backend use root {root}");
@@ -402,7 +414,7 @@ impl Builder for GcsBuilder {
                 signer,
                 predefined_acl: self.config.predefined_acl.clone(),
                 default_storage_class: self.config.default_storage_class.clone(),
-                allow_anonymous: self.config.allow_anonymous,
+                skip_signature,
             }),
         };
 

--- a/core/services/gcs/src/config.rs
+++ b/core/services/gcs/src/config.rs
@@ -58,9 +58,15 @@ pub struct GcsConfig {
     pub predefined_acl: Option<String>,
     /// The default storage class used by gcs.
     pub default_storage_class: Option<String>,
+    /// Skip signature will skip loading credentials and signing requests.
+    #[serde(alias = "google_skip_signature")]
+    pub skip_signature: bool,
     /// Allow opendal to send requests without signing when credentials are not
     /// loaded.
-    #[serde(alias = "google_skip_signature", alias = "skip_signature")]
+    #[deprecated(
+        since = "0.57.0",
+        note = "Please use `skip_signature` instead of `allow_anonymous`"
+    )]
     pub allow_anonymous: bool,
     /// Disable attempting to load credentials from the GCE metadata server when
     /// running within Google Cloud.
@@ -172,14 +178,21 @@ mod tests {
     }
 
     #[test]
-    fn test_allow_anonymous_aliases() {
+    fn test_skip_signature_aliases() {
         let config_json = r#"{"google_skip_signature": true}"#;
         let config: GcsConfig = serde_json::from_str(config_json).unwrap();
-        assert!(config.allow_anonymous);
+        assert!(config.skip_signature);
 
         let config_json = r#"{"skip_signature": true}"#;
         let config: GcsConfig = serde_json::from_str(config_json).unwrap();
-        assert!(config.allow_anonymous);
+        assert!(config.skip_signature);
+
+        let config_json = r#"{"allow_anonymous": true}"#;
+        let config: GcsConfig = serde_json::from_str(config_json).unwrap();
+        #[allow(deprecated)]
+        {
+            assert!(config.allow_anonymous);
+        }
     }
 
     #[test]

--- a/core/services/gcs/src/core.rs
+++ b/core/services/gcs/src/core.rs
@@ -35,7 +35,6 @@ use http::header::IF_MATCH;
 use http::header::IF_MODIFIED_SINCE;
 use http::header::IF_NONE_MATCH;
 use http::header::IF_UNMODIFIED_SINCE;
-use reqsign_core::ErrorKind as ReqsignErrorKind;
 use reqsign_core::Signer;
 use reqsign_google::Credential;
 use serde::Deserialize;
@@ -70,7 +69,7 @@ pub struct GcsCore {
     pub predefined_acl: Option<String>,
     pub default_storage_class: Option<String>,
 
-    pub allow_anonymous: bool,
+    pub skip_signature: bool,
 }
 
 impl Debug for GcsCore {
@@ -85,53 +84,47 @@ impl Debug for GcsCore {
 
 impl GcsCore {
     pub async fn sign<T>(&self, req: Request<T>) -> Result<Request<T>> {
+        if self.skip_signature {
+            return Ok(req);
+        }
+
         let (mut parts, body) = req.into_parts();
 
-        let signed = match self.signer.sign(&mut parts, None).await {
-            Ok(()) => true,
-            Err(err)
-                if self.allow_anonymous && err.kind() == ReqsignErrorKind::CredentialInvalid =>
-            {
-                false
-            }
-            Err(err) => return Err(new_request_sign_error(err.into())),
-        };
+        self.signer
+            .sign(&mut parts, None)
+            .await
+            .map_err(|err| new_request_sign_error(err.into()))?;
 
-        if signed {
-            // Always remove host header, let users' client to set it based on
-            // HTTP version.
-            //
-            // As discussed in <https://github.com/seanmonstar/reqwest/issues/1809>,
-            // google server could send RST_STREAM of PROTOCOL_ERROR if our
-            // request contains host header.
-            parts.headers.remove(HOST);
-        }
+        // Always remove host header, let users' client to set it based on
+        // HTTP version.
+        //
+        // As discussed in <https://github.com/seanmonstar/reqwest/issues/1809>,
+        // google server could send RST_STREAM of PROTOCOL_ERROR if our
+        // request contains host header.
+        parts.headers.remove(HOST);
 
         Ok(Request::from_parts(parts, body))
     }
 
     pub async fn sign_query<T>(&self, req: Request<T>, duration: Duration) -> Result<Request<T>> {
+        if self.skip_signature {
+            return Ok(req);
+        }
+
         let (mut parts, body) = req.into_parts();
 
-        let signed = match self.signer.sign(&mut parts, Some(duration)).await {
-            Ok(()) => true,
-            Err(err)
-                if self.allow_anonymous && err.kind() == ReqsignErrorKind::CredentialInvalid =>
-            {
-                false
-            }
-            Err(err) => return Err(new_request_sign_error(err.into())),
-        };
+        self.signer
+            .sign(&mut parts, Some(duration))
+            .await
+            .map_err(|err| new_request_sign_error(err.into()))?;
 
-        if signed {
-            // Always remove host header, let users' client to set it based on
-            // HTTP version.
-            //
-            // As discussed in <https://github.com/seanmonstar/reqwest/issues/1809>,
-            // google server could send RST_STREAM of PROTOCOL_ERROR if our
-            // request contains host header.
-            parts.headers.remove(HOST);
-        }
+        // Always remove host header, let users' client to set it based on
+        // HTTP version.
+        //
+        // As discussed in <https://github.com/seanmonstar/reqwest/issues/1809>,
+        // google server could send RST_STREAM of PROTOCOL_ERROR if our
+        // request contains host header.
+        parts.headers.remove(HOST);
 
         Ok(Request::from_parts(parts, body))
     }


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #7537. 

## Rationale for this change

This PR renames the option to `skip_signature` and changes the semantics to unconditional skip

## What changes are included in this PR?

- Add `GcsBuilder::skip_signature` and `GcsConfig::skip_signature`.
- Deprecate `GcsBuilder::allow_anonymous` and `GcsConfig::allow_anonymous`; both keep working and are merged into `skip_signature` at build time.
- Change signing semantics from fallback-on-error to eager skip, matching other services.
- Update .NET / Java / Python bindings accordingly 

## Are there any user-facing changes?

**Behavior change** for users who relied on the fallback semantics: if you previously set `allow_anonymous(true)` and provided valid credentials, GCS would sign requests. Now `skip_signature(true)` (and the deprecated
`allow_anonymous(true)`) **unconditionally** skips signing. Users who want signing should not set this option.

No source-breaking changes. `allow_anonymous` still compiles with a deprecation warning suggesting `skip_signature`.