### PR TITLE
fix(layers): wrap copier with all layers

### DIFF
--- a/core/layers/await-tree/src/lib.rs
+++ b/core/layers/await-tree/src/lib.rs
@@ -79,7 +79,7 @@ impl<A: Access> LayeredAccess for AwaitTreeAccessor<A> {
     type Writer = AwaitTreeWrapper<A::Writer>;
     type Lister = AwaitTreeWrapper<A::Lister>;
     type Deleter = AwaitTreeWrapper<A::Deleter>;
-    type Copier = A::Copier;
+    type Copier = AwaitTreeWrapper<A::Copier>;
 
     fn inner(&self) -> &Self::Inner {
         &self.inner
@@ -112,6 +112,7 @@ impl<A: Access> LayeredAccess for AwaitTreeAccessor<A> {
             .copy(from, to, args, opts.clone())
             .instrument_await(format!("opendal::{}", Operation::Copy))
             .await
+            .map(|(rp, r)| (rp, AwaitTreeWrapper::new(r)))
     }
 
     async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
@@ -211,5 +212,19 @@ impl<R: oio::Delete> oio::Delete for AwaitTreeWrapper<R> {
             .close()
             .instrument_await(format!("opendal::{}", Operation::Delete))
             .await
+    }
+}
+
+impl<C: oio::Copy> oio::Copy for AwaitTreeWrapper<C> {
+    fn next(&mut self) -> impl Future<Output = Result<Option<usize>>> + MaybeSend {
+        self.inner
+            .next()
+            .instrument_await(format!("opendal::{}", Operation::Copy.into_static()))
+    }
+
+    fn abort(&mut self) -> impl Future<Output = Result<()>> + MaybeSend {
+        self.inner
+            .abort()
+            .instrument_await(format!("opendal::{}", Operation::Copy.into_static()))
     }
 }

--- a/core/layers/concurrent-limit/src/lib.rs
+++ b/core/layers/concurrent-limit/src/lib.rs
@@ -249,7 +249,7 @@ where
     type Writer = ConcurrentLimitWrapper<A::Writer, S::Permit>;
     type Lister = ConcurrentLimitWrapper<A::Lister, S::Permit>;
     type Deleter = ConcurrentLimitWrapper<A::Deleter, S::Permit>;
-    type Copier = A::Copier;
+    type Copier = ConcurrentLimitWrapper<A::Copier, S::Permit>;
 
     fn inner(&self) -> &Self::Inner {
         &self.inner
@@ -286,9 +286,12 @@ where
         args: OpCopy,
         opts: OpCopier,
     ) -> Result<(RpCopy, Self::Copier)> {
-        let _permit = self.semaphore.acquire().await;
+        let permit = self.semaphore.acquire().await;
 
-        self.inner.copy(from, to, args, opts.clone()).await
+        self.inner
+            .copy(from, to, args, opts.clone())
+            .await
+            .map(|(rp, c)| (rp, ConcurrentLimitWrapper::new(c, permit)))
     }
 
     async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
@@ -374,6 +377,16 @@ impl<R: oio::Delete, P: Send + Sync + 'static + Unpin> oio::Delete
 
     async fn close(&mut self) -> Result<()> {
         self.inner.close().await
+    }
+}
+
+impl<C: oio::Copy, P: Send + Sync + 'static + Unpin> oio::Copy for ConcurrentLimitWrapper<C, P> {
+    async fn next(&mut self) -> Result<Option<usize>> {
+        self.inner.next().await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        self.inner.abort().await
     }
 }
 
@@ -483,6 +496,72 @@ mod tests {
             .await
             .expect("rename should proceed once permit is released")
             .expect("rename should succeed");
+    }
+
+    #[tokio::test]
+    async fn operation_semaphore_held_until_copier_dropped() {
+        #[derive(Clone, Debug)]
+        struct CopierBackend {
+            info: Arc<AccessorInfo>,
+        }
+
+        impl Access for CopierBackend {
+            type Reader = ();
+            type Writer = ();
+            type Lister = ();
+            type Deleter = ();
+            type Copier = oio::Copier;
+
+            fn info(&self) -> Arc<AccessorInfo> {
+                self.info.clone()
+            }
+
+            async fn copy(
+                &self,
+                _: &str,
+                _: &str,
+                _: OpCopy,
+                _: OpCopier,
+            ) -> Result<(RpCopy, Self::Copier)> {
+                Ok((RpCopy::default(), Box::new(())))
+            }
+
+            async fn stat(&self, _: &str, _: OpStat) -> Result<RpStat> {
+                Ok(RpStat::new(Metadata::new(EntryMode::FILE)))
+            }
+        }
+
+        let semaphore = Arc::new(Semaphore::new(1));
+        let layer = ConcurrentLimitLayer::with_semaphore(semaphore.clone());
+        let info = Arc::new(AccessorInfo::default());
+        info.set_native_capability(Capability {
+            copy: true,
+            stat: true,
+            ..Default::default()
+        });
+        let op = OperatorBuilder::new(CopierBackend { info })
+            .layer(layer)
+            .finish();
+
+        let copier = timeout(Duration::from_millis(50), op.copier("from", "to"))
+            .await
+            .expect("copier setup should not block")
+            .expect("copier should be created");
+
+        // The permit is held by the live copier, so concurrent operations
+        // must time out until the copier is dropped.
+        let blocked = timeout(Duration::from_millis(50), op.stat("any")).await;
+        assert!(
+            blocked.is_err(),
+            "stat should wait while the copier holds the permit"
+        );
+
+        drop(copier);
+
+        timeout(Duration::from_millis(50), op.stat("any"))
+            .await
+            .expect("stat should proceed once the copier is dropped")
+            .expect("stat should succeed");
     }
 
     #[tokio::test]

--- a/core/layers/fastrace/src/lib.rs
+++ b/core/layers/fastrace/src/lib.rs
@@ -134,7 +134,7 @@ impl<A: Access> LayeredAccess for FastraceAccessor<A> {
     type Writer = FastraceWrapper<A::Writer>;
     type Lister = FastraceWrapper<A::Lister>;
     type Deleter = FastraceWrapper<A::Deleter>;
-    type Copier = A::Copier;
+    type Copier = FastraceWrapper<A::Copier>;
 
     fn inner(&self) -> &Self::Inner {
         &self.inner
@@ -184,7 +184,18 @@ impl<A: Access> LayeredAccess for FastraceAccessor<A> {
         args: OpCopy,
         opts: OpCopier,
     ) -> Result<(RpCopy, Self::Copier)> {
-        self.inner().copy(from, to, args, opts.clone()).await
+        self.inner()
+            .copy(from, to, args, opts.clone())
+            .await
+            .map(|(rp, c)| {
+                (
+                    rp,
+                    FastraceWrapper::new(
+                        Span::enter_with_local_parent(Operation::Copy.into_static()),
+                        c,
+                    ),
+                )
+            })
     }
 
     #[trace(enter_on_poll = true)]
@@ -284,5 +295,19 @@ impl<R: oio::Delete> oio::Delete for FastraceWrapper<R> {
     #[trace(enter_on_poll = true)]
     async fn close(&mut self) -> Result<()> {
         self.inner.close().await
+    }
+}
+
+impl<C: oio::Copy> oio::Copy for FastraceWrapper<C> {
+    fn next(&mut self) -> impl Future<Output = Result<Option<usize>>> + MaybeSend {
+        let _g = self.span.set_local_parent();
+        let _span = LocalSpan::enter_with_local_parent(Operation::Copy.into_static());
+        self.inner.next()
+    }
+
+    fn abort(&mut self) -> impl Future<Output = Result<()>> + MaybeSend {
+        let _g = self.span.set_local_parent();
+        let _span = LocalSpan::enter_with_local_parent(Operation::Copy.into_static());
+        self.inner.abort()
     }
 }

--- a/core/layers/hotpath/src/lib.rs
+++ b/core/layers/hotpath/src/lib.rs
@@ -46,6 +46,8 @@ const LABEL_WRITER_ABORT: &str = "opendal.writer.abort";
 const LABEL_LISTER_NEXT: &str = "opendal.lister.next";
 const LABEL_DELETER_DELETE: &str = "opendal.deleter.delete";
 const LABEL_DELETER_CLOSE: &str = "opendal.deleter.close";
+const LABEL_COPIER_NEXT: &str = "opendal.copier.next";
+const LABEL_COPIER_ABORT: &str = "opendal.copier.abort";
 const LABEL_HTTP_FETCH: &str = "opendal.http.fetch";
 const LABEL_HTTP_BODY_POLL: &str = "opendal.http.body.poll";
 
@@ -113,7 +115,7 @@ impl<A: Access> LayeredAccess for HotpathAccessor<A> {
     type Writer = HotpathWrapper<A::Writer>;
     type Lister = HotpathWrapper<A::Lister>;
     type Deleter = HotpathWrapper<A::Deleter>;
-    type Copier = A::Copier;
+    type Copier = HotpathWrapper<A::Copier>;
 
     fn inner(&self) -> &Self::Inner {
         &self.inner
@@ -141,7 +143,10 @@ impl<A: Access> LayeredAccess for HotpathAccessor<A> {
         args: OpCopy,
         opts: OpCopier,
     ) -> Result<(RpCopy, Self::Copier)> {
-        hotpath::measure_async(LABEL_COPY, self.inner.copy(from, to, args, opts.clone())).await
+        let (rp, copier) =
+            hotpath::measure_async(LABEL_COPY, self.inner.copy(from, to, args, opts.clone()))
+                .await?;
+        Ok((rp, HotpathWrapper::new(copier)))
     }
 
     async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
@@ -211,6 +216,16 @@ impl<R: oio::Delete> oio::Delete for HotpathWrapper<R> {
 
     async fn close(&mut self) -> Result<()> {
         hotpath::measure_async(LABEL_DELETER_CLOSE, self.inner.close()).await
+    }
+}
+
+impl<C: oio::Copy> oio::Copy for HotpathWrapper<C> {
+    async fn next(&mut self) -> Result<Option<usize>> {
+        hotpath::measure_async(LABEL_COPIER_NEXT, self.inner.next()).await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        hotpath::measure_async(LABEL_COPIER_ABORT, self.inner.abort()).await
     }
 }
 

--- a/core/layers/logging/src/lib.rs
+++ b/core/layers/logging/src/lib.rs
@@ -251,7 +251,7 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
     type Writer = LoggingWriter<A::Writer, I>;
     type Lister = LoggingLister<A::Lister, I>;
     type Deleter = LoggingDeleter<A::Deleter, I>;
-    type Copier = A::Copier;
+    type Copier = LoggingCopier<A::Copier, I>;
 
     fn inner(&self) -> &Self::Inner {
         &self.inner
@@ -381,14 +381,16 @@ impl<A: Access, I: LoggingInterceptor> LayeredAccess for LoggingAccessor<A, I> {
         self.inner
             .copy(from, to, args, opts.clone())
             .await
-            .inspect(|_| {
+            .map(|(rp, c)| {
                 self.logger.log(
                     &self.info,
                     Operation::Copy,
                     &[("from", from), ("to", to)],
-                    "finished",
+                    "created copier",
                     None,
                 );
+                let c = LoggingCopier::new(self.info.clone(), self.logger.clone(), from, to, c);
+                (rp, c)
             })
             .inspect_err(|err| {
                 self.logger.log(
@@ -841,5 +843,102 @@ impl<D: oio::Delete, I: LoggingInterceptor> oio::Delete for LoggingDeleter<D, I>
         };
 
         res
+    }
+}
+
+#[doc(hidden)]
+pub struct LoggingCopier<C, I: LoggingInterceptor> {
+    info: Arc<AccessorInfo>,
+    logger: I,
+    from: String,
+    to: String,
+
+    copied: u64,
+    inner: C,
+}
+
+impl<C, I: LoggingInterceptor> LoggingCopier<C, I> {
+    fn new(info: Arc<AccessorInfo>, logger: I, from: &str, to: &str, inner: C) -> Self {
+        Self {
+            info,
+            logger,
+            from: from.to_string(),
+            to: to.to_string(),
+
+            copied: 0,
+            inner,
+        }
+    }
+}
+
+impl<C: oio::Copy, I: LoggingInterceptor> oio::Copy for LoggingCopier<C, I> {
+    async fn next(&mut self) -> Result<Option<usize>> {
+        match self.inner.next().await {
+            Ok(Some(n)) => {
+                self.copied += n as u64;
+                Ok(Some(n))
+            }
+            Ok(None) => {
+                self.logger.log(
+                    &self.info,
+                    Operation::Copy,
+                    &[
+                        ("from", &self.from),
+                        ("to", &self.to),
+                        ("copied", &self.copied.to_string()),
+                    ],
+                    "finished",
+                    None,
+                );
+                Ok(None)
+            }
+            Err(err) => {
+                self.logger.log(
+                    &self.info,
+                    Operation::Copy,
+                    &[
+                        ("from", &self.from),
+                        ("to", &self.to),
+                        ("copied", &self.copied.to_string()),
+                    ],
+                    "failed",
+                    Some(&err),
+                );
+                Err(err)
+            }
+        }
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        match self.inner.abort().await {
+            Ok(_) => {
+                self.logger.log(
+                    &self.info,
+                    Operation::Copy,
+                    &[
+                        ("from", &self.from),
+                        ("to", &self.to),
+                        ("copied", &self.copied.to_string()),
+                    ],
+                    "abort succeeded",
+                    None,
+                );
+                Ok(())
+            }
+            Err(err) => {
+                self.logger.log(
+                    &self.info,
+                    Operation::Copy,
+                    &[
+                        ("from", &self.from),
+                        ("to", &self.to),
+                        ("copied", &self.copied.to_string()),
+                    ],
+                    "abort failed",
+                    Some(&err),
+                );
+                Err(err)
+            }
+        }
     }
 }

--- a/core/layers/observe-metrics-common/src/lib.rs
+++ b/core/layers/observe-metrics-common/src/lib.rs
@@ -720,7 +720,7 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
     type Writer = MetricsWrapper<A::Writer, I>;
     type Lister = MetricsWrapper<A::Lister, I>;
     type Deleter = MetricsWrapper<A::Deleter, I>;
-    type Copier = A::Copier;
+    type Copier = MetricsWrapper<A::Copier, I>;
 
     fn inner(&self) -> &Self::Inner {
         &self.inner
@@ -835,25 +835,23 @@ impl<A: Access, I: MetricsIntercept> LayeredAccess for MetricsAccessor<A, I> {
         let mut guard =
             ExecutingGuard::new_operation(self.interceptor.clone(), labels.clone(), start);
 
-        let res = self
-            .inner()
-            .copy(from, to, args, opts.clone())
-            .await
-            .inspect(|_| {
-                self.interceptor.observe(
-                    labels.clone(),
-                    MetricValue::OperationDurationSeconds(start.elapsed()),
-                );
-            })
-            .inspect_err(|err| {
+        match self.inner.copy(from, to, args, opts.clone()).await {
+            Ok((rp, copier)) => {
+                guard.defuse();
+                Ok((
+                    rp,
+                    MetricsWrapper::new(copier, self.interceptor.clone(), labels, start),
+                ))
+            }
+            Err(err) => {
                 self.interceptor.observe(
                     labels.clone().with_error(err.kind()),
                     MetricValue::OperationErrorsTotal,
                 );
-            });
-
-        guard.complete();
-        res
+                guard.complete();
+                Err(err)
+            }
+        }
     }
 
     async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
@@ -1033,6 +1031,7 @@ impl<R, I: MetricsIntercept> Drop for MetricsWrapper<R, I> {
 
         if self.labels.operation == Operation::Read.into_static()
             || self.labels.operation == Operation::Write.into_static()
+            || self.labels.operation == Operation::Copy.into_static()
         {
             self.interceptor
                 .observe(self.labels.clone(), MetricValue::OperationBytes(self.size));
@@ -1161,6 +1160,29 @@ impl<R: oio::Delete, I: MetricsIntercept> oio::Delete for MetricsWrapper<R, I> {
         let result = self
             .inner
             .close()
+            .await
+            .inspect_err(|err| self.record_error(err));
+        self.completed = true;
+        result
+    }
+}
+
+impl<C: oio::Copy, I: MetricsIntercept> oio::Copy for MetricsWrapper<C, I> {
+    async fn next(&mut self) -> Result<Option<usize>> {
+        self.inner
+            .next()
+            .await
+            .inspect(|n| match n {
+                Some(n) => self.size += *n as u64,
+                None => self.completed = true,
+            })
+            .inspect_err(|err| self.record_error(err))
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        let result = self
+            .inner
+            .abort()
             .await
             .inspect_err(|err| self.record_error(err));
         self.completed = true;

--- a/core/layers/tail-cut/src/lib.rs
+++ b/core/layers/tail-cut/src/lib.rs
@@ -364,7 +364,7 @@ impl<A: Access> LayeredAccess for TailCutAccessor<A> {
     type Writer = TailCutWrapper<A::Writer>;
     type Lister = TailCutWrapper<A::Lister>;
     type Deleter = TailCutWrapper<A::Deleter>;
-    type Copier = A::Copier;
+    type Copier = TailCutWrapper<A::Copier>;
 
     fn inner(&self) -> &Self::Inner {
         &self.inner
@@ -415,6 +415,12 @@ impl<A: Access> LayeredAccess for TailCutAccessor<A> {
             self.inner.copy(from, to, args, opts.clone()),
         )
         .await
+        .map(|(rp, c)| {
+            (
+                rp,
+                TailCutWrapper::new(c, None, self.config.clone(), self.stats.clone()),
+            )
+        })
     }
 
     async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
@@ -615,6 +621,34 @@ impl<R: oio::Delete> oio::Delete for TailCutWrapper<R> {
             self.size,
             Operation::Delete,
             self.inner.close(),
+        )
+        .await
+    }
+}
+
+impl<C: oio::Copy> oio::Copy for TailCutWrapper<C> {
+    async fn next(&mut self) -> Result<Option<usize>> {
+        let deadline = self.calculate_deadline(Operation::Copy);
+        Self::with_io_deadline(
+            deadline,
+            self.config.percentile,
+            &self.stats,
+            self.size,
+            Operation::Copy,
+            self.inner.next(),
+        )
+        .await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        let deadline = self.calculate_deadline(Operation::Copy);
+        Self::with_io_deadline(
+            deadline,
+            self.config.percentile,
+            &self.stats,
+            self.size,
+            Operation::Copy,
+            self.inner.abort(),
         )
         .await
     }


### PR DESCRIPTION
# Rationale for this change

For necessary layers we should wrap copier around, otherwise we loss layer capability (i.e., concurrent limit, logging, etc).

# Are there any user-facing changes?

No

# AI Usage Statement

Opus 4.7 made code change and I did manual change (if I miss any important layers I could loss my job lol)