### PR TITLE
feat(core): return metadata from read

### DIFF
--- a/core/core/src/docs/rfcs/5871_read_returns_metadata.md
+++ b/core/core/src/docs/rfcs/5871_read_returns_metadata.md
@@ -15,7 +15,7 @@ Read metadata is bound to a concrete read stream. Calling `metadata().await` on 
 
 Today, users who need metadata while reading must issue an additional `stat()` request. This is inefficient for services that already return useful metadata from their read APIs, such as S3 `GetObject`, GCS object download, and Azure Blob download. It can also observe a different object version if the object changes between read and stat.
 
-This is especially important for adapters such as `object_store_opendal`. `object_store::GetResult` must contain `ObjectMeta`, returned range, attributes, and a streaming payload at the time `get_opts()` returns. A stat-first implementation can satisfy that contract, but it adds an extra request before every ranged read. OpenDAL should expose read response metadata through its public API so these adapters can construct their result without issuing a redundant `stat`.
+This is especially important for adapters such as `object_store_opendal`. `object_store::GetResult` must contain `ObjectMeta`, returned range, attributes, and a streaming payload at the time `get_opts()` returns. A stat-first implementation can satisfy that contract, but it adds an extra request before every ranged read. OpenDAL should expose read-open object metadata through its public API so these adapters can construct their result without issuing a redundant `stat`.
 
 # Guide-level explanation
 
@@ -79,17 +79,12 @@ Semantics:
 
 - It never performs I/O.
 - It initially returns `None`.
-- It returns object metadata, not read response metadata.
+- It returns object metadata.
 - Its `content_length` is always the full object size.
-- Its `content_range` is always `None`.
-- It is updated only when a read response can be normalized into complete object metadata.
-- If several reads are opened by the same reader, the cache stores the latest complete object metadata observed by those reads.
+- It is updated from metadata returned by successful read opens.
+- If several reads are opened by the same reader, the cache stores the first object metadata observed by those reads.
 
-For a full read response, the object size is `read_metadata.content_length()`.
-
-For a ranged read response, the object size is `read_metadata.content_range().and_then(|v| v.size())`. If the ranged response does not provide the full object size, `Reader::metadata()` must not be updated from that response.
-
-This API is an ergonomic cache for users who read through `Reader::read(...)` and then want the complete object metadata observed along the way. It is not the API adapters should use when metadata must be tied to a concrete streaming payload.
+This API is an ergonomic cache for users who read through `Reader::read(...)` and then want the complete object metadata observed along the way.
 
 ## Stream API
 
@@ -107,14 +102,13 @@ impl FuturesBytesStream {
 
 Semantics:
 
-- The returned metadata describes this concrete stream and its requested range.
+- The returned metadata describes the object being read.
+- Its `content_length` is always the full object size, even for ranged reads.
 - The first `metadata().await` call prepares the stream by opening the underlying read request.
 - The stream stores the returned `raw::RpRead::metadata` and the returned `oio::Reader`.
 - Later `metadata().await` calls return the cached metadata.
 - Later `poll_next` calls consume the cached reader and must not open the same read request again.
 - `metadata().await` does not read the response body. It only opens the read and observes response metadata.
-
-The stream metadata describes the read response. For ranged reads, its `content_length` is the payload length and its `content_range` carries the range and full object size when available.
 
 ## Changes to `raw::RpRead`
 
@@ -134,61 +128,26 @@ impl RpRead {
 }
 ```
 
-`RpRead::size()` and `RpRead::range()` should be removed. Their meanings overlap with `Metadata::content_length()` and `Metadata::content_range()`, and keeping two parallel surfaces would make the range-read semantics ambiguous.
+`RpRead::size()` and `RpRead::range()` should be removed. Metadata should expose object metadata only; returned ranges are derived from the read request and the object size.
 
-Callers that need the payload size should use:
+Callers that need the object size should use:
 
 ```rust,ignore
 rp.metadata().content_length()
 ```
 
-Callers that need the read range or full object size for a ranged read should use:
-
-```rust,ignore
-let range = rp.metadata().content_range();
-let object_size = range.and_then(|v| v.size());
-```
-
 ## `content_length` Semantics
 
-`Metadata::content_length` should describe the body length of the entity represented by this metadata.
-
-For stat and list metadata, the represented entity is the object:
+`Metadata::content_length` always describes the full object size.
 
 ```text
 content_length = full object size
-content_range  = None
 ```
 
-For read metadata, the represented entity is the read response:
+For example, reading `1024..2048` from a 10 MiB object should still produce:
 
 ```text
-content_length = read response payload length
-content_range  = read response range within the full object
-```
-
-For example, reading `1024..2048` from a 10 MiB object should produce:
-
-```text
-content_length = 1024
-content_range  = bytes 1024-2047/10485760
-```
-
-The full object size for a ranged read is available from `content_range.size()`, not from `content_length`.
-
-When updating `Reader::metadata()` from read metadata, OpenDAL must normalize the read response metadata into object metadata:
-
-```text
-full read metadata:
-  reader.content_length = read.content_length
-  reader.content_range  = None
-
-range read metadata with total object size:
-  reader.content_length = read.content_range.size
-  reader.content_range  = None
-
-range read metadata without total object size:
-  reader metadata is not updated
+content_length = 10485760
 ```
 
 HTTP response mapping:
@@ -196,22 +155,18 @@ HTTP response mapping:
 ```text
 HTTP 200 + Content-Length: N
   -> content_length = N
-  -> content_range = None
 
 HTTP 206 + Content-Range: bytes start-end/total
-  -> content_length = end - start + 1
-  -> content_range = start..end/total
+  -> content_length = total
 
 HTTP 206 + Content-Range: bytes start-end/*
-  -> content_length = end - start + 1
-  -> content_range = start..end/*
+  -> content_length cannot be derived from the response alone
 
 HTTP 206 + Content-Length: M, no Content-Range
-  -> content_length = M
-  -> content_range = None
+  -> content_length cannot be derived from the response alone
 ```
 
-Adapters that need full object size, such as `object_store_opendal`, must read it from `content_range.size()` for ranged reads and fall back to `content_length()` for full reads.
+Backends must not expose HTTP `Content-Range` through public `Metadata`. They may parse it internally to populate the full object size.
 
 ## Implementation Details
 
@@ -220,8 +175,7 @@ Backends must return metadata for every successful read open.
 For services that return metadata in read responses:
 
 - Capture metadata from the read response.
-- Populate `content_length` according to the read response payload length.
-- Populate `content_range` when the response provides a valid content range.
+- Populate `content_length` with the full object size. HTTP services may derive it from `Content-Length` for full responses or from `Content-Range` for ranged responses.
 - Populate fields such as `content_type`, `etag`, `version`, `last_modified`, and user metadata when available from the response.
 
 For services whose read primitive does not naturally return metadata:
@@ -241,7 +195,7 @@ metadata().await
   -> prepare/open if needed
   -> accessor.read(path, args_with_range).await
   -> cache RpRead.metadata
-  -> update Reader metadata cache if complete object metadata can be derived
+  -> update Reader metadata cache
   -> cache returned oio::Reader
   -> return cached metadata
 
@@ -252,7 +206,7 @@ poll_next()
 
 For non-chunked streaming reads, one stream maps to one underlying `accessor.read`.
 
-For chunked or concurrent reads, a single physical read response may only describe one chunk. If metadata is exposed for a logical chunked stream, the stream layer must synthesize logical stream metadata from the requested range and the observed object size. Paths that need exact metadata before returning a streaming payload can choose the non-chunked stream path.
+For chunked or concurrent reads, a single physical read response may only return one chunk body, but its metadata still describes the full object.
 
 ## `object_store_opendal` Integration
 
@@ -270,21 +224,16 @@ let reader = self.inner.reader_with(&raw_location)
 let mut stream = reader.into_bytes_stream(read_range.clone()).await?;
 let meta = stream.metadata().await?;
 
-let object_size = meta
-    .content_range()
-    .and_then(|v| v.size())
-    .unwrap_or_else(|| meta.content_length());
-
 let result = GetResult {
     payload: GetResultPayload::Stream(Box::pin(stream.map_err(...))),
     meta: ObjectMeta {
         location: location.clone(),
         last_modified: meta.last_modified().and_then(timestamp_to_datetime).unwrap_or_default(),
-        size: object_size,
+        size: meta.content_length(),
         e_tag: meta.etag().map(ToString::to_string),
         version: meta.version().map(ToString::to_string),
     },
-    range: build_returned_range(&meta, read_range),
+    range: build_returned_range(read_range, meta.content_length()),
     attributes: build_attributes(&meta),
 };
 ```
@@ -301,16 +250,14 @@ Cases that still need stat-first behavior:
 - `RpRead` becomes a stronger backend contract: successful read open must return metadata.
 - Some backends will need extra work during read open to obtain size or status.
 - Stream implementations become more complex because they need a reusable prepare/open state.
-- `Metadata::content_length` becomes operation-scoped: it describes object size for stat/list metadata and response payload length for read metadata. This must be documented clearly.
-- There are two public metadata views: stream metadata describes a read response, while reader metadata describes the complete object metadata cache.
 
 # Rationale and alternatives
 
-This design keeps existing `Reader::read()` and `Operator::read()` return types unchanged. Users can opt into exact read response metadata by working with read streams, or inspect the complete object metadata already observed by `Reader`.
+This design keeps existing `Reader::read()` and `Operator::read()` return types unchanged. Users can opt into read-open metadata by working with read streams, or inspect the complete object metadata already observed by `Reader`.
 
-Using `Reader::metadata()` as the only metadata API is not enough: it is not tied to a concrete range and cannot satisfy APIs that must return metadata before handing out a streaming payload. Another alternative is returning a new `ReadResult` carrier from read APIs, but that would be a broader public API change and would duplicate the existing stream abstraction.
+Using `Reader::metadata()` as the only metadata API is not enough: it is not tied to a concrete read open and cannot satisfy APIs that must return metadata before handing out a streaming payload. Another alternative is returning a new `ReadResult` carrier from read APIs, but that would be a broader public API change and would duplicate the existing stream abstraction.
 
-Removing `RpRead::size()` and `RpRead::range()` avoids a second metadata surface. Payload length is represented by `metadata.content_length()`, and range information is represented by `metadata.content_range()`.
+Removing `RpRead::size()` and `RpRead::range()` avoids a second metadata surface. Object size is represented by `metadata.content_length()`, and returned range information is derived from the read request.
 
 # Prior art
 

--- a/core/core/src/docs/rfcs/5871_read_returns_metadata.md
+++ b/core/core/src/docs/rfcs/5871_read_returns_metadata.md
@@ -5,9 +5,9 @@
 
 # Summary
 
-Expose the metadata returned by read operations without requiring users or adapters to issue a separate `stat` request.
+Expose metadata returned natively by read operations without requiring users or adapters to issue a separate `stat` request.
 
-Read metadata is bound to a concrete read stream. Calling `metadata().await` on the stream opens the underlying read request, stores the returned metadata and reader, and lets subsequent stream consumption reuse the same reader.
+Read metadata is bound to a concrete read stream. Calling `metadata().await` on the stream opens the underlying read request, stores the returned reader, and caches metadata if the service returned it. Subsequent stream consumption reuses the same reader.
 
 `Reader` also maintains a best-effort cache of complete object metadata that has been observed from successful read opens.
 
@@ -15,7 +15,9 @@ Read metadata is bound to a concrete read stream. Calling `metadata().await` on 
 
 Today, users who need metadata while reading must issue an additional `stat()` request. This is inefficient for services that already return useful metadata from their read APIs, such as S3 `GetObject`, GCS object download, and Azure Blob download. It can also observe a different object version if the object changes between read and stat.
 
-This is especially important for adapters such as `object_store_opendal`. `object_store::GetResult` must contain `ObjectMeta`, returned range, attributes, and a streaming payload at the time `get_opts()` returns. A stat-first implementation can satisfy that contract, but it adds an extra request before every ranged read. OpenDAL should expose read-open object metadata through its public API so these adapters can construct their result without issuing a redundant `stat`.
+However, not every service can return metadata as part of read open. Forcing those services to call `stat`, `size`, or `metadata` internally would move the extra request into OpenDAL's core read path and make normal reads more expensive.
+
+This is especially important for adapters such as `object_store_opendal`. `object_store::GetResult` must contain `ObjectMeta`, returned range, attributes, and a streaming payload at the time `get_opts()` returns. A stat-first implementation can satisfy that contract, but it adds an extra request before every ranged read. OpenDAL should expose read-open object metadata when it is available, so these adapters can avoid redundant `stat` on metadata-capable services while preserving the existing fallback for other services.
 
 # Guide-level explanation
 
@@ -44,7 +46,9 @@ if let Some(etag) = meta.etag() {
 let data = stream.try_collect::<Vec<_>>().await?;
 ```
 
-`metadata().await` opens the read request if it has not been opened yet. The stream caches both the metadata and the underlying reader, so consuming the stream afterwards does not open a second read request.
+`metadata().await` opens the read request if it has not been opened yet. If the underlying service returns metadata while opening the read, the stream caches both the metadata and the underlying reader, so consuming the stream afterwards does not open a second read request.
+
+If the service does not return metadata while opening the read, `metadata().await` returns `ErrorKind::Unsupported`. The opened reader is still reused by later stream consumption.
 
 If users do not call `metadata().await`, streams keep their existing lazy behavior: the underlying read request is opened when the stream is first polled.
 
@@ -59,7 +63,7 @@ if let Some(meta) = reader.metadata() {
 }
 ```
 
-`Reader::metadata()` does not perform I/O. It returns `None` until a read opened by this reader has observed enough information to build complete object metadata.
+`Reader::metadata()` does not perform I/O. It returns `None` until a read opened by this reader has observed enough information to build complete object metadata. It also returns `None` for services that do not return metadata while opening read operations.
 
 # Reference-level explanation
 
@@ -82,6 +86,7 @@ Semantics:
 - It returns object metadata.
 - Its `content_length` is always the full object size.
 - It is updated from metadata returned by successful read opens.
+- It remains `None` if the service does not return metadata while opening read operations.
 - If several reads are opened by the same reader, the cache stores the first object metadata observed by those reads.
 
 This API is an ergonomic cache for users who read through `Reader::read(...)` and then want the complete object metadata observed along the way.
@@ -105,35 +110,38 @@ Semantics:
 - The returned metadata describes the object being read.
 - Its `content_length` is always the full object size, even for ranged reads.
 - The first `metadata().await` call prepares the stream by opening the underlying read request.
-- The stream stores the returned `raw::RpRead::metadata` and the returned `oio::Reader`.
+- The stream stores the returned `oio::Reader` and caches `raw::RpRead::metadata` if present.
 - Later `metadata().await` calls return the cached metadata.
 - Later `poll_next` calls consume the cached reader and must not open the same read request again.
 - `metadata().await` does not read the response body. It only opens the read and observes response metadata.
+- If `raw::RpRead::metadata` is absent, `metadata().await` returns `ErrorKind::Unsupported`.
 
 ## Changes to `raw::RpRead`
 
-`raw::RpRead` becomes the metadata carrier for a successful read open:
+`raw::RpRead` becomes an optional metadata carrier for a successful read open:
 
 ```rust,ignore
 pub struct RpRead {
-    metadata: Metadata,
+    metadata: Option<Metadata>,
 }
 
 impl RpRead {
     pub fn new(metadata: Metadata) -> Self;
 
-    pub fn metadata(&self) -> &Metadata;
+    pub fn metadata(&self) -> Option<&Metadata>;
 
-    pub fn into_metadata(self) -> Metadata;
+    pub fn into_metadata(self) -> Option<Metadata>;
 }
 ```
+
+Services should set `RpRead::metadata` only when the read operation natively returns enough information to build complete object metadata. They must not issue an extra request only to fill `RpRead::metadata`.
 
 `RpRead::size()` and `RpRead::range()` should be removed. Metadata should expose object metadata only; returned ranges are derived from the read request and the object size.
 
 Callers that need the object size should use:
 
 ```rust,ignore
-rp.metadata().content_length()
+rp.metadata().map(|m| m.content_length())
 ```
 
 ## `content_length` Semantics
@@ -170,8 +178,6 @@ Backends must not expose HTTP `Content-Range` through public `Metadata`. They ma
 
 ## Implementation Details
 
-Backends must return metadata for every successful read open.
-
 For services that return metadata in read responses:
 
 - Capture metadata from the read response.
@@ -180,11 +186,9 @@ For services that return metadata in read responses:
 
 For services whose read primitive does not naturally return metadata:
 
-- The backend must still satisfy the `RpRead { metadata }` contract.
-- File-like services may use file metadata, seek, or an equivalent backend-local primitive during read open.
-- Remote file-like services such as SFTP, HDFS, and FTP may need an additional status or size request to satisfy the contract.
-
-This cost is part of making read metadata a mandatory read-open contract instead of an optional hint.
+- Return `RpRead::default()`.
+- Do not call `stat`, `size`, `metadata`, `seek`, or equivalent extra APIs only to populate `RpRead::metadata`.
+- Keep any existing service-specific requests that are required for read correctness itself, such as resolving an open-ended range that the underlying API cannot express.
 
 ## Stream State
 
@@ -194,14 +198,14 @@ This cost is part of making read metadata a mandatory read-open contract instead
 metadata().await
   -> prepare/open if needed
   -> accessor.read(path, args_with_range).await
-  -> cache RpRead.metadata
-  -> update Reader metadata cache
+  -> cache RpRead.metadata if present
+  -> update Reader metadata cache if metadata is present
   -> cache returned oio::Reader
-  -> return cached metadata
+  -> return cached metadata, or Unsupported if metadata is absent
 
 poll_next()
-  -> prepare/open if needed
-  -> consume cached oio::Reader
+  -> open if needed
+  -> consume cached or newly opened oio::Reader
 ```
 
 For non-chunked streaming reads, one stream maps to one underlying `accessor.read`.
@@ -242,13 +246,14 @@ Cases that still need stat-first behavior:
 
 - `head = true`, because the caller explicitly asks for no body.
 - suffix ranges, because OpenDAL's public range input does not currently express suffix ranges.
+- read streams whose services do not return metadata while opening the read operation.
 - responses that cannot provide the full object size required by `ObjectMeta::size`.
 - compatibility paths that intentionally preserve existing out-of-range behavior.
 
 # Drawbacks
 
-- `RpRead` becomes a stronger backend contract: successful read open must return metadata.
-- Some backends will need extra work during read open to obtain size or status.
+- `metadata().await` is best-effort across services instead of universally available.
+- Adapters that require metadata still need a fallback path for services without read-open metadata.
 - Stream implementations become more complex because they need a reusable prepare/open state.
 
 # Rationale and alternatives
@@ -256,6 +261,8 @@ Cases that still need stat-first behavior:
 This design keeps existing `Reader::read()` and `Operator::read()` return types unchanged. Users can opt into read-open metadata by working with read streams, or inspect the complete object metadata already observed by `Reader`.
 
 Using `Reader::metadata()` as the only metadata API is not enough: it is not tied to a concrete read open and cannot satisfy APIs that must return metadata before handing out a streaming payload. Another alternative is returning a new `ReadResult` carrier from read APIs, but that would be a broader public API change and would duplicate the existing stream abstraction.
+
+Making `RpRead::metadata` mandatory was rejected because it forces services without native read metadata to add extra status calls to the read path. That violates OpenDAL's zero-extra-cost read design.
 
 Removing `RpRead::size()` and `RpRead::range()` avoids a second metadata surface. Object size is represented by `metadata.content_length()`, and returned range information is derived from the read request.
 
@@ -270,9 +277,9 @@ Similar patterns exist in other storage SDKs:
 # Unresolved questions
 
 - Whether OpenDAL should add a public suffix-range input in the future so suffix reads can also use the no-stat path.
-- How much logical metadata synthesis should be supported for chunked and concurrent streams.
+- Whether OpenDAL should expose a capability bit for services that can return read-open metadata.
 
 # Future possibilities
 
-- `object_store_opendal` can use stream metadata to avoid stat-first bounded range reads.
-- `ReadContext::parse_into_range` can use read metadata or user-provided content length hints to avoid additional stat calls for open-ended ranges.
+- `object_store_opendal` can use stream metadata to avoid stat-first bounded range reads when services support read-open metadata.
+- `ReadContext::parse_into_range` can use user-provided content length hints to avoid additional stat calls for open-ended ranges.

--- a/core/core/src/layers/correctness_check.rs
+++ b/core/core/src/layers/correctness_check.rs
@@ -325,7 +325,10 @@ mod tests {
         }
 
         async fn read(&self, _: &str, _: OpRead) -> Result<(RpRead, Self::Reader)> {
-            Ok((RpRead::new(), Box::new(bytes::Bytes::new())))
+            Ok((
+                RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(0)),
+                Box::new(bytes::Bytes::new()),
+            ))
         }
 
         async fn write(&self, _: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/core/src/raw/futures_util.rs
+++ b/core/core/src/raw/futures_util.rs
@@ -202,12 +202,6 @@ impl<I: Send + 'static, O: Send + 'static> ConcurrentTasks<I, O> {
         !self.results.is_empty()
     }
 
-    /// Return true if there are no running tasks or buffered results.
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.tasks.is_empty() && self.results.is_empty()
-    }
-
     /// Create a task with given input.
     pub fn create_task(&self, input: I) -> Task<(I, Result<O>)> {
         let completed = self.completed_but_unretrieved.clone();
@@ -217,28 +211,6 @@ impl<I: Send + 'static, O: Send + 'static> ConcurrentTasks<I, O> {
         });
 
         self.executor.execute(fut)
-    }
-
-    /// Try to schedule the task with given input in the background.
-    ///
-    /// Unlike [`Self::execute`], this method always schedules the task on the
-    /// executor, even when concurrency is set to 1.
-    ///
-    /// Returns `Ok(false)` if there is no remaining capacity to schedule this task.
-    pub fn try_schedule(&mut self, input: I) -> Result<bool> {
-        if self.errored {
-            return Err(Error::new(
-                ErrorKind::Unexpected,
-                "concurrent tasks met an unrecoverable error",
-            ));
-        }
-
-        if !self.has_remaining() {
-            return Ok(false);
-        }
-
-        self.tasks.push_back(self.create_task(input));
-        Ok(true)
     }
 
     /// Execute the task with given input.

--- a/core/core/src/raw/futures_util.rs
+++ b/core/core/src/raw/futures_util.rs
@@ -202,6 +202,12 @@ impl<I: Send + 'static, O: Send + 'static> ConcurrentTasks<I, O> {
         !self.results.is_empty()
     }
 
+    /// Return true if there are no running tasks or buffered results.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.tasks.is_empty() && self.results.is_empty()
+    }
+
     /// Create a task with given input.
     pub fn create_task(&self, input: I) -> Task<(I, Result<O>)> {
         let completed = self.completed_but_unretrieved.clone();
@@ -211,6 +217,25 @@ impl<I: Send + 'static, O: Send + 'static> ConcurrentTasks<I, O> {
         });
 
         self.executor.execute(fut)
+    }
+
+    /// Try to execute the task with given input without waiting for running tasks.
+    ///
+    /// Returns `Ok(false)` if there is no remaining capacity to schedule this task.
+    pub fn try_execute(&mut self, input: I) -> Result<bool> {
+        if self.errored {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "concurrent tasks met an unrecoverable error",
+            ));
+        }
+
+        if !self.has_remaining() {
+            return Ok(false);
+        }
+
+        self.tasks.push_back(self.create_task(input));
+        Ok(true)
     }
 
     /// Execute the task with given input.

--- a/core/core/src/raw/futures_util.rs
+++ b/core/core/src/raw/futures_util.rs
@@ -219,10 +219,13 @@ impl<I: Send + 'static, O: Send + 'static> ConcurrentTasks<I, O> {
         self.executor.execute(fut)
     }
 
-    /// Try to execute the task with given input without waiting for running tasks.
+    /// Try to schedule the task with given input in the background.
+    ///
+    /// Unlike [`Self::execute`], this method always schedules the task on the
+    /// executor, even when concurrency is set to 1.
     ///
     /// Returns `Ok(false)` if there is no remaining capacity to schedule this task.
-    pub fn try_execute(&mut self, input: I) -> Result<bool> {
+    pub fn try_schedule(&mut self, input: I) -> Result<bool> {
         if self.errored {
             return Err(Error::new(
                 ErrorKind::Unexpected,

--- a/core/core/src/raw/http_util/header.rs
+++ b/core/core/src/raw/http_util/header.rs
@@ -175,8 +175,8 @@ pub fn parse_into_metadata(path: &str, headers: &HeaderMap) -> Result<Metadata> 
         m.set_content_encoding(v);
     }
 
-    if let Some(v) = parse_content_range(headers)? {
-        m.set_content_range(v);
+    if let Some(v) = parse_content_range(headers)?.and_then(|v| v.size()) {
+        m.set_content_length(v);
     }
 
     if let Some(v) = parse_etag(headers)? {

--- a/core/core/src/raw/rps.rs
+++ b/core/core/src/raw/rps.rs
@@ -98,18 +98,10 @@ impl<T: Default> From<PresignedRequest> for Request<T> {
 
 /// Reply for `read` operation.
 ///
-/// `RpRead` carries metadata for the read response opened by this operation.
-/// The metadata describes the returned reader body instead of the object in
-/// general.
-///
-/// - `metadata.content_length()` is the payload length of this read response.
-///   For a range read, this is the range payload length.
-/// - `metadata.content_range()` is set when the read response describes a
-///   ranged body. Its range is the returned byte range, and its size is the
-///   full object size if the backend provides it.
-/// - Full object metadata can be derived from read metadata by callers that
-///   understand the requested range. For full reads, the object size is
-///   `content_length`; for ranged reads, it is `content_range().and_then(|v| v.size())`.
+/// `RpRead` carries metadata observed while opening this read operation.
+/// The metadata describes the object being read. In particular,
+/// `metadata.content_length()` is the full object size, even if this read only
+/// returns a range of the object.
 #[derive(Debug, Clone)]
 pub struct RpRead {
     metadata: Metadata,

--- a/core/core/src/raw/rps.rs
+++ b/core/core/src/raw/rps.rs
@@ -98,28 +98,30 @@ impl<T: Default> From<PresignedRequest> for Request<T> {
 
 /// Reply for `read` operation.
 ///
-/// `RpRead` carries metadata observed while opening this read operation.
-/// The metadata describes the object being read. In particular,
-/// `metadata.content_length()` is the full object size, even if this read only
-/// returns a range of the object.
-#[derive(Debug, Clone)]
+/// `RpRead` can carry metadata observed while opening this read operation.
+/// Services should set it only when the metadata is returned natively by the
+/// read operation. In particular, `metadata.content_length()` is the full
+/// object size, even if this read only returns a range of the object.
+#[derive(Debug, Clone, Default)]
 pub struct RpRead {
-    metadata: Metadata,
+    metadata: Option<Metadata>,
 }
 
 impl RpRead {
     /// Create a new reply for `read`.
     pub fn new(metadata: Metadata) -> Self {
-        RpRead { metadata }
+        Self {
+            metadata: Some(metadata),
+        }
     }
 
     /// Get metadata returned by this read operation.
-    pub fn metadata(&self) -> &Metadata {
-        &self.metadata
+    pub fn metadata(&self) -> Option<&Metadata> {
+        self.metadata.as_ref()
     }
 
     /// Consume RpRead to get the inner metadata.
-    pub fn into_metadata(self) -> Metadata {
+    pub fn into_metadata(self) -> Option<Metadata> {
         self.metadata
     }
 }

--- a/core/core/src/raw/rps.rs
+++ b/core/core/src/raw/rps.rs
@@ -97,6 +97,19 @@ impl<T: Default> From<PresignedRequest> for Request<T> {
 }
 
 /// Reply for `read` operation.
+///
+/// `RpRead` carries metadata for the read response opened by this operation.
+/// The metadata describes the returned reader body instead of the object in
+/// general.
+///
+/// - `metadata.content_length()` is the payload length of this read response.
+///   For a range read, this is the range payload length.
+/// - `metadata.content_range()` is set when the read response describes a
+///   ranged body. Its range is the returned byte range, and its size is the
+///   full object size if the backend provides it.
+/// - Full object metadata can be derived from read metadata by callers that
+///   understand the requested range. For full reads, the object size is
+///   `content_length`; for ranged reads, it is `content_range().and_then(|v| v.size())`.
 #[derive(Debug, Clone)]
 pub struct RpRead {
     metadata: Metadata,

--- a/core/core/src/raw/rps.rs
+++ b/core/core/src/raw/rps.rs
@@ -17,7 +17,6 @@
 
 use http::Request;
 
-use crate::raw::*;
 use crate::*;
 
 /// Reply for `create_dir` operation
@@ -98,58 +97,25 @@ impl<T: Default> From<PresignedRequest> for Request<T> {
 }
 
 /// Reply for `read` operation.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct RpRead {
-    /// Size is the size of the reader returned by this read operation.
-    ///
-    /// - `Some(size)` means the reader has at most size bytes.
-    /// - `None` means the reader has unknown size.
-    ///
-    /// It's ok to leave size as empty, but it's recommended to set size if possible. We will use
-    /// this size as hint to do some optimization like avoid an extra stat or read.
-    size: Option<u64>,
-    /// Range is the range of the reader returned by this read operation.
-    ///
-    /// - `Some(range)` means the reader's content range inside the whole file.
-    /// - `None` means the reader's content range is unknown.
-    ///
-    /// It's ok to leave range as empty, but it's recommended to set range if possible. We will use
-    /// this range as hint to do some optimization like avoid an extra stat or read.
-    range: Option<BytesContentRange>,
+    metadata: Metadata,
 }
 
 impl RpRead {
     /// Create a new reply for `read`.
-    pub fn new() -> Self {
-        RpRead::default()
+    pub fn new(metadata: Metadata) -> Self {
+        RpRead { metadata }
     }
 
-    /// Got the size of the reader returned by this read operation.
-    ///
-    /// - `Some(size)` means the reader has at most size bytes.
-    /// - `None` means the reader has unknown size.
-    pub fn size(&self) -> Option<u64> {
-        self.size
+    /// Get metadata returned by this read operation.
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
     }
 
-    /// Set the size of the reader returned by this read operation.
-    pub fn with_size(mut self, size: Option<u64>) -> Self {
-        self.size = size;
-        self
-    }
-
-    /// Got the range of the reader returned by this read operation.
-    ///
-    /// - `Some(range)` means the reader has content range inside the whole file.
-    /// - `None` means the reader has unknown size.
-    pub fn range(&self) -> Option<BytesContentRange> {
-        self.range
-    }
-
-    /// Set the range of the reader returned by this read operation.
-    pub fn with_range(mut self, range: Option<BytesContentRange>) -> Self {
-        self.range = range;
-        self
+    /// Consume RpRead to get the inner metadata.
+    pub fn into_metadata(self) -> Metadata {
+        self.metadata
     }
 }
 

--- a/core/core/src/services/memory/backend.rs
+++ b/core/core/src/services/memory/backend.rs
@@ -139,10 +139,21 @@ impl Access for MemoryBackend {
             }
         };
 
-        Ok((
-            RpRead::new(),
-            value.content.slice(args.range().to_range_as_usize()),
-        ))
+        let total_size = value.content.len() as u64;
+        let content = value.content.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(total_size),
+            );
+        }
+
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/core/src/services/memory/backend.rs
+++ b/core/core/src/services/memory/backend.rs
@@ -140,7 +140,13 @@ impl Access for MemoryBackend {
         };
 
         let total_size = value.content.len() as u64;
-        let content = value.content.slice(args.range().to_range_as_usize());
+        let range = args.range();
+        let start = range.offset().min(total_size) as usize;
+        let end = match range.size() {
+            Some(size) => range.offset().saturating_add(size).min(total_size),
+            None => total_size,
+        } as usize;
+        let content = value.content.slice(start..end);
         let metadata = Metadata::new(EntryMode::FILE).with_content_length(total_size);
 
         Ok((RpRead::new(metadata), content))

--- a/core/core/src/services/memory/backend.rs
+++ b/core/core/src/services/memory/backend.rs
@@ -141,17 +141,7 @@ impl Access for MemoryBackend {
 
         let total_size = value.content.len() as u64;
         let content = value.content.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(total_size),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(total_size);
 
         Ok((RpRead::new(metadata), content))
     }

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -196,7 +196,9 @@ impl ReadGenerator {
         let args = self.ctx.args.clone().with_range(range);
         let (rp, r) = self.ctx.acc.read(&self.ctx.path, args).await?;
         let metadata = rp.into_metadata();
-        self.ctx.set_metadata(metadata.clone());
+        if self.ctx.metadata().is_none() {
+            self.ctx.set_metadata(metadata.clone());
+        }
         Ok(Some((metadata, r)))
     }
 }

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -90,19 +90,8 @@ impl ReadContext {
     }
 
     /// Set cached read response metadata once.
-    ///
-    /// Returns the metadata back if this context already cached one before.
-    pub(crate) fn set_metadata(&self, metadata: Metadata, range: BytesRange) -> Option<Metadata> {
-        self.read_metadata
-            .set((metadata, range))
-            .err()
-            .map(|(metadata, _)| metadata)
-    }
-
-    /// Get read response metadata observed by this reader.
-    #[inline]
-    pub(crate) fn read_metadata(&self) -> Option<&Metadata> {
-        self.read_metadata.get().map(|(metadata, _)| metadata)
+    pub(crate) fn set_metadata(&self, metadata: Metadata, range: BytesRange) {
+        let _ = self.read_metadata.set((metadata, range));
     }
 
     /// Parse the range bounds into a range.
@@ -207,21 +196,16 @@ impl ReadGenerator {
     }
 
     /// Generate next reader.
-    pub async fn next_reader(&mut self) -> Result<Option<(Option<Metadata>, oio::Reader)>> {
+    pub async fn next_reader(&mut self) -> Result<Option<(Metadata, oio::Reader)>> {
         let Some(range) = self.next_range() else {
             return Ok(None);
         };
 
         let args = self.ctx.args.clone().with_range(range);
         let (rp, r) = self.ctx.acc.read(&self.ctx.path, args).await?;
-        let metadata = self.ctx.set_metadata(rp.into_metadata(), range);
+        let metadata = rp.into_metadata();
+        self.ctx.set_metadata(metadata.clone(), range);
         Ok(Some((metadata, r)))
-    }
-
-    /// Get read response metadata observed by this reader.
-    #[inline]
-    pub(crate) fn read_metadata(&self) -> Option<&Metadata> {
-        self.ctx.read_metadata()
     }
 }
 

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -83,9 +83,8 @@ impl ReadContext {
 
     /// Set cached object metadata from read response metadata once.
     pub(crate) fn set_metadata(&self, metadata: &Metadata, range: BytesRange) {
-        let Some(metadata) = metadata.clone().into_object_metadata(range) else {
-            return;
-        };
+        let mut metadata = metadata.clone();
+        metadata.adjust_by_range(range);
         let _ = self.metadata.set(metadata);
     }
 

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -39,7 +39,7 @@ pub struct ReadContext {
     /// Complete object metadata observed from successful read opens.
     metadata: OnceLock<Metadata>,
     /// Signal that a read-open metadata attempt has finished.
-    metadata_ready: Latch,
+    metadata_attempted: Latch,
 }
 
 impl ReadContext {
@@ -52,7 +52,7 @@ impl ReadContext {
             args,
             options,
             metadata: OnceLock::new(),
-            metadata_ready: Latch::new(1),
+            metadata_attempted: Latch::new(1),
         }
     }
 
@@ -89,21 +89,21 @@ impl ReadContext {
     /// Set cached object metadata observed from successful read opens once.
     pub(crate) fn set_metadata(&self, metadata: Metadata) {
         let _ = self.metadata.set(metadata);
-        self.metadata_ready.count_down();
+        self.metadata_attempted.count_down();
     }
 
     /// Notify waiters that a read-open metadata attempt has finished.
     pub(crate) fn finish_metadata_attempt(&self) {
-        self.metadata_ready.count_down();
+        self.metadata_attempted.count_down();
     }
 
     /// Wait for metadata observed from successful read opens.
-    pub(crate) async fn wait_metadata(&self) -> Option<&Metadata> {
+    pub(crate) async fn wait_metadata_attempt(&self) -> Option<&Metadata> {
         if let Some(metadata) = self.metadata() {
             return Some(metadata);
         }
 
-        self.metadata_ready.wait().await;
+        self.metadata_attempted.wait().await;
         self.metadata()
     }
 

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -21,6 +21,8 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
+use mea::latch::Latch;
+
 use crate::raw::*;
 use crate::*;
 
@@ -36,6 +38,8 @@ pub struct ReadContext {
     options: OpReader,
     /// Complete object metadata observed from successful read opens.
     metadata: OnceLock<Metadata>,
+    /// Signal that a read-open metadata attempt has finished.
+    metadata_ready: Latch,
 }
 
 impl ReadContext {
@@ -48,6 +52,7 @@ impl ReadContext {
             args,
             options,
             metadata: OnceLock::new(),
+            metadata_ready: Latch::new(1),
         }
     }
 
@@ -84,6 +89,22 @@ impl ReadContext {
     /// Set cached object metadata observed from successful read opens once.
     pub(crate) fn set_metadata(&self, metadata: Metadata) {
         let _ = self.metadata.set(metadata);
+        self.metadata_ready.count_down();
+    }
+
+    /// Notify waiters that a read-open metadata attempt has finished.
+    pub(crate) fn finish_metadata_attempt(&self) {
+        self.metadata_ready.count_down();
+    }
+
+    /// Wait for metadata observed from successful read opens.
+    pub(crate) async fn wait_metadata(&self) -> Option<&Metadata> {
+        if let Some(metadata) = self.metadata() {
+            return Some(metadata);
+        }
+
+        self.metadata_ready.wait().await;
+        self.metadata()
     }
 
     /// Parse the range bounds into a range.

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -81,9 +81,8 @@ impl ReadContext {
         self.metadata.get()
     }
 
-    /// Set cached object metadata from read response metadata once.
-    pub(crate) fn set_metadata(&self, mut metadata: Metadata, range: BytesRange) {
-        metadata.adjust_by_range(range);
+    /// Set cached object metadata observed from successful read opens once.
+    pub(crate) fn set_metadata(&self, metadata: Metadata) {
         let _ = self.metadata.set(metadata);
     }
 
@@ -197,7 +196,7 @@ impl ReadGenerator {
         let args = self.ctx.args.clone().with_range(range);
         let (rp, r) = self.ctx.acc.read(&self.ctx.path, args).await?;
         let metadata = rp.into_metadata();
-        self.ctx.set_metadata(metadata.clone(), range);
+        self.ctx.set_metadata(metadata.clone());
         Ok(Some((metadata, r)))
     }
 }

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -35,9 +35,7 @@ pub struct ReadContext {
     /// Options for the reader.
     options: OpReader,
     /// Complete object metadata observed from successful read opens.
-    object_metadata: OnceLock<Metadata>,
-    /// Read response metadata observed from successful read opens.
-    read_metadata: OnceLock<(Metadata, BytesRange)>,
+    metadata: OnceLock<Metadata>,
 }
 
 impl ReadContext {
@@ -49,8 +47,7 @@ impl ReadContext {
             path,
             args,
             options,
-            object_metadata: OnceLock::new(),
-            read_metadata: OnceLock::new(),
+            metadata: OnceLock::new(),
         }
     }
 
@@ -81,17 +78,13 @@ impl ReadContext {
     /// Get complete object metadata observed by this reader.
     #[inline]
     pub fn metadata(&self) -> Option<&Metadata> {
-        let (metadata, range) = self.read_metadata.get()?;
-        Some(self.object_metadata.get_or_init(|| {
-            let mut object_metadata = metadata.clone();
-            object_metadata.adjust_by_range(*range);
-            object_metadata
-        }))
+        self.metadata.get()
     }
 
-    /// Set cached read response metadata once.
-    pub(crate) fn set_metadata(&self, metadata: Metadata, range: BytesRange) {
-        let _ = self.read_metadata.set((metadata, range));
+    /// Set cached object metadata from read response metadata once.
+    pub(crate) fn set_metadata(&self, mut metadata: Metadata, range: BytesRange) {
+        metadata.adjust_by_range(range);
+        let _ = self.metadata.set(metadata);
     }
 
     /// Parse the range bounds into a range.

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -195,8 +195,9 @@ impl ReadGenerator {
 
         let args = self.ctx.args.clone().with_range(range);
         let (rp, r) = self.ctx.acc.read(&self.ctx.path, args).await?;
-        let metadata = rp.into_metadata();
-        if self.ctx.metadata().is_none() {
+        if let Some(metadata) = rp.into_metadata()
+            && self.ctx.metadata().is_none()
+        {
             self.ctx.set_metadata(metadata);
         }
         Ok(Some(r))

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -35,7 +35,9 @@ pub struct ReadContext {
     /// Options for the reader.
     options: OpReader,
     /// Complete object metadata observed from successful read opens.
-    metadata: OnceLock<Metadata>,
+    object_metadata: OnceLock<Metadata>,
+    /// Read response metadata observed from successful read opens.
+    read_metadata: OnceLock<(Metadata, BytesRange)>,
 }
 
 impl ReadContext {
@@ -47,7 +49,8 @@ impl ReadContext {
             path,
             args,
             options,
-            metadata: OnceLock::new(),
+            object_metadata: OnceLock::new(),
+            read_metadata: OnceLock::new(),
         }
     }
 
@@ -78,14 +81,28 @@ impl ReadContext {
     /// Get complete object metadata observed by this reader.
     #[inline]
     pub fn metadata(&self) -> Option<&Metadata> {
-        self.metadata.get()
+        let (metadata, range) = self.read_metadata.get()?;
+        Some(self.object_metadata.get_or_init(|| {
+            let mut object_metadata = metadata.clone();
+            object_metadata.adjust_by_range(*range);
+            object_metadata
+        }))
     }
 
-    /// Set cached object metadata from read response metadata once.
-    pub(crate) fn set_metadata(&self, metadata: &Metadata, range: BytesRange) {
-        let mut metadata = metadata.clone();
-        metadata.adjust_by_range(range);
-        let _ = self.metadata.set(metadata);
+    /// Set cached read response metadata once.
+    ///
+    /// Returns the metadata back if this context already cached one before.
+    pub(crate) fn set_metadata(&self, metadata: Metadata, range: BytesRange) -> Option<Metadata> {
+        self.read_metadata
+            .set((metadata, range))
+            .err()
+            .map(|(metadata, _)| metadata)
+    }
+
+    /// Get read response metadata observed by this reader.
+    #[inline]
+    pub(crate) fn read_metadata(&self) -> Option<&Metadata> {
+        self.read_metadata.get().map(|(metadata, _)| metadata)
     }
 
     /// Parse the range bounds into a range.
@@ -190,16 +207,21 @@ impl ReadGenerator {
     }
 
     /// Generate next reader.
-    pub async fn next_reader(&mut self) -> Result<Option<(Metadata, oio::Reader)>> {
+    pub async fn next_reader(&mut self) -> Result<Option<(Option<Metadata>, oio::Reader)>> {
         let Some(range) = self.next_range() else {
             return Ok(None);
         };
 
         let args = self.ctx.args.clone().with_range(range);
         let (rp, r) = self.ctx.acc.read(&self.ctx.path, args).await?;
-        let metadata = rp.into_metadata();
-        self.ctx.set_metadata(&metadata, range);
+        let metadata = self.ctx.set_metadata(rp.into_metadata(), range);
         Ok(Some((metadata, r)))
+    }
+
+    /// Get read response metadata observed by this reader.
+    #[inline]
+    pub(crate) fn read_metadata(&self) -> Option<&Metadata> {
+        self.ctx.read_metadata()
     }
 }
 

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -19,6 +19,7 @@ use std::ops::Bound;
 use std::ops::Range;
 use std::ops::RangeBounds;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use crate::raw::*;
 use crate::*;
@@ -33,6 +34,8 @@ pub struct ReadContext {
     args: OpRead,
     /// Options for the reader.
     options: OpReader,
+    /// Complete object metadata observed from successful read opens.
+    metadata: Mutex<Option<Metadata>>,
 }
 
 impl ReadContext {
@@ -44,6 +47,7 @@ impl ReadContext {
             path,
             args,
             options,
+            metadata: Mutex::new(None),
         }
     }
 
@@ -69,6 +73,72 @@ impl ReadContext {
     #[inline]
     pub fn options(&self) -> &OpReader {
         &self.options
+    }
+
+    /// Get complete object metadata observed by this reader.
+    #[inline]
+    pub fn metadata(&self) -> Option<Metadata> {
+        self.metadata
+            .lock()
+            .expect("metadata lock poisoned")
+            .clone()
+    }
+
+    /// Update cached object metadata from read response metadata.
+    pub(crate) fn update_metadata(&self, metadata: &Metadata, range: BytesRange) {
+        let Some(metadata) = Self::object_metadata_from_read_metadata(metadata, range) else {
+            return;
+        };
+        *self.metadata.lock().expect("metadata lock poisoned") = Some(metadata);
+    }
+
+    fn object_metadata_from_read_metadata(
+        metadata: &Metadata,
+        range: BytesRange,
+    ) -> Option<Metadata> {
+        let content_length = if range.is_full() {
+            if !metadata.has_content_length() {
+                return None;
+            }
+            metadata.content_length()
+        } else {
+            metadata.content_range().and_then(|range| range.size())?
+        };
+
+        let mut object_metadata = Metadata::new(metadata.mode())
+            .with_content_length(content_length)
+            .with_is_current(metadata.is_current());
+        object_metadata.set_is_deleted(metadata.is_deleted());
+
+        if let Some(v) = metadata.cache_control() {
+            object_metadata.set_cache_control(v);
+        }
+        if let Some(v) = metadata.content_md5() {
+            object_metadata.set_content_md5(v);
+        }
+        if let Some(v) = metadata.content_type() {
+            object_metadata.set_content_type(v);
+        }
+        if let Some(v) = metadata.content_encoding() {
+            object_metadata.set_content_encoding(v);
+        }
+        if let Some(v) = metadata.last_modified() {
+            object_metadata.set_last_modified(v);
+        }
+        if let Some(v) = metadata.etag() {
+            object_metadata.set_etag(v);
+        }
+        if let Some(v) = metadata.content_disposition() {
+            object_metadata.set_content_disposition(v);
+        }
+        if let Some(v) = metadata.version() {
+            object_metadata.set_version(v);
+        }
+        if let Some(v) = metadata.user_metadata() {
+            object_metadata = object_metadata.with_user_metadata(v.clone());
+        }
+
+        Some(object_metadata)
     }
 
     /// Parse the range bounds into a range.
@@ -173,14 +243,16 @@ impl ReadGenerator {
     }
 
     /// Generate next reader.
-    pub async fn next_reader(&mut self) -> Result<Option<oio::Reader>> {
+    pub async fn next_reader(&mut self) -> Result<Option<(Metadata, oio::Reader)>> {
         let Some(range) = self.next_range() else {
             return Ok(None);
         };
 
         let args = self.ctx.args.clone().with_range(range);
-        let (_, r) = self.ctx.acc.read(&self.ctx.path, args).await?;
-        Ok(Some(r))
+        let (rp, r) = self.ctx.acc.read(&self.ctx.path, args).await?;
+        let metadata = rp.into_metadata();
+        self.ctx.update_metadata(&metadata, range);
+        Ok(Some((metadata, r)))
     }
 }
 
@@ -208,7 +280,7 @@ mod tests {
         ));
         let mut generator = ReadGenerator::new(ctx, 0, Some(10));
         let mut readers = vec![];
-        while let Some(r) = generator.next_reader().await? {
+        while let Some((_, r)) = generator.next_reader().await? {
             readers.push(r);
         }
 
@@ -234,7 +306,7 @@ mod tests {
         ));
         let mut generator = ReadGenerator::new(ctx, 0, None);
         let mut readers = vec![];
-        while let Some(r) = generator.next_reader().await? {
+        while let Some((_, r)) = generator.next_reader().await? {
             readers.push(r);
         }
 

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -77,27 +77,15 @@ impl ReadContext {
 
     /// Get complete object metadata observed by this reader.
     #[inline]
-    pub fn metadata(&self) -> Option<Metadata> {
-        self.metadata.get().cloned()
+    pub fn metadata(&self) -> Option<&Metadata> {
+        self.metadata.get()
     }
 
     /// Set cached object metadata from read response metadata once.
     pub(crate) fn set_metadata(&self, metadata: &Metadata, range: BytesRange) {
-        let content_length = if range.is_full() {
-            if !metadata.has_content_length() {
-                return;
-            }
-            metadata.content_length()
-        } else {
-            let Some(content_length) = metadata.content_range().and_then(|range| range.size())
-            else {
-                return;
-            };
-            content_length
+        let Some(metadata) = metadata.clone().into_object_metadata(range) else {
+            return;
         };
-
-        let mut metadata = metadata.clone();
-        metadata.set_content_length(content_length);
         let _ = self.metadata.set(metadata);
     }
 

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -21,8 +21,6 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
-use mea::latch::Latch;
-
 use crate::raw::*;
 use crate::*;
 
@@ -38,8 +36,6 @@ pub struct ReadContext {
     options: OpReader,
     /// Complete object metadata observed from successful read opens.
     metadata: OnceLock<Metadata>,
-    /// Signal that a read-open metadata attempt has finished.
-    metadata_attempted: Latch,
 }
 
 impl ReadContext {
@@ -52,7 +48,6 @@ impl ReadContext {
             args,
             options,
             metadata: OnceLock::new(),
-            metadata_attempted: Latch::new(1),
         }
     }
 
@@ -89,22 +84,6 @@ impl ReadContext {
     /// Set cached object metadata observed from successful read opens once.
     pub(crate) fn set_metadata(&self, metadata: Metadata) {
         let _ = self.metadata.set(metadata);
-        self.metadata_attempted.count_down();
-    }
-
-    /// Notify waiters that a read-open metadata attempt has finished.
-    pub(crate) fn finish_metadata_attempt(&self) {
-        self.metadata_attempted.count_down();
-    }
-
-    /// Wait for metadata observed from successful read opens.
-    pub(crate) async fn wait_metadata_attempt(&self) -> Option<&Metadata> {
-        if let Some(metadata) = self.metadata() {
-            return Some(metadata);
-        }
-
-        self.metadata_attempted.wait().await;
-        self.metadata()
     }
 
     /// Parse the range bounds into a range.

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -188,7 +188,7 @@ impl ReadGenerator {
     }
 
     /// Generate next reader.
-    pub async fn next_reader(&mut self) -> Result<Option<(Metadata, oio::Reader)>> {
+    pub async fn next_reader(&mut self) -> Result<Option<oio::Reader>> {
         let Some(range) = self.next_range() else {
             return Ok(None);
         };
@@ -197,9 +197,14 @@ impl ReadGenerator {
         let (rp, r) = self.ctx.acc.read(&self.ctx.path, args).await?;
         let metadata = rp.into_metadata();
         if self.ctx.metadata().is_none() {
-            self.ctx.set_metadata(metadata.clone());
+            self.ctx.set_metadata(metadata);
         }
-        Ok(Some((metadata, r)))
+        Ok(Some(r))
+    }
+
+    /// Get metadata observed by generated readers.
+    pub(crate) fn metadata(&self) -> Option<&Metadata> {
+        self.ctx.metadata()
     }
 }
 
@@ -227,7 +232,7 @@ mod tests {
         ));
         let mut generator = ReadGenerator::new(ctx, 0, Some(10));
         let mut readers = vec![];
-        while let Some((_, r)) = generator.next_reader().await? {
+        while let Some(r) = generator.next_reader().await? {
             readers.push(r);
         }
 
@@ -253,7 +258,7 @@ mod tests {
         ));
         let mut generator = ReadGenerator::new(ctx, 0, None);
         let mut readers = vec![];
-        while let Some((_, r)) = generator.next_reader().await? {
+        while let Some(r) = generator.next_reader().await? {
             readers.push(r);
         }
 

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -19,7 +19,7 @@ use std::ops::Bound;
 use std::ops::Range;
 use std::ops::RangeBounds;
 use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::OnceLock;
 
 use crate::raw::*;
 use crate::*;
@@ -35,7 +35,7 @@ pub struct ReadContext {
     /// Options for the reader.
     options: OpReader,
     /// Complete object metadata observed from successful read opens.
-    metadata: Mutex<Option<Metadata>>,
+    metadata: OnceLock<Metadata>,
 }
 
 impl ReadContext {
@@ -47,7 +47,7 @@ impl ReadContext {
             path,
             args,
             options,
-            metadata: Mutex::new(None),
+            metadata: OnceLock::new(),
         }
     }
 
@@ -78,67 +78,27 @@ impl ReadContext {
     /// Get complete object metadata observed by this reader.
     #[inline]
     pub fn metadata(&self) -> Option<Metadata> {
-        self.metadata
-            .lock()
-            .expect("metadata lock poisoned")
-            .clone()
+        self.metadata.get().cloned()
     }
 
-    /// Update cached object metadata from read response metadata.
-    pub(crate) fn update_metadata(&self, metadata: &Metadata, range: BytesRange) {
-        let Some(metadata) = Self::object_metadata_from_read_metadata(metadata, range) else {
-            return;
-        };
-        *self.metadata.lock().expect("metadata lock poisoned") = Some(metadata);
-    }
-
-    fn object_metadata_from_read_metadata(
-        metadata: &Metadata,
-        range: BytesRange,
-    ) -> Option<Metadata> {
+    /// Set cached object metadata from read response metadata once.
+    pub(crate) fn set_metadata(&self, metadata: &Metadata, range: BytesRange) {
         let content_length = if range.is_full() {
             if !metadata.has_content_length() {
-                return None;
+                return;
             }
             metadata.content_length()
         } else {
-            metadata.content_range().and_then(|range| range.size())?
+            let Some(content_length) = metadata.content_range().and_then(|range| range.size())
+            else {
+                return;
+            };
+            content_length
         };
 
-        let mut object_metadata = Metadata::new(metadata.mode())
-            .with_content_length(content_length)
-            .with_is_current(metadata.is_current());
-        object_metadata.set_is_deleted(metadata.is_deleted());
-
-        if let Some(v) = metadata.cache_control() {
-            object_metadata.set_cache_control(v);
-        }
-        if let Some(v) = metadata.content_md5() {
-            object_metadata.set_content_md5(v);
-        }
-        if let Some(v) = metadata.content_type() {
-            object_metadata.set_content_type(v);
-        }
-        if let Some(v) = metadata.content_encoding() {
-            object_metadata.set_content_encoding(v);
-        }
-        if let Some(v) = metadata.last_modified() {
-            object_metadata.set_last_modified(v);
-        }
-        if let Some(v) = metadata.etag() {
-            object_metadata.set_etag(v);
-        }
-        if let Some(v) = metadata.content_disposition() {
-            object_metadata.set_content_disposition(v);
-        }
-        if let Some(v) = metadata.version() {
-            object_metadata.set_version(v);
-        }
-        if let Some(v) = metadata.user_metadata() {
-            object_metadata = object_metadata.with_user_metadata(v.clone());
-        }
-
-        Some(object_metadata)
+        let mut metadata = metadata.clone();
+        metadata.set_content_length(content_length);
+        let _ = self.metadata.set(metadata);
     }
 
     /// Parse the range bounds into a range.
@@ -251,7 +211,7 @@ impl ReadGenerator {
         let args = self.ctx.args.clone().with_range(range);
         let (rp, r) = self.ctx.acc.read(&self.ctx.path, args).await?;
         let metadata = rp.into_metadata();
-        self.ctx.update_metadata(&metadata, range);
+        self.ctx.set_metadata(&metadata, range);
         Ok(Some((metadata, r)))
     }
 }

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -195,10 +195,10 @@ impl ReadGenerator {
 
         let args = self.ctx.args.clone().with_range(range);
         let (rp, r) = self.ctx.acc.read(&self.ctx.path, args).await?;
-        if let Some(metadata) = rp.into_metadata()
-            && self.ctx.metadata().is_none()
-        {
-            self.ctx.set_metadata(metadata);
+        if let Some(metadata) = rp.into_metadata() {
+            if self.ctx.metadata().is_none() {
+                self.ctx.set_metadata(metadata);
+            }
         }
         Ok(Some(r))
     }

--- a/core/core/src/types/metadata.rs
+++ b/core/core/src/types/metadata.rs
@@ -56,7 +56,6 @@ pub struct Metadata {
     content_disposition: Option<String>,
     content_length: Option<u64>,
     content_md5: Option<String>,
-    content_range: Option<BytesContentRange>,
     content_type: Option<String>,
     content_encoding: Option<String>,
     etag: Option<String>,
@@ -88,9 +87,6 @@ impl fmt::Debug for Metadata {
         }
         if let Some(content_md5) = &self.content_md5 {
             ds.field("content_md5", content_md5);
-        }
-        if let Some(content_range) = self.content_range {
-            ds.field("content_range", &content_range);
         }
         if let Some(content_type) = &self.content_type {
             ds.field("content_type", content_type);
@@ -129,7 +125,6 @@ impl Metadata {
             content_md5: None,
             content_type: None,
             content_encoding: None,
-            content_range: None,
             last_modified: None,
             etag: None,
             content_disposition: None,
@@ -265,6 +260,10 @@ impl Metadata {
     ///
     /// Refer to [MDN Content-Length](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Length) for more information.
     ///
+    /// For file metadata returned by stat, list, or read operations, this value
+    /// represents the full object size, even if the read operation only returns
+    /// a range of the object.
+    ///
     /// # Returns
     ///
     /// Content length of this entry. It will be `0` if the content length is not set by the storage services.
@@ -345,48 +344,6 @@ impl Metadata {
     pub fn set_content_encoding(&mut self, v: &str) -> &mut Self {
         self.content_encoding = Some(v.to_string());
         self
-    }
-
-    /// Content Range of this entry.
-    ///
-    /// Content Range is defined by [RFC 9110](https://httpwg.org/specs/rfc9110.html#field.content-range).
-    ///
-    /// Refer to [MDN Content-Range](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range) for more information.
-    pub fn content_range(&self) -> Option<BytesContentRange> {
-        self.content_range
-    }
-
-    /// Set Content Range of this entry.
-    pub fn set_content_range(&mut self, v: BytesContentRange) -> &mut Self {
-        self.content_range = Some(v);
-        self
-    }
-
-    /// Set Content Range of this entry.
-    pub fn with_content_range(mut self, v: BytesContentRange) -> Self {
-        self.content_range = Some(v);
-        self
-    }
-
-    /// Adjust read response metadata by the requested range.
-    ///
-    /// Read metadata represents the response body: `content_length` is the
-    /// payload size and `content_range` may carry the full object size. Reader
-    /// metadata represents the object: `content_length` is the full object size
-    /// and `content_range` is unset.
-    pub(crate) fn adjust_by_range(&mut self, range: BytesRange) {
-        if range.is_full() {
-            self.content_range = None;
-            return;
-        }
-
-        self.content_length = Some(
-            self.content_range
-                .expect("range read metadata must have content range")
-                .size()
-                .expect("range read metadata must have complete object size"),
-        );
-        self.content_range = None;
     }
 
     /// Last modified of this entry.

--- a/core/core/src/types/metadata.rs
+++ b/core/core/src/types/metadata.rs
@@ -368,6 +368,23 @@ impl Metadata {
         self
     }
 
+    /// Adjust read response metadata into complete object metadata.
+    ///
+    /// Read metadata represents the response body: `content_length` is the
+    /// payload size and `content_range` may carry the full object size. Reader
+    /// metadata represents the object: `content_length` is the full object size
+    /// and `content_range` is unset.
+    pub(crate) fn into_object_metadata(mut self, range: BytesRange) -> Option<Self> {
+        if range.is_full() {
+            self.content_range = None;
+            return Some(self);
+        }
+
+        self.content_length = Some(self.content_range?.size()?);
+        self.content_range = None;
+        Some(self)
+    }
+
     /// Last modified of this entry.
     ///
     /// `Last-Modified` is defined by [RFC 7232](https://httpwg.org/specs/rfc7232.html#header.last-modified)

--- a/core/core/src/types/metadata.rs
+++ b/core/core/src/types/metadata.rs
@@ -368,21 +368,25 @@ impl Metadata {
         self
     }
 
-    /// Adjust read response metadata into complete object metadata.
+    /// Adjust read response metadata by the requested range.
     ///
     /// Read metadata represents the response body: `content_length` is the
     /// payload size and `content_range` may carry the full object size. Reader
     /// metadata represents the object: `content_length` is the full object size
     /// and `content_range` is unset.
-    pub(crate) fn into_object_metadata(mut self, range: BytesRange) -> Option<Self> {
+    pub(crate) fn adjust_by_range(&mut self, range: BytesRange) {
         if range.is_full() {
             self.content_range = None;
-            return Some(self);
+            return;
         }
 
-        self.content_length = Some(self.content_range?.size()?);
+        self.content_length = Some(
+            self.content_range
+                .expect("range read metadata must have content range")
+                .size()
+                .expect("range read metadata must have complete object size"),
+        );
         self.content_range = None;
-        Some(self)
     }
 
     /// Last modified of this entry.

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -121,7 +121,14 @@ impl ChunkedReader {
                 Box::pin(async move {
                     let args = input.ctx.args().clone().with_range(input.range);
                     let result = async {
-                        let (rp, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
+                        let (rp, mut r) =
+                            match input.ctx.accessor().read(input.ctx.path(), args).await {
+                                Ok(v) => v,
+                                Err(err) => {
+                                    input.ctx.finish_metadata_attempt();
+                                    return Err(err);
+                                }
+                            };
                         let metadata = rp.into_metadata();
                         if input.ctx.metadata().is_none() {
                             input.ctx.set_metadata(metadata);
@@ -139,6 +146,45 @@ impl ChunkedReader {
             remaining: range.size(),
             tasks,
             done: false,
+        }
+    }
+
+    async fn metadata(&mut self) -> Result<Metadata> {
+        if let Some(metadata) = self.ctx.metadata() {
+            return Ok(metadata.clone());
+        }
+
+        let mut scheduled = false;
+        if self.tasks.has_remaining() && !self.done {
+            if let Some(range) = self.next_range() {
+                scheduled = self.tasks.try_execute(ChunkedReadInput {
+                    ctx: self.ctx.clone(),
+                    range,
+                })?;
+            } else {
+                self.done = true;
+            }
+        }
+
+        if !scheduled && self.tasks.is_empty() {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "read stream doesn't have metadata before opening a reader",
+            ));
+        }
+
+        if let Some(metadata) = self.ctx.wait_metadata().await {
+            return Ok(metadata.clone());
+        }
+
+        match self.tasks.next().await.transpose()? {
+            Some(_) => self.ctx.metadata().cloned().ok_or_else(|| {
+                Error::new(ErrorKind::Unexpected, "read stream metadata is not set")
+            }),
+            None => Err(Error::new(
+                ErrorKind::Unexpected,
+                "read stream doesn't have metadata before opening a reader",
+            )),
         }
     }
 
@@ -262,26 +308,14 @@ impl BufferStream {
     /// Get metadata for this stream.
     ///
     /// Calling this method opens the underlying read request if needed.
-    /// Chunked reads may read and buffer the first chunk so following stream
-    /// polling can reuse it.
+    /// Chunked reads wait until one chunk read has opened and observed metadata.
     pub async fn metadata(&mut self) -> Result<Metadata> {
         match std::mem::replace(&mut self.state, State::Idle(None)) {
             State::Idle(reader) => {
                 let mut reader = reader.expect("reader must exist while idle");
                 let result = match &mut reader {
                     TwoWays::One(v) => v.metadata().await,
-                    TwoWays::Two(v) => {
-                        if let Some(metadata) = v.ctx.metadata() {
-                            Ok(metadata.clone())
-                        } else {
-                            let buffer = v.read().await?;
-                            let metadata = v.ctx.metadata().cloned().ok_or_else(|| {
-                                Error::new(ErrorKind::Unexpected, "read stream metadata is not set")
-                            })?;
-                            self.pending = Some(Ok(buffer));
-                            Ok(metadata)
-                        }
-                    }
+                    TwoWays::Two(v) => v.metadata().await,
                 };
                 self.state = State::Idle(Some(reader));
                 result

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -48,16 +48,20 @@ impl StreamingReader {
         }
     }
 
-    async fn metadata(&mut self) -> Result<Metadata> {
-        if let Some(metadata) = self.generator.metadata() {
-            return Ok(metadata.clone());
+    async fn prepare_metadata(&mut self) -> Result<bool> {
+        if self.generator.metadata().is_some() {
+            return Ok(true);
         }
 
         if self.reader.is_none() {
-            if let Some(reader) = self.generator.next_reader().await? {
-                self.reader = Some(reader);
-            }
+            self.reader = self.generator.next_reader().await?;
         }
+
+        Ok(self.generator.metadata().is_some())
+    }
+
+    async fn metadata(&mut self) -> Result<Metadata> {
+        let _ = self.prepare_metadata().await?;
 
         self.generator
             .metadata()
@@ -89,10 +93,16 @@ impl oio::Read for StreamingReader {
     }
 }
 
-/// Input for a chunked read task.
-struct ChunkedReadInput {
-    ctx: Arc<ReadContext>,
-    range: BytesRange,
+enum ChunkedReadInput {
+    Range {
+        ctx: Arc<ReadContext>,
+        range: BytesRange,
+    },
+    Opened {
+        ctx: Arc<ReadContext>,
+        range: BytesRange,
+        reader: oio::Reader,
+    },
 }
 
 /// ChunkedReader will read the file in chunks.
@@ -102,6 +112,7 @@ pub struct ChunkedReader {
     ctx: Arc<ReadContext>,
     offset: u64,
     remaining: Option<u64>,
+    opened: Option<(BytesRange, oio::Reader)>,
     tasks: ConcurrentTasks<ChunkedReadInput, Buffer>,
     done: bool,
 }
@@ -119,24 +130,29 @@ impl ChunkedReader {
             ctx.options().prefetch(),
             |input: ChunkedReadInput| {
                 Box::pin(async move {
-                    let args = input.ctx.args().clone().with_range(input.range);
-                    let result = async {
-                        let (rp, mut r) =
-                            match input.ctx.accessor().read(input.ctx.path(), args).await {
-                                Ok(v) => v,
-                                Err(err) => {
-                                    input.ctx.finish_metadata_attempt();
-                                    return Err(err);
+                    match input {
+                        ChunkedReadInput::Range { ctx, range } => {
+                            let args = ctx.args().clone().with_range(range);
+                            let result = async {
+                                let (rp, mut r) = ctx.accessor().read(ctx.path(), args).await?;
+                                let metadata = rp.into_metadata();
+                                if ctx.metadata().is_none() {
+                                    ctx.set_metadata(metadata);
                                 }
-                            };
-                        let metadata = rp.into_metadata();
-                        if input.ctx.metadata().is_none() {
-                            input.ctx.set_metadata(metadata);
+                                r.read_all().await
+                            }
+                            .await;
+                            (ChunkedReadInput::Range { ctx, range }, result)
                         }
-                        r.read_all().await
+                        ChunkedReadInput::Opened {
+                            ctx,
+                            range,
+                            mut reader,
+                        } => {
+                            let result = reader.read_all().await;
+                            (ChunkedReadInput::Range { ctx, range }, result)
+                        }
                     }
-                    .await;
-                    (input, result)
                 })
             },
         );
@@ -144,48 +160,41 @@ impl ChunkedReader {
             ctx,
             offset: range.offset(),
             remaining: range.size(),
+            opened: None,
             tasks,
             done: false,
         }
     }
 
-    async fn metadata(&mut self) -> Result<Metadata> {
-        if let Some(metadata) = self.ctx.metadata() {
-            return Ok(metadata.clone());
+    async fn prepare_metadata(&mut self) -> Result<bool> {
+        if self.ctx.metadata().is_some() {
+            return Ok(true);
         }
 
-        let mut scheduled = false;
-        if self.tasks.has_remaining() && !self.done {
+        if self.opened.is_none() {
             if let Some(range) = self.next_range() {
-                scheduled = self.tasks.try_schedule(ChunkedReadInput {
-                    ctx: self.ctx.clone(),
-                    range,
-                })?;
+                let args = self.ctx.args().clone().with_range(range);
+                let (rp, reader) = self.ctx.accessor().read(self.ctx.path(), args).await?;
+                let metadata = rp.into_metadata();
+                if self.ctx.metadata().is_none() {
+                    self.ctx.set_metadata(metadata);
+                }
+                self.opened = Some((range, reader));
             } else {
                 self.done = true;
             }
         }
 
-        if !scheduled && self.tasks.is_empty() {
-            return Err(Error::new(
-                ErrorKind::Unexpected,
-                "read stream doesn't have metadata before opening a reader",
-            ));
-        }
+        Ok(self.ctx.metadata().is_some())
+    }
 
-        if let Some(metadata) = self.ctx.wait_metadata_attempt().await {
-            return Ok(metadata.clone());
-        }
+    async fn metadata(&mut self) -> Result<Metadata> {
+        let _ = self.prepare_metadata().await?;
 
-        match self.tasks.next().await.transpose()? {
-            Some(_) => self.ctx.metadata().cloned().ok_or_else(|| {
-                Error::new(ErrorKind::Unexpected, "read stream metadata is not set")
-            }),
-            None => Err(Error::new(
-                ErrorKind::Unexpected,
-                "read stream doesn't have metadata before opening a reader",
-            )),
-        }
+        self.ctx
+            .metadata()
+            .cloned()
+            .ok_or_else(|| Error::new(ErrorKind::Unexpected, "read stream metadata is not set"))
     }
 
     /// Generate the next range to read, advancing internal state.
@@ -219,9 +228,17 @@ impl ChunkedReader {
 impl oio::Read for ChunkedReader {
     async fn read(&mut self) -> Result<Buffer> {
         while self.tasks.has_remaining() && !self.done {
-            if let Some(range) = self.next_range() {
+            if let Some((range, reader)) = self.opened.take() {
                 self.tasks
-                    .execute(ChunkedReadInput {
+                    .execute(ChunkedReadInput::Opened {
+                        ctx: self.ctx.clone(),
+                        range,
+                        reader,
+                    })
+                    .await?;
+            } else if let Some(range) = self.next_range() {
+                self.tasks
+                    .execute(ChunkedReadInput::Range {
                         ctx: self.ctx.clone(),
                         range,
                     })
@@ -248,8 +265,6 @@ impl oio::Read for ChunkedReader {
 /// `BufferStream` implements `Stream` trait.
 pub struct BufferStream {
     ctx: Arc<ReadContext>,
-    /// Buffer produced while `metadata` awaits an in-flight read.
-    pending: Option<Buffer>,
     /// # Notes to maintainers
     ///
     /// The underlying reader is either a StreamingReader or a ChunkedReader.
@@ -263,6 +278,7 @@ pub struct BufferStream {
 #[allow(clippy::large_enum_variant)]
 enum State {
     Idle(Option<TwoWays<StreamingReader, ChunkedReader>>),
+    Opening(BoxedStaticFuture<(TwoWays<StreamingReader, ChunkedReader>, Result<bool>)>),
     Reading(BoxedStaticFuture<(TwoWays<StreamingReader, ChunkedReader>, Result<Buffer>)>),
 }
 
@@ -288,7 +304,6 @@ impl BufferStream {
 
         Self {
             ctx,
-            pending: None,
             state: State::Idle(Some(reader)),
         }
     }
@@ -310,7 +325,6 @@ impl BufferStream {
 
         Ok(Self {
             ctx,
-            pending: None,
             state: State::Idle(Some(reader)),
         })
     }
@@ -327,22 +341,23 @@ impl BufferStream {
         match std::mem::replace(&mut self.state, State::Idle(None)) {
             State::Idle(reader) => {
                 let mut reader = reader.expect("reader must exist while idle");
-                let result = match &mut reader {
+                let prepared = match &mut reader {
                     TwoWays::One(v) => v.metadata().await,
                     TwoWays::Two(v) => v.metadata().await,
                 };
                 self.state = State::Idle(Some(reader));
-                result
+                prepared
+            }
+            State::Opening(fut) => {
+                let (reader, prepared) = fut.await;
+                self.state = State::Idle(Some(reader));
+                let _ = prepared?;
+                self.ctx.metadata().cloned().ok_or_else(|| {
+                    Error::new(ErrorKind::Unexpected, "read stream metadata is not set")
+                })
             }
             State::Reading(fut) => {
-                let (reader, buffer) = fut.await;
-                self.state = State::Idle(Some(reader));
-
-                let buffer = buffer?;
-                if !buffer.is_empty() {
-                    self.pending = Some(buffer);
-                }
-
+                self.state = State::Reading(fut);
                 self.ctx.metadata().cloned().ok_or_else(|| {
                     Error::new(ErrorKind::Unexpected, "read stream metadata is not set")
                 })
@@ -357,18 +372,48 @@ impl Stream for BufferStream {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         loop {
-            if let Some(buf) = this.pending.take() {
-                return Poll::Ready(Some(Ok(buf)));
-            }
-
             match &mut this.state {
                 State::Idle(reader) => {
                     let mut reader = reader.take().unwrap();
+                    if this.ctx.metadata().is_none() {
+                        let fut = async move {
+                            let ret = match &mut reader {
+                                TwoWays::One(v) => v.prepare_metadata().await,
+                                TwoWays::Two(v) => v.prepare_metadata().await,
+                            };
+                            (reader, ret)
+                        };
+                        this.state = State::Opening(Box::pin(fut));
+                        continue;
+                    }
+
                     let fut = async move {
                         let ret = reader.read().await;
                         (reader, ret)
                     };
                     this.state = State::Reading(Box::pin(fut));
+                }
+                State::Opening(fut) => {
+                    let fut = fut.as_mut();
+                    let (reader, prepared) = ready!(fut.poll(cx));
+                    match prepared {
+                        Ok(true) => {
+                            let fut = async move {
+                                let mut reader = reader;
+                                let ret = reader.read().await;
+                                (reader, ret)
+                            };
+                            this.state = State::Reading(Box::pin(fut));
+                        }
+                        Ok(false) => {
+                            this.state = State::Idle(Some(reader));
+                            return Poll::Ready(None);
+                        }
+                        Err(err) => {
+                            this.state = State::Idle(Some(reader));
+                            return Poll::Ready(Some(Err(err)));
+                        }
+                    }
                 }
                 State::Reading(fut) => {
                     let fut = fut.as_mut();
@@ -443,7 +488,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_metadata_awaits_inflight_read() -> Result<()> {
+    async fn test_metadata_awaits_inflight_open() -> Result<()> {
         let acc = Operator::via_iter(services::MEMORY_SCHEME, [])?.into_inner();
         let ctx = Arc::new(ReadContext::new(
             acc,
@@ -451,23 +496,22 @@ mod tests {
             OpRead::new(),
             OpReader::new(),
         ));
-        let reader = StreamingReader::new(ctx.clone(), BytesRange::new(0, Some(0)));
+        let reader = StreamingReader {
+            generator: ReadGenerator::new(ctx.clone(), 0, Some(0)),
+            reader: Some(Box::new(Buffer::from(Bytes::from_static(b"oWor")))),
+        };
         let (tx, rx) = oneshot::channel();
 
         let ctx_in_fut = ctx.clone();
         let fut = async move {
             let _ = rx.await;
             ctx_in_fut.set_metadata(Metadata::new(EntryMode::FILE).with_content_length(10));
-            (
-                TwoWays::One(reader),
-                Ok(Buffer::from(Bytes::from_static(b"oWor"))),
-            )
+            (TwoWays::One(reader), Ok(true))
         };
 
         let mut stream = BufferStream {
             ctx,
-            pending: None,
-            state: State::Reading(Box::pin(fut)),
+            state: State::Opening(Box::pin(fut)),
         };
 
         let _ = tx.send(());

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -55,17 +55,11 @@ impl StreamingReader {
             let Some((metadata, reader)) = self.generator.next_reader().await? else {
                 return Ok(false);
             };
-            self.metadata = metadata;
+            self.metadata = Some(metadata);
             self.reader = Some(reader);
         }
 
         Ok(true)
-    }
-
-    fn metadata_ref(&self) -> Option<&Metadata> {
-        self.metadata
-            .as_ref()
-            .or_else(|| self.generator.read_metadata())
     }
 
     async fn metadata(&mut self) -> Result<Metadata> {
@@ -76,7 +70,8 @@ impl StreamingReader {
             ));
         }
 
-        self.metadata_ref()
+        self.metadata
+            .as_ref()
             .cloned()
             .ok_or_else(|| Error::new(ErrorKind::Unexpected, "read stream metadata is not set"))
     }
@@ -115,7 +110,7 @@ pub struct ChunkedReader {
     ctx: Arc<ReadContext>,
     offset: u64,
     remaining: Option<u64>,
-    tasks: ConcurrentTasks<ChunkedReadInput, (Option<Metadata>, Buffer)>,
+    tasks: ConcurrentTasks<ChunkedReadInput, (Metadata, Buffer)>,
     pending: Option<Buffer>,
     metadata: Option<Metadata>,
     done: bool,
@@ -137,7 +132,8 @@ impl ChunkedReader {
                     let args = input.ctx.args().clone().with_range(input.range);
                     let result = async {
                         let (rp, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
-                        let metadata = input.ctx.set_metadata(rp.into_metadata(), input.range);
+                        let metadata = rp.into_metadata();
+                        input.ctx.set_metadata(metadata.clone(), input.range);
                         let buffer = r.read_all().await?;
                         Ok((metadata, buffer))
                     }
@@ -157,12 +153,8 @@ impl ChunkedReader {
         }
     }
 
-    fn metadata_ref(&self) -> Option<&Metadata> {
-        self.metadata.as_ref().or_else(|| self.ctx.read_metadata())
-    }
-
     async fn metadata(&mut self) -> Result<Metadata> {
-        if let Some(metadata) = self.metadata_ref() {
+        if let Some(metadata) = self.metadata.as_ref() {
             return Ok(metadata.clone());
         }
 
@@ -174,13 +166,14 @@ impl ChunkedReader {
         };
 
         self.pending = Some(buffer);
-        self.metadata = metadata;
-        self.metadata_ref()
+        self.metadata = Some(metadata);
+        self.metadata
+            .as_ref()
             .cloned()
             .ok_or_else(|| Error::new(ErrorKind::Unexpected, "read stream metadata is not set"))
     }
 
-    async fn next_output(&mut self) -> Result<Option<(Option<Metadata>, Buffer)>> {
+    async fn next_output(&mut self) -> Result<Option<(Metadata, Buffer)>> {
         while self.tasks.has_remaining() && !self.done {
             if let Some(range) = self.next_range() {
                 self.tasks
@@ -240,7 +233,7 @@ impl oio::Read for ChunkedReader {
         };
 
         if self.metadata.is_none() {
-            self.metadata = metadata;
+            self.metadata = Some(metadata);
         }
         Ok(buffer)
     }

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -224,13 +224,11 @@ pub struct BufferStream {
     state: State,
 }
 
+#[allow(clippy::large_enum_variant)]
 enum State {
-    Idle(Option<BufferStreamReader>),
-    Reading(BufferStreamFuture),
+    Idle(Option<TwoWays<StreamingReader, ChunkedReader>>),
+    Reading(BoxedStaticFuture<(TwoWays<StreamingReader, ChunkedReader>, Result<Buffer>)>),
 }
-
-type BufferStreamReader = Box<TwoWays<StreamingReader, ChunkedReader>>;
-type BufferStreamFuture = BoxedStaticFuture<(BufferStreamReader, Result<Buffer>)>;
 
 impl BufferStream {
     /// Create a new buffer stream with already calculated offset and size.
@@ -247,7 +245,7 @@ impl BufferStream {
         };
 
         Self {
-            state: State::Idle(Some(Box::new(reader))),
+            state: State::Idle(Some(reader)),
         }
     }
 
@@ -267,7 +265,7 @@ impl BufferStream {
         };
 
         Ok(Self {
-            state: State::Idle(Some(Box::new(reader))),
+            state: State::Idle(Some(reader)),
         })
     }
 
@@ -279,7 +277,7 @@ impl BufferStream {
         match &mut self.state {
             State::Idle(reader) => {
                 let reader = reader.as_mut().expect("reader must exist while idle");
-                match reader.as_mut() {
+                match reader {
                     TwoWays::One(v) => v.metadata().await,
                     TwoWays::Two(v) => v.metadata().await,
                 }

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -50,32 +50,42 @@ impl StreamingReader {
         }
     }
 
-    async fn prepare(&mut self) -> Result<Option<Metadata>> {
+    async fn prepare(&mut self) -> Result<bool> {
         if self.reader.is_none() {
             let Some((metadata, reader)) = self.generator.next_reader().await? else {
-                return Ok(None);
+                return Ok(false);
             };
-            self.metadata = Some(metadata);
+            self.metadata = metadata;
             self.reader = Some(reader);
         }
 
-        Ok(self.metadata.clone())
+        Ok(true)
+    }
+
+    fn metadata_ref(&self) -> Option<&Metadata> {
+        self.metadata
+            .as_ref()
+            .or_else(|| self.generator.read_metadata())
     }
 
     async fn metadata(&mut self) -> Result<Metadata> {
-        self.prepare().await?.ok_or_else(|| {
-            Error::new(
+        if !self.prepare().await? {
+            return Err(Error::new(
                 ErrorKind::Unexpected,
                 "read stream doesn't have metadata before opening a reader",
-            )
-        })
+            ));
+        }
+
+        self.metadata_ref()
+            .cloned()
+            .ok_or_else(|| Error::new(ErrorKind::Unexpected, "read stream metadata is not set"))
     }
 }
 
 impl oio::Read for StreamingReader {
     async fn read(&mut self) -> Result<Buffer> {
         loop {
-            self.prepare().await?;
+            let _ = self.prepare().await?;
             let Some(r) = self.reader.as_mut() else {
                 return Ok(Buffer::new());
             };
@@ -105,7 +115,7 @@ pub struct ChunkedReader {
     ctx: Arc<ReadContext>,
     offset: u64,
     remaining: Option<u64>,
-    tasks: ConcurrentTasks<ChunkedReadInput, (Metadata, Buffer)>,
+    tasks: ConcurrentTasks<ChunkedReadInput, (Option<Metadata>, Buffer)>,
     pending: Option<Buffer>,
     metadata: Option<Metadata>,
     done: bool,
@@ -127,8 +137,7 @@ impl ChunkedReader {
                     let args = input.ctx.args().clone().with_range(input.range);
                     let result = async {
                         let (rp, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
-                        let metadata = rp.into_metadata();
-                        input.ctx.set_metadata(&metadata, input.range);
+                        let metadata = input.ctx.set_metadata(rp.into_metadata(), input.range);
                         let buffer = r.read_all().await?;
                         Ok((metadata, buffer))
                     }
@@ -148,9 +157,13 @@ impl ChunkedReader {
         }
     }
 
+    fn metadata_ref(&self) -> Option<&Metadata> {
+        self.metadata.as_ref().or_else(|| self.ctx.read_metadata())
+    }
+
     async fn metadata(&mut self) -> Result<Metadata> {
-        if let Some(metadata) = self.metadata.clone() {
-            return Ok(metadata);
+        if let Some(metadata) = self.metadata_ref() {
+            return Ok(metadata.clone());
         }
 
         let Some((metadata, buffer)) = self.next_output().await? else {
@@ -161,11 +174,13 @@ impl ChunkedReader {
         };
 
         self.pending = Some(buffer);
-        self.metadata = Some(metadata.clone());
-        Ok(metadata)
+        self.metadata = metadata;
+        self.metadata_ref()
+            .cloned()
+            .ok_or_else(|| Error::new(ErrorKind::Unexpected, "read stream metadata is not set"))
     }
 
-    async fn next_output(&mut self) -> Result<Option<(Metadata, Buffer)>> {
+    async fn next_output(&mut self) -> Result<Option<(Option<Metadata>, Buffer)>> {
         while self.tasks.has_remaining() && !self.done {
             if let Some(range) = self.next_range() {
                 self.tasks
@@ -225,7 +240,7 @@ impl oio::Read for ChunkedReader {
         };
 
         if self.metadata.is_none() {
-            self.metadata = Some(metadata);
+            self.metadata = metadata;
         }
         Ok(buffer)
     }

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -50,24 +50,9 @@ impl StreamingReader {
         }
     }
 
-    async fn prepare(&mut self) -> Result<bool> {
-        if self.reader.is_none() {
-            let Some((metadata, reader)) = self.generator.next_reader().await? else {
-                return Ok(false);
-            };
-            self.metadata = Some(metadata);
-            self.reader = Some(reader);
-        }
-
-        Ok(true)
-    }
-
     async fn metadata(&mut self) -> Result<Metadata> {
-        if !self.prepare().await? {
-            return Err(Error::new(
-                ErrorKind::Unexpected,
-                "read stream doesn't have metadata before opening a reader",
-            ));
+        if self.metadata.is_none() {
+            self.open().await?;
         }
 
         self.metadata
@@ -75,12 +60,32 @@ impl StreamingReader {
             .cloned()
             .ok_or_else(|| Error::new(ErrorKind::Unexpected, "read stream metadata is not set"))
     }
+
+    async fn open(&mut self) -> Result<()> {
+        let Some((metadata, reader)) = self.generator.next_reader().await? else {
+            return Ok(());
+        };
+
+        self.metadata = Some(metadata);
+        self.reader = Some(reader);
+        Ok(())
+    }
+
+    fn metadata_ref(&self) -> Option<&Metadata> {
+        self.metadata.as_ref()
+    }
 }
 
 impl oio::Read for StreamingReader {
     async fn read(&mut self) -> Result<Buffer> {
         loop {
-            let _ = self.prepare().await?;
+            if self.reader.is_none() {
+                if self.metadata.is_some() {
+                    return Ok(Buffer::new());
+                }
+                self.open().await?;
+            }
+
             let Some(r) = self.reader.as_mut() else {
                 return Ok(Buffer::new());
             };
@@ -133,7 +138,6 @@ impl ChunkedReader {
                     let result = async {
                         let (rp, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
                         let metadata = rp.into_metadata();
-                        input.ctx.set_metadata(metadata.clone());
                         let buffer = r.read_all().await?;
                         Ok((metadata, buffer))
                     }
@@ -166,11 +170,22 @@ impl ChunkedReader {
         };
 
         self.pending = Some(buffer);
-        self.metadata = Some(metadata);
+        self.set_metadata(metadata);
         self.metadata
             .as_ref()
             .cloned()
             .ok_or_else(|| Error::new(ErrorKind::Unexpected, "read stream metadata is not set"))
+    }
+
+    fn metadata_ref(&self) -> Option<&Metadata> {
+        self.metadata.as_ref()
+    }
+
+    fn set_metadata(&mut self, metadata: Metadata) {
+        if self.metadata.is_none() {
+            self.ctx.set_metadata(metadata.clone());
+            self.metadata = Some(metadata);
+        }
     }
 
     async fn next_output(&mut self) -> Result<Option<(Metadata, Buffer)>> {
@@ -232,9 +247,7 @@ impl oio::Read for ChunkedReader {
             return Ok(Buffer::new());
         };
 
-        if self.metadata.is_none() {
-            self.metadata = Some(metadata);
-        }
+        self.set_metadata(metadata);
         Ok(buffer)
     }
 }
@@ -251,6 +264,8 @@ pub struct BufferStream {
     ///   data in streaming way.
     /// - Otherwise, BufferStream will use ChunkedReader to read data in chunks.
     state: State,
+    metadata: Option<Metadata>,
+    pending: Option<Result<Buffer>>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -275,6 +290,8 @@ impl BufferStream {
 
         Self {
             state: State::Idle(Some(reader)),
+            metadata: None,
+            pending: None,
         }
     }
 
@@ -295,6 +312,8 @@ impl BufferStream {
 
         Ok(Self {
             state: State::Idle(Some(reader)),
+            metadata: None,
+            pending: None,
         })
     }
 
@@ -304,18 +323,43 @@ impl BufferStream {
     /// Chunked reads may read and buffer the first chunk so following stream
     /// polling can reuse it.
     pub async fn metadata(&mut self) -> Result<Metadata> {
-        match &mut self.state {
-            State::Idle(reader) => {
-                let reader = reader.as_mut().expect("reader must exist while idle");
-                match reader {
-                    TwoWays::One(v) => v.metadata().await,
-                    TwoWays::Two(v) => v.metadata().await,
+        loop {
+            if let Some(metadata) = self.metadata.as_ref() {
+                return Ok(metadata.clone());
+            }
+
+            match std::mem::replace(&mut self.state, State::Idle(None)) {
+                State::Idle(reader) => {
+                    let mut reader = reader.expect("reader must exist while idle");
+                    let result = match &mut reader {
+                        TwoWays::One(v) => v.metadata().await,
+                        TwoWays::Two(v) => v.metadata().await,
+                    };
+                    self.state = State::Idle(Some(reader));
+
+                    self.metadata = Some(result?);
+                }
+                State::Reading(fut) => {
+                    let (reader, result) = fut.await;
+
+                    self.metadata = match &reader {
+                        TwoWays::One(v) => v.metadata_ref().cloned(),
+                        TwoWays::Two(v) => v.metadata_ref().cloned(),
+                    };
+                    self.state = State::Idle(Some(reader));
+
+                    if self.metadata.is_some() {
+                        self.pending = Some(result);
+                    } else {
+                        self.pending = None;
+                        result?;
+                        return Err(Error::new(
+                            ErrorKind::Unexpected,
+                            "read stream metadata is not set",
+                        ));
+                    }
                 }
             }
-            State::Reading(_) => Err(Error::new(
-                ErrorKind::Unexpected,
-                "can't get metadata while read stream is being polled",
-            )),
         }
     }
 }
@@ -326,6 +370,14 @@ impl Stream for BufferStream {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         loop {
+            if let Some(buf) = this.pending.take() {
+                return match buf {
+                    Ok(buf) if buf.is_empty() => Poll::Ready(None),
+                    Ok(buf) => Poll::Ready(Some(Ok(buf))),
+                    Err(err) => Poll::Ready(Some(Err(err))),
+                };
+            }
+
             match &mut this.state {
                 State::Idle(reader) => {
                     let mut reader = reader.take().unwrap();
@@ -338,6 +390,12 @@ impl Stream for BufferStream {
                 State::Reading(fut) => {
                     let fut = fut.as_mut();
                     let (reader, buf) = ready!(fut.poll(cx));
+                    if this.metadata.is_none() {
+                        this.metadata = match &reader {
+                            TwoWays::One(v) => v.metadata_ref().cloned(),
+                            TwoWays::Two(v) => v.metadata_ref().cloned(),
+                        };
+                    }
                     this.state = State::Idle(Some(reader));
                     return match buf {
                         Ok(buf) if buf.is_empty() => Poll::Ready(None),

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -131,10 +131,10 @@ impl ChunkedReader {
 
                         let args = input.ctx.args().clone().with_range(input.range);
                         let (rp, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
-                        if let Some(metadata) = rp.into_metadata()
-                            && input.ctx.metadata().is_none()
-                        {
-                            input.ctx.set_metadata(metadata);
+                        if let Some(metadata) = rp.into_metadata() {
+                            if input.ctx.metadata().is_none() {
+                                input.ctx.set_metadata(metadata);
+                            }
                         }
                         r.read_all().await
                     }
@@ -162,10 +162,10 @@ impl ChunkedReader {
             if let Some(range) = self.next_range() {
                 let args = self.ctx.args().clone().with_range(range);
                 let (rp, reader) = self.ctx.accessor().read(self.ctx.path(), args).await?;
-                if let Some(metadata) = rp.into_metadata()
-                    && self.ctx.metadata().is_none()
-                {
-                    self.ctx.set_metadata(metadata);
+                if let Some(metadata) = rp.into_metadata() {
+                    if self.ctx.metadata().is_none() {
+                        self.ctx.set_metadata(metadata);
+                    }
                 }
                 self.opened = Some(ChunkedReadInput {
                     ctx: self.ctx.clone(),
@@ -430,5 +430,4 @@ mod tests {
 
         Ok(())
     }
-
 }

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -157,7 +157,7 @@ impl ChunkedReader {
         let mut scheduled = false;
         if self.tasks.has_remaining() && !self.done {
             if let Some(range) = self.next_range() {
-                scheduled = self.tasks.try_execute(ChunkedReadInput {
+                scheduled = self.tasks.try_schedule(ChunkedReadInput {
                     ctx: self.ctx.clone(),
                     range,
                 })?;
@@ -173,7 +173,7 @@ impl ChunkedReader {
             ));
         }
 
-        if let Some(metadata) = self.ctx.wait_metadata().await {
+        if let Some(metadata) = self.ctx.wait_metadata_attempt().await {
             return Ok(metadata.clone());
         }
 
@@ -248,6 +248,8 @@ impl oio::Read for ChunkedReader {
 /// `BufferStream` implements `Stream` trait.
 pub struct BufferStream {
     ctx: Arc<ReadContext>,
+    /// Buffer produced while `metadata` awaits an in-flight read.
+    pending: Option<Buffer>,
     /// # Notes to maintainers
     ///
     /// The underlying reader is either a StreamingReader or a ChunkedReader.
@@ -286,6 +288,7 @@ impl BufferStream {
 
         Self {
             ctx,
+            pending: None,
             state: State::Idle(Some(reader)),
         }
     }
@@ -307,6 +310,7 @@ impl BufferStream {
 
         Ok(Self {
             ctx,
+            pending: None,
             state: State::Idle(Some(reader)),
         })
     }
@@ -331,11 +335,17 @@ impl BufferStream {
                 result
             }
             State::Reading(fut) => {
-                self.state = State::Reading(fut);
-                Err(Error::new(
-                    ErrorKind::Unexpected,
-                    "read stream metadata is not ready while read stream is being polled",
-                ))
+                let (reader, buffer) = fut.await;
+                self.state = State::Idle(Some(reader));
+
+                let buffer = buffer?;
+                if !buffer.is_empty() {
+                    self.pending = Some(buffer);
+                }
+
+                self.ctx.metadata().cloned().ok_or_else(|| {
+                    Error::new(ErrorKind::Unexpected, "read stream metadata is not set")
+                })
             }
         }
     }
@@ -347,6 +357,10 @@ impl Stream for BufferStream {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         loop {
+            if let Some(buf) = this.pending.take() {
+                return Poll::Ready(Some(Ok(buf)));
+            }
+
             match &mut this.state {
                 State::Idle(reader) => {
                     let mut reader = reader.take().unwrap();
@@ -379,6 +393,7 @@ mod tests {
     use bytes::Bytes;
     use futures::TryStreamExt;
     use pretty_assertions::assert_eq;
+    use tokio::sync::oneshot;
 
     use super::*;
 
@@ -423,6 +438,45 @@ mod tests {
         let buf: Buffer = bufs.into_iter().flatten().collect();
         assert_eq!(buf.len(), 4);
         assert_eq!(&buf.to_vec(), "oWor".as_bytes());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_metadata_awaits_inflight_read() -> Result<()> {
+        let acc = Operator::via_iter(services::MEMORY_SCHEME, [])?.into_inner();
+        let ctx = Arc::new(ReadContext::new(
+            acc,
+            "test".to_string(),
+            OpRead::new(),
+            OpReader::new(),
+        ));
+        let reader = StreamingReader::new(ctx.clone(), BytesRange::new(0, Some(0)));
+        let (tx, rx) = oneshot::channel();
+
+        let ctx_in_fut = ctx.clone();
+        let fut = async move {
+            let _ = rx.await;
+            ctx_in_fut.set_metadata(Metadata::new(EntryMode::FILE).with_content_length(10));
+            (
+                TwoWays::One(reader),
+                Ok(Buffer::from(Bytes::from_static(b"oWor"))),
+            )
+        };
+
+        let mut stream = BufferStream {
+            ctx,
+            pending: None,
+            state: State::Reading(Box::pin(fut)),
+        };
+
+        let _ = tx.send(());
+        let meta = stream.metadata().await?;
+        assert_eq!(meta.content_length(), 10);
+
+        let bufs: Vec<_> = stream.try_collect().await?;
+        let buf: Buffer = bufs.into_iter().flatten().collect();
+        assert_eq!(&buf.to_vec(), b"oWor");
 
         Ok(())
     }

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -103,10 +103,10 @@ struct ChunkedReadInput {
 /// ChunkedReader is good for concurrent read and optimized for throughput.
 pub struct ChunkedReader {
     ctx: Arc<ReadContext>,
-    range: BytesRange,
     offset: u64,
     remaining: Option<u64>,
-    tasks: ConcurrentTasks<ChunkedReadInput, Buffer>,
+    tasks: ConcurrentTasks<ChunkedReadInput, (Metadata, Buffer)>,
+    pending: Option<Buffer>,
     metadata: Option<Metadata>,
     done: bool,
 }
@@ -129,7 +129,8 @@ impl ChunkedReader {
                         let (rp, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
                         let metadata = rp.into_metadata();
                         input.ctx.set_metadata(&metadata, input.range);
-                        r.read_all().await
+                        let buffer = r.read_all().await?;
+                        Ok((metadata, buffer))
                     }
                     .await;
                     (input, result)
@@ -138,10 +139,10 @@ impl ChunkedReader {
         );
         Self {
             ctx,
-            range,
             offset: range.offset(),
             remaining: range.size(),
             tasks,
+            pending: None,
             metadata: None,
             done: false,
         }
@@ -152,12 +153,37 @@ impl ChunkedReader {
             return Ok(metadata);
         }
 
-        let args = self.ctx.args().clone().with_range(self.range);
-        let (rp, _) = self.ctx.accessor().read(self.ctx.path(), args).await?;
-        let metadata = rp.into_metadata();
-        self.ctx.set_metadata(&metadata, self.range);
+        let Some((metadata, buffer)) = self.next_output().await? else {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "read stream doesn't have metadata before opening a reader",
+            ));
+        };
+
+        self.pending = Some(buffer);
         self.metadata = Some(metadata.clone());
         Ok(metadata)
+    }
+
+    async fn next_output(&mut self) -> Result<Option<(Metadata, Buffer)>> {
+        while self.tasks.has_remaining() && !self.done {
+            if let Some(range) = self.next_range() {
+                self.tasks
+                    .execute(ChunkedReadInput {
+                        ctx: self.ctx.clone(),
+                        range,
+                    })
+                    .await?;
+            } else {
+                self.done = true;
+                break;
+            }
+            if self.tasks.has_result() {
+                break;
+            }
+        }
+
+        self.tasks.next().await.transpose()
     }
 
     /// Generate the next range to read, advancing internal state.
@@ -190,23 +216,18 @@ impl ChunkedReader {
 
 impl oio::Read for ChunkedReader {
     async fn read(&mut self) -> Result<Buffer> {
-        while self.tasks.has_remaining() && !self.done {
-            if let Some(range) = self.next_range() {
-                self.tasks
-                    .execute(ChunkedReadInput {
-                        ctx: self.ctx.clone(),
-                        range,
-                    })
-                    .await?;
-            } else {
-                self.done = true;
-                break;
-            }
-            if self.tasks.has_result() {
-                break;
-            }
+        if let Some(buffer) = self.pending.take() {
+            return Ok(buffer);
         }
-        Ok(self.tasks.next().await.transpose()?.unwrap_or_default())
+
+        let Some((metadata, buffer)) = self.next_output().await? else {
+            return Ok(Buffer::new());
+        };
+
+        if self.metadata.is_none() {
+            self.metadata = Some(metadata);
+        }
+        Ok(buffer)
     }
 }
 
@@ -271,8 +292,9 @@ impl BufferStream {
 
     /// Get metadata for this stream.
     ///
-    /// Calling this method opens the underlying read request if needed, but
-    /// doesn't consume the response body.
+    /// Calling this method opens the underlying read request if needed.
+    /// Chunked reads may read and buffer the first chunk so following stream
+    /// polling can reuse it.
     pub async fn metadata(&mut self) -> Result<Metadata> {
         match &mut self.state {
             State::Idle(reader) => {

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -48,25 +48,25 @@ impl StreamingReader {
         }
     }
 
-    async fn prepare_metadata(&mut self) -> Result<bool> {
+    async fn prepare_metadata(&mut self) -> Result<()> {
         if self.generator.metadata().is_some() {
-            return Ok(true);
+            return Ok(());
         }
 
         if self.reader.is_none() {
             self.reader = self.generator.next_reader().await?;
         }
 
-        Ok(self.generator.metadata().is_some())
+        Ok(())
     }
 
     async fn metadata(&mut self) -> Result<Metadata> {
-        let _ = self.prepare_metadata().await?;
+        self.prepare_metadata().await?;
 
         self.generator
             .metadata()
             .cloned()
-            .ok_or_else(|| Error::new(ErrorKind::Unexpected, "read stream metadata is not set"))
+            .ok_or_else(|| Error::new(ErrorKind::Unsupported, "read metadata is not available"))
     }
 }
 
@@ -131,8 +131,9 @@ impl ChunkedReader {
 
                         let args = input.ctx.args().clone().with_range(input.range);
                         let (rp, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
-                        let metadata = rp.into_metadata();
-                        if input.ctx.metadata().is_none() {
+                        if let Some(metadata) = rp.into_metadata()
+                            && input.ctx.metadata().is_none()
+                        {
                             input.ctx.set_metadata(metadata);
                         }
                         r.read_all().await
@@ -152,17 +153,18 @@ impl ChunkedReader {
         }
     }
 
-    async fn prepare_metadata(&mut self) -> Result<bool> {
+    async fn prepare_metadata(&mut self) -> Result<()> {
         if self.ctx.metadata().is_some() {
-            return Ok(true);
+            return Ok(());
         }
 
         if self.opened.is_none() {
             if let Some(range) = self.next_range() {
                 let args = self.ctx.args().clone().with_range(range);
                 let (rp, reader) = self.ctx.accessor().read(self.ctx.path(), args).await?;
-                let metadata = rp.into_metadata();
-                if self.ctx.metadata().is_none() {
+                if let Some(metadata) = rp.into_metadata()
+                    && self.ctx.metadata().is_none()
+                {
                     self.ctx.set_metadata(metadata);
                 }
                 self.opened = Some(ChunkedReadInput {
@@ -175,16 +177,16 @@ impl ChunkedReader {
             }
         }
 
-        Ok(self.ctx.metadata().is_some())
+        Ok(())
     }
 
     async fn metadata(&mut self) -> Result<Metadata> {
-        let _ = self.prepare_metadata().await?;
+        self.prepare_metadata().await?;
 
         self.ctx
             .metadata()
             .cloned()
-            .ok_or_else(|| Error::new(ErrorKind::Unexpected, "read stream metadata is not set"))
+            .ok_or_else(|| Error::new(ErrorKind::Unsupported, "read metadata is not available"))
     }
 
     /// Generate the next range to read, advancing internal state.
@@ -263,7 +265,6 @@ pub struct BufferStream {
 #[allow(clippy::large_enum_variant)]
 enum State {
     Idle(Option<TwoWays<StreamingReader, ChunkedReader>>),
-    Opening(BoxedStaticFuture<(TwoWays<StreamingReader, ChunkedReader>, Result<bool>)>),
     Reading(BoxedStaticFuture<(TwoWays<StreamingReader, ChunkedReader>, Result<Buffer>)>),
 }
 
@@ -317,7 +318,8 @@ impl BufferStream {
     /// Get metadata for this stream.
     ///
     /// Calling this method opens the underlying read request if needed.
-    /// Chunked reads wait until one chunk read has opened and observed metadata.
+    /// Returns [`ErrorKind::Unsupported`] if the underlying service doesn't
+    /// return metadata while opening the read operation.
     pub async fn metadata(&mut self) -> Result<Metadata> {
         if let Some(metadata) = self.ctx.metadata() {
             return Ok(metadata.clone());
@@ -333,18 +335,10 @@ impl BufferStream {
                 self.state = State::Idle(Some(reader));
                 prepared
             }
-            State::Opening(fut) => {
-                let (reader, prepared) = fut.await;
-                self.state = State::Idle(Some(reader));
-                let _ = prepared?;
-                self.ctx.metadata().cloned().ok_or_else(|| {
-                    Error::new(ErrorKind::Unexpected, "read stream metadata is not set")
-                })
-            }
             State::Reading(fut) => {
                 self.state = State::Reading(fut);
                 self.ctx.metadata().cloned().ok_or_else(|| {
-                    Error::new(ErrorKind::Unexpected, "read stream metadata is not set")
+                    Error::new(ErrorKind::Unsupported, "read metadata is not available")
                 })
             }
         }
@@ -360,45 +354,11 @@ impl Stream for BufferStream {
             match &mut this.state {
                 State::Idle(reader) => {
                     let mut reader = reader.take().unwrap();
-                    if this.ctx.metadata().is_none() {
-                        let fut = async move {
-                            let ret = match &mut reader {
-                                TwoWays::One(v) => v.prepare_metadata().await,
-                                TwoWays::Two(v) => v.prepare_metadata().await,
-                            };
-                            (reader, ret)
-                        };
-                        this.state = State::Opening(Box::pin(fut));
-                        continue;
-                    }
-
                     let fut = async move {
                         let ret = reader.read().await;
                         (reader, ret)
                     };
                     this.state = State::Reading(Box::pin(fut));
-                }
-                State::Opening(fut) => {
-                    let fut = fut.as_mut();
-                    let (reader, prepared) = ready!(fut.poll(cx));
-                    match prepared {
-                        Ok(true) => {
-                            let fut = async move {
-                                let mut reader = reader;
-                                let ret = reader.read().await;
-                                (reader, ret)
-                            };
-                            this.state = State::Reading(Box::pin(fut));
-                        }
-                        Ok(false) => {
-                            this.state = State::Idle(Some(reader));
-                            return Poll::Ready(None);
-                        }
-                        Err(err) => {
-                            this.state = State::Idle(Some(reader));
-                            return Poll::Ready(Some(Err(err)));
-                        }
-                    }
                 }
                 State::Reading(fut) => {
                     let fut = fut.as_mut();
@@ -423,7 +383,6 @@ mod tests {
     use bytes::Bytes;
     use futures::TryStreamExt;
     use pretty_assertions::assert_eq;
-    use tokio::sync::oneshot;
 
     use super::*;
 
@@ -472,41 +431,4 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn test_metadata_awaits_inflight_open() -> Result<()> {
-        let acc = Operator::via_iter(services::MEMORY_SCHEME, [])?.into_inner();
-        let ctx = Arc::new(ReadContext::new(
-            acc,
-            "test".to_string(),
-            OpRead::new(),
-            OpReader::new(),
-        ));
-        let reader = StreamingReader {
-            generator: ReadGenerator::new(ctx.clone(), 0, Some(0)),
-            reader: Some(Box::new(Buffer::from(Bytes::from_static(b"oWor")))),
-        };
-        let (tx, rx) = oneshot::channel();
-
-        let ctx_in_fut = ctx.clone();
-        let fut = async move {
-            let _ = rx.await;
-            ctx_in_fut.set_metadata(Metadata::new(EntryMode::FILE).with_content_length(10));
-            (TwoWays::One(reader), Ok(true))
-        };
-
-        let mut stream = BufferStream {
-            ctx,
-            state: State::Opening(Box::pin(fut)),
-        };
-
-        let _ = tx.send(());
-        let meta = stream.metadata().await?;
-        assert_eq!(meta.content_length(), 10);
-
-        let bufs: Vec<_> = stream.try_collect().await?;
-        let buf: Buffer = bufs.into_iter().flatten().collect();
-        assert_eq!(&buf.to_vec(), b"oWor");
-
-        Ok(())
-    }
 }

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -247,6 +247,7 @@ impl oio::Read for ChunkedReader {
 ///
 /// `BufferStream` implements `Stream` trait.
 pub struct BufferStream {
+    ctx: Arc<ReadContext>,
     /// # Notes to maintainers
     ///
     /// The underlying reader is either a StreamingReader or a ChunkedReader.
@@ -255,7 +256,6 @@ pub struct BufferStream {
     ///   data in streaming way.
     /// - Otherwise, BufferStream will use ChunkedReader to read data in chunks.
     state: State,
-    pending: Option<Result<Buffer>>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -273,14 +273,20 @@ impl BufferStream {
         );
 
         let reader = if ctx.options().chunk().is_some() {
-            TwoWays::Two(ChunkedReader::new(ctx, BytesRange::new(offset, size)))
+            TwoWays::Two(ChunkedReader::new(
+                ctx.clone(),
+                BytesRange::new(offset, size),
+            ))
         } else {
-            TwoWays::One(StreamingReader::new(ctx, BytesRange::new(offset, size)))
+            TwoWays::One(StreamingReader::new(
+                ctx.clone(),
+                BytesRange::new(offset, size),
+            ))
         };
 
         Self {
+            ctx,
             state: State::Idle(Some(reader)),
-            pending: None,
         }
     }
 
@@ -294,14 +300,14 @@ impl BufferStream {
     ) -> Result<Self> {
         let reader = if ctx.options().chunk().is_some() {
             let range = ctx.parse_into_range(range).await?;
-            TwoWays::Two(ChunkedReader::new(ctx, range.into()))
+            TwoWays::Two(ChunkedReader::new(ctx.clone(), range.into()))
         } else {
-            TwoWays::One(StreamingReader::new(ctx, range.into()))
+            TwoWays::One(StreamingReader::new(ctx.clone(), range.into()))
         };
 
         Ok(Self {
+            ctx,
             state: State::Idle(Some(reader)),
-            pending: None,
         })
     }
 
@@ -310,6 +316,10 @@ impl BufferStream {
     /// Calling this method opens the underlying read request if needed.
     /// Chunked reads wait until one chunk read has opened and observed metadata.
     pub async fn metadata(&mut self) -> Result<Metadata> {
+        if let Some(metadata) = self.ctx.metadata() {
+            return Ok(metadata.clone());
+        }
+
         match std::mem::replace(&mut self.state, State::Idle(None)) {
             State::Idle(reader) => {
                 let mut reader = reader.expect("reader must exist while idle");
@@ -321,25 +331,11 @@ impl BufferStream {
                 result
             }
             State::Reading(fut) => {
-                let (reader, result) = fut.await;
-
-                let metadata = match &reader {
-                    TwoWays::One(v) => v.generator.metadata().cloned(),
-                    TwoWays::Two(v) => v.ctx.metadata().cloned(),
-                };
-                self.state = State::Idle(Some(reader));
-
-                if let Some(metadata) = metadata {
-                    self.pending = Some(result);
-                    Ok(metadata)
-                } else {
-                    self.pending = None;
-                    result?;
-                    Err(Error::new(
-                        ErrorKind::Unexpected,
-                        "read stream metadata is not set",
-                    ))
-                }
+                self.state = State::Reading(fut);
+                Err(Error::new(
+                    ErrorKind::Unexpected,
+                    "read stream metadata is not ready while read stream is being polled",
+                ))
             }
         }
     }
@@ -351,14 +347,6 @@ impl Stream for BufferStream {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
         loop {
-            if let Some(buf) = this.pending.take() {
-                return match buf {
-                    Ok(buf) if buf.is_empty() => Poll::Ready(None),
-                    Ok(buf) => Poll::Ready(Some(Ok(buf))),
-                    Err(err) => Poll::Ready(Some(Err(err))),
-                };
-            }
-
             match &mut this.state {
                 State::Idle(reader) => {
                     let mut reader = reader.take().unwrap();

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -133,7 +133,7 @@ impl ChunkedReader {
                     let result = async {
                         let (rp, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
                         let metadata = rp.into_metadata();
-                        input.ctx.set_metadata(metadata.clone(), input.range);
+                        input.ctx.set_metadata(metadata.clone());
                         let buffer = r.read_all().await?;
                         Ok((metadata, buffer))
                     }

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -127,7 +127,7 @@ impl ChunkedReader {
                     let result = async {
                         let (rp, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
                         let metadata = rp.into_metadata();
-                        input.ctx.update_metadata(&metadata, input.range);
+                        input.ctx.set_metadata(&metadata, input.range);
                         r.read_all().await
                     }
                     .await;

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -35,7 +35,6 @@ use crate::*;
 pub struct StreamingReader {
     generator: ReadGenerator,
     reader: Option<oio::Reader>,
-    metadata: Option<Metadata>,
 }
 
 impl StreamingReader {
@@ -46,33 +45,34 @@ impl StreamingReader {
         Self {
             generator,
             reader: None,
-            metadata: None,
         }
     }
 
     async fn metadata(&mut self) -> Result<Metadata> {
-        if self.metadata.is_none() {
+        if let Some(metadata) = self.metadata_ref() {
+            return Ok(metadata.clone());
+        }
+
+        if self.reader.is_none() {
             self.open().await?;
         }
 
-        self.metadata
-            .as_ref()
+        self.metadata_ref()
             .cloned()
             .ok_or_else(|| Error::new(ErrorKind::Unexpected, "read stream metadata is not set"))
     }
 
     async fn open(&mut self) -> Result<()> {
-        let Some((metadata, reader)) = self.generator.next_reader().await? else {
+        let Some(reader) = self.generator.next_reader().await? else {
             return Ok(());
         };
 
-        self.metadata = Some(metadata);
         self.reader = Some(reader);
         Ok(())
     }
 
     fn metadata_ref(&self) -> Option<&Metadata> {
-        self.metadata.as_ref()
+        self.generator.metadata()
     }
 }
 
@@ -80,9 +80,6 @@ impl oio::Read for StreamingReader {
     async fn read(&mut self) -> Result<Buffer> {
         loop {
             if self.reader.is_none() {
-                if self.metadata.is_some() {
-                    return Ok(Buffer::new());
-                }
                 self.open().await?;
             }
 
@@ -115,9 +112,8 @@ pub struct ChunkedReader {
     ctx: Arc<ReadContext>,
     offset: u64,
     remaining: Option<u64>,
-    tasks: ConcurrentTasks<ChunkedReadInput, (Metadata, Buffer)>,
+    tasks: ConcurrentTasks<ChunkedReadInput, Buffer>,
     pending: Option<Buffer>,
-    metadata: Option<Metadata>,
     done: bool,
 }
 
@@ -138,8 +134,10 @@ impl ChunkedReader {
                     let result = async {
                         let (rp, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
                         let metadata = rp.into_metadata();
-                        let buffer = r.read_all().await?;
-                        Ok((metadata, buffer))
+                        if input.ctx.metadata().is_none() {
+                            input.ctx.set_metadata(metadata);
+                        }
+                        r.read_all().await
                     }
                     .await;
                     (input, result)
@@ -152,17 +150,16 @@ impl ChunkedReader {
             remaining: range.size(),
             tasks,
             pending: None,
-            metadata: None,
             done: false,
         }
     }
 
     async fn metadata(&mut self) -> Result<Metadata> {
-        if let Some(metadata) = self.metadata.as_ref() {
+        if let Some(metadata) = self.metadata_ref() {
             return Ok(metadata.clone());
         }
 
-        let Some((metadata, buffer)) = self.next_output().await? else {
+        let Some(buffer) = self.next_output().await? else {
             return Err(Error::new(
                 ErrorKind::Unexpected,
                 "read stream doesn't have metadata before opening a reader",
@@ -170,25 +167,16 @@ impl ChunkedReader {
         };
 
         self.pending = Some(buffer);
-        self.set_metadata(metadata);
-        self.metadata
-            .as_ref()
+        self.metadata_ref()
             .cloned()
             .ok_or_else(|| Error::new(ErrorKind::Unexpected, "read stream metadata is not set"))
     }
 
     fn metadata_ref(&self) -> Option<&Metadata> {
-        self.metadata.as_ref()
+        self.ctx.metadata()
     }
 
-    fn set_metadata(&mut self, metadata: Metadata) {
-        if self.metadata.is_none() {
-            self.ctx.set_metadata(metadata.clone());
-            self.metadata = Some(metadata);
-        }
-    }
-
-    async fn next_output(&mut self) -> Result<Option<(Metadata, Buffer)>> {
+    async fn next_output(&mut self) -> Result<Option<Buffer>> {
         while self.tasks.has_remaining() && !self.done {
             if let Some(range) = self.next_range() {
                 self.tasks
@@ -243,11 +231,10 @@ impl oio::Read for ChunkedReader {
             return Ok(buffer);
         }
 
-        let Some((metadata, buffer)) = self.next_output().await? else {
+        let Some(buffer) = self.next_output().await? else {
             return Ok(Buffer::new());
         };
 
-        self.set_metadata(metadata);
         Ok(buffer)
     }
 }
@@ -264,7 +251,6 @@ pub struct BufferStream {
     ///   data in streaming way.
     /// - Otherwise, BufferStream will use ChunkedReader to read data in chunks.
     state: State,
-    metadata: Option<Metadata>,
     pending: Option<Result<Buffer>>,
 }
 
@@ -290,7 +276,6 @@ impl BufferStream {
 
         Self {
             state: State::Idle(Some(reader)),
-            metadata: None,
             pending: None,
         }
     }
@@ -312,7 +297,6 @@ impl BufferStream {
 
         Ok(Self {
             state: State::Idle(Some(reader)),
-            metadata: None,
             pending: None,
         })
     }
@@ -323,41 +307,35 @@ impl BufferStream {
     /// Chunked reads may read and buffer the first chunk so following stream
     /// polling can reuse it.
     pub async fn metadata(&mut self) -> Result<Metadata> {
-        loop {
-            if let Some(metadata) = self.metadata.as_ref() {
-                return Ok(metadata.clone());
+        match std::mem::replace(&mut self.state, State::Idle(None)) {
+            State::Idle(reader) => {
+                let mut reader = reader.expect("reader must exist while idle");
+                let result = match &mut reader {
+                    TwoWays::One(v) => v.metadata().await,
+                    TwoWays::Two(v) => v.metadata().await,
+                };
+                self.state = State::Idle(Some(reader));
+                result
             }
+            State::Reading(fut) => {
+                let (reader, result) = fut.await;
 
-            match std::mem::replace(&mut self.state, State::Idle(None)) {
-                State::Idle(reader) => {
-                    let mut reader = reader.expect("reader must exist while idle");
-                    let result = match &mut reader {
-                        TwoWays::One(v) => v.metadata().await,
-                        TwoWays::Two(v) => v.metadata().await,
-                    };
-                    self.state = State::Idle(Some(reader));
+                let metadata = match &reader {
+                    TwoWays::One(v) => v.metadata_ref().cloned(),
+                    TwoWays::Two(v) => v.metadata_ref().cloned(),
+                };
+                self.state = State::Idle(Some(reader));
 
-                    self.metadata = Some(result?);
-                }
-                State::Reading(fut) => {
-                    let (reader, result) = fut.await;
-
-                    self.metadata = match &reader {
-                        TwoWays::One(v) => v.metadata_ref().cloned(),
-                        TwoWays::Two(v) => v.metadata_ref().cloned(),
-                    };
-                    self.state = State::Idle(Some(reader));
-
-                    if self.metadata.is_some() {
-                        self.pending = Some(result);
-                    } else {
-                        self.pending = None;
-                        result?;
-                        return Err(Error::new(
-                            ErrorKind::Unexpected,
-                            "read stream metadata is not set",
-                        ));
-                    }
+                if let Some(metadata) = metadata {
+                    self.pending = Some(result);
+                    Ok(metadata)
+                } else {
+                    self.pending = None;
+                    result?;
+                    Err(Error::new(
+                        ErrorKind::Unexpected,
+                        "read stream metadata is not set",
+                    ))
                 }
             }
         }
@@ -390,12 +368,6 @@ impl Stream for BufferStream {
                 State::Reading(fut) => {
                     let fut = fut.as_mut();
                     let (reader, buf) = ready!(fut.poll(cx));
-                    if this.metadata.is_none() {
-                        this.metadata = match &reader {
-                            TwoWays::One(v) => v.metadata_ref().cloned(),
-                            TwoWays::Two(v) => v.metadata_ref().cloned(),
-                        };
-                    }
                     this.state = State::Idle(Some(reader));
                     return match buf {
                         Ok(buf) if buf.is_empty() => Poll::Ready(None),

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -107,6 +107,7 @@ pub struct ChunkedReader {
     offset: u64,
     remaining: Option<u64>,
     tasks: ConcurrentTasks<ChunkedReadInput, Buffer>,
+    metadata: Option<Metadata>,
     done: bool,
 }
 
@@ -141,13 +142,22 @@ impl ChunkedReader {
             offset: range.offset(),
             remaining: range.size(),
             tasks,
+            metadata: None,
             done: false,
         }
     }
 
-    fn metadata(&self) -> Metadata {
-        let content_length = self.range.size().unwrap_or_default();
-        Metadata::new(EntryMode::FILE).with_content_length(content_length)
+    async fn metadata(&mut self) -> Result<Metadata> {
+        if let Some(metadata) = self.metadata.clone() {
+            return Ok(metadata);
+        }
+
+        let args = self.ctx.args().clone().with_range(self.range);
+        let (rp, _) = self.ctx.accessor().read(self.ctx.path(), args).await?;
+        let metadata = rp.into_metadata();
+        self.ctx.set_metadata(&metadata, self.range);
+        self.metadata = Some(metadata.clone());
+        Ok(metadata)
     }
 
     /// Generate the next range to read, advancing internal state.
@@ -271,7 +281,7 @@ impl BufferStream {
                 let reader = reader.as_mut().expect("reader must exist while idle");
                 match reader.as_mut() {
                     TwoWays::One(v) => v.metadata().await,
-                    TwoWays::Two(v) => Ok(v.metadata()),
+                    TwoWays::Two(v) => v.metadata().await,
                 }
             }
             State::Reading(_) => Err(Error::new(

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -49,30 +49,20 @@ impl StreamingReader {
     }
 
     async fn metadata(&mut self) -> Result<Metadata> {
-        if let Some(metadata) = self.metadata_ref() {
+        if let Some(metadata) = self.generator.metadata() {
             return Ok(metadata.clone());
         }
 
         if self.reader.is_none() {
-            self.open().await?;
+            if let Some(reader) = self.generator.next_reader().await? {
+                self.reader = Some(reader);
+            }
         }
 
-        self.metadata_ref()
+        self.generator
+            .metadata()
             .cloned()
             .ok_or_else(|| Error::new(ErrorKind::Unexpected, "read stream metadata is not set"))
-    }
-
-    async fn open(&mut self) -> Result<()> {
-        let Some(reader) = self.generator.next_reader().await? else {
-            return Ok(());
-        };
-
-        self.reader = Some(reader);
-        Ok(())
-    }
-
-    fn metadata_ref(&self) -> Option<&Metadata> {
-        self.generator.metadata()
     }
 }
 
@@ -80,7 +70,7 @@ impl oio::Read for StreamingReader {
     async fn read(&mut self) -> Result<Buffer> {
         loop {
             if self.reader.is_none() {
-                self.open().await?;
+                self.reader = self.generator.next_reader().await?;
             }
 
             let Some(r) = self.reader.as_mut() else {
@@ -113,7 +103,6 @@ pub struct ChunkedReader {
     offset: u64,
     remaining: Option<u64>,
     tasks: ConcurrentTasks<ChunkedReadInput, Buffer>,
-    pending: Option<Buffer>,
     done: bool,
 }
 
@@ -149,52 +138,8 @@ impl ChunkedReader {
             offset: range.offset(),
             remaining: range.size(),
             tasks,
-            pending: None,
             done: false,
         }
-    }
-
-    async fn metadata(&mut self) -> Result<Metadata> {
-        if let Some(metadata) = self.metadata_ref() {
-            return Ok(metadata.clone());
-        }
-
-        let Some(buffer) = self.next_output().await? else {
-            return Err(Error::new(
-                ErrorKind::Unexpected,
-                "read stream doesn't have metadata before opening a reader",
-            ));
-        };
-
-        self.pending = Some(buffer);
-        self.metadata_ref()
-            .cloned()
-            .ok_or_else(|| Error::new(ErrorKind::Unexpected, "read stream metadata is not set"))
-    }
-
-    fn metadata_ref(&self) -> Option<&Metadata> {
-        self.ctx.metadata()
-    }
-
-    async fn next_output(&mut self) -> Result<Option<Buffer>> {
-        while self.tasks.has_remaining() && !self.done {
-            if let Some(range) = self.next_range() {
-                self.tasks
-                    .execute(ChunkedReadInput {
-                        ctx: self.ctx.clone(),
-                        range,
-                    })
-                    .await?;
-            } else {
-                self.done = true;
-                break;
-            }
-            if self.tasks.has_result() {
-                break;
-            }
-        }
-
-        self.tasks.next().await.transpose()
     }
 
     /// Generate the next range to read, advancing internal state.
@@ -227,11 +172,24 @@ impl ChunkedReader {
 
 impl oio::Read for ChunkedReader {
     async fn read(&mut self) -> Result<Buffer> {
-        if let Some(buffer) = self.pending.take() {
-            return Ok(buffer);
+        while self.tasks.has_remaining() && !self.done {
+            if let Some(range) = self.next_range() {
+                self.tasks
+                    .execute(ChunkedReadInput {
+                        ctx: self.ctx.clone(),
+                        range,
+                    })
+                    .await?;
+            } else {
+                self.done = true;
+                break;
+            }
+            if self.tasks.has_result() {
+                break;
+            }
         }
 
-        let Some(buffer) = self.next_output().await? else {
+        let Some(buffer) = self.tasks.next().await.transpose()? else {
             return Ok(Buffer::new());
         };
 
@@ -312,7 +270,18 @@ impl BufferStream {
                 let mut reader = reader.expect("reader must exist while idle");
                 let result = match &mut reader {
                     TwoWays::One(v) => v.metadata().await,
-                    TwoWays::Two(v) => v.metadata().await,
+                    TwoWays::Two(v) => {
+                        if let Some(metadata) = v.ctx.metadata() {
+                            Ok(metadata.clone())
+                        } else {
+                            let buffer = v.read().await?;
+                            let metadata = v.ctx.metadata().cloned().ok_or_else(|| {
+                                Error::new(ErrorKind::Unexpected, "read stream metadata is not set")
+                            })?;
+                            self.pending = Some(Ok(buffer));
+                            Ok(metadata)
+                        }
+                    }
                 };
                 self.state = State::Idle(Some(reader));
                 result
@@ -321,8 +290,8 @@ impl BufferStream {
                 let (reader, result) = fut.await;
 
                 let metadata = match &reader {
-                    TwoWays::One(v) => v.metadata_ref().cloned(),
-                    TwoWays::Two(v) => v.metadata_ref().cloned(),
+                    TwoWays::One(v) => v.generator.metadata().cloned(),
+                    TwoWays::Two(v) => v.ctx.metadata().cloned(),
                 };
                 self.state = State::Idle(Some(reader));
 

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -35,6 +35,7 @@ use crate::*;
 pub struct StreamingReader {
     generator: ReadGenerator,
     reader: Option<oio::Reader>,
+    metadata: Option<Metadata>,
 }
 
 impl StreamingReader {
@@ -45,16 +46,36 @@ impl StreamingReader {
         Self {
             generator,
             reader: None,
+            metadata: None,
         }
+    }
+
+    async fn prepare(&mut self) -> Result<Option<Metadata>> {
+        if self.reader.is_none() {
+            let Some((metadata, reader)) = self.generator.next_reader().await? else {
+                return Ok(None);
+            };
+            self.metadata = Some(metadata);
+            self.reader = Some(reader);
+        }
+
+        Ok(self.metadata.clone())
+    }
+
+    async fn metadata(&mut self) -> Result<Metadata> {
+        self.prepare().await?.ok_or_else(|| {
+            Error::new(
+                ErrorKind::Unexpected,
+                "read stream doesn't have metadata before opening a reader",
+            )
+        })
     }
 }
 
 impl oio::Read for StreamingReader {
     async fn read(&mut self) -> Result<Buffer> {
         loop {
-            if self.reader.is_none() {
-                self.reader = self.generator.next_reader().await?;
-            }
+            self.prepare().await?;
             let Some(r) = self.reader.as_mut() else {
                 return Ok(Buffer::new());
             };
@@ -82,6 +103,7 @@ struct ChunkedReadInput {
 /// ChunkedReader is good for concurrent read and optimized for throughput.
 pub struct ChunkedReader {
     ctx: Arc<ReadContext>,
+    range: BytesRange,
     offset: u64,
     remaining: Option<u64>,
     tasks: ConcurrentTasks<ChunkedReadInput, Buffer>,
@@ -103,7 +125,9 @@ impl ChunkedReader {
                 Box::pin(async move {
                     let args = input.ctx.args().clone().with_range(input.range);
                     let result = async {
-                        let (_, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
+                        let (rp, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
+                        let metadata = rp.into_metadata();
+                        input.ctx.update_metadata(&metadata, input.range);
                         r.read_all().await
                     }
                     .await;
@@ -113,11 +137,17 @@ impl ChunkedReader {
         );
         Self {
             ctx,
+            range,
             offset: range.offset(),
             remaining: range.size(),
             tasks,
             done: false,
         }
+    }
+
+    fn metadata(&self) -> Metadata {
+        let content_length = self.range.size().unwrap_or_default();
+        Metadata::new(EntryMode::FILE).with_content_length(content_length)
     }
 
     /// Generate the next range to read, advancing internal state.
@@ -185,9 +215,12 @@ pub struct BufferStream {
 }
 
 enum State {
-    Idle(Option<TwoWays<StreamingReader, ChunkedReader>>),
-    Reading(BoxedStaticFuture<(TwoWays<StreamingReader, ChunkedReader>, Result<Buffer>)>),
+    Idle(Option<BufferStreamReader>),
+    Reading(BufferStreamFuture),
 }
+
+type BufferStreamReader = Box<TwoWays<StreamingReader, ChunkedReader>>;
+type BufferStreamFuture = BoxedStaticFuture<(BufferStreamReader, Result<Buffer>)>;
 
 impl BufferStream {
     /// Create a new buffer stream with already calculated offset and size.
@@ -204,7 +237,7 @@ impl BufferStream {
         };
 
         Self {
-            state: State::Idle(Some(reader)),
+            state: State::Idle(Some(Box::new(reader))),
         }
     }
 
@@ -224,8 +257,28 @@ impl BufferStream {
         };
 
         Ok(Self {
-            state: State::Idle(Some(reader)),
+            state: State::Idle(Some(Box::new(reader))),
         })
+    }
+
+    /// Get metadata for this stream.
+    ///
+    /// Calling this method opens the underlying read request if needed, but
+    /// doesn't consume the response body.
+    pub async fn metadata(&mut self) -> Result<Metadata> {
+        match &mut self.state {
+            State::Idle(reader) => {
+                let reader = reader.as_mut().expect("reader must exist while idle");
+                match reader.as_mut() {
+                    TwoWays::One(v) => v.metadata().await,
+                    TwoWays::Two(v) => Ok(v.metadata()),
+                }
+            }
+            State::Reading(_) => Err(Error::new(
+                ErrorKind::Unexpected,
+                "can't get metadata while read stream is being polled",
+            )),
+        }
     }
 }
 

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -93,16 +93,10 @@ impl oio::Read for StreamingReader {
     }
 }
 
-enum ChunkedReadInput {
-    Range {
-        ctx: Arc<ReadContext>,
-        range: BytesRange,
-    },
-    Opened {
-        ctx: Arc<ReadContext>,
-        range: BytesRange,
-        reader: oio::Reader,
-    },
+struct ChunkedReadInput {
+    ctx: Arc<ReadContext>,
+    range: BytesRange,
+    reader: Option<oio::Reader>,
 }
 
 /// ChunkedReader will read the file in chunks.
@@ -112,7 +106,7 @@ pub struct ChunkedReader {
     ctx: Arc<ReadContext>,
     offset: u64,
     remaining: Option<u64>,
-    opened: Option<(BytesRange, oio::Reader)>,
+    opened: Option<ChunkedReadInput>,
     tasks: ConcurrentTasks<ChunkedReadInput, Buffer>,
     done: bool,
 }
@@ -128,31 +122,23 @@ impl ChunkedReader {
             ctx.accessor().info().executor(),
             ctx.options().concurrent(),
             ctx.options().prefetch(),
-            |input: ChunkedReadInput| {
+            |mut input: ChunkedReadInput| {
                 Box::pin(async move {
-                    match input {
-                        ChunkedReadInput::Range { ctx, range } => {
-                            let args = ctx.args().clone().with_range(range);
-                            let result = async {
-                                let (rp, mut r) = ctx.accessor().read(ctx.path(), args).await?;
-                                let metadata = rp.into_metadata();
-                                if ctx.metadata().is_none() {
-                                    ctx.set_metadata(metadata);
-                                }
-                                r.read_all().await
-                            }
-                            .await;
-                            (ChunkedReadInput::Range { ctx, range }, result)
+                    let result = async {
+                        if let Some(mut reader) = input.reader.take() {
+                            return reader.read_all().await;
                         }
-                        ChunkedReadInput::Opened {
-                            ctx,
-                            range,
-                            mut reader,
-                        } => {
-                            let result = reader.read_all().await;
-                            (ChunkedReadInput::Range { ctx, range }, result)
+
+                        let args = input.ctx.args().clone().with_range(input.range);
+                        let (rp, mut r) = input.ctx.accessor().read(input.ctx.path(), args).await?;
+                        let metadata = rp.into_metadata();
+                        if input.ctx.metadata().is_none() {
+                            input.ctx.set_metadata(metadata);
                         }
+                        r.read_all().await
                     }
+                    .await;
+                    (input, result)
                 })
             },
         );
@@ -179,7 +165,11 @@ impl ChunkedReader {
                 if self.ctx.metadata().is_none() {
                     self.ctx.set_metadata(metadata);
                 }
-                self.opened = Some((range, reader));
+                self.opened = Some(ChunkedReadInput {
+                    ctx: self.ctx.clone(),
+                    range,
+                    reader: Some(reader),
+                });
             } else {
                 self.done = true;
             }
@@ -228,19 +218,14 @@ impl ChunkedReader {
 impl oio::Read for ChunkedReader {
     async fn read(&mut self) -> Result<Buffer> {
         while self.tasks.has_remaining() && !self.done {
-            if let Some((range, reader)) = self.opened.take() {
-                self.tasks
-                    .execute(ChunkedReadInput::Opened {
-                        ctx: self.ctx.clone(),
-                        range,
-                        reader,
-                    })
-                    .await?;
+            if let Some(input) = self.opened.take() {
+                self.tasks.execute(input).await?;
             } else if let Some(range) = self.next_range() {
                 self.tasks
-                    .execute(ChunkedReadInput::Range {
+                    .execute(ChunkedReadInput {
                         ctx: self.ctx.clone(),
                         range,
+                        reader: None,
                     })
                     .await?;
             } else {

--- a/core/core/src/types/read/futures_bytes_stream.rs
+++ b/core/core/src/types/read/futures_bytes_stream.rs
@@ -54,6 +54,14 @@ impl FuturesBytesStream {
             buf: Buffer::new(),
         })
     }
+
+    /// Get metadata for this stream.
+    ///
+    /// Calling this method opens the underlying read request if needed, but
+    /// doesn't consume the response body.
+    pub async fn metadata(&mut self) -> Result<Metadata> {
+        self.stream.metadata().await
+    }
 }
 
 impl Stream for FuturesBytesStream {

--- a/core/core/src/types/read/futures_bytes_stream.rs
+++ b/core/core/src/types/read/futures_bytes_stream.rs
@@ -58,8 +58,7 @@ impl FuturesBytesStream {
     /// Get metadata for this stream.
     ///
     /// Calling this method opens the underlying read request if needed.
-    /// Chunked reads may read and buffer the first chunk so following stream
-    /// polling can reuse it.
+    /// Chunked reads wait until one chunk read has opened and observed metadata.
     pub async fn metadata(&mut self) -> Result<Metadata> {
         self.stream.metadata().await
     }

--- a/core/core/src/types/read/futures_bytes_stream.rs
+++ b/core/core/src/types/read/futures_bytes_stream.rs
@@ -57,8 +57,9 @@ impl FuturesBytesStream {
 
     /// Get metadata for this stream.
     ///
-    /// Calling this method opens the underlying read request if needed, but
-    /// doesn't consume the response body.
+    /// Calling this method opens the underlying read request if needed.
+    /// Chunked reads may read and buffer the first chunk so following stream
+    /// polling can reuse it.
     pub async fn metadata(&mut self) -> Result<Metadata> {
         self.stream.metadata().await
     }

--- a/core/core/src/types/read/futures_bytes_stream.rs
+++ b/core/core/src/types/read/futures_bytes_stream.rs
@@ -58,7 +58,8 @@ impl FuturesBytesStream {
     /// Get metadata for this stream.
     ///
     /// Calling this method opens the underlying read request if needed.
-    /// Chunked reads wait until one chunk read has opened and observed metadata.
+    /// Returns [`ErrorKind::Unsupported`] if the underlying service doesn't
+    /// return metadata while opening the read operation.
     pub async fn metadata(&mut self) -> Result<Metadata> {
         self.stream.metadata().await
     }

--- a/core/core/src/types/read/reader.rs
+++ b/core/core/src/types/read/reader.rs
@@ -519,11 +519,11 @@ mod tests {
         let mut stream = reader.clone().into_stream(4..8).await?;
 
         let stream_meta = stream.metadata().await?;
-        assert_eq!(stream_meta.content_length(), 4);
+        assert_eq!(stream_meta.content_length(), 2);
         let range = stream_meta
             .content_range()
             .expect("range read must have content range");
-        assert_eq!(range.range(), Some(4..8));
+        assert_eq!(range.range(), Some(4..6));
         assert_eq!(range.size(), Some(10));
 
         let bufs: Vec<_> = stream.try_collect().await?;

--- a/core/core/src/types/read/reader.rs
+++ b/core/core/src/types/read/reader.rs
@@ -478,7 +478,11 @@ mod tests {
 
         let meta = reader.metadata().expect("metadata must be observed");
         assert_eq!(meta.content_length(), 10);
-        assert_eq!(meta.content_range(), None);
+        let range = meta
+            .content_range()
+            .expect("range read must have content range");
+        assert_eq!(range.range(), Some(4..8));
+        assert_eq!(range.size(), Some(10));
 
         Ok(())
     }
@@ -505,7 +509,11 @@ mod tests {
 
         let reader_meta = reader.metadata().expect("reader metadata must be observed");
         assert_eq!(reader_meta.content_length(), 10);
-        assert_eq!(reader_meta.content_range(), None);
+        let range = reader_meta
+            .content_range()
+            .expect("range read must have content range");
+        assert_eq!(range.range(), Some(4..8));
+        assert_eq!(range.size(), Some(10));
 
         Ok(())
     }

--- a/core/core/src/types/read/reader.rs
+++ b/core/core/src/types/read/reader.rs
@@ -105,6 +105,14 @@ impl Reader {
         Reader { ctx: Arc::new(ctx) }
     }
 
+    /// Get complete object metadata observed by this reader.
+    ///
+    /// This method doesn't perform I/O. It returns `None` if no read has
+    /// observed complete object metadata yet.
+    pub fn metadata(&self) -> Option<Metadata> {
+        self.ctx.metadata()
+    }
+
     /// Read give range from reader into [`Buffer`].
     ///
     /// This operation is zero-copy, which means it keeps the [`bytes::Bytes`] returned by underlying
@@ -453,6 +461,51 @@ mod tests {
         let ctx = ReadContext::new(acc, "test".to_string(), OpRead::new(), OpReader::new());
 
         let _: Box<dyn Unpin + MaybeSend + Sync + 'static> = Box::new(Reader::new(ctx));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_reader_metadata_after_read() -> Result<()> {
+        let op = Operator::via_iter(services::MEMORY_SCHEME, [])?;
+        op.write("test", Buffer::from("HelloWorld")).await?;
+
+        let reader = op.reader("test").await?;
+        assert_eq!(reader.metadata(), None);
+
+        let buf = reader.read(4..8).await?;
+        assert_eq!(&buf.to_vec(), b"oWor");
+
+        let meta = reader.metadata().expect("metadata must be observed");
+        assert_eq!(meta.content_length(), 10);
+        assert_eq!(meta.content_range(), None);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_stream_metadata_updates_reader_metadata() -> Result<()> {
+        let op = Operator::via_iter(services::MEMORY_SCHEME, [])?;
+        op.write("test", Buffer::from("HelloWorld")).await?;
+
+        let reader = op.reader("test").await?;
+        let mut stream = reader.clone().into_stream(4..8).await?;
+
+        let stream_meta = stream.metadata().await?;
+        assert_eq!(stream_meta.content_length(), 4);
+        let range = stream_meta
+            .content_range()
+            .expect("range read must have content range");
+        assert_eq!(range.range(), Some(4..8));
+        assert_eq!(range.size(), Some(10));
+
+        let bufs: Vec<_> = stream.try_collect().await?;
+        let buf: Buffer = bufs.into_iter().flatten().collect();
+        assert_eq!(&buf.to_vec(), b"oWor");
+
+        let reader_meta = reader.metadata().expect("reader metadata must be observed");
+        assert_eq!(reader_meta.content_length(), 10);
+        assert_eq!(reader_meta.content_range(), None);
 
         Ok(())
     }

--- a/core/core/src/types/read/reader.rs
+++ b/core/core/src/types/read/reader.rs
@@ -478,7 +478,6 @@ mod tests {
 
         let meta = reader.metadata().expect("metadata must be observed");
         assert_eq!(meta.content_length(), 10);
-        assert_eq!(meta.content_range(), None);
 
         Ok(())
     }
@@ -492,12 +491,7 @@ mod tests {
         let mut stream = reader.clone().into_stream(4..8).await?;
 
         let stream_meta = stream.metadata().await?;
-        assert_eq!(stream_meta.content_length(), 4);
-        let range = stream_meta
-            .content_range()
-            .expect("range read must have content range");
-        assert_eq!(range.range(), Some(4..8));
-        assert_eq!(range.size(), Some(10));
+        assert_eq!(stream_meta.content_length(), 10);
 
         let bufs: Vec<_> = stream.try_collect().await?;
         let buf: Buffer = bufs.into_iter().flatten().collect();
@@ -505,7 +499,6 @@ mod tests {
 
         let reader_meta = reader.metadata().expect("reader metadata must be observed");
         assert_eq!(reader_meta.content_length(), 10);
-        assert_eq!(reader_meta.content_range(), None);
 
         Ok(())
     }
@@ -519,12 +512,7 @@ mod tests {
         let mut stream = reader.clone().into_stream(4..8).await?;
 
         let stream_meta = stream.metadata().await?;
-        assert_eq!(stream_meta.content_length(), 2);
-        let range = stream_meta
-            .content_range()
-            .expect("range read must have content range");
-        assert_eq!(range.range(), Some(4..6));
-        assert_eq!(range.size(), Some(10));
+        assert_eq!(stream_meta.content_length(), 10);
 
         let bufs: Vec<_> = stream.try_collect().await?;
         let buf: Buffer = bufs.into_iter().flatten().collect();
@@ -532,7 +520,6 @@ mod tests {
 
         let reader_meta = reader.metadata().expect("reader metadata must be observed");
         assert_eq!(reader_meta.content_length(), 10);
-        assert_eq!(reader_meta.content_range(), None);
 
         Ok(())
     }

--- a/core/core/src/types/read/reader.rs
+++ b/core/core/src/types/read/reader.rs
@@ -510,6 +510,33 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn test_chunked_stream_metadata_updates_reader_metadata() -> Result<()> {
+        let op = Operator::via_iter(services::MEMORY_SCHEME, [])?;
+        op.write("test", Buffer::from("HelloWorld")).await?;
+
+        let reader = op.reader_with("test").chunk(2).await?;
+        let mut stream = reader.clone().into_stream(4..8).await?;
+
+        let stream_meta = stream.metadata().await?;
+        assert_eq!(stream_meta.content_length(), 4);
+        let range = stream_meta
+            .content_range()
+            .expect("range read must have content range");
+        assert_eq!(range.range(), Some(4..8));
+        assert_eq!(range.size(), Some(10));
+
+        let bufs: Vec<_> = stream.try_collect().await?;
+        let buf: Buffer = bufs.into_iter().flatten().collect();
+        assert_eq!(&buf.to_vec(), b"oWor");
+
+        let reader_meta = reader.metadata().expect("reader metadata must be observed");
+        assert_eq!(reader_meta.content_length(), 10);
+        assert_eq!(reader_meta.content_range(), None);
+
+        Ok(())
+    }
+
     fn gen_random_bytes() -> Vec<u8> {
         let mut rng = rand::rng();
         // Generate size between 1B..16MB.

--- a/core/core/src/types/read/reader.rs
+++ b/core/core/src/types/read/reader.rs
@@ -108,7 +108,8 @@ impl Reader {
     /// Get complete object metadata observed by this reader.
     ///
     /// This method doesn't perform I/O. It returns `None` if no read has
-    /// observed complete object metadata yet.
+    /// observed complete object metadata yet, or if the underlying service
+    /// doesn't return metadata while opening read operations.
     pub fn metadata(&self) -> Option<&Metadata> {
         self.ctx.metadata()
     }

--- a/core/core/src/types/read/reader.rs
+++ b/core/core/src/types/read/reader.rs
@@ -109,7 +109,7 @@ impl Reader {
     ///
     /// This method doesn't perform I/O. It returns `None` if no read has
     /// observed complete object metadata yet.
-    pub fn metadata(&self) -> Option<Metadata> {
+    pub fn metadata(&self) -> Option<&Metadata> {
         self.ctx.metadata()
     }
 
@@ -478,11 +478,7 @@ mod tests {
 
         let meta = reader.metadata().expect("metadata must be observed");
         assert_eq!(meta.content_length(), 10);
-        let range = meta
-            .content_range()
-            .expect("range read must have content range");
-        assert_eq!(range.range(), Some(4..8));
-        assert_eq!(range.size(), Some(10));
+        assert_eq!(meta.content_range(), None);
 
         Ok(())
     }
@@ -509,11 +505,7 @@ mod tests {
 
         let reader_meta = reader.metadata().expect("reader metadata must be observed");
         assert_eq!(reader_meta.content_length(), 10);
-        let range = reader_meta
-            .content_range()
-            .expect("range read must have content range");
-        assert_eq!(range.range(), Some(4..8));
-        assert_eq!(range.size(), Some(10));
+        assert_eq!(reader_meta.content_range(), None);
 
         Ok(())
     }

--- a/core/layers/concurrent-limit/src/lib.rs
+++ b/core/layers/concurrent-limit/src/lib.rs
@@ -613,7 +613,10 @@ mod tests {
                 };
                 let req = http::Request::get("http://fake").body(data).unwrap();
                 let resp = self.info.http_client().fetch(req).await?;
-                Ok((RpRead::default(), resp.into_body()))
+                Ok((
+                    RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(0)),
+                    resp.into_body(),
+                ))
             }
 
             async fn stat(&self, _: &str, _: OpStat) -> Result<RpStat> {

--- a/core/layers/foyer/src/full.rs
+++ b/core/layers/foyer/src/full.rs
@@ -18,7 +18,9 @@
 use std::sync::Arc;
 
 use opendal_core::Buffer;
+use opendal_core::EntryMode;
 use opendal_core::Error;
+use opendal_core::Metadata;
 use opendal_core::Result;
 use opendal_core::raw::Access;
 use opendal_core::raw::BytesContentRange;
@@ -128,9 +130,11 @@ impl<A: Access> FullReader<A> {
                     .with_range(range_start, end - 1)
                     .with_size(entry.len() as _);
                 let buffer = entry.slice(range_start as usize..end as usize);
-                let rp = RpRead::new()
-                    .with_size(Some(buffer.len() as _))
-                    .with_range(Some(range));
+                let rp = RpRead::new(
+                    Metadata::new(EntryMode::FILE)
+                        .with_content_length(buffer.len() as _)
+                        .with_content_range(range),
+                );
                 Ok((rp, buffer))
             }
             Err(e) => match e.downcast_ref::<FetchError>() {

--- a/core/layers/foyer/src/full.rs
+++ b/core/layers/foyer/src/full.rs
@@ -23,7 +23,6 @@ use opendal_core::Error;
 use opendal_core::Metadata;
 use opendal_core::Result;
 use opendal_core::raw::Access;
-use opendal_core::raw::BytesContentRange;
 use opendal_core::raw::BytesRange;
 use opendal_core::raw::OpRead;
 use opendal_core::raw::OpStat;
@@ -126,14 +125,9 @@ impl<A: Access> FullReader<A> {
         match result {
             Ok(entry) => {
                 let end = range_end.unwrap_or(entry.len() as u64);
-                let range = BytesContentRange::default()
-                    .with_range(range_start, end - 1)
-                    .with_size(entry.len() as _);
                 let buffer = entry.slice(range_start as usize..end as usize);
                 let rp = RpRead::new(
-                    Metadata::new(EntryMode::FILE)
-                        .with_content_length(buffer.len() as _)
-                        .with_content_range(range),
+                    Metadata::new(EntryMode::FILE).with_content_length(entry.len() as _),
                 );
                 Ok((rp, buffer))
             }

--- a/core/layers/retry/src/lib.rs
+++ b/core/layers/retry/src/lib.rs
@@ -919,7 +919,7 @@ mod tests {
 
         async fn read(&self, _: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
             Ok((
-                RpRead::new(),
+                RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(0)),
                 MockReader {
                     buf: Bytes::from("Hello, World!").into(),
                     range: args.range(),

--- a/core/layers/timeout/src/lib.rs
+++ b/core/layers/timeout/src/lib.rs
@@ -420,7 +420,10 @@ mod tests {
 
         /// This function will build a reader that always return pending.
         async fn read(&self, _: &str, _: OpRead) -> Result<(RpRead, Self::Reader)> {
-            Ok((RpRead::new(), Box::new(MockReader)))
+            Ok((
+                RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(0)),
+                Box::new(MockReader),
+            ))
         }
 
         /// This function will never return.

--- a/core/services/aliyun-drive/src/backend.rs
+++ b/core/services/aliyun-drive/src/backend.rs
@@ -327,9 +327,10 @@ impl Access for AliyunDriveBackend {
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/alluxio/src/backend.rs
+++ b/core/services/alluxio/src/backend.rs
@@ -165,7 +165,10 @@ impl Access for AlluxioBackend {
             let buf = body.to_buffer().await?;
             return Err(parse_error(Response::from_parts(part, buf)));
         }
-        Ok((RpRead::new(), resp.into_body()))
+        Ok((
+            RpRead::new(parse_into_metadata(path, resp.headers())?),
+            resp.into_body(),
+        ))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/azblob/src/backend.rs
+++ b/core/services/azblob/src/backend.rs
@@ -504,7 +504,10 @@ impl Access for AzblobBackend {
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((RpRead::new(), resp.into_body())),
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/azdls/src/backend.rs
+++ b/core/services/azdls/src/backend.rs
@@ -407,7 +407,10 @@ impl Access for AzdlsBackend {
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((RpRead::new(), resp.into_body())),
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/azfile/src/backend.rs
+++ b/core/services/azfile/src/backend.rs
@@ -337,7 +337,10 @@ impl Access for AzfileBackend {
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((RpRead::new(), resp.into_body())),
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/b2/src/backend.rs
+++ b/core/services/b2/src/backend.rs
@@ -257,9 +257,10 @@ impl Access for B2Backend {
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/cacache/src/backend.rs
+++ b/core/services/cacache/src/backend.rs
@@ -127,7 +127,9 @@ impl Access for CacacheBackend {
                     };
                     Buffer::from(bytes.slice(start..end.min(bytes.len())))
                 };
-                Ok((RpRead::new(), buffer))
+                let metadata =
+                    Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
+                Ok((RpRead::new(metadata), buffer))
             }
             None => Err(Error::new(ErrorKind::NotFound, "entry not found")),
         }

--- a/core/services/cacache/src/backend.rs
+++ b/core/services/cacache/src/backend.rs
@@ -117,6 +117,7 @@ impl Access for CacacheBackend {
         match data {
             Some(bytes) => {
                 let range = args.range();
+                let content_length = bytes.len() as u64;
                 let buffer = if range.is_full() {
                     Buffer::from(bytes)
                 } else {
@@ -127,8 +128,7 @@ impl Access for CacacheBackend {
                     };
                     Buffer::from(bytes.slice(start..end.min(bytes.len())))
                 };
-                let metadata =
-                    Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
+                let metadata = Metadata::new(EntryMode::FILE).with_content_length(content_length);
                 Ok((RpRead::new(metadata), buffer))
             }
             None => Err(Error::new(ErrorKind::NotFound, "entry not found")),

--- a/core/services/cloudflare-kv/src/backend.rs
+++ b/core/services/cloudflare-kv/src/backend.rs
@@ -445,6 +445,7 @@ impl Access for CloudflareKvBackend {
         }
 
         let range = args.range();
+        let total_size = resp_body.len() as u64;
         let buffer = if range.is_full() {
             resp_body
         } else {
@@ -455,7 +456,15 @@ impl Access for CloudflareKvBackend {
             };
             resp_body.slice(start..end.min(resp_body.len()))
         };
-        Ok((RpRead::new(), buffer))
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
+        if !range.is_full() && !buffer.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(range.offset(), range.offset() + buffer.len() as u64 - 1)
+                    .with_size(total_size),
+            );
+        }
+        Ok((RpRead::new(metadata), buffer))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/cloudflare-kv/src/backend.rs
+++ b/core/services/cloudflare-kv/src/backend.rs
@@ -456,14 +456,7 @@ impl Access for CloudflareKvBackend {
             };
             resp_body.slice(start..end.min(resp_body.len()))
         };
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
-        if !range.is_full() && !buffer.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(range.offset(), range.offset() + buffer.len() as u64 - 1)
-                    .with_size(total_size),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(total_size);
         Ok((RpRead::new(metadata), buffer))
     }
 

--- a/core/services/compfs/src/backend.rs
+++ b/core/services/compfs/src/backend.rs
@@ -230,7 +230,12 @@ impl Access for CompfsBackend {
             .await?;
 
         let r = CompfsReader::new(self.core.clone(), file, op.range());
-        Ok((RpRead::new(), r))
+        Ok((
+            RpRead::new(
+                Metadata::new(EntryMode::FILE).with_content_length(op.range().size().unwrap_or(0)),
+            ),
+            r,
+        ))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/compfs/src/backend.rs
+++ b/core/services/compfs/src/backend.rs
@@ -224,23 +224,19 @@ impl Access for CompfsBackend {
     async fn read(&self, path: &str, op: OpRead) -> Result<(RpRead, Self::Reader)> {
         let path = self.core.prepare_path(path);
 
-        let (file, content_length) = self
+        let file = self
             .core
             .exec(|| async move {
                 let file = compio::fs::OpenOptions::new()
                     .read(true)
                     .open(&path)
                     .await?;
-                let content_length = file.metadata().await?.len();
-                Ok((file, content_length))
+                Ok(file)
             })
             .await?;
 
         let r = CompfsReader::new(self.core.clone(), file, op.range());
-        Ok((
-            RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(content_length)),
-            r,
-        ))
+        Ok((RpRead::default(), r))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/compfs/src/backend.rs
+++ b/core/services/compfs/src/backend.rs
@@ -224,16 +224,21 @@ impl Access for CompfsBackend {
     async fn read(&self, path: &str, op: OpRead) -> Result<(RpRead, Self::Reader)> {
         let path = self.core.prepare_path(path);
 
-        let file = self
+        let (file, content_length) = self
             .core
-            .exec(|| async move { compio::fs::OpenOptions::new().read(true).open(&path).await })
+            .exec(|| async move {
+                let file = compio::fs::OpenOptions::new()
+                    .read(true)
+                    .open(&path)
+                    .await?;
+                let content_length = file.metadata().await?.len();
+                Ok((file, content_length))
+            })
             .await?;
 
         let r = CompfsReader::new(self.core.clone(), file, op.range());
         Ok((
-            RpRead::new(
-                Metadata::new(EntryMode::FILE).with_content_length(op.range().size().unwrap_or(0)),
-            ),
+            RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(content_length)),
             r,
         ))
     }

--- a/core/services/cos/src/backend.rs
+++ b/core/services/cos/src/backend.rs
@@ -356,9 +356,10 @@ impl Access for CosBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/d1/src/backend.rs
+++ b/core/services/d1/src/backend.rs
@@ -258,17 +258,7 @@ impl Access for D1Backend {
             }
         };
         let content = bs.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(bs.len() as u64),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
         Ok((RpRead::new(metadata), content))
     }
 

--- a/core/services/d1/src/backend.rs
+++ b/core/services/d1/src/backend.rs
@@ -257,7 +257,19 @@ impl Access for D1Backend {
                 return Err(Error::new(ErrorKind::NotFound, "kv not found in d1"));
             }
         };
-        Ok((RpRead::new(), bs.slice(args.range().to_range_as_usize())))
+        let content = bs.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(bs.len() as u64),
+            );
+        }
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/dashmap/src/backend.rs
+++ b/core/services/dashmap/src/backend.rs
@@ -147,6 +147,7 @@ impl Access for DashmapBackend {
 
         match self.core.get(&p)? {
             Some(value) => {
+                let total_size = value.content.len() as u64;
                 let buffer = if args.range().is_full() {
                     value.content
                 } else {
@@ -158,7 +159,19 @@ impl Access for DashmapBackend {
                     };
                     value.content.slice(start..end.min(value.content.len()))
                 };
-                Ok((RpRead::new(), buffer))
+                let mut metadata =
+                    Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
+                if !args.range().is_full() && !buffer.is_empty() {
+                    metadata.set_content_range(
+                        BytesContentRange::default()
+                            .with_range(
+                                args.range().offset(),
+                                args.range().offset() + buffer.len() as u64 - 1,
+                            )
+                            .with_size(total_size),
+                    );
+                }
+                Ok((RpRead::new(metadata), buffer))
             }
             None => Err(Error::new(ErrorKind::NotFound, "key not found in dashmap")),
         }

--- a/core/services/dashmap/src/backend.rs
+++ b/core/services/dashmap/src/backend.rs
@@ -159,18 +159,7 @@ impl Access for DashmapBackend {
                     };
                     value.content.slice(start..end.min(value.content.len()))
                 };
-                let mut metadata =
-                    Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
-                if !args.range().is_full() && !buffer.is_empty() {
-                    metadata.set_content_range(
-                        BytesContentRange::default()
-                            .with_range(
-                                args.range().offset(),
-                                args.range().offset() + buffer.len() as u64 - 1,
-                            )
-                            .with_size(total_size),
-                    );
-                }
+                let metadata = Metadata::new(EntryMode::FILE).with_content_length(total_size);
                 Ok((RpRead::new(metadata), buffer))
             }
             None => Err(Error::new(ErrorKind::NotFound, "key not found in dashmap")),

--- a/core/services/dropbox/src/backend.rs
+++ b/core/services/dropbox/src/backend.rs
@@ -110,9 +110,10 @@ impl Access for DropboxBackend {
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/etcd/src/backend.rs
+++ b/core/services/etcd/src/backend.rs
@@ -268,10 +268,12 @@ impl Access for EtcdBackend {
         match self.core.get(&abs_path).await? {
             Some(buffer) => {
                 let range = op.range();
+                let total_size = buffer.len() as u64;
 
                 // If range is full, return the buffer directly
                 if range.is_full() {
-                    return Ok((RpRead::new(), buffer));
+                    let metadata = Metadata::new(EntryMode::FILE).with_content_length(total_size);
+                    return Ok((RpRead::new(metadata), buffer));
                 }
 
                 // Handle range requests
@@ -286,8 +288,20 @@ impl Access for EtcdBackend {
                 let size = range.size().map(|s| s as usize);
                 let end = size.map_or(buffer.len(), |s| (offset + s).min(buffer.len()));
                 let sliced_buffer = buffer.slice(offset..end);
+                let mut metadata =
+                    Metadata::new(EntryMode::FILE).with_content_length(sliced_buffer.len() as u64);
+                if !sliced_buffer.is_empty() {
+                    metadata.set_content_range(
+                        BytesContentRange::default()
+                            .with_range(
+                                range.offset(),
+                                range.offset() + sliced_buffer.len() as u64 - 1,
+                            )
+                            .with_size(total_size),
+                    );
+                }
 
-                Ok((RpRead::new(), sliced_buffer))
+                Ok((RpRead::new(metadata), sliced_buffer))
             }
             None => Err(Error::new(ErrorKind::NotFound, "path not found")),
         }

--- a/core/services/etcd/src/backend.rs
+++ b/core/services/etcd/src/backend.rs
@@ -288,18 +288,7 @@ impl Access for EtcdBackend {
                 let size = range.size().map(|s| s as usize);
                 let end = size.map_or(buffer.len(), |s| (offset + s).min(buffer.len()));
                 let sliced_buffer = buffer.slice(offset..end);
-                let mut metadata =
-                    Metadata::new(EntryMode::FILE).with_content_length(sliced_buffer.len() as u64);
-                if !sliced_buffer.is_empty() {
-                    metadata.set_content_range(
-                        BytesContentRange::default()
-                            .with_range(
-                                range.offset(),
-                                range.offset() + sliced_buffer.len() as u64 - 1,
-                            )
-                            .with_size(total_size),
-                    );
-                }
+                let metadata = Metadata::new(EntryMode::FILE).with_content_length(total_size);
 
                 Ok((RpRead::new(metadata), sliced_buffer))
             }

--- a/core/services/foundationdb/src/backend.rs
+++ b/core/services/foundationdb/src/backend.rs
@@ -162,17 +162,7 @@ impl Access for FoundationdbBackend {
             }
         };
         let content = bs.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(bs.len() as u64),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
         Ok((RpRead::new(metadata), content))
     }
 

--- a/core/services/foundationdb/src/backend.rs
+++ b/core/services/foundationdb/src/backend.rs
@@ -161,7 +161,19 @@ impl Access for FoundationdbBackend {
                 ));
             }
         };
-        Ok((RpRead::new(), bs.slice(args.range().to_range_as_usize())))
+        let content = bs.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(bs.len() as u64),
+            );
+        }
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/foyer/src/backend.rs
+++ b/core/services/foyer/src/backend.rs
@@ -272,6 +272,7 @@ impl Access for FoyerBackend {
             Some(bs) => bs,
             None => return Err(Error::new(ErrorKind::NotFound, "key not found in foyer")),
         };
+        let content_length = buffer.len() as u64;
 
         let buffer = if args.range().is_full() {
             buffer
@@ -285,7 +286,7 @@ impl Access for FoyerBackend {
             buffer.slice(start..end.min(buffer.len()))
         };
 
-        let metadata = Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(content_length);
         Ok((RpRead::new(metadata), buffer))
     }
 

--- a/core/services/foyer/src/backend.rs
+++ b/core/services/foyer/src/backend.rs
@@ -285,7 +285,8 @@ impl Access for FoyerBackend {
             buffer.slice(start..end.min(buffer.len()))
         };
 
-        Ok((RpRead::new(), buffer))
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
+        Ok((RpRead::new(metadata), buffer))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/fs/src/backend.rs
+++ b/core/services/fs/src/backend.rs
@@ -217,23 +217,11 @@ impl Access for FsBackend {
         let f = self.core.fs_read(path, &args).await?;
         let file_metadata = f.metadata().await.map_err(new_std_io_error)?;
         let total_size = file_metadata.len();
-        let range = args.range();
-        let content_length = range
-            .size()
-            .unwrap_or_else(|| total_size.saturating_sub(range.offset()))
-            .min(total_size.saturating_sub(range.offset()));
-        let mut metadata = Metadata::new(EntryMode::FILE)
-            .with_content_length(content_length)
+        let metadata = Metadata::new(EntryMode::FILE)
+            .with_content_length(total_size)
             .with_last_modified(Timestamp::try_from(
                 file_metadata.modified().map_err(new_std_io_error)?,
             )?);
-        if !range.is_full() && content_length > 0 {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(range.offset(), range.offset() + content_length - 1)
-                    .with_size(total_size),
-            );
-        }
         let r = FsReader::new(
             self.core.clone(),
             f,

--- a/core/services/fs/src/backend.rs
+++ b/core/services/fs/src/backend.rs
@@ -215,12 +215,31 @@ impl Access for FsBackend {
     /// Benchmark could be found [here](https://gist.github.com/Xuanwo/48f9cfbc3022ea5f865388bb62e1a70f)
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let f = self.core.fs_read(path, &args).await?;
+        let file_metadata = f.metadata().await.map_err(new_std_io_error)?;
+        let total_size = file_metadata.len();
+        let range = args.range();
+        let content_length = range
+            .size()
+            .unwrap_or_else(|| total_size.saturating_sub(range.offset()))
+            .min(total_size.saturating_sub(range.offset()));
+        let mut metadata = Metadata::new(EntryMode::FILE)
+            .with_content_length(content_length)
+            .with_last_modified(Timestamp::try_from(
+                file_metadata.modified().map_err(new_std_io_error)?,
+            )?);
+        if !range.is_full() && content_length > 0 {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(range.offset(), range.offset() + content_length - 1)
+                    .with_size(total_size),
+            );
+        }
         let r = FsReader::new(
             self.core.clone(),
             f,
             args.range().size().unwrap_or(u64::MAX) as _,
         );
-        Ok((RpRead::new(), r))
+        Ok((RpRead::new(metadata), r))
     }
 
     async fn write(&self, path: &str, op: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/fs/src/backend.rs
+++ b/core/services/fs/src/backend.rs
@@ -204,30 +204,14 @@ impl Access for FsBackend {
         Ok(RpStat::new(m))
     }
 
-    /// # Notes
-    ///
-    /// There are three ways to get the total file length:
-    ///
-    /// - call std::fs::metadata directly and then open. (400ns)
-    /// - open file first, and then use `f.metadata()` (300ns)
-    /// - open file first, and then use `seek`. (100ns)
-    ///
-    /// Benchmark could be found [here](https://gist.github.com/Xuanwo/48f9cfbc3022ea5f865388bb62e1a70f)
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let f = self.core.fs_read(path, &args).await?;
-        let file_metadata = f.metadata().await.map_err(new_std_io_error)?;
-        let total_size = file_metadata.len();
-        let metadata = Metadata::new(EntryMode::FILE)
-            .with_content_length(total_size)
-            .with_last_modified(Timestamp::try_from(
-                file_metadata.modified().map_err(new_std_io_error)?,
-            )?);
         let r = FsReader::new(
             self.core.clone(),
             f,
             args.range().size().unwrap_or(u64::MAX) as _,
         );
-        Ok((RpRead::new(metadata), r))
+        Ok((RpRead::default(), r))
     }
 
     async fn write(&self, path: &str, op: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/ftp/src/backend.rs
+++ b/core/services/ftp/src/backend.rs
@@ -246,9 +246,13 @@ impl Access for FtpBackend {
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let ftp_stream = self.core.ftp_connect(Operation::Read).await?;
+        let content_length = args.range().size().unwrap_or(0);
 
         let reader = FtpReader::new(ftp_stream, path.to_string(), args).await?;
-        Ok((RpRead::new(), reader))
+        Ok((
+            RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(content_length)),
+            reader,
+        ))
     }
 
     async fn write(&self, path: &str, op: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/ftp/src/backend.rs
+++ b/core/services/ftp/src/backend.rs
@@ -245,14 +245,9 @@ impl Access for FtpBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let mut ftp_stream = self.core.ftp_connect(Operation::Read).await?;
-        let content_length = ftp_stream.size(path).await.map_err(format_ftp_error)? as u64;
-
+        let ftp_stream = self.core.ftp_connect(Operation::Read).await?;
         let reader = FtpReader::new(ftp_stream, path.to_string(), args).await?;
-        Ok((
-            RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(content_length)),
-            reader,
-        ))
+        Ok((RpRead::default(), reader))
     }
 
     async fn write(&self, path: &str, op: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/ftp/src/backend.rs
+++ b/core/services/ftp/src/backend.rs
@@ -245,8 +245,8 @@ impl Access for FtpBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let ftp_stream = self.core.ftp_connect(Operation::Read).await?;
-        let content_length = args.range().size().unwrap_or(0);
+        let mut ftp_stream = self.core.ftp_connect(Operation::Read).await?;
+        let content_length = ftp_stream.size(path).await.map_err(format_ftp_error)? as u64;
 
         let reader = FtpReader::new(ftp_stream, path.to_string(), args).await?;
         Ok((

--- a/core/services/gcs/src/backend.rs
+++ b/core/services/gcs/src/backend.rs
@@ -458,9 +458,10 @@ impl Access for GcsBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/gdrive/src/backend.rs
+++ b/core/services/gdrive/src/backend.rs
@@ -148,15 +148,19 @@ impl Access for GdriveBackend {
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((RpRead::new(), resp.into_body())),
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             StatusCode::NOT_FOUND => {
                 self.core.refresh_path(&abs_path).await;
                 let resp = self.core.gdrive_get(path, args.range()).await?;
                 let status = resp.status();
                 match status {
-                    StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                        Ok((RpRead::new(), resp.into_body()))
-                    }
+                    StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                        RpRead::new(parse_into_metadata(path, resp.headers())?),
+                        resp.into_body(),
+                    )),
                     _ => {
                         let (part, mut body) = resp.into_parts();
                         let buf = body.to_buffer().await?;

--- a/core/services/ghac/src/backend.rs
+++ b/core/services/ghac/src/backend.rs
@@ -231,15 +231,7 @@ impl Access for GhacBackend {
         let status = resp.status();
         match status {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT | StatusCode::RANGE_NOT_SATISFIABLE => {
-                let mut meta = parse_into_metadata(path, resp.headers())?;
-                // Correct content length via returning content range.
-                meta.set_content_length(
-                    meta.content_range()
-                        .expect("content range must be valid")
-                        .size()
-                        .expect("content range must contains size"),
-                );
-
+                let meta = parse_into_metadata(path, resp.headers())?;
                 Ok(RpStat::new(meta))
             }
             _ => Err(parse_error(resp)),

--- a/core/services/ghac/src/backend.rs
+++ b/core/services/ghac/src/backend.rs
@@ -251,9 +251,10 @@ impl Access for GhacBackend {
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/github/src/backend.rs
+++ b/core/services/github/src/backend.rs
@@ -218,9 +218,10 @@ impl Access for GithubBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/goosefs/src/backend.rs
+++ b/core/services/goosefs/src/backend.rs
@@ -324,12 +324,15 @@ impl Access for GoosefsBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let content_length = args.range().size().unwrap_or(0);
-        let reader = GoosefsReader::new(self.core.clone(), path.to_string(), args);
-        Ok((
-            RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(content_length)),
-            reader,
-        ))
+        let file_info = self.core.get_status(path).await?;
+        let metadata = self.core.file_info_to_metadata(&file_info);
+        let reader = GoosefsReader::new(
+            self.core.clone(),
+            path.to_string(),
+            args,
+            metadata.content_length(),
+        );
+        Ok((RpRead::new(metadata), reader))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/goosefs/src/backend.rs
+++ b/core/services/goosefs/src/backend.rs
@@ -324,8 +324,12 @@ impl Access for GoosefsBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        let content_length = args.range().size().unwrap_or(0);
         let reader = GoosefsReader::new(self.core.clone(), path.to_string(), args);
-        Ok((RpRead::new(), reader))
+        Ok((
+            RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(content_length)),
+            reader,
+        ))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/goosefs/src/backend.rs
+++ b/core/services/goosefs/src/backend.rs
@@ -330,12 +330,7 @@ impl Access for GoosefsBackend {
         } else {
             None
         };
-        let reader = GoosefsReader::new(
-            self.core.clone(),
-            path.to_string(),
-            args,
-            content_length,
-        );
+        let reader = GoosefsReader::new(self.core.clone(), path.to_string(), args, content_length);
         Ok((RpRead::default(), reader))
     }
 

--- a/core/services/goosefs/src/backend.rs
+++ b/core/services/goosefs/src/backend.rs
@@ -324,15 +324,19 @@ impl Access for GoosefsBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let file_info = self.core.get_status(path).await?;
-        let metadata = self.core.file_info_to_metadata(&file_info);
+        let content_length = if args.range().offset() != 0 && args.range().size().is_none() {
+            let file_info = self.core.get_status(path).await?;
+            Some(self.core.file_info_to_metadata(&file_info).content_length())
+        } else {
+            None
+        };
         let reader = GoosefsReader::new(
             self.core.clone(),
             path.to_string(),
             args,
-            metadata.content_length(),
+            content_length,
         );
-        Ok((RpRead::new(metadata), reader))
+        Ok((RpRead::default(), reader))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/goosefs/src/reader.rs
+++ b/core/services/goosefs/src/reader.rs
@@ -72,7 +72,7 @@ pub struct GoosefsReader {
     core: Arc<GoosefsCore>,
     path: String,
     args: OpRead,
-    content_length: u64,
+    content_length: Option<u64>,
     /// Lazily-opened SDK reader. `None` until the first `read()` call.
     inner: Option<SdkReader>,
     /// Terminal flag: once the underlying stream has returned `None`,
@@ -83,7 +83,12 @@ pub struct GoosefsReader {
 }
 
 impl GoosefsReader {
-    pub fn new(core: Arc<GoosefsCore>, path: String, args: OpRead, content_length: u64) -> Self {
+    pub fn new(
+        core: Arc<GoosefsCore>,
+        path: String,
+        args: OpRead,
+        content_length: Option<u64>,
+    ) -> Self {
         GoosefsReader {
             core,
             path,
@@ -112,7 +117,13 @@ impl GoosefsReader {
             (0, None) => self.core.open_reader(&self.path).await,
             (off, Some(len)) => self.core.open_range_reader(&self.path, off, len).await,
             (off, None) => {
-                let len = self.content_length.saturating_sub(off);
+                let content_length = self.content_length.ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::Unexpected,
+                        "content length must be known for offset reads",
+                    )
+                })?;
+                let len = content_length.saturating_sub(off);
                 if len == 0 {
                     // Empty tail — short-circuit with a zero-length
                     // ranged open so the very next `read_next_block`

--- a/core/services/goosefs/src/reader.rs
+++ b/core/services/goosefs/src/reader.rs
@@ -72,6 +72,7 @@ pub struct GoosefsReader {
     core: Arc<GoosefsCore>,
     path: String,
     args: OpRead,
+    content_length: u64,
     /// Lazily-opened SDK reader. `None` until the first `read()` call.
     inner: Option<SdkReader>,
     /// Terminal flag: once the underlying stream has returned `None`,
@@ -82,11 +83,12 @@ pub struct GoosefsReader {
 }
 
 impl GoosefsReader {
-    pub fn new(core: Arc<GoosefsCore>, path: String, args: OpRead) -> Self {
+    pub fn new(core: Arc<GoosefsCore>, path: String, args: OpRead, content_length: u64) -> Self {
         GoosefsReader {
             core,
             path,
             args,
+            content_length,
             inner: None,
             done: false,
         }
@@ -110,9 +112,7 @@ impl GoosefsReader {
             (0, None) => self.core.open_reader(&self.path).await,
             (off, Some(len)) => self.core.open_range_reader(&self.path, off, len).await,
             (off, None) => {
-                let info = self.core.get_status(&self.path).await?;
-                let file_len = info.length.unwrap_or(0) as u64;
-                let len = file_len.saturating_sub(off);
+                let len = self.content_length.saturating_sub(off);
                 if len == 0 {
                     // Empty tail — short-circuit with a zero-length
                     // ranged open so the very next `read_next_block`

--- a/core/services/gridfs/src/backend.rs
+++ b/core/services/gridfs/src/backend.rs
@@ -221,7 +221,19 @@ impl Access for GridfsBackend {
                 return Err(Error::new(ErrorKind::NotFound, "kv not found in gridfs"));
             }
         };
-        Ok((RpRead::new(), bs.slice(args.range().to_range_as_usize())))
+        let content = bs.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(bs.len() as u64),
+            );
+        }
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/gridfs/src/backend.rs
+++ b/core/services/gridfs/src/backend.rs
@@ -222,17 +222,7 @@ impl Access for GridfsBackend {
             }
         };
         let content = bs.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(bs.len() as u64),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
         Ok((RpRead::new(metadata), content))
     }
 

--- a/core/services/hdfs-native/src/backend.rs
+++ b/core/services/hdfs-native/src/backend.rs
@@ -191,14 +191,12 @@ impl Access for HdfsNativeBackend {
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let (f, offset, size) = self.core.hdfs_read(path, &args).await?;
+        let content_length = f.file_length() as u64;
 
         let r = HdfsNativeReader::new(f, offset as _, size as _);
 
         Ok((
-            RpRead::new(
-                Metadata::new(EntryMode::FILE)
-                    .with_content_length(args.range().size().unwrap_or(0)),
-            ),
+            RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(content_length)),
             r,
         ))
     }

--- a/core/services/hdfs-native/src/backend.rs
+++ b/core/services/hdfs-native/src/backend.rs
@@ -194,7 +194,13 @@ impl Access for HdfsNativeBackend {
 
         let r = HdfsNativeReader::new(f, offset as _, size as _);
 
-        Ok((RpRead::new(), r))
+        Ok((
+            RpRead::new(
+                Metadata::new(EntryMode::FILE)
+                    .with_content_length(args.range().size().unwrap_or(0)),
+            ),
+            r,
+        ))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/hdfs/src/backend.rs
+++ b/core/services/hdfs/src/backend.rs
@@ -219,13 +219,11 @@ impl Access for HdfsBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        let metadata = self.core.hdfs_stat(path)?;
         let f = self.core.hdfs_read(path, &args).await?;
 
         Ok((
-            RpRead::new(
-                Metadata::new(EntryMode::FILE)
-                    .with_content_length(args.range().size().unwrap_or(0)),
-            ),
+            RpRead::new(metadata),
             HdfsReader::new(f, args.range().size().unwrap_or(u64::MAX) as _),
         ))
     }

--- a/core/services/hdfs/src/backend.rs
+++ b/core/services/hdfs/src/backend.rs
@@ -222,7 +222,10 @@ impl Access for HdfsBackend {
         let f = self.core.hdfs_read(path, &args).await?;
 
         Ok((
-            RpRead::new(),
+            RpRead::new(
+                Metadata::new(EntryMode::FILE)
+                    .with_content_length(args.range().size().unwrap_or(0)),
+            ),
             HdfsReader::new(f, args.range().size().unwrap_or(u64::MAX) as _),
         ))
     }

--- a/core/services/hdfs/src/backend.rs
+++ b/core/services/hdfs/src/backend.rs
@@ -219,11 +219,10 @@ impl Access for HdfsBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let metadata = self.core.hdfs_stat(path)?;
         let f = self.core.hdfs_read(path, &args).await?;
 
         Ok((
-            RpRead::new(metadata),
+            RpRead::default(),
             HdfsReader::new(f, args.range().size().unwrap_or(u64::MAX) as _),
         ))
     }

--- a/core/services/hf/src/backend.rs
+++ b/core/services/hf/src/backend.rs
@@ -268,8 +268,8 @@ impl Access for HfBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let reader = HfReader::try_new(&self.core, path, args.range()).await?;
-        Ok((RpRead::default(), reader))
+        let (metadata, reader) = HfReader::try_new(&self.core, path, args.range()).await?;
+        Ok((RpRead::new(metadata), reader))
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {

--- a/core/services/hf/src/reader.rs
+++ b/core/services/hf/src/reader.rs
@@ -112,19 +112,9 @@ impl HfReader {
         stream.start();
 
         let total_size = file_info.file_size.unwrap_or_default();
-        let content_length = range
-            .size()
-            .unwrap_or_else(|| total_size.saturating_sub(range.offset()));
-        let mut metadata = Metadata::new(EntryMode::FILE)
-            .with_content_length(content_length)
+        let metadata = Metadata::new(EntryMode::FILE)
+            .with_content_length(total_size)
             .with_etag(file_info.hash().to_string());
-        if !range.is_full() && content_length > 0 {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(range.offset(), range.offset() + content_length - 1)
-                    .with_size(total_size),
-            );
-        }
 
         Ok((metadata, Self::Xet(stream)))
     }

--- a/core/services/hf/src/reader.rs
+++ b/core/services/hf/src/reader.rs
@@ -36,7 +36,7 @@ impl HfReader {
     /// Buckets always use XET. For other repo types, a HEAD request
     /// probes for the `X-Xet-Hash` header. Files stored on XET are
     /// downloaded via the CAS protocol; all others fall back to HTTP GET.
-    pub async fn try_new(core: &HfCore, path: &str, range: BytesRange) -> Result<Self> {
+    pub async fn try_new(core: &HfCore, path: &str, range: BytesRange) -> Result<(Metadata, Self)> {
         if let Some(xet_file) = core.maybe_xet_file(path).await? {
             return Self::try_new_xet(core, &xet_file, range).await;
         }
@@ -51,7 +51,11 @@ impl HfReader {
         Self::try_new_http(core, path, range).await
     }
 
-    pub async fn try_new_http(core: &HfCore, path: &str, range: BytesRange) -> Result<Self> {
+    pub async fn try_new_http(
+        core: &HfCore,
+        path: &str,
+        range: BytesRange,
+    ) -> Result<(Metadata, Self)> {
         let client = core.info.http_client();
         let uri = core.uri(path);
         let url = uri.resolve_url(&core.endpoint);
@@ -68,7 +72,10 @@ impl HfReader {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok(Self::Http(resp.into_body())),
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                parse_into_metadata(path, resp.headers())?,
+                Self::Http(resp.into_body()),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
@@ -81,7 +88,7 @@ impl HfReader {
         core: &HfCore,
         file_info: &XetFileInfo,
         range: BytesRange,
-    ) -> Result<Self> {
+    ) -> Result<(Metadata, Self)> {
         let group = core.xet_download_group().await?;
 
         let xet_range = if range.is_full() {
@@ -103,7 +110,23 @@ impl HfReader {
                 .set_source(err)
             })?;
         stream.start();
-        Ok(Self::Xet(stream))
+
+        let total_size = file_info.file_size.unwrap_or_default();
+        let content_length = range
+            .size()
+            .unwrap_or_else(|| total_size.saturating_sub(range.offset()));
+        let mut metadata = Metadata::new(EntryMode::FILE)
+            .with_content_length(content_length)
+            .with_etag(file_info.hash().to_string());
+        if !range.is_full() && content_length > 0 {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(range.offset(), range.offset() + content_length - 1)
+                    .with_size(total_size),
+            );
+        }
+
+        Ok((metadata, Self::Xet(stream)))
     }
 }
 

--- a/core/services/http/src/backend.rs
+++ b/core/services/http/src/backend.rs
@@ -207,9 +207,10 @@ impl Access for HttpBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/ipfs/src/backend.rs
+++ b/core/services/ipfs/src/backend.rs
@@ -164,9 +164,10 @@ impl Access for IpfsBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/ipmfs/src/backend.rs
+++ b/core/services/ipmfs/src/backend.rs
@@ -97,9 +97,10 @@ impl Access for IpmfsBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/ipmfs/src/backend.rs
+++ b/core/services/ipmfs/src/backend.rs
@@ -97,10 +97,9 @@ impl Access for IpmfsBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
-                RpRead::new(parse_into_metadata(path, resp.headers())?),
-                resp.into_body(),
-            )),
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
+                Ok((RpRead::default(), resp.into_body()))
+            }
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/koofr/src/backend.rs
+++ b/core/services/koofr/src/backend.rs
@@ -244,9 +244,10 @@ impl Access for KoofrBackend {
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/lakefs/src/backend.rs
+++ b/core/services/lakefs/src/backend.rs
@@ -234,9 +234,10 @@ impl Access for LakefsBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/memcached/src/backend.rs
+++ b/core/services/memcached/src/backend.rs
@@ -249,17 +249,7 @@ impl Access for MemcachedBackend {
             None => return Err(Error::new(ErrorKind::NotFound, "kv not found in memcached")),
         };
         let content = bs.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(bs.len() as u64),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
         Ok((RpRead::new(metadata), content))
     }
 

--- a/core/services/memcached/src/backend.rs
+++ b/core/services/memcached/src/backend.rs
@@ -248,7 +248,19 @@ impl Access for MemcachedBackend {
             Some(bs) => bs,
             None => return Err(Error::new(ErrorKind::NotFound, "kv not found in memcached")),
         };
-        Ok((RpRead::new(), bs.slice(args.range().to_range_as_usize())))
+        let content = bs.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(bs.len() as u64),
+            );
+        }
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/mini_moka/src/backend.rs
+++ b/core/services/mini_moka/src/backend.rs
@@ -195,10 +195,12 @@ impl Access for MiniMokaBackend {
         match self.core.get(&p) {
             Some(value) => {
                 let range = op.range();
+                let total_size = value.content.len() as u64;
 
                 // If range is full, return the content buffer directly
                 if range.is_full() {
-                    return Ok((RpRead::new(), value.content));
+                    let metadata = Metadata::new(EntryMode::FILE).with_content_length(total_size);
+                    return Ok((RpRead::new(metadata), value.content));
                 }
 
                 let offset = range.offset() as usize;
@@ -214,8 +216,20 @@ impl Access for MiniMokaBackend {
                     (offset + s).min(value.content.len())
                 });
                 let sliced_content = value.content.slice(offset..end);
+                let mut metadata =
+                    Metadata::new(EntryMode::FILE).with_content_length(sliced_content.len() as u64);
+                if !sliced_content.is_empty() {
+                    metadata.set_content_range(
+                        BytesContentRange::default()
+                            .with_range(
+                                range.offset(),
+                                range.offset() + sliced_content.len() as u64 - 1,
+                            )
+                            .with_size(total_size),
+                    );
+                }
 
-                Ok((RpRead::new(), sliced_content))
+                Ok((RpRead::new(metadata), sliced_content))
             }
             None => Err(Error::new(ErrorKind::NotFound, "path not found")),
         }

--- a/core/services/mini_moka/src/backend.rs
+++ b/core/services/mini_moka/src/backend.rs
@@ -216,18 +216,7 @@ impl Access for MiniMokaBackend {
                     (offset + s).min(value.content.len())
                 });
                 let sliced_content = value.content.slice(offset..end);
-                let mut metadata =
-                    Metadata::new(EntryMode::FILE).with_content_length(sliced_content.len() as u64);
-                if !sliced_content.is_empty() {
-                    metadata.set_content_range(
-                        BytesContentRange::default()
-                            .with_range(
-                                range.offset(),
-                                range.offset() + sliced_content.len() as u64 - 1,
-                            )
-                            .with_size(total_size),
-                    );
-                }
+                let metadata = Metadata::new(EntryMode::FILE).with_content_length(total_size);
 
                 Ok((RpRead::new(metadata), sliced_content))
             }

--- a/core/services/moka/src/backend.rs
+++ b/core/services/moka/src/backend.rs
@@ -290,18 +290,7 @@ impl Access for MokaBackend {
                     };
                     value.content.slice(start..end.min(value.content.len()))
                 };
-                let mut metadata =
-                    Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
-                if !args.range().is_full() && !buffer.is_empty() {
-                    metadata.set_content_range(
-                        BytesContentRange::default()
-                            .with_range(
-                                args.range().offset(),
-                                args.range().offset() + buffer.len() as u64 - 1,
-                            )
-                            .with_size(total_size),
-                    );
-                }
+                let metadata = Metadata::new(EntryMode::FILE).with_content_length(total_size);
                 Ok((RpRead::new(metadata), buffer))
             }
             None => Err(Error::new(ErrorKind::NotFound, "key not found in moka")),

--- a/core/services/moka/src/backend.rs
+++ b/core/services/moka/src/backend.rs
@@ -278,6 +278,7 @@ impl Access for MokaBackend {
 
         match self.core.get(&p).await? {
             Some(value) => {
+                let total_size = value.content.len() as u64;
                 let buffer = if args.range().is_full() {
                     value.content
                 } else {
@@ -289,7 +290,19 @@ impl Access for MokaBackend {
                     };
                     value.content.slice(start..end.min(value.content.len()))
                 };
-                Ok((RpRead::new(), buffer))
+                let mut metadata =
+                    Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
+                if !args.range().is_full() && !buffer.is_empty() {
+                    metadata.set_content_range(
+                        BytesContentRange::default()
+                            .with_range(
+                                args.range().offset(),
+                                args.range().offset() + buffer.len() as u64 - 1,
+                            )
+                            .with_size(total_size),
+                    );
+                }
+                Ok((RpRead::new(metadata), buffer))
             }
             None => Err(Error::new(ErrorKind::NotFound, "key not found in moka")),
         }

--- a/core/services/mongodb/src/backend.rs
+++ b/core/services/mongodb/src/backend.rs
@@ -239,7 +239,19 @@ impl Access for MongodbBackend {
                 return Err(Error::new(ErrorKind::NotFound, "kv not found in mongodb"));
             }
         };
-        Ok((RpRead::new(), bs.slice(args.range().to_range_as_usize())))
+        let content = bs.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(bs.len() as u64),
+            );
+        }
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/mongodb/src/backend.rs
+++ b/core/services/mongodb/src/backend.rs
@@ -240,17 +240,7 @@ impl Access for MongodbBackend {
             }
         };
         let content = bs.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(bs.len() as u64),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
         Ok((RpRead::new(metadata), content))
     }
 

--- a/core/services/monoiofs/src/backend.rs
+++ b/core/services/monoiofs/src/backend.rs
@@ -127,12 +127,10 @@ impl Access for MonoiofsBackend {
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let path = self.core.prepare_path(path);
-        let reader = MonoiofsReader::new(self.core.clone(), path, args.range()).await?;
+        let (reader, content_length) =
+            MonoiofsReader::new(self.core.clone(), path, args.range()).await?;
         Ok((
-            RpRead::new(
-                Metadata::new(EntryMode::FILE)
-                    .with_content_length(args.range().size().unwrap_or(0)),
-            ),
+            RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(content_length)),
             reader,
         ))
     }

--- a/core/services/monoiofs/src/backend.rs
+++ b/core/services/monoiofs/src/backend.rs
@@ -127,12 +127,8 @@ impl Access for MonoiofsBackend {
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let path = self.core.prepare_path(path);
-        let (reader, content_length) =
-            MonoiofsReader::new(self.core.clone(), path, args.range()).await?;
-        Ok((
-            RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(content_length)),
-            reader,
-        ))
+        let reader = MonoiofsReader::new(self.core.clone(), path, args.range()).await?;
+        Ok((RpRead::default(), reader))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/monoiofs/src/backend.rs
+++ b/core/services/monoiofs/src/backend.rs
@@ -128,7 +128,13 @@ impl Access for MonoiofsBackend {
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let path = self.core.prepare_path(path);
         let reader = MonoiofsReader::new(self.core.clone(), path, args.range()).await?;
-        Ok((RpRead::default(), reader))
+        Ok((
+            RpRead::new(
+                Metadata::new(EntryMode::FILE)
+                    .with_content_length(args.range().size().unwrap_or(0)),
+            ),
+            reader,
+        ))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/monoiofs/src/reader.rs
+++ b/core/services/monoiofs/src/reader.rs
@@ -46,46 +46,32 @@ pub struct MonoiofsReader {
 }
 
 impl MonoiofsReader {
-    pub async fn new(
-        core: Arc<MonoiofsCore>,
-        path: PathBuf,
-        range: BytesRange,
-    ) -> Result<(Self, u64)> {
+    pub async fn new(core: Arc<MonoiofsCore>, path: PathBuf, range: BytesRange) -> Result<Self> {
         let (open_result_tx, open_result_rx) = oneshot::channel();
         let (tx, rx) = mpsc::unbounded();
         core.spawn(move || Self::worker_entrypoint(path, rx, open_result_tx))
             .await;
-        let content_length = core.unwrap(open_result_rx.await)?;
-        Ok((
-            Self {
-                core,
-                tx,
-                pos: range.offset(),
-                end_pos: range.size().map(|size| range.offset() + size),
-            },
-            content_length,
-        ))
+        core.unwrap(open_result_rx.await)?;
+        Ok(Self {
+            core,
+            tx,
+            pos: range.offset(),
+            end_pos: range.size().map(|size| range.offset() + size),
+        })
     }
 
     /// entrypoint of worker task that runs in context of monoio
     async fn worker_entrypoint(
         path: PathBuf,
         mut rx: mpsc::UnboundedReceiver<ReaderRequest>,
-        open_result_tx: oneshot::Sender<Result<u64>>,
+        open_result_tx: oneshot::Sender<Result<()>>,
     ) {
         let result = OpenOptions::new().read(true).open(path).await;
         // [`monoio::fs::File`] is non-Send, hence it is kept within
         // worker thread
         let file = match result {
             Ok(file) => {
-                let content_length = match file.metadata().await {
-                    Ok(metadata) => metadata.len(),
-                    Err(err) => {
-                        let _ = open_result_tx.send(Err(new_std_io_error(err)));
-                        return;
-                    }
-                };
-                let Ok(()) = open_result_tx.send(Ok(content_length)) else {
+                let Ok(()) = open_result_tx.send(Ok(())) else {
                     // MonoiofsReader::new is cancelled, exit worker task
                     return;
                 };

--- a/core/services/monoiofs/src/reader.rs
+++ b/core/services/monoiofs/src/reader.rs
@@ -46,32 +46,46 @@ pub struct MonoiofsReader {
 }
 
 impl MonoiofsReader {
-    pub async fn new(core: Arc<MonoiofsCore>, path: PathBuf, range: BytesRange) -> Result<Self> {
+    pub async fn new(
+        core: Arc<MonoiofsCore>,
+        path: PathBuf,
+        range: BytesRange,
+    ) -> Result<(Self, u64)> {
         let (open_result_tx, open_result_rx) = oneshot::channel();
         let (tx, rx) = mpsc::unbounded();
         core.spawn(move || Self::worker_entrypoint(path, rx, open_result_tx))
             .await;
-        core.unwrap(open_result_rx.await)?;
-        Ok(Self {
-            core,
-            tx,
-            pos: range.offset(),
-            end_pos: range.size().map(|size| range.offset() + size),
-        })
+        let content_length = core.unwrap(open_result_rx.await)?;
+        Ok((
+            Self {
+                core,
+                tx,
+                pos: range.offset(),
+                end_pos: range.size().map(|size| range.offset() + size),
+            },
+            content_length,
+        ))
     }
 
     /// entrypoint of worker task that runs in context of monoio
     async fn worker_entrypoint(
         path: PathBuf,
         mut rx: mpsc::UnboundedReceiver<ReaderRequest>,
-        open_result_tx: oneshot::Sender<Result<()>>,
+        open_result_tx: oneshot::Sender<Result<u64>>,
     ) {
         let result = OpenOptions::new().read(true).open(path).await;
         // [`monoio::fs::File`] is non-Send, hence it is kept within
         // worker thread
         let file = match result {
             Ok(file) => {
-                let Ok(()) = open_result_tx.send(Ok(())) else {
+                let content_length = match file.metadata().await {
+                    Ok(metadata) => metadata.len(),
+                    Err(err) => {
+                        let _ = open_result_tx.send(Err(new_std_io_error(err)));
+                        return;
+                    }
+                };
+                let Ok(()) = open_result_tx.send(Ok(content_length)) else {
                     // MonoiofsReader::new is cancelled, exit worker task
                     return;
                 };

--- a/core/services/mysql/src/backend.rs
+++ b/core/services/mysql/src/backend.rs
@@ -222,7 +222,19 @@ impl Access for MysqlBackend {
             Some(bs) => bs,
             None => return Err(Error::new(ErrorKind::NotFound, "kv not found in mysql")),
         };
-        Ok((RpRead::new(), bs.slice(args.range().to_range_as_usize())))
+        let content = bs.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(bs.len() as u64),
+            );
+        }
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/mysql/src/backend.rs
+++ b/core/services/mysql/src/backend.rs
@@ -223,17 +223,7 @@ impl Access for MysqlBackend {
             None => return Err(Error::new(ErrorKind::NotFound, "kv not found in mysql")),
         };
         let content = bs.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(bs.len() as u64),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
         Ok((RpRead::new(metadata), content))
     }
 

--- a/core/services/obs/src/backend.rs
+++ b/core/services/obs/src/backend.rs
@@ -327,9 +327,10 @@ impl Access for ObsBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/onedrive/src/backend.rs
+++ b/core/services/onedrive/src/backend.rs
@@ -67,9 +67,10 @@ impl Access for OnedriveBackend {
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let response = self.core.onedrive_get_content(path, &args).await?;
         match response.status() {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), response.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, response.headers())?),
+                response.into_body(),
+            )),
             _ => {
                 let (part, mut body) = response.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/opfs/src/backend.rs
+++ b/core/services/opfs/src/backend.rs
@@ -109,7 +109,13 @@ impl Access for OpfsBackend {
         let p = build_abs_path(&self.core.root, path);
         let handle = get_file_handle(&p, false).await?;
 
-        Ok((RpRead::new(), OpfsReader::new(handle, args.range())))
+        Ok((
+            RpRead::new(
+                Metadata::new(EntryMode::FILE)
+                    .with_content_length(args.range().size().unwrap_or(0)),
+            ),
+            OpfsReader::new(handle, args.range()),
+        ))
     }
 
     async fn list(&self, path: &str, _args: OpList) -> Result<(RpList, Self::Lister)> {

--- a/core/services/opfs/src/backend.rs
+++ b/core/services/opfs/src/backend.rs
@@ -108,18 +108,7 @@ impl Access for OpfsBackend {
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let p = build_abs_path(&self.core.root, path);
         let handle = get_file_handle(&p, false).await?;
-        let file: File = JsFuture::from(handle.get_file())
-            .await
-            .and_then(JsCast::dyn_into)
-            .map_err(parse_js_error)?;
-
-        let mut meta = Metadata::new(EntryMode::FILE);
-        meta.set_content_length(file.size() as u64);
-        if let Ok(t) = Timestamp::from_millisecond(file.last_modified() as i64) {
-            meta.set_last_modified(t);
-        }
-
-        Ok((RpRead::new(meta), OpfsReader::new(handle, args.range())))
+        Ok((RpRead::default(), OpfsReader::new(handle, args.range())))
     }
 
     async fn list(&self, path: &str, _args: OpList) -> Result<(RpList, Self::Lister)> {

--- a/core/services/opfs/src/backend.rs
+++ b/core/services/opfs/src/backend.rs
@@ -108,14 +108,18 @@ impl Access for OpfsBackend {
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
         let p = build_abs_path(&self.core.root, path);
         let handle = get_file_handle(&p, false).await?;
+        let file: File = JsFuture::from(handle.get_file())
+            .await
+            .and_then(JsCast::dyn_into)
+            .map_err(parse_js_error)?;
 
-        Ok((
-            RpRead::new(
-                Metadata::new(EntryMode::FILE)
-                    .with_content_length(args.range().size().unwrap_or(0)),
-            ),
-            OpfsReader::new(handle, args.range()),
-        ))
+        let mut meta = Metadata::new(EntryMode::FILE);
+        meta.set_content_length(file.size() as u64);
+        if let Ok(t) = Timestamp::from_millisecond(file.last_modified() as i64) {
+            meta.set_last_modified(t);
+        }
+
+        Ok((RpRead::new(meta), OpfsReader::new(handle, args.range())))
     }
 
     async fn list(&self, path: &str, _args: OpList) -> Result<(RpList, Self::Lister)> {

--- a/core/services/oss/src/backend.rs
+++ b/core/services/oss/src/backend.rs
@@ -676,9 +676,10 @@ impl Access for OssBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/pcloud/src/backend.rs
+++ b/core/services/pcloud/src/backend.rs
@@ -231,9 +231,10 @@ impl Access for PcloudBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/persy/src/backend.rs
+++ b/core/services/persy/src/backend.rs
@@ -185,17 +185,7 @@ impl Access for PersyBackend {
             }
         };
         let content = bs.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(bs.len() as u64),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
         Ok((RpRead::new(metadata), content))
     }
 

--- a/core/services/persy/src/backend.rs
+++ b/core/services/persy/src/backend.rs
@@ -184,7 +184,19 @@ impl Access for PersyBackend {
                 return Err(Error::new(ErrorKind::NotFound, "kv not found in persy"));
             }
         };
-        Ok((RpRead::new(), bs.slice(args.range().to_range_as_usize())))
+        let content = bs.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(bs.len() as u64),
+            );
+        }
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/postgresql/src/backend.rs
+++ b/core/services/postgresql/src/backend.rs
@@ -223,17 +223,7 @@ impl Access for PostgresqlBackend {
             }
         };
         let content = bs.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(bs.len() as u64),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
         Ok((RpRead::new(metadata), content))
     }
 

--- a/core/services/postgresql/src/backend.rs
+++ b/core/services/postgresql/src/backend.rs
@@ -222,7 +222,19 @@ impl Access for PostgresqlBackend {
                 ));
             }
         };
-        Ok((RpRead::new(), bs.slice(args.range().to_range_as_usize())))
+        let content = bs.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(bs.len() as u64),
+            );
+        }
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/redb/src/backend.rs
+++ b/core/services/redb/src/backend.rs
@@ -202,7 +202,19 @@ impl Access for RedbBackend {
                 return Err(Error::new(ErrorKind::NotFound, "kv not found in redb"));
             }
         };
-        Ok((RpRead::new(), bs.slice(args.range().to_range_as_usize())))
+        let content = bs.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(bs.len() as u64),
+            );
+        }
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/redb/src/backend.rs
+++ b/core/services/redb/src/backend.rs
@@ -203,17 +203,7 @@ impl Access for RedbBackend {
             }
         };
         let content = bs.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(bs.len() as u64),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
         Ok((RpRead::new(metadata), content))
     }
 

--- a/core/services/redis/src/backend.rs
+++ b/core/services/redis/src/backend.rs
@@ -338,12 +338,13 @@ impl Access for RedisBackend {
         let p = build_abs_path(&self.root, path);
 
         let range = args.range();
-        let (buffer, content_length) = if range.is_full() {
+        let (buffer, metadata) = if range.is_full() {
             // Full read - use GET
             match self.core.get(&p).await? {
                 Some(bs) => {
-                    let content_length = bs.len() as u64;
-                    (bs, content_length)
+                    let metadata =
+                        Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
+                    (bs, Some(metadata))
                 }
                 None => return Err(Error::new(ErrorKind::NotFound, "key not found in redis")),
             }
@@ -356,16 +357,13 @@ impl Access for RedisBackend {
             };
 
             match self.core.get_range(&p, start, end).await? {
-                Some(bs) => {
-                    let content_length = self.core.len(&p).await? as u64;
-                    (bs, content_length)
-                }
+                Some(bs) => (bs, None),
                 None => return Err(Error::new(ErrorKind::NotFound, "key not found in redis")),
             }
         };
 
-        let metadata = Metadata::new(EntryMode::FILE).with_content_length(content_length);
-        Ok((RpRead::new(metadata), buffer))
+        let rp = metadata.map_or_else(RpRead::default, RpRead::new);
+        Ok((rp, buffer))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/redis/src/backend.rs
+++ b/core/services/redis/src/backend.rs
@@ -338,10 +338,13 @@ impl Access for RedisBackend {
         let p = build_abs_path(&self.root, path);
 
         let range = args.range();
-        let buffer = if range.is_full() {
+        let (buffer, content_length) = if range.is_full() {
             // Full read - use GET
             match self.core.get(&p).await? {
-                Some(bs) => bs,
+                Some(bs) => {
+                    let content_length = bs.len() as u64;
+                    (bs, content_length)
+                }
                 None => return Err(Error::new(ErrorKind::NotFound, "key not found in redis")),
             }
         } else {
@@ -353,12 +356,15 @@ impl Access for RedisBackend {
             };
 
             match self.core.get_range(&p, start, end).await? {
-                Some(bs) => bs,
+                Some(bs) => {
+                    let content_length = self.core.len(&p).await? as u64;
+                    (bs, content_length)
+                }
                 None => return Err(Error::new(ErrorKind::NotFound, "key not found in redis")),
             }
         };
 
-        let metadata = Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(content_length);
         Ok((RpRead::new(metadata), buffer))
     }
 

--- a/core/services/redis/src/backend.rs
+++ b/core/services/redis/src/backend.rs
@@ -358,7 +358,8 @@ impl Access for RedisBackend {
             }
         };
 
-        Ok((RpRead::new(), buffer))
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
+        Ok((RpRead::new(metadata), buffer))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/redis/src/core.rs
+++ b/core/services/redis/src/core.rs
@@ -184,6 +184,11 @@ impl RedisCore {
         Ok(result.map(Buffer::from))
     }
 
+    pub async fn len(&self, key: &str) -> Result<usize> {
+        let mut conn = self.conn().await?;
+        conn.strlen(key).await.map_err(format_redis_error)
+    }
+
     pub async fn set(&self, key: &str, value: Buffer) -> Result<()> {
         let mut conn = self.conn().await?;
         let value = value.to_vec();

--- a/core/services/redis/src/core.rs
+++ b/core/services/redis/src/core.rs
@@ -184,11 +184,6 @@ impl RedisCore {
         Ok(result.map(Buffer::from))
     }
 
-    pub async fn len(&self, key: &str) -> Result<usize> {
-        let mut conn = self.conn().await?;
-        conn.strlen(key).await.map_err(format_redis_error)
-    }
-
     pub async fn set(&self, key: &str, value: Buffer) -> Result<()> {
         let mut conn = self.conn().await?;
         let value = value.to_vec();

--- a/core/services/rocksdb/src/backend.rs
+++ b/core/services/rocksdb/src/backend.rs
@@ -153,17 +153,7 @@ impl Access for RocksdbBackend {
             }
         };
         let content = bs.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(bs.len() as u64),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
         Ok((RpRead::new(metadata), content))
     }
 

--- a/core/services/rocksdb/src/backend.rs
+++ b/core/services/rocksdb/src/backend.rs
@@ -152,7 +152,19 @@ impl Access for RocksdbBackend {
                 return Err(Error::new(ErrorKind::NotFound, "kv not found in rocksdb"));
             }
         };
-        Ok((RpRead::new(), bs.slice(args.range().to_range_as_usize())))
+        let content = bs.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(bs.len() as u64),
+            );
+        }
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -1082,9 +1082,10 @@ impl Access for S3Backend {
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/s3/src/error.rs
+++ b/core/services/s3/src/error.rs
@@ -131,6 +131,7 @@ pub fn parse_s3_error_code(code: &str) -> Option<(ErrorKind, bool)> {
         | "ExceedAccountRateLimit"
         | "ExceedBucketQPSLimit"
         | "ExceedBucketRateLimit" => Some((ErrorKind::RateLimited, true)),
+        "InvalidRange" => Some((ErrorKind::RangeNotSatisfied, false)),
         _ => None,
     }
 }
@@ -179,5 +180,13 @@ mod tests {
 
         let out: S3Error = de::from_reader(bs.reader()).expect("must success");
         assert_eq!(out, S3Error::default());
+    }
+
+    #[test]
+    fn test_parse_s3_error_code_invalid_range() {
+        assert_eq!(
+            parse_s3_error_code("InvalidRange"),
+            Some((ErrorKind::RangeNotSatisfied, false))
+        );
     }
 }

--- a/core/services/seafile/src/backend.rs
+++ b/core/services/seafile/src/backend.rs
@@ -237,9 +237,10 @@ impl Access for SeafileBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/sftp/src/backend.rs
+++ b/core/services/sftp/src/backend.rs
@@ -266,6 +266,7 @@ impl Access for SftpBackend {
             .open(path.as_path())
             .await
             .map_err(parse_sftp_error)?;
+        let metadata = to_metadata(f.metadata().await.map_err(parse_sftp_error)?);
 
         if args.range().offset() != 0 {
             f.seek(SeekFrom::Start(args.range().offset()))
@@ -274,10 +275,7 @@ impl Access for SftpBackend {
         }
 
         Ok((
-            RpRead::new(
-                Metadata::new(EntryMode::FILE)
-                    .with_content_length(args.range().size().unwrap_or(0)),
-            ),
+            RpRead::new(metadata),
             SftpReader::new(client, f, args.range().size()),
         ))
     }

--- a/core/services/sftp/src/backend.rs
+++ b/core/services/sftp/src/backend.rs
@@ -266,7 +266,6 @@ impl Access for SftpBackend {
             .open(path.as_path())
             .await
             .map_err(parse_sftp_error)?;
-        let metadata = to_metadata(f.metadata().await.map_err(parse_sftp_error)?);
 
         if args.range().offset() != 0 {
             f.seek(SeekFrom::Start(args.range().offset()))
@@ -275,7 +274,7 @@ impl Access for SftpBackend {
         }
 
         Ok((
-            RpRead::new(metadata),
+            RpRead::default(),
             SftpReader::new(client, f, args.range().size()),
         ))
     }

--- a/core/services/sftp/src/backend.rs
+++ b/core/services/sftp/src/backend.rs
@@ -274,7 +274,10 @@ impl Access for SftpBackend {
         }
 
         Ok((
-            RpRead::default(),
+            RpRead::new(
+                Metadata::new(EntryMode::FILE)
+                    .with_content_length(args.range().size().unwrap_or(0)),
+            ),
             SftpReader::new(client, f, args.range().size()),
         ))
     }

--- a/core/services/sled/src/backend.rs
+++ b/core/services/sled/src/backend.rs
@@ -176,7 +176,19 @@ impl Access for SledBackend {
                 return Err(Error::new(ErrorKind::NotFound, "kv not found in sled"));
             }
         };
-        Ok((RpRead::new(), bs.slice(args.range().to_range_as_usize())))
+        let content = bs.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(bs.len() as u64),
+            );
+        }
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/sled/src/backend.rs
+++ b/core/services/sled/src/backend.rs
@@ -177,17 +177,7 @@ impl Access for SledBackend {
             }
         };
         let content = bs.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(bs.len() as u64),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
         Ok((RpRead::new(metadata), content))
     }
 

--- a/core/services/sqlite/src/backend.rs
+++ b/core/services/sqlite/src/backend.rs
@@ -280,7 +280,8 @@ impl Access for SqliteBackend {
             }
         };
 
-        Ok((RpRead::new(), buffer))
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
+        Ok((RpRead::new(metadata), buffer))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/sqlite/src/backend.rs
+++ b/core/services/sqlite/src/backend.rs
@@ -260,10 +260,13 @@ impl Access for SqliteBackend {
         let p = build_abs_path(&self.root, path);
 
         let range = args.range();
-        let buffer = if range.is_full() {
+        let (buffer, content_length) = if range.is_full() {
             // Full read - use GET
             match self.core.get(&p).await? {
-                Some(bs) => bs,
+                Some(bs) => {
+                    let content_length = bs.len() as u64;
+                    (bs, content_length)
+                }
                 None => return Err(Error::new(ErrorKind::NotFound, "key not found in sqlite")),
             }
         } else {
@@ -275,12 +278,12 @@ impl Access for SqliteBackend {
             };
 
             match self.core.get_range(&p, start, limit).await? {
-                Some(bs) => bs,
+                Some((bs, content_length)) => (bs, content_length),
                 None => return Err(Error::new(ErrorKind::NotFound, "key not found in sqlite")),
             }
         };
 
-        let metadata = Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as u64);
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(content_length);
         Ok((RpRead::new(metadata), buffer))
     }
 

--- a/core/services/sqlite/src/core.rs
+++ b/core/services/sqlite/src/core.rs
@@ -65,13 +65,14 @@ impl SqliteCore {
         path: &str,
         start: isize,
         limit: isize,
-    ) -> Result<Option<Buffer>> {
+    ) -> Result<Option<(Buffer, u64)>> {
         let pool = self.get_client().await?;
-        let value: Option<Vec<u8>> = sqlx::query_scalar(&format!(
-            "SELECT SUBSTR(`{}`, {}, {}) FROM `{}` WHERE `{}` = $1 LIMIT 1",
+        let value: Option<(Vec<u8>, i64)> = sqlx::query_as(&format!(
+            "SELECT SUBSTR(`{}`, {}, {}), LENGTH(`{}`) FROM `{}` WHERE `{}` = $1 LIMIT 1",
             self.value_field,
             start + 1,
             limit,
+            self.value_field,
             self.table,
             self.key_field
         ))
@@ -80,7 +81,7 @@ impl SqliteCore {
         .await
         .map_err(parse_sqlite_error)?;
 
-        Ok(value.map(Buffer::from))
+        Ok(value.map(|(bs, size)| (Buffer::from(bs), size as u64)))
     }
 
     pub async fn set(&self, path: &str, value: Buffer) -> Result<()> {

--- a/core/services/surrealdb/src/backend.rs
+++ b/core/services/surrealdb/src/backend.rs
@@ -271,17 +271,7 @@ impl Access for SurrealdbBackend {
             }
         };
         let content = bs.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(bs.len() as u64),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
         Ok((RpRead::new(metadata), content))
     }
 

--- a/core/services/surrealdb/src/backend.rs
+++ b/core/services/surrealdb/src/backend.rs
@@ -270,7 +270,19 @@ impl Access for SurrealdbBackend {
                 return Err(Error::new(ErrorKind::NotFound, "kv not found in surrealdb"));
             }
         };
-        Ok((RpRead::new(), bs.slice(args.range().to_range_as_usize())))
+        let content = bs.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(bs.len() as u64),
+            );
+        }
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/swift/src/backend.rs
+++ b/core/services/swift/src/backend.rs
@@ -271,7 +271,10 @@ impl Access for SwiftBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((RpRead::new(), resp.into_body())),
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/tikv/src/backend.rs
+++ b/core/services/tikv/src/backend.rs
@@ -176,7 +176,19 @@ impl Access for TikvBackend {
             Some(bs) => bs,
             None => return Err(Error::new(ErrorKind::NotFound, "kv not found in tikv")),
         };
-        Ok((RpRead::new(), bs.slice(args.range().to_range_as_usize())))
+        let content = bs.slice(args.range().to_range_as_usize());
+        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
+        if !args.range().is_full() && !content.is_empty() {
+            metadata.set_content_range(
+                BytesContentRange::default()
+                    .with_range(
+                        args.range().offset(),
+                        args.range().offset() + content.len() as u64 - 1,
+                    )
+                    .with_size(bs.len() as u64),
+            );
+        }
+        Ok((RpRead::new(metadata), content))
     }
 
     async fn write(&self, path: &str, _: OpWrite) -> Result<(RpWrite, Self::Writer)> {

--- a/core/services/tikv/src/backend.rs
+++ b/core/services/tikv/src/backend.rs
@@ -177,17 +177,7 @@ impl Access for TikvBackend {
             None => return Err(Error::new(ErrorKind::NotFound, "kv not found in tikv")),
         };
         let content = bs.slice(args.range().to_range_as_usize());
-        let mut metadata = Metadata::new(EntryMode::FILE).with_content_length(content.len() as u64);
-        if !args.range().is_full() && !content.is_empty() {
-            metadata.set_content_range(
-                BytesContentRange::default()
-                    .with_range(
-                        args.range().offset(),
-                        args.range().offset() + content.len() as u64 - 1,
-                    )
-                    .with_size(bs.len() as u64),
-            );
-        }
+        let metadata = Metadata::new(EntryMode::FILE).with_content_length(bs.len() as u64);
         Ok((RpRead::new(metadata), content))
     }
 

--- a/core/services/tos/src/backend.rs
+++ b/core/services/tos/src/backend.rs
@@ -322,9 +322,10 @@ impl Access for TosBackend {
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/upyun/src/backend.rs
+++ b/core/services/upyun/src/backend.rs
@@ -227,9 +227,10 @@ impl Access for UpyunBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/vercel-artifacts/src/backend.rs
+++ b/core/services/vercel-artifacts/src/backend.rs
@@ -67,9 +67,10 @@ impl Access for VercelArtifactsBackend {
         let status = response.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::new(), response.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, response.headers())?),
+                response.into_body(),
+            )),
             _ => {
                 let (part, mut body) = response.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/vercel-blob/src/backend.rs
+++ b/core/services/vercel-blob/src/backend.rs
@@ -172,9 +172,10 @@ impl Access for VercelBlobBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/webdav/src/backend.rs
+++ b/core/services/webdav/src/backend.rs
@@ -276,9 +276,10 @@ impl Access for WebdavBackend {
         let status = resp.status();
 
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/webhdfs/src/backend.rs
+++ b/core/services/webhdfs/src/backend.rs
@@ -310,14 +310,14 @@ impl Access for WebhdfsBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        let metadata = self.stat(path, OpStat::new()).await?.into_metadata();
         let resp = self.core.webhdfs_read_file(path, args.range()).await?;
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
-                RpRead::new(parse_into_metadata(path, resp.headers())?),
-                resp.into_body(),
-            )),
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
+                Ok((RpRead::new(metadata), resp.into_body()))
+            }
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/webhdfs/src/backend.rs
+++ b/core/services/webhdfs/src/backend.rs
@@ -310,13 +310,12 @@ impl Access for WebhdfsBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let metadata = self.stat(path, OpStat::new()).await?.into_metadata();
         let resp = self.core.webhdfs_read_file(path, args.range()).await?;
 
         let status = resp.status();
         match status {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::new(metadata), resp.into_body()))
+                Ok((RpRead::default(), resp.into_body()))
             }
             _ => {
                 let (part, mut body) = resp.into_parts();

--- a/core/services/webhdfs/src/backend.rs
+++ b/core/services/webhdfs/src/backend.rs
@@ -314,9 +314,10 @@ impl Access for WebhdfsBackend {
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
-                Ok((RpRead::default(), resp.into_body()))
-            }
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/services/yandex-disk/src/backend.rs
+++ b/core/services/yandex-disk/src/backend.rs
@@ -190,7 +190,10 @@ impl Access for YandexDiskBackend {
 
         let status = resp.status();
         match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((RpRead::new(), resp.into_body())),
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok((
+                RpRead::new(parse_into_metadata(path, resp.headers())?),
+                resp.into_body(),
+            )),
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;

--- a/core/tests/behavior/async_read.rs
+++ b/core/tests/behavior/async_read.rs
@@ -35,6 +35,10 @@ pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
             test_read_full,
             test_read_range,
             test_reader,
+            test_buffer_stream_metadata,
+            test_buffer_stream_metadata_with_concurrent,
+            test_futures_bytes_stream_metadata,
+            test_futures_bytes_stream_metadata_with_concurrent,
             test_reader_with_if_match,
             test_reader_with_if_none_match,
             test_reader_with_if_modified_since,
@@ -146,6 +150,110 @@ pub async fn test_reader(op: Operator) -> anyhow::Result<()> {
     futures_reader.read_to_end(&mut bs).await?;
     assert_eq!(size, bs.len(), "read size");
     assert_eq!(sha256_digest(&bs), sha256_digest(&content), "read content");
+
+    Ok(())
+}
+
+/// BufferStream should return complete object metadata before reading.
+pub async fn test_buffer_stream_metadata(op: Operator) -> anyhow::Result<()> {
+    test_buffer_stream_metadata_with_options(op, false).await
+}
+
+/// BufferStream should return complete object metadata with concurrent reads.
+pub async fn test_buffer_stream_metadata_with_concurrent(op: Operator) -> anyhow::Result<()> {
+    test_buffer_stream_metadata_with_options(op, true).await
+}
+
+async fn test_buffer_stream_metadata_with_options(
+    op: Operator,
+    concurrent: bool,
+) -> anyhow::Result<()> {
+    let path = TEST_FIXTURE.new_file_path();
+    let content = gen_fixed_bytes(1024);
+    let start = 128;
+    let end = 640;
+
+    op.write(&path, content.clone())
+        .await
+        .expect("write must succeed");
+
+    let reader = if concurrent {
+        op.reader_with(&path).chunk(128).concurrent(4).await?
+    } else {
+        op.reader(&path).await?
+    };
+    let mut stream = reader.into_stream(start as u64..end as u64).await?;
+
+    let meta = stream.metadata().await?;
+    assert_eq!(
+        meta.content_length(),
+        content.len() as u64,
+        "metadata content length"
+    );
+
+    let bs: Vec<_> = stream.try_collect().await?;
+    let bs: Buffer = bs.into_iter().flatten().collect();
+    assert_eq!(bs.len(), end - start, "read size");
+    assert_eq!(
+        sha256_digest(bs.to_bytes()),
+        sha256_digest(&content[start..end]),
+        "read content"
+    );
+
+    Ok(())
+}
+
+/// FuturesBytesStream should return complete object metadata before reading.
+pub async fn test_futures_bytes_stream_metadata(op: Operator) -> anyhow::Result<()> {
+    test_futures_bytes_stream_metadata_with_options(op, false).await
+}
+
+/// FuturesBytesStream should return complete object metadata with concurrent reads.
+pub async fn test_futures_bytes_stream_metadata_with_concurrent(
+    op: Operator,
+) -> anyhow::Result<()> {
+    test_futures_bytes_stream_metadata_with_options(op, true).await
+}
+
+async fn test_futures_bytes_stream_metadata_with_options(
+    op: Operator,
+    concurrent: bool,
+) -> anyhow::Result<()> {
+    let path = TEST_FIXTURE.new_file_path();
+    let content = gen_fixed_bytes(1024);
+    let start = 128;
+    let end = 640;
+
+    op.write(&path, content.clone())
+        .await
+        .expect("write must succeed");
+
+    let reader = if concurrent {
+        op.reader_with(&path).chunk(128).concurrent(4).await?
+    } else {
+        op.reader(&path).await?
+    };
+    let mut stream = reader.into_bytes_stream(start as u64..end as u64).await?;
+
+    let meta = stream.metadata().await?;
+    assert_eq!(
+        meta.content_length(),
+        content.len() as u64,
+        "metadata content length"
+    );
+
+    let bs = stream
+        .try_fold(Vec::new(), |mut acc, chunk| {
+            acc.extend_from_slice(&chunk);
+            async { Ok(acc) }
+        })
+        .await?;
+    assert_eq!(bs.len(), end - start, "read size");
+    assert_eq!(
+        sha256_digest(&bs),
+        sha256_digest(&content[start..end]),
+        "read content"
+    );
 
     Ok(())
 }

--- a/core/tests/behavior/async_read.rs
+++ b/core/tests/behavior/async_read.rs
@@ -156,18 +156,6 @@ pub async fn test_reader(op: Operator) -> anyhow::Result<()> {
 
 /// BufferStream should return complete object metadata before reading.
 pub async fn test_buffer_stream_metadata(op: Operator) -> anyhow::Result<()> {
-    test_buffer_stream_metadata_with_options(op, false).await
-}
-
-/// BufferStream should return complete object metadata with concurrent reads.
-pub async fn test_buffer_stream_metadata_with_concurrent(op: Operator) -> anyhow::Result<()> {
-    test_buffer_stream_metadata_with_options(op, true).await
-}
-
-async fn test_buffer_stream_metadata_with_options(
-    op: Operator,
-    concurrent: bool,
-) -> anyhow::Result<()> {
     let path = TEST_FIXTURE.new_file_path();
     let content = gen_fixed_bytes(1024);
     let start = 128;
@@ -177,12 +165,49 @@ async fn test_buffer_stream_metadata_with_options(
         .await
         .expect("write must succeed");
 
-    let reader = if concurrent {
-        op.reader_with(&path).chunk(128).concurrent(4).await?
-    } else {
-        op.reader(&path).await?
-    };
-    let mut stream = reader.into_stream(start as u64..end as u64).await?;
+    let mut stream = op
+        .reader(&path)
+        .await?
+        .into_stream(start as u64..end as u64)
+        .await?;
+
+    let meta = stream.metadata().await?;
+    assert_eq!(
+        meta.content_length(),
+        content.len() as u64,
+        "metadata content length"
+    );
+
+    let bs: Vec<_> = stream.try_collect().await?;
+    let bs: Buffer = bs.into_iter().flatten().collect();
+    assert_eq!(bs.len(), end - start, "read size");
+    assert_eq!(
+        sha256_digest(bs.to_bytes()),
+        sha256_digest(&content[start..end]),
+        "read content"
+    );
+
+    Ok(())
+}
+
+/// BufferStream should return complete object metadata with concurrent reads.
+pub async fn test_buffer_stream_metadata_with_concurrent(op: Operator) -> anyhow::Result<()> {
+    let path = TEST_FIXTURE.new_file_path();
+    let content = gen_fixed_bytes(1024);
+    let start = 128;
+    let end = 640;
+
+    op.write(&path, content.clone())
+        .await
+        .expect("write must succeed");
+
+    let mut stream = op
+        .reader_with(&path)
+        .chunk(128)
+        .concurrent(4)
+        .await?
+        .into_stream(start as u64..end as u64)
+        .await?;
 
     let meta = stream.metadata().await?;
     assert_eq!(
@@ -205,19 +230,47 @@ async fn test_buffer_stream_metadata_with_options(
 
 /// FuturesBytesStream should return complete object metadata before reading.
 pub async fn test_futures_bytes_stream_metadata(op: Operator) -> anyhow::Result<()> {
-    test_futures_bytes_stream_metadata_with_options(op, false).await
+    let path = TEST_FIXTURE.new_file_path();
+    let content = gen_fixed_bytes(1024);
+    let start = 128;
+    let end = 640;
+
+    op.write(&path, content.clone())
+        .await
+        .expect("write must succeed");
+
+    let mut stream = op
+        .reader(&path)
+        .await?
+        .into_bytes_stream(start as u64..end as u64)
+        .await?;
+
+    let meta = stream.metadata().await?;
+    assert_eq!(
+        meta.content_length(),
+        content.len() as u64,
+        "metadata content length"
+    );
+
+    let bs = stream
+        .try_fold(Vec::new(), |mut acc, chunk| {
+            acc.extend_from_slice(&chunk);
+            async { Ok(acc) }
+        })
+        .await?;
+    assert_eq!(bs.len(), end - start, "read size");
+    assert_eq!(
+        sha256_digest(&bs),
+        sha256_digest(&content[start..end]),
+        "read content"
+    );
+
+    Ok(())
 }
 
 /// FuturesBytesStream should return complete object metadata with concurrent reads.
 pub async fn test_futures_bytes_stream_metadata_with_concurrent(
     op: Operator,
-) -> anyhow::Result<()> {
-    test_futures_bytes_stream_metadata_with_options(op, true).await
-}
-
-async fn test_futures_bytes_stream_metadata_with_options(
-    op: Operator,
-    concurrent: bool,
 ) -> anyhow::Result<()> {
     let path = TEST_FIXTURE.new_file_path();
     let content = gen_fixed_bytes(1024);
@@ -228,12 +281,13 @@ async fn test_futures_bytes_stream_metadata_with_options(
         .await
         .expect("write must succeed");
 
-    let reader = if concurrent {
-        op.reader_with(&path).chunk(128).concurrent(4).await?
-    } else {
-        op.reader(&path).await?
-    };
-    let mut stream = reader.into_bytes_stream(start as u64..end as u64).await?;
+    let mut stream = op
+        .reader_with(&path)
+        .chunk(128)
+        .concurrent(4)
+        .await?
+        .into_bytes_stream(start as u64..end as u64)
+        .await?;
 
     let meta = stream.metadata().await?;
     assert_eq!(

--- a/core/tests/behavior/async_read.rs
+++ b/core/tests/behavior/async_read.rs
@@ -154,7 +154,7 @@ pub async fn test_reader(op: Operator) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// BufferStream should return complete object metadata before reading.
+/// BufferStream should return complete object metadata before reading if supported.
 pub async fn test_buffer_stream_metadata(op: Operator) -> anyhow::Result<()> {
     let path = TEST_FIXTURE.new_file_path();
     let content = gen_fixed_bytes(1024);
@@ -171,12 +171,15 @@ pub async fn test_buffer_stream_metadata(op: Operator) -> anyhow::Result<()> {
         .into_stream(start as u64..end as u64)
         .await?;
 
-    let meta = stream.metadata().await?;
-    assert_eq!(
-        meta.content_length(),
-        content.len() as u64,
-        "metadata content length"
-    );
+    match stream.metadata().await {
+        Ok(meta) => assert_eq!(
+            meta.content_length(),
+            content.len() as u64,
+            "metadata content length"
+        ),
+        Err(err) if err.kind() == ErrorKind::Unsupported => {}
+        Err(err) => return Err(err.into()),
+    }
 
     let bs: Vec<_> = stream.try_collect().await?;
     let bs: Buffer = bs.into_iter().flatten().collect();
@@ -190,7 +193,7 @@ pub async fn test_buffer_stream_metadata(op: Operator) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// BufferStream should return complete object metadata with concurrent reads.
+/// BufferStream should return complete object metadata with concurrent reads if supported.
 pub async fn test_buffer_stream_metadata_with_concurrent(op: Operator) -> anyhow::Result<()> {
     let path = TEST_FIXTURE.new_file_path();
     let content = gen_fixed_bytes(1024);
@@ -209,12 +212,15 @@ pub async fn test_buffer_stream_metadata_with_concurrent(op: Operator) -> anyhow
         .into_stream(start as u64..end as u64)
         .await?;
 
-    let meta = stream.metadata().await?;
-    assert_eq!(
-        meta.content_length(),
-        content.len() as u64,
-        "metadata content length"
-    );
+    match stream.metadata().await {
+        Ok(meta) => assert_eq!(
+            meta.content_length(),
+            content.len() as u64,
+            "metadata content length"
+        ),
+        Err(err) if err.kind() == ErrorKind::Unsupported => {}
+        Err(err) => return Err(err.into()),
+    }
 
     let bs: Vec<_> = stream.try_collect().await?;
     let bs: Buffer = bs.into_iter().flatten().collect();
@@ -228,7 +234,7 @@ pub async fn test_buffer_stream_metadata_with_concurrent(op: Operator) -> anyhow
     Ok(())
 }
 
-/// FuturesBytesStream should return complete object metadata before reading.
+/// FuturesBytesStream should return complete object metadata before reading if supported.
 pub async fn test_futures_bytes_stream_metadata(op: Operator) -> anyhow::Result<()> {
     let path = TEST_FIXTURE.new_file_path();
     let content = gen_fixed_bytes(1024);
@@ -245,12 +251,15 @@ pub async fn test_futures_bytes_stream_metadata(op: Operator) -> anyhow::Result<
         .into_bytes_stream(start as u64..end as u64)
         .await?;
 
-    let meta = stream.metadata().await?;
-    assert_eq!(
-        meta.content_length(),
-        content.len() as u64,
-        "metadata content length"
-    );
+    match stream.metadata().await {
+        Ok(meta) => assert_eq!(
+            meta.content_length(),
+            content.len() as u64,
+            "metadata content length"
+        ),
+        Err(err) if err.kind() == ErrorKind::Unsupported => {}
+        Err(err) => return Err(err.into()),
+    }
 
     let bs = stream
         .try_fold(Vec::new(), |mut acc, chunk| {
@@ -268,7 +277,7 @@ pub async fn test_futures_bytes_stream_metadata(op: Operator) -> anyhow::Result<
     Ok(())
 }
 
-/// FuturesBytesStream should return complete object metadata with concurrent reads.
+/// FuturesBytesStream should return complete object metadata with concurrent reads if supported.
 pub async fn test_futures_bytes_stream_metadata_with_concurrent(
     op: Operator,
 ) -> anyhow::Result<()> {
@@ -289,12 +298,15 @@ pub async fn test_futures_bytes_stream_metadata_with_concurrent(
         .into_bytes_stream(start as u64..end as u64)
         .await?;
 
-    let meta = stream.metadata().await?;
-    assert_eq!(
-        meta.content_length(),
-        content.len() as u64,
-        "metadata content length"
-    );
+    match stream.metadata().await {
+        Ok(meta) => assert_eq!(
+            meta.content_length(),
+            content.len() as u64,
+            "metadata content length"
+        ),
+        Err(err) if err.kind() == ErrorKind::Unsupported => {}
+        Err(err) => return Err(err.into()),
+    }
 
     let bs = stream
         .try_fold(Vec::new(), |mut acc, chunk| {

--- a/integrations/object_store/src/service/reader.rs
+++ b/integrations/object_store/src/service/reader.rs
@@ -26,6 +26,7 @@ use object_store::path::Path as ObjectStorePath;
 use opendal::raw::*;
 use opendal::*;
 
+use super::core::format_metadata;
 use super::core::parse_op_read;
 use super::error::parse_error;
 
@@ -33,7 +34,6 @@ use super::error::parse_error;
 pub struct ObjectStoreReader {
     bytes_stream: BoxStream<'static, object_store::Result<Bytes>>,
     meta: object_store::ObjectMeta,
-    args: OpRead,
 }
 
 impl ObjectStoreReader {
@@ -47,32 +47,11 @@ impl ObjectStoreReader {
         let result = store.get_opts(&path, opts).await.map_err(parse_error)?;
         let meta = result.meta.clone();
         let bytes_stream = result.into_stream();
-        Ok(Self {
-            bytes_stream,
-            meta,
-            args,
-        })
+        Ok(Self { bytes_stream, meta })
     }
 
     pub(crate) fn rp(&self) -> RpRead {
-        let mut meta = Metadata::new(EntryMode::FILE);
-        if !self.args.range().is_full() {
-            let range = self.args.range();
-            let size = range
-                .size()
-                .unwrap_or_else(|| self.meta.size.saturating_sub(range.offset()));
-            meta.set_content_length(size);
-            if size > 0 {
-                meta.set_content_range(
-                    BytesContentRange::default()
-                        .with_range(range.offset(), range.offset() + size - 1)
-                        .with_size(self.meta.size),
-                );
-            }
-        } else {
-            meta.set_content_length(self.meta.size);
-        }
-        RpRead::new(meta)
+        RpRead::new(format_metadata(&self.meta))
     }
 }
 

--- a/integrations/object_store/src/service/reader.rs
+++ b/integrations/object_store/src/service/reader.rs
@@ -55,18 +55,24 @@ impl ObjectStoreReader {
     }
 
     pub(crate) fn rp(&self) -> RpRead {
-        let mut rp = RpRead::new().with_size(Some(self.meta.size));
+        let mut meta = Metadata::new(EntryMode::FILE);
         if !self.args.range().is_full() {
             let range = self.args.range();
-            let size = match range.size() {
-                Some(size) => size,
-                None => self.meta.size,
-            };
-            rp = rp.with_range(Some(
-                BytesContentRange::default().with_range(range.offset(), range.offset() + size - 1),
-            ));
+            let size = range
+                .size()
+                .unwrap_or_else(|| self.meta.size.saturating_sub(range.offset()));
+            meta.set_content_length(size);
+            if size > 0 {
+                meta.set_content_range(
+                    BytesContentRange::default()
+                        .with_range(range.offset(), range.offset() + size - 1)
+                        .with_size(self.meta.size),
+                );
+            }
+        } else {
+            meta.set_content_length(self.meta.size);
         }
-        rp
+        RpRead::new(meta)
     }
 }
 

--- a/integrations/object_store/src/store.rs
+++ b/integrations/object_store/src/store.rs
@@ -115,6 +115,17 @@ fn format_read_range(range: Option<&GetRange>, size: u64) -> Range<u64> {
     }
 }
 
+fn format_without_stat_error(err: opendal::Error, path: &str) -> object_store::Error {
+    match err.kind() {
+        opendal::ErrorKind::Unsupported | opendal::ErrorKind::RangeNotSatisfied => {
+            object_store::Error::NotSupported {
+                source: Box::new(err),
+            }
+        }
+        _ => format_object_store_error(err, path),
+    }
+}
+
 /// OpendalStore implements ObjectStore trait by using opendal.
 ///
 /// This allows users to use opendal as an object store without extra cost.
@@ -193,7 +204,7 @@ impl OpendalStore {
             .reader_options(raw_location, format_reader_options(options, None))
             .into_send()
             .await
-            .map_err(|err| format_object_store_error(err, location.as_ref()))?;
+            .map_err(|err| format_without_stat_error(err, location.as_ref()))?;
 
         let mut stream = match options.range.as_ref() {
             Some(GetRange::Bounded(range)) => {
@@ -206,13 +217,13 @@ impl OpendalStore {
             Some(GetRange::Suffix(_)) => unreachable!("suffix range needs object metadata"),
             None => reader.into_bytes_stream(..).into_send().await,
         }
-        .map_err(|err| format_object_store_error(err, location.as_ref()))?;
+        .map_err(|err| format_without_stat_error(err, location.as_ref()))?;
 
         let metadata = stream
             .metadata()
             .into_send()
             .await
-            .map_err(|err| format_object_store_error(err, location.as_ref()))?;
+            .map_err(|err| format_without_stat_error(err, location.as_ref()))?;
         let attributes = format_object_attributes(&metadata);
         let meta = format_object_meta(location.as_ref(), &metadata);
         let read_range = format_read_range(options.range.as_ref(), meta.size);

--- a/integrations/object_store/src/store.rs
+++ b/integrations/object_store/src/store.rs
@@ -117,6 +117,8 @@ fn format_read_range(range: Option<&GetRange>, size: u64) -> Range<u64> {
 
 fn format_without_stat_error(err: opendal::Error, path: &str) -> object_store::Error {
     match err.kind() {
+        // Ask get_opts to fall back to the stat path when read-open can't provide
+        // enough metadata to build a valid GetResult, such as ranges beyond EOF.
         opendal::ErrorKind::Unsupported | opendal::ErrorKind::RangeNotSatisfied => {
             object_store::Error::NotSupported {
                 source: Box::new(err),

--- a/integrations/object_store/src/store.rs
+++ b/integrations/object_store/src/store.rs
@@ -21,8 +21,8 @@ use std::io;
 use std::ops::Range;
 use std::sync::Arc;
 
+use crate::datetime_to_timestamp;
 use crate::utils::*;
-use crate::{datetime_to_timestamp, timestamp_to_datetime};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::FutureExt;
@@ -31,6 +31,7 @@ use futures::TryStreamExt;
 use futures::stream::BoxStream;
 use mea::mutex::Mutex;
 use mea::oneshot;
+use object_store::Attributes;
 use object_store::CopyMode as ObjectStoreCopyMode;
 use object_store::CopyOptions as ObjectStoreCopyOptions;
 use object_store::ListResult;
@@ -48,11 +49,71 @@ use object_store::{GetResult, PutMode};
 use opendal::Buffer;
 use opendal::Writer;
 use opendal::options::CopyOptions;
+use opendal::options::ReaderOptions;
+use opendal::options::StatOptions;
 use opendal::raw::percent_decode_path;
 use opendal::{Operator, OperatorInfo};
 use std::collections::HashMap;
 
 const DEFAULT_CONCURRENT: usize = 8;
+
+fn format_object_attributes(meta: &opendal::Metadata) -> Attributes {
+    let mut attributes = Attributes::new();
+    if let Some(user_meta) = meta.user_metadata() {
+        for (key, value) in user_meta {
+            attributes.insert(
+                object_store::Attribute::Metadata(key.clone().into()),
+                value.clone().into(),
+            );
+        }
+    }
+
+    attributes
+}
+
+fn format_reader_options(options: &GetOptions, content_length_hint: Option<u64>) -> ReaderOptions {
+    ReaderOptions {
+        version: options.version.clone(),
+        if_match: options.if_match.clone(),
+        if_none_match: options.if_none_match.clone(),
+        if_modified_since: options.if_modified_since.and_then(datetime_to_timestamp),
+        if_unmodified_since: options.if_unmodified_since.and_then(datetime_to_timestamp),
+        content_length_hint,
+        ..Default::default()
+    }
+}
+
+fn format_stat_options(options: &GetOptions) -> StatOptions {
+    StatOptions {
+        version: options.version.clone(),
+        if_match: options.if_match.clone(),
+        if_none_match: options.if_none_match.clone(),
+        if_modified_since: options.if_modified_since.and_then(datetime_to_timestamp),
+        if_unmodified_since: options.if_unmodified_since.and_then(datetime_to_timestamp),
+        ..Default::default()
+    }
+}
+
+fn format_read_range(range: Option<&GetRange>, size: u64) -> Range<u64> {
+    match range {
+        Some(GetRange::Bounded(r)) => {
+            if r.start >= r.end || r.start >= size {
+                0..0
+            } else {
+                r.start..r.end.min(size)
+            }
+        }
+        Some(GetRange::Offset(offset)) => {
+            if *offset < size {
+                *offset..size
+            } else {
+                0..0
+            }
+        }
+        Some(GetRange::Suffix(suffix)) if *suffix < size => (size - *suffix)..size,
+        _ => 0..size,
+    }
+}
 
 /// OpendalStore implements ObjectStore trait by using opendal.
 ///
@@ -119,6 +180,147 @@ impl OpendalStore {
     /// Get the Operator info.
     pub fn info(&self) -> &OperatorInfo {
         self.info.as_ref()
+    }
+
+    async fn get_opts_without_stat(
+        &self,
+        location: &Path,
+        raw_location: &str,
+        options: &GetOptions,
+    ) -> object_store::Result<GetResult> {
+        let reader = self
+            .inner
+            .reader_options(raw_location, format_reader_options(options, None))
+            .into_send()
+            .await
+            .map_err(|err| format_object_store_error(err, location.as_ref()))?;
+
+        let mut stream = match options.range.as_ref() {
+            Some(GetRange::Bounded(range)) => {
+                reader
+                    .into_bytes_stream(range.start..range.end)
+                    .into_send()
+                    .await
+            }
+            Some(GetRange::Offset(offset)) => reader.into_bytes_stream(*offset..).into_send().await,
+            Some(GetRange::Suffix(_)) => unreachable!("suffix range needs object metadata"),
+            None => reader.into_bytes_stream(..).into_send().await,
+        }
+        .map_err(|err| format_object_store_error(err, location.as_ref()))?;
+
+        let metadata = stream
+            .metadata()
+            .into_send()
+            .await
+            .map_err(|err| format_object_store_error(err, location.as_ref()))?;
+        let attributes = format_object_attributes(&metadata);
+        let meta = format_object_meta(location.as_ref(), &metadata);
+        let read_range = format_read_range(options.range.as_ref(), meta.size);
+
+        if read_range.start >= read_range.end {
+            return Ok(GetResult {
+                payload: GetResultPayload::Stream(Box::pin(futures::stream::empty())),
+                range: read_range,
+                meta,
+                attributes,
+            });
+        }
+
+        if matches!(
+            options.range.as_ref(),
+            Some(GetRange::Bounded(range)) if range.end > meta.size
+        ) {
+            let reader = self
+                .inner
+                .reader_options(
+                    raw_location,
+                    format_reader_options(options, Some(meta.size)),
+                )
+                .into_send()
+                .await
+                .map_err(|err| format_object_store_error(err, location.as_ref()))?;
+            stream = reader
+                .into_bytes_stream(read_range.start..read_range.end)
+                .into_send()
+                .await
+                .map_err(|err| format_object_store_error(err, location.as_ref()))?;
+        }
+
+        let stream = stream
+            .into_send()
+            .map_err(|err: io::Error| object_store::Error::Generic {
+                store: "IoError",
+                source: Box::new(err),
+            });
+
+        Ok(GetResult {
+            payload: GetResultPayload::Stream(Box::pin(stream)),
+            range: read_range,
+            meta,
+            attributes,
+        })
+    }
+
+    async fn get_opts_with_stat(
+        &self,
+        location: &Path,
+        raw_location: &str,
+        options: &GetOptions,
+    ) -> object_store::Result<GetResult> {
+        let metadata = self
+            .inner
+            .stat_options(raw_location, format_stat_options(options))
+            .into_send()
+            .await
+            .map_err(|err| format_object_store_error(err, location.as_ref()))?;
+        let attributes = format_object_attributes(&metadata);
+        let meta = format_object_meta(location.as_ref(), &metadata);
+
+        if options.head {
+            return Ok(GetResult {
+                payload: GetResultPayload::Stream(Box::pin(futures::stream::empty())),
+                range: 0..0,
+                meta,
+                attributes,
+            });
+        }
+
+        let read_range = format_read_range(options.range.as_ref(), meta.size);
+        if read_range.start >= read_range.end {
+            return Ok(GetResult {
+                payload: GetResultPayload::Stream(Box::pin(futures::stream::empty())),
+                range: read_range,
+                meta,
+                attributes,
+            });
+        }
+
+        let reader = self
+            .inner
+            .reader_options(
+                raw_location,
+                format_reader_options(options, Some(meta.size)),
+            )
+            .into_send()
+            .await
+            .map_err(|err| format_object_store_error(err, location.as_ref()))?;
+        let stream = reader
+            .into_bytes_stream(read_range.start..read_range.end)
+            .into_send()
+            .await
+            .map_err(|err| format_object_store_error(err, location.as_ref()))?
+            .into_send()
+            .map_err(|err: io::Error| object_store::Error::Generic {
+                store: "IoError",
+                source: Box::new(err),
+            });
+
+        Ok(GetResult {
+            payload: GetResultPayload::Stream(Box::pin(stream)),
+            range: read_range,
+            meta,
+            attributes,
+        })
     }
 
     /// Copy a file from one location to another
@@ -296,126 +498,26 @@ impl ObjectStore for OpendalStore {
         options: GetOptions,
     ) -> object_store::Result<GetResult> {
         let raw_location = percent_decode_path(location.as_ref());
-        let meta = {
-            let mut s = self.inner.stat_with(&raw_location);
-            if let Some(version) = &options.version {
-                s = s.version(version.as_str())
-            }
-            if let Some(if_match) = &options.if_match {
-                s = s.if_match(if_match.as_str());
-            }
-            if let Some(if_none_match) = &options.if_none_match {
-                s = s.if_none_match(if_none_match.as_str());
-            }
-            if let Some(if_modified_since) =
-                options.if_modified_since.and_then(datetime_to_timestamp)
-            {
-                s = s.if_modified_since(if_modified_since);
-            }
-            if let Some(if_unmodified_since) =
-                options.if_unmodified_since.and_then(datetime_to_timestamp)
-            {
-                s = s.if_unmodified_since(if_unmodified_since);
-            }
-            s.into_send()
-                .await
-                .map_err(|err| format_object_store_error(err, location.as_ref()))?
-        };
-
-        // Convert user defined metadata from OpenDAL to object_store attributes
-        let mut attributes = object_store::Attributes::new();
-        if let Some(user_meta) = meta.user_metadata() {
-            for (key, value) in user_meta {
-                attributes.insert(
-                    object_store::Attribute::Metadata(key.clone().into()),
-                    value.clone().into(),
-                );
-            }
-        }
-
-        let meta = ObjectMeta {
-            location: location.clone(),
-            last_modified: meta
-                .last_modified()
-                .and_then(timestamp_to_datetime)
-                .unwrap_or_default(),
-            size: meta.content_length(),
-            e_tag: meta.etag().map(|x| x.to_string()),
-            version: meta.version().map(|x| x.to_string()),
-        };
 
         if options.head {
-            return Ok(GetResult {
-                payload: GetResultPayload::Stream(Box::pin(futures::stream::empty())),
-                range: 0..0,
-                meta,
-                attributes,
-            });
+            return self
+                .get_opts_with_stat(location, &raw_location, &options)
+                .await;
         }
 
-        let reader = {
-            let mut r = self.inner.reader_with(raw_location.as_ref());
-            if let Some(version) = options.version {
-                r = r.version(version.as_str());
-            }
-            if let Some(if_match) = options.if_match {
-                r = r.if_match(if_match.as_str());
-            }
-            if let Some(if_none_match) = options.if_none_match {
-                r = r.if_none_match(if_none_match.as_str());
-            }
-            if let Some(if_modified_since) =
-                options.if_modified_since.and_then(datetime_to_timestamp)
-            {
-                r = r.if_modified_since(if_modified_since);
-            }
-            if let Some(if_unmodified_since) =
-                options.if_unmodified_since.and_then(datetime_to_timestamp)
-            {
-                r = r.if_unmodified_since(if_unmodified_since);
-            }
-            r.into_send()
+        if !matches!(options.range.as_ref(), Some(GetRange::Suffix(_))) {
+            match self
+                .get_opts_without_stat(location, &raw_location, &options)
                 .await
-                .map_err(|err| format_object_store_error(err, location.as_ref()))?
-        };
-
-        let read_range = match options.range {
-            Some(GetRange::Bounded(r)) => {
-                if r.start >= r.end || r.start >= meta.size {
-                    0..0
-                } else {
-                    let end = r.end.min(meta.size);
-                    r.start..end
-                }
+            {
+                Ok(result) => return Ok(result),
+                Err(object_store::Error::NotSupported { .. }) => {}
+                Err(err) => return Err(err),
             }
-            Some(GetRange::Offset(r)) => {
-                if r < meta.size {
-                    r..meta.size
-                } else {
-                    0..0
-                }
-            }
-            Some(GetRange::Suffix(r)) if r < meta.size => (meta.size - r)..meta.size,
-            _ => 0..meta.size,
-        };
+        }
 
-        let stream = reader
-            .into_bytes_stream(read_range.start..read_range.end)
-            .into_send()
+        self.get_opts_with_stat(location, &raw_location, &options)
             .await
-            .map_err(|err| format_object_store_error(err, location.as_ref()))?
-            .into_send()
-            .map_err(|err: io::Error| object_store::Error::Generic {
-                store: "IoError",
-                source: Box::new(err),
-            });
-
-        Ok(GetResult {
-            payload: GetResultPayload::Stream(Box::pin(stream)),
-            range: read_range.start..read_range.end,
-            meta,
-            attributes,
-        })
     }
 
     async fn get_ranges(
@@ -1017,17 +1119,75 @@ mod tests {
         // Reset counter
         stat_count.store(0, Ordering::SeqCst);
 
-        // Test 2: get_opts SHOULD call stat() to get metadata
+        // Test 2: get_opts should NOT call stat() for bounded range reads
         let opts = object_store::GetOptions {
             range: Some(object_store::GetRange::Bounded(0..5)),
             ..Default::default()
         };
         let ret = store.get_opts(&location, opts).await.unwrap();
+        assert_eq!(ret.meta.size, value.len() as u64);
+        assert_eq!(ret.range, 0..5);
         let data = ret.bytes().await.unwrap();
         assert_eq!(Bytes::from_static(b"Hello"), data);
+        assert_eq!(
+            stat_count.load(Ordering::SeqCst),
+            0,
+            "get_opts should not call stat() for bounded range reads"
+        );
+
+        // Reset counter
+        stat_count.store(0, Ordering::SeqCst);
+
+        // Test 3: get_opts should NOT call stat() for offset range reads
+        let opts = object_store::GetOptions {
+            range: Some(object_store::GetRange::Offset(7)),
+            ..Default::default()
+        };
+        let ret = store.get_opts(&location, opts).await.unwrap();
+        assert_eq!(ret.meta.size, value.len() as u64);
+        assert_eq!(ret.range, 7..value.len() as u64);
+        let data = ret.bytes().await.unwrap();
+        assert_eq!(Bytes::from_static(b"world!"), data);
+        assert_eq!(
+            stat_count.load(Ordering::SeqCst),
+            0,
+            "get_opts should not call stat() for offset range reads"
+        );
+
+        // Reset counter
+        stat_count.store(0, Ordering::SeqCst);
+
+        // Test 4: get_opts should NOT call stat() for full reads
+        let ret = store
+            .get_opts(&location, object_store::GetOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(ret.meta.size, value.len() as u64);
+        assert_eq!(ret.range, 0..value.len() as u64);
+        let data = ret.bytes().await.unwrap();
+        assert_eq!(value, data);
+        assert_eq!(
+            stat_count.load(Ordering::SeqCst),
+            0,
+            "get_opts should not call stat() for full reads"
+        );
+
+        // Reset counter
+        stat_count.store(0, Ordering::SeqCst);
+
+        // Test 5: get_opts should still call stat() for suffix range reads
+        let opts = object_store::GetOptions {
+            range: Some(object_store::GetRange::Suffix(6)),
+            ..Default::default()
+        };
+        let ret = store.get_opts(&location, opts).await.unwrap();
+        assert_eq!(ret.meta.size, value.len() as u64);
+        assert_eq!(ret.range, 7..value.len() as u64);
+        let data = ret.bytes().await.unwrap();
+        assert_eq!(Bytes::from_static(b"world!"), data);
         assert!(
             stat_count.load(Ordering::SeqCst) > 0,
-            "get_opts should call stat() to get metadata"
+            "get_opts should call stat() for suffix range reads"
         );
 
         // Cleanup


### PR DESCRIPTION
# Which issue does this PR close?

Closes #5872.

# Rationale for this change

Read responses already carry useful metadata such as payload length, content range, ETag, and last modified time. Returning this metadata from `RpRead` lets upper layers observe read metadata without forcing an extra stat on the hot read path.

# What changes are included in this PR?

This updates `RpRead` to carry `Metadata` instead of separate size/range hints, exposes observed metadata from readers and read streams, and wires existing services to populate read metadata from response headers, in-memory buffers, fs metadata, or existing service-specific read information.

# Are there any user-facing changes?

Yes. `Reader::metadata()` can return complete object metadata observed after reads, and stream adapters can expose read response metadata before consuming the response body. `RpRead::size` and `RpRead::range` are replaced by `RpRead::metadata`.

# AI Usage Statement

Used OpenAI GPT-5 to assist implementation.
