### PR TITLE
feat(services/goosefs): bump goosefs-sdk to 0.1.2 and image to v2.1.0.1

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3906,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "goosefs-sdk"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617aa41d5a617b3f902506e8fe4162f3c9c6d7594041024a56a71eeec640b919"
+checksum = "a28e6b1bfe5aef24eed29a15013a5b4202b187b464b90e93d73161500017f815"
 dependencies = [
  "async-trait",
  "bytes",

--- a/core/services/goosefs/Cargo.toml
+++ b/core/services/goosefs/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 bytes = { workspace = true }
-goosefs-sdk = "0.1.1"
+goosefs-sdk = "0.1.2"
 log = { workspace = true }
 opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/fixtures/goosefs/docker-compose-goosefs.yml
+++ b/fixtures/goosefs/docker-compose-goosefs.yml
@@ -42,13 +42,13 @@ services:
   # Ports (host:container) are mapped on 127.0.0.1 so the fixture can
   # coexist with other fixtures on a dev machine.
   #
-  # Image source: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0
+  # Image source: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1
   #
   # The image is built from the official GooseFS 2.1.0 release tarball
   # (goosefs-2.1.0-SNAPSHOT.tar.gz) and published to Tencent Cloud
   # Container Registry (public, no auth required) so that GitHub Actions
   # runners can pull it without credentials. The tag is intentionally
-  # pinned to `v2.1.0` (never `latest`) so behavior tests stay
+  # pinned to `v2.1.0.1` (never `latest`) so behavior tests stay
   # reproducible and cannot silently break when a new image is published.
   #
   # The image is published as a multi-arch manifest list covering both
@@ -79,7 +79,7 @@ services:
   # `--profile local-full`.
   # --------------------------------------------------------------------------
   goosefs:
-    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0
+    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1
     container_name: opendal-goosefs
     profiles: ["", "local"]
     # Bypass the image's stock `docker-entrypoint.sh` and run the
@@ -205,7 +205,7 @@ services:
   # Opt-in via `--profile distributed`.
   # --------------------------------------------------------------------------
   goosefs-master:
-    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0
+    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1
     container_name: opendal-goosefs-master
     profiles: ["distributed"]
     command: master
@@ -231,7 +231,7 @@ services:
       start_period: 60s
 
   goosefs-job-master:
-    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0
+    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1
     container_name: opendal-goosefs-job-master
     profiles: ["distributed"]
     command: job_master
@@ -244,7 +244,7 @@ services:
         condition: service_healthy
 
   goosefs-worker:
-    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0
+    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1
     container_name: opendal-goosefs-worker
     profiles: ["distributed"]
     command: worker
@@ -262,7 +262,7 @@ services:
         condition: service_healthy
 
   goosefs-job-worker:
-    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0
+    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1
     container_name: opendal-goosefs-job-worker
     profiles: ["distributed"]
     command: job_worker


### PR DESCRIPTION
### Which issue does this PR close?

Closes #.

### Rationale for this change

The `goosefs-sdk` 0.1.2 has been published to crates.io. This PR switches the `services/goosefs` crate to depend on the published version (instead of an in-tree path patch), so the GooseFS service can be built and released from a clean dependency graph.

In addition, the GooseFS test fixture image `goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0` is broken for OpenDAL: the master returns `WorkerInfo.virtual_node_num` with a protobuf wire-type that does not match the field's declared type, which causes `GetWorkerInfoList` decoding to fail and breaks every behavior test that needs to enumerate workers (read/write/list/stat/...). The newly released image `v2.1.0.1` fixes this on the server side, so we bump the fixture to it to make GooseFS CI green again.

### What changes are included in this PR?

- `core/services/goosefs/Cargo.toml`: bump `goosefs-sdk` from `0.1.1` to `0.1.2` (now sourced from crates.io, no `[patch.crates-io]` override).
- `core/Cargo.lock`: regenerated to pick up `goosefs-sdk 0.1.2` from the registry with its checksum.
- `fixtures/goosefs/docker-compose-goosefs.yml`: bump master/worker image from `v2.1.0` to `v2.1.0.1` (applied to all `goosefs.tencentcloudcr.com/goosefs/repo` references in the compose file) so the fixture no longer hits the `virtual_node_num` wire-type bug.

Verified locally:
- `cargo build -p opendal-service-goosefs` — clean.
- `cargo fmt --check -p opendal-service-goosefs` — no diff.
- `cargo clippy -p opendal-service-goosefs --all-targets -- -D warnings` — 0 warnings.
- Behavior tests against the new fixture: **99/99 passed**.

### Are there any user-facing changes?

No public API change. Users of `opendal::services::Goosefs` will transitively pull `goosefs-sdk 0.1.2` from crates.io after this PR. Anyone running the GooseFS integration tests locally or in CI will need to re-pull the fixture image (`v2.1.0.1`); the existing `v2.1.0` image is known-broken and should no longer be used.

<!-- For breaking changes, add the following note:
This PR contains breaking changes for [...].
-->

### AI Usage Statement

Parts of this PR (commit message, debugging walkthrough of the `virtual_node_num` decoding error, and this description) were drafted with the assistance of an AI coding assistant. All code/config changes were reviewed, executed, and verified locally by the author (build / fmt / clippy / 99-case behavior test suite all green).