### PR TITLE
fix(ci/goosefs): bind master internal RPC to 0.0.0.0 and force IPv4

### DIFF
--- a/fixtures/goosefs/bin/start-default.sh
+++ b/fixtures/goosefs/bin/start-default.sh
@@ -64,6 +64,16 @@
 
 set -euo pipefail
 
+# Force the JVM (master/worker/goosefs CLI) to resolve `localhost` to
+# 127.0.0.1 instead of ::1. On Ubuntu 24.04 GitHub Actions runners the
+# default JDK resolves `localhost` to ::1 first, so the master binds
+# 9200/9212/9202 on ::1 while the worker / `fs` CLI dials 127.0.0.1 ->
+# `Connection refused`, looping on `Failed to connect to ... :9212`
+# until the compose healthcheck times out. Pinning the stack to IPv4
+# keeps bind and dial on the same family without touching the host
+# kernel.
+export GOOSEFS_JAVA_OPTS="${GOOSEFS_JAVA_OPTS:-} -Djava.net.preferIPv4Stack=true"
+
 : "${GOOSEFS_HOME:=/opt/goosefs}"
 : "${GOOSEFS_MASTER_HOSTNAME:=localhost}"
 # OpenDAL writes to the worker via `127.0.0.1:9203` from the host; see
@@ -99,6 +109,17 @@ apply_runtime_config() {
   upsert_prop "goosefs.master.web.bind.host"   "0.0.0.0"
   upsert_prop "goosefs.worker.bind.host"       "0.0.0.0"
   upsert_prop "goosefs.worker.web.bind.host"   "0.0.0.0"
+  # The master also runs two *internal* RPC endpoints that default to
+  # binding the resolved hostname only:
+  #   * 9212 -- master <-> worker RPC (block heartbeat, register)
+  #   * 9202 -- embedded Raft journal
+  # Without these the worker logs `Failed to connect to ... :9212 ...
+  # Connection refused` in a tight retry loop and never registers,
+  # which makes the data-plane healthcheck (`fs copyFromLocal`) hang
+  # the entire compose `--wait`. Bind both on 0.0.0.0 so loopback
+  # dials from inside the container always succeed.
+  upsert_prop "goosefs.master.rpc.bind.host"             "0.0.0.0"
+  upsert_prop "goosefs.master.embedded.journal.bind.host" "0.0.0.0"
 }
 
 ensure_dirs() {


### PR DESCRIPTION

The single-container goosefs fixture occasionally fails CI with the worker stuck in a retry loop on `Failed to connect to ... localhost:9212 ... Connection refused`, which makes the compose data-plane healthcheck time out.

`start-default.sh` already overrides `goosefs.{master,worker}.bind.host` to `0.0.0.0`, but it does NOT override the master <-> worker internal RPC bind host (9212) nor the embedded journal bind host (9202). On Ubuntu 24.04 runners those JVMs resolve `localhost` to `::1` first while the worker / `fs` CLI dials `127.0.0.1`, so the worker can never register.

- upsert `goosefs.master.rpc.bind.host = 0.0.0.0`
- upsert `goosefs.master.embedded.journal.bind.host = 0.0.0.0`
- export `GOOSEFS_JAVA_OPTS` with `-Djava.net.preferIPv4Stack=true` so the JVM resolves `localhost` to `127.0.0.1` consistently

# Which issue does this PR close?

<!-- No tracking issue; this is a CI fixture flake fix. Link the issue number here if one is opened later. -->

Closes #.

# Rationale for this change

The `binding_nodejs` / `services-goosefs` job has been intermittently failing with the goosefs worker hanging in a tight retry loop:

Failed to connect to RemoteWorker(... localhost:9212 ...): Connection refused



The worker never registers, so the compose `--wait` healthcheck (which probes the data plane via `fs copyFromLocal`) times out and the whole job is marked failed even though the build artifacts are fine.

Root cause: on Ubuntu 24.04 GitHub Actions runners the JDK's address resolution order returns `::1` for `localhost` before `127.0.0.1`. The master JVM happily binds `9212` (master <-> worker RPC) and `9202` (embedded Raft journal) on `::1`, while the worker JVM and the `goosefs fs` CLI dial `127.0.0.1`, so every RPC gets `ECONNREFUSED`. `start-default.sh` already overrides the *external* bind hosts (9200 / 9201 / 9203 / 9204) to `0.0.0.0`, but the two *internal* bind hosts inherit the JVM-resolved hostname and were missed.

# What changes are included in this PR?

Only [fixtures/goosefs/bin/start-default.sh](fixtures/goosefs/bin/start-default.sh) is touched (+21 lines):

1. In `apply_runtime_config()`, add two more `upsert_prop` calls so the rendered `goosefs-site.properties` pins both internal endpoints to all-interfaces:
   - `goosefs.master.rpc.bind.host = 0.0.0.0`
   - `goosefs.master.embedded.journal.bind.host = 0.0.0.0`
2. Near the top of the script, export `GOOSEFS_JAVA_OPTS` with `-Djava.net.preferIPv4Stack=true` so the master / worker / CLI JVMs all resolve `localhost` to `127.0.0.1`. This keeps bind and dial on the same address family without requiring any host-kernel changes (e.g. disabling IPv6).
3. Inline comments above each new block explain the failure mode, so the next person who looks at the fixture has the full context.

No production code, no public APIs, and no docs are affected — this is purely a CI fixture hardening.

# Are there any user-facing changes?

No.

This change only affects [fixtures/goosefs/](fixtures/goosefs/), which is a CI / local-dev test harness. It does not modify any crate under `core/`, `bindings/`, or `bin/`, and there are no changes to public APIs, configuration knobs, or documented behaviour. End users of `opendal` are unaffected.

# AI Usage Statement

This PR was drafted with assistance from an AI coding assistant (Claude). The assistant was used to:

- analyse the failing CI log (`worker -> localhost:9212 connection refused` retry loop) and pinpoint the IPv6/IPv4 resolution mismatch as the root cause,
- propose the minimal `start-default.sh` patch (two extra `upsert_prop` calls + `-Djava.net.preferIPv4Stack=true`),
- draft the commit message and this PR description.
