### PR TITLE
feat(core): implement debug for readers and writers

### DIFF
--- a/core/core/src/types/read/futures_async_reader.rs
+++ b/core/core/src/types/read/futures_async_reader.rs
@@ -54,6 +54,25 @@ pub struct FuturesAsyncReader {
 /// Safety: FuturesAsyncReader only exposes `&mut self` to the outside world,
 unsafe impl Sync for FuturesAsyncReader {}
 
+impl std::fmt::Debug for FuturesAsyncReader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let info = self.ctx.accessor().info();
+        let root = info.root();
+
+        f.debug_struct("FuturesAsyncReader")
+            .field("scheme", &info.scheme())
+            .field("root", &root)
+            .field("path", &self.ctx.path())
+            .field("args", self.ctx.args())
+            .field("options", self.ctx.options())
+            .field("start", &self.start)
+            .field("end", &self.end)
+            .field("pos", &self.pos)
+            .field("buffered", &self.buf.len())
+            .finish_non_exhaustive()
+    }
+}
+
 impl FuturesAsyncReader {
     /// NOTE: don't allow users to create FuturesAsyncReader directly.
     ///
@@ -215,8 +234,10 @@ mod tests {
         let srv = op.service().clone();
         let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new())?);
 
-        let v = FuturesAsyncReader::new(ctx, 4..8);
+        fn assert_reader_traits<T: std::fmt::Debug + Unpin + MaybeSend + Sync + 'static>(_: &T) {}
 
+        let v = FuturesAsyncReader::new(ctx, 4..8);
+        assert_reader_traits(&v);
         let _: Box<dyn Unpin + MaybeSend + Sync + 'static> = Box::new(v);
         Ok(())
     }

--- a/core/core/src/types/read/reader.rs
+++ b/core/core/src/types/read/reader.rs
@@ -108,6 +108,21 @@ struct FetchReadOutput {
     buffer: Buffer,
 }
 
+impl std::fmt::Debug for Reader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let info = self.ctx.accessor().info();
+        let root = info.root();
+
+        f.debug_struct("Reader")
+            .field("scheme", &info.scheme())
+            .field("root", &root)
+            .field("path", &self.ctx.path())
+            .field("args", self.ctx.args())
+            .field("options", self.ctx.options())
+            .finish_non_exhaustive()
+    }
+}
+
 impl Reader {
     /// Create a new reader.
     ///
@@ -649,7 +664,28 @@ mod tests {
         let srv = op.service().clone();
         let ctx = new_read_context(ctx, srv, "test", OpReader::new())?;
 
-        let _: Box<dyn Unpin + MaybeSend + Sync + 'static> = Box::new(Reader::new(ctx));
+        fn assert_reader_traits<T: std::fmt::Debug + Unpin + MaybeSend + Sync + 'static>(_: &T) {}
+
+        let reader = Reader::new(ctx);
+        assert_reader_traits(&reader);
+        let _: Box<dyn Unpin + MaybeSend + Sync + 'static> = Box::new(reader);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_debug() -> Result<()> {
+        let op = Operator::via_iter(services::MEMORY_SCHEME, [])?;
+        op.write("test", "hello").await?;
+
+        let reader = op.reader_with("test").chunk(8).await?;
+        let output = format!("{reader:?}");
+
+        assert!(output.contains("Reader"), "{output}");
+        assert!(output.contains("memory"), "{output}");
+        assert!(output.contains("test"), "{output}");
+        assert!(output.contains("args"), "{output}");
+        assert!(output.contains("options"), "{output}");
 
         Ok(())
     }

--- a/core/core/src/types/write/futures_async_writer.rs
+++ b/core/core/src/types/write/futures_async_writer.rs
@@ -37,6 +37,12 @@ pub struct FuturesAsyncWriter {
     buf: oio::FlexBuf,
 }
 
+impl std::fmt::Debug for FuturesAsyncWriter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FuturesAsyncWriter").finish_non_exhaustive()
+    }
+}
+
 impl FuturesAsyncWriter {
     /// NOTE: don't allow users to create directly.
     #[inline]
@@ -131,8 +137,10 @@ mod tests {
         ));
         let write_gen = WriteGenerator::create(ctx).unwrap();
 
-        let v = FuturesAsyncWriter::new(write_gen);
+        fn assert_writer_traits<T: std::fmt::Debug + Unpin + MaybeSend + Sync + 'static>(_: &T) {}
 
+        let v = FuturesAsyncWriter::new(write_gen);
+        assert_writer_traits(&v);
         let _: Box<dyn Unpin + MaybeSend + Sync + 'static> = Box::new(v);
     }
 }

--- a/core/core/src/types/write/writer.rs
+++ b/core/core/src/types/write/writer.rs
@@ -99,8 +99,23 @@ use crate::*;
 ///   creating writer with `append` enabled.
 pub struct Writer {
     /// Keep a reference to write context in writer.
-    _ctx: Arc<WriteContext>,
+    ctx: Arc<WriteContext>,
     inner: WriteGenerator<oio::Writer>,
+}
+
+impl std::fmt::Debug for Writer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let info = self.ctx.accessor().info();
+        let root = info.root();
+
+        f.debug_struct("Writer")
+            .field("scheme", &info.scheme())
+            .field("root", &root)
+            .field("path", &self.ctx.path())
+            .field("args", self.ctx.args())
+            .field("options", self.ctx.options())
+            .finish_non_exhaustive()
+    }
 }
 
 impl Writer {
@@ -109,7 +124,7 @@ impl Writer {
         let ctx = Arc::new(ctx);
         let inner = std::future::ready(WriteGenerator::create(ctx.clone())).await?;
 
-        Ok(Self { _ctx: ctx, inner })
+        Ok(Self { ctx, inner })
     }
 
     /// Write [`Buffer`] into writer.
@@ -383,6 +398,7 @@ mod tests {
     use rand::{Rng, RngExt};
 
     use crate::Operator;
+    use crate::Result;
     use crate::services;
 
     fn gen_random_bytes() -> Vec<u8> {
@@ -451,5 +467,23 @@ mod tests {
             buf.to_bytes(),
             chain_same.copy_to_bytes(chain_same.remaining())
         );
+    }
+
+    #[tokio::test]
+    async fn test_debug() -> Result<()> {
+        let op = Operator::new(services::Memory::default()).unwrap().finish();
+        let path = "test_file";
+
+        let mut writer = op.writer_with(path).chunk(8).await?;
+        let output = format!("{writer:?}");
+        writer.abort().await?;
+
+        assert!(output.contains("Writer"), "{output}");
+        assert!(output.contains("memory"), "{output}");
+        assert!(output.contains(path), "{output}");
+        assert!(output.contains("args"), "{output}");
+        assert!(output.contains("options"), "{output}");
+
+        Ok(())
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6076.

# Rationale for this change

`Reader` and `Writer` are useful to store inside downstream types that require `Debug`, and their current lack of debug output also makes operation context harder to inspect.

# What changes are included in this PR?

- Implement `Debug` for `Reader` and `Writer` using existing operation context.
- Implement `Debug` for `FuturesAsyncReader` and `FuturesAsyncWriter`.
- Add focused tests for reader and writer debug output.
- Extend trait assertions to cover the new `Debug` bounds.

# Are there any user-facing changes?

`Reader`, `Writer`, `FuturesAsyncReader`, and `FuturesAsyncWriter` now implement `Debug`.

# AI Usage Statement

Not applicable.
