### PR TITLE
docs(services/tos): add service docs

### DIFF
--- a/core/services/tos/src/backend.rs
+++ b/core/services/tos/src/backend.rs
@@ -40,6 +40,7 @@ use reqsign_volcengine_tos::{EnvCredentialProvider, RequestSigner, StaticCredent
 const TOS_SCHEME: &str = "tos";
 
 /// Builder for Volcengine TOS service.
+#[doc = include_str!("docs.md")]
 #[derive(Default)]
 pub struct TosBuilder {
     pub(super) config: TosConfig,

--- a/core/services/tos/src/docs.md
+++ b/core/services/tos/src/docs.md
@@ -1,0 +1,61 @@
+## Capabilities
+
+This service can be used to:
+
+- [ ] create_dir
+- [x] stat
+- [x] read
+- [x] write
+- [x] delete
+- [x] list
+- [x] copy
+- [ ] rename
+- [ ] presign
+
+## Configuration
+
+- `root`: Set the work directory for backend.
+- `bucket`: Set the bucket name for backend.
+- `endpoint`: Set the endpoint for backend.
+- `region`: Set the region for backend.
+- `access_key_id`: Set the access_key_id for backend.
+- `secret_access_key`: Set the secret_access_key for backend.
+- `security_token`: Set the security token for backend.
+
+Refer to [`TosBuilder`]'s public API docs for more information.
+
+## Example
+
+### Via Builder
+
+```rust,no_run
+use opendal_core::Operator;
+use opendal_core::Result;
+use opendal_service_tos::Tos;
+
+fn main() -> Result<()> {
+    let builder = Tos::default()
+        // Set the root for TOS, all operations will happen under this root.
+        .root("/path/to/dir")
+        // Set the bucket name. This is required.
+        .bucket("test")
+        // Set the endpoint.
+        //
+        // For example:
+        // - "https://tos-cn-beijing.volces.com"
+        // - "https://tos-cn-shanghai.volces.com"
+        .endpoint("https://tos-cn-beijing.volces.com")
+        // Set the region.
+        .region("cn-beijing")
+        // Set the access_key_id and secret_access_key.
+        //
+        // OpenDAL will try to load credentials from the environment if
+        // credentials are not set explicitly.
+        .access_key_id("access_key_id")
+        .secret_access_key("secret_access_key");
+
+    let _op: Operator = Operator::new(builder)?.finish();
+
+    Ok(())
+}
+```


### PR DESCRIPTION
# Which issue does this PR close?

Part of #7152.

# Rationale for this change

TOS is missing service docs while other object storage services already document capabilities, configuration, and builder usage.

# What changes are included in this PR?

- Add TOS service docs.
- Attach the docs to `TosBuilder`.

# Are there any user-facing changes?

Yes. TOS users now have service documentation in Rust docs.

# AI Usage Statement

Implemented with assistance from OpenAI Codex.

Validation:

- `cargo fmt --check`
- `cargo test -p opendal-service-tos`
- Real TOS smoke test for builder + write/read/list/delete using environment credentials.
