### PR TITLE
feat(binding/c): add timeout layer by default

### DIFF
--- a/bindings/c/src/operator.rs
+++ b/bindings/c/src/operator.rs
@@ -90,7 +90,9 @@ fn build_operator(
 ) -> core::Result<core::blocking::Operator> {
     core::init_default_registry();
 
-    let op = core::Operator::via_iter(schema, map)?.layer(core::layers::RetryLayer::new());
+    let op = core::Operator::via_iter(schema, map)?
+        .layer(core::layers::TimeoutLayer::default())
+        .layer(core::layers::RetryLayer::new());
 
     let runtime =
         tokio::runtime::Handle::try_current().unwrap_or_else(|_| RUNTIME.handle().clone());


### PR DESCRIPTION
# Rationale for this change

Hi team, when I'm using golang binding, I found currently we don't have an elegant way to control timeout for IO operations, see issue https://github.com/apache/opendal/issues/7609, which is bad.

# What changes are included in this PR?

This PR adds default timeout layer to operator by default -- I think retry and timeout are must-have for IO operations.
There're quite a few followup items, just to name a few, for example, use context in golang functions, expose customizable layer to C and golang, add timeout in the `opendal_options` C API, etc.

# Are there any user-facing changes?

No.

# AI Usage Statement

No.