### PR TITLE
feat(services/tos): implement copier

### DIFF
--- a/core/services/tos/src/backend.rs
+++ b/core/services/tos/src/backend.rs
@@ -19,6 +19,8 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use crate::config::TosConfig;
+use crate::copier::TosCopiers;
+use crate::copier::new_tos_copier;
 use crate::core::constants::X_TOS_VERSION_ID;
 use crate::core::constants::{X_TOS_DIRECTORY, X_TOS_META_PREFIX};
 use crate::core::*;
@@ -198,6 +200,13 @@ impl Builder for TosBuilder {
                     delete_with_version: true,
 
                     copy: true,
+                    copy_can_multi: true,
+                    copy_multi_min_size: Some(5 * 1024 * 1024),
+                    copy_multi_max_size: if cfg!(target_pointer_width = "64") {
+                        Some(5 * 1024 * 1024 * 1024)
+                    } else {
+                        Some(usize::MAX)
+                    },
 
                     list: true,
                     list_with_limit: true,
@@ -256,7 +265,7 @@ impl Access for TosBackend {
     type Writer = oio::MultipartWriter<TosWriter>;
     type Lister = TosListers;
     type Deleter = oio::BatchDeleter<TosDeleter>;
-    type Copier = ();
+    type Copier = TosCopiers;
 
     fn info(&self) -> Arc<AccessorInfo> {
         self.core.info.clone()
@@ -359,13 +368,9 @@ impl Access for TosBackend {
         from: &str,
         to: &str,
         args: OpCopy,
-        _opts: OpCopier,
+        opts: OpCopier,
     ) -> Result<(RpCopy, Self::Copier)> {
-        let resp = self.core.tos_copy_object(from, to, &args).await?;
-
-        match resp.status() {
-            StatusCode::OK => Ok((RpCopy::default(), ())),
-            _ => Err(parse_error(resp)),
-        }
+        let copier = new_tos_copier(self.core.clone(), from, to, args, opts)?;
+        Ok((RpCopy::default(), copier))
     }
 }

--- a/core/services/tos/src/copier.rs
+++ b/core/services/tos/src/copier.rs
@@ -1,0 +1,275 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use bytes::Buf;
+use http::StatusCode;
+
+use crate::core::constants::X_TOS_VERSION_ID;
+use crate::core::*;
+use crate::error::parse_error;
+use crate::utils::tos_parse_into_metadata;
+use opendal_core::raw::*;
+use opendal_core::*;
+
+pub type TosCopiers = oio::MultipartCopier<TosCopier>;
+
+pub fn new_tos_copier(
+    core: Arc<TosCore>,
+    from: &str,
+    to: &str,
+    args: OpCopy,
+    opts: OpCopier,
+) -> Result<TosCopiers> {
+    let capability = core.info.full_capability();
+    let max_part_size = capability.copy_multi_max_size.ok_or_else(|| {
+        Error::new(
+            ErrorKind::Unexpected,
+            "multipart copy requires copy_multi_max_size capability",
+        )
+    })?;
+
+    let (copy_once_threshold, part_size) = match opts.chunk() {
+        Some(chunk) => {
+            let min_part_size = capability.copy_multi_min_size.ok_or_else(|| {
+                Error::new(
+                    ErrorKind::Unexpected,
+                    "multipart copy requires copy_multi_min_size capability",
+                )
+            })?;
+            let part_size = chunk.clamp(min_part_size, max_part_size) as u64;
+            (part_size.saturating_sub(1), part_size)
+        }
+        None => {
+            let part_size = max_part_size as u64;
+            (part_size, part_size)
+        }
+    };
+
+    Ok(oio::MultipartCopier::new(
+        core.info.clone(),
+        TosCopier {
+            core,
+            from: from.to_string(),
+            to: to.to_string(),
+            args,
+            source_metadata: Mutex::new(None),
+        },
+        opts.source_content_length_hint(),
+        copy_once_threshold,
+        part_size,
+        opts.concurrent(),
+    ))
+}
+
+pub struct TosCopier {
+    core: Arc<TosCore>,
+    from: String,
+    to: String,
+    args: OpCopy,
+    source_metadata: Mutex<Option<Metadata>>,
+}
+
+impl TosCopier {
+    async fn load_source_metadata(&self) -> Result<Metadata> {
+        {
+            let source_metadata = self
+                .source_metadata
+                .lock()
+                .expect("source metadata mutex poisoned");
+            if let Some(meta) = source_metadata.as_ref() {
+                return Ok(meta.clone());
+            }
+        }
+
+        let resp = self
+            .core
+            .tos_head_object(&self.from, OpStat::default())
+            .await?;
+
+        match resp.status() {
+            StatusCode::OK => {
+                let headers = resp.headers();
+                let mut meta = tos_parse_into_metadata(&self.from, headers)?;
+
+                if let Some(v) = parse_header_to_str(headers, X_TOS_VERSION_ID)? {
+                    meta.set_version(v);
+                }
+
+                let mut source_metadata = self
+                    .source_metadata
+                    .lock()
+                    .expect("source metadata mutex poisoned");
+                *source_metadata = Some(meta.clone());
+
+                Ok(meta)
+            }
+            _ => Err(parse_error(resp)),
+        }
+    }
+}
+
+impl oio::MultipartCopy for TosCopier {
+    async fn source_metadata(&self) -> Result<Metadata> {
+        self.load_source_metadata().await
+    }
+
+    async fn copy_once(&self) -> Result<()> {
+        let resp = self
+            .core
+            .tos_copy_object(&self.from, &self.to, &self.args)
+            .await?;
+
+        match resp.status() {
+            StatusCode::OK => {
+                let result: CopyObjectOutput = serde_json::from_reader(resp.into_body().reader())
+                    .map_err(new_json_deserialize_error)?;
+                if result.etag.is_empty() {
+                    return Err(Error::new(
+                        ErrorKind::Unexpected,
+                        "ETag not present in copy response",
+                    )
+                    .set_temporary());
+                }
+
+                Ok(())
+            }
+            _ => Err(parse_error(resp)),
+        }
+    }
+
+    async fn initiate_copy(&self) -> Result<String> {
+        self.load_source_metadata().await?;
+
+        let resp = self.core.tos_initiate_multipart_copy(&self.to).await?;
+
+        match resp.status() {
+            StatusCode::OK => {
+                let result: InitiateMultipartUploadResult =
+                    serde_json::from_reader(resp.into_body().reader())
+                        .map_err(new_json_deserialize_error)?;
+
+                Ok(result.upload_id)
+            }
+            _ => Err(parse_error(resp)),
+        }
+    }
+
+    async fn copy_part(
+        &self,
+        upload_id: &str,
+        part_number: usize,
+        range: BytesRange,
+    ) -> Result<oio::MultipartPart> {
+        let size = range.size().expect("multipart copy range must be sized");
+        let part_number = part_number + 1;
+        let (source_etag, source_version) = {
+            let source_metadata = self
+                .source_metadata
+                .lock()
+                .expect("source metadata mutex poisoned");
+            (
+                source_metadata
+                    .as_ref()
+                    .and_then(|meta| meta.etag())
+                    .map(ToOwned::to_owned),
+                source_metadata
+                    .as_ref()
+                    .and_then(|meta| meta.version())
+                    .map(ToOwned::to_owned),
+            )
+        };
+
+        let req = self
+            .core
+            .tos_upload_part_copy_request(TosUploadPartCopyRequest {
+                from: &self.from,
+                to: &self.to,
+                upload_id,
+                part_number,
+                range,
+                source_etag: source_etag.as_deref(),
+                source_version: source_version.as_deref(),
+            })?;
+        let resp = self.core.send(req).await?;
+
+        match resp.status() {
+            StatusCode::OK => {
+                let result: UploadPartCopyOutput =
+                    serde_json::from_reader(resp.into_body().reader())
+                        .map_err(new_json_deserialize_error)?;
+                if result.etag.is_empty() {
+                    return Err(Error::new(
+                        ErrorKind::Unexpected,
+                        "ETag not present in copy part response",
+                    )
+                    .set_temporary());
+                }
+
+                Ok(oio::MultipartPart {
+                    part_number,
+                    etag: result.etag.trim_matches('"').to_string(),
+                    checksum: None,
+                    size: Some(size),
+                })
+            }
+            _ => Err(parse_error(resp)),
+        }
+    }
+
+    async fn complete_copy(&self, upload_id: &str, parts: &[oio::MultipartPart]) -> Result<()> {
+        let parts = parts
+            .iter()
+            .map(|p| CompleteMultipartUploadRequestPart {
+                part_number: p.part_number,
+                etag: p.etag.clone(),
+            })
+            .collect();
+
+        let resp = self
+            .core
+            .tos_complete_multipart_copy(&self.to, upload_id, parts, &self.args)
+            .await?;
+
+        match resp.status() {
+            StatusCode::OK => {
+                let ret: CompleteMultipartUploadResult =
+                    serde_json::from_reader(resp.into_body().reader())
+                        .map_err(new_json_deserialize_error)?;
+                if !ret.code.is_empty() {
+                    return Err(Error::new(ErrorKind::Unexpected, ret.message));
+                }
+
+                Ok(())
+            }
+            _ => Err(parse_error(resp)),
+        }
+    }
+
+    async fn abort_copy(&self, upload_id: &str) -> Result<()> {
+        let resp = self
+            .core
+            .tos_abort_multipart_copy(&self.to, upload_id)
+            .await?;
+        match resp.status() {
+            StatusCode::NO_CONTENT => Ok(()),
+            _ => Err(parse_error(resp)),
+        }
+    }
+}

--- a/core/services/tos/src/core.rs
+++ b/core/services/tos/src/core.rs
@@ -35,6 +35,9 @@ use opendal_core::*;
 pub mod constants {
     pub const X_TOS_ACL: &str = "x-tos-acl";
     pub const X_TOS_COPY_SOURCE: &str = "x-tos-copy-source";
+    pub const X_TOS_COPY_SOURCE_IF_MATCH: &str = "x-tos-copy-source-if-match";
+    pub const X_TOS_COPY_SOURCE_RANGE: &str = "x-tos-copy-source-range";
+    pub const X_TOS_FORBID_OVERWRITE: &str = "x-tos-forbid-overwrite";
 
     pub const X_TOS_STORAGE_CLASS: &str = "x-tos-storage-class";
 
@@ -63,6 +66,16 @@ pub struct TosCore {
     pub skip_signature: bool,
 
     pub signer: Signer<Credential>,
+}
+
+pub(crate) struct TosUploadPartCopyRequest<'a> {
+    pub from: &'a str,
+    pub to: &'a str,
+    pub upload_id: &'a str,
+    pub part_number: usize,
+    pub range: BytesRange,
+    pub source_etag: Option<&'a str>,
+    pub source_version: Option<&'a str>,
 }
 
 impl Debug for TosCore {
@@ -452,10 +465,134 @@ impl TosCore {
             .header(constants::X_TOS_ACL, "default");
 
         if args.if_not_exists() {
-            req = req.header(http::header::IF_NONE_MATCH, "*");
+            req = req.header(constants::X_TOS_FORBID_OVERWRITE, "true");
         }
 
         let req = req
+            .extension(Operation::Copy)
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+
+        self.send(req).await
+    }
+
+    pub async fn tos_initiate_multipart_copy(&self, path: &str) -> Result<Response<Buffer>> {
+        let p = build_abs_path(&self.root, path);
+
+        let url = format!(
+            "https://{}.{}/{}?uploads",
+            self.bucket,
+            self.endpoint_domain,
+            percent_encode_path(&p)
+        );
+
+        let mut req = Request::post(&url).header(constants::X_TOS_ACL, "default");
+
+        if let Some(v) = &self.default_storage_class {
+            req = req.header(
+                http::HeaderName::from_static(constants::X_TOS_STORAGE_CLASS),
+                v,
+            );
+        }
+
+        let req = req
+            .extension(Operation::Copy)
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
+
+        self.send(req).await
+    }
+
+    pub fn tos_upload_part_copy_request(
+        &self,
+        input: TosUploadPartCopyRequest<'_>,
+    ) -> Result<Request<Buffer>> {
+        let source = build_abs_path(&self.root, input.from);
+        let target = build_abs_path(&self.root, input.to);
+
+        let mut url = format!(
+            "https://{}.{}/{}?partNumber={}&uploadId={}",
+            self.bucket,
+            self.endpoint_domain,
+            percent_encode_path(&target),
+            input.part_number,
+            percent_encode_query(input.upload_id)
+        );
+        if let Some(version) = input.source_version {
+            url.push_str(&format!(
+                "&{}={}",
+                constants::TOS_QUERY_VERSION_ID,
+                percent_encode_query(version)
+            ));
+        }
+        let source = format!("/{}/{}", self.bucket, percent_encode_path(&source));
+
+        let mut req = Request::put(&url)
+            .extension(Operation::Copy)
+            .header(constants::X_TOS_COPY_SOURCE, source)
+            .header(constants::X_TOS_COPY_SOURCE_RANGE, input.range.to_header());
+
+        if let Some(etag) = input.source_etag {
+            req = req.header(constants::X_TOS_COPY_SOURCE_IF_MATCH, etag);
+        }
+
+        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
+
+        Ok(req)
+    }
+
+    pub async fn tos_complete_multipart_copy(
+        &self,
+        path: &str,
+        upload_id: &str,
+        parts: Vec<CompleteMultipartUploadRequestPart>,
+        args: &OpCopy,
+    ) -> Result<Response<Buffer>> {
+        let p = build_abs_path(&self.root, path);
+
+        let url = format!(
+            "https://{}.{}/{}?uploadId={}",
+            self.bucket,
+            self.endpoint_domain,
+            percent_encode_path(&p),
+            percent_encode_query(upload_id)
+        );
+
+        let content = serde_json::to_string(&CompleteMultipartUploadRequest { parts })
+            .map_err(new_json_serialize_error)?;
+
+        let mut req = Request::post(&url)
+            .header(CONTENT_LENGTH, content.len())
+            .header(CONTENT_TYPE, "application/json");
+
+        if args.if_not_exists() {
+            req = req.header(constants::X_TOS_FORBID_OVERWRITE, "true");
+        }
+
+        let req = req
+            .extension(Operation::Copy)
+            .body(Buffer::from(content))
+            .map_err(new_request_build_error)?;
+
+        self.send(req).await
+    }
+
+    pub async fn tos_abort_multipart_copy(
+        &self,
+        path: &str,
+        upload_id: &str,
+    ) -> Result<Response<Buffer>> {
+        let p = build_abs_path(&self.root, path);
+
+        let url = format!(
+            "https://{}.{}/{}?uploadId={}",
+            self.bucket,
+            self.endpoint_domain,
+            percent_encode_path(&p),
+            percent_encode_query(upload_id)
+        );
+
+        let req = Request::delete(&url)
             .extension(Operation::Copy)
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
@@ -840,4 +977,18 @@ pub struct ListObjectVersionsOutputDeleteMarker {
     pub version_id: String,
     pub is_latest: bool,
     pub last_modified: String,
+}
+
+#[derive(Default, Debug, Deserialize)]
+#[serde(default, rename_all = "PascalCase")]
+pub struct UploadPartCopyOutput {
+    #[serde(rename = "ETag")]
+    pub etag: String,
+}
+
+#[derive(Default, Debug, Deserialize)]
+#[serde(default, rename_all = "PascalCase")]
+pub struct CopyObjectOutput {
+    #[serde(rename = "ETag")]
+    pub etag: String,
 }

--- a/core/services/tos/src/lib.rs
+++ b/core/services/tos/src/lib.rs
@@ -21,6 +21,7 @@
 
 mod backend;
 mod config;
+mod copier;
 mod core;
 mod deleter;
 mod error;


### PR DESCRIPTION
# Which issue does this PR close?

Part of #7152.

# Rationale for this change

This PR implements the `Copier` path so `Operator::copier` can drive TOS copy operations consistently with other object storage services.

# What changes are included in this PR?

- Add a TOS `MultipartCopier` implementation. Support one-shot copy via `CopyObject` and multipart copy via `UploadPartCopy`.

# Are there any user-facing changes?

TOS now supports stateful copier operations, including chunked and concurrent copy.

# AI Usage Statement

This PR was implemented with Codex using GPT-5.5.