### PR TITLE
docs(services/s3): add Tigris compatible service

### DIFF
--- a/core/services/s3/src/compatible_services.md
+++ b/core/services/s3/src/compatible_services.md
@@ -85,6 +85,22 @@ To connect to COS, we need to set:
 - `endpoint`: The endpoint of cos, for example: `https://cos.ap-beijing.myqcloud.com`
 - `bucket`: The bucket name of cos.
 
+### Tigris
+
+[Tigris](https://www.tigrisdata.com/) is a globally distributed S3-compatible object storage service.
+
+To connect to Tigris, we need to set:
+
+- `endpoint`: The endpoint of Tigris, for example: `https://fly.storage.tigris.dev`
+- `region`: The region of Tigris. Please set it to `auto`.
+- `bucket`: The bucket name of Tigris.
+
+```rust,ignore
+builder.endpoint("https://fly.storage.tigris.dev");
+builder.region("auto");
+builder.bucket("<bucket_name>");
+```
+
 ### Wasabi Object Storage
 
 [Wasabi](https://wasabi.com/) is a s3 compatible service.


### PR DESCRIPTION
## Summary
- add Tigris to the S3 compatible services documentation
- document the Tigris endpoint, `auto` region, bucket setting, and Rust builder example

Closes #4668.

## Validation
- `cargo check -q` from `core/` with `RUSTUP_TOOLCHAIN=stable-x86_64-pc-windows-msvc`