### PR TITLE
fix(ci/goosefs): bind master 9200 to IPv4 literal so worker can register

### DIFF
--- a/fixtures/goosefs/bin/start-default.sh
+++ b/fixtures/goosefs/bin/start-default.sh
@@ -75,7 +75,24 @@ set -euo pipefail
 export GOOSEFS_JAVA_OPTS="${GOOSEFS_JAVA_OPTS:-} -Djava.net.preferIPv4Stack=true"
 
 : "${GOOSEFS_HOME:=/opt/goosefs}"
-: "${GOOSEFS_MASTER_HOSTNAME:=localhost}"
+# Use the IPv4 literal `127.0.0.1` (not the name `localhost`) for the
+# master hostname on purpose. The master's *client-facing* RPC port
+# 9200 is bound directly to whatever `goosefs.master.hostname` resolves
+# to (there is no separate `goosefs.master.client.rpc.bind.host` in
+# GooseFS 2.x). On Ubuntu 24.04 GitHub Actions runners and many Linux
+# images, `/etc/hosts` resolves `localhost` to BOTH `::1` and
+# `127.0.0.1`, and the JVM's default resolver may hand back `::1`
+# first — even with `-Djava.net.preferIPv4Stack=true`, because that
+# flag only suppresses *creating* IPv6 sockets, it does not change
+# `InetAddress.getByName("localhost")`'s ordering when the name maps
+# to both families. Result: master binds 9200 on `[::1]`, while the
+# in-container worker (and the `fs` CLI used by the healthcheck) dials
+# `127.0.0.1:9200` over IPv4 and gets `Connection refused` in a tight
+# retry loop, never registers, and the data-plane healthcheck times
+# out. Pinning the hostname to the v4 literal forces bind+dial onto
+# the same loopback address and matches what `GOOSEFS_WORKER_HOSTNAME`
+# already does for the worker side.
+: "${GOOSEFS_MASTER_HOSTNAME:=127.0.0.1}"
 # OpenDAL writes to the worker via `127.0.0.1:9203` from the host; see
 # the long comment in docker-compose-goosefs.yml for why this must be
 # the IPv4 literal and not the `localhost` name.

--- a/fixtures/goosefs/docker-compose-goosefs.yml
+++ b/fixtures/goosefs/docker-compose-goosefs.yml
@@ -88,7 +88,22 @@ services:
     # keep pulling the same artifact).
     entrypoint: ["/bin/bash", "/opt/opendal/bin/start-default.sh"]
     environment:
-      GOOSEFS_MASTER_HOSTNAME: localhost
+      # Bind the master to the IPv4 loopback literal (not the name
+      # `localhost`). The master's client-facing RPC on 9200 is bound
+      # to whatever `goosefs.master.hostname` resolves to, and there
+      # is no separate `*.client.rpc.bind.host` knob in GooseFS 2.x.
+      # On runners where `/etc/hosts` maps `localhost` to BOTH `::1`
+      # and `127.0.0.1`, the JVM ends up binding `[::1]:9200` while
+      # the in-container worker (and the `fs` CLI used by the
+      # healthcheck) dials `127.0.0.1:9200` over IPv4 -- yielding
+      # `Connection refused` in a tight retry loop, no worker
+      # registration, and the data-plane healthcheck eventually
+      # timing out. The previous `-Djava.net.preferIPv4Stack=true`
+      # only fixed the v6/v4 issue for ports the launcher binds
+      # explicitly to `0.0.0.0` (9202 / 9212); 9200 still followed
+      # the hostname. Using the literal `127.0.0.1` here removes the
+      # name-resolution ambiguity entirely.
+      GOOSEFS_MASTER_HOSTNAME: 127.0.0.1
       # The worker must register itself with the master using an address
       # that OpenDAL, running on the Docker *host*, can resolve AND reach —
       # because OpenDAL first talks to the master over 9200 to locate a


### PR DESCRIPTION

The previous force-IPv4 fix only covered the master's internal RPC ports (9202 Raft, 9212 service RPC), which were bound explicitly to 0.0.0.0 via `goosefs.master.embedded.journal.bind.host` and `goosefs.master.rpc.bind.host`.

The client-facing RPC on 9200 has no separate `bind.host` knob in GooseFS 2.x — it's bound directly to whatever `goosefs.master.hostname` resolves to. With `GOOSEFS_MASTER_HOSTNAME=localhost`, on Ubuntu 24.04 GHA runners the JVM resolves `localhost` to `::1` first (even with `-Djava.net.preferIPv4Stack=true`, which only suppresses *creating* IPv6 sockets — it does not reorder `InetAddress.getByName("localhost")` results). The master then binds `[::1]:9200`, while the in-container worker and the `goosefs fs` CLI used by the healthcheck dial `127.0.0.1:9200` over IPv4 — yielding `Connection refused` in a tight retry loop, no worker registration, and an eventual data-plane healthcheck timeout.

Set `GOOSEFS_MASTER_HOSTNAME=127.0.0.1` (matching what `GOOSEFS_WORKER_HOSTNAME` already does) so master bind and worker dial land on the same loopback address, removing the name-resolution ambiguity entirely.

# Which issue does this PR close?

<!-- Link the issue here if there is one; otherwise leave blank. -->
Closes #.

# Rationale for this change

The GooseFS integration test job has been flaky / failing on Ubuntu 24.04 GHA runners: the master comes up but the worker never registers, and the data-plane healthcheck eventually times out. Logs show a tight `Connection refused` retry loop from the worker against `127.0.0.1:9200`.

Root cause is an IPv6/IPv4 loopback split-brain on the master's *client-facing* RPC port:

- `goosefs.master.hostname` controls the bind address of port 9200, and there is no separate `*.client.rpc.bind.host` knob in GooseFS 2.x.
- With `GOOSEFS_MASTER_HOSTNAME=localhost` and `/etc/hosts` mapping `localhost` to both `::1` and `127.0.0.1`, the JVM picks `::1` first and binds `[::1]:9200`.
- The previous `-Djava.net.preferIPv4Stack=true` flag only suppresses *creating* IPv6 sockets; it does not reorder `InetAddress.getByName("localhost")`. It also only helped the ports the launcher already pins to `0.0.0.0` (9202 / 9212).
- The in-container worker (and the `goosefs fs` CLI used by the healthcheck) dials `127.0.0.1:9200` over IPv4, hits `Connection refused`, never registers.

Pinning the master hostname to the IPv4 literal `127.0.0.1` makes bind and dial land on the same address and removes the name-resolution ambiguity, without any code change in OpenDAL itself.

# What changes are included in this PR?

CI fixture only — no library / public-API changes:

- `fixtures/goosefs/bin/start-default.sh`: change the default for `GOOSEFS_MASTER_HOSTNAME` from `localhost` to `127.0.0.1`, and add an in-source comment explaining why the IPv4 literal is required (so the next person doesn't "fix" it back).
- `fixtures/goosefs/docker-compose-goosefs.yml`: set the `goosefs-master` service's `GOOSEFS_MASTER_HOSTNAME` env to `127.0.0.1` (was `localhost`), with the same explanatory comment alongside the existing worker-side note.

# Are there any user-facing changes?

No. This only affects the GooseFS integration test fixtures used by CI; no Rust crate, public API, behavior, or documented configuration is changed. End users of `opendal` are not affected.

<!-- If there are any breaking changes to public APIs, please add the `breaking` label. -->

# AI Usage Statement

<!-- Per https://opendal.apache.org/community/policies/ai-usage -->
AI assistance (Claude) was used to help analyze the GooseFS startup / worker-registration logs and to draft the explanatory comments and this PR description. The root-cause analysis was cross-checked against the GooseFS 2.x source and JVM networking docs (specifically the documented behavior of `java.net.preferIPv4Stack` vs. `InetAddress.getByName` ordering). All committed changes were reviewed and verified by the author before submission.
