### PR TITLE
fix(services/hf): avoid logging full HTML error pages

### DIFF
--- a/.github/actions/hf-temp-repo/common.js
+++ b/.github/actions/hf-temp-repo/common.js
@@ -39,11 +39,18 @@ function hfRequest(method, path, token, body) {
       (res) => {
         let result = "";
         res.on("data", (chunk) => (result += chunk));
-        res.on("end", () =>
-          res.statusCode >= 200 && res.statusCode < 300
-            ? resolve(result)
-            : reject(new Error(`HTTP ${res.statusCode}: ${result}`))
-        );
+        res.on("end", () => {
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            resolve(result);
+          } else {
+            // Prefer the structured error header to avoid logging large HTML pages.
+            const msg =
+              res.headers["x-error-message"] ||
+              result.slice(0, 200) ||
+              "unknown error";
+            reject(new Error(`HTTP ${res.statusCode}: ${msg}`));
+          }
+        });
       }
     );
     req.on("error", reject);

--- a/core/services/hf/src/core.rs
+++ b/core/services/hf/src/core.rs
@@ -402,14 +402,18 @@ impl HfCore {
             .to_string()
     }
 
-    /// Send a request and return the successful response or a parsed error.
-    async fn send(&self, req: Request<Buffer>) -> Result<Response<Buffer>> {
-        let resp = self.info.http_client().send(req).await?;
-        if resp.status().is_success() {
-            Ok(resp)
+    /// Send a request and return the successful streaming response or a parsed error.
+    ///
+    /// Uses `fetch` so error response bodies are never read into memory —
+    /// `parse_error` reads only response headers.
+    async fn send(&self, req: Request<Buffer>) -> Result<Response<HttpBody>> {
+        let resp = self.info.http_client().fetch(req).await?;
+        let (parts, body) = resp.into_parts();
+        if parts.status.is_success() {
+            Ok(Response::from_parts(parts, body))
         } else {
-            let (parts, body) = resp.into_parts();
-            Err(parse_error(parts, body))
+            // Drop the streaming body without reading it.
+            Err(parse_error(parts))
         }
     }
 
@@ -421,8 +425,10 @@ impl HfCore {
         &self,
         req: Request<Buffer>,
     ) -> Result<(http::response::Parts, T)> {
-        let (parts, body) = self.send(req).await?.into_parts();
-        let parsed = serde_json::from_reader(body.reader()).map_err(new_json_deserialize_error)?;
+        let (parts, mut body) = self.send(req).await?.into_parts();
+        let buffer = body.to_buffer().await?;
+        let parsed =
+            serde_json::from_reader(buffer.reader()).map_err(new_json_deserialize_error)?;
         Ok((parts, parsed))
     }
 
@@ -474,9 +480,11 @@ impl HfCore {
         let resp = self.info.http_client().fetch(req).await?;
 
         if !resp.status().is_success() {
-            let (parts, mut body) = resp.into_parts();
-            let buf = body.to_buffer().await?;
-            return Err(parse_error(parts, buf));
+            // Drop the streaming body without reading it — parse_error reads
+            // only response headers, so there is no need to buffer the body
+            // (which may be a large HTML error page).
+            let (parts, _) = resp.into_parts();
+            return Err(parse_error(parts));
         }
 
         Ok(resp)

--- a/core/services/hf/src/error.rs
+++ b/core/services/hf/src/error.rs
@@ -15,33 +15,21 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::fmt::Debug;
-
 use http::StatusCode;
-use serde::Deserialize;
 
 use opendal_core::raw::*;
 use opendal_core::*;
 
-#[derive(Default, Deserialize)]
-struct HfError {
-    error: String,
-}
-
-impl Debug for HfError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("HfError")
-            .field("message", &self.error.replace('\n', " "))
-            .finish()
-    }
-}
-
-pub(super) fn parse_error(parts: http::response::Parts, body: Buffer) -> Error {
-    let bs = body.to_bytes();
-    let message = match serde_json::from_slice::<HfError>(&bs) {
-        Ok(hf_error) => hf_error.error,
-        Err(_) => String::from_utf8_lossy(&bs).into_owned(),
-    };
+pub(super) fn parse_error(parts: http::response::Parts) -> Error {
+    // HF sets x-error-message on every error response with a short human-readable
+    // description. Using the header avoids reading the response body, which can be
+    // a large HTML error page (e.g. 52 KB on 404s from the /resolve/ endpoint).
+    let message = parts
+        .headers
+        .get("x-error-message")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown error")
+        .to_string();
 
     // HF git-style commit APIs reject stale branch snapshots with 412.
     // Treat this specific conflict as temporary so RetryLayer can replay
@@ -81,32 +69,18 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_parse_error() -> Result<()> {
-        let resp = r#"
-            {
-                "error": "Invalid username or password."
-            }
-            "#;
-        let decoded_response = serde_json::from_slice::<HfError>(resp.as_bytes())
-            .map_err(new_json_deserialize_error)?;
-
-        assert_eq!(decoded_response.error, "Invalid username or password.");
-
-        Ok(())
-    }
-
-    #[test]
     fn test_parse_error_branch_update_conflict_is_temporary() {
-        let body = Buffer::from(bytes::Bytes::from(
-            r#"{"error":"The branch was updated since you opened this page. Please refresh and try again."}"#,
-        ));
         let (parts, _) = Response::builder()
             .status(StatusCode::PRECONDITION_FAILED)
+            .header(
+                "x-error-message",
+                "The branch was updated since you opened this page. Please refresh and try again.",
+            )
             .body(())
             .unwrap()
             .into_parts();
 
-        let err = parse_error(parts, body);
+        let err = parse_error(parts);
 
         assert_eq!(err.kind(), ErrorKind::ConditionNotMatch);
         assert!(err.is_temporary());
@@ -114,14 +88,14 @@ mod test {
 
     #[test]
     fn test_parse_error_other_precondition_failed_is_not_temporary() {
-        let body = Buffer::from(bytes::Bytes::from(r#"{"error":"etag mismatch"}"#));
         let (parts, _) = Response::builder()
             .status(StatusCode::PRECONDITION_FAILED)
+            .header("x-error-message", "etag mismatch")
             .body(())
             .unwrap()
             .into_parts();
 
-        let err = parse_error(parts, body);
+        let err = parse_error(parts);
 
         assert_eq!(err.kind(), ErrorKind::ConditionNotMatch);
         assert!(!err.is_temporary());


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7630.

# Rationale for this change

HF error responses can include large HTML pages (e.g. 52 KB on CDN-level 404s). OpenDAL was logging the full body, polluting CI output.

# What changes are included in this PR?

- `parse_error` now reads the `x-error-message` response header instead of parsing the body. HF sets this header on every error with a short human-readable message.
- `HfCore::send` switches from `http_client::send` (which buffers the full body) to `fetch`, so error bodies are dropped without being read.
- `HfCore::resolve` already used `fetch`; the body is now explicitly dropped on error.
- `.github/actions/hf-temp-repo/common.js` gets the same fix: prefer `x-error-message` header, fall back to first 200 chars of the body.

# Are there any user-facing changes?

No. Error messages are now shorter and cleaner (e.g. `File not found` instead of a full HTML dump), but the `ErrorKind` mapping is unchanged.

# AI Usage Statement

Developed with Claude Code (claude-sonnet-4-6).