### PR TITLE
fix(bindings/nodejs): Align versioned list startAfter test

### DIFF
--- a/bindings/nodejs/tests/suites/asyncListOptions.suite.mjs
+++ b/bindings/nodejs/tests/suites/asyncListOptions.suite.mjs
@@ -146,8 +146,14 @@ export function run(op) {
             await op.write(entry, '2')
           }
           const lists = await op.list(dirname, { versions: true, startAfter: given[2] })
-          const actual = lists.filter((item) => item.path() !== dirname)
-          const expected = given.slice(3)
+          const actual = lists
+            .filter((item) => item.path() !== dirname)
+            .map((item) => item.path())
+            .sort()
+          const expected = given
+            .slice(3)
+            .flatMap((item) => [item, item])
+            .sort()
           expect(actual).toEqual(expected)
 
           await op.removeAll(dirname)

--- a/bindings/nodejs/tests/suites/syncListOptions.suite.mjs
+++ b/bindings/nodejs/tests/suites/syncListOptions.suite.mjs
@@ -146,8 +146,14 @@ export function run(op) {
             op.writeSync(entry, '2')
           }
           const lists = op.listSync(dirname, { versions: true, startAfter: given[2] })
-          const actual = lists.filter((item) => item.path() !== dirname)
-          const expected = given.slice(3)
+          const actual = lists
+            .filter((item) => item.path() !== dirname)
+            .map((item) => item.path())
+            .sort()
+          const expected = given
+            .slice(3)
+            .flatMap((item) => [item, item])
+            .sort()
           expect(actual).toEqual(expected)
 
           op.removeAllSync(dirname)


### PR DESCRIPTION
# Which issue does this PR close?

N/A. This fixes a CI-only behavior test regression after TOS versioning support was enabled.

https://github.com/apache/opendal/actions/runs/26219601739/job/77150890707

# Rationale for this change

The Node.js binding `list with versions and start after` test was comparing `Entry[]` directly with path strings. It also expected one result per object, but `versions: true` returns one entry per object version.

This was exposed by the TOS behavior job because TOS now enables both `list_with_versions` and `list_with_start_after` without overriding versioning in CI.

# What changes are included in this PR?

- Map listed entries to `entry.path()` before comparing.
- Expect two entries for each object written twice.
- Apply the same assertion fix to async and sync Node.js list option tests.

# Are there any user-facing changes?

No. This only fixes Node.js binding behavior test expectations.

# AI Usage Statement

Used OpenAI Codex to investigate the CI failure and prepare this patch.

Validation:

- `OPENDAL_TEST=tos cargo test --test behavior --features services-tos,tests behavior::test_list_with_versions_and_start_after -- --test-threads=1 --show-output`
- `OPENDAL_TEST=tos pnpm test -- tests/service.test.mjs -t "list with versions and start after" --testTimeout=600000 --hookTimeout=600000`
- `pnpm exec prettier --check tests/suites/asyncListOptions.suite.mjs tests/suites/syncListOptions.suite.mjs`