### PR TITLE
feat(core): complete copy_with_if_match implementation

### DIFF
--- a/core/core/src/types/operator/operator_futures.rs
+++ b/core/core/src/types/operator/operator_futures.rs
@@ -1437,6 +1437,15 @@ impl<F: Future<Output = Result<Metadata>>> FutureCopy<F> {
         self
     }
 
+    /// Sets the condition that copy operation will succeed only if the
+    /// destination object currently has the given ETag.
+    ///
+    /// Refer to [`options::CopyOptions::if_match`] for more details.
+    pub fn if_match(mut self, etag: &str) -> Self {
+        self.args.0.if_match = Some(etag.to_string());
+        self
+    }
+
     /// Sets concurrent copy operations for this copy.
     ///
     /// Refer to [`options::CopyOptions::concurrent`] for more details.
@@ -1473,6 +1482,15 @@ impl<F: Future<Output = Result<Copier>>> FutureCopier<F> {
     /// Refer to [`options::CopyOptions::if_not_exists`] for more details.
     pub fn if_not_exists(mut self, v: bool) -> Self {
         self.args.0.if_not_exists = v;
+        self
+    }
+
+    /// Sets the condition that copy operation will succeed only if the
+    /// destination object currently has the given ETag.
+    ///
+    /// Refer to [`options::CopyOptions::if_match`] for more details.
+    pub fn if_match(mut self, etag: &str) -> Self {
+        self.args.0.if_match = Some(etag.to_string());
         self
     }
 

--- a/core/layers/capability-check/src/lib.rs
+++ b/core/layers/capability-check/src/lib.rs
@@ -162,6 +162,13 @@ impl<A: Access> LayeredAccess for CapabilityAccessor<A> {
                 "if_not_exists",
             ));
         }
+        if args.if_match().is_some() && !capability.copy_with_if_match {
+            return Err(new_unsupported_error(
+                self.info.as_ref(),
+                Operation::Copy,
+                "if_match",
+            ));
+        }
 
         self.inner.copy(from, to, args, opts).await
     }

--- a/core/tests/behavior/async_copy.rs
+++ b/core/tests/behavior/async_copy.rs
@@ -56,6 +56,14 @@ pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
             test_copier_with_if_not_exists_to_existing_file
         ))
     }
+
+    if cap.read && cap.write && cap.copy && cap.copy_with_if_match {
+        tests.extend(async_trials!(
+            op,
+            test_copy_with_if_match_match,
+            test_copy_with_if_match_mismatch
+        ))
+    }
 }
 
 fn copy_multi_chunk_size(cap: Capability) -> Option<(usize, usize)> {
@@ -334,6 +342,83 @@ pub async fn test_copy_with_if_not_exists_to_existing_file(op: Operator) -> Resu
     assert_eq!(err.kind(), ErrorKind::ConditionNotMatch);
 
     // Verify target file content is unchanged
+    let current_content = op
+        .read(&target_path)
+        .await
+        .expect("read must succeed")
+        .to_bytes();
+    assert_eq!(
+        sha256_digest(current_content),
+        sha256_digest(&target_content),
+    );
+
+    op.delete(&source_path).await.expect("delete must succeed");
+    op.delete(&target_path).await.expect("delete must succeed");
+    Ok(())
+}
+
+/// Copy with if_match matching the destination ETag should overwrite it.
+pub async fn test_copy_with_if_match_match(op: Operator) -> Result<()> {
+    if !op.info().full_capability().copy_with_if_match {
+        return Ok(());
+    }
+
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (source_content, _) = gen_bytes(op.info().full_capability());
+    op.write(&source_path, source_content.clone()).await?;
+
+    let target_path = uuid::Uuid::new_v4().to_string();
+    let (target_content, _) = gen_bytes(op.info().full_capability());
+    assert_ne!(source_content, target_content);
+    op.write(&target_path, target_content.clone()).await?;
+
+    let Some(etag) = op.stat(&target_path).await?.etag().map(|s| s.to_string()) else {
+        op.delete(&source_path).await.expect("delete must succeed");
+        op.delete(&target_path).await.expect("delete must succeed");
+        return Ok(());
+    };
+
+    op.copy_with(&source_path, &target_path)
+        .if_match(&etag)
+        .await?;
+
+    let current_content = op
+        .read(&target_path)
+        .await
+        .expect("read must succeed")
+        .to_bytes();
+    assert_eq!(
+        sha256_digest(current_content),
+        sha256_digest(&source_content),
+    );
+
+    op.delete(&source_path).await.expect("delete must succeed");
+    op.delete(&target_path).await.expect("delete must succeed");
+    Ok(())
+}
+
+/// Copy with if_match not matching the destination ETag should fail.
+pub async fn test_copy_with_if_match_mismatch(op: Operator) -> Result<()> {
+    if !op.info().full_capability().copy_with_if_match {
+        return Ok(());
+    }
+
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (source_content, _) = gen_bytes(op.info().full_capability());
+    op.write(&source_path, source_content.clone()).await?;
+
+    let target_path = uuid::Uuid::new_v4().to_string();
+    let (target_content, _) = gen_bytes(op.info().full_capability());
+    assert_ne!(source_content, target_content);
+    op.write(&target_path, target_content.clone()).await?;
+
+    let err = op
+        .copy_with(&source_path, &target_path)
+        .if_match("\"00000000000000000000000000000000\"")
+        .await
+        .expect_err("copy must fail");
+    assert_eq!(err.kind(), ErrorKind::ConditionNotMatch);
+
     let current_content = op
         .read(&target_path)
         .await


### PR DESCRIPTION
## Which issue does this PR close?

Follow-up on #7090 / #7600.

## Rationale for this change

#7600 left three loose ends:
1. No `.if_match()` builder on `FutureCopy` / `FutureCopier` — callers had to drop down to `CopyOptions`.
2. The `capability-check` layer only validated `copy_with_if_not_exists`, not `copy_with_if_match` (the inner `correctness_check.rs` already did both).


## What changes are included in this PR?
- `FutureCopy::if_match(&str)` and `FutureCopier::if_match(&str)`, mirroring `if_not_exists(bool)`.
- `copy_with_if_match` check in the `capability-check` layer.
- `test_copy_with_if_match_match` / `_mismatch` in `core/tests/behavior/async_copy.rs`.

## Are there any user-facing changes?

Yes, additive only — `op.copy_with(from, to).if_match(etag)` is a new convenience builder. Existing API surface is unchanged.

## AI Usage Statement

AI-assisted implementation.