### PR TITLE
chore(release): prepare v0.57.0

### DIFF
--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -6,17 +6,17 @@ anstyle-query@1.1.5	X							X
 anstyle-wincon@3.0.11	X							X				
 anyhow@1.0.102	X							X				
 atomic-waker@1.1.2	X							X				
-aws-lc-rs@1.16.3	X					X						
-aws-lc-sys@0.40.0	X		X			X		X	X			
+aws-lc-rs@1.17.0	X					X						
+aws-lc-sys@0.41.0	X		X			X		X	X			
 backon@1.6.0	X											
 base64@0.22.1	X							X				
 bitflags@2.11.1	X							X				
 block-buffer@0.10.4	X							X				
+block-buffer@0.12.0	X							X				
 bumpalo@3.20.2	X							X				
 bytes@1.11.1								X				
 cbindgen@0.29.2										X		
-cc@1.2.60	X							X				
-cesu8@1.1.0	X							X				
+cc@1.2.62	X							X				
 cfg-if@1.0.4	X							X				
 clap@4.6.1	X							X				
 clap_builder@4.6.0	X							X				
@@ -24,17 +24,17 @@ clap_lex@1.1.0	X							X
 cmake@0.1.58	X							X				
 colorchoice@1.0.5	X							X				
 combine@4.6.7								X				
+const-oid@0.10.2	X							X				
 const-oid@0.9.6	X							X				
 core-foundation@0.10.1	X							X				
 core-foundation-sys@0.8.7	X							X				
 cpufeatures@0.2.17	X							X				
 crypto-common@0.1.7	X							X				
-ctor@0.6.3	X							X				
-ctor-proc-macro@0.0.7	X							X				
+crypto-common@0.2.2	X							X				
+ctor@1.0.6	X							X				
 digest@0.10.7	X							X				
+digest@0.11.3	X							X				
 displaydoc@0.2.5	X							X				
-dtor@0.1.1	X							X				
-dtor-proc-macro@0.0.6	X							X				
 dunce@1.0.5	X			X					X			
 equivalent@1.0.2	X							X				
 errno@0.3.14	X							X				
@@ -55,7 +55,7 @@ generic-array@0.14.7								X
 getrandom@0.3.4	X							X				
 getrandom@0.4.2	X							X				
 gloo-timers@0.3.0	X							X				
-hashbrown@0.17.0	X							X				
+hashbrown@0.17.1	X							X				
 heck@0.5.0	X							X				
 hex@0.4.3	X							X				
 hmac@0.12.1	X							X				
@@ -63,6 +63,7 @@ http@1.4.0	X							X
 http-body@1.0.1								X				
 http-body-util@0.1.3								X				
 httparse@1.10.1	X							X				
+hybrid-array@0.4.12	X							X				
 hyper@1.9.0								X				
 hyper-rustls@0.27.9	X					X		X				
 hyper-util@0.1.20								X				
@@ -74,71 +75,76 @@ icu_properties@2.2.0											X
 icu_properties_data@2.2.0											X	
 icu_provider@2.2.0											X	
 idna@1.1.0	X							X				
-idna_adapter@1.2.1	X							X				
+idna_adapter@1.2.2	X							X				
 indexmap@2.14.0	X							X				
 ipnet@2.12.0	X							X				
-iri-string@0.7.12	X							X				
 is_terminal_polyfill@1.70.2	X							X				
 itoa@1.0.18	X							X				
-jiff@0.2.23								X				X
+jiff@0.2.24								X				X
 jiff-tzdb@0.1.6								X				X
 jiff-tzdb-platform@0.1.3								X				X
-jni@0.21.1	X							X				
-jni-sys@0.3.1	X							X				
+jni@0.22.4	X							X				
+jni-macros@0.22.4	X							X				
 jni-sys@0.4.1	X							X				
 jni-sys-macros@0.4.1	X							X				
 jobserver@0.1.34	X							X				
-js-sys@0.3.95	X							X				
-libc@0.2.185	X							X				
+js-sys@0.3.98	X							X				
+libc@0.2.186	X							X				
+link-section@0.17.2	X							X				
+linktime-proc-macro@0.1.0	X							X				
 linux-raw-sys@0.12.1	X	X						X				
 litemap@0.8.2											X	
 log@0.4.29	X							X				
-md-5@0.10.6	X							X				
+md-5@0.11.0	X							X				
 mea@0.6.3	X											
 memchr@2.8.0								X				X
 mio@1.2.0								X				
 once_cell@1.21.4	X							X				
 once_cell_polyfill@1.70.2	X							X				
-opendal@0.56.0	X											
+opendal@0.57.0	X											
 opendal-c@0.0.0	X											
-opendal-core@0.56.0	X											
-opendal-layer-concurrent-limit@0.56.0	X											
-opendal-layer-logging@0.56.0	X											
-opendal-layer-retry@0.56.0	X											
-opendal-layer-timeout@0.56.0	X											
+opendal-core@0.57.0	X											
+opendal-layer-concurrent-limit@0.57.0	X											
+opendal-layer-logging@0.57.0	X											
+opendal-layer-retry@0.57.0	X											
+opendal-layer-timeout@0.57.0	X											
 openssl-probe@0.2.1	X							X				
 percent-encoding@2.3.2	X							X				
 pin-project-lite@0.2.17	X							X				
 portable-atomic@1.13.1	X							X				
-portable-atomic-util@0.2.6	X							X				
+portable-atomic-util@0.2.7	X							X				
 potential_utf@0.1.5											X	
 proc-macro2@1.0.106	X							X				
-quick-xml@0.38.4								X				
+quick-xml@0.39.4								X				
 quote@1.0.45	X							X				
 r-efi@5.3.0	X						X	X				
 r-efi@6.0.0	X						X	X				
 reqsign-core@3.0.0	X											
-reqwest@0.13.2	X							X				
+reqwest@0.13.3	X							X				
+rustc_version@0.4.1	X							X				
 rustix@1.1.4	X	X						X				
-rustls@0.23.38	X					X		X				
+rustls@0.23.40	X					X		X				
 rustls-native-certs@0.8.3	X					X		X				
-rustls-pki-types@1.14.0	X							X				
-rustls-platform-verifier@0.6.2	X							X				
+rustls-pki-types@1.14.1	X							X				
+rustls-platform-verifier@0.7.0	X							X				
 rustls-platform-verifier-android@0.1.1	X							X				
-rustls-webpki@0.103.12						X						
+rustls-webpki@0.103.13						X						
 rustversion@1.0.22	X							X				
 same-file@1.0.6								X				X
 schannel@0.1.29								X				
 security-framework@3.7.0	X							X				
 security-framework-sys@2.17.0	X							X				
+semver@1.0.28	X							X				
 serde@1.0.228	X							X				
 serde_core@1.0.228	X							X				
 serde_derive@1.0.228	X							X				
-serde_json@1.0.149	X							X				
+serde_json@1.0.150	X							X				
 serde_spanned@1.1.1	X							X				
 sha1@0.10.6	X							X				
 sha2@0.10.9	X							X				
 shlex@1.3.0	X							X				
+simd_cesu8@1.1.1	X							X				
+simdutf8@0.1.5	X							X				
 slab@0.4.12								X				
 smallvec@1.15.1	X							X				
 socket2@0.6.3	X							X				
@@ -149,10 +155,10 @@ syn@2.0.117	X							X
 sync_wrapper@1.0.2	X											
 synstructure@0.13.2								X				
 tempfile@3.27.0	X							X				
-thiserror@1.0.69	X							X				
-thiserror-impl@1.0.69	X							X				
+thiserror@2.0.18	X							X				
+thiserror-impl@2.0.18	X							X				
 tinystr@0.8.3											X	
-tokio@1.52.0								X				
+tokio@1.52.3								X				
 tokio-macros@2.7.0								X				
 tokio-rustls@0.26.4	X							X				
 tokio-util@0.7.18								X				
@@ -160,13 +166,13 @@ toml@0.9.12+spec-1.1.0	X							X
 toml_datetime@0.7.5+spec-1.1.0	X							X				
 toml_parser@1.1.2+spec-1.1.0	X							X				
 tower@0.5.3								X				
-tower-http@0.6.8								X				
+tower-http@0.6.11								X				
 tower-layer@0.3.3								X				
 tower-service@0.3.3								X				
 tracing@0.1.44								X				
 tracing-core@0.1.36								X				
 try-lock@0.2.5								X				
-typenum@1.19.0	X							X				
+typenum@1.20.0	X							X				
 unicode-ident@1.0.24	X							X			X	
 untrusted@0.9.0						X						
 url@2.5.8	X							X				
@@ -177,36 +183,28 @@ version_check@0.9.5	X							X
 walkdir@2.5.0								X				X
 want@0.3.1								X				
 wasi@0.11.1+wasi-snapshot-preview1	X	X						X				
-wasip2@1.0.2+wasi-0.2.9	X	X						X				
+wasip2@1.0.3+wasi-0.2.9	X	X						X				
 wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X						X				
-wasm-bindgen@0.2.118	X							X				
-wasm-bindgen-futures@0.4.68	X							X				
-wasm-bindgen-macro@0.2.118	X							X				
-wasm-bindgen-macro-support@0.2.118	X							X				
-wasm-bindgen-shared@0.2.118	X							X				
+wasm-bindgen@0.2.121	X							X				
+wasm-bindgen-futures@0.4.71	X							X				
+wasm-bindgen-macro@0.2.121	X							X				
+wasm-bindgen-macro-support@0.2.121	X							X				
+wasm-bindgen-shared@0.2.121	X							X				
 wasm-streams@0.5.0	X							X				
-web-sys@0.3.95	X							X				
+web-sys@0.3.98	X							X				
 web-time@1.1.0	X							X				
-webpki-root-certs@1.0.6					X							
+webpki-root-certs@1.0.7					X							
 winapi-util@0.1.11								X				X
 windows-link@0.2.1	X							X				
-windows-sys@0.45.0	X							X				
 windows-sys@0.61.2	X							X				
-windows-targets@0.42.2	X							X				
-windows_aarch64_gnullvm@0.42.2	X							X				
-windows_aarch64_msvc@0.42.2	X							X				
-windows_i686_gnu@0.42.2	X							X				
-windows_i686_msvc@0.42.2	X							X				
-windows_x86_64_gnu@0.42.2	X							X				
-windows_x86_64_gnullvm@0.42.2	X							X				
-windows_x86_64_msvc@0.42.2	X							X				
 winnow@0.7.15								X				
-winnow@1.0.1								X				
+winnow@1.0.3								X				
 wit-bindgen@0.51.0	X	X						X				
+wit-bindgen@0.57.1	X	X						X				
 writeable@0.6.3											X	
 yoke@0.8.2											X	
 yoke-derive@0.8.2											X	
-zerofrom@0.1.7											X	
+zerofrom@0.1.8											X	
 zerofrom-derive@0.1.7											X	
 zeroize@1.8.2	X							X				
 zerotrie@0.2.4											X	

--- a/bindings/cpp/DEPENDENCIES.rust.tsv
+++ b/bindings/cpp/DEPENDENCIES.rust.tsv
@@ -1,35 +1,35 @@
 crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib
 anyhow@1.0.102	X							X				
 atomic-waker@1.1.2	X							X				
-aws-lc-rs@1.16.3	X					X						
-aws-lc-sys@0.40.0	X		X			X		X	X			
+aws-lc-rs@1.17.0	X					X						
+aws-lc-sys@0.41.0	X		X			X		X	X			
 backon@1.6.0	X											
 base64@0.22.1	X							X				
 bitflags@2.11.1	X							X				
 block-buffer@0.10.4	X							X				
+block-buffer@0.12.0	X							X				
 bumpalo@3.20.2	X							X				
 bytes@1.11.1								X				
-cc@1.2.60	X							X				
-cesu8@1.1.0	X							X				
+cc@1.2.62	X							X				
 cfg-if@1.0.4	X							X				
 cmake@0.1.58	X							X				
 codespan-reporting@0.13.1	X											
 combine@4.6.7								X				
+const-oid@0.10.2	X							X				
 const-oid@0.9.6	X							X				
 core-foundation@0.10.1	X							X				
 core-foundation-sys@0.8.7	X							X				
 cpufeatures@0.2.17	X							X				
 crypto-common@0.1.7	X							X				
-ctor@0.6.3	X							X				
-ctor-proc-macro@0.0.7	X							X				
+crypto-common@0.2.2	X							X				
+ctor@1.0.6	X							X				
 cxx@1.0.194	X							X				
 cxx-build@1.0.194	X							X				
 cxxbridge-flags@1.0.194	X							X				
 cxxbridge-macro@1.0.194	X							X				
 digest@0.10.7	X							X				
+digest@0.11.3	X							X				
 displaydoc@0.2.5	X							X				
-dtor@0.1.1	X							X				
-dtor-proc-macro@0.0.6	X							X				
 dunce@1.0.5	X			X					X			
 equivalent@1.0.2	X							X				
 fastrand@2.4.1	X							X				
@@ -50,13 +50,14 @@ generic-array@0.14.7								X
 getrandom@0.3.4	X							X				
 getrandom@0.4.2	X							X				
 gloo-timers@0.3.0	X							X				
-hashbrown@0.17.0	X							X				
+hashbrown@0.17.1	X							X				
 hex@0.4.3	X							X				
 hmac@0.12.1	X							X				
 http@1.4.0	X							X				
 http-body@1.0.1								X				
 http-body-util@0.1.3								X				
 httparse@1.10.1	X							X				
+hybrid-array@0.4.12	X							X				
 hyper@1.9.0								X				
 hyper-rustls@0.27.9	X					X		X				
 hyper-util@0.1.20								X				
@@ -71,65 +72,70 @@ idna@1.1.0	X							X
 idna_adapter@1.2.1	X							X				
 indexmap@2.14.0	X							X				
 ipnet@2.12.0	X							X				
-iri-string@0.7.12	X							X				
 itoa@1.0.18	X							X				
-jiff@0.2.23								X			X	
+jiff@0.2.24								X			X	
 jiff-tzdb@0.1.6								X			X	
 jiff-tzdb-platform@0.1.3								X			X	
-jni@0.21.1	X							X				
-jni-sys@0.3.1	X							X				
+jni@0.22.4	X							X				
+jni-macros@0.22.4	X							X				
 jni-sys@0.4.1	X							X				
 jni-sys-macros@0.4.1	X							X				
 jobserver@0.1.34	X							X				
-js-sys@0.3.95	X							X				
-libc@0.2.185	X							X				
+js-sys@0.3.98	X							X				
+libc@0.2.186	X							X				
 link-cplusplus@1.0.12	X							X				
+link-section@0.17.2	X							X				
+linktime-proc-macro@0.1.0	X							X				
 litemap@0.8.2										X		
 log@0.4.29	X							X				
-md-5@0.10.6	X							X				
+md-5@0.11.0	X							X				
 mea@0.6.3	X											
 memchr@2.8.0								X			X	
 mio@1.2.0								X				
 once_cell@1.21.4	X							X				
-opendal@0.56.0	X											
-opendal-core@0.56.0	X											
+opendal@0.57.0	X											
+opendal-core@0.57.0	X											
 opendal-cpp@0.0.0	X											
-opendal-layer-concurrent-limit@0.56.0	X											
-opendal-layer-logging@0.56.0	X											
-opendal-layer-retry@0.56.0	X											
-opendal-layer-timeout@0.56.0	X											
+opendal-layer-concurrent-limit@0.57.0	X											
+opendal-layer-logging@0.57.0	X											
+opendal-layer-retry@0.57.0	X											
+opendal-layer-timeout@0.57.0	X											
 openssl-probe@0.2.1	X							X				
 percent-encoding@2.3.2	X							X				
 pin-project-lite@0.2.17	X							X				
 portable-atomic@1.13.1	X							X				
-portable-atomic-util@0.2.6	X							X				
+portable-atomic-util@0.2.7	X							X				
 potential_utf@0.1.5										X		
 proc-macro2@1.0.106	X							X				
-quick-xml@0.38.4								X				
+quick-xml@0.39.4								X				
 quote@1.0.45	X							X				
 r-efi@5.3.0	X						X	X				
 r-efi@6.0.0	X						X	X				
 reqsign-core@3.0.0	X											
-reqwest@0.13.2	X							X				
-rustls@0.23.38	X					X		X				
+reqwest@0.13.3	X							X				
+rustc_version@0.4.1	X							X				
+rustls@0.23.40	X					X		X				
 rustls-native-certs@0.8.3	X					X		X				
-rustls-pki-types@1.14.0	X							X				
-rustls-platform-verifier@0.6.2	X							X				
+rustls-pki-types@1.14.1	X							X				
+rustls-platform-verifier@0.7.0	X							X				
 rustls-platform-verifier-android@0.1.1	X							X				
-rustls-webpki@0.103.12						X						
+rustls-webpki@0.103.13						X						
 rustversion@1.0.22	X							X				
 same-file@1.0.6								X			X	
 schannel@0.1.29								X				
 scratch@1.0.9	X							X				
 security-framework@3.7.0	X							X				
 security-framework-sys@2.17.0	X							X				
+semver@1.0.28	X							X				
 serde@1.0.228	X							X				
 serde_core@1.0.228	X							X				
 serde_derive@1.0.228	X							X				
-serde_json@1.0.149	X							X				
+serde_json@1.0.150	X							X				
 sha1@0.10.6	X							X				
 sha2@0.10.9	X							X				
 shlex@1.3.0	X							X				
+simd_cesu8@1.1.1	X							X				
+simdutf8@0.1.5	X							X				
 slab@0.4.12								X				
 smallvec@1.15.1	X							X				
 socket2@0.6.3	X							X				
@@ -139,21 +145,21 @@ syn@2.0.117	X							X
 sync_wrapper@1.0.2	X											
 synstructure@0.13.2								X				
 termcolor@1.4.1								X			X	
-thiserror@1.0.69	X							X				
-thiserror-impl@1.0.69	X							X				
+thiserror@2.0.18	X							X				
+thiserror-impl@2.0.18	X							X				
 tinystr@0.8.3										X		
-tokio@1.52.0								X				
+tokio@1.52.3								X				
 tokio-macros@2.7.0								X				
 tokio-rustls@0.26.4	X							X				
 tokio-util@0.7.18								X				
 tower@0.5.3								X				
-tower-http@0.6.8								X				
+tower-http@0.6.11								X				
 tower-layer@0.3.3								X				
 tower-service@0.3.3								X				
 tracing@0.1.44								X				
 tracing-core@0.1.36								X				
 try-lock@0.2.5								X				
-typenum@1.19.0	X							X				
+typenum@1.20.0	X							X				
 unicode-ident@1.0.24	X							X		X		
 unicode-width@0.2.2	X							X				
 untrusted@0.9.0						X						
@@ -166,33 +172,24 @@ want@0.3.1								X
 wasi@0.11.1+wasi-snapshot-preview1	X	X						X				
 wasip2@1.0.1+wasi-0.2.4	X	X						X				
 wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X						X				
-wasm-bindgen@0.2.118	X							X				
-wasm-bindgen-futures@0.4.68	X							X				
-wasm-bindgen-macro@0.2.118	X							X				
-wasm-bindgen-macro-support@0.2.118	X							X				
-wasm-bindgen-shared@0.2.118	X							X				
+wasm-bindgen@0.2.121	X							X				
+wasm-bindgen-futures@0.4.71	X							X				
+wasm-bindgen-macro@0.2.121	X							X				
+wasm-bindgen-macro-support@0.2.121	X							X				
+wasm-bindgen-shared@0.2.121	X							X				
 wasm-streams@0.5.0	X							X				
-web-sys@0.3.95	X							X				
+web-sys@0.3.98	X							X				
 web-time@1.1.0	X							X				
-webpki-root-certs@1.0.6					X							
+webpki-root-certs@1.0.7					X							
 winapi-util@0.1.11								X			X	
 windows-link@0.2.1	X							X				
-windows-sys@0.45.0	X							X				
 windows-sys@0.61.2	X							X				
-windows-targets@0.42.2	X							X				
-windows_aarch64_gnullvm@0.42.2	X							X				
-windows_aarch64_msvc@0.42.2	X							X				
-windows_i686_gnu@0.42.2	X							X				
-windows_i686_msvc@0.42.2	X							X				
-windows_x86_64_gnu@0.42.2	X							X				
-windows_x86_64_gnullvm@0.42.2	X							X				
-windows_x86_64_msvc@0.42.2	X							X				
 wit-bindgen@0.46.0	X	X						X				
 wit-bindgen@0.51.0	X	X						X				
 writeable@0.6.3										X		
 yoke@0.8.2										X		
 yoke-derive@0.8.2										X		
-zerofrom@0.1.7										X		
+zerofrom@0.1.8										X		
 zerofrom-derive@0.1.7										X		
 zeroize@1.8.2	X							X				
 zerotrie@0.2.4										X		

--- a/bindings/dotnet/DEPENDENCIES.rust.tsv
+++ b/bindings/dotnet/DEPENDENCIES.rust.tsv
@@ -1,697 +1,718 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib
-aes@0.8.4	X									X					
-ahash@0.8.12	X									X					
-aho-corasick@1.1.4										X				X	
-allocator-api2@0.2.21	X									X					
-android_system_properties@0.1.5	X									X					
-anstream@1.0.0	X									X					
-anstyle@1.0.14	X									X					
-anstyle-parse@1.0.0	X									X					
-anstyle-query@1.1.5	X									X					
-anstyle-wincon@3.0.11	X									X					
-anyhow@1.0.102	X									X					
-approx@0.5.1	X														
-arc-swap@1.9.1	X									X					
-arcstr@1.2.0	X									X					X
-arrayref@0.3.9			X												
-arrayvec@0.7.6	X									X					
-async-lock@3.4.2	X									X					
-async-recursion@0.3.2	X									X					
-async-stream@0.3.6										X					
-async-stream-impl@0.3.6										X					
-async-task@4.7.1	X									X					
-async-trait@0.1.89	X									X					
-atoi@2.0.0										X					
-atomic-waker@1.1.2	X									X					
-auto-const-array@0.2.2	X									X					
-autocfg@1.5.0	X									X					
-awaitable@0.4.0										X					
-awaitable-error@0.1.0										X					
-aws-lc-rs@1.16.3	X							X							
-aws-lc-sys@0.40.0	X			X				X		X	X				
-axum@0.6.20										X					
-axum@0.8.9										X					
-axum-core@0.3.4										X					
-axum-core@0.5.6										X					
-backon@1.6.0	X														
-base64@0.21.7	X									X					
-base64@0.22.1	X									X					
-base64ct@1.8.3	X									X					
-bitflags@1.3.2	X									X					
-bitflags@2.11.1	X									X					
-bitvec@1.0.1										X					
-blake3@1.8.4	X	X				X									
-block-buffer@0.10.4	X									X					
-block-padding@0.3.3	X									X					
-bson@2.15.0										X					
-bstr@1.12.1	X									X					
-bumpalo@3.20.2	X									X					
-bytecount@0.6.9	X									X					
-bytemuck@1.25.0	X									X					X
-byteorder@1.5.0										X				X	
-bytes@1.11.1										X					
-cacache@13.1.0	X														
-camino@1.2.2	X									X					
-cargo-platform@0.1.9	X									X					
-cargo_metadata@0.14.2										X					
-cbc@0.1.2	X									X					
-cc@1.2.60	X									X					
-cesu8@1.1.0	X									X					
-cfg-if@0.1.10	X									X					
-cfg-if@1.0.4	X									X					
-cfg_aliases@0.2.1										X					
-chacha20@0.10.0	X									X					
-chrono@0.4.44	X									X					
-cipher@0.4.4	X									X					
-clap@4.6.1	X									X					
-clap_builder@4.6.0	X									X					
-clap_derive@4.6.1	X									X					
-clap_lex@1.1.0	X									X					
-cmake@0.1.58	X									X					
-colorchoice@1.0.5	X									X					
-colored@3.1.1												X			
-combine@4.6.7										X					
-compio@0.17.0										X					
-compio-buf@0.7.2										X					
-compio-dispatcher@0.9.0										X					
-compio-driver@0.10.0										X					
-compio-fs@0.10.0										X					
-compio-io@0.8.4										X					
-compio-log@0.1.0										X					
-compio-net@0.10.0										X					
-compio-runtime@0.10.1										X					
-concurrent-queue@2.5.0	X									X					
-concurrent_arena@0.1.11										X					
-const-oid@0.9.6	X									X					
-const-random@0.1.18	X									X					
-const-random-macro@0.1.16	X									X					
-const-str@1.1.0										X					
-const_panic@0.2.15															X
-constant_time_eq@0.4.2	X					X					X				
-convert_case@0.10.0										X					
-core-foundation@0.10.1	X									X					
-core-foundation@0.9.4	X									X					
-core-foundation-sys@0.8.7	X									X					
-core_affinity@0.8.3	X									X					
-countio@0.3.0										X					
-cpufeatures@0.2.17	X									X					
-cpufeatures@0.3.0	X									X					
-crc@3.4.0	X									X					
-crc-catalog@2.4.0	X									X					
-crc16@0.4.0										X					
-crc32c@0.6.8	X									X					
-crc32fast@1.5.0	X									X					
-critical-section@1.2.0	X									X					
-crossbeam-channel@0.5.15	X									X					
-crossbeam-epoch@0.9.18	X									X					
-crossbeam-queue@0.3.12	X									X					
-crossbeam-utils@0.8.21	X									X					
-crunchy@0.2.4										X					
-crypto-common@0.1.7	X									X					
-csv@1.4.0										X				X	
-csv-core@0.1.13										X				X	
-ctor@0.6.3	X									X					
-ctor-proc-macro@0.0.7	X									X					
-darling@0.21.3										X					
-darling_core@0.21.3										X					
-darling_macro@0.21.3										X					
-dashmap@5.5.3										X					
-dashmap@6.1.0										X					
-data-encoding@2.10.0										X					
-der@0.7.10	X									X					
-deranged@0.5.8	X									X					
-derivative@2.2.0	X									X					
-derive-new@0.5.9										X					
-derive-syn-parse@0.2.0	X									X					
-derive-where@1.6.1	X									X					
-derive_destructure2@0.1.3	X									X					
-derive_more@2.1.1										X					
-derive_more-impl@2.1.1										X					
-digest@0.10.7	X									X					
-dirs@6.0.0	X									X					
-dirs-sys@0.5.0	X									X					
-displaydoc@0.2.5	X									X					
-dlv-list@0.5.2	X									X					
-dotenvy@0.15.7										X					
-dtor@0.1.1	X									X					
-dtor-proc-macro@0.0.6	X									X					
-dunce@1.0.5	X					X					X				
-either@1.15.0	X									X					
-enum-as-inner@0.6.1	X									X					
-equivalent@1.0.2	X									X					
-errno@0.3.14	X									X					
-error-chain@0.12.4	X									X					
-etcd-client@0.17.0	X									X					
-etcetera@0.8.0	X									X					
-event-listener@5.4.1	X									X					
-event-listener-strategy@0.5.4	X									X					
-fail@0.4.0	X														
-fastpool@1.1.0	X														
-fastrand@2.4.1	X									X					
-find-msvc-tools@0.1.9	X									X					
-fixedbitset@0.5.7	X									X					
-flume@0.11.1	X									X					
-flume@0.12.0	X									X					
-fnv@1.0.7	X									X					
-foldhash@0.1.5															X
-form_urlencoded@1.2.2	X									X					
-fs2@0.4.3	X									X					
-fs_extra@1.3.0										X					
-funty@2.0.0										X					
-futures@0.3.32	X									X					
-futures-channel@0.3.32	X									X					
-futures-core@0.3.32	X									X					
-futures-executor@0.3.32	X									X					
-futures-intrusive@0.5.0	X									X					
-futures-io@0.3.32	X									X					
-futures-macro@0.3.32	X									X					
-futures-sink@0.3.32	X									X					
-futures-task@0.3.32	X									X					
-futures-util@0.3.32	X									X					
-fxhash@0.2.1	X									X					
-gearhash@0.1.3	X									X					
-generic-array@0.14.7										X					
-getrandom@0.1.16	X									X					
-getrandom@0.2.17	X									X					
-getrandom@0.3.4	X									X					
-getrandom@0.4.2	X									X					
-ghac@0.2.0	X														
-git-version@0.3.9			X												
-git-version-macro@0.3.9			X												
-glob@0.3.3	X									X					
-gloo-timers@0.3.0	X									X					
-h2@0.3.27										X					
-h2@0.4.13										X					
-hashbrown@0.12.3	X									X					
-hashbrown@0.14.5	X									X					
-hashbrown@0.15.5	X									X					
-hashbrown@0.17.0	X									X					
-hashlink@0.10.0	X									X					
-heapify@0.2.0	X									X					
-heck@0.5.0	X									X					
-hermit-abi@0.5.2	X									X					
-hex@0.4.3	X									X					
-hf-xet@1.5.1	X														
-hickory-proto@0.25.2	X									X					
-hickory-resolver@0.25.2	X									X					
-hkdf@0.12.4	X									X					
-hmac@0.12.1	X									X					
-home@0.5.11	X									X					
-http@0.2.12	X									X					
-http@1.4.0	X									X					
-http-body@0.4.6										X					
-http-body@1.0.1										X					
-http-body-util@0.1.3										X					
-httparse@1.10.1	X									X					
-httpdate@1.0.3	X									X					
-humantime@2.3.0	X									X					
-hyper@0.14.32										X					
-hyper@1.9.0										X					
-hyper-rustls@0.27.9	X							X		X					
-hyper-timeout@0.4.1	X									X					
-hyper-timeout@0.5.2	X									X					
-hyper-util@0.1.20										X					
-iana-time-zone@0.1.65	X									X					
-iana-time-zone-haiku@0.1.2	X									X					
-icu_collections@2.1.1													X		
-icu_locale_core@2.1.1													X		
-icu_normalizer@2.1.1													X		
-icu_normalizer_data@2.1.1													X		
-icu_properties@2.1.2													X		
-icu_properties_data@2.1.2													X		
-icu_provider@2.1.1													X		
-ident_case@1.0.1	X									X					
-idna@1.1.0	X									X					
-idna_adapter@1.2.1	X									X					
-indexmap@1.9.3	X									X					
-indexmap@2.14.0	X									X					
-inout@0.1.4	X									X					
-instant@0.1.13				X											
-io-uring@0.6.4	X									X					
-io-uring@0.7.11	X									X					
-io_uring_buf_ring@0.2.3										X					
-ipconfig@0.3.4	X									X					
-ipnet@2.12.0	X									X					
-iri-string@0.7.12	X									X					
-is_terminal_polyfill@1.70.2	X									X					
-itertools@0.12.1	X									X					
-itertools@0.14.0	X									X					
-itoa@1.0.18	X									X					
-jiff@0.2.23										X				X	
-jiff-tzdb@0.1.6										X				X	
-jiff-tzdb-platform@0.1.3										X				X	
-jni@0.21.1	X									X					
-jni-sys@0.3.1	X									X					
-jni-sys@0.4.1	X									X					
-jni-sys-macros@0.4.1	X									X					
-jobserver@0.1.34	X									X					
-js-sys@0.3.95	X									X					
-jsonwebtoken@10.3.0										X					
-konst@0.4.3															X
-konst_proc_macros@0.4.1															X
-lazy_static@1.5.0	X									X					
-libc@0.2.185	X									X					
-libm@0.2.16										X					
-libredox@0.1.16										X					
-libsqlite3-sys@0.30.1										X					
-linked-hash-map@0.5.6	X									X					
-linux-raw-sys@0.12.1	X	X								X					
-litemap@0.8.2													X		
-lock_api@0.4.14	X									X					
-log@0.4.29	X									X					
-lz4_flex@0.13.0										X					
-macro_magic@0.5.1										X					
-macro_magic_core@0.5.1										X					
-macro_magic_core_macros@0.5.1										X					
-macro_magic_macros@0.5.1										X					
-matchers@0.2.0										X					
-matchit@0.7.3				X						X					
-matchit@0.8.4				X						X					
-md-5@0.10.6	X									X					
-mea@0.6.3	X														
-memchr@2.8.0										X				X	
-memmap2@0.5.10	X									X					
-memoffset@0.7.1										X					
-miette@5.10.0	X														
-miette-derive@5.10.0	X														
-mime@0.3.17	X									X					
-mini-moka@0.10.3	X									X					
-mio@0.8.11										X					
-mio@1.2.0										X					
-moka@0.12.15	X									X					
-mongodb@3.5.2	X														
-mongodb-internal-macros@3.5.2	X														
-monoio@0.2.4	X									X					
-monoio-macros@0.1.0	X									X					
-more-asserts@0.3.1	X					X				X				X	
-multimap@0.10.1	X									X					
-nanorand@0.7.0															X
-nix@0.26.4										X					
-ntapi@0.4.3	X									X					
-nu-ansi-term@0.50.3										X					
-num-bigint@0.4.6	X									X					
-num-bigint-dig@0.8.6	X									X					
-num-conv@0.2.1	X									X					
-num-derive@0.4.2	X									X					
-num-integer@0.1.46	X									X					
-num-iter@0.1.45	X									X					
-num-traits@0.2.19	X									X					
-num_cpus@1.17.0	X									X					
-objc2-core-foundation@0.3.2	X									X					X
-objc2-io-kit@0.3.2	X									X					X
-objc2-system-configuration@0.3.2	X									X					X
-once_cell@1.21.4	X									X					
-once_cell_polyfill@1.70.2	X									X					
-oneshot@0.1.13	X									X					
-opendal@0.56.0	X														
-opendal-core@0.56.0	X														
-opendal-dotnet@0.0.0	X														
-opendal-layer-concurrent-limit@0.56.0	X														
-opendal-layer-logging@0.56.0	X														
-opendal-layer-retry@0.56.0	X														
-opendal-layer-timeout@0.56.0	X														
-opendal-service-aliyun-drive@0.56.0	X														
-opendal-service-alluxio@0.56.0	X														
-opendal-service-azblob@0.56.0	X														
-opendal-service-azdls@0.56.0	X														
-opendal-service-azfile@0.56.0	X														
-opendal-service-azure-common@0.56.0	X														
-opendal-service-b2@0.56.0	X														
-opendal-service-cacache@0.56.0	X														
-opendal-service-compfs@0.56.0	X														
-opendal-service-cos@0.56.0	X														
-opendal-service-dashmap@0.56.0	X														
-opendal-service-dropbox@0.56.0	X														
-opendal-service-etcd@0.56.0	X														
-opendal-service-fs@0.56.0	X														
-opendal-service-gcs@0.56.0	X														
-opendal-service-gdrive@0.56.0	X														
-opendal-service-ghac@0.56.0	X														
-opendal-service-gridfs@0.56.0	X														
-opendal-service-hf@0.56.0	X														
-opendal-service-http@0.56.0	X														
-opendal-service-ipfs@0.56.0	X														
-opendal-service-ipmfs@0.56.0	X														
-opendal-service-koofr@0.56.0	X														
-opendal-service-memcached@0.56.0	X														
-opendal-service-mini-moka@0.56.0	X														
-opendal-service-moka@0.56.0	X														
-opendal-service-mongodb@0.56.0	X														
-opendal-service-monoiofs@0.56.0	X														
-opendal-service-mysql@0.56.0	X														
-opendal-service-obs@0.56.0	X														
-opendal-service-onedrive@0.56.0	X														
-opendal-service-oss@0.56.0	X														
-opendal-service-persy@0.56.0	X														
-opendal-service-postgresql@0.56.0	X														
-opendal-service-redb@0.56.0	X														
-opendal-service-redis@0.56.0	X														
-opendal-service-s3@0.56.0	X														
-opendal-service-seafile@0.56.0	X														
-opendal-service-sftp@0.56.0	X														
-opendal-service-sled@0.56.0	X														
-opendal-service-sqlite@0.56.0	X														
-opendal-service-swift@0.56.0	X														
-opendal-service-tikv@0.56.0	X														
-opendal-service-upyun@0.56.0	X														
-opendal-service-vercel-artifacts@0.56.0	X														
-opendal-service-webdav@0.56.0	X														
-opendal-service-webhdfs@0.56.0	X														
-opendal-service-yandex-disk@0.56.0	X														
-openssh@0.11.6	X									X					
-openssh-sftp-client@0.15.6										X					
-openssh-sftp-client-lowlevel@0.7.2										X					
-openssh-sftp-error@0.5.1										X					
-openssh-sftp-protocol@0.24.1										X					
-openssh-sftp-protocol-error@0.1.1										X					
-openssl-probe@0.2.1	X									X					
-option-ext@0.2.0												X			
-ordered-multimap@0.7.3										X					
-os_pipe@1.2.3										X					
-os_str_bytes@6.6.1	X									X					
-parking@2.2.1	X									X					
-parking_lot@0.11.2	X									X					
-parking_lot@0.12.5	X									X					
-parking_lot_core@0.8.6	X									X					
-parking_lot_core@0.9.12	X									X					
-paste@1.0.15	X									X					
-pbkdf2@0.12.2	X									X					
-pem@3.0.6										X					
-pem-rfc7468@0.7.0	X									X					
-percent-encoding@2.3.2	X									X					
-persy@1.7.1												X			
-petgraph@0.8.3	X									X					
-pin-project@1.1.11	X									X					
-pin-project-internal@1.1.11	X									X					
-pin-project-lite@0.2.17	X									X					
-pin-utils@0.1.0	X									X					
-pkcs1@0.7.5	X									X					
-pkcs5@0.7.1	X									X					
-pkcs8@0.10.2	X									X					
-pkg-config@0.3.33	X									X					
-plain@0.2.3	X									X					
-polling@3.11.0	X									X					
-portable-atomic@1.13.1	X									X					
-portable-atomic-util@0.2.6	X									X					
-potential_utf@0.1.5													X		
-powerfmt@0.2.0	X									X					
-ppv-lite86@0.2.21	X									X					
-prettyplease@0.2.37	X									X					
-proc-macro2@1.0.106	X									X					
-prometheus@0.13.4	X														
-prost@0.12.6	X														
-prost@0.13.5	X														
-prost@0.14.3	X														
-prost-build@0.14.3	X														
-prost-derive@0.12.6	X														
-prost-derive@0.13.5	X														
-prost-derive@0.14.3	X														
-prost-types@0.14.3	X														
-pulldown-cmark@0.13.3										X					
-pulldown-cmark@0.9.6										X					
-pulldown-cmark-to-cmark@22.0.0	X														
-quick-xml@0.38.4										X					
-quick-xml@0.39.2										X					
-quote@1.0.45	X									X					
-r-efi@5.3.0	X								X	X					
-r-efi@6.0.0	X								X	X					
-radium@0.7.0										X					
-rand@0.10.1	X									X					
-rand@0.7.3	X									X					
-rand@0.8.5	X									X					
-rand@0.9.4	X									X					
-rand_chacha@0.2.2	X									X					
-rand_chacha@0.3.1	X									X					
-rand_chacha@0.9.0	X									X					
-rand_core@0.10.1	X									X					
-rand_core@0.5.1	X									X					
-rand_core@0.6.4	X									X					
-rand_core@0.9.5	X									X					
-rand_hc@0.2.0	X									X					
-redb@2.6.3	X									X					
-redb@3.1.3	X									X					
-redis@1.2.0				X											
-redox_syscall@0.2.16										X					
-redox_syscall@0.5.18										X					
-redox_users@0.5.2										X					
-reflink-copy@0.1.29	X									X					
-regex@1.12.3	X									X					
-regex-automata@0.4.14	X									X					
-regex-syntax@0.8.10	X									X					
-reqsign-aliyun-oss@3.0.0	X														
-reqsign-aws-v4@3.0.0	X														
-reqsign-azure-storage@3.0.0	X														
-reqsign-core@3.0.0	X														
-reqsign-file-read-tokio@3.0.0	X														
-reqsign-google@3.0.0	X														
-reqsign-huaweicloud-obs@3.0.0	X														
-reqsign-tencent-cos@3.0.0	X														
-reqwest@0.13.2	X									X					
-reqwest-middleware@0.5.1	X									X					
-reqwest-retry@0.9.1	X									X					
-resolv-conf@0.7.6	X									X					
-retry-policies@0.5.1	X									X					
-ring@0.17.14	X							X							
-rsa@0.9.10	X									X					
-rust-ini@0.21.3										X					
-rustc_version@0.4.1	X									X					
-rustc_version_runtime@0.3.0										X					
-rustix@1.1.4	X	X								X					
-rustls@0.21.12	X							X		X					
-rustls@0.23.38	X							X		X					
-rustls-native-certs@0.8.3	X							X		X					
-rustls-pemfile@1.0.4	X							X		X					
-rustls-pki-types@1.14.0	X									X					
-rustls-platform-verifier@0.6.2	X									X					
-rustls-platform-verifier-android@0.1.1	X									X					
-rustls-webpki@0.101.7								X							
-rustls-webpki@0.103.12								X							
-rustversion@1.0.22	X									X					
-ryu@1.0.23	X				X										
-safe-transmute@0.11.3										X					
-salsa20@0.10.2	X									X					
-same-file@1.0.6										X				X	
-schannel@0.1.29										X					
-scoped-tls@1.0.1	X									X					
-scopeguard@1.2.0	X									X					
-scrypt@0.11.0	X									X					
-sct@0.7.1	X							X		X					
-security-framework@3.7.0	X									X					
-security-framework-sys@2.17.0	X									X					
-semver@1.0.28	X									X					
-serde@1.0.228	X									X					
-serde_bytes@0.11.19	X									X					
-serde_core@1.0.228	X									X					
-serde_derive@1.0.228	X									X					
-serde_json@1.0.149	X									X					
-serde_repr@0.1.20	X									X					
-serde_urlencoded@0.7.1	X									X					
-serde_with@3.17.0	X									X					
-serde_with_macros@3.17.0	X									X					
-sha-1@0.10.1	X									X					
-sha1@0.10.6	X									X					
-sha1_smol@1.0.1				X											
-sha2@0.10.9	X									X					
-sha2-asm@0.6.4										X					
-sharded-slab@0.1.7										X					
-shell-escape@0.1.5	X									X					
-shellexpand@3.1.2	X									X					
-shlex@1.3.0	X									X					
-signal-hook-registry@1.4.8	X									X					
-signature@2.2.0	X									X					
-simple_asn1@0.6.4								X							
-skeptic@0.13.7	X									X					
-slab@0.4.12										X					
-sled@0.34.7	X									X					
-smallvec@1.15.1	X									X					
-socket2@0.5.10	X									X					
-socket2@0.6.3	X									X					
-spin@0.9.8										X					
-spki@0.7.3	X									X					
-sqlx@0.8.6	X									X					
-sqlx-core@0.8.6	X									X					
-sqlx-macros@0.8.6	X									X					
-sqlx-macros-core@0.8.6	X									X					
-sqlx-mysql@0.8.6	X									X					
-sqlx-postgres@0.8.6	X									X					
-sqlx-sqlite@0.8.6	X									X					
-ssh_format@0.14.1										X					
-ssh_format_error@0.1.0										X					
-ssri@9.2.0	X														
-stable_deref_trait@1.2.1	X									X					
-static_assertions@1.1.0	X									X					
-statrs@0.18.0										X					
-stringprep@0.1.5	X									X					
-strsim@0.11.1										X					
-subtle@2.6.1				X											
-syn@1.0.109	X									X					
-syn@2.0.117	X									X					
-sync_wrapper@0.1.2	X														
-sync_wrapper@1.0.2	X														
-synstructure@0.13.2										X					
-sysinfo@0.38.4										X					
-system-configuration@0.7.0	X									X					
-system-configuration-sys@0.6.0	X									X					
-tagptr@0.2.0	X									X					
-take_mut@0.2.2										X					
-tap@1.0.1										X					
-tempfile@3.27.0	X									X					
-thin-vec@0.2.16	X									X					
-thiserror@1.0.69	X									X					
-thiserror@2.0.18	X									X					
-thiserror-impl@1.0.69	X									X					
-thiserror-impl@2.0.18	X									X					
-thread_local@1.1.9	X									X					
-threadpool@1.8.1	X									X					
-tikv-client@0.3.0	X														
-time@0.3.47	X									X					
-time-core@0.1.8	X									X					
-time-macros@0.2.27	X									X					
-tiny-keccak@2.0.2						X									
-tinystr@0.8.3													X		
-tinyvec@1.11.0	X									X					X
-tinyvec_macros@0.1.1	X									X					X
-tokio@1.52.0										X					
-tokio-io-timeout@1.2.1	X									X					
-tokio-io-utility@0.7.6										X					
-tokio-macros@2.7.0										X					
-tokio-retry@0.3.1										X					
-tokio-rustls@0.24.1	X									X					
-tokio-rustls@0.26.4	X									X					
-tokio-stream@0.1.18										X					
-tokio-util@0.7.18										X					
-tonic@0.10.2										X					
-tonic@0.14.5										X					
-tonic-build@0.14.5										X					
-tonic-prost@0.14.5										X					
-tonic-prost-build@0.14.5										X					
-tower@0.4.13										X					
-tower@0.5.3										X					
-tower-http@0.6.8										X					
-tower-layer@0.3.3										X					
-tower-service@0.3.3										X					
-tracing@0.1.44										X					
-tracing-appender@0.2.4										X					
-tracing-attributes@0.1.31										X					
-tracing-core@0.1.36										X					
-tracing-log@0.2.0										X					
-tracing-serde@0.2.0										X					
-tracing-subscriber@0.3.23										X					
-triomphe@0.1.15	X									X					
-try-lock@0.2.5										X					
-twox-hash@2.1.2										X					
-typed-builder@0.22.0	X									X					
-typed-builder-macro@0.22.0	X									X					
-typenum@1.19.0	X									X					
-typewit@1.15.2															X
-ulid@1.2.1										X					
-unicase@2.9.0	X									X					
-unicode-bidi@0.3.18	X									X					
-unicode-ident@1.0.24	X									X			X		
-unicode-normalization@0.1.25	X									X					
-unicode-properties@0.1.4	X									X					
-unicode-segmentation@1.13.2	X									X					
-unicode-width@0.1.14	X									X					
-unicode-xid@0.2.6	X									X					
-unsigned-varint@0.8.0										X					
-untrusted@0.7.1								X							
-untrusted@0.9.0								X							
-url@2.5.8	X									X					
-urlencoding@2.1.3										X					
-utf8_iter@1.0.4	X									X					
-utf8parse@0.2.2	X									X					
-uuid@1.23.1	X									X					
-vcpkg@0.2.15	X									X					
-vec-strings@0.4.8										X					
-version_check@0.9.5	X									X					
-walkdir@2.5.0										X				X	
-want@0.3.1										X					
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X					
-wasi@0.14.7+wasi-0.2.4	X	X								X					
-wasi@0.9.0+wasi-snapshot-preview1	X	X								X					
-wasip2@1.0.1+wasi-0.2.4	X	X								X					
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X					
-wasite@0.1.0	X				X					X					
-wasite@1.0.2	X				X					X					
-wasm-bindgen@0.2.118	X									X					
-wasm-bindgen-futures@0.4.68	X									X					
-wasm-bindgen-macro@0.2.118	X									X					
-wasm-bindgen-macro-support@0.2.118	X									X					
-wasm-bindgen-shared@0.2.118	X									X					
-wasm-streams@0.5.0	X									X					
-wasmtimer@0.4.3										X					
-web-sys@0.3.95	X									X					
-web-time@1.1.0	X									X					
-webpki-root-certs@1.0.6							X								
-webpki-roots@0.26.11							X								
-webpki-roots@1.0.6							X								
-whoami@1.6.1	X				X					X					
-whoami@2.1.1	X				X					X					
-widestring@1.2.1	X									X					
-winapi@0.3.9	X									X					
-winapi-i686-pc-windows-gnu@0.4.0	X									X					
-winapi-util@0.1.11										X				X	
-winapi-x86_64-pc-windows-gnu@0.4.0	X									X					
-windows@0.62.2	X									X					
-windows-collections@0.3.2	X									X					
-windows-core@0.62.2	X									X					
-windows-future@0.3.2	X									X					
-windows-implement@0.60.2	X									X					
-windows-interface@0.59.3	X									X					
-windows-link@0.2.1	X									X					
-windows-numerics@0.3.1	X									X					
-windows-registry@0.6.1	X									X					
-windows-result@0.4.1	X									X					
-windows-strings@0.5.1	X									X					
-windows-sys@0.45.0	X									X					
-windows-sys@0.48.0	X									X					
-windows-sys@0.52.0	X									X					
-windows-sys@0.59.0	X									X					
-windows-sys@0.61.2	X									X					
-windows-targets@0.42.2	X									X					
-windows-targets@0.48.5	X									X					
-windows-targets@0.52.6	X									X					
-windows-threading@0.2.1	X									X					
-windows_aarch64_gnullvm@0.42.2	X									X					
-windows_aarch64_gnullvm@0.48.5	X									X					
-windows_aarch64_gnullvm@0.52.6	X									X					
-windows_aarch64_msvc@0.42.2	X									X					
-windows_aarch64_msvc@0.48.5	X									X					
-windows_aarch64_msvc@0.52.6	X									X					
-windows_i686_gnu@0.42.2	X									X					
-windows_i686_gnu@0.48.5	X									X					
-windows_i686_gnu@0.52.6	X									X					
-windows_i686_gnullvm@0.52.6	X									X					
-windows_i686_msvc@0.42.2	X									X					
-windows_i686_msvc@0.48.5	X									X					
-windows_i686_msvc@0.52.6	X									X					
-windows_x86_64_gnu@0.42.2	X									X					
-windows_x86_64_gnu@0.48.5	X									X					
-windows_x86_64_gnu@0.52.6	X									X					
-windows_x86_64_gnullvm@0.42.2	X									X					
-windows_x86_64_gnullvm@0.48.5	X									X					
-windows_x86_64_gnullvm@0.52.6	X									X					
-windows_x86_64_msvc@0.42.2	X									X					
-windows_x86_64_msvc@0.48.5	X									X					
-windows_x86_64_msvc@0.52.6	X									X					
-wit-bindgen@0.46.0	X	X								X					
-wit-bindgen@0.51.0	X	X								X					
-writeable@0.6.3													X		
-wyz@0.5.1										X					
-xattr@1.6.1	X									X					
-xet-client@1.5.1	X														
-xet-core-structures@1.5.1	X														
-xet-data@1.5.1	X														
-xet-runtime@1.5.1	X														
-xxhash-rust@0.8.15					X										
-yoke@0.8.2													X		
-yoke-derive@0.8.2													X		
-zerocopy@0.8.48	X		X							X					
-zerofrom@0.1.7													X		
-zerofrom-derive@0.1.7													X		
-zeroize@1.8.2	X									X					
-zerotrie@0.2.4													X		
-zerovec@0.11.6													X		
-zerovec-derive@0.11.3													X		
-zigzag@0.1.0										X					
-zmij@1.0.21										X					
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X					
+aes@0.8.4		X									X					
+ahash@0.8.12		X									X					
+aho-corasick@1.1.4											X				X	
+allocator-api2@0.2.21		X									X					
+android_system_properties@0.1.5		X									X					
+anstream@1.0.0		X									X					
+anstyle@1.0.14		X									X					
+anstyle-parse@1.0.0		X									X					
+anstyle-query@1.1.5		X									X					
+anstyle-wincon@3.0.11		X									X					
+anyhow@1.0.102		X									X					
+approx@0.5.1		X														
+arc-swap@1.9.1		X									X					
+arcstr@1.2.0		X									X					X
+arrayref@0.3.9				X												
+arrayvec@0.7.6		X									X					
+async-lock@3.4.2		X									X					
+async-recursion@0.3.2		X									X					
+async-stream@0.3.6											X					
+async-stream-impl@0.3.6											X					
+async-task@4.7.1		X									X					
+async-trait@0.1.89		X									X					
+atoi@2.0.0											X					
+atomic-waker@1.1.2		X									X					
+auto-const-array@0.2.2		X									X					
+autocfg@1.5.0		X									X					
+awaitable@0.4.0											X					
+awaitable-error@0.1.0											X					
+aws-lc-rs@1.17.0		X							X							
+aws-lc-sys@0.41.0		X			X				X		X	X				
+axum@0.6.20											X					
+axum@0.7.9											X					
+axum@0.8.9											X					
+axum-core@0.3.4											X					
+axum-core@0.4.5											X					
+axum-core@0.5.6											X					
+backon@1.6.0		X														
+base64@0.21.7		X									X					
+base64@0.22.1		X									X					
+base64ct@1.8.3		X									X					
+bitflags@1.3.2		X									X					
+bitflags@2.11.1		X									X					
+bitvec@1.0.1											X					
+blake3@1.8.5		X	X				X									
+block-buffer@0.10.4		X									X					
+block-buffer@0.12.0		X									X					
+block-padding@0.3.3		X									X					
+bson@2.15.0											X					
+bstr@1.12.1		X									X					
+bumpalo@3.20.2		X									X					
+bytecount@0.6.9		X									X					
+bytemuck@1.25.0		X									X					X
+byteorder@1.5.0											X				X	
+bytes@1.11.1											X					
+cacache@13.1.0		X														
+camino@1.2.2		X									X					
+cargo-platform@0.1.9		X									X					
+cargo_metadata@0.14.2											X					
+cbc@0.1.2		X									X					
+cc@1.2.62		X									X					
+cfg-if@0.1.10		X									X					
+cfg-if@1.0.4		X									X					
+cfg_aliases@0.2.1											X					
+chacha20@0.10.0		X									X					
+chrono@0.4.44		X									X					
+cipher@0.4.4		X									X					
+clap@4.6.1		X									X					
+clap_builder@4.6.0		X									X					
+clap_derive@4.6.1		X									X					
+clap_lex@1.1.0		X									X					
+cmake@0.1.58		X									X					
+cmov@0.5.3		X									X					
+colorchoice@1.0.5		X									X					
+colored@3.1.1													X			
+combine@4.6.7											X					
+compio@0.18.0											X					
+compio-buf@0.8.1											X					
+compio-dispatcher@0.10.0											X					
+compio-driver@0.11.4											X					
+compio-fs@0.11.0											X					
+compio-io@0.9.1											X					
+compio-log@0.1.0											X					
+compio-runtime@0.11.0											X					
+concurrent-queue@2.5.0		X									X					
+concurrent_arena@0.1.11											X					
+const-oid@0.10.2		X									X					
+const-oid@0.9.6		X									X					
+const-random@0.1.18		X									X					
+const-random-macro@0.1.16		X									X					
+const-str@1.1.0											X					
+const_panic@0.2.15																X
+constant_time_eq@0.4.2		X					X					X				
+convert_case@0.10.0											X					
+core-foundation@0.10.1		X									X					
+core-foundation@0.9.4		X									X					
+core-foundation-sys@0.8.7		X									X					
+core_affinity@0.8.3		X									X					
+countio@0.3.0											X					
+cpufeatures@0.2.17		X									X					
+cpufeatures@0.3.0		X									X					
+crc@3.4.0		X									X					
+crc-catalog@2.5.0		X									X					
+crc16@0.4.0											X					
+crc32c@0.6.8		X									X					
+crc32fast@1.5.0		X									X					
+critical-section@1.2.0		X									X					
+crossbeam-channel@0.5.15		X									X					
+crossbeam-epoch@0.9.18		X									X					
+crossbeam-queue@0.3.12		X									X					
+crossbeam-utils@0.8.21		X									X					
+crunchy@0.2.4											X					
+crypto-common@0.1.7		X									X					
+crypto-common@0.2.2		X									X					
+csv@1.4.0											X				X	
+csv-core@0.1.13											X				X	
+ctor@0.6.3		X									X					
+ctor@1.0.6		X									X					
+ctor-proc-macro@0.0.7		X									X					
+ctutils@0.4.2		X									X					
+darling@0.21.3											X					
+darling_core@0.21.3											X					
+darling_macro@0.21.3											X					
+dashmap@5.5.3											X					
+dashmap@6.2.1											X					
+data-encoding@2.11.0											X					
+der@0.7.10		X									X					
+deranged@0.5.8		X									X					
+derive-new@0.5.9											X					
+derive-syn-parse@0.2.0		X									X					
+derive-where@1.6.1		X									X					
+derive_destructure2@0.1.3		X									X					
+derive_more@2.1.1											X					
+derive_more-impl@2.1.1											X					
+digest@0.10.7		X									X					
+digest@0.11.3		X									X					
+dirs@6.0.0		X									X					
+dirs-sys@0.5.0		X									X					
+displaydoc@0.2.5		X									X					
+dlv-list@0.5.2		X									X					
+dotenvy@0.15.7											X					
+dtor@0.1.1		X									X					
+dtor-proc-macro@0.0.6		X									X					
+dunce@1.0.5		X					X					X				
+either@1.16.0		X									X					
+enum-as-inner@0.6.1		X									X					
+equivalent@1.0.2		X									X					
+errno@0.3.14		X									X					
+error-chain@0.12.4		X									X					
+etcd-client@0.18.0		X									X					
+etcetera@0.8.0		X									X					
+event-listener@5.4.1		X									X					
+event-listener-strategy@0.5.4		X									X					
+fail@0.4.0		X														
+fastpool@1.1.0		X														
+fastrand@2.4.1		X									X					
+find-msvc-tools@0.1.9		X									X					
+fixedbitset@0.5.7		X									X					
+flate2@1.1.9		X									X					
+flume@0.11.1		X									X					
+flume@0.12.0		X									X					
+fnv@1.0.7		X									X					
+foldhash@0.1.5																X
+form_urlencoded@1.2.2		X									X					
+fs2@0.4.3		X									X					
+fs_extra@1.3.0											X					
+funty@2.0.0											X					
+futures@0.3.32		X									X					
+futures-channel@0.3.32		X									X					
+futures-core@0.3.32		X									X					
+futures-executor@0.3.32		X									X					
+futures-intrusive@0.5.0		X									X					
+futures-io@0.3.32		X									X					
+futures-macro@0.3.32		X									X					
+futures-sink@0.3.32		X									X					
+futures-task@0.3.32		X									X					
+futures-util@0.3.32		X									X					
+fxhash@0.2.1		X									X					
+gearhash@0.1.3		X									X					
+generator@0.8.8		X									X					
+generic-array@0.14.7											X					
+getrandom@0.1.16		X									X					
+getrandom@0.2.17		X									X					
+getrandom@0.3.4		X									X					
+getrandom@0.4.2		X									X					
+ghac@0.3.0		X														
+git-version@0.3.9				X												
+git-version-macro@0.3.9				X												
+glob@0.3.3		X									X					
+gloo-timers@0.3.0		X									X					
+goosefs-sdk@0.1.2		X														
+h2@0.3.27											X					
+h2@0.4.14											X					
+hashbrown@0.12.3		X									X					
+hashbrown@0.14.5		X									X					
+hashbrown@0.15.5		X									X					
+hashbrown@0.17.1		X									X					
+hashlink@0.10.0		X									X					
+heapify@0.2.0		X									X					
+heck@0.5.0		X									X					
+hermit-abi@0.5.2		X									X					
+hex@0.4.3		X									X					
+hf-xet@1.5.2		X														
+hickory-proto@0.25.2		X									X					
+hickory-resolver@0.25.2		X									X					
+hkdf@0.12.4		X									X					
+hmac@0.12.1		X									X					
+hmac@0.13.0		X									X					
+home@0.5.11		X									X					
+hostname@0.3.1											X					
+http@0.2.12		X									X					
+http@1.4.0		X									X					
+http-body@0.4.6											X					
+http-body@1.0.1											X					
+http-body-util@0.1.3											X					
+httparse@1.10.1		X									X					
+httpdate@1.0.3		X									X					
+humantime@2.3.0		X									X					
+hybrid-array@0.4.12		X									X					
+hyper@0.14.32											X					
+hyper@1.9.0											X					
+hyper-rustls@0.27.9		X							X		X					
+hyper-timeout@0.4.1		X									X					
+hyper-timeout@0.5.2		X									X					
+hyper-util@0.1.20											X					
+iana-time-zone@0.1.65		X									X					
+iana-time-zone-haiku@0.1.2		X									X					
+icu_collections@2.1.1														X		
+icu_locale_core@2.1.1														X		
+icu_normalizer@2.1.1														X		
+icu_normalizer_data@2.1.1														X		
+icu_properties@2.1.2														X		
+icu_properties_data@2.1.2														X		
+icu_provider@2.1.1														X		
+ident_case@1.0.1		X									X					
+idna@1.1.0		X									X					
+idna_adapter@1.2.1		X									X					
+indexmap@1.9.3		X									X					
+indexmap@2.14.0		X									X					
+inout@0.1.4		X									X					
+instant@0.1.13					X											
+io-uring@0.6.4		X									X					
+io-uring@0.7.12		X									X					
+io_uring_buf_ring@0.2.3											X					
+ipconfig@0.3.4		X									X					
+ipnet@2.12.0		X									X					
+is_terminal_polyfill@1.70.2		X									X					
+itertools@0.12.1		X									X					
+itertools@0.14.0		X									X					
+itoa@1.0.18		X									X					
+jiff@0.2.24											X				X	
+jiff-tzdb@0.1.6											X				X	
+jiff-tzdb-platform@0.1.3											X				X	
+jni@0.22.4		X									X					
+jni-macros@0.22.4		X									X					
+jni-sys@0.4.1		X									X					
+jni-sys-macros@0.4.1		X									X					
+jobserver@0.1.34		X									X					
+js-sys@0.3.98		X									X					
+jsonwebtoken@10.3.0											X					
+konst@0.4.3																X
+konst_proc_macros@0.4.1																X
+lazy_static@1.5.0		X									X					
+libc@0.2.186		X									X					
+libm@0.2.16											X					
+libredox@0.1.16											X					
+libsqlite3-sys@0.30.1											X					
+link-section@0.17.2		X									X					
+linked-hash-map@0.5.6		X									X					
+linktime-proc-macro@0.1.0		X									X					
+linux-raw-sys@0.12.1		X	X								X					
+litemap@0.8.2														X		
+lock_api@0.4.14		X									X					
+log@0.4.29		X									X					
+loom@0.7.2											X					
+lz4_flex@0.13.1											X					
+macro_magic@0.5.1											X					
+macro_magic_core@0.5.1											X					
+macro_magic_core_macros@0.5.1											X					
+macro_magic_macros@0.5.1											X					
+match_cfg@0.1.0		X									X					
+matchers@0.2.0											X					
+matchit@0.7.3					X						X					
+matchit@0.8.4					X						X					
+md-5@0.10.6		X									X					
+md-5@0.11.0		X									X					
+mea@0.6.3		X														
+memchr@2.8.0											X				X	
+memmap2@0.5.10		X									X					
+memoffset@0.7.1											X					
+miette@5.10.0		X														
+miette-derive@5.10.0		X														
+mime@0.3.17		X									X					
+mini-moka@0.10.3		X									X					
+miniz_oxide@0.8.9		X									X					X
+mio@0.8.11											X					
+mio@1.2.0											X					
+moka@0.12.15		X									X					
+mongodb@3.6.0		X														
+mongodb-internal-macros@3.6.0		X														
+monoio@0.2.4		X									X					
+monoio-macros@0.1.0		X									X					
+more-asserts@0.3.1		X					X				X				X	
+multimap@0.10.1		X									X					
+nanorand@0.7.0																X
+nix@0.26.4											X					
+ntapi@0.4.3		X									X					
+nu-ansi-term@0.50.3											X					
+num-bigint@0.4.6		X									X					
+num-bigint-dig@0.8.6		X									X					
+num-conv@0.2.2		X									X					
+num-derive@0.4.2		X									X					
+num-integer@0.1.46		X									X					
+num-iter@0.1.45		X									X					
+num-traits@0.2.19		X									X					
+num_cpus@1.17.0		X									X					
+objc2-core-foundation@0.3.2		X									X					X
+objc2-io-kit@0.3.2		X									X					X
+objc2-system-configuration@0.3.2		X									X					X
+once_cell@1.21.4		X									X					
+once_cell_polyfill@1.70.2		X									X					
+oneshot@0.1.13		X									X					
+opendal@0.57.0		X														
+opendal-core@0.57.0		X														
+opendal-dotnet@0.0.0		X														
+opendal-layer-concurrent-limit@0.57.0		X														
+opendal-layer-logging@0.57.0		X														
+opendal-layer-retry@0.57.0		X														
+opendal-layer-timeout@0.57.0		X														
+opendal-service-aliyun-drive@0.57.0		X														
+opendal-service-alluxio@0.57.0		X														
+opendal-service-azblob@0.57.0		X														
+opendal-service-azdls@0.57.0		X														
+opendal-service-azfile@0.57.0		X														
+opendal-service-azure-common@0.57.0		X														
+opendal-service-b2@0.57.0		X														
+opendal-service-cacache@0.57.0		X														
+opendal-service-compfs@0.57.0		X														
+opendal-service-cos@0.57.0		X														
+opendal-service-dashmap@0.57.0		X														
+opendal-service-dropbox@0.57.0		X														
+opendal-service-etcd@0.57.0		X														
+opendal-service-fs@0.57.0		X														
+opendal-service-gcs@0.57.0		X														
+opendal-service-gdrive@0.57.0		X														
+opendal-service-ghac@0.57.0		X														
+opendal-service-goosefs@0.57.0		X														
+opendal-service-gridfs@0.57.0		X														
+opendal-service-hf@0.57.0		X														
+opendal-service-http@0.57.0		X														
+opendal-service-ipfs@0.57.0		X														
+opendal-service-ipmfs@0.57.0		X														
+opendal-service-koofr@0.57.0		X														
+opendal-service-memcached@0.57.0		X														
+opendal-service-mini-moka@0.57.0		X														
+opendal-service-moka@0.57.0		X														
+opendal-service-mongodb@0.57.0		X														
+opendal-service-monoiofs@0.57.0		X														
+opendal-service-mysql@0.57.0		X														
+opendal-service-obs@0.57.0		X														
+opendal-service-onedrive@0.57.0		X														
+opendal-service-oss@0.57.0		X														
+opendal-service-persy@0.57.0		X														
+opendal-service-postgresql@0.57.0		X														
+opendal-service-redb@0.57.0		X														
+opendal-service-redis@0.57.0		X														
+opendal-service-s3@0.57.0		X														
+opendal-service-seafile@0.57.0		X														
+opendal-service-sftp@0.57.0		X														
+opendal-service-sled@0.57.0		X														
+opendal-service-sqlite@0.57.0		X														
+opendal-service-swift@0.57.0		X														
+opendal-service-tikv@0.57.0		X														
+opendal-service-tos@0.57.0		X														
+opendal-service-upyun@0.57.0		X														
+opendal-service-vercel-artifacts@0.57.0		X														
+opendal-service-webdav@0.57.0		X														
+opendal-service-webhdfs@0.57.0		X														
+opendal-service-yandex-disk@0.57.0		X														
+openssh@0.11.6		X									X					
+openssh-sftp-client@0.15.7											X					
+openssh-sftp-client-lowlevel@0.7.2											X					
+openssh-sftp-error@0.5.1											X					
+openssh-sftp-protocol@0.24.1											X					
+openssh-sftp-protocol-error@0.1.1											X					
+openssl-probe@0.2.1		X									X					
+option-ext@0.2.0													X			
+ordered-multimap@0.7.3											X					
+os_pipe@1.2.3											X					
+os_str_bytes@6.6.1		X									X					
+parking@2.2.1		X									X					
+parking_lot@0.11.2		X									X					
+parking_lot@0.12.5		X									X					
+parking_lot_core@0.8.6		X									X					
+parking_lot_core@0.9.12		X									X					
+paste@1.0.15		X									X					
+pbkdf2@0.12.2		X									X					
+pem@3.0.6											X					
+pem-rfc7468@0.7.0		X									X					
+percent-encoding@2.3.2		X									X					
+persy@1.7.1													X			
+petgraph@0.7.1		X									X					
+petgraph@0.8.3		X									X					
+pin-project@1.1.13		X									X					
+pin-project-internal@1.1.13		X									X					
+pin-project-lite@0.2.17		X									X					
+pin-utils@0.1.0		X									X					
+pkcs1@0.7.5		X									X					
+pkcs5@0.7.1		X									X					
+pkcs8@0.10.2		X									X					
+pkg-config@0.3.33		X									X					
+plain@0.2.3		X									X					
+polling@3.11.0		X									X					
+portable-atomic@1.13.1		X									X					
+portable-atomic-util@0.2.7		X									X					
+potential_utf@0.1.5														X		
+powerfmt@0.2.0		X									X					
+ppv-lite86@0.2.21		X									X					
+prettyplease@0.2.37		X									X					
+proc-macro2@1.0.106		X									X					
+prometheus@0.13.4		X														
+prost@0.12.6		X														
+prost@0.13.5		X														
+prost@0.14.3		X														
+prost-build@0.13.5		X														
+prost-build@0.14.3		X														
+prost-derive@0.12.6		X														
+prost-derive@0.13.5		X														
+prost-derive@0.14.3		X														
+prost-types@0.13.5		X														
+prost-types@0.14.3		X														
+pulldown-cmark@0.13.4											X					
+pulldown-cmark@0.9.6											X					
+pulldown-cmark-to-cmark@22.0.0		X														
+quick-xml@0.39.4											X					
+quote@1.0.45		X									X					
+r-efi@5.3.0		X								X	X					
+r-efi@6.0.0		X								X	X					
+radium@0.7.0											X					
+rand@0.10.1		X									X					
+rand@0.7.3		X									X					
+rand@0.8.6		X									X					
+rand@0.9.4		X									X					
+rand_chacha@0.2.2		X									X					
+rand_chacha@0.3.1		X									X					
+rand_chacha@0.9.0		X									X					
+rand_core@0.10.1		X									X					
+rand_core@0.5.1		X									X					
+rand_core@0.6.4		X									X					
+rand_core@0.9.5		X									X					
+rand_hc@0.2.0		X									X					
+redb@2.6.3		X									X					
+redb@3.1.3		X									X					
+redis@1.2.1					X											
+redox_syscall@0.2.16											X					
+redox_syscall@0.5.18											X					
+redox_users@0.5.2											X					
+reflink-copy@0.1.29		X									X					
+regex@1.12.3		X									X					
+regex-automata@0.4.14		X									X					
+regex-syntax@0.8.10		X									X					
+reqsign-aliyun-oss@3.0.0		X														
+reqsign-aws-v4@3.0.0		X														
+reqsign-azure-storage@3.0.0		X														
+reqsign-core@3.0.0		X														
+reqsign-file-read-tokio@3.0.0		X														
+reqsign-google@3.0.0		X														
+reqsign-huaweicloud-obs@3.0.0		X														
+reqsign-tencent-cos@3.0.0		X														
+reqsign-volcengine-tos@3.0.0		X														
+reqwest@0.13.3		X									X					
+reqwest-middleware@0.5.2		X									X					
+resolv-conf@0.7.6		X									X					
+ring@0.17.14		X							X							
+rsa@0.9.10		X									X					
+rust-ini@0.21.3											X					
+rustc_version@0.4.1		X									X					
+rustc_version_runtime@0.3.0											X					
+rustix@1.1.4		X	X								X					
+rustls@0.21.12		X							X		X					
+rustls@0.23.40		X							X		X					
+rustls-native-certs@0.8.3		X							X		X					
+rustls-pemfile@1.0.4		X							X		X					
+rustls-pemfile@2.2.0		X							X		X					
+rustls-pki-types@1.14.1		X									X					
+rustls-platform-verifier@0.7.0		X									X					
+rustls-platform-verifier-android@0.1.1		X									X					
+rustls-webpki@0.101.7									X							
+rustls-webpki@0.103.13									X							
+rustversion@1.0.22		X									X					
+ryu@1.0.23		X				X										
+safe-transmute@0.11.3											X					
+salsa20@0.10.2		X									X					
+same-file@1.0.6											X				X	
+schannel@0.1.29											X					
+scoped-tls@1.0.1		X									X					
+scopeguard@1.2.0		X									X					
+scrypt@0.11.0		X									X					
+sct@0.7.1		X							X		X					
+security-framework@3.7.0		X									X					
+security-framework-sys@2.17.0		X									X					
+semver@1.0.28		X									X					
+serde@1.0.228		X									X					
+serde_bytes@0.11.19		X									X					
+serde_core@1.0.228		X									X					
+serde_derive@1.0.228		X									X					
+serde_json@1.0.150		X									X					
+serde_repr@0.1.20		X									X					
+serde_urlencoded@0.7.1		X									X					
+serde_with@3.17.0		X									X					
+serde_with_macros@3.17.0		X									X					
+sha-1@0.10.1		X									X					
+sha1@0.10.6		X									X					
+sha1@0.11.0		X									X					
+sha1_smol@1.0.1					X											
+sha2@0.10.9		X									X					
+sha2@0.11.0		X									X					
+sha2-asm@0.6.4											X					
+sharded-slab@0.1.7											X					
+shell-escape@0.1.5		X									X					
+shellexpand@3.1.2		X									X					
+shlex@1.3.0		X									X					
+signal-hook-registry@1.4.8		X									X					
+signature@2.2.0		X									X					
+simd-adler32@0.3.9											X					
+simd_cesu8@1.1.1		X									X					
+simdutf8@0.1.5		X									X					
+simple_asn1@0.6.4									X							
+skeptic@0.13.7		X									X					
+slab@0.4.12											X					
+sled@0.34.7		X									X					
+smallvec@1.15.1		X									X					
+socket2@0.5.10		X									X					
+socket2@0.6.3		X									X					
+spin@0.9.8											X					
+spki@0.7.3		X									X					
+sqlx@0.8.6		X									X					
+sqlx-core@0.8.6		X									X					
+sqlx-macros@0.8.6		X									X					
+sqlx-macros-core@0.8.6		X									X					
+sqlx-mysql@0.8.6		X									X					
+sqlx-postgres@0.8.6		X									X					
+sqlx-sqlite@0.8.6		X									X					
+ssh_format@0.14.1											X					
+ssh_format_error@0.1.0											X					
+ssri@9.2.0		X														
+stable_deref_trait@1.2.1		X									X					
+static_assertions@1.1.0		X									X					
+statrs@0.18.0											X					
+stringprep@0.1.5		X									X					
+strsim@0.11.1											X					
+subtle@2.6.1					X											
+symlink@0.1.0		X									X					
+syn@1.0.109		X									X					
+syn@2.0.117		X									X					
+sync_wrapper@0.1.2		X														
+sync_wrapper@1.0.2		X														
+synchrony@0.1.8											X					
+synstructure@0.13.2											X					
+sysinfo@0.38.4											X					
+system-configuration@0.7.0		X									X					
+system-configuration-sys@0.6.0		X									X					
+tagptr@0.2.0		X									X					
+take_mut@0.2.2											X					
+tap@1.0.1											X					
+tempfile@3.27.0		X									X					
+thin-cell@0.1.2											X					
+thin-vec@0.2.18		X									X					
+thiserror@1.0.69		X									X					
+thiserror@2.0.18		X									X					
+thiserror-impl@1.0.69		X									X					
+thiserror-impl@2.0.18		X									X					
+thread_local@1.1.9		X									X					
+threadpool@1.8.1		X									X					
+tikv-client@0.4.0		X														
+time@0.3.47		X									X					
+time-core@0.1.8		X									X					
+time-macros@0.2.27		X									X					
+tiny-keccak@2.0.2							X									
+tinystr@0.8.3														X		
+tinyvec@1.11.0		X									X					X
+tinyvec_macros@0.1.1		X									X					X
+tokio@1.52.3											X					
+tokio-io-timeout@1.2.1		X									X					
+tokio-io-utility@0.7.6											X					
+tokio-macros@2.7.0											X					
+tokio-retry@0.3.1											X					
+tokio-rustls@0.24.1		X									X					
+tokio-rustls@0.26.4		X									X					
+tokio-stream@0.1.18											X					
+tokio-util@0.7.18											X					
+tonic@0.10.2											X					
+tonic@0.12.3											X					
+tonic@0.14.5											X					
+tonic-build@0.12.3											X					
+tonic-build@0.14.5											X					
+tonic-prost@0.14.5											X					
+tonic-prost-build@0.14.5											X					
+tower@0.4.13											X					
+tower@0.5.3											X					
+tower-http@0.6.11											X					
+tower-layer@0.3.3											X					
+tower-service@0.3.3											X					
+tracing@0.1.44											X					
+tracing-appender@0.2.5											X					
+tracing-attributes@0.1.31											X					
+tracing-core@0.1.36											X					
+tracing-log@0.2.0											X					
+tracing-serde@0.2.0											X					
+tracing-subscriber@0.3.23											X					
+triomphe@0.1.15		X									X					
+try-lock@0.2.5											X					
+twox-hash@2.1.2											X					
+typed-builder@0.22.0		X									X					
+typed-builder-macro@0.22.0		X									X					
+typenum@1.20.0		X									X					
+typewit@1.15.2																X
+unicase@2.9.0		X									X					
+unicode-bidi@0.3.18		X									X					
+unicode-ident@1.0.24		X									X			X		
+unicode-normalization@0.1.25		X									X					
+unicode-properties@0.1.4		X									X					
+unicode-segmentation@1.13.2		X									X					
+unicode-width@0.1.14		X									X					
+unicode-xid@0.2.6		X									X					
+unsigned-varint@0.8.0											X					
+untrusted@0.7.1									X							
+untrusted@0.9.0									X							
+url@2.5.8		X									X					
+urlencoding@2.1.3											X					
+utf8_iter@1.0.4		X									X					
+utf8parse@0.2.2		X									X					
+uuid@1.23.1		X									X					
+vcpkg@0.2.15		X									X					
+vec-strings@0.4.8											X					
+version_check@0.9.5		X									X					
+walkdir@2.5.0											X				X	
+want@0.3.1											X					
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X					
+wasi@0.14.7+wasi-0.2.4		X	X								X					
+wasi@0.9.0+wasi-snapshot-preview1		X	X								X					
+wasip2@1.0.1+wasi-0.2.4		X	X								X					
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X					
+wasite@0.1.0		X				X					X					
+wasite@1.0.2		X				X					X					
+wasm-bindgen@0.2.121		X									X					
+wasm-bindgen-futures@0.4.71		X									X					
+wasm-bindgen-macro@0.2.121		X									X					
+wasm-bindgen-macro-support@0.2.121		X									X					
+wasm-bindgen-shared@0.2.121		X									X					
+wasm-streams@0.5.0		X									X					
+web-sys@0.3.98		X									X					
+web-time@1.1.0		X									X					
+webpki-root-certs@1.0.7								X								
+webpki-roots@0.26.11								X								
+webpki-roots@1.0.7								X								
+whoami@1.6.1		X				X					X					
+whoami@2.1.2		X				X					X					
+widestring@1.2.1		X									X					
+winapi@0.3.9		X									X					
+winapi-i686-pc-windows-gnu@0.4.0		X									X					
+winapi-util@0.1.11											X				X	
+winapi-x86_64-pc-windows-gnu@0.4.0		X									X					
+windows@0.62.2		X									X					
+windows-collections@0.3.2		X									X					
+windows-core@0.62.2		X									X					
+windows-future@0.3.2		X									X					
+windows-implement@0.60.2		X									X					
+windows-interface@0.59.3		X									X					
+windows-link@0.2.1		X									X					
+windows-numerics@0.3.1		X									X					
+windows-registry@0.6.1		X									X					
+windows-result@0.4.1		X									X					
+windows-strings@0.5.1		X									X					
+windows-sys@0.48.0		X									X					
+windows-sys@0.52.0		X									X					
+windows-sys@0.59.0		X									X					
+windows-sys@0.61.2		X									X					
+windows-targets@0.48.5		X									X					
+windows-targets@0.52.6		X									X					
+windows-threading@0.2.1		X									X					
+windows_aarch64_gnullvm@0.48.5		X									X					
+windows_aarch64_gnullvm@0.52.6		X									X					
+windows_aarch64_msvc@0.48.5		X									X					
+windows_aarch64_msvc@0.52.6		X									X					
+windows_i686_gnu@0.48.5		X									X					
+windows_i686_gnu@0.52.6		X									X					
+windows_i686_gnullvm@0.52.6		X									X					
+windows_i686_msvc@0.48.5		X									X					
+windows_i686_msvc@0.52.6		X									X					
+windows_x86_64_gnu@0.48.5		X									X					
+windows_x86_64_gnu@0.52.6		X									X					
+windows_x86_64_gnullvm@0.48.5		X									X					
+windows_x86_64_gnullvm@0.52.6		X									X					
+windows_x86_64_msvc@0.48.5		X									X					
+windows_x86_64_msvc@0.52.6		X									X					
+wit-bindgen@0.46.0		X	X								X					
+wit-bindgen@0.51.0		X	X								X					
+writeable@0.6.3														X		
+wyz@0.5.1											X					
+xattr@1.6.1		X									X					
+xet-client@1.5.2		X														
+xet-core-structures@1.5.2		X														
+xet-data@1.5.2		X														
+xet-runtime@1.5.2		X														
+xxhash-rust@0.8.15						X										
+yoke@0.8.2														X		
+yoke-derive@0.8.2														X		
+zerocopy@0.8.48		X		X							X					
+zerofrom@0.1.8														X		
+zerofrom-derive@0.1.7														X		
+zeroize@1.8.2		X									X					
+zerotrie@0.2.4														X		
+zerovec@0.11.6														X		
+zerovec-derive@0.11.3														X		
+zigzag@0.1.0											X					
+zmij@1.0.21											X					

--- a/bindings/haskell/DEPENDENCIES.rust.tsv
+++ b/bindings/haskell/DEPENDENCIES.rust.tsv
@@ -4,43 +4,44 @@ anyhow@1.0.102	X									X
 async-trait@0.1.89	X									X			
 atomic-waker@1.1.2	X									X			
 autocfg@1.5.0	X									X			
-aws-lc-rs@1.16.3	X							X					
-aws-lc-sys@0.40.0	X			X				X		X	X		
+aws-lc-rs@1.17.0	X							X					
+aws-lc-sys@0.41.0	X			X				X		X	X		
 backon@1.6.0	X												
 base64@0.22.1	X									X			
 base64ct@1.8.3	X									X			
 bitflags@2.11.1	X									X			
 block-buffer@0.10.4	X									X			
+block-buffer@0.12.0	X									X			
 block-padding@0.3.3	X									X			
 bumpalo@3.20.2	X									X			
 bytes@1.11.1										X			
 cbc@0.1.2	X									X			
-cc@1.2.60	X									X			
-cesu8@1.1.0	X									X			
+cc@1.2.62	X									X			
 cfg-if@1.0.4	X									X			
 cipher@0.4.4	X									X			
 cmake@0.1.58	X									X			
 combine@4.6.7										X			
+const-oid@0.10.2	X									X			
 const-oid@0.9.6	X									X			
 const-random@0.1.18	X									X			
 const-random-macro@0.1.16	X									X			
 core-foundation@0.10.1	X									X			
 core-foundation-sys@0.8.7	X									X			
 cpufeatures@0.2.17	X									X			
+cpufeatures@0.3.0	X									X			
 crc32c@0.6.8	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
-ctor@0.6.3	X									X			
-ctor-proc-macro@0.0.7	X									X			
+crypto-common@0.2.2	X									X			
+ctor@1.0.6	X									X			
 der@0.7.10	X									X			
 deranged@0.5.8	X									X			
 digest@0.10.7	X									X			
+digest@0.11.3	X									X			
 displaydoc@0.2.5	X									X			
 dlv-list@0.5.2	X									X			
-dtor@0.1.1	X									X			
-dtor-proc-macro@0.0.6	X									X			
 dunce@1.0.5	X					X					X		
-either@1.15.0	X									X			
+either@1.16.0	X									X			
 errno@0.3.14	X									X			
 fastrand@2.4.1	X									X			
 find-msvc-tools@0.1.9	X									X			
@@ -59,7 +60,7 @@ generic-array@0.14.7										X
 getrandom@0.2.17	X									X			
 getrandom@0.3.4	X									X			
 getrandom@0.4.2	X									X			
-ghac@0.2.0	X												
+ghac@0.3.0	X												
 gloo-timers@0.3.0	X									X			
 hashbrown@0.14.5	X									X			
 hex@0.4.3	X									X			
@@ -68,6 +69,7 @@ http@1.4.0	X									X
 http-body@1.0.1										X			
 http-body-util@0.1.3										X			
 httparse@1.10.1	X									X			
+hybrid-array@0.4.12	X									X			
 hyper@1.9.0										X			
 hyper-rustls@0.27.9	X							X		X			
 hyper-util@0.1.20										X			
@@ -82,59 +84,60 @@ idna@1.1.0	X									X
 idna_adapter@1.2.1	X									X			
 inout@0.1.4	X									X			
 ipnet@2.12.0	X									X			
-iri-string@0.7.12	X									X			
 itertools@0.14.0	X									X			
 itoa@1.0.18	X									X			
-jiff@0.2.23										X			X
+jiff@0.2.24										X			X
 jiff-tzdb@0.1.6										X			X
 jiff-tzdb-platform@0.1.3										X			X
-jni@0.21.1	X									X			
-jni-sys@0.3.1	X									X			
+jni@0.22.4	X									X			
+jni-macros@0.22.4	X									X			
 jni-sys@0.4.1	X									X			
 jni-sys-macros@0.4.1	X									X			
 jobserver@0.1.34	X									X			
-js-sys@0.3.95	X									X			
+js-sys@0.3.98	X									X			
 jsonwebtoken@10.3.0										X			
 lazy_static@1.5.0	X									X			
-libc@0.2.185	X									X			
+libc@0.2.186	X									X			
 libm@0.2.16										X			
+link-section@0.17.2	X									X			
+linktime-proc-macro@0.1.0	X									X			
 linux-raw-sys@0.12.1	X	X								X			
 litemap@0.8.2												X	
 lock_api@0.4.14	X									X			
 log@0.4.29	X									X			
-md-5@0.10.6	X									X			
+md-5@0.11.0	X									X			
 mea@0.6.3	X												
 memchr@2.8.0										X			X
 mio@1.2.0										X			
 num-bigint@0.4.6	X									X			
 num-bigint-dig@0.8.6	X									X			
-num-conv@0.2.1	X									X			
+num-conv@0.2.2	X									X			
 num-integer@0.1.46	X									X			
 num-iter@0.1.45	X									X			
 num-traits@0.2.19	X									X			
 once_cell@1.21.4	X									X			
-opendal@0.56.0	X												
-opendal-core@0.56.0	X												
+opendal@0.57.0	X												
+opendal-core@0.57.0	X												
 opendal-hs@0.0.0	X												
-opendal-layer-concurrent-limit@0.56.0	X												
-opendal-layer-logging@0.56.0	X												
-opendal-layer-retry@0.56.0	X												
-opendal-layer-timeout@0.56.0	X												
-opendal-service-azblob@0.56.0	X												
-opendal-service-azdls@0.56.0	X												
-opendal-service-azfile@0.56.0	X												
-opendal-service-azure-common@0.56.0	X												
-opendal-service-cos@0.56.0	X												
-opendal-service-fs@0.56.0	X												
-opendal-service-gcs@0.56.0	X												
-opendal-service-ghac@0.56.0	X												
-opendal-service-http@0.56.0	X												
-opendal-service-ipmfs@0.56.0	X												
-opendal-service-obs@0.56.0	X												
-opendal-service-oss@0.56.0	X												
-opendal-service-s3@0.56.0	X												
-opendal-service-webdav@0.56.0	X												
-opendal-service-webhdfs@0.56.0	X												
+opendal-layer-concurrent-limit@0.57.0	X												
+opendal-layer-logging@0.57.0	X												
+opendal-layer-retry@0.57.0	X												
+opendal-layer-timeout@0.57.0	X												
+opendal-service-azblob@0.57.0	X												
+opendal-service-azdls@0.57.0	X												
+opendal-service-azfile@0.57.0	X												
+opendal-service-azure-common@0.57.0	X												
+opendal-service-cos@0.57.0	X												
+opendal-service-fs@0.57.0	X												
+opendal-service-gcs@0.57.0	X												
+opendal-service-ghac@0.57.0	X												
+opendal-service-http@0.57.0	X												
+opendal-service-ipmfs@0.57.0	X												
+opendal-service-obs@0.57.0	X												
+opendal-service-oss@0.57.0	X												
+opendal-service-s3@0.57.0	X												
+opendal-service-webdav@0.57.0	X												
+opendal-service-webhdfs@0.57.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-multimap@0.7.3										X			
 parking_lot@0.12.5	X									X			
@@ -148,19 +151,18 @@ pkcs1@0.7.5	X									X
 pkcs5@0.7.1	X									X			
 pkcs8@0.10.2	X									X			
 portable-atomic@1.13.1	X									X			
-portable-atomic-util@0.2.6	X									X			
+portable-atomic-util@0.2.7	X									X			
 potential_utf@0.1.5												X	
 powerfmt@0.2.0	X									X			
 ppv-lite86@0.2.21	X									X			
 proc-macro2@1.0.106	X									X			
-prost@0.13.5	X												
-prost-derive@0.13.5	X												
-quick-xml@0.38.4										X			
-quick-xml@0.39.2										X			
+prost@0.14.3	X												
+prost-derive@0.14.3	X												
+quick-xml@0.39.4										X			
 quote@1.0.45	X									X			
 r-efi@5.3.0	X								X	X			
 r-efi@6.0.0	X								X	X			
-rand@0.8.5	X									X			
+rand@0.8.6	X									X			
 rand_chacha@0.3.1	X									X			
 rand_core@0.6.4	X									X			
 redox_syscall@0.5.18										X			
@@ -172,17 +174,17 @@ reqsign-file-read-tokio@3.0.0	X
 reqsign-google@3.0.0	X												
 reqsign-huaweicloud-obs@3.0.0	X												
 reqsign-tencent-cos@3.0.0	X												
-reqwest@0.13.2	X									X			
+reqwest@0.13.3	X									X			
 rsa@0.9.10	X									X			
 rust-ini@0.21.3										X			
 rustc_version@0.4.1	X									X			
 rustix@1.1.4	X	X								X			
-rustls@0.23.38	X							X		X			
+rustls@0.23.40	X							X		X			
 rustls-native-certs@0.8.3	X							X		X			
-rustls-pki-types@1.14.0	X									X			
-rustls-platform-verifier@0.6.2	X									X			
+rustls-pki-types@1.14.1	X									X			
+rustls-platform-verifier@0.7.0	X									X			
 rustls-platform-verifier-android@0.1.1	X									X			
-rustls-webpki@0.103.12								X					
+rustls-webpki@0.103.13								X					
 rustversion@1.0.22	X									X			
 ryu@1.0.23	X				X								
 salsa20@0.10.2	X									X			
@@ -196,13 +198,16 @@ semver@1.0.28	X									X
 serde@1.0.228	X									X			
 serde_core@1.0.228	X									X			
 serde_derive@1.0.228	X									X			
-serde_json@1.0.149	X									X			
+serde_json@1.0.150	X									X			
 serde_urlencoded@0.7.1	X									X			
 sha1@0.10.6	X									X			
 sha2@0.10.9	X									X			
+sha2@0.11.0	X									X			
 shlex@1.3.0	X									X			
 signal-hook-registry@1.4.8	X									X			
 signature@2.2.0	X									X			
+simd_cesu8@1.1.1	X									X			
+simdutf8@0.1.5	X									X			
 simple_asn1@0.6.4								X					
 slab@0.4.12										X			
 smallvec@1.15.1	X									X			
@@ -214,27 +219,25 @@ subtle@2.6.1				X
 syn@2.0.117	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
-thiserror@1.0.69	X									X			
 thiserror@2.0.18	X									X			
-thiserror-impl@1.0.69	X									X			
 thiserror-impl@2.0.18	X									X			
 time@0.3.47	X									X			
 time-core@0.1.8	X									X			
 time-macros@0.2.27	X									X			
 tiny-keccak@2.0.2						X							
 tinystr@0.8.3												X	
-tokio@1.52.0										X			
+tokio@1.52.3										X			
 tokio-macros@2.7.0										X			
 tokio-rustls@0.26.4	X									X			
 tokio-util@0.7.18										X			
 tower@0.5.3										X			
-tower-http@0.6.8										X			
+tower-http@0.6.11										X			
 tower-layer@0.3.3										X			
 tower-service@0.3.3										X			
 tracing@0.1.44										X			
 tracing-core@0.1.36										X			
 try-lock@0.2.5										X			
-typenum@1.19.0	X									X			
+typenum@1.20.0	X									X			
 unicode-ident@1.0.24	X									X		X	
 untrusted@0.7.1								X					
 untrusted@0.9.0								X					
@@ -247,27 +250,18 @@ want@0.3.1										X
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
 wasip2@1.0.1+wasi-0.2.4	X	X								X			
 wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
-wasm-bindgen@0.2.118	X									X			
-wasm-bindgen-futures@0.4.68	X									X			
-wasm-bindgen-macro@0.2.118	X									X			
-wasm-bindgen-macro-support@0.2.118	X									X			
-wasm-bindgen-shared@0.2.118	X									X			
+wasm-bindgen@0.2.121	X									X			
+wasm-bindgen-futures@0.4.71	X									X			
+wasm-bindgen-macro@0.2.121	X									X			
+wasm-bindgen-macro-support@0.2.121	X									X			
+wasm-bindgen-shared@0.2.121	X									X			
 wasm-streams@0.5.0	X									X			
-web-sys@0.3.95	X									X			
+web-sys@0.3.98	X									X			
 web-time@1.1.0	X									X			
-webpki-root-certs@1.0.6							X						
+webpki-root-certs@1.0.7							X						
 winapi-util@0.1.11										X			X
 windows-link@0.2.1	X									X			
-windows-sys@0.45.0	X									X			
 windows-sys@0.61.2	X									X			
-windows-targets@0.42.2	X									X			
-windows_aarch64_gnullvm@0.42.2	X									X			
-windows_aarch64_msvc@0.42.2	X									X			
-windows_i686_gnu@0.42.2	X									X			
-windows_i686_msvc@0.42.2	X									X			
-windows_x86_64_gnu@0.42.2	X									X			
-windows_x86_64_gnullvm@0.42.2	X									X			
-windows_x86_64_msvc@0.42.2	X									X			
 wit-bindgen@0.46.0	X	X								X			
 wit-bindgen@0.51.0	X	X								X			
 writeable@0.6.3												X	
@@ -275,7 +269,7 @@ xattr@1.6.1	X									X
 yoke@0.8.2												X	
 yoke-derive@0.8.2												X	
 zerocopy@0.8.48	X		X							X			
-zerofrom@0.1.7												X	
+zerofrom@0.1.8												X	
 zerofrom-derive@0.1.7												X	
 zeroize@1.8.2	X									X			
 zerotrie@0.2.4												X	

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -1,665 +1,694 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib
-aes@0.8.4	X									X					
-ahash@0.8.12	X									X					
-aho-corasick@1.1.4										X				X	
-allocator-api2@0.2.21	X									X					
-android_system_properties@0.1.5	X									X					
-anstream@1.0.0	X									X					
-anstyle@1.0.14	X									X					
-anstyle-parse@1.0.0	X									X					
-anstyle-query@1.1.5	X									X					
-anstyle-wincon@3.0.11	X									X					
-anyhow@1.0.102	X									X					
-approx@0.5.1	X														
-arc-swap@1.9.1	X									X					
-arcstr@1.2.0	X									X					X
-arrayref@0.3.9			X												
-arrayvec@0.7.6	X									X					
-async-lock@3.4.2	X									X					
-async-recursion@0.3.2	X									X					
-async-stream@0.3.6										X					
-async-stream-impl@0.3.6										X					
-async-trait@0.1.89	X									X					
-atoi@2.0.0										X					
-atomic-waker@1.1.2	X									X					
-autocfg@1.5.0	X									X					
-awaitable@0.4.0										X					
-awaitable-error@0.1.0										X					
-aws-lc-rs@1.16.3	X							X							
-aws-lc-sys@0.40.0	X			X				X		X	X				
-axum@0.6.20										X					
-axum@0.8.9										X					
-axum-core@0.3.4										X					
-axum-core@0.5.6										X					
-backon@1.6.0	X														
-base64@0.21.7	X									X					
-base64@0.22.1	X									X					
-base64ct@1.8.3	X									X					
-bitflags@1.3.2	X									X					
-bitflags@2.11.1	X									X					
-bitvec@1.0.1										X					
-blake3@1.8.4	X	X				X									
-block-buffer@0.10.4	X									X					
-block-padding@0.3.3	X									X					
-bson@2.15.0										X					
-bstr@1.12.1	X									X					
-bumpalo@3.20.2	X									X					
-bytecount@0.6.9	X									X					
-bytemuck@1.25.0	X									X					X
-byteorder@1.5.0										X				X	
-bytes@1.11.1										X					
-cacache@13.1.0	X														
-camino@1.2.2	X									X					
-cargo-platform@0.1.9	X									X					
-cargo_metadata@0.14.2										X					
-cbc@0.1.2	X									X					
-cc@1.2.60	X									X					
-cesu8@1.1.0	X									X					
-cfg-if@0.1.10	X									X					
-cfg-if@1.0.4	X									X					
-chacha20@0.10.0	X									X					
-chrono@0.4.44	X									X					
-cipher@0.4.4	X									X					
-clap@4.6.1	X									X					
-clap_builder@4.6.0	X									X					
-clap_derive@4.6.1	X									X					
-clap_lex@1.1.0	X									X					
-cmake@0.1.58	X									X					
-colorchoice@1.0.5	X									X					
-colored@3.1.1												X			
-combine@4.6.7										X					
-concurrent-queue@2.5.0	X									X					
-concurrent_arena@0.1.11										X					
-const-oid@0.9.6	X									X					
-const-random@0.1.18	X									X					
-const-random-macro@0.1.16	X									X					
-const-str@1.1.0										X					
-const_panic@0.2.15															X
-constant_time_eq@0.4.2	X					X					X				
-convert_case@0.10.0										X					
-core-foundation@0.10.1	X									X					
-core-foundation@0.9.4	X									X					
-core-foundation-sys@0.8.7	X									X					
-countio@0.3.0										X					
-cpufeatures@0.2.17	X									X					
-cpufeatures@0.3.0	X									X					
-crc@3.4.0	X									X					
-crc-catalog@2.4.0	X									X					
-crc16@0.4.0										X					
-crc32c@0.6.8	X									X					
-crc32fast@1.5.0	X									X					
-critical-section@1.2.0	X									X					
-crossbeam-channel@0.5.15	X									X					
-crossbeam-epoch@0.9.18	X									X					
-crossbeam-queue@0.3.12	X									X					
-crossbeam-utils@0.8.21	X									X					
-crunchy@0.2.4										X					
-crypto-common@0.1.7	X									X					
-csv@1.4.0										X				X	
-csv-core@0.1.13										X				X	
-ctor@0.6.3	X									X					
-ctor-proc-macro@0.0.7	X									X					
-darling@0.21.3										X					
-darling_core@0.21.3										X					
-darling_macro@0.21.3										X					
-dashmap@5.5.3										X					
-dashmap@6.1.0										X					
-data-encoding@2.10.0										X					
-der@0.7.10	X									X					
-deranged@0.5.8	X									X					
-derivative@2.2.0	X									X					
-derive-new@0.5.9										X					
-derive-syn-parse@0.2.0	X									X					
-derive-where@1.6.1	X									X					
-derive_destructure2@0.1.3	X									X					
-derive_more@2.1.1										X					
-derive_more-impl@2.1.1										X					
-digest@0.10.7	X									X					
-dirs@6.0.0	X									X					
-dirs-sys@0.5.0	X									X					
-displaydoc@0.2.5	X									X					
-dlv-list@0.5.2	X									X					
-dotenvy@0.15.7										X					
-dtor@0.1.1	X									X					
-dtor-proc-macro@0.0.6	X									X					
-dunce@1.0.5	X					X					X				
-either@1.15.0	X									X					
-enum-as-inner@0.6.1	X									X					
-equivalent@1.0.2	X									X					
-errno@0.3.14	X									X					
-error-chain@0.12.4	X									X					
-etcd-client@0.17.0	X									X					
-etcetera@0.8.0	X									X					
-event-listener@5.4.1	X									X					
-event-listener-strategy@0.5.4	X									X					
-fail@0.4.0	X														
-fastpool@1.1.0	X														
-fastrand@2.4.1	X									X					
-find-msvc-tools@0.1.9	X									X					
-fixedbitset@0.5.7	X									X					
-flume@0.11.1	X									X					
-fnv@1.0.7	X									X					
-foldhash@0.1.5															X
-form_urlencoded@1.2.2	X									X					
-fs2@0.4.3	X									X					
-fs_extra@1.3.0										X					
-funty@2.0.0										X					
-futures@0.3.32	X									X					
-futures-channel@0.3.32	X									X					
-futures-core@0.3.32	X									X					
-futures-executor@0.3.32	X									X					
-futures-intrusive@0.5.0	X									X					
-futures-io@0.3.32	X									X					
-futures-macro@0.3.32	X									X					
-futures-sink@0.3.32	X									X					
-futures-task@0.3.32	X									X					
-futures-util@0.3.32	X									X					
-fxhash@0.2.1	X									X					
-gearhash@0.1.3	X									X					
-generic-array@0.14.7										X					
-getrandom@0.1.16	X									X					
-getrandom@0.2.17	X									X					
-getrandom@0.3.4	X									X					
-getrandom@0.4.2	X									X					
-ghac@0.2.0	X														
-git-version@0.3.9			X												
-git-version-macro@0.3.9			X												
-glob@0.3.3	X									X					
-gloo-timers@0.3.0	X									X					
-h2@0.3.27										X					
-h2@0.4.13										X					
-hashbrown@0.12.3	X									X					
-hashbrown@0.14.5	X									X					
-hashbrown@0.15.5	X									X					
-hashbrown@0.17.0	X									X					
-hashlink@0.10.0	X									X					
-heapify@0.2.0	X									X					
-heck@0.5.0	X									X					
-hex@0.4.3	X									X					
-hf-xet@1.5.1	X														
-hickory-proto@0.25.2	X									X					
-hickory-resolver@0.25.2	X									X					
-hkdf@0.12.4	X									X					
-hmac@0.12.1	X									X					
-home@0.5.11	X									X					
-http@0.2.12	X									X					
-http@1.4.0	X									X					
-http-body@0.4.6										X					
-http-body@1.0.1										X					
-http-body-util@0.1.3										X					
-httparse@1.10.1	X									X					
-httpdate@1.0.3	X									X					
-humantime@2.3.0	X									X					
-hyper@0.14.32										X					
-hyper@1.9.0										X					
-hyper-rustls@0.27.9	X							X		X					
-hyper-timeout@0.4.1	X									X					
-hyper-timeout@0.5.2	X									X					
-hyper-util@0.1.20										X					
-iana-time-zone@0.1.65	X									X					
-iana-time-zone-haiku@0.1.2	X									X					
-icu_collections@2.1.1													X		
-icu_locale_core@2.1.1													X		
-icu_normalizer@2.1.1													X		
-icu_normalizer_data@2.1.1													X		
-icu_properties@2.1.2													X		
-icu_properties_data@2.1.2													X		
-icu_provider@2.1.1													X		
-ident_case@1.0.1	X									X					
-idna@1.1.0	X									X					
-idna_adapter@1.2.1	X									X					
-indexmap@1.9.3	X									X					
-indexmap@2.14.0	X									X					
-inout@0.1.4	X									X					
-instant@0.1.13				X											
-ipconfig@0.3.4	X									X					
-ipnet@2.12.0	X									X					
-iri-string@0.7.12	X									X					
-is_terminal_polyfill@1.70.2	X									X					
-itertools@0.12.1	X									X					
-itertools@0.14.0	X									X					
-itoa@1.0.18	X									X					
-jiff@0.2.23										X				X	
-jiff-tzdb@0.1.6										X				X	
-jiff-tzdb-platform@0.1.3										X				X	
-jni@0.21.1	X									X					
-jni-sys@0.3.1	X									X					
-jni-sys@0.4.1	X									X					
-jni-sys-macros@0.4.1	X									X					
-jobserver@0.1.34	X									X					
-js-sys@0.3.95	X									X					
-jsonwebtoken@10.3.0										X					
-konst@0.4.3															X
-konst_proc_macros@0.4.1															X
-lazy_static@1.5.0	X									X					
-libc@0.2.185	X									X					
-libm@0.2.16										X					
-libredox@0.1.16										X					
-libsqlite3-sys@0.30.1										X					
-linked-hash-map@0.5.6	X									X					
-linux-raw-sys@0.12.1	X	X								X					
-litemap@0.8.2													X		
-lock_api@0.4.14	X									X					
-log@0.4.29	X									X					
-lz4_flex@0.13.0										X					
-macro_magic@0.5.1										X					
-macro_magic_core@0.5.1										X					
-macro_magic_core_macros@0.5.1										X					
-macro_magic_macros@0.5.1										X					
-matchers@0.2.0										X					
-matchit@0.7.3				X						X					
-matchit@0.8.4				X						X					
-md-5@0.10.6	X									X					
-mea@0.6.3	X														
-memchr@2.8.0										X				X	
-memmap2@0.5.10	X									X					
-miette@5.10.0	X														
-miette-derive@5.10.0	X														
-mime@0.3.17	X									X					
-mini-moka@0.10.3	X									X					
-mio@1.2.0										X					
-moka@0.12.15	X									X					
-mongodb@3.5.2	X														
-mongodb-internal-macros@3.5.2	X														
-more-asserts@0.3.1	X					X				X				X	
-multimap@0.10.1	X									X					
-ntapi@0.4.3	X									X					
-nu-ansi-term@0.50.3										X					
-num-bigint@0.4.6	X									X					
-num-bigint-dig@0.8.6	X									X					
-num-conv@0.2.1	X									X					
-num-derive@0.4.2	X									X					
-num-integer@0.1.46	X									X					
-num-iter@0.1.45	X									X					
-num-traits@0.2.19	X									X					
-objc2-core-foundation@0.3.2	X									X					X
-objc2-io-kit@0.3.2	X									X					X
-objc2-system-configuration@0.3.2	X									X					X
-once_cell@1.21.4	X									X					
-once_cell_polyfill@1.70.2	X									X					
-oneshot@0.1.13	X									X					
-opendal@0.56.0	X														
-opendal-core@0.56.0	X														
-opendal-java@0.0.0	X														
-opendal-layer-concurrent-limit@0.56.0	X														
-opendal-layer-logging@0.56.0	X														
-opendal-layer-retry@0.56.0	X														
-opendal-layer-timeout@0.56.0	X														
-opendal-service-aliyun-drive@0.56.0	X														
-opendal-service-alluxio@0.56.0	X														
-opendal-service-azblob@0.56.0	X														
-opendal-service-azdls@0.56.0	X														
-opendal-service-azfile@0.56.0	X														
-opendal-service-azure-common@0.56.0	X														
-opendal-service-b2@0.56.0	X														
-opendal-service-cacache@0.56.0	X														
-opendal-service-cos@0.56.0	X														
-opendal-service-dashmap@0.56.0	X														
-opendal-service-dropbox@0.56.0	X														
-opendal-service-etcd@0.56.0	X														
-opendal-service-fs@0.56.0	X														
-opendal-service-gcs@0.56.0	X														
-opendal-service-gdrive@0.56.0	X														
-opendal-service-ghac@0.56.0	X														
-opendal-service-gridfs@0.56.0	X														
-opendal-service-hf@0.56.0	X														
-opendal-service-http@0.56.0	X														
-opendal-service-ipfs@0.56.0	X														
-opendal-service-ipmfs@0.56.0	X														
-opendal-service-koofr@0.56.0	X														
-opendal-service-memcached@0.56.0	X														
-opendal-service-mini-moka@0.56.0	X														
-opendal-service-moka@0.56.0	X														
-opendal-service-mongodb@0.56.0	X														
-opendal-service-mysql@0.56.0	X														
-opendal-service-obs@0.56.0	X														
-opendal-service-onedrive@0.56.0	X														
-opendal-service-oss@0.56.0	X														
-opendal-service-persy@0.56.0	X														
-opendal-service-postgresql@0.56.0	X														
-opendal-service-redb@0.56.0	X														
-opendal-service-redis@0.56.0	X														
-opendal-service-s3@0.56.0	X														
-opendal-service-seafile@0.56.0	X														
-opendal-service-sftp@0.56.0	X														
-opendal-service-sled@0.56.0	X														
-opendal-service-sqlite@0.56.0	X														
-opendal-service-swift@0.56.0	X														
-opendal-service-tikv@0.56.0	X														
-opendal-service-upyun@0.56.0	X														
-opendal-service-vercel-artifacts@0.56.0	X														
-opendal-service-webdav@0.56.0	X														
-opendal-service-webhdfs@0.56.0	X														
-opendal-service-yandex-disk@0.56.0	X														
-openssh@0.11.6	X									X					
-openssh-sftp-client@0.15.6										X					
-openssh-sftp-client-lowlevel@0.7.2										X					
-openssh-sftp-error@0.5.1										X					
-openssh-sftp-protocol@0.24.1										X					
-openssh-sftp-protocol-error@0.1.1										X					
-openssl-probe@0.2.1	X									X					
-option-ext@0.2.0												X			
-ordered-multimap@0.7.3										X					
-os_str_bytes@6.6.1	X									X					
-parking@2.2.1	X									X					
-parking_lot@0.11.2	X									X					
-parking_lot@0.12.5	X									X					
-parking_lot_core@0.8.6	X									X					
-parking_lot_core@0.9.12	X									X					
-pbkdf2@0.12.2	X									X					
-pem@3.0.6										X					
-pem-rfc7468@0.7.0	X									X					
-percent-encoding@2.3.2	X									X					
-persy@1.7.1												X			
-petgraph@0.8.3	X									X					
-pin-project@1.1.11	X									X					
-pin-project-internal@1.1.11	X									X					
-pin-project-lite@0.2.17	X									X					
-pin-utils@0.1.0	X									X					
-pkcs1@0.7.5	X									X					
-pkcs5@0.7.1	X									X					
-pkcs8@0.10.2	X									X					
-pkg-config@0.3.33	X									X					
-plain@0.2.3	X									X					
-portable-atomic@1.13.1	X									X					
-portable-atomic-util@0.2.6	X									X					
-potential_utf@0.1.5													X		
-powerfmt@0.2.0	X									X					
-ppv-lite86@0.2.21	X									X					
-prettyplease@0.2.37	X									X					
-proc-macro2@1.0.106	X									X					
-prometheus@0.13.4	X														
-prost@0.12.6	X														
-prost@0.13.5	X														
-prost@0.14.3	X														
-prost-build@0.14.3	X														
-prost-derive@0.12.6	X														
-prost-derive@0.13.5	X														
-prost-derive@0.14.3	X														
-prost-types@0.14.3	X														
-pulldown-cmark@0.13.3										X					
-pulldown-cmark@0.9.6										X					
-pulldown-cmark-to-cmark@22.0.0	X														
-quick-xml@0.38.4										X					
-quick-xml@0.39.2										X					
-quote@1.0.45	X									X					
-r-efi@5.3.0	X								X	X					
-r-efi@6.0.0	X								X	X					
-radium@0.7.0										X					
-rand@0.10.1	X									X					
-rand@0.7.3	X									X					
-rand@0.8.5	X									X					
-rand@0.9.4	X									X					
-rand_chacha@0.2.2	X									X					
-rand_chacha@0.3.1	X									X					
-rand_chacha@0.9.0	X									X					
-rand_core@0.10.1	X									X					
-rand_core@0.5.1	X									X					
-rand_core@0.6.4	X									X					
-rand_core@0.9.5	X									X					
-rand_hc@0.2.0	X									X					
-redb@2.6.3	X									X					
-redb@3.1.3	X									X					
-redis@1.2.0				X											
-redox_syscall@0.2.16										X					
-redox_syscall@0.5.18										X					
-redox_users@0.5.2										X					
-reflink-copy@0.1.29	X									X					
-regex@1.12.3	X									X					
-regex-automata@0.4.14	X									X					
-regex-syntax@0.8.10	X									X					
-reqsign-aliyun-oss@3.0.0	X														
-reqsign-aws-v4@3.0.0	X														
-reqsign-azure-storage@3.0.0	X														
-reqsign-core@3.0.0	X														
-reqsign-file-read-tokio@3.0.0	X														
-reqsign-google@3.0.0	X														
-reqsign-huaweicloud-obs@3.0.0	X														
-reqsign-tencent-cos@3.0.0	X														
-reqwest@0.13.2	X									X					
-reqwest-middleware@0.5.1	X									X					
-reqwest-retry@0.9.1	X									X					
-resolv-conf@0.7.6	X									X					
-retry-policies@0.5.1	X									X					
-ring@0.17.14	X							X							
-rsa@0.9.10	X									X					
-rust-ini@0.21.3										X					
-rustc_version@0.4.1	X									X					
-rustc_version_runtime@0.3.0										X					
-rustix@1.1.4	X	X								X					
-rustls@0.21.12	X							X		X					
-rustls@0.23.38	X							X		X					
-rustls-native-certs@0.8.3	X							X		X					
-rustls-pemfile@1.0.4	X							X		X					
-rustls-pki-types@1.14.0	X									X					
-rustls-platform-verifier@0.6.2	X									X					
-rustls-platform-verifier-android@0.1.1	X									X					
-rustls-webpki@0.101.7								X							
-rustls-webpki@0.103.12								X							
-rustversion@1.0.22	X									X					
-ryu@1.0.23	X				X										
-safe-transmute@0.11.3										X					
-salsa20@0.10.2	X									X					
-same-file@1.0.6										X				X	
-schannel@0.1.29										X					
-scopeguard@1.2.0	X									X					
-scrypt@0.11.0	X									X					
-sct@0.7.1	X							X		X					
-security-framework@3.7.0	X									X					
-security-framework-sys@2.17.0	X									X					
-semver@1.0.28	X									X					
-serde@1.0.228	X									X					
-serde_bytes@0.11.19	X									X					
-serde_core@1.0.228	X									X					
-serde_derive@1.0.228	X									X					
-serde_json@1.0.149	X									X					
-serde_repr@0.1.20	X									X					
-serde_urlencoded@0.7.1	X									X					
-serde_with@3.17.0	X									X					
-serde_with_macros@3.17.0	X									X					
-sha-1@0.10.1	X									X					
-sha1@0.10.6	X									X					
-sha1_smol@1.0.1				X											
-sha2@0.10.9	X									X					
-sha2-asm@0.6.4										X					
-sharded-slab@0.1.7										X					
-shell-escape@0.1.5	X									X					
-shellexpand@3.1.2	X									X					
-shlex@1.3.0	X									X					
-signal-hook-registry@1.4.8	X									X					
-signature@2.2.0	X									X					
-simple_asn1@0.6.4								X							
-skeptic@0.13.7	X									X					
-slab@0.4.12										X					
-sled@0.34.7	X									X					
-smallvec@1.15.1	X									X					
-socket2@0.5.10	X									X					
-socket2@0.6.3	X									X					
-spin@0.9.8										X					
-spki@0.7.3	X									X					
-sqlx@0.8.6	X									X					
-sqlx-core@0.8.6	X									X					
-sqlx-macros@0.8.6	X									X					
-sqlx-macros-core@0.8.6	X									X					
-sqlx-mysql@0.8.6	X									X					
-sqlx-postgres@0.8.6	X									X					
-sqlx-sqlite@0.8.6	X									X					
-ssh_format@0.14.1										X					
-ssh_format_error@0.1.0										X					
-ssri@9.2.0	X														
-stable_deref_trait@1.2.1	X									X					
-static_assertions@1.1.0	X									X					
-statrs@0.18.0										X					
-stringprep@0.1.5	X									X					
-strsim@0.11.1										X					
-subtle@2.6.1				X											
-syn@1.0.109	X									X					
-syn@2.0.117	X									X					
-sync_wrapper@0.1.2	X														
-sync_wrapper@1.0.2	X														
-synstructure@0.13.2										X					
-sysinfo@0.38.4										X					
-system-configuration@0.7.0	X									X					
-system-configuration-sys@0.6.0	X									X					
-tagptr@0.2.0	X									X					
-take_mut@0.2.2										X					
-tap@1.0.1										X					
-tempfile@3.27.0	X									X					
-thin-vec@0.2.16	X									X					
-thiserror@1.0.69	X									X					
-thiserror@2.0.18	X									X					
-thiserror-impl@1.0.69	X									X					
-thiserror-impl@2.0.18	X									X					
-thread_local@1.1.9	X									X					
-tikv-client@0.3.0	X														
-time@0.3.47	X									X					
-time-core@0.1.8	X									X					
-time-macros@0.2.27	X									X					
-tiny-keccak@2.0.2						X									
-tinystr@0.8.3													X		
-tinyvec@1.11.0	X									X					X
-tinyvec_macros@0.1.1	X									X					X
-tokio@1.52.0										X					
-tokio-io-timeout@1.2.1	X									X					
-tokio-io-utility@0.7.6										X					
-tokio-macros@2.7.0										X					
-tokio-retry@0.3.1										X					
-tokio-rustls@0.24.1	X									X					
-tokio-rustls@0.26.4	X									X					
-tokio-stream@0.1.18										X					
-tokio-util@0.7.18										X					
-tonic@0.10.2										X					
-tonic@0.14.5										X					
-tonic-build@0.14.5										X					
-tonic-prost@0.14.5										X					
-tonic-prost-build@0.14.5										X					
-tower@0.4.13										X					
-tower@0.5.3										X					
-tower-http@0.6.8										X					
-tower-layer@0.3.3										X					
-tower-service@0.3.3										X					
-tracing@0.1.44										X					
-tracing-appender@0.2.4										X					
-tracing-attributes@0.1.31										X					
-tracing-core@0.1.36										X					
-tracing-log@0.2.0										X					
-tracing-serde@0.2.0										X					
-tracing-subscriber@0.3.23										X					
-triomphe@0.1.15	X									X					
-try-lock@0.2.5										X					
-twox-hash@2.1.2										X					
-typed-builder@0.22.0	X									X					
-typed-builder-macro@0.22.0	X									X					
-typenum@1.19.0	X									X					
-typewit@1.15.2															X
-ulid@1.2.1										X					
-unicase@2.9.0	X									X					
-unicode-bidi@0.3.18	X									X					
-unicode-ident@1.0.24	X									X			X		
-unicode-normalization@0.1.25	X									X					
-unicode-properties@0.1.4	X									X					
-unicode-segmentation@1.13.2	X									X					
-unicode-width@0.1.14	X									X					
-unicode-xid@0.2.6	X									X					
-unsigned-varint@0.8.0										X					
-untrusted@0.7.1								X							
-untrusted@0.9.0								X							
-url@2.5.8	X									X					
-urlencoding@2.1.3										X					
-utf8_iter@1.0.4	X									X					
-utf8parse@0.2.2	X									X					
-uuid@1.23.1	X									X					
-vcpkg@0.2.15	X									X					
-vec-strings@0.4.8										X					
-version_check@0.9.5	X									X					
-walkdir@2.5.0										X				X	
-want@0.3.1										X					
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X					
-wasi@0.14.7+wasi-0.2.4	X	X								X					
-wasi@0.9.0+wasi-snapshot-preview1	X	X								X					
-wasip2@1.0.1+wasi-0.2.4	X	X								X					
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X					
-wasite@0.1.0	X				X					X					
-wasite@1.0.2	X				X					X					
-wasm-bindgen@0.2.118	X									X					
-wasm-bindgen-futures@0.4.68	X									X					
-wasm-bindgen-macro@0.2.118	X									X					
-wasm-bindgen-macro-support@0.2.118	X									X					
-wasm-bindgen-shared@0.2.118	X									X					
-wasm-streams@0.5.0	X									X					
-wasmtimer@0.4.3										X					
-web-sys@0.3.95	X									X					
-web-time@1.1.0	X									X					
-webpki-root-certs@1.0.6							X								
-webpki-roots@0.26.11							X								
-webpki-roots@1.0.6							X								
-whoami@1.6.1	X				X					X					
-whoami@2.1.1	X				X					X					
-widestring@1.2.1	X									X					
-winapi@0.3.9	X									X					
-winapi-i686-pc-windows-gnu@0.4.0	X									X					
-winapi-util@0.1.11										X				X	
-winapi-x86_64-pc-windows-gnu@0.4.0	X									X					
-windows@0.62.2	X									X					
-windows-collections@0.3.2	X									X					
-windows-core@0.62.2	X									X					
-windows-future@0.3.2	X									X					
-windows-implement@0.60.2	X									X					
-windows-interface@0.59.3	X									X					
-windows-link@0.2.1	X									X					
-windows-numerics@0.3.1	X									X					
-windows-registry@0.6.1	X									X					
-windows-result@0.4.1	X									X					
-windows-strings@0.5.1	X									X					
-windows-sys@0.45.0	X									X					
-windows-sys@0.48.0	X									X					
-windows-sys@0.52.0	X									X					
-windows-sys@0.59.0	X									X					
-windows-sys@0.61.2	X									X					
-windows-targets@0.42.2	X									X					
-windows-targets@0.48.5	X									X					
-windows-targets@0.52.6	X									X					
-windows-threading@0.2.1	X									X					
-windows_aarch64_gnullvm@0.42.2	X									X					
-windows_aarch64_gnullvm@0.48.5	X									X					
-windows_aarch64_gnullvm@0.52.6	X									X					
-windows_aarch64_msvc@0.42.2	X									X					
-windows_aarch64_msvc@0.48.5	X									X					
-windows_aarch64_msvc@0.52.6	X									X					
-windows_i686_gnu@0.42.2	X									X					
-windows_i686_gnu@0.48.5	X									X					
-windows_i686_gnu@0.52.6	X									X					
-windows_i686_gnullvm@0.52.6	X									X					
-windows_i686_msvc@0.42.2	X									X					
-windows_i686_msvc@0.48.5	X									X					
-windows_i686_msvc@0.52.6	X									X					
-windows_x86_64_gnu@0.42.2	X									X					
-windows_x86_64_gnu@0.48.5	X									X					
-windows_x86_64_gnu@0.52.6	X									X					
-windows_x86_64_gnullvm@0.42.2	X									X					
-windows_x86_64_gnullvm@0.48.5	X									X					
-windows_x86_64_gnullvm@0.52.6	X									X					
-windows_x86_64_msvc@0.42.2	X									X					
-windows_x86_64_msvc@0.48.5	X									X					
-windows_x86_64_msvc@0.52.6	X									X					
-wit-bindgen@0.46.0	X	X								X					
-wit-bindgen@0.51.0	X	X								X					
-writeable@0.6.3													X		
-wyz@0.5.1										X					
-xattr@1.6.1	X									X					
-xet-client@1.5.1	X														
-xet-core-structures@1.5.1	X														
-xet-data@1.5.1	X														
-xet-runtime@1.5.1	X														
-xxhash-rust@0.8.15					X										
-yoke@0.8.2													X		
-yoke-derive@0.8.2													X		
-zerocopy@0.8.48	X		X							X					
-zerofrom@0.1.7													X		
-zerofrom-derive@0.1.7													X		
-zeroize@1.8.2	X									X					
-zerotrie@0.2.4													X		
-zerovec@0.11.6													X		
-zerovec-derive@0.11.3													X		
-zigzag@0.1.0										X					
-zmij@1.0.21										X					
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib
+adler2@2.0.1	X	X									X					
+aes@0.8.4		X									X					
+ahash@0.8.12		X									X					
+aho-corasick@1.1.4											X				X	
+allocator-api2@0.2.21		X									X					
+android_system_properties@0.1.5		X									X					
+anstream@1.0.0		X									X					
+anstyle@1.0.14		X									X					
+anstyle-parse@1.0.0		X									X					
+anstyle-query@1.1.5		X									X					
+anstyle-wincon@3.0.11		X									X					
+anyhow@1.0.102		X									X					
+approx@0.5.1		X														
+arc-swap@1.9.1		X									X					
+arcstr@1.2.0		X									X					X
+arrayref@0.3.9				X												
+arrayvec@0.7.6		X									X					
+async-lock@3.4.2		X									X					
+async-recursion@0.3.2		X									X					
+async-stream@0.3.6											X					
+async-stream-impl@0.3.6											X					
+async-trait@0.1.89		X									X					
+atoi@2.0.0											X					
+atomic-waker@1.1.2		X									X					
+autocfg@1.5.0		X									X					
+awaitable@0.4.0											X					
+awaitable-error@0.1.0											X					
+aws-lc-rs@1.17.0		X							X							
+aws-lc-sys@0.41.0		X			X				X		X	X				
+axum@0.6.20											X					
+axum@0.7.9											X					
+axum@0.8.9											X					
+axum-core@0.3.4											X					
+axum-core@0.4.5											X					
+axum-core@0.5.6											X					
+backon@1.6.0		X														
+base64@0.21.7		X									X					
+base64@0.22.1		X									X					
+base64ct@1.8.3		X									X					
+bitflags@1.3.2		X									X					
+bitflags@2.11.1		X									X					
+bitvec@1.0.1											X					
+blake3@1.8.5		X	X				X									
+block-buffer@0.10.4		X									X					
+block-buffer@0.12.0		X									X					
+block-padding@0.3.3		X									X					
+bson@2.15.0											X					
+bstr@1.12.1		X									X					
+bumpalo@3.20.2		X									X					
+bytecount@0.6.9		X									X					
+bytemuck@1.25.0		X									X					X
+byteorder@1.5.0											X				X	
+bytes@1.11.1											X					
+cacache@13.1.0		X														
+camino@1.2.2		X									X					
+cargo-platform@0.1.9		X									X					
+cargo_metadata@0.14.2											X					
+cbc@0.1.2		X									X					
+cc@1.2.62		X									X					
+cesu8@1.1.0		X									X					
+cfg-if@0.1.10		X									X					
+cfg-if@1.0.4		X									X					
+chacha20@0.10.0		X									X					
+chrono@0.4.44		X									X					
+cipher@0.4.4		X									X					
+clap@4.6.1		X									X					
+clap_builder@4.6.0		X									X					
+clap_derive@4.6.1		X									X					
+clap_lex@1.1.0		X									X					
+cmake@0.1.58		X									X					
+cmov@0.5.3		X									X					
+colorchoice@1.0.5		X									X					
+colored@3.1.1													X			
+combine@4.6.7											X					
+concurrent-queue@2.5.0		X									X					
+concurrent_arena@0.1.11											X					
+const-oid@0.10.2		X									X					
+const-oid@0.9.6		X									X					
+const-random@0.1.18		X									X					
+const-random-macro@0.1.16		X									X					
+const-str@1.1.0											X					
+const_panic@0.2.15																X
+constant_time_eq@0.4.2		X					X					X				
+convert_case@0.10.0											X					
+core-foundation@0.10.1		X									X					
+core-foundation@0.9.4		X									X					
+core-foundation-sys@0.8.7		X									X					
+countio@0.3.0											X					
+cpufeatures@0.2.17		X									X					
+cpufeatures@0.3.0		X									X					
+crc@3.4.0		X									X					
+crc-catalog@2.5.0		X									X					
+crc16@0.4.0											X					
+crc32c@0.6.8		X									X					
+crc32fast@1.5.0		X									X					
+critical-section@1.2.0		X									X					
+crossbeam-channel@0.5.15		X									X					
+crossbeam-epoch@0.9.18		X									X					
+crossbeam-queue@0.3.12		X									X					
+crossbeam-utils@0.8.21		X									X					
+crunchy@0.2.4											X					
+crypto-common@0.1.7		X									X					
+crypto-common@0.2.2		X									X					
+csv@1.4.0											X				X	
+csv-core@0.1.13											X				X	
+ctor@0.6.3		X									X					
+ctor@1.0.6		X									X					
+ctor-proc-macro@0.0.7		X									X					
+ctutils@0.4.2		X									X					
+darling@0.21.3											X					
+darling_core@0.21.3											X					
+darling_macro@0.21.3											X					
+dashmap@5.5.3											X					
+dashmap@6.2.1											X					
+data-encoding@2.11.0											X					
+der@0.7.10		X									X					
+deranged@0.5.8		X									X					
+derive-new@0.5.9											X					
+derive-syn-parse@0.2.0		X									X					
+derive-where@1.6.1		X									X					
+derive_destructure2@0.1.3		X									X					
+derive_more@2.1.1											X					
+derive_more-impl@2.1.1											X					
+digest@0.10.7		X									X					
+digest@0.11.3		X									X					
+dirs@6.0.0		X									X					
+dirs-sys@0.5.0		X									X					
+displaydoc@0.2.5		X									X					
+dlv-list@0.5.2		X									X					
+dotenvy@0.15.7											X					
+dtor@0.1.1		X									X					
+dtor-proc-macro@0.0.6		X									X					
+dunce@1.0.5		X					X					X				
+either@1.16.0		X									X					
+enum-as-inner@0.6.1		X									X					
+equivalent@1.0.2		X									X					
+errno@0.3.14		X									X					
+error-chain@0.12.4		X									X					
+etcd-client@0.18.0		X									X					
+etcetera@0.8.0		X									X					
+event-listener@5.4.1		X									X					
+event-listener-strategy@0.5.4		X									X					
+fail@0.4.0		X														
+fastpool@1.1.0		X														
+fastrand@2.4.1		X									X					
+find-msvc-tools@0.1.9		X									X					
+fixedbitset@0.5.7		X									X					
+flate2@1.1.9		X									X					
+flume@0.11.1		X									X					
+fnv@1.0.7		X									X					
+foldhash@0.1.5																X
+form_urlencoded@1.2.2		X									X					
+fs2@0.4.3		X									X					
+fs_extra@1.3.0											X					
+funty@2.0.0											X					
+futures@0.3.32		X									X					
+futures-channel@0.3.32		X									X					
+futures-core@0.3.32		X									X					
+futures-executor@0.3.32		X									X					
+futures-intrusive@0.5.0		X									X					
+futures-io@0.3.32		X									X					
+futures-macro@0.3.32		X									X					
+futures-sink@0.3.32		X									X					
+futures-task@0.3.32		X									X					
+futures-util@0.3.32		X									X					
+fxhash@0.2.1		X									X					
+gearhash@0.1.3		X									X					
+generic-array@0.14.7											X					
+getrandom@0.1.16		X									X					
+getrandom@0.2.17		X									X					
+getrandom@0.3.4		X									X					
+getrandom@0.4.2		X									X					
+ghac@0.3.0		X														
+git-version@0.3.9				X												
+git-version-macro@0.3.9				X												
+glob@0.3.3		X									X					
+gloo-timers@0.3.0		X									X					
+goosefs-sdk@0.1.2		X														
+h2@0.3.27											X					
+h2@0.4.14											X					
+hashbrown@0.12.3		X									X					
+hashbrown@0.14.5		X									X					
+hashbrown@0.15.5		X									X					
+hashbrown@0.17.1		X									X					
+hashlink@0.10.0		X									X					
+heapify@0.2.0		X									X					
+heck@0.5.0		X									X					
+hex@0.4.3		X									X					
+hf-xet@1.5.2		X														
+hickory-proto@0.25.2		X									X					
+hickory-resolver@0.25.2		X									X					
+hkdf@0.12.4		X									X					
+hmac@0.12.1		X									X					
+hmac@0.13.0		X									X					
+home@0.5.11		X									X					
+hostname@0.3.1											X					
+http@0.2.12		X									X					
+http@1.4.0		X									X					
+http-body@0.4.6											X					
+http-body@1.0.1											X					
+http-body-util@0.1.3											X					
+httparse@1.10.1		X									X					
+httpdate@1.0.3		X									X					
+humantime@2.3.0		X									X					
+hybrid-array@0.4.12		X									X					
+hyper@0.14.32											X					
+hyper@1.9.0											X					
+hyper-rustls@0.27.9		X							X		X					
+hyper-timeout@0.4.1		X									X					
+hyper-timeout@0.5.2		X									X					
+hyper-util@0.1.20											X					
+iana-time-zone@0.1.65		X									X					
+iana-time-zone-haiku@0.1.2		X									X					
+icu_collections@2.1.1														X		
+icu_locale_core@2.1.1														X		
+icu_normalizer@2.1.1														X		
+icu_normalizer_data@2.1.1														X		
+icu_properties@2.1.2														X		
+icu_properties_data@2.1.2														X		
+icu_provider@2.1.1														X		
+ident_case@1.0.1		X									X					
+idna@1.1.0		X									X					
+idna_adapter@1.2.1		X									X					
+indexmap@1.9.3		X									X					
+indexmap@2.14.0		X									X					
+inout@0.1.4		X									X					
+instant@0.1.13					X											
+ipconfig@0.3.4		X									X					
+ipnet@2.12.0		X									X					
+is_terminal_polyfill@1.70.2		X									X					
+itertools@0.12.1		X									X					
+itertools@0.14.0		X									X					
+itoa@1.0.18		X									X					
+jiff@0.2.24											X				X	
+jiff-tzdb@0.1.6											X				X	
+jiff-tzdb-platform@0.1.3											X				X	
+jni@0.21.1		X									X					
+jni@0.22.4		X									X					
+jni-macros@0.22.4		X									X					
+jni-sys@0.3.1		X									X					
+jni-sys@0.4.1		X									X					
+jni-sys-macros@0.4.1		X									X					
+jobserver@0.1.34		X									X					
+js-sys@0.3.98		X									X					
+jsonwebtoken@10.3.0											X					
+konst@0.4.3																X
+konst_proc_macros@0.4.1																X
+lazy_static@1.5.0		X									X					
+libc@0.2.186		X									X					
+libm@0.2.16											X					
+libredox@0.1.16											X					
+libsqlite3-sys@0.30.1											X					
+link-section@0.17.2		X									X					
+linked-hash-map@0.5.6		X									X					
+linktime-proc-macro@0.1.0		X									X					
+linux-raw-sys@0.12.1		X	X								X					
+litemap@0.8.2														X		
+lock_api@0.4.14		X									X					
+log@0.4.29		X									X					
+lz4_flex@0.13.1											X					
+macro_magic@0.5.1											X					
+macro_magic_core@0.5.1											X					
+macro_magic_core_macros@0.5.1											X					
+macro_magic_macros@0.5.1											X					
+match_cfg@0.1.0		X									X					
+matchers@0.2.0											X					
+matchit@0.7.3					X						X					
+matchit@0.8.4					X						X					
+md-5@0.10.6		X									X					
+md-5@0.11.0		X									X					
+mea@0.6.3		X														
+memchr@2.8.0											X				X	
+memmap2@0.5.10		X									X					
+miette@5.10.0		X														
+miette-derive@5.10.0		X														
+mime@0.3.17		X									X					
+mini-moka@0.10.3		X									X					
+miniz_oxide@0.8.9		X									X					X
+mio@1.2.0											X					
+moka@0.12.15		X									X					
+mongodb@3.6.0		X														
+mongodb-internal-macros@3.6.0		X														
+more-asserts@0.3.1		X					X				X				X	
+multimap@0.10.1		X									X					
+ntapi@0.4.3		X									X					
+nu-ansi-term@0.50.3											X					
+num-bigint@0.4.6		X									X					
+num-bigint-dig@0.8.6		X									X					
+num-conv@0.2.2		X									X					
+num-derive@0.4.2		X									X					
+num-integer@0.1.46		X									X					
+num-iter@0.1.45		X									X					
+num-traits@0.2.19		X									X					
+objc2-core-foundation@0.3.2		X									X					X
+objc2-io-kit@0.3.2		X									X					X
+objc2-system-configuration@0.3.2		X									X					X
+once_cell@1.21.4		X									X					
+once_cell_polyfill@1.70.2		X									X					
+oneshot@0.1.13		X									X					
+opendal@0.57.0		X														
+opendal-core@0.57.0		X														
+opendal-java@0.0.0		X														
+opendal-layer-concurrent-limit@0.57.0		X														
+opendal-layer-logging@0.57.0		X														
+opendal-layer-retry@0.57.0		X														
+opendal-layer-timeout@0.57.0		X														
+opendal-service-aliyun-drive@0.57.0		X														
+opendal-service-alluxio@0.57.0		X														
+opendal-service-azblob@0.57.0		X														
+opendal-service-azdls@0.57.0		X														
+opendal-service-azfile@0.57.0		X														
+opendal-service-azure-common@0.57.0		X														
+opendal-service-b2@0.57.0		X														
+opendal-service-cacache@0.57.0		X														
+opendal-service-cos@0.57.0		X														
+opendal-service-dashmap@0.57.0		X														
+opendal-service-dropbox@0.57.0		X														
+opendal-service-etcd@0.57.0		X														
+opendal-service-fs@0.57.0		X														
+opendal-service-gcs@0.57.0		X														
+opendal-service-gdrive@0.57.0		X														
+opendal-service-ghac@0.57.0		X														
+opendal-service-goosefs@0.57.0		X														
+opendal-service-gridfs@0.57.0		X														
+opendal-service-hf@0.57.0		X														
+opendal-service-http@0.57.0		X														
+opendal-service-ipfs@0.57.0		X														
+opendal-service-ipmfs@0.57.0		X														
+opendal-service-koofr@0.57.0		X														
+opendal-service-memcached@0.57.0		X														
+opendal-service-mini-moka@0.57.0		X														
+opendal-service-moka@0.57.0		X														
+opendal-service-mongodb@0.57.0		X														
+opendal-service-mysql@0.57.0		X														
+opendal-service-obs@0.57.0		X														
+opendal-service-onedrive@0.57.0		X														
+opendal-service-oss@0.57.0		X														
+opendal-service-persy@0.57.0		X														
+opendal-service-postgresql@0.57.0		X														
+opendal-service-redb@0.57.0		X														
+opendal-service-redis@0.57.0		X														
+opendal-service-s3@0.57.0		X														
+opendal-service-seafile@0.57.0		X														
+opendal-service-sftp@0.57.0		X														
+opendal-service-sled@0.57.0		X														
+opendal-service-sqlite@0.57.0		X														
+opendal-service-swift@0.57.0		X														
+opendal-service-tikv@0.57.0		X														
+opendal-service-tos@0.57.0		X														
+opendal-service-upyun@0.57.0		X														
+opendal-service-vercel-artifacts@0.57.0		X														
+opendal-service-webdav@0.57.0		X														
+opendal-service-webhdfs@0.57.0		X														
+opendal-service-yandex-disk@0.57.0		X														
+openssh@0.11.6		X									X					
+openssh-sftp-client@0.15.7											X					
+openssh-sftp-client-lowlevel@0.7.2											X					
+openssh-sftp-error@0.5.1											X					
+openssh-sftp-protocol@0.24.1											X					
+openssh-sftp-protocol-error@0.1.1											X					
+openssl-probe@0.2.1		X									X					
+option-ext@0.2.0													X			
+ordered-multimap@0.7.3											X					
+os_str_bytes@6.6.1		X									X					
+parking@2.2.1		X									X					
+parking_lot@0.11.2		X									X					
+parking_lot@0.12.5		X									X					
+parking_lot_core@0.8.6		X									X					
+parking_lot_core@0.9.12		X									X					
+pbkdf2@0.12.2		X									X					
+pem@3.0.6											X					
+pem-rfc7468@0.7.0		X									X					
+percent-encoding@2.3.2		X									X					
+persy@1.7.1													X			
+petgraph@0.7.1		X									X					
+petgraph@0.8.3		X									X					
+pin-project@1.1.13		X									X					
+pin-project-internal@1.1.13		X									X					
+pin-project-lite@0.2.17		X									X					
+pkcs1@0.7.5		X									X					
+pkcs5@0.7.1		X									X					
+pkcs8@0.10.2		X									X					
+pkg-config@0.3.33		X									X					
+plain@0.2.3		X									X					
+portable-atomic@1.13.1		X									X					
+portable-atomic-util@0.2.7		X									X					
+potential_utf@0.1.5														X		
+powerfmt@0.2.0		X									X					
+ppv-lite86@0.2.21		X									X					
+prettyplease@0.2.37		X									X					
+proc-macro2@1.0.106		X									X					
+prometheus@0.13.4		X														
+prost@0.12.6		X														
+prost@0.13.5		X														
+prost@0.14.3		X														
+prost-build@0.13.5		X														
+prost-build@0.14.3		X														
+prost-derive@0.12.6		X														
+prost-derive@0.13.5		X														
+prost-derive@0.14.3		X														
+prost-types@0.13.5		X														
+prost-types@0.14.3		X														
+pulldown-cmark@0.13.4											X					
+pulldown-cmark@0.9.6											X					
+pulldown-cmark-to-cmark@22.0.0		X														
+quick-xml@0.39.4											X					
+quote@1.0.45		X									X					
+r-efi@5.3.0		X								X	X					
+r-efi@6.0.0		X								X	X					
+radium@0.7.0											X					
+rand@0.10.1		X									X					
+rand@0.7.3		X									X					
+rand@0.8.6		X									X					
+rand@0.9.4		X									X					
+rand_chacha@0.2.2		X									X					
+rand_chacha@0.3.1		X									X					
+rand_chacha@0.9.0		X									X					
+rand_core@0.10.1		X									X					
+rand_core@0.5.1		X									X					
+rand_core@0.6.4		X									X					
+rand_core@0.9.5		X									X					
+rand_hc@0.2.0		X									X					
+redb@2.6.3		X									X					
+redb@3.1.3		X									X					
+redis@1.2.1					X											
+redox_syscall@0.2.16											X					
+redox_syscall@0.5.18											X					
+redox_users@0.5.2											X					
+reflink-copy@0.1.29		X									X					
+regex@1.12.3		X									X					
+regex-automata@0.4.14		X									X					
+regex-syntax@0.8.10		X									X					
+reqsign-aliyun-oss@3.0.0		X														
+reqsign-aws-v4@3.0.0		X														
+reqsign-azure-storage@3.0.0		X														
+reqsign-core@3.0.0		X														
+reqsign-file-read-tokio@3.0.0		X														
+reqsign-google@3.0.0		X														
+reqsign-huaweicloud-obs@3.0.0		X														
+reqsign-tencent-cos@3.0.0		X														
+reqsign-volcengine-tos@3.0.0		X														
+reqwest@0.13.3		X									X					
+reqwest-middleware@0.5.2		X									X					
+resolv-conf@0.7.6		X									X					
+ring@0.17.14		X							X							
+rsa@0.9.10		X									X					
+rust-ini@0.21.3											X					
+rustc_version@0.4.1		X									X					
+rustc_version_runtime@0.3.0											X					
+rustix@1.1.4		X	X								X					
+rustls@0.21.12		X							X		X					
+rustls@0.23.40		X							X		X					
+rustls-native-certs@0.8.3		X							X		X					
+rustls-pemfile@1.0.4		X							X		X					
+rustls-pemfile@2.2.0		X							X		X					
+rustls-pki-types@1.14.1		X									X					
+rustls-platform-verifier@0.7.0		X									X					
+rustls-platform-verifier-android@0.1.1		X									X					
+rustls-webpki@0.101.7									X							
+rustls-webpki@0.103.13									X							
+rustversion@1.0.22		X									X					
+ryu@1.0.23		X				X										
+safe-transmute@0.11.3											X					
+salsa20@0.10.2		X									X					
+same-file@1.0.6											X				X	
+schannel@0.1.29											X					
+scopeguard@1.2.0		X									X					
+scrypt@0.11.0		X									X					
+sct@0.7.1		X							X		X					
+security-framework@3.7.0		X									X					
+security-framework-sys@2.17.0		X									X					
+semver@1.0.28		X									X					
+serde@1.0.228		X									X					
+serde_bytes@0.11.19		X									X					
+serde_core@1.0.228		X									X					
+serde_derive@1.0.228		X									X					
+serde_json@1.0.150		X									X					
+serde_repr@0.1.20		X									X					
+serde_urlencoded@0.7.1		X									X					
+serde_with@3.17.0		X									X					
+serde_with_macros@3.17.0		X									X					
+sha-1@0.10.1		X									X					
+sha1@0.10.6		X									X					
+sha1@0.11.0		X									X					
+sha1_smol@1.0.1					X											
+sha2@0.10.9		X									X					
+sha2@0.11.0		X									X					
+sha2-asm@0.6.4											X					
+sharded-slab@0.1.7											X					
+shell-escape@0.1.5		X									X					
+shellexpand@3.1.2		X									X					
+shlex@1.3.0		X									X					
+signal-hook-registry@1.4.8		X									X					
+signature@2.2.0		X									X					
+simd-adler32@0.3.9											X					
+simd_cesu8@1.1.1		X									X					
+simdutf8@0.1.5		X									X					
+simple_asn1@0.6.4									X							
+skeptic@0.13.7		X									X					
+slab@0.4.12											X					
+sled@0.34.7		X									X					
+smallvec@1.15.1		X									X					
+socket2@0.5.10		X									X					
+socket2@0.6.3		X									X					
+spin@0.9.8											X					
+spki@0.7.3		X									X					
+sqlx@0.8.6		X									X					
+sqlx-core@0.8.6		X									X					
+sqlx-macros@0.8.6		X									X					
+sqlx-macros-core@0.8.6		X									X					
+sqlx-mysql@0.8.6		X									X					
+sqlx-postgres@0.8.6		X									X					
+sqlx-sqlite@0.8.6		X									X					
+ssh_format@0.14.1											X					
+ssh_format_error@0.1.0											X					
+ssri@9.2.0		X														
+stable_deref_trait@1.2.1		X									X					
+static_assertions@1.1.0		X									X					
+statrs@0.18.0											X					
+stringprep@0.1.5		X									X					
+strsim@0.11.1											X					
+subtle@2.6.1					X											
+symlink@0.1.0		X									X					
+syn@1.0.109		X									X					
+syn@2.0.117		X									X					
+sync_wrapper@0.1.2		X														
+sync_wrapper@1.0.2		X														
+synstructure@0.13.2											X					
+sysinfo@0.38.4											X					
+system-configuration@0.7.0		X									X					
+system-configuration-sys@0.6.0		X									X					
+tagptr@0.2.0		X									X					
+take_mut@0.2.2											X					
+tap@1.0.1											X					
+tempfile@3.27.0		X									X					
+thin-vec@0.2.18		X									X					
+thiserror@1.0.69		X									X					
+thiserror@2.0.18		X									X					
+thiserror-impl@1.0.69		X									X					
+thiserror-impl@2.0.18		X									X					
+thread_local@1.1.9		X									X					
+tikv-client@0.4.0		X														
+time@0.3.47		X									X					
+time-core@0.1.8		X									X					
+time-macros@0.2.27		X									X					
+tiny-keccak@2.0.2							X									
+tinystr@0.8.3														X		
+tinyvec@1.11.0		X									X					X
+tinyvec_macros@0.1.1		X									X					X
+tokio@1.52.3											X					
+tokio-io-timeout@1.2.1		X									X					
+tokio-io-utility@0.7.6											X					
+tokio-macros@2.7.0											X					
+tokio-retry@0.3.1											X					
+tokio-rustls@0.24.1		X									X					
+tokio-rustls@0.26.4		X									X					
+tokio-stream@0.1.18											X					
+tokio-util@0.7.18											X					
+tonic@0.10.2											X					
+tonic@0.12.3											X					
+tonic@0.14.5											X					
+tonic-build@0.12.3											X					
+tonic-build@0.14.5											X					
+tonic-prost@0.14.5											X					
+tonic-prost-build@0.14.5											X					
+tower@0.4.13											X					
+tower@0.5.3											X					
+tower-http@0.6.11											X					
+tower-layer@0.3.3											X					
+tower-service@0.3.3											X					
+tracing@0.1.44											X					
+tracing-appender@0.2.5											X					
+tracing-attributes@0.1.31											X					
+tracing-core@0.1.36											X					
+tracing-log@0.2.0											X					
+tracing-serde@0.2.0											X					
+tracing-subscriber@0.3.23											X					
+triomphe@0.1.15		X									X					
+try-lock@0.2.5											X					
+twox-hash@2.1.2											X					
+typed-builder@0.22.0		X									X					
+typed-builder-macro@0.22.0		X									X					
+typenum@1.20.0		X									X					
+typewit@1.15.2																X
+unicase@2.9.0		X									X					
+unicode-bidi@0.3.18		X									X					
+unicode-ident@1.0.24		X									X			X		
+unicode-normalization@0.1.25		X									X					
+unicode-properties@0.1.4		X									X					
+unicode-segmentation@1.13.2		X									X					
+unicode-width@0.1.14		X									X					
+unicode-xid@0.2.6		X									X					
+unsigned-varint@0.8.0											X					
+untrusted@0.7.1									X							
+untrusted@0.9.0									X							
+url@2.5.8		X									X					
+urlencoding@2.1.3											X					
+utf8_iter@1.0.4		X									X					
+utf8parse@0.2.2		X									X					
+uuid@1.23.1		X									X					
+vcpkg@0.2.15		X									X					
+vec-strings@0.4.8											X					
+version_check@0.9.5		X									X					
+walkdir@2.5.0											X				X	
+want@0.3.1											X					
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X					
+wasi@0.14.7+wasi-0.2.4		X	X								X					
+wasi@0.9.0+wasi-snapshot-preview1		X	X								X					
+wasip2@1.0.1+wasi-0.2.4		X	X								X					
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X					
+wasite@0.1.0		X				X					X					
+wasite@1.0.2		X				X					X					
+wasm-bindgen@0.2.121		X									X					
+wasm-bindgen-futures@0.4.71		X									X					
+wasm-bindgen-macro@0.2.121		X									X					
+wasm-bindgen-macro-support@0.2.121		X									X					
+wasm-bindgen-shared@0.2.121		X									X					
+wasm-streams@0.5.0		X									X					
+web-sys@0.3.98		X									X					
+web-time@1.1.0		X									X					
+webpki-root-certs@1.0.7								X								
+webpki-roots@0.26.11								X								
+webpki-roots@1.0.7								X								
+whoami@1.6.1		X				X					X					
+whoami@2.1.2		X				X					X					
+widestring@1.2.1		X									X					
+winapi@0.3.9		X									X					
+winapi-i686-pc-windows-gnu@0.4.0		X									X					
+winapi-util@0.1.11											X				X	
+winapi-x86_64-pc-windows-gnu@0.4.0		X									X					
+windows@0.62.2		X									X					
+windows-collections@0.3.2		X									X					
+windows-core@0.62.2		X									X					
+windows-future@0.3.2		X									X					
+windows-implement@0.60.2		X									X					
+windows-interface@0.59.3		X									X					
+windows-link@0.2.1		X									X					
+windows-numerics@0.3.1		X									X					
+windows-registry@0.6.1		X									X					
+windows-result@0.4.1		X									X					
+windows-strings@0.5.1		X									X					
+windows-sys@0.45.0		X									X					
+windows-sys@0.48.0		X									X					
+windows-sys@0.52.0		X									X					
+windows-sys@0.59.0		X									X					
+windows-sys@0.61.2		X									X					
+windows-targets@0.42.2		X									X					
+windows-targets@0.48.5		X									X					
+windows-targets@0.52.6		X									X					
+windows-threading@0.2.1		X									X					
+windows_aarch64_gnullvm@0.42.2		X									X					
+windows_aarch64_gnullvm@0.48.5		X									X					
+windows_aarch64_gnullvm@0.52.6		X									X					
+windows_aarch64_msvc@0.42.2		X									X					
+windows_aarch64_msvc@0.48.5		X									X					
+windows_aarch64_msvc@0.52.6		X									X					
+windows_i686_gnu@0.42.2		X									X					
+windows_i686_gnu@0.48.5		X									X					
+windows_i686_gnu@0.52.6		X									X					
+windows_i686_gnullvm@0.52.6		X									X					
+windows_i686_msvc@0.42.2		X									X					
+windows_i686_msvc@0.48.5		X									X					
+windows_i686_msvc@0.52.6		X									X					
+windows_x86_64_gnu@0.42.2		X									X					
+windows_x86_64_gnu@0.48.5		X									X					
+windows_x86_64_gnu@0.52.6		X									X					
+windows_x86_64_gnullvm@0.42.2		X									X					
+windows_x86_64_gnullvm@0.48.5		X									X					
+windows_x86_64_gnullvm@0.52.6		X									X					
+windows_x86_64_msvc@0.42.2		X									X					
+windows_x86_64_msvc@0.48.5		X									X					
+windows_x86_64_msvc@0.52.6		X									X					
+wit-bindgen@0.46.0		X	X								X					
+wit-bindgen@0.51.0		X	X								X					
+writeable@0.6.3														X		
+wyz@0.5.1											X					
+xattr@1.6.1		X									X					
+xet-client@1.5.2		X														
+xet-core-structures@1.5.2		X														
+xet-data@1.5.2		X														
+xet-runtime@1.5.2		X														
+xxhash-rust@0.8.15						X										
+yoke@0.8.2														X		
+yoke-derive@0.8.2														X		
+zerocopy@0.8.48		X		X							X					
+zerofrom@0.1.8														X		
+zerofrom-derive@0.1.7														X		
+zeroize@1.8.2		X									X					
+zerotrie@0.2.4														X		
+zerovec@0.11.6														X		
+zerovec-derive@0.11.3														X		
+zigzag@0.1.0											X					
+zmij@1.0.21											X					

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal</artifactId>
-    <version>0.48.3</version> <!-- update version number -->
+    <version>0.48.4</version> <!-- update version number -->
 
     <name>Apache OpenDAL™</name>
     <description>

--- a/bindings/lua/DEPENDENCIES.rust.tsv
+++ b/bindings/lua/DEPENDENCIES.rust.tsv
@@ -5,44 +5,45 @@ anyhow@1.0.102	X									X
 async-trait@0.1.89	X									X			
 atomic-waker@1.1.2	X									X			
 autocfg@1.5.0	X									X			
-aws-lc-rs@1.16.3	X							X					
-aws-lc-sys@0.40.0	X			X				X		X	X		
+aws-lc-rs@1.17.0	X							X					
+aws-lc-sys@0.41.0	X			X				X		X	X		
 backon@1.6.0	X												
 base64@0.22.1	X									X			
 base64ct@1.8.3	X									X			
 bitflags@2.11.1	X									X			
 block-buffer@0.10.4	X									X			
+block-buffer@0.12.0	X									X			
 block-padding@0.3.3	X									X			
 bstr@1.12.1	X									X			
 bumpalo@3.20.2	X									X			
 bytes@1.11.1										X			
 cbc@0.1.2	X									X			
-cc@1.2.60	X									X			
-cesu8@1.1.0	X									X			
+cc@1.2.62	X									X			
 cfg-if@1.0.4	X									X			
 cipher@0.4.4	X									X			
 cmake@0.1.58	X									X			
 combine@4.6.7										X			
+const-oid@0.10.2	X									X			
 const-oid@0.9.6	X									X			
 const-random@0.1.18	X									X			
 const-random-macro@0.1.16	X									X			
 core-foundation@0.10.1	X									X			
 core-foundation-sys@0.8.7	X									X			
 cpufeatures@0.2.17	X									X			
+cpufeatures@0.3.0	X									X			
 crc32c@0.6.8	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
-ctor@0.6.3	X									X			
-ctor-proc-macro@0.0.7	X									X			
+crypto-common@0.2.2	X									X			
+ctor@1.0.6	X									X			
 der@0.7.10	X									X			
 deranged@0.5.8	X									X			
 digest@0.10.7	X									X			
+digest@0.11.3	X									X			
 displaydoc@0.2.5	X									X			
 dlv-list@0.5.2	X									X			
-dtor@0.1.1	X									X			
-dtor-proc-macro@0.0.6	X									X			
 dunce@1.0.5	X					X					X		
-either@1.15.0	X									X			
+either@1.16.0	X									X			
 errno@0.3.14	X									X			
 fastrand@2.4.1	X									X			
 find-msvc-tools@0.1.9	X									X			
@@ -61,7 +62,7 @@ generic-array@0.14.7										X
 getrandom@0.2.17	X									X			
 getrandom@0.3.4	X									X			
 getrandom@0.4.2	X									X			
-ghac@0.2.0	X												
+ghac@0.3.0	X												
 gloo-timers@0.3.0	X									X			
 hashbrown@0.14.5	X									X			
 hex@0.4.3	X									X			
@@ -70,6 +71,7 @@ http@1.4.0	X									X
 http-body@1.0.1										X			
 http-body-util@0.1.3										X			
 httparse@1.10.1	X									X			
+hybrid-array@0.4.12	X									X			
 hyper@1.9.0										X			
 hyper-rustls@0.27.9	X							X		X			
 hyper-util@0.1.20										X			
@@ -84,28 +86,29 @@ idna@1.1.0	X									X
 idna_adapter@1.2.1	X									X			
 inout@0.1.4	X									X			
 ipnet@2.12.0	X									X			
-iri-string@0.7.12	X									X			
 itertools@0.12.1	X									X			
 itertools@0.14.0	X									X			
 itoa@1.0.18	X									X			
-jiff@0.2.23										X			X
+jiff@0.2.24										X			X
 jiff-tzdb@0.1.6										X			X
 jiff-tzdb-platform@0.1.3										X			X
-jni@0.21.1	X									X			
-jni-sys@0.3.1	X									X			
+jni@0.22.4	X									X			
+jni-macros@0.22.4	X									X			
 jni-sys@0.4.1	X									X			
 jni-sys-macros@0.4.1	X									X			
 jobserver@0.1.34	X									X			
-js-sys@0.3.95	X									X			
+js-sys@0.3.98	X									X			
 jsonwebtoken@10.3.0										X			
 lazy_static@1.5.0	X									X			
-libc@0.2.185	X									X			
+libc@0.2.186	X									X			
 libm@0.2.16										X			
+link-section@0.17.2	X									X			
+linktime-proc-macro@0.1.0	X									X			
 linux-raw-sys@0.12.1	X	X								X			
 litemap@0.8.2												X	
 lock_api@0.4.14	X									X			
 log@0.4.29	X									X			
-md-5@0.10.6	X									X			
+md-5@0.11.0	X									X			
 mea@0.6.3	X												
 memchr@2.8.0										X			X
 mio@1.2.0										X			
@@ -114,33 +117,33 @@ mlua-sys@0.6.8										X
 mlua_derive@0.9.3										X			
 num-bigint@0.4.6	X									X			
 num-bigint-dig@0.8.6	X									X			
-num-conv@0.2.1	X									X			
+num-conv@0.2.2	X									X			
 num-integer@0.1.46	X									X			
 num-iter@0.1.45	X									X			
 num-traits@0.2.19	X									X			
 once_cell@1.21.4	X									X			
-opendal@0.56.0	X												
-opendal-core@0.56.0	X												
-opendal-layer-concurrent-limit@0.56.0	X												
-opendal-layer-logging@0.56.0	X												
-opendal-layer-retry@0.56.0	X												
-opendal-layer-timeout@0.56.0	X												
+opendal@0.57.0	X												
+opendal-core@0.57.0	X												
+opendal-layer-concurrent-limit@0.57.0	X												
+opendal-layer-logging@0.57.0	X												
+opendal-layer-retry@0.57.0	X												
+opendal-layer-timeout@0.57.0	X												
 opendal-lua@0.0.0	X												
-opendal-service-azblob@0.56.0	X												
-opendal-service-azdls@0.56.0	X												
-opendal-service-azfile@0.56.0	X												
-opendal-service-azure-common@0.56.0	X												
-opendal-service-cos@0.56.0	X												
-opendal-service-fs@0.56.0	X												
-opendal-service-gcs@0.56.0	X												
-opendal-service-ghac@0.56.0	X												
-opendal-service-http@0.56.0	X												
-opendal-service-ipmfs@0.56.0	X												
-opendal-service-obs@0.56.0	X												
-opendal-service-oss@0.56.0	X												
-opendal-service-s3@0.56.0	X												
-opendal-service-webdav@0.56.0	X												
-opendal-service-webhdfs@0.56.0	X												
+opendal-service-azblob@0.57.0	X												
+opendal-service-azdls@0.57.0	X												
+opendal-service-azfile@0.57.0	X												
+opendal-service-azure-common@0.57.0	X												
+opendal-service-cos@0.57.0	X												
+opendal-service-fs@0.57.0	X												
+opendal-service-gcs@0.57.0	X												
+opendal-service-ghac@0.57.0	X												
+opendal-service-http@0.57.0	X												
+opendal-service-ipmfs@0.57.0	X												
+opendal-service-obs@0.57.0	X												
+opendal-service-oss@0.57.0	X												
+opendal-service-s3@0.57.0	X												
+opendal-service-webdav@0.57.0	X												
+opendal-service-webhdfs@0.57.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-multimap@0.7.3										X			
 parking_lot@0.12.5	X									X			
@@ -155,21 +158,20 @@ pkcs5@0.7.1	X									X
 pkcs8@0.10.2	X									X			
 pkg-config@0.3.33	X									X			
 portable-atomic@1.13.1	X									X			
-portable-atomic-util@0.2.6	X									X			
+portable-atomic-util@0.2.7	X									X			
 potential_utf@0.1.5												X	
 powerfmt@0.2.0	X									X			
 ppv-lite86@0.2.21	X									X			
 proc-macro-error@1.0.4	X									X			
 proc-macro-error-attr@1.0.4	X									X			
 proc-macro2@1.0.106	X									X			
-prost@0.13.5	X												
-prost-derive@0.13.5	X												
-quick-xml@0.38.4										X			
-quick-xml@0.39.2										X			
+prost@0.14.3	X												
+prost-derive@0.14.3	X												
+quick-xml@0.39.4										X			
 quote@1.0.45	X									X			
 r-efi@5.3.0	X								X	X			
 r-efi@6.0.0	X								X	X			
-rand@0.8.5	X									X			
+rand@0.8.6	X									X			
 rand_chacha@0.3.1	X									X			
 rand_core@0.6.4	X									X			
 redox_syscall@0.5.18										X			
@@ -184,18 +186,18 @@ reqsign-file-read-tokio@3.0.0	X
 reqsign-google@3.0.0	X												
 reqsign-huaweicloud-obs@3.0.0	X												
 reqsign-tencent-cos@3.0.0	X												
-reqwest@0.13.2	X									X			
+reqwest@0.13.3	X									X			
 rsa@0.9.10	X									X			
 rust-ini@0.21.3										X			
 rustc-hash@2.1.2	X									X			
 rustc_version@0.4.1	X									X			
 rustix@1.1.4	X	X								X			
-rustls@0.23.38	X							X		X			
+rustls@0.23.40	X							X		X			
 rustls-native-certs@0.8.3	X							X		X			
-rustls-pki-types@1.14.0	X									X			
-rustls-platform-verifier@0.6.2	X									X			
+rustls-pki-types@1.14.1	X									X			
+rustls-platform-verifier@0.7.0	X									X			
 rustls-platform-verifier-android@0.1.1	X									X			
-rustls-webpki@0.103.12								X					
+rustls-webpki@0.103.13								X					
 rustversion@1.0.22	X									X			
 ryu@1.0.23	X				X								
 salsa20@0.10.2	X									X			
@@ -209,13 +211,16 @@ semver@1.0.28	X									X
 serde@1.0.228	X									X			
 serde_core@1.0.228	X									X			
 serde_derive@1.0.228	X									X			
-serde_json@1.0.149	X									X			
+serde_json@1.0.150	X									X			
 serde_urlencoded@0.7.1	X									X			
 sha1@0.10.6	X									X			
 sha2@0.10.9	X									X			
+sha2@0.11.0	X									X			
 shlex@1.3.0	X									X			
 signal-hook-registry@1.4.8	X									X			
 signature@2.2.0	X									X			
+simd_cesu8@1.1.1	X									X			
+simdutf8@0.1.5	X									X			
 simple_asn1@0.6.4								X					
 slab@0.4.12										X			
 smallvec@1.15.1	X									X			
@@ -228,27 +233,25 @@ syn@1.0.109	X									X
 syn@2.0.117	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
-thiserror@1.0.69	X									X			
 thiserror@2.0.18	X									X			
-thiserror-impl@1.0.69	X									X			
 thiserror-impl@2.0.18	X									X			
 time@0.3.47	X									X			
 time-core@0.1.8	X									X			
 time-macros@0.2.27	X									X			
 tiny-keccak@2.0.2						X							
 tinystr@0.8.3												X	
-tokio@1.52.0										X			
+tokio@1.52.3										X			
 tokio-macros@2.7.0										X			
 tokio-rustls@0.26.4	X									X			
 tokio-util@0.7.18										X			
 tower@0.5.3										X			
-tower-http@0.6.8										X			
+tower-http@0.6.11										X			
 tower-layer@0.3.3										X			
 tower-service@0.3.3										X			
 tracing@0.1.44										X			
 tracing-core@0.1.36										X			
 try-lock@0.2.5										X			
-typenum@1.19.0	X									X			
+typenum@1.20.0	X									X			
 unicode-ident@1.0.24	X									X		X	
 untrusted@0.7.1								X					
 untrusted@0.9.0								X					
@@ -261,27 +264,18 @@ want@0.3.1										X
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
 wasip2@1.0.1+wasi-0.2.4	X	X								X			
 wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
-wasm-bindgen@0.2.118	X									X			
-wasm-bindgen-futures@0.4.68	X									X			
-wasm-bindgen-macro@0.2.118	X									X			
-wasm-bindgen-macro-support@0.2.118	X									X			
-wasm-bindgen-shared@0.2.118	X									X			
+wasm-bindgen@0.2.121	X									X			
+wasm-bindgen-futures@0.4.71	X									X			
+wasm-bindgen-macro@0.2.121	X									X			
+wasm-bindgen-macro-support@0.2.121	X									X			
+wasm-bindgen-shared@0.2.121	X									X			
 wasm-streams@0.5.0	X									X			
-web-sys@0.3.95	X									X			
+web-sys@0.3.98	X									X			
 web-time@1.1.0	X									X			
-webpki-root-certs@1.0.6							X						
+webpki-root-certs@1.0.7							X						
 winapi-util@0.1.11										X			X
 windows-link@0.2.1	X									X			
-windows-sys@0.45.0	X									X			
 windows-sys@0.61.2	X									X			
-windows-targets@0.42.2	X									X			
-windows_aarch64_gnullvm@0.42.2	X									X			
-windows_aarch64_msvc@0.42.2	X									X			
-windows_i686_gnu@0.42.2	X									X			
-windows_i686_msvc@0.42.2	X									X			
-windows_x86_64_gnu@0.42.2	X									X			
-windows_x86_64_gnullvm@0.42.2	X									X			
-windows_x86_64_msvc@0.42.2	X									X			
 wit-bindgen@0.46.0	X	X								X			
 wit-bindgen@0.51.0	X	X								X			
 writeable@0.6.3												X	
@@ -289,7 +283,7 @@ xattr@1.6.1	X									X
 yoke@0.8.2												X	
 yoke-derive@0.8.2												X	
 zerocopy@0.8.48	X		X							X			
-zerofrom@0.1.7												X	
+zerofrom@0.1.8												X	
 zerofrom-derive@0.1.7												X	
 zeroize@1.8.2	X									X			
 zerotrie@0.2.4												X	

--- a/bindings/nodejs/DEPENDENCIES.rust.tsv
+++ b/bindings/nodejs/DEPENDENCIES.rust.tsv
@@ -5,23 +5,24 @@ anyhow@1.0.102	X									X
 async-trait@0.1.89	X									X				
 atomic-waker@1.1.2	X									X				
 autocfg@1.5.0	X									X				
-aws-lc-rs@1.16.3	X							X						
-aws-lc-sys@0.40.0	X			X				X		X	X			
+aws-lc-rs@1.17.0	X							X						
+aws-lc-sys@0.41.0	X			X				X		X	X			
 backon@1.6.0	X													
 base64@0.22.1	X									X				
 base64ct@1.8.3	X									X				
 bitflags@2.11.1	X									X				
 block-buffer@0.10.4	X									X				
+block-buffer@0.12.0	X									X				
 block-padding@0.3.3	X									X				
 bumpalo@3.20.2	X									X				
 bytes@1.11.1										X				
 cbc@0.1.2	X									X				
-cc@1.2.60	X									X				
-cesu8@1.1.0	X									X				
+cc@1.2.62	X									X				
 cfg-if@1.0.4	X									X				
 cipher@0.4.4	X									X				
 cmake@0.1.58	X									X				
 combine@4.6.7										X				
+const-oid@0.10.2	X									X				
 const-oid@0.9.6	X									X				
 const-random@0.1.18	X									X				
 const-random-macro@0.1.16	X									X				
@@ -29,22 +30,26 @@ convert_case@0.8.0										X
 core-foundation@0.10.1	X									X				
 core-foundation-sys@0.8.7	X									X				
 cpufeatures@0.2.17	X									X				
+cpufeatures@0.3.0	X									X				
 crc32c@0.6.8	X									X				
 crossbeam-utils@0.8.21	X									X				
 crunchy@0.2.4										X				
 crypto-common@0.1.7	X									X				
+crypto-common@0.2.2	X									X				
 ctor@0.6.3	X									X				
+ctor@1.0.6	X									X				
 ctor-proc-macro@0.0.7	X									X				
-dashmap@6.1.0										X				
+dashmap@6.2.1										X				
 der@0.7.10	X									X				
 deranged@0.5.8	X									X				
 digest@0.10.7	X									X				
+digest@0.11.3	X									X				
 displaydoc@0.2.5	X									X				
 dlv-list@0.5.2	X									X				
 dtor@0.1.1	X									X				
 dtor-proc-macro@0.0.6	X									X				
 dunce@1.0.5	X					X					X			
-either@1.15.0	X									X				
+either@1.16.0	X									X				
 equivalent@1.0.2	X									X				
 errno@0.3.14	X									X				
 fastrand@2.4.1	X									X				
@@ -60,13 +65,13 @@ futures-io@0.3.32	X									X
 futures-macro@0.3.32	X									X				
 futures-sink@0.3.32	X									X				
 futures-task@0.3.32	X									X				
-futures-timer@3.0.3	X									X				
+futures-timer@3.0.4	X									X				
 futures-util@0.3.32	X									X				
 generic-array@0.14.7										X				
 getrandom@0.2.17	X									X				
 getrandom@0.3.4	X									X				
 getrandom@0.4.2	X									X				
-ghac@0.2.0	X													
+ghac@0.3.0	X													
 gloo-timers@0.3.0	X									X				
 governor@0.10.4										X				
 hashbrown@0.14.5	X									X				
@@ -77,6 +82,7 @@ http@1.4.0	X									X
 http-body@1.0.1										X				
 http-body-util@0.1.3										X				
 httparse@1.10.1	X									X				
+hybrid-array@0.4.12	X									X				
 hyper@1.9.0										X				
 hyper-rustls@0.27.9	X							X		X				
 hyper-util@0.1.20										X				
@@ -91,28 +97,29 @@ idna@1.1.0	X									X
 idna_adapter@1.2.1	X									X				
 inout@0.1.4	X									X				
 ipnet@2.12.0	X									X				
-iri-string@0.7.12	X									X				
 itertools@0.14.0	X									X				
 itoa@1.0.18	X									X				
-jiff@0.2.23										X			X	
+jiff@0.2.24										X			X	
 jiff-tzdb@0.1.6										X			X	
 jiff-tzdb-platform@0.1.3										X			X	
-jni@0.21.1	X									X				
-jni-sys@0.3.1	X									X				
+jni@0.22.4	X									X				
+jni-macros@0.22.4	X									X				
 jni-sys@0.4.1	X									X				
 jni-sys-macros@0.4.1	X									X				
 jobserver@0.1.34	X									X				
-js-sys@0.3.95	X									X				
+js-sys@0.3.98	X									X				
 jsonwebtoken@10.3.0										X				
 lazy_static@1.5.0	X									X				
-libc@0.2.185	X									X				
+libc@0.2.186	X									X				
 libloading@0.8.9								X						
 libm@0.2.16										X				
+link-section@0.17.2	X									X				
+linktime-proc-macro@0.1.0	X									X				
 linux-raw-sys@0.12.1	X	X								X				
 litemap@0.8.2												X		
 lock_api@0.4.14	X									X				
 log@0.4.29	X									X				
-md-5@0.10.6	X									X				
+md-5@0.11.0	X									X				
 mea@0.6.3	X													
 memchr@2.8.0										X			X	
 mio@1.2.0										X				
@@ -125,33 +132,33 @@ nohash-hasher@0.2.0	X									X
 nonzero_ext@0.3.0	X													
 num-bigint@0.4.6	X									X				
 num-bigint-dig@0.8.6	X									X				
-num-conv@0.2.1	X									X				
+num-conv@0.2.2	X									X				
 num-integer@0.1.46	X									X				
 num-iter@0.1.45	X									X				
 num-traits@0.2.19	X									X				
 once_cell@1.21.4	X									X				
-opendal@0.56.0	X													
-opendal-core@0.56.0	X													
-opendal-layer-concurrent-limit@0.56.0	X													
-opendal-layer-logging@0.56.0	X													
-opendal-layer-retry@0.56.0	X													
-opendal-layer-throttle@0.56.0	X													
-opendal-layer-timeout@0.56.0	X													
+opendal@0.57.0	X													
+opendal-core@0.57.0	X													
+opendal-layer-concurrent-limit@0.57.0	X													
+opendal-layer-logging@0.57.0	X													
+opendal-layer-retry@0.57.0	X													
+opendal-layer-throttle@0.57.0	X													
+opendal-layer-timeout@0.57.0	X													
 opendal-nodejs@0.0.0	X													
-opendal-service-azblob@0.56.0	X													
-opendal-service-azdls@0.56.0	X													
-opendal-service-azure-common@0.56.0	X													
-opendal-service-cos@0.56.0	X													
-opendal-service-fs@0.56.0	X													
-opendal-service-gcs@0.56.0	X													
-opendal-service-ghac@0.56.0	X													
-opendal-service-http@0.56.0	X													
-opendal-service-ipmfs@0.56.0	X													
-opendal-service-obs@0.56.0	X													
-opendal-service-oss@0.56.0	X													
-opendal-service-s3@0.56.0	X													
-opendal-service-webdav@0.56.0	X													
-opendal-service-webhdfs@0.56.0	X													
+opendal-service-azblob@0.57.0	X													
+opendal-service-azdls@0.57.0	X													
+opendal-service-azure-common@0.57.0	X													
+opendal-service-cos@0.57.0	X													
+opendal-service-fs@0.57.0	X													
+opendal-service-gcs@0.57.0	X													
+opendal-service-ghac@0.57.0	X													
+opendal-service-http@0.57.0	X													
+opendal-service-ipmfs@0.57.0	X													
+opendal-service-obs@0.57.0	X													
+opendal-service-oss@0.57.0	X													
+opendal-service-s3@0.57.0	X													
+opendal-service-webdav@0.57.0	X													
+opendal-service-webhdfs@0.57.0	X													
 openssl-probe@0.2.1	X									X				
 ordered-multimap@0.7.3										X				
 parking_lot@0.12.5	X									X				
@@ -165,20 +172,19 @@ pkcs1@0.7.5	X									X
 pkcs5@0.7.1	X									X				
 pkcs8@0.10.2	X									X				
 portable-atomic@1.13.1	X									X				
-portable-atomic-util@0.2.6	X									X				
+portable-atomic-util@0.2.7	X									X				
 potential_utf@0.1.5												X		
 powerfmt@0.2.0	X									X				
 ppv-lite86@0.2.21	X									X				
 proc-macro2@1.0.106	X									X				
-prost@0.13.5	X													
-prost-derive@0.13.5	X													
+prost@0.14.3	X													
+prost-derive@0.14.3	X													
 quanta@0.12.6										X				
-quick-xml@0.38.4										X				
-quick-xml@0.39.2										X				
+quick-xml@0.39.4										X				
 quote@1.0.45	X									X				
 r-efi@5.3.0	X								X	X				
 r-efi@6.0.0	X								X	X				
-rand@0.8.5	X									X				
+rand@0.8.6	X									X				
 rand@0.9.4	X									X				
 rand_chacha@0.3.1	X									X				
 rand_chacha@0.9.0	X									X				
@@ -194,18 +200,18 @@ reqsign-file-read-tokio@3.0.0	X
 reqsign-google@3.0.0	X													
 reqsign-huaweicloud-obs@3.0.0	X													
 reqsign-tencent-cos@3.0.0	X													
-reqwest@0.13.2	X									X				
+reqwest@0.13.3	X									X				
 rsa@0.9.10	X									X				
 rust-ini@0.21.3										X				
 rustc-hash@2.1.2	X									X				
 rustc_version@0.4.1	X									X				
 rustix@1.1.4	X	X								X				
-rustls@0.23.38	X							X		X				
+rustls@0.23.40	X							X		X				
 rustls-native-certs@0.8.3	X							X		X				
-rustls-pki-types@1.14.0	X									X				
-rustls-platform-verifier@0.6.2	X									X				
+rustls-pki-types@1.14.1	X									X				
+rustls-platform-verifier@0.7.0	X									X				
 rustls-platform-verifier-android@0.1.1	X									X				
-rustls-webpki@0.103.12								X						
+rustls-webpki@0.103.13								X						
 rustversion@1.0.22	X									X				
 ryu@1.0.23	X				X									
 salsa20@0.10.2	X									X				
@@ -219,12 +225,15 @@ semver@1.0.28	X									X
 serde@1.0.228	X									X				
 serde_core@1.0.228	X									X				
 serde_derive@1.0.228	X									X				
-serde_json@1.0.149	X									X				
+serde_json@1.0.150	X									X				
 serde_urlencoded@0.7.1	X									X				
 sha1@0.10.6	X									X				
 sha2@0.10.9	X									X				
+sha2@0.11.0	X									X				
 shlex@1.3.0	X									X				
 signature@2.2.0	X									X				
+simd_cesu8@1.1.1	X									X				
+simdutf8@0.1.5	X									X				
 simple_asn1@0.6.4								X						
 slab@0.4.12										X				
 smallvec@1.15.1	X									X				
@@ -237,27 +246,25 @@ subtle@2.6.1				X
 syn@2.0.117	X									X				
 sync_wrapper@1.0.2	X													
 synstructure@0.13.2										X				
-thiserror@1.0.69	X									X				
 thiserror@2.0.18	X									X				
-thiserror-impl@1.0.69	X									X				
 thiserror-impl@2.0.18	X									X				
 time@0.3.47	X									X				
 time-core@0.1.8	X									X				
 time-macros@0.2.27	X									X				
 tiny-keccak@2.0.2						X								
 tinystr@0.8.3												X		
-tokio@1.52.0										X				
+tokio@1.52.3										X				
 tokio-macros@2.7.0										X				
 tokio-rustls@0.26.4	X									X				
 tokio-util@0.7.18										X				
 tower@0.5.3										X				
-tower-http@0.6.8										X				
+tower-http@0.6.11										X				
 tower-layer@0.3.3										X				
 tower-service@0.3.3										X				
 tracing@0.1.44										X				
 tracing-core@0.1.36										X				
 try-lock@0.2.5										X				
-typenum@1.19.0	X									X				
+typenum@1.20.0	X									X				
 unicode-ident@1.0.24	X									X		X		
 unicode-segmentation@1.13.2	X									X				
 untrusted@0.7.1								X						
@@ -271,30 +278,21 @@ want@0.3.1										X
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X				
 wasip2@1.0.1+wasi-0.2.4	X	X								X				
 wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X				
-wasm-bindgen@0.2.118	X									X				
-wasm-bindgen-futures@0.4.68	X									X				
-wasm-bindgen-macro@0.2.118	X									X				
-wasm-bindgen-macro-support@0.2.118	X									X				
-wasm-bindgen-shared@0.2.118	X									X				
+wasm-bindgen@0.2.121	X									X				
+wasm-bindgen-futures@0.4.71	X									X				
+wasm-bindgen-macro@0.2.121	X									X				
+wasm-bindgen-macro-support@0.2.121	X									X				
+wasm-bindgen-shared@0.2.121	X									X				
 wasm-streams@0.5.0	X									X				
-web-sys@0.3.95	X									X				
+web-sys@0.3.98	X									X				
 web-time@1.1.0	X									X				
-webpki-root-certs@1.0.6							X							
+webpki-root-certs@1.0.7							X							
 winapi@0.3.9	X									X				
 winapi-i686-pc-windows-gnu@0.4.0	X									X				
 winapi-util@0.1.11										X			X	
 winapi-x86_64-pc-windows-gnu@0.4.0	X									X				
 windows-link@0.2.1	X									X				
-windows-sys@0.45.0	X									X				
 windows-sys@0.61.2	X									X				
-windows-targets@0.42.2	X									X				
-windows_aarch64_gnullvm@0.42.2	X									X				
-windows_aarch64_msvc@0.42.2	X									X				
-windows_i686_gnu@0.42.2	X									X				
-windows_i686_msvc@0.42.2	X									X				
-windows_x86_64_gnu@0.42.2	X									X				
-windows_x86_64_gnullvm@0.42.2	X									X				
-windows_x86_64_msvc@0.42.2	X									X				
 wit-bindgen@0.46.0	X	X								X				
 wit-bindgen@0.51.0	X	X								X				
 writeable@0.6.3												X		
@@ -302,7 +300,7 @@ xattr@1.6.1	X									X
 yoke@0.8.2												X		
 yoke-derive@0.8.2												X		
 zerocopy@0.8.48	X		X							X				
-zerofrom@0.1.7												X		
+zerofrom@0.1.8												X		
 zerofrom-derive@0.1.7												X		
 zeroize@1.8.2	X									X				
 zerotrie@0.2.4												X		

--- a/bindings/nodejs/generated.js
+++ b/bindings/nodejs/generated.js
@@ -99,8 +99,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-android-arm64')
         const bindingPackageVersion = require('@opendal/lib-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -115,8 +115,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-android-arm-eabi')
         const bindingPackageVersion = require('@opendal/lib-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -135,8 +135,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-x64-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-ia32-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-arm64-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@opendal/lib-darwin-universal')
       const bindingPackageVersion = require('@opendal/lib-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-darwin-x64')
         const bindingPackageVersion = require('@opendal/lib-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-darwin-arm64')
         const bindingPackageVersion = require('@opendal/lib-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-freebsd-x64')
         const bindingPackageVersion = require('@opendal/lib-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-freebsd-arm64')
         const bindingPackageVersion = require('@opendal/lib-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-x64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-x64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm-musleabihf')
           const bindingPackageVersion = require('@opendal/lib-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@opendal/lib-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-riscv64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-riscv64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -410,8 +410,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-linux-ppc64-gnu')
         const bindingPackageVersion = require('@opendal/lib-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -426,8 +426,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-linux-s390x-gnu')
         const bindingPackageVersion = require('@opendal/lib-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -446,8 +446,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-arm64')
         const bindingPackageVersion = require('@opendal/lib-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -462,8 +462,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-x64')
         const bindingPackageVersion = require('@opendal/lib-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -478,8 +478,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-arm')
         const bindingPackageVersion = require('@opendal/lib-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.49.3' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.3 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-arm64",
-  "version": "0.49.3",
+  "version": "0.49.4",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-x64",
-  "version": "0.49.3",
+  "version": "0.49.4",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-gnu",
-  "version": "0.49.3",
+  "version": "0.49.4",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-musl",
-  "version": "0.49.3",
+  "version": "0.49.4",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.49.3",
+  "version": "0.49.4",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/linux-x64-musl/package.json
+++ b/bindings/nodejs/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-musl",
-  "version": "0.49.3",
+  "version": "0.49.4",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-arm64-msvc",
-  "version": "0.49.3",
+  "version": "0.49.4",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.49.3",
+  "version": "0.49.4",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "Apache OpenDAL <dev@opendal.apache.org>",
-  "version": "0.49.3",
+  "version": "0.49.4",
   "license": "Apache-2.0",
   "main": "index.cjs",
   "module": "index.mjs",

--- a/bindings/ocaml/DEPENDENCIES.rust.tsv
+++ b/bindings/ocaml/DEPENDENCIES.rust.tsv
@@ -4,44 +4,45 @@ anyhow@1.0.102	X									X
 async-trait@0.1.89	X									X			
 atomic-waker@1.1.2	X									X			
 autocfg@1.5.0	X									X			
-aws-lc-rs@1.16.3	X							X					
-aws-lc-sys@0.40.0	X			X				X		X	X		
+aws-lc-rs@1.17.0	X							X					
+aws-lc-sys@0.41.0	X			X				X		X	X		
 backon@1.6.0	X												
 base64@0.22.1	X									X			
 base64ct@1.8.3	X									X			
 bitflags@2.11.1	X									X			
 block-buffer@0.10.4	X									X			
+block-buffer@0.12.0	X									X			
 block-padding@0.3.3	X									X			
 bumpalo@3.20.2	X									X			
 bytes@1.11.1										X			
 cbc@0.1.2	X									X			
-cc@1.2.60	X									X			
-cesu8@1.1.0	X									X			
+cc@1.2.62	X									X			
 cfg-if@1.0.4	X									X			
 cipher@0.4.4	X									X			
 cmake@0.1.58	X									X			
 combine@4.6.7										X			
+const-oid@0.10.2	X									X			
 const-oid@0.9.6	X									X			
 const-random@0.1.18	X									X			
 const-random-macro@0.1.16	X									X			
 core-foundation@0.10.1	X									X			
 core-foundation-sys@0.8.7	X									X			
 cpufeatures@0.2.17	X									X			
+cpufeatures@0.3.0	X									X			
 crc32c@0.6.8	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
-ctor@0.6.3	X									X			
-ctor-proc-macro@0.0.7	X									X			
+crypto-common@0.2.2	X									X			
+ctor@1.0.6	X									X			
 cty@0.2.2	X									X			
 der@0.7.10	X									X			
 deranged@0.5.8	X									X			
 digest@0.10.7	X									X			
+digest@0.11.3	X									X			
 displaydoc@0.2.5	X									X			
 dlv-list@0.5.2	X									X			
-dtor@0.1.1	X									X			
-dtor-proc-macro@0.0.6	X									X			
 dunce@1.0.5	X					X					X		
-either@1.15.0	X									X			
+either@1.16.0	X									X			
 errno@0.3.14	X									X			
 fastrand@2.4.1	X									X			
 find-msvc-tools@0.1.9	X									X			
@@ -60,7 +61,7 @@ generic-array@0.14.7										X
 getrandom@0.2.17	X									X			
 getrandom@0.3.4	X									X			
 getrandom@0.4.2	X									X			
-ghac@0.2.0	X												
+ghac@0.3.0	X												
 gloo-timers@0.3.0	X									X			
 hashbrown@0.14.5	X									X			
 hex@0.4.3	X									X			
@@ -69,6 +70,7 @@ http@1.4.0	X									X
 http-body@1.0.1										X			
 http-body-util@0.1.3										X			
 httparse@1.10.1	X									X			
+hybrid-array@0.4.12	X									X			
 hyper@1.9.0										X			
 hyper-rustls@0.27.9	X							X		X			
 hyper-util@0.1.20										X			
@@ -83,33 +85,34 @@ idna@1.1.0	X									X
 idna_adapter@1.2.1	X									X			
 inout@0.1.4	X									X			
 ipnet@2.12.0	X									X			
-iri-string@0.7.12	X									X			
 itertools@0.14.0	X									X			
 itoa@1.0.18	X									X			
-jiff@0.2.23										X			X
+jiff@0.2.24										X			X
 jiff-tzdb@0.1.6										X			X
 jiff-tzdb-platform@0.1.3										X			X
-jni@0.21.1	X									X			
-jni-sys@0.3.1	X									X			
+jni@0.22.4	X									X			
+jni-macros@0.22.4	X									X			
 jni-sys@0.4.1	X									X			
 jni-sys-macros@0.4.1	X									X			
 jobserver@0.1.34	X									X			
-js-sys@0.3.95	X									X			
+js-sys@0.3.98	X									X			
 jsonwebtoken@10.3.0										X			
 lazy_static@1.5.0	X									X			
-libc@0.2.185	X									X			
+libc@0.2.186	X									X			
 libm@0.2.16										X			
+link-section@0.17.2	X									X			
+linktime-proc-macro@0.1.0	X									X			
 linux-raw-sys@0.12.1	X	X								X			
 litemap@0.8.2												X	
 lock_api@0.4.14	X									X			
 log@0.4.29	X									X			
-md-5@0.10.6	X									X			
+md-5@0.11.0	X									X			
 mea@0.6.3	X												
 memchr@2.8.0										X			X
 mio@1.2.0										X			
 num-bigint@0.4.6	X									X			
 num-bigint-dig@0.8.6	X									X			
-num-conv@0.2.1	X									X			
+num-conv@0.2.2	X									X			
 num-integer@0.1.46	X									X			
 num-iter@0.1.45	X									X			
 num-traits@0.2.19	X									X			
@@ -119,28 +122,28 @@ ocaml-build@1.0.0								X
 ocaml-derive@1.0.0								X					
 ocaml-sys@0.26.0								X					
 once_cell@1.21.4	X									X			
-opendal@0.56.0	X												
-opendal-core@0.56.0	X												
-opendal-layer-concurrent-limit@0.56.0	X												
-opendal-layer-logging@0.56.0	X												
-opendal-layer-retry@0.56.0	X												
-opendal-layer-timeout@0.56.0	X												
+opendal@0.57.0	X												
+opendal-core@0.57.0	X												
+opendal-layer-concurrent-limit@0.57.0	X												
+opendal-layer-logging@0.57.0	X												
+opendal-layer-retry@0.57.0	X												
+opendal-layer-timeout@0.57.0	X												
 opendal-ocaml@0.0.0	X												
-opendal-service-azblob@0.56.0	X												
-opendal-service-azdls@0.56.0	X												
-opendal-service-azfile@0.56.0	X												
-opendal-service-azure-common@0.56.0	X												
-opendal-service-cos@0.56.0	X												
-opendal-service-fs@0.56.0	X												
-opendal-service-gcs@0.56.0	X												
-opendal-service-ghac@0.56.0	X												
-opendal-service-http@0.56.0	X												
-opendal-service-ipmfs@0.56.0	X												
-opendal-service-obs@0.56.0	X												
-opendal-service-oss@0.56.0	X												
-opendal-service-s3@0.56.0	X												
-opendal-service-webdav@0.56.0	X												
-opendal-service-webhdfs@0.56.0	X												
+opendal-service-azblob@0.57.0	X												
+opendal-service-azdls@0.57.0	X												
+opendal-service-azfile@0.57.0	X												
+opendal-service-azure-common@0.57.0	X												
+opendal-service-cos@0.57.0	X												
+opendal-service-fs@0.57.0	X												
+opendal-service-gcs@0.57.0	X												
+opendal-service-ghac@0.57.0	X												
+opendal-service-http@0.57.0	X												
+opendal-service-ipmfs@0.57.0	X												
+opendal-service-obs@0.57.0	X												
+opendal-service-oss@0.57.0	X												
+opendal-service-s3@0.57.0	X												
+opendal-service-webdav@0.57.0	X												
+opendal-service-webhdfs@0.57.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-multimap@0.7.3										X			
 parking_lot@0.12.5	X									X			
@@ -154,19 +157,18 @@ pkcs1@0.7.5	X									X
 pkcs5@0.7.1	X									X			
 pkcs8@0.10.2	X									X			
 portable-atomic@1.13.1	X									X			
-portable-atomic-util@0.2.6	X									X			
+portable-atomic-util@0.2.7	X									X			
 potential_utf@0.1.5												X	
 powerfmt@0.2.0	X									X			
 ppv-lite86@0.2.21	X									X			
 proc-macro2@1.0.106	X									X			
-prost@0.13.5	X												
-prost-derive@0.13.5	X												
-quick-xml@0.38.4										X			
-quick-xml@0.39.2										X			
+prost@0.14.3	X												
+prost-derive@0.14.3	X												
+quick-xml@0.39.4										X			
 quote@1.0.45	X									X			
 r-efi@5.3.0	X								X	X			
 r-efi@6.0.0	X								X	X			
-rand@0.8.5	X									X			
+rand@0.8.6	X									X			
 rand_chacha@0.3.1	X									X			
 rand_core@0.6.4	X									X			
 redox_syscall@0.5.18										X			
@@ -178,17 +180,17 @@ reqsign-file-read-tokio@3.0.0	X
 reqsign-google@3.0.0	X												
 reqsign-huaweicloud-obs@3.0.0	X												
 reqsign-tencent-cos@3.0.0	X												
-reqwest@0.13.2	X									X			
+reqwest@0.13.3	X									X			
 rsa@0.9.10	X									X			
 rust-ini@0.21.3										X			
 rustc_version@0.4.1	X									X			
 rustix@1.1.4	X	X								X			
-rustls@0.23.38	X							X		X			
+rustls@0.23.40	X							X		X			
 rustls-native-certs@0.8.3	X							X		X			
-rustls-pki-types@1.14.0	X									X			
-rustls-platform-verifier@0.6.2	X									X			
+rustls-pki-types@1.14.1	X									X			
+rustls-platform-verifier@0.7.0	X									X			
 rustls-platform-verifier-android@0.1.1	X									X			
-rustls-webpki@0.103.12								X					
+rustls-webpki@0.103.13								X					
 rustversion@1.0.22	X									X			
 ryu@1.0.23	X				X								
 salsa20@0.10.2	X									X			
@@ -202,13 +204,16 @@ semver@1.0.28	X									X
 serde@1.0.228	X									X			
 serde_core@1.0.228	X									X			
 serde_derive@1.0.228	X									X			
-serde_json@1.0.149	X									X			
+serde_json@1.0.150	X									X			
 serde_urlencoded@0.7.1	X									X			
 sha1@0.10.6	X									X			
 sha2@0.10.9	X									X			
+sha2@0.11.0	X									X			
 shlex@1.3.0	X									X			
 signal-hook-registry@1.4.8	X									X			
 signature@2.2.0	X									X			
+simd_cesu8@1.1.1	X									X			
+simdutf8@0.1.5	X									X			
 simple_asn1@0.6.4								X					
 slab@0.4.12										X			
 smallvec@1.15.1	X									X			
@@ -220,27 +225,25 @@ subtle@2.6.1				X
 syn@2.0.117	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
-thiserror@1.0.69	X									X			
 thiserror@2.0.18	X									X			
-thiserror-impl@1.0.69	X									X			
 thiserror-impl@2.0.18	X									X			
 time@0.3.47	X									X			
 time-core@0.1.8	X									X			
 time-macros@0.2.27	X									X			
 tiny-keccak@2.0.2						X							
 tinystr@0.8.3												X	
-tokio@1.52.0										X			
+tokio@1.52.3										X			
 tokio-macros@2.7.0										X			
 tokio-rustls@0.26.4	X									X			
 tokio-util@0.7.18										X			
 tower@0.5.3										X			
-tower-http@0.6.8										X			
+tower-http@0.6.11										X			
 tower-layer@0.3.3										X			
 tower-service@0.3.3										X			
 tracing@0.1.44										X			
 tracing-core@0.1.36										X			
 try-lock@0.2.5										X			
-typenum@1.19.0	X									X			
+typenum@1.20.0	X									X			
 unicode-ident@1.0.24	X									X		X	
 untrusted@0.7.1								X					
 untrusted@0.9.0								X					
@@ -253,27 +256,18 @@ want@0.3.1										X
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
 wasip2@1.0.1+wasi-0.2.4	X	X								X			
 wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
-wasm-bindgen@0.2.118	X									X			
-wasm-bindgen-futures@0.4.68	X									X			
-wasm-bindgen-macro@0.2.118	X									X			
-wasm-bindgen-macro-support@0.2.118	X									X			
-wasm-bindgen-shared@0.2.118	X									X			
+wasm-bindgen@0.2.121	X									X			
+wasm-bindgen-futures@0.4.71	X									X			
+wasm-bindgen-macro@0.2.121	X									X			
+wasm-bindgen-macro-support@0.2.121	X									X			
+wasm-bindgen-shared@0.2.121	X									X			
 wasm-streams@0.5.0	X									X			
-web-sys@0.3.95	X									X			
+web-sys@0.3.98	X									X			
 web-time@1.1.0	X									X			
-webpki-root-certs@1.0.6							X						
+webpki-root-certs@1.0.7							X						
 winapi-util@0.1.11										X			X
 windows-link@0.2.1	X									X			
-windows-sys@0.45.0	X									X			
 windows-sys@0.61.2	X									X			
-windows-targets@0.42.2	X									X			
-windows_aarch64_gnullvm@0.42.2	X									X			
-windows_aarch64_msvc@0.42.2	X									X			
-windows_i686_gnu@0.42.2	X									X			
-windows_i686_msvc@0.42.2	X									X			
-windows_x86_64_gnu@0.42.2	X									X			
-windows_x86_64_gnullvm@0.42.2	X									X			
-windows_x86_64_msvc@0.42.2	X									X			
 wit-bindgen@0.46.0	X	X								X			
 wit-bindgen@0.51.0	X	X								X			
 writeable@0.6.3												X	
@@ -281,7 +275,7 @@ xattr@1.6.1	X									X
 yoke@0.8.2												X	
 yoke-derive@0.8.2												X	
 zerocopy@0.8.48	X		X							X			
-zerofrom@0.1.7												X	
+zerofrom@0.1.8												X	
 zerofrom-derive@0.1.7												X	
 zeroize@1.8.2	X									X			
 zerotrie@0.2.4												X	

--- a/bindings/php/DEPENDENCIES.rust.tsv
+++ b/bindings/php/DEPENDENCIES.rust.tsv
@@ -5,14 +5,15 @@ anyhow@1.0.102		X									X
 async-trait@0.1.89		X									X				
 atomic-waker@1.1.2		X									X				
 autocfg@1.5.0		X									X				
-aws-lc-rs@1.16.3		X							X						
-aws-lc-sys@0.40.0		X			X				X		X	X			
+aws-lc-rs@1.17.0		X							X						
+aws-lc-sys@0.41.0		X			X				X		X	X			
 backon@1.6.0		X													
 base64@0.22.1		X									X				
 base64ct@1.8.3		X									X				
 bindgen@0.68.1					X										
 bitflags@2.11.1		X									X				
 block-buffer@0.10.4		X									X				
+block-buffer@0.12.0		X									X				
 block-padding@0.3.3		X									X				
 bumpalo@3.20.2		X									X				
 bytecount@0.6.9		X									X				
@@ -24,14 +25,14 @@ camino@1.2.2		X									X
 cargo-platform@0.1.9		X									X				
 cargo_metadata@0.14.2											X				
 cbc@0.1.2		X									X				
-cc@1.2.60		X									X				
-cesu8@1.1.0		X									X				
+cc@1.2.62		X									X				
 cexpr@0.6.0		X									X				
 cfg-if@1.0.4		X									X				
 cipher@0.4.4		X									X				
 clang-sys@1.8.1		X													
 cmake@0.1.58		X									X				
 combine@4.6.7											X				
+const-oid@0.10.2		X									X				
 const-oid@0.9.6		X									X				
 const-random@0.1.18		X									X				
 const-random-macro@0.1.16		X									X				
@@ -39,25 +40,25 @@ constant_time_eq@0.1.5							X
 core-foundation@0.10.1		X									X				
 core-foundation-sys@0.8.7		X									X				
 cpufeatures@0.2.17		X									X				
+cpufeatures@0.3.0		X									X				
 crc32c@0.6.8		X									X				
 crc32fast@1.5.0		X									X				
 crossbeam-utils@0.8.21		X									X				
 crunchy@0.2.4											X				
 crypto-common@0.1.7		X									X				
-ctor@0.6.3		X									X				
-ctor-proc-macro@0.0.7		X									X				
+crypto-common@0.2.2		X									X				
+ctor@1.0.6		X									X				
 darling@0.14.4											X				
 darling_core@0.14.4											X				
 darling_macro@0.14.4											X				
 der@0.7.10		X									X				
 deranged@0.5.8		X									X				
 digest@0.10.7		X									X				
+digest@0.11.3		X									X				
 displaydoc@0.2.5		X									X				
 dlv-list@0.5.2		X									X				
-dtor@0.1.1		X									X				
-dtor-proc-macro@0.0.6		X									X				
 dunce@1.0.5		X					X					X			
-either@1.15.0		X									X				
+either@1.16.0		X									X				
 errno@0.3.14		X									X				
 error-chain@0.12.4		X									X				
 ext-php-rs@0.13.1		X									X				
@@ -83,7 +84,7 @@ generic-array@0.14.7											X
 getrandom@0.2.17		X									X				
 getrandom@0.3.4		X									X				
 getrandom@0.4.2		X									X				
-ghac@0.2.0		X													
+ghac@0.3.0		X													
 glob@0.3.3		X									X				
 gloo-timers@0.3.0		X									X				
 hashbrown@0.14.5		X									X				
@@ -94,6 +95,7 @@ http@1.4.0		X									X
 http-body@1.0.1											X				
 http-body-util@0.1.3											X				
 httparse@1.10.1		X									X				
+hybrid-array@0.4.12		X									X				
 hyper@1.9.0											X				
 hyper-rustls@0.27.9		X							X		X				
 hyper-util@0.1.20											X				
@@ -109,30 +111,31 @@ idna@1.1.0		X									X
 idna_adapter@1.2.1		X									X				
 inout@0.1.4		X									X				
 ipnet@2.12.0		X									X				
-iri-string@0.7.12		X									X				
 itertools@0.14.0		X									X				
 itoa@1.0.18		X									X				
-jiff@0.2.23											X			X	
+jiff@0.2.24											X			X	
 jiff-tzdb@0.1.6											X			X	
 jiff-tzdb-platform@0.1.3											X			X	
-jni@0.21.1		X									X				
-jni-sys@0.3.1		X									X				
+jni@0.22.4		X									X				
+jni-macros@0.22.4		X									X				
 jni-sys@0.4.1		X									X				
 jni-sys-macros@0.4.1		X									X				
 jobserver@0.1.34		X									X				
-js-sys@0.3.95		X									X				
+js-sys@0.3.98		X									X				
 jsonwebtoken@10.3.0											X				
 lazy_static@1.5.0		X									X				
 lazycell@1.3.0		X									X				
-libc@0.2.185		X									X				
+libc@0.2.186		X									X				
 libloading@0.8.9									X						
 libm@0.2.16											X				
+link-section@0.17.2		X									X				
+linktime-proc-macro@0.1.0		X									X				
 linux-raw-sys@0.12.1		X	X								X				
 linux-raw-sys@0.4.15		X	X								X				
 litemap@0.8.2													X		
 lock_api@0.4.14		X									X				
 log@0.4.29		X									X				
-md-5@0.10.6		X									X				
+md-5@0.11.0		X									X				
 mea@0.6.3		X													
 memchr@2.8.0											X			X	
 minimal-lexical@0.2.1		X									X				
@@ -142,37 +145,37 @@ native-tls@0.2.18		X									X
 nom@7.1.3											X				
 num-bigint@0.4.6		X									X				
 num-bigint-dig@0.8.6		X									X				
-num-conv@0.2.1		X									X				
+num-conv@0.2.2		X									X				
 num-integer@0.1.46		X									X				
 num-iter@0.1.45		X									X				
 num-traits@0.2.19		X									X				
 once_cell@1.21.4		X									X				
-opendal@0.56.0		X													
-opendal-core@0.56.0		X													
-opendal-layer-concurrent-limit@0.56.0		X													
-opendal-layer-logging@0.56.0		X													
-opendal-layer-retry@0.56.0		X													
-opendal-layer-timeout@0.56.0		X													
+opendal@0.57.0		X													
+opendal-core@0.57.0		X													
+opendal-layer-concurrent-limit@0.57.0		X													
+opendal-layer-logging@0.57.0		X													
+opendal-layer-retry@0.57.0		X													
+opendal-layer-timeout@0.57.0		X													
 opendal-php@0.0.0		X													
-opendal-service-azblob@0.56.0		X													
-opendal-service-azdls@0.56.0		X													
-opendal-service-azfile@0.56.0		X													
-opendal-service-azure-common@0.56.0		X													
-opendal-service-cos@0.56.0		X													
-opendal-service-fs@0.56.0		X													
-opendal-service-gcs@0.56.0		X													
-opendal-service-ghac@0.56.0		X													
-opendal-service-http@0.56.0		X													
-opendal-service-ipmfs@0.56.0		X													
-opendal-service-obs@0.56.0		X													
-opendal-service-oss@0.56.0		X													
-opendal-service-s3@0.56.0		X													
-opendal-service-webdav@0.56.0		X													
-opendal-service-webhdfs@0.56.0		X													
-openssl@0.10.77		X													
+opendal-service-azblob@0.57.0		X													
+opendal-service-azdls@0.57.0		X													
+opendal-service-azfile@0.57.0		X													
+opendal-service-azure-common@0.57.0		X													
+opendal-service-cos@0.57.0		X													
+opendal-service-fs@0.57.0		X													
+opendal-service-gcs@0.57.0		X													
+opendal-service-ghac@0.57.0		X													
+opendal-service-http@0.57.0		X													
+opendal-service-ipmfs@0.57.0		X													
+opendal-service-obs@0.57.0		X													
+opendal-service-oss@0.57.0		X													
+opendal-service-s3@0.57.0		X													
+opendal-service-webdav@0.57.0		X													
+opendal-service-webhdfs@0.57.0		X													
+openssl@0.10.80		X													
 openssl-macros@0.1.1		X									X				
 openssl-probe@0.2.1		X									X				
-openssl-sys@0.9.113											X				
+openssl-sys@0.9.116											X				
 ordered-multimap@0.7.3											X				
 parking_lot@0.12.5		X									X				
 parking_lot_core@0.9.12		X									X				
@@ -189,21 +192,20 @@ pkcs5@0.7.1		X									X
 pkcs8@0.10.2		X									X				
 pkg-config@0.3.33		X									X				
 portable-atomic@1.13.1		X									X				
-portable-atomic-util@0.2.6		X									X				
+portable-atomic-util@0.2.7		X									X				
 potential_utf@0.1.5													X		
 powerfmt@0.2.0		X									X				
 ppv-lite86@0.2.21		X									X				
 prettyplease@0.2.37		X									X				
 proc-macro2@1.0.106		X									X				
-prost@0.13.5		X													
-prost-derive@0.13.5		X													
+prost@0.14.3		X													
+prost-derive@0.14.3		X													
 pulldown-cmark@0.9.6											X				
-quick-xml@0.38.4											X				
-quick-xml@0.39.2											X				
+quick-xml@0.39.4											X				
 quote@1.0.45		X									X				
 r-efi@5.3.0		X								X	X				
 r-efi@6.0.0		X								X	X				
-rand@0.8.5		X									X				
+rand@0.8.6		X									X				
 rand_chacha@0.3.1		X									X				
 rand_core@0.6.4		X									X				
 redox_syscall@0.5.18											X				
@@ -218,19 +220,19 @@ reqsign-file-read-tokio@3.0.0		X
 reqsign-google@3.0.0		X													
 reqsign-huaweicloud-obs@3.0.0		X													
 reqsign-tencent-cos@3.0.0		X													
-reqwest@0.13.2		X									X				
+reqwest@0.13.3		X									X				
 rsa@0.9.10		X									X				
 rust-ini@0.21.3											X				
 rustc-hash@1.1.0		X									X				
 rustc_version@0.4.1		X									X				
 rustix@0.38.44		X	X								X				
 rustix@1.1.4		X	X								X				
-rustls@0.23.38		X							X		X				
+rustls@0.23.40		X							X		X				
 rustls-native-certs@0.8.3		X							X		X				
-rustls-pki-types@1.14.0		X									X				
-rustls-platform-verifier@0.6.2		X									X				
+rustls-pki-types@1.14.1		X									X				
+rustls-platform-verifier@0.7.0		X									X				
 rustls-platform-verifier-android@0.1.1		X									X				
-rustls-webpki@0.103.12									X						
+rustls-webpki@0.103.13									X						
 rustversion@1.0.22		X									X				
 ryu@1.0.23		X				X									
 salsa20@0.10.2		X									X				
@@ -244,14 +246,17 @@ semver@1.0.28		X									X
 serde@1.0.228		X									X				
 serde_core@1.0.228		X									X				
 serde_derive@1.0.228		X									X				
-serde_json@1.0.149		X									X				
+serde_json@1.0.150		X									X				
 serde_urlencoded@0.7.1		X									X				
 sha1@0.10.6		X									X				
 sha2@0.10.9		X									X				
+sha2@0.11.0		X									X				
 shlex@1.3.0		X									X				
 signal-hook-registry@1.4.8		X									X				
 signature@2.2.0		X									X				
 simd-adler32@0.3.9											X				
+simd_cesu8@1.1.1		X									X				
+simdutf8@0.1.5		X									X				
 simple_asn1@0.6.4									X						
 skeptic@0.13.7		X									X				
 slab@0.4.12											X				
@@ -267,27 +272,25 @@ syn@2.0.117		X									X
 sync_wrapper@1.0.2		X													
 synstructure@0.13.2											X				
 tempfile@3.27.0		X									X				
-thiserror@1.0.69		X									X				
 thiserror@2.0.18		X									X				
-thiserror-impl@1.0.69		X									X				
 thiserror-impl@2.0.18		X									X				
 time@0.3.47		X									X				
 time-core@0.1.8		X									X				
 time-macros@0.2.27		X									X				
 tiny-keccak@2.0.2							X								
 tinystr@0.8.3													X		
-tokio@1.52.0											X				
+tokio@1.52.3											X				
 tokio-macros@2.7.0											X				
 tokio-rustls@0.26.4		X									X				
 tokio-util@0.7.18											X				
 tower@0.5.3											X				
-tower-http@0.6.8											X				
+tower-http@0.6.11											X				
 tower-layer@0.3.3											X				
 tower-service@0.3.3											X				
 tracing@0.1.44											X				
 tracing-core@0.1.36											X				
 try-lock@0.2.5											X				
-typenum@1.19.0		X									X				
+typenum@1.20.0		X									X				
 unicase@2.9.0		X									X				
 unicode-ident@1.0.24		X									X		X		
 untrusted@0.7.1									X						
@@ -303,37 +306,28 @@ want@0.3.1											X
 wasi@0.11.1+wasi-snapshot-preview1		X	X								X				
 wasip2@1.0.1+wasi-0.2.4		X	X								X				
 wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X				
-wasm-bindgen@0.2.118		X									X				
-wasm-bindgen-futures@0.4.68		X									X				
-wasm-bindgen-macro@0.2.118		X									X				
-wasm-bindgen-macro-support@0.2.118		X									X				
-wasm-bindgen-shared@0.2.118		X									X				
+wasm-bindgen@0.2.121		X									X				
+wasm-bindgen-futures@0.4.71		X									X				
+wasm-bindgen-macro@0.2.121		X									X				
+wasm-bindgen-macro-support@0.2.121		X									X				
+wasm-bindgen-shared@0.2.121		X									X				
 wasm-streams@0.5.0		X									X				
-web-sys@0.3.95		X									X				
+web-sys@0.3.98		X									X				
 web-time@1.1.0		X									X				
-webpki-root-certs@1.0.6								X							
+webpki-root-certs@1.0.7								X							
 which@4.4.2											X				
 winapi-util@0.1.11											X			X	
 windows-link@0.2.1		X									X				
-windows-sys@0.45.0		X									X				
 windows-sys@0.59.0		X									X				
 windows-sys@0.61.2		X									X				
-windows-targets@0.42.2		X									X				
 windows-targets@0.52.6		X									X				
-windows_aarch64_gnullvm@0.42.2		X									X				
 windows_aarch64_gnullvm@0.52.6		X									X				
-windows_aarch64_msvc@0.42.2		X									X				
 windows_aarch64_msvc@0.52.6		X									X				
-windows_i686_gnu@0.42.2		X									X				
 windows_i686_gnu@0.52.6		X									X				
 windows_i686_gnullvm@0.52.6		X									X				
-windows_i686_msvc@0.42.2		X									X				
 windows_i686_msvc@0.52.6		X									X				
-windows_x86_64_gnu@0.42.2		X									X				
 windows_x86_64_gnu@0.52.6		X									X				
-windows_x86_64_gnullvm@0.42.2		X									X				
 windows_x86_64_gnullvm@0.52.6		X									X				
-windows_x86_64_msvc@0.42.2		X									X				
 windows_x86_64_msvc@0.52.6		X									X				
 wit-bindgen@0.46.0		X	X								X				
 wit-bindgen@0.51.0		X	X								X				
@@ -342,7 +336,7 @@ xattr@1.6.1		X									X
 yoke@0.8.2													X		
 yoke-derive@0.8.2													X		
 zerocopy@0.8.48		X		X							X				
-zerofrom@0.1.7													X		
+zerofrom@0.1.8													X		
 zerofrom-derive@0.1.7													X		
 zeroize@1.8.2		X									X				
 zerotrie@0.2.4													X		

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.85"
-version = "0.47.1"
+version = "0.47.2"
 
 [features]
 default = [

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -5,44 +5,45 @@ anyhow@1.0.102	X									X
 async-trait@0.1.89	X									X				
 atomic-waker@1.1.2	X									X				
 autocfg@1.5.0	X									X				
-aws-lc-rs@1.16.3	X							X						
-aws-lc-sys@0.40.0	X			X				X		X	X			
+aws-lc-rs@1.17.0	X							X						
+aws-lc-sys@0.41.0	X			X				X		X	X			
 backon@1.6.0	X													
 base64@0.22.1	X									X				
 base64ct@1.8.3	X									X				
 bitflags@2.11.1	X									X				
 block-buffer@0.10.4	X									X				
+block-buffer@0.12.0	X									X				
 block-padding@0.3.3	X									X				
 bumpalo@3.20.2	X									X				
 bytes@1.11.1										X				
 cbc@0.1.2	X									X				
-cc@1.2.60	X									X				
-cesu8@1.1.0	X									X				
+cc@1.2.62	X									X				
 cfg-if@1.0.4	X									X				
 chrono@0.4.44	X									X				
 cipher@0.4.4	X									X				
 cmake@0.1.58	X									X				
 combine@4.6.7										X				
+const-oid@0.10.2	X									X				
 const-oid@0.9.6	X									X				
 const-random@0.1.18	X									X				
 const-random-macro@0.1.16	X									X				
 core-foundation@0.10.1	X									X				
 core-foundation-sys@0.8.7	X									X				
 cpufeatures@0.2.17	X									X				
+cpufeatures@0.3.0	X									X				
 crc32c@0.6.8	X									X				
 crunchy@0.2.4										X				
 crypto-common@0.1.7	X									X				
-ctor@0.6.3	X									X				
-ctor-proc-macro@0.0.7	X									X				
+crypto-common@0.2.2	X									X				
+ctor@1.0.6	X									X				
 der@0.7.10	X									X				
 deranged@0.5.8	X									X				
 digest@0.10.7	X									X				
+digest@0.11.3	X									X				
 displaydoc@0.2.5	X									X				
 dlv-list@0.5.2	X									X				
-dtor@0.1.1	X									X				
-dtor-proc-macro@0.0.6	X									X				
 dunce@1.0.5	X					X					X			
-either@1.15.0	X									X				
+either@1.16.0	X									X				
 equivalent@1.0.2	X									X				
 errno@0.3.14	X									X				
 fastrand@2.4.1	X									X				
@@ -63,10 +64,10 @@ getopts@0.2.24	X									X
 getrandom@0.2.17	X									X				
 getrandom@0.3.4	X									X				
 getrandom@0.4.2	X									X				
-ghac@0.2.0	X													
+ghac@0.3.0	X													
 gloo-timers@0.3.0	X									X				
 hashbrown@0.14.5	X									X				
-hashbrown@0.17.0	X									X				
+hashbrown@0.17.1	X									X				
 heck@0.5.0	X									X				
 hex@0.4.3	X									X				
 hmac@0.12.1	X									X				
@@ -74,6 +75,7 @@ http@1.4.0	X									X
 http-body@1.0.1										X				
 http-body-util@0.1.3										X				
 httparse@1.10.1	X									X				
+hybrid-array@0.4.12	X									X				
 hyper@1.9.0										X				
 hyper-rustls@0.27.9	X							X		X				
 hyper-util@0.1.20										X				
@@ -93,31 +95,32 @@ indoc@2.0.7	X									X
 inout@0.1.4	X									X				
 inventory@0.3.24	X									X				
 ipnet@2.12.0	X									X				
-iri-string@0.7.12	X									X				
 is-macro@0.3.7	X													
 itertools@0.11.0	X									X				
 itertools@0.14.0	X									X				
 itoa@1.0.18	X									X				
-jiff@0.2.23										X				X
+jiff@0.2.24										X				X
 jiff-tzdb@0.1.6										X				X
 jiff-tzdb-platform@0.1.3										X				X
-jni@0.21.1	X									X				
-jni-sys@0.3.1	X									X				
+jni@0.22.4	X									X				
+jni-macros@0.22.4	X									X				
 jni-sys@0.4.1	X									X				
 jni-sys-macros@0.4.1	X									X				
 jobserver@0.1.34	X									X				
-js-sys@0.3.95	X									X				
+js-sys@0.3.98	X									X				
 jsonwebtoken@10.3.0										X				
 lalrpop-util@0.20.2	X									X				
 lazy_static@1.5.0	X									X				
-libc@0.2.185	X									X				
+libc@0.2.186	X									X				
 libm@0.2.16										X				
+link-section@0.17.2	X									X				
+linktime-proc-macro@0.1.0	X									X				
 linux-raw-sys@0.12.1	X	X								X				
 litemap@0.8.2												X		
 log@0.4.29	X									X				
 maplit@1.0.2	X									X				
 matrixmultiply@0.3.10	X									X				
-md-5@0.10.6	X									X				
+md-5@0.11.0	X									X				
 mea@0.6.3	X													
 memchr@2.8.0										X				X
 memoffset@0.9.1										X				
@@ -128,34 +131,34 @@ ndarray@0.17.2	X									X
 num-bigint@0.4.6	X									X				
 num-bigint-dig@0.8.6	X									X				
 num-complex@0.4.6	X									X				
-num-conv@0.2.1	X									X				
+num-conv@0.2.2	X									X				
 num-integer@0.1.46	X									X				
 num-iter@0.1.45	X									X				
 num-traits@0.2.19	X									X				
 numpy@0.27.1			X											
 once_cell@1.21.4	X									X				
-opendal@0.56.0	X													
-opendal-core@0.56.0	X													
-opendal-layer-concurrent-limit@0.56.0	X													
-opendal-layer-logging@0.56.0	X													
-opendal-layer-mime-guess@0.56.0	X													
-opendal-layer-retry@0.56.0	X													
-opendal-layer-timeout@0.56.0	X													
-opendal-python@0.47.1	X													
-opendal-service-azblob@0.56.0	X													
-opendal-service-azdls@0.56.0	X													
-opendal-service-azure-common@0.56.0	X													
-opendal-service-cos@0.56.0	X													
-opendal-service-fs@0.56.0	X													
-opendal-service-gcs@0.56.0	X													
-opendal-service-ghac@0.56.0	X													
-opendal-service-http@0.56.0	X													
-opendal-service-ipmfs@0.56.0	X													
-opendal-service-obs@0.56.0	X													
-opendal-service-oss@0.56.0	X													
-opendal-service-s3@0.56.0	X													
-opendal-service-webdav@0.56.0	X													
-opendal-service-webhdfs@0.56.0	X													
+opendal@0.57.0	X													
+opendal-core@0.57.0	X													
+opendal-layer-concurrent-limit@0.57.0	X													
+opendal-layer-logging@0.57.0	X													
+opendal-layer-mime-guess@0.57.0	X													
+opendal-layer-retry@0.57.0	X													
+opendal-layer-timeout@0.57.0	X													
+opendal-python@0.47.2	X													
+opendal-service-azblob@0.57.0	X													
+opendal-service-azdls@0.57.0	X													
+opendal-service-azure-common@0.57.0	X													
+opendal-service-cos@0.57.0	X													
+opendal-service-fs@0.57.0	X													
+opendal-service-gcs@0.57.0	X													
+opendal-service-ghac@0.57.0	X													
+opendal-service-http@0.57.0	X													
+opendal-service-ipmfs@0.57.0	X													
+opendal-service-obs@0.57.0	X													
+opendal-service-oss@0.57.0	X													
+opendal-service-s3@0.57.0	X													
+opendal-service-webdav@0.57.0	X													
+opendal-service-webhdfs@0.57.0	X													
 openssl-probe@0.2.1	X									X				
 ordered-float@5.3.0										X				
 ordered-multimap@0.7.3										X				
@@ -172,13 +175,13 @@ pkcs1@0.7.5	X									X
 pkcs5@0.7.1	X									X				
 pkcs8@0.10.2	X									X				
 portable-atomic@1.13.1	X									X				
-portable-atomic-util@0.2.6	X									X				
+portable-atomic-util@0.2.7	X									X				
 potential_utf@0.1.5												X		
 powerfmt@0.2.0	X									X				
 ppv-lite86@0.2.21	X									X				
 proc-macro2@1.0.106	X									X				
-prost@0.13.5	X													
-prost-derive@0.13.5	X													
+prost@0.14.3	X													
+prost-derive@0.14.3	X													
 pyo3@0.27.2	X									X				
 pyo3-async-runtimes@0.27.0	X													
 pyo3-build-config@0.27.2	X									X				
@@ -188,12 +191,11 @@ pyo3-macros-backend@0.27.2	X									X
 pyo3-stub-gen@0.17.2	X									X				
 pyo3-stub-gen-derive@0.17.2	X									X				
 python3-dll-a@0.2.15										X				
-quick-xml@0.38.4										X				
-quick-xml@0.39.2										X				
+quick-xml@0.39.4										X				
 quote@1.0.45	X									X				
 r-efi@5.3.0	X								X	X				
 r-efi@6.0.0	X								X	X				
-rand@0.8.5	X									X				
+rand@0.8.6	X									X				
 rand_chacha@0.3.1	X									X				
 rand_core@0.6.4	X									X				
 rawpointer@0.2.1	X									X				
@@ -205,19 +207,19 @@ reqsign-file-read-tokio@3.0.0	X
 reqsign-google@3.0.0	X													
 reqsign-huaweicloud-obs@3.0.0	X													
 reqsign-tencent-cos@3.0.0	X													
-reqwest@0.13.2	X									X				
+reqwest@0.13.3	X									X				
 rsa@0.9.10	X									X				
 rust-ini@0.21.3										X				
 rustc-hash@1.1.0	X									X				
 rustc-hash@2.1.2	X									X				
 rustc_version@0.4.1	X									X				
 rustix@1.1.4	X	X								X				
-rustls@0.23.38	X							X		X				
+rustls@0.23.40	X							X		X				
 rustls-native-certs@0.8.3	X							X		X				
-rustls-pki-types@1.14.0	X									X				
-rustls-platform-verifier@0.6.2	X									X				
+rustls-pki-types@1.14.1	X									X				
+rustls-platform-verifier@0.7.0	X									X				
 rustls-platform-verifier-android@0.1.1	X									X				
-rustls-webpki@0.103.12								X						
+rustls-webpki@0.103.13								X						
 rustpython-ast@0.4.0										X				
 rustpython-parser@0.4.0										X				
 rustpython-parser-core@0.4.0										X				
@@ -234,15 +236,18 @@ semver@1.0.28	X									X
 serde@1.0.228	X									X				
 serde_core@1.0.228	X									X				
 serde_derive@1.0.228	X									X				
-serde_json@1.0.149	X									X				
+serde_json@1.0.150	X									X				
 serde_spanned@1.1.1	X									X				
 serde_urlencoded@0.7.1	X									X				
 sha1@0.10.6	X									X				
 sha2@0.10.9	X									X				
+sha2@0.11.0	X									X				
 shlex@1.3.0	X									X				
 signature@2.2.0	X									X				
+simd_cesu8@1.1.1	X									X				
+simdutf8@0.1.5	X									X				
 simple_asn1@0.6.4								X						
-siphasher@1.0.2	X									X				
+siphasher@1.0.3	X									X				
 slab@0.4.12										X				
 smallvec@1.15.1	X									X				
 socket2@0.6.3	X									X				
@@ -255,16 +260,14 @@ syn@2.0.117	X									X
 sync_wrapper@1.0.2	X													
 synstructure@0.13.2										X				
 target-lexicon@0.13.5		X												
-thiserror@1.0.69	X									X				
 thiserror@2.0.18	X									X				
-thiserror-impl@1.0.69	X									X				
 thiserror-impl@2.0.18	X									X				
 time@0.3.47	X									X				
 time-core@0.1.8	X									X				
 time-macros@0.2.27	X									X				
 tiny-keccak@2.0.2						X								
 tinystr@0.8.3												X		
-tokio@1.52.0										X				
+tokio@1.52.3										X				
 tokio-macros@2.7.0										X				
 tokio-rustls@0.26.4	X									X				
 tokio-util@0.7.18										X				
@@ -273,13 +276,13 @@ toml_datetime@0.7.5+spec-1.1.0	X									X
 toml_parser@1.1.2+spec-1.1.0	X									X				
 toml_writer@1.1.1+spec-1.1.0	X									X				
 tower@0.5.3										X				
-tower-http@0.6.8										X				
+tower-http@0.6.11										X				
 tower-layer@0.3.3										X				
 tower-service@0.3.3										X				
 tracing@0.1.44										X				
 tracing-core@0.1.36										X				
 try-lock@0.2.5										X				
-typenum@1.19.0	X									X				
+typenum@1.20.0	X									X				
 unic-char-property@0.9.0	X									X				
 unic-char-range@0.9.0	X									X				
 unic-common@0.9.0	X									X				
@@ -303,15 +306,15 @@ want@0.3.1										X
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X				
 wasip2@1.0.1+wasi-0.2.4	X	X								X				
 wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X				
-wasm-bindgen@0.2.118	X									X				
-wasm-bindgen-futures@0.4.68	X									X				
-wasm-bindgen-macro@0.2.118	X									X				
-wasm-bindgen-macro-support@0.2.118	X									X				
-wasm-bindgen-shared@0.2.118	X									X				
+wasm-bindgen@0.2.121	X									X				
+wasm-bindgen-futures@0.4.71	X									X				
+wasm-bindgen-macro@0.2.121	X									X				
+wasm-bindgen-macro-support@0.2.121	X									X				
+wasm-bindgen-shared@0.2.121	X									X				
 wasm-streams@0.5.0	X									X				
-web-sys@0.3.95	X									X				
+web-sys@0.3.98	X									X				
 web-time@1.1.0	X									X				
-webpki-root-certs@1.0.6							X							
+webpki-root-certs@1.0.7							X							
 winapi-util@0.1.11										X				X
 windows-core@0.62.2	X									X				
 windows-implement@0.60.2	X									X				
@@ -319,18 +322,9 @@ windows-interface@0.59.3	X									X
 windows-link@0.2.1	X									X				
 windows-result@0.4.1	X									X				
 windows-strings@0.5.1	X									X				
-windows-sys@0.45.0	X									X				
 windows-sys@0.61.2	X									X				
-windows-targets@0.42.2	X									X				
-windows_aarch64_gnullvm@0.42.2	X									X				
-windows_aarch64_msvc@0.42.2	X									X				
-windows_i686_gnu@0.42.2	X									X				
-windows_i686_msvc@0.42.2	X									X				
-windows_x86_64_gnu@0.42.2	X									X				
-windows_x86_64_gnullvm@0.42.2	X									X				
-windows_x86_64_msvc@0.42.2	X									X				
 winnow@0.7.15										X				
-winnow@1.0.1										X				
+winnow@1.0.3										X				
 wit-bindgen@0.46.0	X	X								X				
 wit-bindgen@0.51.0	X	X								X				
 writeable@0.6.3												X		
@@ -338,7 +332,7 @@ xattr@1.6.1	X									X
 yoke@0.8.2												X		
 yoke-derive@0.8.2												X		
 zerocopy@0.8.48	X		X							X				
-zerofrom@0.1.7												X		
+zerofrom@0.1.8												X		
 zerofrom-derive@0.1.7												X		
 zeroize@1.8.2	X									X				
 zerotrie@0.2.4												X		

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.85"
-version = "0.1.6-rc.2"                                # updates this version to bump Rubygem version during release process
+version = "0.1.6"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -143,7 +143,7 @@ opendal-layer-logging@0.57.0	X
 opendal-layer-retry@0.57.0	X													
 opendal-layer-throttle@0.57.0	X													
 opendal-layer-timeout@0.57.0	X													
-opendal-ruby@0.1.6-rc.2	X													
+opendal-ruby@0.1.6	X													
 opendal-service-azblob@0.57.0	X													
 opendal-service-azdls@0.57.0	X													
 opendal-service-azfile@0.57.0	X													

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -6,48 +6,49 @@ anyhow@1.0.102	X									X
 async-trait@0.1.89	X									X				
 atomic-waker@1.1.2	X									X				
 autocfg@1.5.0	X									X				
-aws-lc-rs@1.16.3	X							X						
-aws-lc-sys@0.40.0	X			X				X		X	X			
+aws-lc-rs@1.17.0	X							X						
+aws-lc-sys@0.41.0	X			X				X		X	X			
 backon@1.6.0	X													
 base64@0.22.1	X									X				
 base64ct@1.8.3	X									X				
 bindgen@0.72.1				X										
 bitflags@2.11.1	X									X				
 block-buffer@0.10.4	X									X				
+block-buffer@0.12.0	X									X				
 block-padding@0.3.3	X									X				
 bumpalo@3.20.2	X									X				
 bytes@1.11.1										X				
 cbc@0.1.2	X									X				
-cc@1.2.60	X									X				
-cesu8@1.1.0	X									X				
+cc@1.2.62	X									X				
 cexpr@0.6.0	X									X				
 cfg-if@1.0.4	X									X				
 cipher@0.4.4	X									X				
 clang-sys@1.8.1	X													
 cmake@0.1.58	X									X				
 combine@4.6.7										X				
+const-oid@0.10.2	X									X				
 const-oid@0.9.6	X									X				
 const-random@0.1.18	X									X				
 const-random-macro@0.1.16	X									X				
 core-foundation@0.10.1	X									X				
 core-foundation-sys@0.8.7	X									X				
 cpufeatures@0.2.17	X									X				
+cpufeatures@0.3.0	X									X				
 crc32c@0.6.8	X									X				
 crossbeam-utils@0.8.21	X									X				
 crunchy@0.2.4										X				
 crypto-common@0.1.7	X									X				
-ctor@0.6.3	X									X				
-ctor-proc-macro@0.0.7	X									X				
-dashmap@6.1.0										X				
+crypto-common@0.2.2	X									X				
+ctor@1.0.6	X									X				
+dashmap@6.2.1										X				
 der@0.7.10	X									X				
 deranged@0.5.8	X									X				
 digest@0.10.7	X									X				
+digest@0.11.3	X									X				
 displaydoc@0.2.5	X									X				
 dlv-list@0.5.2	X									X				
-dtor@0.1.1	X									X				
-dtor-proc-macro@0.0.6	X									X				
 dunce@1.0.5	X					X					X			
-either@1.15.0	X									X				
+either@1.16.0	X									X				
 equivalent@1.0.2	X									X				
 errno@0.3.14	X									X				
 fastrand@2.4.1	X									X				
@@ -63,13 +64,13 @@ futures-io@0.3.32	X									X
 futures-macro@0.3.32	X									X				
 futures-sink@0.3.32	X									X				
 futures-task@0.3.32	X									X				
-futures-timer@3.0.3	X									X				
+futures-timer@3.0.4	X									X				
 futures-util@0.3.32	X									X				
 generic-array@0.14.7										X				
 getrandom@0.2.17	X									X				
 getrandom@0.3.4	X									X				
 getrandom@0.4.2	X									X				
-ghac@0.2.0	X													
+ghac@0.3.0	X													
 glob@0.3.3	X									X				
 gloo-timers@0.3.0	X									X				
 governor@0.10.4										X				
@@ -81,6 +82,7 @@ http@1.4.0	X									X
 http-body@1.0.1										X				
 http-body-util@0.1.3										X				
 httparse@1.10.1	X									X				
+hybrid-array@0.4.12	X									X				
 hyper@1.9.0										X				
 hyper-rustls@0.27.9	X							X		X				
 hyper-util@0.1.20										X				
@@ -95,31 +97,32 @@ idna@1.1.0	X									X
 idna_adapter@1.2.1	X									X				
 inout@0.1.4	X									X				
 ipnet@2.12.0	X									X				
-iri-string@0.7.12	X									X				
 itertools@0.13.0	X									X				
 itertools@0.14.0	X									X				
 itoa@1.0.18	X									X				
-jiff@0.2.23										X			X	
+jiff@0.2.24										X			X	
 jiff-tzdb@0.1.6										X			X	
 jiff-tzdb-platform@0.1.3										X			X	
-jni@0.21.1	X									X				
-jni-sys@0.3.1	X									X				
+jni@0.22.4	X									X				
+jni-macros@0.22.4	X									X				
 jni-sys@0.4.1	X									X				
 jni-sys-macros@0.4.1	X									X				
 jobserver@0.1.34	X									X				
-js-sys@0.3.95	X									X				
+js-sys@0.3.98	X									X				
 jsonwebtoken@10.3.0										X				
 lazy_static@1.5.0	X									X				
-libc@0.2.185	X									X				
+libc@0.2.186	X									X				
 libloading@0.8.9								X						
 libm@0.2.16										X				
+link-section@0.17.2	X									X				
+linktime-proc-macro@0.1.0	X									X				
 linux-raw-sys@0.12.1	X	X								X				
 litemap@0.8.2												X		
 lock_api@0.4.14	X									X				
 log@0.4.29	X									X				
 magnus@0.8.2										X				
 magnus-macros@0.8.0										X				
-md-5@0.10.6	X									X				
+md-5@0.11.0	X									X				
 mea@0.6.3	X													
 memchr@2.8.0										X			X	
 minimal-lexical@0.2.1	X									X				
@@ -128,34 +131,34 @@ nom@7.1.3										X
 nonzero_ext@0.3.0	X													
 num-bigint@0.4.6	X									X				
 num-bigint-dig@0.8.6	X									X				
-num-conv@0.2.1	X									X				
+num-conv@0.2.2	X									X				
 num-integer@0.1.46	X									X				
 num-iter@0.1.45	X									X				
 num-traits@0.2.19	X									X				
 once_cell@1.21.4	X									X				
-opendal@0.56.0	X													
-opendal-core@0.56.0	X													
-opendal-layer-concurrent-limit@0.56.0	X													
-opendal-layer-logging@0.56.0	X													
-opendal-layer-retry@0.56.0	X													
-opendal-layer-throttle@0.56.0	X													
-opendal-layer-timeout@0.56.0	X													
+opendal@0.57.0	X													
+opendal-core@0.57.0	X													
+opendal-layer-concurrent-limit@0.57.0	X													
+opendal-layer-logging@0.57.0	X													
+opendal-layer-retry@0.57.0	X													
+opendal-layer-throttle@0.57.0	X													
+opendal-layer-timeout@0.57.0	X													
 opendal-ruby@0.1.6-rc.2	X													
-opendal-service-azblob@0.56.0	X													
-opendal-service-azdls@0.56.0	X													
-opendal-service-azfile@0.56.0	X													
-opendal-service-azure-common@0.56.0	X													
-opendal-service-cos@0.56.0	X													
-opendal-service-fs@0.56.0	X													
-opendal-service-gcs@0.56.0	X													
-opendal-service-ghac@0.56.0	X													
-opendal-service-http@0.56.0	X													
-opendal-service-ipmfs@0.56.0	X													
-opendal-service-obs@0.56.0	X													
-opendal-service-oss@0.56.0	X													
-opendal-service-s3@0.56.0	X													
-opendal-service-webdav@0.56.0	X													
-opendal-service-webhdfs@0.56.0	X													
+opendal-service-azblob@0.57.0	X													
+opendal-service-azdls@0.57.0	X													
+opendal-service-azfile@0.57.0	X													
+opendal-service-azure-common@0.57.0	X													
+opendal-service-cos@0.57.0	X													
+opendal-service-fs@0.57.0	X													
+opendal-service-gcs@0.57.0	X													
+opendal-service-ghac@0.57.0	X													
+opendal-service-http@0.57.0	X													
+opendal-service-ipmfs@0.57.0	X													
+opendal-service-obs@0.57.0	X													
+opendal-service-oss@0.57.0	X													
+opendal-service-s3@0.57.0	X													
+opendal-service-webdav@0.57.0	X													
+opendal-service-webhdfs@0.57.0	X													
 openssl-probe@0.2.1	X									X				
 ordered-multimap@0.7.3										X				
 parking_lot@0.12.5	X									X				
@@ -169,28 +172,27 @@ pkcs1@0.7.5	X									X
 pkcs5@0.7.1	X									X				
 pkcs8@0.10.2	X									X				
 portable-atomic@1.13.1	X									X				
-portable-atomic-util@0.2.6	X									X				
+portable-atomic-util@0.2.7	X									X				
 potential_utf@0.1.5												X		
 powerfmt@0.2.0	X									X				
 ppv-lite86@0.2.21	X									X				
 proc-macro2@1.0.106	X									X				
-prost@0.13.5	X													
-prost-derive@0.13.5	X													
+prost@0.14.3	X													
+prost-derive@0.14.3	X													
 quanta@0.12.6										X				
-quick-xml@0.38.4										X				
-quick-xml@0.39.2										X				
+quick-xml@0.39.4										X				
 quote@1.0.45	X									X				
 r-efi@5.3.0	X								X	X				
 r-efi@6.0.0	X								X	X				
-rand@0.8.5	X									X				
+rand@0.8.6	X									X				
 rand@0.9.4	X									X				
 rand_chacha@0.3.1	X									X				
 rand_chacha@0.9.0	X									X				
 rand_core@0.6.4	X									X				
 rand_core@0.9.5	X									X				
 raw-cpuid@11.6.0										X				
-rb-sys@0.9.126	X									X				
-rb-sys-build@0.9.126	X									X				
+rb-sys@0.9.128	X									X				
+rb-sys-build@0.9.128	X									X				
 rb-sys-env@0.1.2	X									X				
 rb-sys-env@0.2.3	X									X				
 redox_syscall@0.5.18										X				
@@ -205,18 +207,18 @@ reqsign-file-read-tokio@3.0.0	X
 reqsign-google@3.0.0	X													
 reqsign-huaweicloud-obs@3.0.0	X													
 reqsign-tencent-cos@3.0.0	X													
-reqwest@0.13.2	X									X				
+reqwest@0.13.3	X									X				
 rsa@0.9.10	X									X				
 rust-ini@0.21.3										X				
 rustc-hash@2.1.2	X									X				
 rustc_version@0.4.1	X									X				
 rustix@1.1.4	X	X								X				
-rustls@0.23.38	X							X		X				
+rustls@0.23.40	X							X		X				
 rustls-native-certs@0.8.3	X							X		X				
-rustls-pki-types@1.14.0	X									X				
-rustls-platform-verifier@0.6.2	X									X				
+rustls-pki-types@1.14.1	X									X				
+rustls-platform-verifier@0.7.0	X									X				
 rustls-platform-verifier-android@0.1.1	X									X				
-rustls-webpki@0.103.12								X						
+rustls-webpki@0.103.13								X						
 rustversion@1.0.22	X									X				
 ryu@1.0.23	X				X									
 salsa20@0.10.2	X									X				
@@ -231,14 +233,17 @@ seq-macro@0.3.6	X									X
 serde@1.0.228	X									X				
 serde_core@1.0.228	X									X				
 serde_derive@1.0.228	X									X				
-serde_json@1.0.149	X									X				
+serde_json@1.0.150	X									X				
 serde_urlencoded@0.7.1	X									X				
 sha1@0.10.6	X									X				
 sha2@0.10.9	X									X				
+sha2@0.11.0	X									X				
 shell-words@1.1.1	X									X				
 shlex@1.3.0	X									X				
 signal-hook-registry@1.4.8	X									X				
 signature@2.2.0	X									X				
+simd_cesu8@1.1.1	X									X				
+simdutf8@0.1.5	X									X				
 simple_asn1@0.6.4								X						
 slab@0.4.12										X				
 smallvec@1.15.1	X									X				
@@ -251,27 +256,25 @@ subtle@2.6.1				X
 syn@2.0.117	X									X				
 sync_wrapper@1.0.2	X													
 synstructure@0.13.2										X				
-thiserror@1.0.69	X									X				
 thiserror@2.0.18	X									X				
-thiserror-impl@1.0.69	X									X				
 thiserror-impl@2.0.18	X									X				
 time@0.3.47	X									X				
 time-core@0.1.8	X									X				
 time-macros@0.2.27	X									X				
 tiny-keccak@2.0.2						X								
 tinystr@0.8.3												X		
-tokio@1.52.0										X				
+tokio@1.52.3										X				
 tokio-macros@2.7.0										X				
 tokio-rustls@0.26.4	X									X				
 tokio-util@0.7.18										X				
 tower@0.5.3										X				
-tower-http@0.6.8										X				
+tower-http@0.6.11										X				
 tower-layer@0.3.3										X				
 tower-service@0.3.3										X				
 tracing@0.1.44										X				
 tracing-core@0.1.36										X				
 try-lock@0.2.5										X				
-typenum@1.19.0	X									X				
+typenum@1.20.0	X									X				
 unicode-ident@1.0.24	X									X		X		
 untrusted@0.7.1								X						
 untrusted@0.9.0								X						
@@ -284,30 +287,21 @@ want@0.3.1										X
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X				
 wasip2@1.0.1+wasi-0.2.4	X	X								X				
 wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X				
-wasm-bindgen@0.2.118	X									X				
-wasm-bindgen-futures@0.4.68	X									X				
-wasm-bindgen-macro@0.2.118	X									X				
-wasm-bindgen-macro-support@0.2.118	X									X				
-wasm-bindgen-shared@0.2.118	X									X				
+wasm-bindgen@0.2.121	X									X				
+wasm-bindgen-futures@0.4.71	X									X				
+wasm-bindgen-macro@0.2.121	X									X				
+wasm-bindgen-macro-support@0.2.121	X									X				
+wasm-bindgen-shared@0.2.121	X									X				
 wasm-streams@0.5.0	X									X				
-web-sys@0.3.95	X									X				
+web-sys@0.3.98	X									X				
 web-time@1.1.0	X									X				
-webpki-root-certs@1.0.6							X							
+webpki-root-certs@1.0.7							X							
 winapi@0.3.9	X									X				
 winapi-i686-pc-windows-gnu@0.4.0	X									X				
 winapi-util@0.1.11										X			X	
 winapi-x86_64-pc-windows-gnu@0.4.0	X									X				
 windows-link@0.2.1	X									X				
-windows-sys@0.45.0	X									X				
 windows-sys@0.61.2	X									X				
-windows-targets@0.42.2	X									X				
-windows_aarch64_gnullvm@0.42.2	X									X				
-windows_aarch64_msvc@0.42.2	X									X				
-windows_i686_gnu@0.42.2	X									X				
-windows_i686_msvc@0.42.2	X									X				
-windows_x86_64_gnu@0.42.2	X									X				
-windows_x86_64_gnullvm@0.42.2	X									X				
-windows_x86_64_msvc@0.42.2	X									X				
 wit-bindgen@0.46.0	X	X								X				
 wit-bindgen@0.51.0	X	X								X				
 writeable@0.6.3												X		
@@ -315,7 +309,7 @@ xattr@1.6.1	X									X
 yoke@0.8.2												X		
 yoke-derive@0.8.2												X		
 zerocopy@0.8.48	X		X							X				
-zerofrom@0.1.7												X		
+zerofrom@0.1.8												X		
 zerofrom-derive@0.1.7												X		
 zeroize@1.8.2	X									X				
 zerotrie@0.2.4												X		

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_aws_s3_assume_role_with_web_identity"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "logforth",
  "opendal",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_file_write_on_full_disk"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal",
  "rand 0.10.1",
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_opfs_wasm32"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "futures",
  "opendal",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_s3_read_on_wasm"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal",
  "wasm-bindgen",
@@ -6206,7 +6206,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opendal"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6318,7 +6318,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-benchmark-vs-fs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "criterion",
  "opendal",
@@ -6329,7 +6329,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-benchmark-vs-s3"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -6344,7 +6344,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-core"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6375,7 +6375,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-basic"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6383,7 +6383,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-concurrent-upload"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6391,7 +6391,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-multipart-upload"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6399,7 +6399,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-fuzz"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -6411,7 +6411,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-async-backtrace"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "async-backtrace",
  "opendal-core",
@@ -6419,7 +6419,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-await-tree"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "await-tree",
  "futures",
@@ -6428,7 +6428,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-capability-check"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -6436,7 +6436,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-chaos"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal-core",
  "rand 0.10.1",
@@ -6444,7 +6444,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-concurrent-limit"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -6455,7 +6455,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-dtrace"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "opendal-core",
@@ -6465,7 +6465,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-fastmetrics"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "fastmetrics",
  "log",
@@ -6476,7 +6476,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-fastrace"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6488,7 +6488,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-foyer"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bincode",
  "foyer",
@@ -6501,7 +6501,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-hotpath"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "futures",
  "hotpath",
@@ -6512,7 +6512,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-immutable-index"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "futures",
  "log",
@@ -6523,7 +6523,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-logging"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "log",
  "opendal-core",
@@ -6531,7 +6531,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-metrics"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "metrics",
  "opendal-core",
@@ -6540,7 +6540,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-mime-guess"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "futures",
  "mime_guess",
@@ -6550,7 +6550,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-observe-metrics-common"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -6560,7 +6560,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-otelmetrics"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal-core",
  "opendal-layer-observe-metrics-common",
@@ -6569,7 +6569,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-oteltrace"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal-core",
  "opentelemetry 0.32.0",
@@ -6577,7 +6577,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-prometheus"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "log",
  "opendal-core",
@@ -6588,7 +6588,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-prometheus-client"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "log",
  "opendal-core",
@@ -6599,7 +6599,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-retry"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "backon",
  "bytes",
@@ -6614,7 +6614,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-route"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "futures",
  "globset",
@@ -6625,7 +6625,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-tail-cut"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -6633,7 +6633,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-throttle"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "governor",
  "opendal-core",
@@ -6641,7 +6641,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-timeout"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "futures",
  "opendal-core",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-tracing"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6669,7 +6669,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-aliyun-drive"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-alluxio"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6696,7 +6696,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azblob"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6718,7 +6718,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azdls"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6737,7 +6737,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azfile"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6754,7 +6754,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azure-common"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "http 1.4.0",
  "opendal-core",
@@ -6762,7 +6762,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-b2"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cacache"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "cacache",
@@ -6787,7 +6787,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cloudflare-kv"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6798,7 +6798,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-compfs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "compio",
@@ -6809,7 +6809,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cos"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6825,7 +6825,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-d1"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6837,7 +6837,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dashmap"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "dashmap 6.1.0",
  "log",
@@ -6848,7 +6848,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dbfs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6862,7 +6862,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dropbox"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6875,7 +6875,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-etcd"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "etcd-client",
  "fastpool",
@@ -6886,7 +6886,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-foundationdb"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "foundationdb",
  "opendal-core",
@@ -6896,7 +6896,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-foyer"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "foyer",
  "log",
@@ -6910,7 +6910,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-fs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "log",
@@ -6922,7 +6922,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ftp"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "fastpool",
@@ -6939,7 +6939,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6958,7 +6958,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gdrive"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -6972,7 +6972,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ghac"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "ghac",
@@ -6991,7 +6991,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-github"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7005,7 +7005,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-goosefs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "goosefs-sdk",
@@ -7018,7 +7018,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gridfs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "futures",
  "mea",
@@ -7030,7 +7030,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hdfs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "futures",
@@ -7043,7 +7043,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hdfs-native"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "futures",
@@ -7055,7 +7055,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hf"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "futures",
@@ -7072,7 +7072,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-http"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "http 1.4.0",
  "log",
@@ -7083,7 +7083,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ipfs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7096,7 +7096,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ipmfs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7109,7 +7109,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-koofr"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7123,7 +7123,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-lakefs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7136,7 +7136,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-memcached"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "fastpool",
  "opendal-core",
@@ -7147,7 +7147,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mini-moka"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "log",
  "mini-moka",
@@ -7157,7 +7157,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-moka"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "log",
  "moka",
@@ -7168,7 +7168,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mongodb"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "mea",
@@ -7180,7 +7180,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-monoiofs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "flume 0.12.0",
@@ -7193,7 +7193,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mysql"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-obs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7220,7 +7220,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-onedrive"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7234,7 +7234,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-opfs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "js-sys",
  "opendal-core",
@@ -7247,7 +7247,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-oss"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7264,7 +7264,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-pcloud"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7277,7 +7277,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-persy"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal-core",
  "persy",
@@ -7287,7 +7287,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-postgresql"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7298,7 +7298,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-redb"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal-core",
  "redb 2.6.3",
@@ -7308,7 +7308,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-redis"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "fastpool",
@@ -7321,7 +7321,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-rocksdb"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal-core",
  "rocksdb",
@@ -7331,7 +7331,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-s3"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7353,7 +7353,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-seafile"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7367,7 +7367,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sftp"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7383,7 +7383,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sled"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "opendal-core",
  "serde",
@@ -7393,7 +7393,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sqlite"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7404,7 +7404,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-surrealdb"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7415,7 +7415,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-swift"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7435,7 +7435,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-tikv"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7446,7 +7446,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-tos"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7461,7 +7461,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-upyun"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7479,7 +7479,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-vercel-artifacts"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7493,7 +7493,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-vercel-blob"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7507,7 +7507,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webdav"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7522,7 +7522,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webhdfs"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7538,7 +7538,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-yandex-disk"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "http 1.4.0",
@@ -7552,7 +7552,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-testkit"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytes",
  "dotenvy",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,7 +38,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.85"
-version = "0.56.0"
+version = "0.57.0"
 
 [workspace.dependencies]
 base64 = "0.22"
@@ -214,101 +214,101 @@ required-features = ["tests"]
 
 [dependencies]
 ctor = { workspace = true, optional = true }
-opendal-core = { path = "core", version = "0.56.0", default-features = false }
-opendal-layer-async-backtrace = { path = "layers/async-backtrace", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-await-tree = { path = "layers/await-tree", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-capability-check = { path = "layers/capability-check", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-chaos = { path = "layers/chaos", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-concurrent-limit = { path = "layers/concurrent-limit", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-fastmetrics = { path = "layers/fastmetrics", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-fastrace = { path = "layers/fastrace", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-foyer = { path = "layers/foyer", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-hotpath = { path = "layers/hotpath", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-immutable-index = { path = "layers/immutable-index", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-logging = { path = "layers/logging", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-metrics = { path = "layers/metrics", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-mime-guess = { path = "layers/mime-guess", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-observe-metrics-common = { path = "layers/observe-metrics-common", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-otelmetrics = { path = "layers/otelmetrics", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-oteltrace = { path = "layers/oteltrace", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-prometheus = { path = "layers/prometheus", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-prometheus-client = { path = "layers/prometheus-client", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-retry = { path = "layers/retry", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-route = { path = "layers/route", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-tail-cut = { path = "layers/tail-cut", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-throttle = { path = "layers/throttle", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-timeout = { path = "layers/timeout", version = "0.56.0", optional = true, default-features = false }
-opendal-layer-tracing = { path = "layers/tracing", version = "0.56.0", optional = true, default-features = false }
-opendal-service-aliyun-drive = { path = "services/aliyun-drive", version = "0.56.0", optional = true, default-features = false }
-opendal-service-alluxio = { path = "services/alluxio", version = "0.56.0", optional = true, default-features = false }
-opendal-service-azblob = { path = "services/azblob", version = "0.56.0", optional = true, default-features = false }
-opendal-service-azdls = { path = "services/azdls", version = "0.56.0", optional = true, default-features = false }
-opendal-service-azfile = { path = "services/azfile", version = "0.56.0", optional = true, default-features = false }
-opendal-service-b2 = { path = "services/b2", version = "0.56.0", optional = true, default-features = false }
-opendal-service-cacache = { path = "services/cacache", version = "0.56.0", optional = true, default-features = false }
-opendal-service-cloudflare-kv = { path = "services/cloudflare-kv", version = "0.56.0", optional = true, default-features = false }
-opendal-service-compfs = { path = "services/compfs", version = "0.56.0", optional = true, default-features = false }
-opendal-service-cos = { path = "services/cos", version = "0.56.0", optional = true, default-features = false }
-opendal-service-d1 = { path = "services/d1", version = "0.56.0", optional = true, default-features = false }
-opendal-service-dashmap = { path = "services/dashmap", version = "0.56.0", optional = true, default-features = false }
-opendal-service-dbfs = { path = "services/dbfs", version = "0.56.0", optional = true, default-features = false }
-opendal-service-dropbox = { path = "services/dropbox", version = "0.56.0", optional = true, default-features = false }
-opendal-service-etcd = { path = "services/etcd", version = "0.56.0", optional = true, default-features = false }
-opendal-service-foundationdb = { path = "services/foundationdb", version = "0.56.0", optional = true, default-features = false }
-opendal-service-foyer = { path = "services/foyer", version = "0.56.0", optional = true, default-features = false }
-opendal-service-fs = { path = "services/fs", version = "0.56.0", optional = true, default-features = false }
-opendal-service-ftp = { path = "services/ftp", version = "0.56.0", optional = true, default-features = false }
-opendal-service-gcs = { path = "services/gcs", version = "0.56.0", optional = true, default-features = false }
-opendal-service-gdrive = { path = "services/gdrive", version = "0.56.0", optional = true, default-features = false }
-opendal-service-ghac = { path = "services/ghac", version = "0.56.0", optional = true, default-features = false }
-opendal-service-github = { path = "services/github", version = "0.56.0", optional = true, default-features = false }
-opendal-service-goosefs = { path = "services/goosefs", version = "0.56.0", optional = true, default-features = false }
-opendal-service-gridfs = { path = "services/gridfs", version = "0.56.0", optional = true, default-features = false }
-opendal-service-hdfs = { path = "services/hdfs", version = "0.56.0", optional = true, default-features = false }
-opendal-service-hdfs-native = { path = "services/hdfs-native", version = "0.56.0", optional = true, default-features = false }
-opendal-service-hf = { path = "services/hf", version = "0.56.0", optional = true, default-features = false }
-opendal-service-http = { path = "services/http", version = "0.56.0", optional = true, default-features = false }
-opendal-service-ipfs = { path = "services/ipfs", version = "0.56.0", optional = true, default-features = false }
-opendal-service-ipmfs = { path = "services/ipmfs", version = "0.56.0", optional = true, default-features = false }
-opendal-service-koofr = { path = "services/koofr", version = "0.56.0", optional = true, default-features = false }
-opendal-service-lakefs = { path = "services/lakefs", version = "0.56.0", optional = true, default-features = false }
-opendal-service-memcached = { path = "services/memcached", version = "0.56.0", optional = true, default-features = false }
-opendal-service-mini-moka = { path = "services/mini_moka", version = "0.56.0", optional = true, default-features = false }
-opendal-service-moka = { path = "services/moka", version = "0.56.0", optional = true, default-features = false }
-opendal-service-mongodb = { path = "services/mongodb", version = "0.56.0", optional = true, default-features = false }
-opendal-service-monoiofs = { path = "services/monoiofs", version = "0.56.0", optional = true, default-features = false }
-opendal-service-mysql = { path = "services/mysql", version = "0.56.0", optional = true, default-features = false }
-opendal-service-obs = { path = "services/obs", version = "0.56.0", optional = true, default-features = false }
-opendal-service-onedrive = { path = "services/onedrive", version = "0.56.0", optional = true, default-features = false }
-opendal-service-oss = { path = "services/oss", version = "0.56.0", optional = true, default-features = false }
-opendal-service-pcloud = { path = "services/pcloud", version = "0.56.0", optional = true, default-features = false }
-opendal-service-persy = { path = "services/persy", version = "0.56.0", optional = true, default-features = false }
-opendal-service-postgresql = { path = "services/postgresql", version = "0.56.0", optional = true, default-features = false }
-opendal-service-redb = { path = "services/redb", version = "0.56.0", optional = true, default-features = false }
-opendal-service-redis = { path = "services/redis", version = "0.56.0", optional = true, default-features = false }
-opendal-service-rocksdb = { path = "services/rocksdb", version = "0.56.0", optional = true, default-features = false }
-opendal-service-s3 = { path = "services/s3", version = "0.56.0", optional = true, default-features = false }
-opendal-service-seafile = { path = "services/seafile", version = "0.56.0", optional = true, default-features = false }
-opendal-service-sftp = { path = "services/sftp", version = "0.56.0", optional = true, default-features = false }
-opendal-service-sled = { path = "services/sled", version = "0.56.0", optional = true, default-features = false }
-opendal-service-sqlite = { path = "services/sqlite", version = "0.56.0", optional = true, default-features = false }
-opendal-service-surrealdb = { path = "services/surrealdb", version = "0.56.0", optional = true, default-features = false }
-opendal-service-swift = { path = "services/swift", version = "0.56.0", optional = true, default-features = false }
-opendal-service-tikv = { path = "services/tikv", version = "0.56.0", optional = true, default-features = false }
-opendal-service-tos = { path = "services/tos", version = "0.56.0", optional = true, default-features = false }
-opendal-service-upyun = { path = "services/upyun", version = "0.56.0", optional = true, default-features = false }
-opendal-service-vercel-artifacts = { path = "services/vercel-artifacts", version = "0.56.0", optional = true, default-features = false }
-opendal-service-vercel-blob = { path = "services/vercel-blob", version = "0.56.0", optional = true, default-features = false }
-opendal-service-webdav = { path = "services/webdav", version = "0.56.0", optional = true, default-features = false }
-opendal-service-webhdfs = { path = "services/webhdfs", version = "0.56.0", optional = true, default-features = false }
-opendal-service-yandex-disk = { path = "services/yandex-disk", version = "0.56.0", optional = true, default-features = false }
-opendal-testkit = { path = "testkit", version = "0.56.0", optional = true }
+opendal-core = { path = "core", version = "0.57.0", default-features = false }
+opendal-layer-async-backtrace = { path = "layers/async-backtrace", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-await-tree = { path = "layers/await-tree", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-capability-check = { path = "layers/capability-check", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-chaos = { path = "layers/chaos", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-concurrent-limit = { path = "layers/concurrent-limit", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-fastmetrics = { path = "layers/fastmetrics", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-fastrace = { path = "layers/fastrace", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-foyer = { path = "layers/foyer", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-hotpath = { path = "layers/hotpath", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-immutable-index = { path = "layers/immutable-index", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-logging = { path = "layers/logging", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-metrics = { path = "layers/metrics", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-mime-guess = { path = "layers/mime-guess", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-observe-metrics-common = { path = "layers/observe-metrics-common", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-otelmetrics = { path = "layers/otelmetrics", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-oteltrace = { path = "layers/oteltrace", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-prometheus = { path = "layers/prometheus", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-prometheus-client = { path = "layers/prometheus-client", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-retry = { path = "layers/retry", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-route = { path = "layers/route", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-tail-cut = { path = "layers/tail-cut", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-throttle = { path = "layers/throttle", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-timeout = { path = "layers/timeout", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-tracing = { path = "layers/tracing", version = "0.57.0", optional = true, default-features = false }
+opendal-service-aliyun-drive = { path = "services/aliyun-drive", version = "0.57.0", optional = true, default-features = false }
+opendal-service-alluxio = { path = "services/alluxio", version = "0.57.0", optional = true, default-features = false }
+opendal-service-azblob = { path = "services/azblob", version = "0.57.0", optional = true, default-features = false }
+opendal-service-azdls = { path = "services/azdls", version = "0.57.0", optional = true, default-features = false }
+opendal-service-azfile = { path = "services/azfile", version = "0.57.0", optional = true, default-features = false }
+opendal-service-b2 = { path = "services/b2", version = "0.57.0", optional = true, default-features = false }
+opendal-service-cacache = { path = "services/cacache", version = "0.57.0", optional = true, default-features = false }
+opendal-service-cloudflare-kv = { path = "services/cloudflare-kv", version = "0.57.0", optional = true, default-features = false }
+opendal-service-compfs = { path = "services/compfs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-cos = { path = "services/cos", version = "0.57.0", optional = true, default-features = false }
+opendal-service-d1 = { path = "services/d1", version = "0.57.0", optional = true, default-features = false }
+opendal-service-dashmap = { path = "services/dashmap", version = "0.57.0", optional = true, default-features = false }
+opendal-service-dbfs = { path = "services/dbfs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-dropbox = { path = "services/dropbox", version = "0.57.0", optional = true, default-features = false }
+opendal-service-etcd = { path = "services/etcd", version = "0.57.0", optional = true, default-features = false }
+opendal-service-foundationdb = { path = "services/foundationdb", version = "0.57.0", optional = true, default-features = false }
+opendal-service-foyer = { path = "services/foyer", version = "0.57.0", optional = true, default-features = false }
+opendal-service-fs = { path = "services/fs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-ftp = { path = "services/ftp", version = "0.57.0", optional = true, default-features = false }
+opendal-service-gcs = { path = "services/gcs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-gdrive = { path = "services/gdrive", version = "0.57.0", optional = true, default-features = false }
+opendal-service-ghac = { path = "services/ghac", version = "0.57.0", optional = true, default-features = false }
+opendal-service-github = { path = "services/github", version = "0.57.0", optional = true, default-features = false }
+opendal-service-goosefs = { path = "services/goosefs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-gridfs = { path = "services/gridfs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-hdfs = { path = "services/hdfs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-hdfs-native = { path = "services/hdfs-native", version = "0.57.0", optional = true, default-features = false }
+opendal-service-hf = { path = "services/hf", version = "0.57.0", optional = true, default-features = false }
+opendal-service-http = { path = "services/http", version = "0.57.0", optional = true, default-features = false }
+opendal-service-ipfs = { path = "services/ipfs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-ipmfs = { path = "services/ipmfs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-koofr = { path = "services/koofr", version = "0.57.0", optional = true, default-features = false }
+opendal-service-lakefs = { path = "services/lakefs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-memcached = { path = "services/memcached", version = "0.57.0", optional = true, default-features = false }
+opendal-service-mini-moka = { path = "services/mini_moka", version = "0.57.0", optional = true, default-features = false }
+opendal-service-moka = { path = "services/moka", version = "0.57.0", optional = true, default-features = false }
+opendal-service-mongodb = { path = "services/mongodb", version = "0.57.0", optional = true, default-features = false }
+opendal-service-monoiofs = { path = "services/monoiofs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-mysql = { path = "services/mysql", version = "0.57.0", optional = true, default-features = false }
+opendal-service-obs = { path = "services/obs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-onedrive = { path = "services/onedrive", version = "0.57.0", optional = true, default-features = false }
+opendal-service-oss = { path = "services/oss", version = "0.57.0", optional = true, default-features = false }
+opendal-service-pcloud = { path = "services/pcloud", version = "0.57.0", optional = true, default-features = false }
+opendal-service-persy = { path = "services/persy", version = "0.57.0", optional = true, default-features = false }
+opendal-service-postgresql = { path = "services/postgresql", version = "0.57.0", optional = true, default-features = false }
+opendal-service-redb = { path = "services/redb", version = "0.57.0", optional = true, default-features = false }
+opendal-service-redis = { path = "services/redis", version = "0.57.0", optional = true, default-features = false }
+opendal-service-rocksdb = { path = "services/rocksdb", version = "0.57.0", optional = true, default-features = false }
+opendal-service-s3 = { path = "services/s3", version = "0.57.0", optional = true, default-features = false }
+opendal-service-seafile = { path = "services/seafile", version = "0.57.0", optional = true, default-features = false }
+opendal-service-sftp = { path = "services/sftp", version = "0.57.0", optional = true, default-features = false }
+opendal-service-sled = { path = "services/sled", version = "0.57.0", optional = true, default-features = false }
+opendal-service-sqlite = { path = "services/sqlite", version = "0.57.0", optional = true, default-features = false }
+opendal-service-surrealdb = { path = "services/surrealdb", version = "0.57.0", optional = true, default-features = false }
+opendal-service-swift = { path = "services/swift", version = "0.57.0", optional = true, default-features = false }
+opendal-service-tikv = { path = "services/tikv", version = "0.57.0", optional = true, default-features = false }
+opendal-service-tos = { path = "services/tos", version = "0.57.0", optional = true, default-features = false }
+opendal-service-upyun = { path = "services/upyun", version = "0.57.0", optional = true, default-features = false }
+opendal-service-vercel-artifacts = { path = "services/vercel-artifacts", version = "0.57.0", optional = true, default-features = false }
+opendal-service-vercel-blob = { path = "services/vercel-blob", version = "0.57.0", optional = true, default-features = false }
+opendal-service-webdav = { path = "services/webdav", version = "0.57.0", optional = true, default-features = false }
+opendal-service-webhdfs = { path = "services/webhdfs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-yandex-disk = { path = "services/yandex-disk", version = "0.57.0", optional = true, default-features = false }
+opendal-testkit = { path = "testkit", version = "0.57.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-opendal-layer-dtrace = { path = "layers/dtrace", version = "0.56.0", optional = true, default-features = false }
+opendal-layer-dtrace = { path = "layers/dtrace", version = "0.57.0", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-opendal-service-opfs = { path = "services/opfs", version = "0.56.0", optional = true, default-features = false }
+opendal-service-opfs = { path = "services/opfs", version = "0.57.0", optional = true, default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -1,19 +1,27 @@
 crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
 anyhow@1.0.102	X									X			
+async-stream@0.3.6										X			
+async-stream-impl@0.3.6										X			
+async-trait@0.1.89	X									X			
 atomic-waker@1.1.2	X									X			
-aws-lc-rs@1.16.2	X							X					
-aws-lc-sys@0.39.0	X			X				X		X	X		
+autocfg@1.5.0	X									X			
+aws-lc-rs@1.16.3	X							X					
+aws-lc-sys@0.40.0	X			X				X		X	X		
+axum@0.7.9										X			
+axum-core@0.4.5										X			
 backon@1.6.0	X												
 base64@0.22.1	X									X			
-bitflags@2.11.0	X									X			
+bitflags@2.11.1	X									X			
 block-buffer@0.10.4	X									X			
+block-buffer@0.12.0	X									X			
 bumpalo@3.20.2	X									X			
 bytes@1.11.1										X			
-cc@1.2.57	X									X			
-cesu8@1.1.0	X									X			
+cc@1.2.61	X									X			
 cfg-if@1.0.4	X									X			
-cmake@0.1.57	X									X			
+chacha20@0.10.0	X									X			
+cmake@0.1.58	X									X			
 combine@4.6.7										X			
+const-oid@0.10.2	X									X			
 const-oid@0.9.6	X									X			
 const-random@0.1.18	X									X			
 const-random-macro@0.1.16	X									X			
@@ -21,24 +29,28 @@ core-foundation@0.10.1	X									X
 core-foundation@0.9.4	X									X			
 core-foundation-sys@0.8.7	X									X			
 cpufeatures@0.2.17	X									X			
+cpufeatures@0.3.0	X									X			
 crc32c@0.6.8	X									X			
+crossbeam-utils@0.8.21	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
-ctor@0.6.3	X									X			
-ctor-proc-macro@0.0.7	X									X			
+crypto-common@0.2.1	X									X			
+ctor@1.0.3	X									X			
+dashmap@6.1.0										X			
 digest@0.10.7	X									X			
+digest@0.11.3	X									X			
 displaydoc@0.2.5	X									X			
 dlv-list@0.5.2	X									X			
 dotenvy@0.15.7										X			
-dtor@0.1.1	X									X			
-dtor-proc-macro@0.0.6	X									X			
 dunce@1.0.5	X					X					X		
+either@1.15.0	X									X			
 encoding_rs@0.8.35	X			X						X			
 equivalent@1.0.2	X									X			
 erased-serde@0.4.10	X									X			
 errno@0.3.14	X									X			
-fastrand@2.3.0	X									X			
+fastrand@2.4.1	X									X			
 find-msvc-tools@0.1.9	X									X			
+fixedbitset@0.5.7	X									X			
 fnv@1.0.7	X									X			
 form_urlencoded@1.2.2	X									X			
 fs_extra@1.3.0										X			
@@ -56,17 +68,24 @@ getrandom@0.2.17	X									X
 getrandom@0.3.4	X									X			
 getrandom@0.4.2	X									X			
 gloo-timers@0.3.0	X									X			
-h2@0.4.13										X			
+goosefs-sdk@0.1.2	X												
+h2@0.4.14										X			
+hashbrown@0.12.3	X									X			
 hashbrown@0.14.5	X									X			
-hashbrown@0.16.1	X									X			
+hashbrown@0.17.0	X									X			
+heck@0.5.0	X									X			
 hex@0.4.3	X									X			
 hmac@0.12.1	X									X			
+hostname@0.3.1										X			
 http@1.4.0	X									X			
 http-body@1.0.1										X			
 http-body-util@0.1.3										X			
 httparse@1.10.1	X									X			
-hyper@1.8.1										X			
-hyper-rustls@0.27.7	X							X		X			
+httpdate@1.0.3	X									X			
+hybrid-array@0.4.12	X									X			
+hyper@1.9.0										X			
+hyper-rustls@0.27.9	X							X		X			
+hyper-timeout@0.5.2	X									X			
 hyper-util@0.1.20										X			
 icu_collections@2.1.1												X	
 icu_locale_core@2.1.1												X	
@@ -77,76 +96,103 @@ icu_properties_data@2.1.2												X
 icu_provider@2.1.1												X	
 idna@1.1.0	X									X			
 idna_adapter@1.2.1	X									X			
-indexmap@2.13.0	X									X			
+indexmap@1.9.3	X									X			
+indexmap@2.14.0	X									X			
 ipnet@2.12.0	X									X			
-iri-string@0.7.11	X									X			
+itertools@0.14.0	X									X			
 itoa@1.0.18	X									X			
-jiff@0.2.23										X			X
+jiff@0.2.24										X			X
 jiff-tzdb@0.1.6										X			X
 jiff-tzdb-platform@0.1.3										X			X
-jni@0.21.1	X									X			
-jni-sys@0.3.1	X									X			
+jni@0.22.4	X									X			
+jni-macros@0.22.4	X									X			
 jni-sys@0.4.1	X									X			
 jni-sys-macros@0.4.1	X									X			
 jobserver@0.1.34	X									X			
-js-sys@0.3.91	X									X			
-libc@0.2.183	X									X			
+js-sys@0.3.98	X									X			
+libc@0.2.186	X									X			
+link-section@0.15.0	X									X			
+linktime-proc-macro@0.1.0	X									X			
 linux-raw-sys@0.12.1	X	X								X			
-litemap@0.8.1												X	
+litemap@0.8.2												X	
+lock_api@0.4.14	X									X			
 log@0.4.29	X									X			
-md-5@0.10.6	X									X			
+match_cfg@0.1.0	X									X			
+matchit@0.7.3				X						X			
+md-5@0.11.0	X									X			
 mea@0.6.3	X												
 memchr@2.8.0										X			X
 mime@0.3.17	X									X			
-mio@1.1.1										X			
+mio@1.2.0										X			
+multimap@0.10.1	X									X			
 once_cell@1.21.4	X									X			
-opendal@0.56.0	X												
-opendal-core@0.56.0	X												
-opendal-layer-concurrent-limit@0.56.0	X												
-opendal-layer-logging@0.56.0	X												
-opendal-layer-retry@0.56.0	X												
-opendal-layer-timeout@0.56.0	X												
-opendal-service-fs@0.56.0	X												
-opendal-service-s3@0.56.0	X												
-opendal-testkit@0.56.0	X												
+opendal@0.57.0	X												
+opendal-core@0.57.0	X												
+opendal-layer-concurrent-limit@0.57.0	X												
+opendal-layer-logging@0.57.0	X												
+opendal-layer-retry@0.57.0	X												
+opendal-layer-timeout@0.57.0	X												
+opendal-service-fs@0.57.0	X												
+opendal-service-goosefs@0.57.0	X												
+opendal-service-opfs@0.57.0	X												
+opendal-service-s3@0.57.0	X												
+opendal-testkit@0.57.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-multimap@0.7.3										X			
+parking_lot@0.12.5	X									X			
+parking_lot_core@0.9.12	X									X			
 percent-encoding@2.3.2	X									X			
+petgraph@0.7.1	X									X			
+pin-project@1.1.12	X									X			
+pin-project-internal@1.1.12	X									X			
 pin-project-lite@0.2.17	X									X			
-pin-utils@0.1.0	X									X			
 portable-atomic@1.13.1	X									X			
-portable-atomic-util@0.2.6	X									X			
-potential_utf@0.1.4												X	
+portable-atomic-util@0.2.7	X									X			
+potential_utf@0.1.5												X	
 ppv-lite86@0.2.21	X									X			
+prettyplease@0.2.37	X									X			
 proc-macro2@1.0.106	X									X			
-quick-xml@0.38.4										X			
-quick-xml@0.39.2										X			
+prost@0.13.5	X												
+prost-build@0.13.5	X												
+prost-derive@0.13.5	X												
+prost-types@0.13.5	X												
+quick-xml@0.39.3										X			
 quote@1.0.45	X									X			
 r-efi@5.3.0	X								X	X			
 r-efi@6.0.0	X								X	X			
-rand@0.8.5	X									X			
+rand@0.10.1	X									X			
+rand@0.8.6	X									X			
 rand_chacha@0.3.1	X									X			
+rand_core@0.10.1	X									X			
 rand_core@0.6.4	X									X			
+redox_syscall@0.5.18										X			
+regex@1.12.3	X									X			
+regex-automata@0.4.14	X									X			
+regex-syntax@0.8.10	X									X			
 reqsign-aws-v4@3.0.0	X												
 reqsign-core@3.0.0	X												
 reqsign-file-read-tokio@3.0.0	X												
-reqwest@0.13.2	X									X			
+reqwest@0.13.3	X									X			
+ring@0.17.14	X							X					
 rust-ini@0.21.3										X			
 rustc_version@0.4.1	X									X			
 rustix@1.1.4	X	X								X			
-rustls@0.23.37	X							X		X			
+rustls@0.23.40	X							X		X			
 rustls-native-certs@0.8.3	X							X		X			
-rustls-pki-types@1.14.0	X									X			
-rustls-platform-verifier@0.6.2	X									X			
+rustls-pemfile@2.2.0	X							X		X			
+rustls-pki-types@1.14.1	X									X			
+rustls-platform-verifier@0.7.0	X									X			
 rustls-platform-verifier-android@0.1.1	X									X			
-rustls-webpki@0.103.10								X					
+rustls-webpki@0.103.13								X					
 rustversion@1.0.22	X									X			
 ryu@1.0.23	X				X								
 same-file@1.0.6										X			X
 schannel@0.1.29										X			
+scopeguard@1.2.0	X									X			
 security-framework@3.7.0	X									X			
 security-framework-sys@2.17.0	X									X			
-semver@1.0.27	X									X			
+semver@1.0.28	X									X			
+send_wrapper@0.6.0	X									X			
 serde@1.0.228	X									X			
 serde_buf@0.1.2	X									X			
 serde_core@1.0.228	X									X			
@@ -156,46 +202,57 @@ serde_json@1.0.149	X									X
 serde_urlencoded@0.7.1	X									X			
 sha1@0.10.6	X									X			
 sha2@0.10.9	X									X			
+sha2@0.11.0	X									X			
 shlex@1.3.0	X									X			
+signal-hook-registry@1.4.8	X									X			
+simd_cesu8@1.1.1	X									X			
+simdutf8@0.1.5	X									X			
 slab@0.4.12										X			
 smallvec@1.15.1	X									X			
+socket2@0.5.10	X									X			
 socket2@0.6.3	X									X			
 stable_deref_trait@1.2.1	X									X			
 subtle@2.6.1				X									
-sval@2.17.0	X									X			
-sval_buffer@2.17.0	X									X			
-sval_dynamic@2.17.0	X									X			
-sval_fmt@2.17.0	X									X			
-sval_nested@2.17.0	X									X			
-sval_ref@2.17.0	X									X			
-sval_serde@2.17.0	X									X			
+sval@2.19.0	X									X			
+sval_buffer@2.19.0	X									X			
+sval_dynamic@2.19.0	X									X			
+sval_fmt@2.19.0	X									X			
+sval_nested@2.19.0	X									X			
+sval_ref@2.19.0	X									X			
+sval_serde@2.19.0	X									X			
 syn@2.0.117	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
 system-configuration@0.7.0	X									X			
 system-configuration-sys@0.6.0	X									X			
-thiserror@1.0.69	X									X			
-thiserror-impl@1.0.69	X									X			
+tempfile@3.27.0	X									X			
+thiserror@2.0.18	X									X			
+thiserror-impl@2.0.18	X									X			
 tiny-keccak@2.0.2						X							
-tinystr@0.8.2												X	
-tokio@1.50.0										X			
-tokio-macros@2.6.1										X			
+tinystr@0.8.3												X	
+tokio@1.52.2										X			
+tokio-macros@2.7.0										X			
 tokio-rustls@0.26.4	X									X			
+tokio-stream@0.1.18										X			
 tokio-util@0.7.18										X			
+tonic@0.12.3										X			
+tonic-build@0.12.3										X			
+tower@0.4.13										X			
 tower@0.5.3										X			
-tower-http@0.6.8										X			
+tower-http@0.6.10										X			
 tower-layer@0.3.3										X			
 tower-service@0.3.3										X			
 tracing@0.1.44										X			
+tracing-attributes@0.1.31										X			
 tracing-core@0.1.36										X			
 try-lock@0.2.5										X			
 typeid@1.0.3	X									X			
-typenum@1.19.0	X									X			
+typenum@1.20.0	X									X			
 unicode-ident@1.0.24	X									X		X	
 untrusted@0.9.0								X					
 url@2.5.8	X									X			
 utf8_iter@1.0.4	X									X			
-uuid@1.22.0	X									X			
+uuid@1.23.1	X									X			
 value-bag@1.12.0	X									X			
 value-bag-serde1@1.12.0	X									X			
 value-bag-sval2@1.12.0	X									X			
@@ -205,41 +262,45 @@ want@0.3.1										X
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
 wasip2@1.0.1+wasi-0.2.4	X	X								X			
 wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
-wasm-bindgen@0.2.114	X									X			
-wasm-bindgen-futures@0.4.64	X									X			
-wasm-bindgen-macro@0.2.114	X									X			
-wasm-bindgen-macro-support@0.2.114	X									X			
-wasm-bindgen-shared@0.2.114	X									X			
+wasm-bindgen@0.2.121	X									X			
+wasm-bindgen-futures@0.4.71	X									X			
+wasm-bindgen-macro@0.2.121	X									X			
+wasm-bindgen-macro-support@0.2.121	X									X			
+wasm-bindgen-shared@0.2.121	X									X			
 wasm-streams@0.5.0	X									X			
-web-sys@0.3.91	X									X			
+web-sys@0.3.98	X									X			
 web-time@1.1.0	X									X			
-webpki-root-certs@1.0.6							X						
+webpki-root-certs@1.0.7							X						
+winapi@0.3.9	X									X			
+winapi-i686-pc-windows-gnu@0.4.0	X									X			
 winapi-util@0.1.11										X			X
+winapi-x86_64-pc-windows-gnu@0.4.0	X									X			
 windows-link@0.2.1	X									X			
 windows-registry@0.6.1	X									X			
 windows-result@0.4.1	X									X			
 windows-strings@0.5.1	X									X			
-windows-sys@0.45.0	X									X			
+windows-sys@0.52.0	X									X			
 windows-sys@0.61.2	X									X			
-windows-targets@0.42.2	X									X			
-windows_aarch64_gnullvm@0.42.2	X									X			
-windows_aarch64_msvc@0.42.2	X									X			
-windows_i686_gnu@0.42.2	X									X			
-windows_i686_msvc@0.42.2	X									X			
-windows_x86_64_gnu@0.42.2	X									X			
-windows_x86_64_gnullvm@0.42.2	X									X			
-windows_x86_64_msvc@0.42.2	X									X			
+windows-targets@0.52.6	X									X			
+windows_aarch64_gnullvm@0.52.6	X									X			
+windows_aarch64_msvc@0.52.6	X									X			
+windows_i686_gnu@0.52.6	X									X			
+windows_i686_gnullvm@0.52.6	X									X			
+windows_i686_msvc@0.52.6	X									X			
+windows_x86_64_gnu@0.52.6	X									X			
+windows_x86_64_gnullvm@0.52.6	X									X			
+windows_x86_64_msvc@0.52.6	X									X			
 wit-bindgen@0.46.0	X	X								X			
 wit-bindgen@0.51.0	X	X								X			
-writeable@0.6.2												X	
+writeable@0.6.3												X	
 xattr@1.6.1	X									X			
-yoke@0.8.1												X	
-yoke-derive@0.8.1												X	
-zerocopy@0.8.47	X		X							X			
-zerofrom@0.1.6												X	
-zerofrom-derive@0.1.6												X	
+yoke@0.8.2												X	
+yoke-derive@0.8.2												X	
+zerocopy@0.8.48	X		X							X			
+zerofrom@0.1.7												X	
+zerofrom-derive@0.1.7												X	
 zeroize@1.8.2	X									X			
-zerotrie@0.2.3												X	
-zerovec@0.11.5												X	
-zerovec-derive@0.11.2												X	
+zerotrie@0.2.4												X	
+zerovec@0.11.6												X	
+zerovec-derive@0.11.3												X	
 zmij@1.0.21										X			

--- a/core/benches/vs_fs/Cargo.toml
+++ b/core/benches/vs_fs/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "opendal-benchmark-vs-fs"
 publish = false
 rust-version = "1.86"
-version = "0.56.0"
+version = "0.57.0"
 
 [dependencies]
 criterion = { version = "0.8.2", features = ["async", "async_tokio"] }

--- a/core/benches/vs_s3/Cargo.toml
+++ b/core/benches/vs_s3/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "opendal-benchmark-vs-s3"
 publish = false
 rust-version = "1.86"
-version = "0.56.0"
+version = "0.57.0"
 
 [dependencies]
 aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }

--- a/core/layers/async-backtrace/Cargo.toml
+++ b/core/layers/async-backtrace/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 async-backtrace = "0.2.6"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }

--- a/core/layers/await-tree/Cargo.toml
+++ b/core/layers/await-tree/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 await-tree = "0.3"
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }

--- a/core/layers/capability-check/Cargo.toml
+++ b/core/layers/capability-check/Cargo.toml
@@ -31,8 +31,8 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/chaos/Cargo.toml
+++ b/core/layers/chaos/Cargo.toml
@@ -31,8 +31,8 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 rand = { workspace = true }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }

--- a/core/layers/concurrent-limit/Cargo.toml
+++ b/core/layers/concurrent-limit/Cargo.toml
@@ -34,8 +34,8 @@ all-features = true
 futures = { workspace = true }
 http = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/core/layers/dtrace/Cargo.toml
+++ b/core/layers/dtrace/Cargo.toml
@@ -32,9 +32,9 @@ all-features = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 bytes = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 probe = "0.5.1"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/fastmetrics/Cargo.toml
+++ b/core/layers/fastmetrics/Cargo.toml
@@ -32,10 +32,10 @@ all-features = true
 
 [dependencies]
 fastmetrics = "0.7"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/fastrace/Cargo.toml
+++ b/core/layers/fastrace/Cargo.toml
@@ -32,12 +32,12 @@ all-features = true
 
 [dependencies]
 fastrace = "0.7.16"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0"
 dotenvy = "0.15"
 fastrace = { version = "0.7", features = ["enable"] }
 fastrace-jaeger = "0.7"
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/foyer/Cargo.toml
+++ b/core/layers/foyer/Cargo.toml
@@ -33,11 +33,11 @@ all-features = true
 [dependencies]
 bincode = "1"
 foyer = { version = "0.22.3", features = ["serde"] }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", features = [
+opendal-core = { path = "../../core", version = "0.57.0", features = [
   "services-memory",
 ] }
 size = "0.5"

--- a/core/layers/hotpath/Cargo.toml
+++ b/core/layers/hotpath/Cargo.toml
@@ -34,8 +34,8 @@ all-features = true
 futures = { workspace = true }
 hotpath = "0.16.0"
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/immutable-index/Cargo.toml
+++ b/core/layers/immutable-index/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
 log = { workspace = true }
 logforth = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/logging/Cargo.toml
+++ b/core/layers/logging/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }

--- a/core/layers/metrics/Cargo.toml
+++ b/core/layers/metrics/Cargo.toml
@@ -32,8 +32,8 @@ all-features = true
 
 [dependencies]
 metrics = "0.24"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }

--- a/core/layers/mime-guess/Cargo.toml
+++ b/core/layers/mime-guess/Cargo.toml
@@ -32,9 +32,9 @@ all-features = true
 
 [dependencies]
 mime_guess = "2.0.5"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/observe-metrics-common/Cargo.toml
+++ b/core/layers/observe-metrics-common/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 futures = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros"] }

--- a/core/layers/otelmetrics/Cargo.toml
+++ b/core/layers/otelmetrics/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.57.0" }
 opentelemetry = { version = "0.32.0", default-features = false, features = [
   "metrics",
 ] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }

--- a/core/layers/oteltrace/Cargo.toml
+++ b/core/layers/oteltrace/Cargo.toml
@@ -31,10 +31,10 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 opentelemetry = { version = "0.32.0", default-features = false, features = [
   "trace",
 ] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }

--- a/core/layers/prometheus-client/Cargo.toml
+++ b/core/layers/prometheus-client/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.57.0" }
 prometheus-client = { version = "0.24" }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/prometheus/Cargo.toml
+++ b/core/layers/prometheus/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.57.0" }
 prometheus = { version = "0.14", features = ["process"] }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/retry/Cargo.toml
+++ b/core/layers/retry/Cargo.toml
@@ -33,13 +33,13 @@ all-features = true
 [dependencies]
 backon = { version = "1.6", features = ["tokio-sleep"] }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
 bytes = { workspace = true }
 futures = { workspace = true }
 logforth = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0" }
-opendal-layer-logging = { path = "../logging", version = "0.56.0" }
-opendal-layer-timeout = { path = "../timeout", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-layer-logging = { path = "../logging", version = "0.57.0" }
+opendal-layer-timeout = { path = "../timeout", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/route/Cargo.toml
+++ b/core/layers/route/Cargo.toml
@@ -32,10 +32,10 @@ all-features = true
 
 [dependencies]
 globset = "0.4.15"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0" }
-opendal-service-fs = { path = "../../services/fs", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-service-fs = { path = "../../services/fs", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/tail-cut/Cargo.toml
+++ b/core/layers/tail-cut/Cargo.toml
@@ -31,9 +31,9 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/throttle/Cargo.toml
+++ b/core/layers/throttle/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 governor = "0.10.4"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }

--- a/core/layers/timeout/Cargo.toml
+++ b/core/layers/timeout/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0" }
-opendal-layer-retry = { path = "../retry", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-layer-retry = { path = "../retry", version = "0.57.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/tracing/Cargo.toml
+++ b/core/layers/tracing/Cargo.toml
@@ -33,13 +33,13 @@ all-features = true
 [dependencies]
 futures = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 tracing = "0.1"
 
 [dev-dependencies]
 anyhow = "1.0"
 dotenvy = "0.15"
-opendal-core = { path = "../../core", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0" }
 opentelemetry = { version = "0.32.0", default-features = false, features = [
   "trace",
 ] }

--- a/core/services/aliyun-drive/Cargo.toml
+++ b/core/services/aliyun-drive/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/alluxio/Cargo.toml
+++ b/core/services/alluxio/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/azblob/Cargo.toml
+++ b/core/services/azblob/Cargo.toml
@@ -35,8 +35,8 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
-opendal-service-azure-common = { path = "../azure-common", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-service-azure-common = { path = "../azure-common", version = "0.57.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/azdls/Cargo.toml
+++ b/core/services/azdls/Cargo.toml
@@ -35,8 +35,8 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
-opendal-service-azure-common = { path = "../azure-common", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-service-azure-common = { path = "../azure-common", version = "0.57.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/azfile/Cargo.toml
+++ b/core/services/azfile/Cargo.toml
@@ -34,8 +34,8 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
-opendal-service-azure-common = { path = "../azure-common", version = "0.56.0" }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-service-azure-common = { path = "../azure-common", version = "0.57.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/azure-common/Cargo.toml
+++ b/core/services/azure-common/Cargo.toml
@@ -32,4 +32,4 @@ all-features = true
 
 [dependencies]
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }

--- a/core/services/b2/Cargo.toml
+++ b/core/services/b2/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/cacache/Cargo.toml
+++ b/core/services/cacache/Cargo.toml
@@ -36,7 +36,7 @@ cacache = { version = "13.0", default-features = false, features = [
   "tokio-runtime",
   "mmap",
 ] }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/cloudflare-kv/Cargo.toml
+++ b/core/services/cloudflare-kv/Cargo.toml
@@ -33,6 +33,6 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/compfs/Cargo.toml
+++ b/core/services/compfs/Cargo.toml
@@ -40,7 +40,7 @@ compio = { version = "0.18.0", features = [
   "runtime",
   "sync",
 ] }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/cos/Cargo.toml
+++ b/core/services/cos/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-core = { version = "3.0.0", default-features = false }
 reqsign-file-read-tokio = { version = "3.0.0", default-features = false }

--- a/core/services/d1/Cargo.toml
+++ b/core/services/d1/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/dashmap/Cargo.toml
+++ b/core/services/dashmap/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 dashmap = "6"
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/dbfs/Cargo.toml
+++ b/core/services/dbfs/Cargo.toml
@@ -35,7 +35,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/dropbox/Cargo.toml
+++ b/core/services/dropbox/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/etcd/Cargo.toml
+++ b/core/services/etcd/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 etcd-client = { version = "0.18.0", features = ["tls"] }
 fastpool = "1.0.2"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["time"] }
 

--- a/core/services/foundationdb/Cargo.toml
+++ b/core/services/foundationdb/Cargo.toml
@@ -35,7 +35,7 @@ foundationdb = { version = "0.10.0", features = [
   "embedded-fdb-include",
   "fdb-7_3",
 ] }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/foyer/Cargo.toml
+++ b/core/services/foyer/Cargo.toml
@@ -33,12 +33,12 @@ all-features = true
 [dependencies]
 foyer = { version = "0.22.3", features = ["serde"] }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-opendal = { path = "../..", version = "0.56.0", features = ["services-memory"] }
-opendal-core = { path = "../../core", version = "0.56.0", features = [
+opendal = { path = "../..", version = "0.57.0", features = ["services-memory"] }
+opendal-core = { path = "../../core", version = "0.57.0", features = [
   "services-memory",
 ] }
 size = "0.5"

--- a/core/services/fs/Cargo.toml
+++ b/core/services/fs/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
   "internal-tokio-rt",
 ] }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/ftp/Cargo.toml
+++ b/core/services/ftp/Cargo.toml
@@ -37,7 +37,7 @@ futures = { workspace = true, features = ["std", "async-await"] }
 futures-rustls = "0.26.0"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 rustls-native-certs = "0.8"
 serde = { workspace = true, features = ["derive"] }
 suppaftp = { version = "8.0.3", default-features = false, features = [

--- a/core/services/gcs/Cargo.toml
+++ b/core/services/gcs/Cargo.toml
@@ -35,7 +35,7 @@ async-trait = "0.1"
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 percent-encoding = "2.3"
 quick-xml = { workspace = true, features = ["serialize"] }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/gdrive/Cargo.toml
+++ b/core/services/gdrive/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
   "internal-path-cache",
 ] }
 

--- a/core/services/ghac/Cargo.toml
+++ b/core/services/ghac/Cargo.toml
@@ -35,8 +35,8 @@ bytes = { workspace = true }
 ghac = { version = "0.3.0", default-features = false }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
-opendal-service-azblob = { path = "../azblob", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-service-azblob = { path = "../azblob", version = "0.57.0", default-features = false }
 prost = { version = "0.14.3", default-features = false }
 reqsign-azure-storage = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/github/Cargo.toml
+++ b/core/services/github/Cargo.toml
@@ -35,7 +35,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/goosefs/Cargo.toml
+++ b/core/services/goosefs/Cargo.toml
@@ -34,12 +34,12 @@ all-features = true
 bytes = { workspace = true }
 goosefs-sdk = "0.1.2"
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true }
 
 [dev-dependencies]
-opendal = { path = "../..", version = "0.56.0", features = [
+opendal = { path = "../..", version = "0.57.0", features = [
   "services-goosefs",
 ] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/gridfs/Cargo.toml
+++ b/core/services/gridfs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 futures = { workspace = true }
 mea = { workspace = true }
 mongodb = "3.3.0"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/hdfs-native/Cargo.toml
+++ b/core/services/hdfs-native/Cargo.toml
@@ -35,5 +35,5 @@ bytes = { workspace = true }
 futures = { workspace = true }
 hdfs-native = { version = "0.13" }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/hdfs/Cargo.toml
+++ b/core/services/hdfs/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 bytes = { workspace = true }
 futures = { workspace = true }

--- a/core/services/hf/Cargo.toml
+++ b/core/services/hf/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 hf-xet = "1.5.0"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 percent-encoding = "2"
 reqwest = { version = "0.13.2", default-features = false, features = [
   "rustls",
@@ -45,7 +45,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", features = [
+opendal-core = { path = "../../core", version = "0.57.0", features = [
   "reqwest-rustls-tls",
 ] }
 serde_json = { workspace = true }

--- a/core/services/http/Cargo.toml
+++ b/core/services/http/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2024"
 license = "Apache-2.0"
 name = "opendal-service-http"
 repository = "https://github.com/apache/opendal"
-version = "0.56.0"
+version = "0.57.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -29,9 +29,9 @@ all-features = true
 [dependencies]
 http = "1.1"
 log = "0.4"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 tokio = { version = "1.48", features = ["macros", "rt-multi-thread"] }

--- a/core/services/ipfs/Cargo.toml
+++ b/core/services/ipfs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 prost = "0.14.3"
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/ipmfs/Cargo.toml
+++ b/core/services/ipmfs/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/koofr/Cargo.toml
+++ b/core/services/koofr/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/lakefs/Cargo.toml
+++ b/core/services/lakefs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/memcached/Cargo.toml
+++ b/core/services/memcached/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 fastpool = "1.0.2"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["net", "io-util"] }
 url = { workspace = true }

--- a/core/services/mini_moka/Cargo.toml
+++ b/core/services/mini_moka/Cargo.toml
@@ -33,5 +33,5 @@ all-features = true
 [dependencies]
 log = { workspace = true }
 mini-moka = "0.10"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/moka/Cargo.toml
+++ b/core/services/moka/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 log = { workspace = true }
 moka = { version = "0.12", features = ["future", "sync"] }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/mongodb/Cargo.toml
+++ b/core/services/mongodb/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 mea = { workspace = true }
 mongodb = { version = "3.3.0" }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/monoiofs/Cargo.toml
+++ b/core/services/monoiofs/Cargo.toml
@@ -40,7 +40,7 @@ monoio = { version = "0.2.4", features = [
   "unlinkat",
   "renameat",
 ] }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/mysql/Cargo.toml
+++ b/core/services/mysql/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "mysql"] }
 

--- a/core/services/obs/Cargo.toml
+++ b/core/services/obs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-core = "3.0.0"
 reqsign-file-read-tokio = "3.0.0"

--- a/core/services/onedrive/Cargo.toml
+++ b/core/services/onedrive/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time"] }

--- a/core/services/opfs/Cargo.toml
+++ b/core/services/opfs/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.77"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 send_wrapper = "0.6"
 serde = { workspace = true, features = ["derive"] }
 wasm-bindgen = "0.2.100"

--- a/core/services/oss/Cargo.toml
+++ b/core/services/oss/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-aliyun-oss = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/pcloud/Cargo.toml
+++ b/core/services/pcloud/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/persy/Cargo.toml
+++ b/core/services/persy/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 persy = "1.7.1"
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/postgresql/Cargo.toml
+++ b/core/services/postgresql/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "postgres"] }
 

--- a/core/services/redb/Cargo.toml
+++ b/core/services/redb/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 redb = { version = "2" }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/redis/Cargo.toml
+++ b/core/services/redis/Cargo.toml
@@ -39,7 +39,7 @@ rustls = ["redis/tokio-rustls-comp"]
 bytes = { workspace = true }
 fastpool = "1.0.2"
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 redis = { version = "1.0", features = [
   "cluster-async",
   "tokio-comp",

--- a/core/services/rocksdb/Cargo.toml
+++ b/core/services/rocksdb/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 rocksdb = { version = "0.24.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/s3/Cargo.toml
+++ b/core/services/s3/Cargo.toml
@@ -37,7 +37,7 @@ crc32c = "0.6.6"
 http = { workspace = true }
 log = { workspace = true }
 md-5 = "0.11.0"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-aws-v4 = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.0", default-features = false }

--- a/core/services/seafile/Cargo.toml
+++ b/core/services/seafile/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/sftp/Cargo.toml
+++ b/core/services/sftp/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 bytes = { workspace = true }
 fastpool = "1.0.2"

--- a/core/services/sled/Cargo.toml
+++ b/core/services/sled/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sled = "0.34.7"
 

--- a/core/services/sqlite/Cargo.toml
+++ b/core/services/sqlite/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "sqlite"] }
 

--- a/core/services/surrealdb/Cargo.toml
+++ b/core/services/surrealdb/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 surrealdb = { version = "3", features = ["protocol-http"] }
 

--- a/core/services/swift/Cargo.toml
+++ b/core/services/swift/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 hmac = "0.13.0"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 percent-encoding = "2"
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/tikv/Cargo.toml
+++ b/core/services/tikv/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tikv-client = { version = "0.4.0", default-features = false }
 

--- a/core/services/tos/Cargo.toml
+++ b/core/services/tos/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-core = { version = "3.0.0", default-features = false }
 reqsign-file-read-tokio = { version = "3.0.0", default-features = false }

--- a/core/services/upyun/Cargo.toml
+++ b/core/services/upyun/Cargo.toml
@@ -37,7 +37,7 @@ hmac = "0.13.0"
 http = { workspace = true }
 log = { workspace = true }
 md-5 = "0.11.0"
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/vercel-artifacts/Cargo.toml
+++ b/core/services/vercel-artifacts/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/vercel-blob/Cargo.toml
+++ b/core/services/vercel-blob/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/webdav/Cargo.toml
+++ b/core/services/webdav/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/webhdfs/Cargo.toml
+++ b/core/services/webhdfs/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/core/services/yandex-disk/Cargo.toml
+++ b/core/services/yandex-disk/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/testkit/Cargo.toml
+++ b/core/testkit/Cargo.toml
@@ -33,10 +33,10 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 dotenvy = "0.15"
-opendal-core = { path = "../core", version = "0.56.0", default-features = false }
-opendal-layer-logging = { path = "../layers/logging", version = "0.56.0", default-features = false }
-opendal-layer-retry = { path = "../layers/retry", version = "0.56.0", default-features = false }
-opendal-layer-timeout = { path = "../layers/timeout", version = "0.56.0", default-features = false }
+opendal-core = { path = "../core", version = "0.57.0", default-features = false }
+opendal-layer-logging = { path = "../layers/logging", version = "0.57.0", default-features = false }
+opendal-layer-retry = { path = "../layers/retry", version = "0.57.0", default-features = false }
+opendal-layer-timeout = { path = "../layers/timeout", version = "0.57.0", default-features = false }
 rand = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/dev/src/release/package.rs
+++ b/dev/src/release/package.rs
@@ -77,6 +77,7 @@ pub fn all_packages() -> Vec<Package> {
     let java = make_package("bindings/java", "0.48.4", vec![core.clone()]);
     let nodejs = make_package("bindings/nodejs", "0.49.4", vec![core.clone()]);
     let python = make_package("bindings/python", "0.47.2", vec![core.clone()]);
+    let ruby = make_package("bindings/ruby", "0.1.6", vec![core.clone()]);
 
     vec![
         core,
@@ -89,6 +90,7 @@ pub fn all_packages() -> Vec<Package> {
         java,
         nodejs,
         python,
+        ruby,
     ]
 }
 
@@ -113,6 +115,9 @@ pub fn update_package_version(package: &Package) -> bool {
         "bindings/lua" => false, // Lua bindings has no version to update
 
         "bindings/python" => update_cargo_version(&package.path, &package.version, &[]),
+        "bindings/ruby" => {
+            update_cargo_version(&package.path, &package.version, package.dependencies())
+        }
         "bindings/java" => update_maven_version(&package.path, &package.version),
         "bindings/nodejs" => update_nodejs_version(&package.path, &package.version),
 
@@ -536,6 +541,16 @@ mod tests {
             .unwrap();
 
         assert_eq!(parquet.version, Version::parse("0.8.1").unwrap());
+    }
+
+    #[test]
+    fn ruby_release_version_matches_manifest() {
+        let ruby = all_packages()
+            .into_iter()
+            .find(|package| package.name() == "bindings/ruby")
+            .unwrap();
+
+        assert_eq!(ruby.version, Version::parse("0.1.6").unwrap());
     }
 
     #[test]

--- a/dev/src/release/package.rs
+++ b/dev/src/release/package.rs
@@ -61,22 +61,22 @@ fn make_package(path: &str, version: &str, dependencies: Vec<Package>) -> Packag
 
 /// List all packages that are ready for release.
 pub fn all_packages() -> Vec<Package> {
-    let core = make_package("core", "0.56.0", vec![]);
+    let core = make_package("core", "0.57.0", vec![]);
 
     // Integrations
-    let dav_server = make_package("integrations/dav-server", "0.7.1", vec![core.clone()]);
-    let object_store = make_package("integrations/object_store", "0.56.0", vec![core.clone()]);
-    let parquet = make_package("integrations/parquet", "0.8.0", vec![core.clone()]);
-    let unftp_sbe = make_package("integrations/unftp-sbe", "0.4.1", vec![core.clone()]);
+    let dav_server = make_package("integrations/dav-server", "0.7.2", vec![core.clone()]);
+    let object_store = make_package("integrations/object_store", "0.57.0", vec![core.clone()]);
+    let parquet = make_package("integrations/parquet", "0.8.1", vec![core.clone()]);
+    let unftp_sbe = make_package("integrations/unftp-sbe", "0.4.2", vec![core.clone()]);
 
     // Binaries moved to separate repositories; no longer released from this repo
 
     // Bindings
-    let c = make_package("bindings/c", "0.46.5", vec![core.clone()]);
-    let cpp = make_package("bindings/cpp", "0.45.25", vec![core.clone()]);
-    let java = make_package("bindings/java", "0.48.3", vec![core.clone()]);
-    let nodejs = make_package("bindings/nodejs", "0.49.3", vec![core.clone()]);
-    let python = make_package("bindings/python", "0.47.1", vec![core.clone()]);
+    let c = make_package("bindings/c", "0.46.6", vec![core.clone()]);
+    let cpp = make_package("bindings/cpp", "0.45.26", vec![core.clone()]);
+    let java = make_package("bindings/java", "0.48.4", vec![core.clone()]);
+    let nodejs = make_package("bindings/nodejs", "0.49.4", vec![core.clone()]);
+    let python = make_package("bindings/python", "0.47.2", vec![core.clone()]);
 
     vec![
         core,
@@ -535,7 +535,7 @@ mod tests {
             .find(|package| package.name() == "integrations/parquet")
             .unwrap();
 
-        assert_eq!(parquet.version, Version::parse("0.8.0").unwrap());
+        assert_eq!(parquet.version, Version::parse("0.8.1").unwrap());
     }
 
     #[test]

--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 description = "Use OpenDAL as a backend to access data in various service with WebDAV protocol"
 name = "dav-server-opendalfs"
-version = "0.7.1"
+version = "0.7.2"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2024"
@@ -32,10 +32,10 @@ anyhow = "1"
 bytes = { version = "1.4.0" }
 dav-server = { version = "0.11.0" }
 futures = "0.3"
-opendal = { version = "0.56.0", path = "../../core" }
+opendal = { version = "0.57.0", path = "../../core" }
 
 [dev-dependencies]
-opendal = { version = "0.56.0", path = "../../core", features = [
+opendal = { version = "0.57.0", path = "../../core", features = [
   "services-fs",
 ] }
 tokio = { version = "1.27", features = ["macros", "rt-multi-thread", "io-std"] }

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -4,12 +4,13 @@ android_system_properties@0.1.5	X							X
 anyhow@1.0.102	X							X					
 atomic-waker@1.1.2	X							X					
 autocfg@1.5.0	X							X					
-aws-lc-rs@1.16.3	X					X							
-aws-lc-sys@0.40.0	X		X			X		X	X				
+aws-lc-rs@1.17.0	X					X							
+aws-lc-sys@0.41.0	X		X			X		X	X				
 backon@1.6.0	X												
 base64@0.22.1	X							X					
 bitflags@2.11.1	X							X					
 block-buffer@0.10.4	X							X					
+block-buffer@0.12.0	X							X					
 bumpalo@3.20.2	X							X					
 bytes@1.11.1								X					
 cc@1.2.62	X							X					
@@ -17,16 +18,19 @@ cfg-if@1.0.4	X							X
 chrono@0.4.44	X							X					
 cmake@0.1.58	X							X					
 combine@4.6.7								X					
+const-oid@0.10.2	X							X					
 const-oid@0.9.6	X							X					
 core-foundation@0.10.1	X							X					
 core-foundation-sys@0.8.7	X							X					
 cpufeatures@0.2.17	X							X					
 crypto-common@0.1.7	X							X					
-ctor@1.0.4	X							X					
+crypto-common@0.2.2	X							X					
+ctor@1.0.6	X							X					
 dav-server@0.11.0	X												
-dav-server-opendalfs@0.7.1	X												
+dav-server-opendalfs@0.7.2	X												
 derive-where@1.6.1	X							X					
 digest@0.10.7	X							X					
+digest@0.11.3	X							X					
 displaydoc@0.2.5	X							X					
 dunce@1.0.5	X			X					X				
 dyn-clone@1.0.20	X							X					
@@ -61,6 +65,7 @@ http-body@1.0.1								X
 http-body-util@0.1.3								X					
 httparse@1.10.1	X							X					
 httpdate@1.0.3	X							X					
+hybrid-array@0.4.12	X							X					
 hyper@1.9.0								X					
 hyper-rustls@0.27.9	X					X		X					
 hyper-util@0.1.20								X					
@@ -87,14 +92,14 @@ jni-sys-macros@0.4.1	X							X
 jobserver@0.1.34	X							X					
 js-sys@0.3.98	X							X					
 libc@0.2.186	X							X					
-link-section@0.16.0	X							X					
+link-section@0.17.2	X							X					
 linktime-proc-macro@0.1.0	X							X					
 linux-raw-sys@0.12.1	X	X						X					
 litemap@0.8.2											X		
 lock_api@0.4.14	X							X					
 log@0.4.29	X							X					
 lru@0.16.4								X					
-md-5@0.10.6	X							X					
+md-5@0.11.0	X							X					
 mea@0.6.3	X												
 memchr@2.8.0								X				X	
 mime@0.3.17	X							X					
@@ -102,13 +107,13 @@ mime_guess@2.0.5								X
 mio@1.2.0								X					
 num-traits@0.2.19	X							X					
 once_cell@1.21.4	X							X					
-opendal@0.56.0	X												
-opendal-core@0.56.0	X												
-opendal-layer-concurrent-limit@0.56.0	X												
-opendal-layer-logging@0.56.0	X												
-opendal-layer-retry@0.56.0	X												
-opendal-layer-timeout@0.56.0	X												
-opendal-service-fs@0.56.0	X												
+opendal@0.57.0	X												
+opendal-core@0.57.0	X												
+opendal-layer-concurrent-limit@0.57.0	X												
+opendal-layer-logging@0.57.0	X												
+opendal-layer-retry@0.57.0	X												
+opendal-layer-timeout@0.57.0	X												
+opendal-service-fs@0.57.0	X												
 openssl-probe@0.2.1	X							X					
 parking_lot@0.12.5	X							X					
 parking_lot_core@0.9.12	X							X					
@@ -144,7 +149,7 @@ semver@1.0.28	X							X
 serde@1.0.228	X							X					
 serde_core@1.0.228	X							X					
 serde_derive@1.0.228	X							X					
-serde_json@1.0.149	X							X					
+serde_json@1.0.150	X							X					
 sha1@0.10.6	X							X					
 sha2@0.10.9	X							X					
 shlex@1.3.0	X							X					
@@ -166,7 +171,7 @@ tokio-macros@2.7.0								X
 tokio-rustls@0.26.4	X							X					
 tokio-util@0.7.18								X					
 tower@0.5.3								X					
-tower-http@0.6.10								X					
+tower-http@0.6.11								X					
 tower-layer@0.3.3								X					
 tower-service@0.3.3								X					
 tracing@0.1.44								X					
@@ -216,7 +221,7 @@ xml-rs@1.0.0								X
 xmltree@0.12.0								X					
 yoke@0.8.2											X		
 yoke-derive@0.8.2											X		
-zerofrom@0.1.7											X		
+zerofrom@0.1.8											X		
 zerofrom-derive@0.1.7											X		
 zeroize@1.8.2	X							X					
 zerotrie@0.2.4											X		

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.85"
-version = "0.56.0"
+version = "0.57.0"
 
 [features]
 send_wrapper = ["dep:send_wrapper"]
@@ -43,7 +43,7 @@ chrono = { version = "0.4.42", features = ["std", "clock"] }
 futures = "0.3"
 mea = "0.6"
 object_store = "0.13.1"
-opendal = { version = "0.56.0", path = "../../core", default-features = false }
+opendal = { version = "0.57.0", path = "../../core", default-features = false }
 pin-project = "1.1"
 send_wrapper = { version = "0.6", features = ["futures"], optional = true }
 tokio = { version = "1", default-features = false }
@@ -52,7 +52,7 @@ tokio = { version = "1", default-features = false }
 anyhow = "1.0.86"
 datafusion = "53.0.0"
 libtest-mimic = "0.8.1"
-opendal = { version = "0.56.0", path = "../../core", features = [
+opendal = { version = "0.57.0", path = "../../core", features = [
   "services-fs",
   "services-memory",
   "services-s3",

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -1,246 +1,237 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
-android_system_properties@0.1.5	X									X			
-anyhow@1.0.102	X									X			
-async-trait@0.1.89	X									X			
-atomic-waker@1.1.2	X									X			
-autocfg@1.5.0	X									X			
-aws-lc-rs@1.16.3	X							X					
-aws-lc-sys@0.40.0	X			X				X		X	X		
-backon@1.6.0	X												
-base64@0.22.1	X									X			
-bitflags@2.11.1	X									X			
-block-buffer@0.10.4	X									X			
-bumpalo@3.20.2	X									X			
-bytes@1.11.1										X			
-cc@1.2.60	X									X			
-cesu8@1.1.0	X									X			
-cfg-if@1.0.4	X									X			
-chrono@0.4.44	X									X			
-cmake@0.1.58	X									X			
-combine@4.6.7										X			
-const-oid@0.9.6	X									X			
-const-random@0.1.18	X									X			
-const-random-macro@0.1.16	X									X			
-core-foundation@0.10.1	X									X			
-core-foundation-sys@0.8.7	X									X			
-cpufeatures@0.2.17	X									X			
-crc32c@0.6.8	X									X			
-crunchy@0.2.4										X			
-crypto-common@0.1.7	X									X			
-ctor@0.6.3	X									X			
-ctor-proc-macro@0.0.7	X									X			
-digest@0.10.7	X									X			
-displaydoc@0.2.5	X									X			
-dlv-list@0.5.2	X									X			
-dotenvy@0.15.7										X			
-dtor@0.1.1	X									X			
-dtor-proc-macro@0.0.6	X									X			
-dunce@1.0.5	X					X					X		
-either@1.15.0	X									X			
-errno@0.3.14	X									X			
-fastrand@2.4.1	X									X			
-find-msvc-tools@0.1.9	X									X			
-form_urlencoded@1.2.2	X									X			
-fs_extra@1.3.0										X			
-futures@0.3.32	X									X			
-futures-channel@0.3.32	X									X			
-futures-core@0.3.32	X									X			
-futures-executor@0.3.32	X									X			
-futures-io@0.3.32	X									X			
-futures-macro@0.3.32	X									X			
-futures-sink@0.3.32	X									X			
-futures-task@0.3.32	X									X			
-futures-util@0.3.32	X									X			
-generic-array@0.14.7										X			
-getrandom@0.2.17	X									X			
-getrandom@0.3.4	X									X			
-getrandom@0.4.2	X									X			
-gloo-timers@0.3.0	X									X			
-hashbrown@0.14.5	X									X			
-hex@0.4.3	X									X			
-hmac@0.12.1	X									X			
-http@1.4.0	X									X			
-http-body@1.0.1										X			
-http-body-util@0.1.3										X			
-httparse@1.10.1	X									X			
-humantime@2.3.0	X									X			
-hyper@1.9.0										X			
-hyper-rustls@0.27.9	X							X		X			
-hyper-util@0.1.20										X			
-iana-time-zone@0.1.65	X									X			
-iana-time-zone-haiku@0.1.2	X									X			
-icu_collections@2.1.1												X	
-icu_locale_core@2.1.1												X	
-icu_normalizer@2.1.1												X	
-icu_normalizer_data@2.1.1												X	
-icu_properties@2.1.2												X	
-icu_properties_data@2.1.2												X	
-icu_provider@2.1.1												X	
-idna@1.1.0	X									X			
-idna_adapter@1.2.1	X									X			
-ipnet@2.12.0	X									X			
-iri-string@0.7.12	X									X			
-itertools@0.14.0	X									X			
-itoa@1.0.18	X									X			
-jiff@0.2.23										X			X
-jiff-tzdb@0.1.6										X			X
-jiff-tzdb-platform@0.1.3										X			X
-jni@0.21.1	X									X			
-jni-sys@0.3.1	X									X			
-jni-sys@0.4.1	X									X			
-jni-sys-macros@0.4.1	X									X			
-jobserver@0.1.34	X									X			
-js-sys@0.3.95	X									X			
-libc@0.2.185	X									X			
-libm@0.2.16										X			
-linux-raw-sys@0.12.1	X	X								X			
-litemap@0.8.2												X	
-lock_api@0.4.14	X									X			
-log@0.4.29	X									X			
-md-5@0.10.6	X									X			
-mea@0.6.3	X												
-memchr@2.8.0										X			X
-mio@1.2.0										X			
-num-traits@0.2.19	X									X			
-object_store@0.13.2	X									X			
-object_store_opendal@0.56.0	X												
-once_cell@1.21.4	X									X			
-opendal@0.56.0	X												
-opendal-core@0.56.0	X												
-opendal-layer-concurrent-limit@0.56.0	X												
-opendal-layer-logging@0.56.0	X												
-opendal-layer-retry@0.56.0	X												
-opendal-layer-timeout@0.56.0	X												
-opendal-service-fs@0.56.0	X												
-opendal-service-s3@0.56.0	X												
-opendal-testkit@0.56.0	X												
-openssl-probe@0.2.1	X									X			
-ordered-multimap@0.7.3										X			
-parking_lot@0.12.5	X									X			
-parking_lot_core@0.9.12	X									X			
-percent-encoding@2.3.2	X									X			
-pin-project@1.1.11	X									X			
-pin-project-internal@1.1.11	X									X			
-pin-project-lite@0.2.17	X									X			
-portable-atomic@1.13.1	X									X			
-portable-atomic-util@0.2.6	X									X			
-potential_utf@0.1.5												X	
-ppv-lite86@0.2.21	X									X			
-proc-macro2@1.0.106	X									X			
-quick-xml@0.38.4										X			
-quick-xml@0.39.2										X			
-quote@1.0.45	X									X			
-r-efi@5.3.0	X								X	X			
-r-efi@6.0.0	X								X	X			
-rand@0.8.5	X									X			
-rand_chacha@0.3.1	X									X			
-rand_core@0.6.4	X									X			
-redox_syscall@0.5.18										X			
-reqsign-aws-v4@3.0.0	X												
-reqsign-core@3.0.0	X												
-reqsign-file-read-tokio@3.0.0	X												
-reqwest@0.13.2	X									X			
-rust-ini@0.21.3										X			
-rustc_version@0.4.1	X									X			
-rustix@1.1.4	X	X								X			
-rustls@0.23.38	X							X		X			
-rustls-native-certs@0.8.3	X							X		X			
-rustls-pki-types@1.14.0	X									X			
-rustls-platform-verifier@0.6.2	X									X			
-rustls-platform-verifier-android@0.1.1	X									X			
-rustls-webpki@0.103.12								X					
-rustversion@1.0.22	X									X			
-ryu@1.0.23	X				X								
-same-file@1.0.6										X			X
-schannel@0.1.29										X			
-scopeguard@1.2.0	X									X			
-security-framework@3.7.0	X									X			
-security-framework-sys@2.17.0	X									X			
-semver@1.0.28	X									X			
-serde@1.0.228	X									X			
-serde_core@1.0.228	X									X			
-serde_derive@1.0.228	X									X			
-serde_json@1.0.149	X									X			
-serde_urlencoded@0.7.1	X									X			
-sha1@0.10.6	X									X			
-sha2@0.10.9	X									X			
-shlex@1.3.0	X									X			
-slab@0.4.12										X			
-smallvec@1.15.1	X									X			
-socket2@0.6.3	X									X			
-stable_deref_trait@1.2.1	X									X			
-subtle@2.6.1				X									
-syn@2.0.117	X									X			
-sync_wrapper@1.0.2	X												
-synstructure@0.13.2										X			
-thiserror@1.0.69	X									X			
-thiserror@2.0.18	X									X			
-thiserror-impl@1.0.69	X									X			
-thiserror-impl@2.0.18	X									X			
-tiny-keccak@2.0.2						X							
-tinystr@0.8.3												X	
-tokio@1.52.0										X			
-tokio-macros@2.7.0										X			
-tokio-rustls@0.26.4	X									X			
-tokio-util@0.7.18										X			
-tower@0.5.3										X			
-tower-http@0.6.8										X			
-tower-layer@0.3.3										X			
-tower-service@0.3.3										X			
-tracing@0.1.44										X			
-tracing-attributes@0.1.31										X			
-tracing-core@0.1.36										X			
-try-lock@0.2.5										X			
-typenum@1.19.0	X									X			
-unicode-ident@1.0.24	X									X		X	
-untrusted@0.9.0								X					
-url@2.5.8	X									X			
-utf8_iter@1.0.4	X									X			
-uuid@1.23.1	X									X			
-version_check@0.9.5	X									X			
-walkdir@2.5.0										X			X
-want@0.3.1										X			
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
-wasip2@1.0.1+wasi-0.2.4	X	X								X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
-wasm-bindgen@0.2.118	X									X			
-wasm-bindgen-futures@0.4.68	X									X			
-wasm-bindgen-macro@0.2.118	X									X			
-wasm-bindgen-macro-support@0.2.118	X									X			
-wasm-bindgen-shared@0.2.118	X									X			
-wasm-streams@0.5.0	X									X			
-web-sys@0.3.95	X									X			
-web-time@1.1.0	X									X			
-webpki-root-certs@1.0.6							X						
-winapi-util@0.1.11										X			X
-windows-core@0.62.2	X									X			
-windows-implement@0.60.2	X									X			
-windows-interface@0.59.3	X									X			
-windows-link@0.2.1	X									X			
-windows-result@0.4.1	X									X			
-windows-strings@0.5.1	X									X			
-windows-sys@0.45.0	X									X			
-windows-sys@0.61.2	X									X			
-windows-targets@0.42.2	X									X			
-windows_aarch64_gnullvm@0.42.2	X									X			
-windows_aarch64_msvc@0.42.2	X									X			
-windows_i686_gnu@0.42.2	X									X			
-windows_i686_msvc@0.42.2	X									X			
-windows_x86_64_gnu@0.42.2	X									X			
-windows_x86_64_gnullvm@0.42.2	X									X			
-windows_x86_64_msvc@0.42.2	X									X			
-wit-bindgen@0.46.0	X	X								X			
-wit-bindgen@0.51.0	X	X								X			
-writeable@0.6.3												X	
-xattr@1.6.1	X									X			
-yoke@0.8.2												X	
-yoke-derive@0.8.2												X	
-zerocopy@0.8.48	X		X							X			
-zerocopy-derive@0.8.48	X		X							X			
-zerofrom@0.1.7												X	
-zerofrom-derive@0.1.7												X	
-zeroize@1.8.2	X									X			
-zerotrie@0.2.4												X	
-zerovec@0.11.6												X	
-zerovec-derive@0.11.3												X	
-zmij@1.0.21										X			
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
+android_system_properties@0.1.5	X								X			
+anyhow@1.0.102	X								X			
+async-trait@0.1.89	X								X			
+atomic-waker@1.1.2	X								X			
+autocfg@1.5.0	X								X			
+aws-lc-rs@1.17.0	X						X					
+aws-lc-sys@0.41.0	X		X				X		X	X		
+backon@1.6.0	X											
+base64@0.22.1	X								X			
+bitflags@2.11.1	X								X			
+block-buffer@0.10.4	X								X			
+block-buffer@0.12.0	X								X			
+bumpalo@3.20.2	X								X			
+bytes@1.11.1									X			
+cc@1.2.62	X								X			
+cfg-if@1.0.4	X								X			
+chacha20@0.10.0	X								X			
+chrono@0.4.44	X								X			
+cmake@0.1.58	X								X			
+combine@4.6.7									X			
+const-oid@0.10.2	X								X			
+const-oid@0.9.6	X								X			
+const-random@0.1.18	X								X			
+const-random-macro@0.1.16	X								X			
+core-foundation@0.10.1	X								X			
+core-foundation-sys@0.8.7	X								X			
+cpufeatures@0.2.17	X								X			
+cpufeatures@0.3.0	X								X			
+crc32c@0.6.8	X								X			
+crunchy@0.2.4									X			
+crypto-common@0.1.7	X								X			
+crypto-common@0.2.2	X								X			
+ctor@1.0.6	X								X			
+digest@0.10.7	X								X			
+digest@0.11.3	X								X			
+displaydoc@0.2.5	X								X			
+dlv-list@0.5.2	X								X			
+dotenvy@0.15.7									X			
+dunce@1.0.5	X				X					X		
+either@1.16.0	X								X			
+errno@0.3.14	X								X			
+fastrand@2.4.1	X								X			
+find-msvc-tools@0.1.9	X								X			
+form_urlencoded@1.2.2	X								X			
+fs_extra@1.3.0									X			
+futures@0.3.32	X								X			
+futures-channel@0.3.32	X								X			
+futures-core@0.3.32	X								X			
+futures-executor@0.3.32	X								X			
+futures-io@0.3.32	X								X			
+futures-macro@0.3.32	X								X			
+futures-sink@0.3.32	X								X			
+futures-task@0.3.32	X								X			
+futures-util@0.3.32	X								X			
+generic-array@0.14.7									X			
+getrandom@0.2.17	X								X			
+getrandom@0.3.4	X								X			
+getrandom@0.4.2	X								X			
+gloo-timers@0.3.0	X								X			
+hashbrown@0.14.5	X								X			
+hex@0.4.3	X								X			
+hmac@0.12.1	X								X			
+http@1.4.0	X								X			
+http-body@1.0.1									X			
+http-body-util@0.1.3									X			
+httparse@1.10.1	X								X			
+humantime@2.3.0	X								X			
+hybrid-array@0.4.12	X								X			
+hyper@1.9.0									X			
+hyper-rustls@0.27.9	X						X		X			
+hyper-util@0.1.20									X			
+iana-time-zone@0.1.65	X								X			
+iana-time-zone-haiku@0.1.2	X								X			
+icu_collections@2.1.1											X	
+icu_locale_core@2.1.1											X	
+icu_normalizer@2.1.1											X	
+icu_normalizer_data@2.1.1											X	
+icu_properties@2.1.2											X	
+icu_properties_data@2.1.2											X	
+icu_provider@2.1.1											X	
+idna@1.1.0	X								X			
+idna_adapter@1.2.1	X								X			
+ipnet@2.12.0	X								X			
+itertools@0.14.0	X								X			
+itoa@1.0.18	X								X			
+jiff@0.2.24									X			X
+jiff-tzdb@0.1.6									X			X
+jiff-tzdb-platform@0.1.3									X			X
+jni@0.22.4	X								X			
+jni-macros@0.22.4	X								X			
+jni-sys@0.4.1	X								X			
+jni-sys-macros@0.4.1	X								X			
+jobserver@0.1.34	X								X			
+js-sys@0.3.98	X								X			
+libc@0.2.186	X								X			
+libm@0.2.16									X			
+link-section@0.17.2	X								X			
+linktime-proc-macro@0.1.0	X								X			
+linux-raw-sys@0.12.1	X	X							X			
+litemap@0.8.2											X	
+lock_api@0.4.14	X								X			
+log@0.4.29	X								X			
+md-5@0.11.0	X								X			
+mea@0.6.3	X											
+memchr@2.8.0									X			X
+mio@1.2.0									X			
+num-traits@0.2.19	X								X			
+object_store@0.13.2	X								X			
+object_store_opendal@0.57.0	X											
+once_cell@1.21.4	X								X			
+opendal@0.57.0	X											
+opendal-core@0.57.0	X											
+opendal-layer-concurrent-limit@0.57.0	X											
+opendal-layer-logging@0.57.0	X											
+opendal-layer-retry@0.57.0	X											
+opendal-layer-timeout@0.57.0	X											
+opendal-service-fs@0.57.0	X											
+opendal-service-s3@0.57.0	X											
+opendal-testkit@0.57.0	X											
+openssl-probe@0.2.1	X								X			
+ordered-multimap@0.7.3									X			
+parking_lot@0.12.5	X								X			
+parking_lot_core@0.9.12	X								X			
+percent-encoding@2.3.2	X								X			
+pin-project@1.1.13	X								X			
+pin-project-internal@1.1.13	X								X			
+pin-project-lite@0.2.17	X								X			
+portable-atomic@1.13.1	X								X			
+portable-atomic-util@0.2.7	X								X			
+potential_utf@0.1.5											X	
+proc-macro2@1.0.106	X								X			
+quick-xml@0.39.4									X			
+quote@1.0.45	X								X			
+r-efi@5.3.0	X							X	X			
+r-efi@6.0.0	X							X	X			
+rand@0.10.1	X								X			
+rand_core@0.10.1	X								X			
+redox_syscall@0.5.18									X			
+reqsign-aws-v4@3.0.0	X											
+reqsign-core@3.0.0	X											
+reqsign-file-read-tokio@3.0.0	X											
+reqwest@0.13.3	X								X			
+rust-ini@0.21.3									X			
+rustc_version@0.4.1	X								X			
+rustix@1.1.4	X	X							X			
+rustls@0.23.40	X						X		X			
+rustls-native-certs@0.8.3	X						X		X			
+rustls-pki-types@1.14.1	X								X			
+rustls-platform-verifier@0.7.0	X								X			
+rustls-platform-verifier-android@0.1.1	X								X			
+rustls-webpki@0.103.13							X					
+rustversion@1.0.22	X								X			
+ryu@1.0.23	X			X								
+same-file@1.0.6									X			X
+schannel@0.1.29									X			
+scopeguard@1.2.0	X								X			
+security-framework@3.7.0	X								X			
+security-framework-sys@2.17.0	X								X			
+semver@1.0.28	X								X			
+serde@1.0.228	X								X			
+serde_core@1.0.228	X								X			
+serde_derive@1.0.228	X								X			
+serde_json@1.0.150	X								X			
+serde_urlencoded@0.7.1	X								X			
+sha1@0.10.6	X								X			
+sha2@0.10.9	X								X			
+sha2@0.11.0	X								X			
+shlex@1.3.0	X								X			
+simd_cesu8@1.1.1	X								X			
+simdutf8@0.1.5	X								X			
+slab@0.4.12									X			
+smallvec@1.15.1	X								X			
+socket2@0.6.3	X								X			
+stable_deref_trait@1.2.1	X								X			
+subtle@2.6.1			X									
+syn@2.0.117	X								X			
+sync_wrapper@1.0.2	X											
+synstructure@0.13.2									X			
+thiserror@2.0.18	X								X			
+thiserror-impl@2.0.18	X								X			
+tiny-keccak@2.0.2					X							
+tinystr@0.8.3											X	
+tokio@1.52.3									X			
+tokio-macros@2.7.0									X			
+tokio-rustls@0.26.4	X								X			
+tokio-util@0.7.18									X			
+tower@0.5.3									X			
+tower-http@0.6.11									X			
+tower-layer@0.3.3									X			
+tower-service@0.3.3									X			
+tracing@0.1.44									X			
+tracing-attributes@0.1.31									X			
+tracing-core@0.1.36									X			
+try-lock@0.2.5									X			
+typenum@1.20.0	X								X			
+unicode-ident@1.0.24	X								X		X	
+untrusted@0.9.0							X					
+url@2.5.8	X								X			
+utf8_iter@1.0.4	X								X			
+uuid@1.23.1	X								X			
+version_check@0.9.5	X								X			
+walkdir@2.5.0									X			X
+want@0.3.1									X			
+wasi@0.11.1+wasi-snapshot-preview1	X	X							X			
+wasip2@1.0.1+wasi-0.2.4	X	X							X			
+wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X							X			
+wasm-bindgen@0.2.121	X								X			
+wasm-bindgen-futures@0.4.71	X								X			
+wasm-bindgen-macro@0.2.121	X								X			
+wasm-bindgen-macro-support@0.2.121	X								X			
+wasm-bindgen-shared@0.2.121	X								X			
+wasm-streams@0.5.0	X								X			
+web-sys@0.3.98	X								X			
+web-time@1.1.0	X								X			
+webpki-root-certs@1.0.7						X						
+winapi-util@0.1.11									X			X
+windows-core@0.62.2	X								X			
+windows-implement@0.60.2	X								X			
+windows-interface@0.59.3	X								X			
+windows-link@0.2.1	X								X			
+windows-result@0.4.1	X								X			
+windows-strings@0.5.1	X								X			
+windows-sys@0.61.2	X								X			
+wit-bindgen@0.46.0	X	X							X			
+wit-bindgen@0.51.0	X	X							X			
+writeable@0.6.3											X	
+xattr@1.6.1	X								X			
+yoke@0.8.2											X	
+yoke-derive@0.8.2											X	
+zerofrom@0.1.8											X	
+zerofrom-derive@0.1.7											X	
+zeroize@1.8.2	X								X			
+zerotrie@0.2.4											X	
+zerovec@0.11.6											X	
+zerovec-derive@0.11.3											X	
+zmij@1.0.21									X			

--- a/integrations/parquet/Cargo.toml
+++ b/integrations/parquet/Cargo.toml
@@ -25,13 +25,13 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.85"
-version = "0.8.0"
+version = "0.8.1"
 
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
-opendal = { version = "0.56.0", path = "../../core" }
+opendal = { version = "0.57.0", path = "../../core" }
 parquet = { version = "58.0", default-features = false, features = [
   "async",
   "arrow",
@@ -39,7 +39,7 @@ parquet = { version = "58.0", default-features = false, features = [
 
 [dev-dependencies]
 arrow = { version = "58.0" }
-opendal = { version = "0.56.0", path = "../../core", features = [
+opendal = { version = "0.57.0", path = "../../core", features = [
   "services-memory",
   "services-s3",
 ] }

--- a/integrations/parquet/DEPENDENCIES.rust.tsv
+++ b/integrations/parquet/DEPENDENCIES.rust.tsv
@@ -2,30 +2,31 @@ crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.
 ahash@0.8.12	X									X			
 android_system_properties@0.1.5	X									X			
 anyhow@1.0.102	X									X			
-arrow-array@58.1.0	X												
-arrow-buffer@58.1.0	X												
-arrow-data@58.1.0	X												
-arrow-ipc@58.1.0	X												
-arrow-schema@58.1.0	X												
-arrow-select@58.1.0	X												
+arrow-array@58.3.0	X									X			
+arrow-buffer@58.3.0	X												
+arrow-data@58.3.0	X												
+arrow-ipc@58.3.0	X												
+arrow-schema@58.3.0	X												
+arrow-select@58.3.0	X												
 async-trait@0.1.89	X									X			
 atomic-waker@1.1.2	X									X			
 autocfg@1.5.0	X									X			
-aws-lc-rs@1.16.3	X							X					
-aws-lc-sys@0.40.0	X			X				X		X	X		
+aws-lc-rs@1.17.0	X							X					
+aws-lc-sys@0.41.0	X			X				X		X	X		
 backon@1.6.0	X												
 base64@0.22.1	X									X			
 bitflags@2.11.1	X									X			
 block-buffer@0.10.4	X									X			
+block-buffer@0.12.0	X									X			
 bumpalo@3.20.2	X									X			
 byteorder@1.5.0										X			X
 bytes@1.11.1										X			
-cc@1.2.60	X									X			
-cesu8@1.1.0	X									X			
+cc@1.2.62	X									X			
 cfg-if@1.0.4	X									X			
 chrono@0.4.44	X									X			
 cmake@0.1.58	X									X			
 combine@4.6.7										X			
+const-oid@0.10.2	X									X			
 const-oid@0.9.6	X									X			
 const-random@0.1.18	X									X			
 const-random-macro@0.1.16	X									X			
@@ -35,13 +36,12 @@ cpufeatures@0.2.17	X									X
 crc32c@0.6.8	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
-ctor@0.6.3	X									X			
-ctor-proc-macro@0.0.7	X									X			
+crypto-common@0.2.2	X									X			
+ctor@1.0.6	X									X			
 digest@0.10.7	X									X			
+digest@0.11.3	X									X			
 displaydoc@0.2.5	X									X			
 dlv-list@0.5.2	X									X			
-dtor@0.1.1	X									X			
-dtor-proc-macro@0.0.6	X									X			
 dunce@1.0.5	X					X					X		
 fastrand@2.4.1	X									X			
 find-msvc-tools@0.1.9	X									X			
@@ -64,13 +64,14 @@ getrandom@0.4.2	X									X
 gloo-timers@0.3.0	X									X			
 half@2.7.1	X									X			
 hashbrown@0.14.5	X									X			
-hashbrown@0.16.1	X									X			
+hashbrown@0.17.1	X									X			
 hex@0.4.3	X									X			
 hmac@0.12.1	X									X			
 http@1.4.0	X									X			
 http-body@1.0.1										X			
 http-body-util@0.1.3										X			
 httparse@1.10.1	X									X			
+hybrid-array@0.4.12	X									X			
 hyper@1.9.0										X			
 hyper-rustls@0.27.9	X							X		X			
 hyper-util@0.1.20										X			
@@ -87,22 +88,23 @@ idna@1.1.0	X									X
 idna_adapter@1.2.1	X									X			
 integer-encoding@3.0.4										X			
 ipnet@2.12.0	X									X			
-iri-string@0.7.12	X									X			
 itoa@1.0.18	X									X			
-jiff@0.2.23										X			X
+jiff@0.2.24										X			X
 jiff-tzdb@0.1.6										X			X
 jiff-tzdb-platform@0.1.3										X			X
-jni@0.21.1	X									X			
-jni-sys@0.3.1	X									X			
+jni@0.22.4	X									X			
+jni-macros@0.22.4	X									X			
 jni-sys@0.4.1	X									X			
 jni-sys-macros@0.4.1	X									X			
 jobserver@0.1.34	X									X			
-js-sys@0.3.95	X									X			
-libc@0.2.185	X									X			
+js-sys@0.3.98	X									X			
+libc@0.2.186	X									X			
 libm@0.2.16										X			
+link-section@0.17.2	X									X			
+linktime-proc-macro@0.1.0	X									X			
 litemap@0.8.2												X	
 log@0.4.29	X									X			
-md-5@0.10.6	X									X			
+md-5@0.11.0	X									X			
 mea@0.6.3	X												
 memchr@2.8.0										X			X
 mio@1.2.0										X			
@@ -111,42 +113,42 @@ num-complex@0.4.6	X									X
 num-integer@0.1.46	X									X			
 num-traits@0.2.19	X									X			
 once_cell@1.21.4	X									X			
-opendal@0.56.0	X												
-opendal-core@0.56.0	X												
-opendal-layer-concurrent-limit@0.56.0	X												
-opendal-layer-logging@0.56.0	X												
-opendal-layer-retry@0.56.0	X												
-opendal-layer-timeout@0.56.0	X												
-opendal-service-s3@0.56.0	X												
+opendal@0.57.0	X												
+opendal-core@0.57.0	X												
+opendal-layer-concurrent-limit@0.57.0	X												
+opendal-layer-logging@0.57.0	X												
+opendal-layer-retry@0.57.0	X												
+opendal-layer-timeout@0.57.0	X												
+opendal-service-s3@0.57.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-float@2.10.1										X			
 ordered-multimap@0.7.3										X			
-parquet@58.1.0	X												
-parquet_opendal@0.8.0	X												
+parquet@58.3.0	X												
+parquet_opendal@0.8.1	X												
 paste@1.0.15	X									X			
 percent-encoding@2.3.2	X									X			
 pin-project-lite@0.2.17	X									X			
 portable-atomic@1.13.1	X									X			
-portable-atomic-util@0.2.6	X									X			
+portable-atomic-util@0.2.7	X									X			
 potential_utf@0.1.5												X	
 proc-macro2@1.0.106	X									X			
-quick-xml@0.38.4										X			
-quick-xml@0.39.2										X			
+quick-xml@0.39.4										X			
 quote@1.0.45	X									X			
 r-efi@5.3.0	X								X	X			
 r-efi@6.0.0	X								X	X			
+rand_core@0.10.1	X									X			
 reqsign-aws-v4@3.0.0	X												
 reqsign-core@3.0.0	X												
 reqsign-file-read-tokio@3.0.0	X												
-reqwest@0.13.2	X									X			
+reqwest@0.13.3	X									X			
 rust-ini@0.21.3										X			
 rustc_version@0.4.1	X									X			
-rustls@0.23.38	X							X		X			
+rustls@0.23.40	X							X		X			
 rustls-native-certs@0.8.3	X							X		X			
-rustls-pki-types@1.14.0	X									X			
-rustls-platform-verifier@0.6.2	X									X			
+rustls-pki-types@1.14.1	X									X			
+rustls-platform-verifier@0.7.0	X									X			
 rustls-platform-verifier-android@0.1.1	X									X			
-rustls-webpki@0.103.12								X					
+rustls-webpki@0.103.13								X					
 rustversion@1.0.22	X									X			
 ryu@1.0.23	X				X								
 same-file@1.0.6										X			X
@@ -158,11 +160,13 @@ seq-macro@0.3.6	X									X
 serde@1.0.228	X									X			
 serde_core@1.0.228	X									X			
 serde_derive@1.0.228	X									X			
-serde_json@1.0.149	X									X			
+serde_json@1.0.150	X									X			
 serde_urlencoded@0.7.1	X									X			
 sha1@0.10.6	X									X			
 sha2@0.10.9	X									X			
 shlex@1.3.0	X									X			
+simd_cesu8@1.1.1	X									X			
+simdutf8@0.1.5	X									X			
 slab@0.4.12										X			
 smallvec@1.15.1	X									X			
 socket2@0.6.3	X									X			
@@ -171,24 +175,24 @@ subtle@2.6.1				X
 syn@2.0.117	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
-thiserror@1.0.69	X									X			
-thiserror-impl@1.0.69	X									X			
+thiserror@2.0.18	X									X			
+thiserror-impl@2.0.18	X									X			
 thrift@0.17.0	X												
 tiny-keccak@2.0.2						X							
 tinystr@0.8.3												X	
-tokio@1.52.0										X			
+tokio@1.52.3										X			
 tokio-macros@2.7.0										X			
 tokio-rustls@0.26.4	X									X			
 tokio-util@0.7.18										X			
 tower@0.5.3										X			
-tower-http@0.6.8										X			
+tower-http@0.6.11										X			
 tower-layer@0.3.3										X			
 tower-service@0.3.3										X			
 tracing@0.1.44										X			
 tracing-core@0.1.36										X			
 try-lock@0.2.5										X			
 twox-hash@2.1.2										X			
-typenum@1.19.0	X									X			
+typenum@1.20.0	X									X			
 unicode-ident@1.0.24	X									X		X	
 untrusted@0.9.0								X					
 url@2.5.8	X									X			
@@ -200,15 +204,15 @@ want@0.3.1										X
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
 wasip2@1.0.1+wasi-0.2.4	X	X								X			
 wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
-wasm-bindgen@0.2.118	X									X			
-wasm-bindgen-futures@0.4.68	X									X			
-wasm-bindgen-macro@0.2.118	X									X			
-wasm-bindgen-macro-support@0.2.118	X									X			
-wasm-bindgen-shared@0.2.118	X									X			
+wasm-bindgen@0.2.121	X									X			
+wasm-bindgen-futures@0.4.71	X									X			
+wasm-bindgen-macro@0.2.121	X									X			
+wasm-bindgen-macro-support@0.2.121	X									X			
+wasm-bindgen-shared@0.2.121	X									X			
 wasm-streams@0.5.0	X									X			
-web-sys@0.3.95	X									X			
+web-sys@0.3.98	X									X			
 web-time@1.1.0	X									X			
-webpki-root-certs@1.0.6							X						
+webpki-root-certs@1.0.7							X						
 winapi-util@0.1.11										X			X
 windows-core@0.62.2	X									X			
 windows-implement@0.60.2	X									X			
@@ -216,16 +220,7 @@ windows-interface@0.59.3	X									X
 windows-link@0.2.1	X									X			
 windows-result@0.4.1	X									X			
 windows-strings@0.5.1	X									X			
-windows-sys@0.45.0	X									X			
 windows-sys@0.61.2	X									X			
-windows-targets@0.42.2	X									X			
-windows_aarch64_gnullvm@0.42.2	X									X			
-windows_aarch64_msvc@0.42.2	X									X			
-windows_i686_gnu@0.42.2	X									X			
-windows_i686_msvc@0.42.2	X									X			
-windows_x86_64_gnu@0.42.2	X									X			
-windows_x86_64_gnullvm@0.42.2	X									X			
-windows_x86_64_msvc@0.42.2	X									X			
 wit-bindgen@0.46.0	X	X								X			
 wit-bindgen@0.51.0	X	X								X			
 writeable@0.6.3												X	
@@ -233,7 +228,7 @@ yoke@0.8.2												X
 yoke-derive@0.8.2												X	
 zerocopy@0.8.48	X		X							X			
 zerocopy-derive@0.8.48	X		X							X			
-zerofrom@0.1.7												X	
+zerofrom@0.1.8												X	
 zerofrom-derive@0.1.7												X	
 zeroize@1.8.2	X									X			
 zerotrie@0.2.4												X	

--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -24,11 +24,11 @@ license = "Apache-2.0"
 name = "unftp-sbe-opendal"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.85"
-version = "0.4.1"
+version = "0.4.2"
 
 [dependencies]
 async-trait = "0.1.88"
-opendal = { version = "0.56.0", path = "../../core" }
+opendal = { version = "0.57.0", path = "../../core" }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.7.11", features = ["compat"] }
 unftp-core = "0.1.0"
@@ -36,7 +36,7 @@ unftp-core = "0.1.0"
 [dev-dependencies]
 anyhow = "1"
 libunftp = "0.23.0"
-opendal = { version = "0.56.0", path = "../../core", features = [
+opendal = { version = "0.57.0", path = "../../core", features = [
   "services-s3",
 ] }
 tokio = { version = "1.38.0", default-features = false, features = [

--- a/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
+++ b/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
@@ -1,26 +1,27 @@
 crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
 android_system_properties@0.1.5	X								X			
 anyhow@1.0.102	X								X			
-asn1-rs@0.7.1	X								X			
+asn1-rs@0.7.2	X								X			
 asn1-rs-derive@0.6.0	X								X			
 asn1-rs-impl@0.2.0	X								X			
 async-trait@0.1.89	X								X			
 atomic-waker@1.1.2	X								X			
 autocfg@1.5.0	X								X			
-aws-lc-rs@1.16.3	X						X					
-aws-lc-sys@0.40.0	X		X				X		X	X		
+aws-lc-rs@1.17.0	X						X					
+aws-lc-sys@0.41.0	X		X				X		X	X		
 backon@1.6.0	X											
 base64@0.22.1	X								X			
 bitflags@2.11.1	X								X			
 block-buffer@0.10.4	X								X			
+block-buffer@0.12.0	X								X			
 bumpalo@3.20.2	X								X			
 bytes@1.11.1									X			
-cc@1.2.60	X								X			
-cesu8@1.1.0	X								X			
+cc@1.2.62	X								X			
 cfg-if@1.0.4	X								X			
 chrono@0.4.44	X								X			
 cmake@0.1.58	X								X			
 combine@4.6.7									X			
+const-oid@0.10.2	X								X			
 const-oid@0.9.6	X								X			
 const-random@0.1.18	X								X			
 const-random-macro@0.1.16	X								X			
@@ -31,18 +32,17 @@ cpufeatures@0.2.17	X								X
 crc32c@0.6.8	X								X			
 crunchy@0.2.4									X			
 crypto-common@0.1.7	X								X			
-ctor@0.6.3	X								X			
-ctor-proc-macro@0.0.7	X								X			
-data-encoding@2.10.0									X			
+crypto-common@0.2.2	X								X			
+ctor@1.0.6	X								X			
+data-encoding@2.11.0									X			
 der-parser@10.0.0	X								X			
 deranged@0.5.8	X								X			
 derive_more@2.1.1									X			
 derive_more-impl@2.1.1									X			
 digest@0.10.7	X								X			
+digest@0.11.3	X								X			
 displaydoc@0.2.5	X								X			
 dlv-list@0.5.2	X								X			
-dtor@0.1.1	X								X			
-dtor-proc-macro@0.0.6	X								X			
 dunce@1.0.5	X				X					X		
 errno@0.3.14	X								X			
 fastrand@2.4.1	X								X			
@@ -70,6 +70,7 @@ http@1.4.0	X								X
 http-body@1.0.1									X			
 http-body-util@0.1.3									X			
 httparse@1.10.1	X								X			
+hybrid-array@0.4.12	X								X			
 hyper@1.9.0									X			
 hyper-rustls@0.27.9	X						X		X			
 hyper-util@0.1.20									X			
@@ -85,22 +86,24 @@ icu_provider@2.1.1											X
 idna@1.1.0	X								X			
 idna_adapter@1.2.1	X								X			
 ipnet@2.12.0	X								X			
-iri-string@0.7.12	X								X			
 itoa@1.0.18	X								X			
-jiff@0.2.23									X			X
+jiff@0.2.24									X			X
 jiff-tzdb@0.1.6									X			X
 jiff-tzdb-platform@0.1.3									X			X
-jni@0.21.1	X								X			
-jni-sys@0.3.1	X								X			
+jni@0.22.4	X								X			
+jni-macros@0.22.4	X								X			
 jni-sys@0.4.1	X								X			
 jni-sys-macros@0.4.1	X								X			
 jobserver@0.1.34	X								X			
-js-sys@0.3.95	X								X			
+js-sys@0.3.98	X								X			
 lazy_static@1.5.0	X								X			
-libc@0.2.185	X								X			
+libc@0.2.186	X								X			
+link-section@0.17.2	X								X			
+linktime-proc-macro@0.1.0	X								X			
 litemap@0.8.2											X	
 log@0.4.29	X								X			
 md-5@0.10.6	X								X			
+md-5@0.11.0	X								X			
 mea@0.6.3	X											
 memchr@2.8.0									X			X
 minimal-lexical@0.2.1	X								X			
@@ -112,40 +115,39 @@ num-integer@0.1.46	X								X
 num-traits@0.2.19	X								X			
 oid-registry@0.8.1	X								X			
 once_cell@1.21.4	X								X			
-opendal@0.56.0	X											
-opendal-core@0.56.0	X											
-opendal-layer-concurrent-limit@0.56.0	X											
-opendal-layer-logging@0.56.0	X											
-opendal-layer-retry@0.56.0	X											
-opendal-layer-timeout@0.56.0	X											
-opendal-service-s3@0.56.0	X											
+opendal@0.57.0	X											
+opendal-core@0.57.0	X											
+opendal-layer-concurrent-limit@0.57.0	X											
+opendal-layer-logging@0.57.0	X											
+opendal-layer-retry@0.57.0	X											
+opendal-layer-timeout@0.57.0	X											
+opendal-service-s3@0.57.0	X											
 openssl-probe@0.2.1	X								X			
 ordered-multimap@0.7.3									X			
 percent-encoding@2.3.2	X								X			
 pin-project-lite@0.2.17	X								X			
 portable-atomic@1.13.1	X								X			
-portable-atomic-util@0.2.6	X								X			
+portable-atomic-util@0.2.7	X								X			
 potential_utf@0.1.5											X	
 powerfmt@0.2.0	X								X			
 proc-macro2@1.0.106	X								X			
-quick-xml@0.38.4									X			
-quick-xml@0.39.2									X			
+quick-xml@0.39.4									X			
 quote@1.0.45	X								X			
 r-efi@5.3.0	X							X	X			
 r-efi@6.0.0	X							X	X			
 reqsign-aws-v4@3.0.0	X											
 reqsign-core@3.0.0	X											
 reqsign-file-read-tokio@3.0.0	X											
-reqwest@0.13.2	X								X			
+reqwest@0.13.3	X								X			
 rust-ini@0.21.3									X			
 rustc_version@0.4.1	X								X			
 rusticata-macros@4.1.0	X								X			
-rustls@0.23.38	X						X		X			
+rustls@0.23.40	X						X		X			
 rustls-native-certs@0.8.3	X						X		X			
-rustls-pki-types@1.14.0	X								X			
-rustls-platform-verifier@0.6.2	X								X			
+rustls-pki-types@1.14.1	X								X			
+rustls-platform-verifier@0.7.0	X								X			
 rustls-platform-verifier-android@0.1.1	X								X			
-rustls-webpki@0.103.12							X					
+rustls-webpki@0.103.13							X					
 rustversion@1.0.22	X								X			
 ryu@1.0.23	X			X								
 same-file@1.0.6									X			X
@@ -156,12 +158,14 @@ semver@1.0.28	X								X
 serde@1.0.228	X								X			
 serde_core@1.0.228	X								X			
 serde_derive@1.0.228	X								X			
-serde_json@1.0.149	X								X			
+serde_json@1.0.150	X								X			
 serde_urlencoded@0.7.1	X								X			
 sha1@0.10.6	X								X			
 sha2@0.10.9	X								X			
 shlex@1.3.0	X								X			
 signal-hook-registry@1.4.8	X								X			
+simd_cesu8@1.1.1	X								X			
+simdutf8@0.1.5	X								X			
 slab@0.4.12									X			
 smallvec@1.15.1	X								X			
 socket2@0.6.3	X								X			
@@ -170,29 +174,27 @@ subtle@2.6.1			X
 syn@2.0.117	X								X			
 sync_wrapper@1.0.2	X											
 synstructure@0.13.2									X			
-thiserror@1.0.69	X								X			
 thiserror@2.0.18	X								X			
-thiserror-impl@1.0.69	X								X			
 thiserror-impl@2.0.18	X								X			
 time@0.3.45	X								X			
 time-core@0.1.7	X								X			
 time-macros@0.2.25	X								X			
 tiny-keccak@2.0.2					X							
 tinystr@0.8.3											X	
-tokio@1.52.0									X			
+tokio@1.52.3									X			
 tokio-macros@2.7.0									X			
 tokio-rustls@0.26.4	X								X			
 tokio-util@0.7.18									X			
 tower@0.5.3									X			
-tower-http@0.6.8									X			
+tower-http@0.6.11									X			
 tower-layer@0.3.3									X			
 tower-service@0.3.3									X			
 tracing@0.1.44									X			
 tracing-core@0.1.36									X			
 try-lock@0.2.5									X			
-typenum@1.19.0	X								X			
+typenum@1.20.0	X								X			
 unftp-core@0.1.0	X											
-unftp-sbe-opendal@0.4.1	X											
+unftp-sbe-opendal@0.4.2	X											
 unicode-ident@1.0.24	X								X		X	
 unicode-segmentation@1.13.2	X								X			
 unicode-xid@0.2.6	X								X			
@@ -206,15 +208,15 @@ want@0.3.1									X
 wasi@0.11.1+wasi-snapshot-preview1	X	X							X			
 wasip2@1.0.1+wasi-0.2.4	X	X							X			
 wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X							X			
-wasm-bindgen@0.2.118	X								X			
-wasm-bindgen-futures@0.4.68	X								X			
-wasm-bindgen-macro@0.2.118	X								X			
-wasm-bindgen-macro-support@0.2.118	X								X			
-wasm-bindgen-shared@0.2.118	X								X			
+wasm-bindgen@0.2.121	X								X			
+wasm-bindgen-futures@0.4.71	X								X			
+wasm-bindgen-macro@0.2.121	X								X			
+wasm-bindgen-macro-support@0.2.121	X								X			
+wasm-bindgen-shared@0.2.121	X								X			
 wasm-streams@0.5.0	X								X			
-web-sys@0.3.95	X								X			
+web-sys@0.3.98	X								X			
 web-time@1.1.0	X								X			
-webpki-root-certs@1.0.6						X						
+webpki-root-certs@1.0.7						X						
 winapi-util@0.1.11									X			X
 windows-core@0.62.2	X								X			
 windows-implement@0.60.2	X								X			
@@ -222,23 +224,14 @@ windows-interface@0.59.3	X								X
 windows-link@0.2.1	X								X			
 windows-result@0.4.1	X								X			
 windows-strings@0.5.1	X								X			
-windows-sys@0.45.0	X								X			
 windows-sys@0.61.2	X								X			
-windows-targets@0.42.2	X								X			
-windows_aarch64_gnullvm@0.42.2	X								X			
-windows_aarch64_msvc@0.42.2	X								X			
-windows_i686_gnu@0.42.2	X								X			
-windows_i686_msvc@0.42.2	X								X			
-windows_x86_64_gnu@0.42.2	X								X			
-windows_x86_64_gnullvm@0.42.2	X								X			
-windows_x86_64_msvc@0.42.2	X								X			
 wit-bindgen@0.46.0	X	X							X			
 wit-bindgen@0.51.0	X	X							X			
 writeable@0.6.3											X	
 x509-parser@0.18.1	X								X			
 yoke@0.8.2											X	
 yoke-derive@0.8.2											X	
-zerofrom@0.1.7											X	
+zerofrom@0.1.8											X	
 zerofrom-derive@0.1.7											X	
 zeroize@1.8.2	X								X			
 zerotrie@0.2.4											X	


### PR DESCRIPTION
# Which issue does this PR close?

Refs #7539.

# Rationale for this change

Prepare the repository for the Apache OpenDAL v0.57.0 release after the release blockers tracked in #7539 were completed.

# What changes are included in this PR?

This PR bumps release-managed package versions for v0.57.0, syncs workspace/internal dependency constraints, refreshes lockfiles, and regenerates Rust dependency lists. `CHANGELOG.md` is intentionally left unchanged for a separate release-notes pass.

Draft status is intentional: #7585 is still planned for this release and this branch should be refreshed after it lands.

# Are there any user-facing changes?

No runtime behavior changes are introduced by this PR. It prepares release metadata and package manifests only.

# AI Usage Statement

AI assistance was used to prepare the implementation and validation steps.
