### PR TITLE
docs(services): Document skip_signature in S3 and GCS docs

### DIFF
--- a/core/services/gcs/src/docs.md
+++ b/core/services/gcs/src/docs.md
@@ -22,6 +22,8 @@ This service can be used to:
 - `service_account`: name of Service Account
 - `predefined_acl`: Predefined ACL for GCS
 - `default_storage_class`: Default storage class for GCS
+- `skip_signature`: Skip loading credentials and signing requests.
+- `allow_anonymous`: Deprecated. Use `skip_signature` instead.
 
 Refer to public API docs for more information. For authentication related options, read on.
 

--- a/core/services/s3/src/docs.md
+++ b/core/services/s3/src/docs.md
@@ -30,6 +30,8 @@ This service can be used to:
 - `disable_config_load`: Disable aws config load from env.
 - `enable_virtual_host_style`: Enable virtual host style.
 - `enable_request_payer`: Enable the request payer for backend.
+- `skip_signature`: Skip loading credentials and signing requests.
+- `allow_anonymous`: Deprecated. Use `skip_signature` instead.
 - `batch_max_operations`: Deprecated. S3 delete batch capability is enabled by default and this option is no longer needed.
 - `delete_max_size`: Deprecated. S3 delete batch capability is enabled by default and this option is no longer needed.
 - `disable_stat_with_override`: Deprecated. S3 stat override capabilities are enabled by default and this option is no longer needed.


### PR DESCRIPTION
## Which issue does this PR close?

- Part of #7537.

## Rationale for this change

updating service-level `docs.md` — OSS was done in #7556, leaving S3 and GCS still listing only the old `allow_anonymous`

## What changes are included in this PR?

- Add `skip_signature` and a deprecated `allow_anonymous` entry to the S3 and GCS `docs.md` Configuration lists.


## Are there any user-facing changes?

Documentation only.