### PR TITLE
feat(copy): add conditional destination copy

### DIFF
--- a/.github/services/s3/0_minio_s3/action.yml
+++ b/.github/services/s3/0_minio_s3/action.yml
@@ -43,5 +43,5 @@ runs:
         OPENDAL_S3_ACCESS_KEY_ID=minioadmin
         OPENDAL_S3_SECRET_ACCESS_KEY=minioadmin
         OPENDAL_S3_REGION=us-east-1
-        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false,copy_with_if_not_exists=false,copy_with_if_match=false
         EOF

--- a/.github/services/s3/minio_s3_with_anonymous/action.yml
+++ b/.github/services/s3/minio_s3_with_anonymous/action.yml
@@ -49,5 +49,5 @@ runs:
         OPENDAL_S3_REGION=us-east-1
         OPENDAL_S3_ALLOW_ANONYMOUS=on
         OPENDAL_S3_DISABLE_EC2_METADATA=on
-        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false,copy_with_if_not_exists=false,copy_with_if_match=false
         EOF

--- a/.github/services/s3/minio_s3_with_list_objects_v1/action.yml
+++ b/.github/services/s3/minio_s3_with_list_objects_v1/action.yml
@@ -44,5 +44,5 @@ runs:
         OPENDAL_S3_SECRET_ACCESS_KEY=minioadmin
         OPENDAL_S3_REGION=us-east-1
         OPENDAL_S3_DISABLE_LIST_OBJECTS_V2=true
-        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false,copy_with_if_not_exists=false,copy_with_if_match=false
         EOF

--- a/.github/services/s3/minio_s3_with_versioning/action.yml
+++ b/.github/services/s3/minio_s3_with_versioning/action.yml
@@ -44,5 +44,5 @@ runs:
         OPENDAL_S3_ACCESS_KEY_ID=minioadmin
         OPENDAL_S3_SECRET_ACCESS_KEY=minioadmin
         OPENDAL_S3_REGION=us-east-1
-        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_can_append=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write_can_append=false,copy_with_if_not_exists=false,copy_with_if_match=false
         EOF

--- a/core/core/src/layers/correctness_check.rs
+++ b/core/core/src/layers/correctness_check.rs
@@ -233,6 +233,13 @@ impl<A: Access> LayeredAccess for CorrectnessAccessor<A> {
                 "if_not_exists",
             ));
         }
+        if args.if_match().is_some() && !capability.copy_with_if_match {
+            return Err(new_unsupported_error(
+                &self.info,
+                Operation::Copy,
+                "if_match",
+            ));
+        }
 
         self.inner.copy(from, to, args, opts).await
     }

--- a/core/core/src/raw/ops.rs
+++ b/core/core/src/raw/ops.rs
@@ -894,6 +894,7 @@ impl From<options::WriteOptions> for (OpWrite, OpWriter) {
 #[derive(Debug, Clone, Default)]
 pub struct OpCopy {
     if_not_exists: bool,
+    if_match: Option<String>,
 }
 
 impl OpCopy {
@@ -914,6 +915,20 @@ impl OpCopy {
     /// Get if_not_exists flag.
     pub fn if_not_exists(&self) -> bool {
         self.if_not_exists
+    }
+
+    /// Set the if_match condition for the operation.
+    ///
+    /// When set, the copy operation will only proceed if the existing destination
+    /// object's ETag matches the given value.
+    pub fn with_if_match(mut self, if_match: impl Into<String>) -> Self {
+        self.if_match = Some(if_match.into());
+        self
+    }
+
+    /// Get if_match condition.
+    pub fn if_match(&self) -> Option<&str> {
+        self.if_match.as_deref()
     }
 }
 
@@ -970,6 +985,7 @@ impl From<options::CopyOptions> for (OpCopy, OpCopier) {
         (
             OpCopy {
                 if_not_exists: value.if_not_exists,
+                if_match: value.if_match,
             },
             OpCopier {
                 concurrent: value.concurrent.max(1),

--- a/core/core/src/types/capability.rs
+++ b/core/core/src/types/capability.rs
@@ -156,6 +156,8 @@ pub struct Capability {
     pub copy: bool,
     /// Indicates if conditional copy operations with if-not-exists are supported.
     pub copy_with_if_not_exists: bool,
+    /// Indicates if conditional copy operations with if-match are supported.
+    pub copy_with_if_match: bool,
     /// Indicates if copy operations can be split into multiple server-side tasks.
     pub copy_can_multi: bool,
     /// Maximum size supported for segmented copy tasks.

--- a/core/core/src/types/options.rs
+++ b/core/core/src/types/options.rs
@@ -547,6 +547,19 @@ pub struct CopyOptions {
     /// without overwriting existing ones, useful for implementing "copy if not exists" logic.
     pub if_not_exists: bool,
 
+    /// Sets the condition that copy operation will succeed only if the destination
+    /// currently has the given ETag.
+    ///
+    /// ### Capability
+    ///
+    /// Check [`Capability::copy_with_if_match`] before using this feature.
+    ///
+    /// ### Behavior
+    ///
+    /// - If supported, the copy operation will only succeed when the existing
+    ///   destination object's ETag matches the given value.
+    pub if_match: Option<String>,
+
     /// Known content length of the source object.
     ///
     /// This is an execution hint that allows OpenDAL to avoid extra metadata

--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -973,6 +973,8 @@ impl Builder for S3Builder {
 
                             copy: true,
                             copy_can_multi: true,
+                            copy_with_if_not_exists: true,
+                            copy_with_if_match: true,
                             // The min multipart size of S3 is 5 MiB.
                             //
                             // ref: <https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html>

--- a/core/services/s3/src/copier.rs
+++ b/core/services/s3/src/copier.rs
@@ -100,7 +100,10 @@ impl oio::MultipartCopy for S3Copier {
     }
 
     async fn copy_once(&self) -> Result<()> {
-        let resp = self.core.s3_copy_object(&self.from, &self.to).await?;
+        let resp = self
+            .core
+            .s3_copy_object(&self.from, &self.to, &self.args)
+            .await?;
 
         match resp.status() {
             StatusCode::OK => {

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -648,7 +648,12 @@ impl S3Core {
         self.send(req).await
     }
 
-    pub async fn s3_copy_object(&self, from: &str, to: &str) -> Result<Response<Buffer>> {
+    pub async fn s3_copy_object(
+        &self,
+        from: &str,
+        to: &str,
+        args: &OpCopy,
+    ) -> Result<Response<Buffer>> {
         let from = build_abs_path(&self.root, from);
         let to = build_abs_path(&self.root, to);
 
@@ -656,6 +661,14 @@ impl S3Core {
         let target = format!("{}/{}", self.endpoint, percent_encode_path(&to));
 
         let mut req = Request::put(&target);
+
+        // Set conditional copy headers.
+        if args.if_not_exists() {
+            req = req.header(IF_NONE_MATCH, "*");
+        }
+        if let Some(if_match) = args.if_match() {
+            req = req.header(IF_MATCH, if_match);
+        }
 
         // Set SSE headers.
         req = self.insert_sse_headers(req, true);
@@ -1102,6 +1115,9 @@ impl S3Core {
 
         if args.if_not_exists() {
             req = req.header(IF_NONE_MATCH, "*");
+        }
+        if let Some(if_match) = args.if_match() {
+            req = req.header(IF_MATCH, if_match);
         }
 
         // Set request payer header if enabled.


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7599

# Rationale for this change

Conditional copy, which checks the existence and version for target is supported in S3.
Reference:
- Copy object: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_RequestSyntax
- Multiple part copy is basically the same as multipart upload, initiation/abort/complete requests are the same: https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html#API_CompleteMultipartUpload_RequestSyntax

# What changes are included in this PR?

This PR adds conditional copy feature in S3 against target object.

# Are there any user-facing changes?

Yes, users are able to do conditional copy.

# AI Usage Statement

Opus 4.7 made all the code change for me.