### PR TITLE
fix(ci): keep website root deployment on main only

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -577,7 +577,8 @@ jobs:
 
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v4.0.0
-        if: ${{ (github.event_name == 'push' && github.ref_name == 'main') || (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc')) }}
+        # Keep the public root site pinned to main; tag builds are published below.
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: website/build


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

The docs workflow currently allows non-RC tags to publish `website/build` to `gh-pages`.
If a release tag points to an older commit, that deployment can overwrite the public root site even after `main` has already published a newer homepage.

This happened with `v0.57.0`: the workflow deployed an older site snapshot to `gh-pages`, and then failed later in the nightlies deploy step. The workflow looked red overall, but the public website had already been replaced by the older content.

# What changes are included in this PR?

- Restrict `Deploy to gh-pages` so only pushes on `main` can update the public root site.
- Keep the existing tag-based staging and nightlies deployments unchanged.

Validation:

- `git diff --check`
- Parsed `.github/workflows/docs.yml` with `PyYAML`

# Are there any user-facing changes?

Yes. The public website root will stay pinned to `main` instead of being overwritten by release-tag builds. Tagged docs publishing to the dedicated staging/nightlies paths is unchanged.

# AI Usage Statement

Built with Codex (GPT-5).
