### PR TITLE
fix(s3): fix S3 copy response

### DIFF
--- a/core/services/s3/src/copier.rs
+++ b/core/services/s3/src/copier.rs
@@ -104,14 +104,28 @@ impl oio::MultipartCopy for S3Copier {
 
         match resp.status() {
             StatusCode::OK => {
-                let body = resp.into_body().to_bytes();
+                let (parts, body) = resp.into_parts();
+                let bs = body.to_bytes();
 
-                let result: CopyObjectResult =
-                    quick_xml::de::from_reader(body.as_ref()).map_err(new_xml_deserialize_error)?;
+                let result: CopyObjectResult = quick_xml::de::from_reader(bs.as_ref())
+                    .map_err(new_xml_deserialize_error)?;
+
+                // S3 may return 200 OK with an <Error> body for CopyObject.
+                if !result.etag.is_empty() {
+                    return Err(from_s3_error(
+                        S3Error {
+                            code: result.code,
+                            message: result.message,
+                            resource: String::new(),
+                            request_id: result.request_id,
+                        },
+                        parts,
+                    ));
+                }
 
                 if result.etag.is_empty() {
                     return Err(
-                        Error::new(ErrorKind::Unexpected, String::from_utf8_lossy(&body))
+                        Error::new(ErrorKind::Unexpected, String::from_utf8_lossy(&bs))
                             .set_temporary(),
                     );
                 }
@@ -161,13 +175,27 @@ impl oio::MultipartCopy for S3Copier {
 
         match resp.status() {
             StatusCode::OK => {
-                let body = resp.into_body().to_bytes();
-                let result: CopyObjectResult =
-                    quick_xml::de::from_reader(body.as_ref()).map_err(new_xml_deserialize_error)?;
+                let (parts, body) = resp.into_parts();
+                let bs = body.to_bytes();
+                let result: CopyObjectResult = quick_xml::de::from_reader(bs.as_ref())
+                    .map_err(new_xml_deserialize_error)?;
+
+                // S3 may return 200 OK with an <Error> body for UploadPartCopy.
+                if !result.code.is_empty() {
+                    return Err(from_s3_error(
+                        S3Error {
+                            code: result.code,
+                            message: result.message,
+                            resource: String::new(),
+                            request_id: result.request_id,
+                        },
+                        parts,
+                    ));
+                }
 
                 if result.etag.is_empty() {
                     return Err(
-                        Error::new(ErrorKind::Unexpected, String::from_utf8_lossy(&body))
+                        Error::new(ErrorKind::Unexpected, String::from_utf8_lossy(&bs))
                             .set_temporary(),
                     );
                 }

--- a/core/services/s3/src/copier.rs
+++ b/core/services/s3/src/copier.rs
@@ -107,8 +107,8 @@ impl oio::MultipartCopy for S3Copier {
                 let (parts, body) = resp.into_parts();
                 let bs = body.to_bytes();
 
-                let result: CopyObjectResult = quick_xml::de::from_reader(bs.as_ref())
-                    .map_err(new_xml_deserialize_error)?;
+                let result: CopyObjectResult =
+                    quick_xml::de::from_reader(bs.as_ref()).map_err(new_xml_deserialize_error)?;
 
                 // S3 may return 200 OK with an <Error> body for CopyObject.
                 if !result.etag.is_empty() {
@@ -177,8 +177,8 @@ impl oio::MultipartCopy for S3Copier {
             StatusCode::OK => {
                 let (parts, body) = resp.into_parts();
                 let bs = body.to_bytes();
-                let result: CopyObjectResult = quick_xml::de::from_reader(bs.as_ref())
-                    .map_err(new_xml_deserialize_error)?;
+                let result: CopyObjectResult =
+                    quick_xml::de::from_reader(bs.as_ref()).map_err(new_xml_deserialize_error)?;
 
                 // S3 may return 200 OK with an <Error> body for UploadPartCopy.
                 if !result.code.is_empty() {

--- a/core/services/s3/src/copier.rs
+++ b/core/services/s3/src/copier.rs
@@ -111,7 +111,7 @@ impl oio::MultipartCopy for S3Copier {
                     quick_xml::de::from_reader(bs.as_ref()).map_err(new_xml_deserialize_error)?;
 
                 // S3 may return 200 OK with an <Error> body for CopyObject.
-                if !result.etag.is_empty() {
+                if result.etag.is_empty() {
                     return Err(from_s3_error(
                         S3Error {
                             code: result.code,
@@ -121,13 +121,6 @@ impl oio::MultipartCopy for S3Copier {
                         },
                         parts,
                     ));
-                }
-
-                if result.etag.is_empty() {
-                    return Err(
-                        Error::new(ErrorKind::Unexpected, String::from_utf8_lossy(&bs))
-                            .set_temporary(),
-                    );
                 }
 
                 Ok(())
@@ -181,7 +174,7 @@ impl oio::MultipartCopy for S3Copier {
                     quick_xml::de::from_reader(bs.as_ref()).map_err(new_xml_deserialize_error)?;
 
                 // S3 may return 200 OK with an <Error> body for UploadPartCopy.
-                if !result.code.is_empty() {
+                if result.etag.is_empty() {
                     return Err(from_s3_error(
                         S3Error {
                             code: result.code,
@@ -191,13 +184,6 @@ impl oio::MultipartCopy for S3Copier {
                         },
                         parts,
                     ));
-                }
-
-                if result.etag.is_empty() {
-                    return Err(
-                        Error::new(ErrorKind::Unexpected, String::from_utf8_lossy(&bs))
-                            .set_temporary(),
-                    );
                 }
 
                 Ok(oio::MultipartPart {
@@ -234,7 +220,8 @@ impl oio::MultipartCopy for S3Copier {
 
                 let ret: CompleteMultipartUploadResult =
                     quick_xml::de::from_reader(body.reader()).map_err(new_xml_deserialize_error)?;
-                if !ret.code.is_empty() {
+                // S3 may return 200 OK with an <Error> body for CompleteMultipartUpload.
+                if ret.etag.is_empty() {
                     return Err(from_s3_error(
                         S3Error {
                             code: ret.code,

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -1337,12 +1337,6 @@ pub struct CompleteMultipartUploadResult {
 
 /// Body of a `CopyObject` or `UploadPartCopy` response.
 ///
-/// S3 may return HTTP 200 OK with either a `<CopyObjectResult>` success body or
-/// an `<Error>` body for these operations.
-/// We deserialize permissively so a single struct can capture both shapes; the
-/// caller distinguishes success from failure by checking whether `etag` is
-/// present (success bodies always carry an ETag, error bodies never do).
-///
 /// ref: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_ResponseSyntax>
 /// ref: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html#API_UploadPartCopy_ResponseSyntax>
 #[derive(Debug, Default, Deserialize)]

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -1335,15 +1335,24 @@ pub struct CompleteMultipartUploadResult {
     pub request_id: String,
 }
 
-/// Partial output of a successful `CopyObject` operation.
+/// Body of a `CopyObject` or `UploadPartCopy` response.
+///
+/// S3 may return HTTP 200 OK with either a `<CopyObjectResult>` success body or
+/// an `<Error>` body for these operations.
+/// We deserialize permissively so a single struct can capture both shapes; the
+/// caller distinguishes by checking whether `code` is set.
 ///
 /// ref: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_ResponseSyntax>
+/// ref: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html#API_UploadPartCopy_ResponseSyntax>
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "PascalCase")]
 pub struct CopyObjectResult {
     #[serde(rename = "ETag")]
     pub etag: String,
     pub last_modified: String,
+    pub code: String,
+    pub message: String,
+    pub request_id: String,
 }
 
 /// Request of DeleteObjects.

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -1340,7 +1340,8 @@ pub struct CompleteMultipartUploadResult {
 /// S3 may return HTTP 200 OK with either a `<CopyObjectResult>` success body or
 /// an `<Error>` body for these operations.
 /// We deserialize permissively so a single struct can capture both shapes; the
-/// caller distinguishes by checking whether `code` is set.
+/// caller distinguishes success from failure by checking whether `etag` is
+/// present (success bodies always carry an ETag, error bodies never do).
 ///
 /// ref: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_ResponseSyntax>
 /// ref: <https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPartCopy.html#API_UploadPartCopy_ResponseSyntax>


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7601

# Rationale for this change

S3 request could error in two cases: 
- HTTP request failure, which usually indicates a network failure (i.e., timeout)
- logic error, which is contained in HTTP response with HTTP code 200

Quoted from official:
> A copy request might return an error when Amazon S3 receives the copy request or while Amazon S3 is copying the files. A 200 OK response can contain either a success or an error.

https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_ResponseSyntax

# What changes are included in this PR?

Redo my previous fix PR https://github.com/apache/opendal/pull/7294, which got overwritten by recent copy rewrite.

# Are there any user-facing changes?

No.

# AI Usage Statement

Opus 4.7 did all the code change.