### PR TITLE
fix(services/goosefs): bump goosefs-sdk to 0.1.3

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -3906,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "goosefs-sdk"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28e6b1bfe5aef24eed29a15013a5b4202b187b464b90e93d73161500017f815"
+checksum = "6e083309fbaac55b30c9468d3b40756e0ba47f7fbe89bb032660dd24cd09ec25"
 dependencies = [
  "async-trait",
  "bytes",

--- a/core/services/goosefs/Cargo.toml
+++ b/core/services/goosefs/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 bytes = { workspace = true }
-goosefs-sdk = "0.1.2"
+goosefs-sdk = "0.1.3"
 log = { workspace = true }
 opendal-core = { path = "../../core", version = "0.56.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
`goosefs-sdk` 0.1.3 fixes a concurrent-write race in `MUST_CACHE` mode where `write_with(...).concurrent(N)` could intermittently fail with:
```
WriteBlock server error ... status: Internal, message: "The file length is inconsistent with the amount of data that has been written"
```

Local regression on a real GooseFS cluster (master `127.0.0.1:9200`, `OPENDAL_GOOSEFS_WRITE_TYPE=must_cache`):

- `goosefs-sdk` 0.1.2: `test_writer_write_with_concurrent` fails ~1/50 (matches the OpenDAL CI failure).
- `goosefs-sdk` 0.1.3: 100/100 single-test runs + 3 full behavior rounds (99 cases × 3) all pass.

### Which issue does this PR close?

Closes #.

### Rationale for this change

The GooseFS service has been flaky on CI for the `test_writer_write_with_concurrent` behavior test. The failure surfaces from the underlying `goosefs-sdk` as a `WriteBlock` `Internal` error claiming the file length does not match the amount of data written.

Root cause is a race on the writer-side bookkeeping inside `goosefs-sdk` itself: when OpenDAL drives the writer with `concurrent(N) > 1`, multiple in-flight block writes can interleave and the offset/length accounting on the SDK side becomes inconsistent before the final commit, which the GooseFS master then rejects.

The fix lives in `goosefs-sdk` (released as 0.1.3 on crates.io). On the OpenDAL side we only need to bump the dependency — no API or behavior change in the `services-goosefs` adapter is required.

### What changes are included in this PR?

- Bump `goosefs-sdk` in `core/services/goosefs/Cargo.toml` from `0.1.2` → `0.1.3`.
- Refresh `core/Cargo.lock` accordingly.

That's the entire diff (2 files, +3/-3).

### Are there any user-facing changes?

No public API changes. The only observable difference for end users is that `Operator` configured with `services-goosefs` no longer hits the intermittent `WriteBlock` "file length is inconsistent ..." error when using concurrent writes (e.g. `op.writer_with(path).concurrent(N)`), particularly under `must_cache` write type.

No upgrade notes required.

### Verification

Ran against a local GooseFS cluster with:

```
OPENDAL_TEST=goosefs
OPENDAL_GOOSEFS_ENDPOINT=http://127.0.0.1:9200
OPENDAL_GOOSEFS_ROOT=/opendal-it/
OPENDAL_GOOSEFS_WRITE_TYPE=must_cache
cargo test -p opendal --features tests,services-goosefs --test behavior
```

- Reproduced the original failure on 0.1.2 (≈ 2% flake rate on `test_writer_write_with_concurrent`).
- On 0.1.3:
  - `test_writer_write_with_concurrent` × 100 → 100 pass, 0 fail.
  - Full behavior suite (99 cases) × 3 rounds → 297/297 pass.
- `cargo fmt --all -- --check` ✅
- `cargo build -p opendal --features services-goosefs` ✅
- `cargo clippy -p opendal --features services-goosefs -- -D warnings` ✅
- `cargo clippy -p opendal-service-goosefs -- -D warnings` ✅

### AI Usage Statement

AI tools were used as a development assistant in this PR for: navigating the codebase, drafting the commit message and this PR description, and helping organize the local reproduction / regression-test plan. The actual fix is shipped in upstream `goosefs-sdk` 0.1.3; the change in this repository is a pure dependency-version bump and was reviewed manually. All build / clippy / behavior-test verification was executed locally by the author; results above are real test outputs, not AI-generated.

