### PR TITLE
fix(copy): avoid caching source metadata in copiers

### DIFF
--- a/core/services/s3/src/copier.rs
+++ b/core/services/s3/src/copier.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::sync::Arc;
-use std::sync::Mutex;
 
 use bytes::Buf;
 use http::StatusCode;
@@ -69,7 +68,6 @@ pub fn new_s3_copier(
             from: from.to_string(),
             to: to.to_string(),
             args,
-            source_metadata: Mutex::new(None),
         },
         opts.source_content_length_hint(),
         copy_once_threshold,
@@ -83,7 +81,6 @@ pub struct S3Copier {
     from: String,
     to: String,
     args: OpCopy,
-    source_metadata: Mutex<Option<Metadata>>,
 }
 
 impl oio::MultipartCopy for S3Copier {
@@ -96,19 +93,7 @@ impl oio::MultipartCopy for S3Copier {
         match resp.status() {
             StatusCode::OK => {
                 let headers = resp.headers();
-                let mut meta = parse_into_metadata(&self.from, headers)?;
-
-                if let Some(v) = parse_header_to_str(headers, constants::X_AMZ_VERSION_ID)? {
-                    meta.set_version(v);
-                }
-
-                let mut source_metadata = self
-                    .source_metadata
-                    .lock()
-                    .expect("source metadata mutex poisoned");
-                *source_metadata = Some(meta.clone());
-
-                Ok(meta)
+                parse_into_metadata(&self.from, headers)
             }
             _ => Err(parse_error(resp)),
         }
@@ -161,22 +146,6 @@ impl oio::MultipartCopy for S3Copier {
     ) -> Result<oio::MultipartPart> {
         let size = range.size().expect("multipart copy range must be sized");
         let part_number = part_number + 1;
-        let (source_etag, source_version) = {
-            let source_metadata = self
-                .source_metadata
-                .lock()
-                .expect("source metadata mutex poisoned");
-            (
-                source_metadata
-                    .as_ref()
-                    .and_then(|meta| meta.etag())
-                    .map(ToOwned::to_owned),
-                source_metadata
-                    .as_ref()
-                    .and_then(|meta| meta.version())
-                    .map(ToOwned::to_owned),
-            )
-        };
 
         let req = self
             .core
@@ -186,8 +155,6 @@ impl oio::MultipartCopy for S3Copier {
                 upload_id,
                 part_number,
                 range,
-                source_etag: source_etag.as_deref(),
-                source_version: source_version.as_deref(),
             })?;
 
         let resp = self.core.send(req).await?;

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -48,7 +48,6 @@ use opendal_core::*;
 
 pub mod constants {
     pub const X_AMZ_COPY_SOURCE: &str = "x-amz-copy-source";
-    pub const X_AMZ_COPY_SOURCE_IF_MATCH: &str = "x-amz-copy-source-if-match";
     pub const X_AMZ_COPY_SOURCE_RANGE: &str = "x-amz-copy-source-range";
 
     pub const X_AMZ_SERVER_SIDE_ENCRYPTION: &str = "x-amz-server-side-encryption";
@@ -113,8 +112,6 @@ pub(crate) struct S3UploadPartCopyRequest<'a> {
     pub(crate) upload_id: &'a str,
     pub(crate) part_number: usize,
     pub(crate) range: BytesRange,
-    pub(crate) source_etag: Option<&'a str>,
-    pub(crate) source_version: Option<&'a str>,
 }
 
 impl Debug for S3Core {
@@ -914,14 +911,7 @@ impl S3Core {
         let from = build_abs_path(&self.root, input.from);
         let to = build_abs_path(&self.root, input.to);
 
-        let mut source = format!("{}/{}", self.bucket, percent_encode_path(&from));
-        if let Some(version) = input.source_version {
-            source.push_str(&format!(
-                "?{}={}",
-                constants::S3_QUERY_VERSION_ID,
-                percent_encode_path(version)
-            ));
-        }
+        let source = format!("{}/{}", self.bucket, percent_encode_path(&from));
 
         let url = format!(
             "{}/{}?partNumber={}&uploadId={}",
@@ -970,10 +960,6 @@ impl S3Core {
                 ),
                 v,
             )
-        }
-
-        if let Some(etag) = input.source_etag {
-            req = req.header(constants::X_AMZ_COPY_SOURCE_IF_MATCH, etag);
         }
 
         // Set request payer header if enabled.

--- a/core/services/tos/src/copier.rs
+++ b/core/services/tos/src/copier.rs
@@ -16,12 +16,10 @@
 // under the License.
 
 use std::sync::Arc;
-use std::sync::Mutex;
 
 use bytes::Buf;
 use http::StatusCode;
 
-use crate::core::constants::X_TOS_VERSION_ID;
 use crate::core::*;
 use crate::error::parse_error;
 use crate::utils::tos_parse_into_metadata;
@@ -69,7 +67,6 @@ pub fn new_tos_copier(
             from: from.to_string(),
             to: to.to_string(),
             args,
-            source_metadata: Mutex::new(None),
         },
         opts.source_content_length_hint(),
         copy_once_threshold,
@@ -83,21 +80,10 @@ pub struct TosCopier {
     from: String,
     to: String,
     args: OpCopy,
-    source_metadata: Mutex<Option<Metadata>>,
 }
 
-impl TosCopier {
-    async fn load_source_metadata(&self) -> Result<Metadata> {
-        {
-            let source_metadata = self
-                .source_metadata
-                .lock()
-                .expect("source metadata mutex poisoned");
-            if let Some(meta) = source_metadata.as_ref() {
-                return Ok(meta.clone());
-            }
-        }
-
+impl oio::MultipartCopy for TosCopier {
+    async fn source_metadata(&self) -> Result<Metadata> {
         let resp = self
             .core
             .tos_head_object(&self.from, OpStat::default())
@@ -106,28 +92,10 @@ impl TosCopier {
         match resp.status() {
             StatusCode::OK => {
                 let headers = resp.headers();
-                let mut meta = tos_parse_into_metadata(&self.from, headers)?;
-
-                if let Some(v) = parse_header_to_str(headers, X_TOS_VERSION_ID)? {
-                    meta.set_version(v);
-                }
-
-                let mut source_metadata = self
-                    .source_metadata
-                    .lock()
-                    .expect("source metadata mutex poisoned");
-                *source_metadata = Some(meta.clone());
-
-                Ok(meta)
+                tos_parse_into_metadata(&self.from, headers)
             }
             _ => Err(parse_error(resp)),
         }
-    }
-}
-
-impl oio::MultipartCopy for TosCopier {
-    async fn source_metadata(&self) -> Result<Metadata> {
-        self.load_source_metadata().await
     }
 
     async fn copy_once(&self) -> Result<()> {
@@ -155,8 +123,6 @@ impl oio::MultipartCopy for TosCopier {
     }
 
     async fn initiate_copy(&self) -> Result<String> {
-        self.load_source_metadata().await?;
-
         let resp = self.core.tos_initiate_multipart_copy(&self.to).await?;
 
         match resp.status() {
@@ -179,22 +145,6 @@ impl oio::MultipartCopy for TosCopier {
     ) -> Result<oio::MultipartPart> {
         let size = range.size().expect("multipart copy range must be sized");
         let part_number = part_number + 1;
-        let (source_etag, source_version) = {
-            let source_metadata = self
-                .source_metadata
-                .lock()
-                .expect("source metadata mutex poisoned");
-            (
-                source_metadata
-                    .as_ref()
-                    .and_then(|meta| meta.etag())
-                    .map(ToOwned::to_owned),
-                source_metadata
-                    .as_ref()
-                    .and_then(|meta| meta.version())
-                    .map(ToOwned::to_owned),
-            )
-        };
 
         let req = self
             .core
@@ -204,8 +154,6 @@ impl oio::MultipartCopy for TosCopier {
                 upload_id,
                 part_number,
                 range,
-                source_etag: source_etag.as_deref(),
-                source_version: source_version.as_deref(),
             })?;
         let resp = self.core.send(req).await?;
 

--- a/core/services/tos/src/core.rs
+++ b/core/services/tos/src/core.rs
@@ -35,7 +35,6 @@ use opendal_core::*;
 pub mod constants {
     pub const X_TOS_ACL: &str = "x-tos-acl";
     pub const X_TOS_COPY_SOURCE: &str = "x-tos-copy-source";
-    pub const X_TOS_COPY_SOURCE_IF_MATCH: &str = "x-tos-copy-source-if-match";
     pub const X_TOS_COPY_SOURCE_RANGE: &str = "x-tos-copy-source-range";
     pub const X_TOS_FORBID_OVERWRITE: &str = "x-tos-forbid-overwrite";
 
@@ -74,8 +73,6 @@ pub(crate) struct TosUploadPartCopyRequest<'a> {
     pub upload_id: &'a str,
     pub part_number: usize,
     pub range: BytesRange,
-    pub source_etag: Option<&'a str>,
-    pub source_version: Option<&'a str>,
 }
 
 impl Debug for TosCore {
@@ -510,7 +507,7 @@ impl TosCore {
         let source = build_abs_path(&self.root, input.from);
         let target = build_abs_path(&self.root, input.to);
 
-        let mut url = format!(
+        let url = format!(
             "https://{}.{}/{}?partNumber={}&uploadId={}",
             self.bucket,
             self.endpoint_domain,
@@ -518,23 +515,12 @@ impl TosCore {
             input.part_number,
             percent_encode_query(input.upload_id)
         );
-        if let Some(version) = input.source_version {
-            url.push_str(&format!(
-                "&{}={}",
-                constants::TOS_QUERY_VERSION_ID,
-                percent_encode_query(version)
-            ));
-        }
         let source = format!("/{}/{}", self.bucket, percent_encode_path(&source));
 
-        let mut req = Request::put(&url)
+        let req = Request::put(&url)
             .extension(Operation::Copy)
             .header(constants::X_TOS_COPY_SOURCE, source)
             .header(constants::X_TOS_COPY_SOURCE_RANGE, input.range.to_header());
-
-        if let Some(etag) = input.source_etag {
-            req = req.header(constants::X_TOS_COPY_SOURCE_IF_MATCH, etag);
-        }
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of #7521.

# Rationale for this change

Multipart copy only needs source metadata to plan the source length. S3 and TOS copiers cached HEAD metadata and reused the derived ETag/version as implicit copy-source conditions, making copy semantics depend on backend-internal state instead of explicit user options.

# What changes are included in this PR?

This removes the source metadata cache from S3 and TOS copiers, and removes the internal source ETag/version fields from upload-part-copy request builders. HEAD metadata is still available for multipart planning, but it is no longer reused as an implicit copy condition.

# Are there any user-facing changes?

No public API change. Multipart copy requests no longer add implicit source ETag/version constraints derived from internal HEAD requests.

# AI Usage Statement

OpenAI GPT-5 was used to assist with implementation and validation.
