### PR TITLE
feat(services/oss): support content_encoding in write operations

### DIFF
--- a/core/services/oss/src/backend.rs
+++ b/core/services/oss/src/backend.rs
@@ -578,6 +578,7 @@ impl Builder for OssBuilder {
                             write_with_cache_control: true,
                             write_with_content_type: true,
                             write_with_content_disposition: true,
+                            write_with_content_encoding: true,
                             write_with_if_not_exists: true,
 
                             // The min multipart size of OSS is 100 KiB.

--- a/core/services/oss/src/core.rs
+++ b/core/services/oss/src/core.rs
@@ -27,6 +27,7 @@ use http::Request;
 use http::Response;
 use http::header::CACHE_CONTROL;
 use http::header::CONTENT_DISPOSITION;
+use http::header::CONTENT_ENCODING;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
 use http::header::IF_MATCH;
@@ -164,6 +165,10 @@ impl OssCore {
 
         if let Some(pos) = args.content_disposition() {
             req = req.header(CONTENT_DISPOSITION, pos);
+        }
+
+        if let Some(encoding) = args.content_encoding() {
+            req = req.header(CONTENT_ENCODING, encoding);
         }
 
         if let Some(cache_control) = args.cache_control() {
@@ -616,6 +621,7 @@ impl OssCore {
         content_type: Option<&str>,
         content_disposition: Option<&str>,
         cache_control: Option<&str>,
+        content_encoding: Option<&str>,
         is_presign: bool,
     ) -> Result<Response<Buffer>> {
         let path = build_abs_path(&self.root, path);
@@ -630,6 +636,9 @@ impl OssCore {
         }
         if let Some(cache_control) = cache_control {
             req = req.header(CACHE_CONTROL, cache_control);
+        }
+        if let Some(encoding) = content_encoding {
+            req = req.header(CONTENT_ENCODING, encoding);
         }
         req = self.insert_sse_headers(req);
 

--- a/core/services/oss/src/writer.rs
+++ b/core/services/oss/src/writer.rs
@@ -86,6 +86,7 @@ impl oio::MultipartWrite for OssWriter {
                 self.op.content_type(),
                 self.op.content_disposition(),
                 self.op.cache_control(),
+                self.op.content_encoding(),
                 false,
             )
             .await?;


### PR DESCRIPTION
## Which issue does this PR close?

  Closes #7656.

  ## Rationale for this change

  The OSS backend currently does not honor `OpWrite::content_encoding()`, even
  though the write option already exists and other object storage backends such as
  S3 and GCS support it.

  Users who upload gzip/br/deflate objects to Aliyun OSS through OpenDAL cannot
  preserve the `Content-Encoding` metadata. This breaks CDN/browser transparent
  decompression for compressed static objects.

  ## What changes are included in this PR?

  - `core/services/oss/src/backend.rs`
    - Set `write_with_content_encoding: true` in the OSS capability table.
  - `core/services/oss/src/core.rs`
    - Import `http::header::CONTENT_ENCODING`.
    - Forward `args.content_encoding()` in shared write metadata headers, covering
      `PutObject` and `AppendObject`.
    - Add a `content_encoding` parameter to `oss_initiate_upload` and set the
      header on `InitiateMultipartUpload`.
  - `core/services/oss/src/writer.rs`
    - Pass `self.op.content_encoding()` into `oss_initiate_upload` for multipart
      writes.

  ## Are there any user-facing changes?

  Yes. OSS now advertises `write_with_content_encoding`, and
  `op.write_with(...).content_encoding(...)` will preserve `Content-Encoding`
  metadata on written objects.

  Existing users who do not set `content_encoding` are unaffected.

  ## Tests

  - `cargo fmt --check`
  - `cargo check -p opendal --features services-oss --no-default-features`
  - `cargo clippy -p opendal --features services-oss --no-default-features -- -D warnings`
  - `cargo test -p opendal-service-oss --no-default-features`