### PR TITLE
refactor(services/sftp): deprecate copy option

### DIFF
--- a/bindings/dotnet/OpenDAL/ServiceConfig/SftpServiceConfig.cs
+++ b/bindings/dotnet/OpenDAL/ServiceConfig/SftpServiceConfig.cs
@@ -29,7 +29,7 @@ namespace OpenDAL.ServiceConfig
     public sealed class SftpServiceConfig : IServiceConfig
     {
         /// <summary>
-        /// enable_copy of this backend
+        /// Deprecated: SFTP copy capability is enabled by default.
         /// </summary>
         public bool? EnableCopy { get; init; }
         /// <summary>

--- a/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
+++ b/bindings/java/src/main/java/org/apache/opendal/ServiceConfig.java
@@ -3253,7 +3253,9 @@ public interface ServiceConfig {
     @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
     class Sftp implements ServiceConfig {
         /**
-         * <p>enable_copy of this backend</p>
+         * <p>Deprecated: SFTP copy capability is enabled by default.</p>
+         *
+         * @deprecated SFTP copy capability is enabled by default and this option is no longer needed.
          */
         public final Boolean enableCopy;
         /**

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -2325,7 +2325,8 @@ submit! {
                 Parameters
                 ----------
                 enable_copy : builtins.bool, optional
-                    enable_copy of this backend
+                    Deprecated: SFTP copy capability is enabled by
+                    default.
                 endpoint : builtins.str, optional
                     endpoint of this backend
                 key : builtins.str, optional
@@ -5010,7 +5011,8 @@ submit! {
                 Parameters
                 ----------
                 enable_copy : builtins.bool, optional
-                    enable_copy of this backend
+                    Deprecated: SFTP copy capability is enabled by
+                    default.
                 endpoint : builtins.str, optional
                     endpoint of this backend
                 key : builtins.str, optional

--- a/core/services/sftp/src/backend.rs
+++ b/core/services/sftp/src/backend.rs
@@ -116,11 +116,12 @@ impl SftpBuilder {
         self
     }
 
-    /// set enable_copy for sftp backend.
-    /// It requires the server supports copy-file extension.
-    pub fn enable_copy(mut self, enable_copy: bool) -> Self {
-        self.config.enable_copy = enable_copy;
-
+    /// Deprecated: SFTP copy capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "SFTP copy capability is enabled by default and this option is no longer needed."
+    )]
+    pub fn enable_copy(self, _enable_copy: bool) -> Self {
         self
     }
 }
@@ -181,7 +182,7 @@ impl Builder for SftpBuilder {
                 list: true,
                 list_with_limit: true,
 
-                copy: self.config.enable_copy,
+                copy: true,
                 rename: true,
 
                 shared: true,

--- a/core/services/sftp/src/config.rs
+++ b/core/services/sftp/src/config.rs
@@ -37,7 +37,11 @@ pub struct SftpConfig {
     pub key: Option<String>,
     /// known_hosts_strategy of this backend
     pub known_hosts_strategy: Option<String>,
-    /// enable_copy of this backend
+    /// Deprecated: SFTP copy capability is enabled by default.
+    #[deprecated(
+        since = "0.57.0",
+        note = "SFTP copy capability is enabled by default and this option is no longer needed."
+    )]
     pub enable_copy: bool,
 }
 

--- a/core/services/sftp/src/docs.md
+++ b/core/services/sftp/src/docs.md
@@ -19,7 +19,7 @@ This service can be used to:
 - `user`: Set the login user
 - `key`: Set the file path to the private key for authentication
 - `known_hosts_strategy`: Set the strategy for known hosts, default to `Strict`
-- `enable_copy`: Set whether the remote server has copy-file extension
+- `enable_copy`: Deprecated. SFTP copy capability is enabled by default and this option is no longer needed.
 
 For security reasons, it doesn't support password login. Use SSH key-based authentication (e.g., configure your public key on the server via `ssh-copy-id` and provide the private key here).
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of #6708.

# Rationale for this change

SFTP `enable_copy` only controls the advertised `copy` capability. The SFTP copy implementation does not read this config flag; it streams data through the SFTP client and works with the existing test fixture.

# What changes are included in this PR?

This PR enables SFTP `copy` capability by default, keeps `enable_copy` as a deprecated no-op compatibility option, and updates generated binding config docs.

# Are there any user-facing changes?

No breaking changes. SFTP copy is now advertised by default; endpoints that need to disable copy in tests can use `CapabilityOverrideLayer` or `OPENDAL_TEST_CAPABILITY_OVERRIDES=copy=false`.

# AI Usage Statement

N/A.
