### PR TITLE
feat(services/http): support if_modified_since and if_unmodified_since

### DIFF
--- a/bindings/python/tests/test_read.py
+++ b/bindings/python/tests/test_read.py
@@ -258,7 +258,11 @@ async def test_async_read_not_exists(service_name, operator, async_operator):
 
 
 @pytest.mark.need_capability(
-    "read", "read_with_if_modified_since", "read_with_if_unmodified_since"
+    "read",
+    "write",
+    "delete",
+    "read_with_if_modified_since",
+    "read_with_if_unmodified_since",
 )
 def test_sync_conditional_reads(service_name, operator):
     path = f"random_file_{str(uuid4())}"

--- a/bindings/python/tests/test_read.py
+++ b/bindings/python/tests/test_read.py
@@ -260,7 +260,6 @@ async def test_async_read_not_exists(service_name, operator, async_operator):
 @pytest.mark.need_capability(
     "read",
     "write",
-    "delete",
     "read_with_if_modified_since",
     "read_with_if_unmodified_since",
 )
@@ -286,5 +285,3 @@ def test_sync_conditional_reads(service_name, operator):
     # Should fail: file was modified after `before`
     with pytest.raises(ConditionNotMatch):
         operator.read(path, if_unmodified_since=before)
-
-    operator.delete(path)

--- a/core/services/http/src/backend.rs
+++ b/core/services/http/src/backend.rs
@@ -133,12 +133,16 @@ impl Builder for HttpBuilder {
             stat: true,
             stat_with_if_match: true,
             stat_with_if_none_match: true,
+            stat_with_if_modified_since: true,
+            stat_with_if_unmodified_since: true,
 
             read: true,
             read_with_suffix: true,
 
             read_with_if_match: true,
             read_with_if_none_match: true,
+            read_with_if_modified_since: true,
+            read_with_if_unmodified_since: true,
 
             presign: auth.is_none(),
             presign_read: auth.is_none(),

--- a/core/services/http/src/core.rs
+++ b/core/services/http/src/core.rs
@@ -21,7 +21,9 @@ use http::Request;
 use http::Response;
 use http::header;
 use http::header::IF_MATCH;
+use http::header::IF_MODIFIED_SINCE;
 use http::header::IF_NONE_MATCH;
+use http::header::IF_UNMODIFIED_SINCE;
 
 use opendal_core::raw::*;
 use opendal_core::*;
@@ -70,6 +72,14 @@ impl HttpCore {
             req = req.header(IF_NONE_MATCH, if_none_match);
         }
 
+        if let Some(if_modified_since) = args.if_modified_since() {
+            req = req.header(IF_MODIFIED_SINCE, if_modified_since.format_http_date());
+        }
+
+        if let Some(if_unmodified_since) = args.if_unmodified_since() {
+            req = req.header(IF_UNMODIFIED_SINCE, if_unmodified_since.format_http_date());
+        }
+
         if let Some(auth) = &self.authorization {
             req = req.header(header::AUTHORIZATION, auth.clone())
         }
@@ -109,6 +119,14 @@ impl HttpCore {
 
         if let Some(if_none_match) = args.if_none_match() {
             req = req.header(IF_NONE_MATCH, if_none_match);
+        }
+
+        if let Some(if_modified_since) = args.if_modified_since() {
+            req = req.header(IF_MODIFIED_SINCE, if_modified_since.format_http_date());
+        }
+
+        if let Some(if_unmodified_since) = args.if_unmodified_since() {
+            req = req.header(IF_UNMODIFIED_SINCE, if_unmodified_since.format_http_date());
         }
 
         if let Some(auth) = &self.authorization {


### PR DESCRIPTION
# Which issue does this PR close?

Part of #5486.

# Rationale for this change

The http service already wires `if_match` / `if_none_match` on read and stat. RFC 7232 defines `If-Modified-Since` / `If-Unmodified-Since` as the date-based counterparts, and they're standard on every HTTP/1.1 server

# What changes are included in this PR?

- Inject `If-Modified-Since` / `If-Unmodified-Since` in `http_get_request` and `http_head_request`.
- Declare `read_with_if_modified_since`, `read_with_if_unmodified_since`, `stat_with_if_modified_since`, `stat_with_if_unmodified_since` on the http service capability.

# Are there any user-facing changes?

Yes — `op.reader_with(path).if_modified_since(...)` / `if_unmodified_since(...)` (and the stat equivalents) now work against http backends. No breaking changes. 

# AI Usage Statement

AI-assisted implementation.