### PR TITLE
feat(binding/go): expose all read options

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -402,6 +402,87 @@ typedef struct opendal_result_read {
 } opendal_result_read;
 
 /**
+ * \brief The options for read operations.
+ *
+ * Use `opendal_read_options_new()` to construct and
+ * `opendal_read_options_free()` to free.
+ */
+typedef struct opendal_read_options {
+  /**
+   * The start offset of the range to read; default 0.
+   */
+  uint64_t offset;
+  /**
+   * Whether `length` has been set.
+   */
+  bool has_length;
+  /**
+   * The number of bytes to read starting from `offset`.
+   */
+  uint64_t length;
+  /**
+   * The version of the object to read; NULL means unset.
+   */
+  const char *version;
+  /**
+   * If-Match header value; NULL means unset.
+   */
+  const char *if_match;
+  /**
+   * If-None-Match header value; NULL means unset.
+   */
+  const char *if_none_match;
+  /**
+   * Whether `if_modified_since` has been set.
+   */
+  bool has_if_modified_since;
+  /**
+   * If-Modified-Since condition, in Unix milliseconds.
+   */
+  int64_t if_modified_since;
+  /**
+   * Whether `if_unmodified_since` has been set.
+   */
+  bool has_if_unmodified_since;
+  /**
+   * If-Unmodified-Since condition, in Unix milliseconds.
+   */
+  int64_t if_unmodified_since;
+  /**
+   * Concurrent read operations. `0` means sequential reads.
+   */
+  uintptr_t concurrent;
+  /**
+   * Whether `chunk` has been set.
+   */
+  bool has_chunk;
+  /**
+   * Chunk size for each read request.
+   */
+  uintptr_t chunk;
+  /**
+   * Whether `gap` has been set.
+   */
+  bool has_gap;
+  /**
+   * Gap size for merging nearby range reads.
+   */
+  uintptr_t gap;
+  /**
+   * Override the response Content-Type header (presign only); NULL means unset.
+   */
+  const char *override_content_type;
+  /**
+   * Override the response Cache-Control header (presign only); NULL means unset.
+   */
+  const char *override_cache_control;
+  /**
+   * Override the response Content-Disposition header (presign only); NULL means unset.
+   */
+  const char *override_content_disposition;
+} opendal_read_options;
+
+/**
  * \brief The result type returned by opendal's reader operation.
  *
  * \note The opendal_reader actually owns a pointer to
@@ -621,6 +702,18 @@ typedef struct opendal_capability {
    * if operator supports read with override content type.
    */
   bool read_with_override_content_type;
+  /**
+   * If operator supports read with if modified since.
+   */
+  bool read_with_if_modified_since;
+  /**
+   * If operator supports read with if unmodified since.
+   */
+  bool read_with_if_unmodified_since;
+  /**
+   * If operator supports read with version.
+   */
+  bool read_with_version;
   /**
    * If operator supports write.
    */
@@ -1186,6 +1279,41 @@ struct opendal_error *opendal_operator_write_with(const struct opendal_operator 
  */
 struct opendal_result_read opendal_operator_read(const struct opendal_operator *op,
                                                  const char *path);
+
+/**
+ * \brief Blocking read the data from `path` with options.
+ *
+ * Read the data out from `path` blocking by operator, using the provided
+ * `opendal_read_options` to control the behavior, e.g. range, version, or
+ * conditional headers.
+ *
+ * @param op The opendal_operator created previously
+ * @param path The path you want to read the data out
+ * @param opts The options for the read operation; pass NULL to use defaults
+ * @see opendal_operator
+ * @see opendal_result_read
+ * @see opendal_read_options
+ * @see opendal_error
+ * @return Returns opendal_result_read, the `data` field is a pointer to a newly allocated
+ * opendal_bytes, the `error` field contains the error. If the `error` is not NULL, then
+ * the operation failed and the `data` field is a nullptr.
+ *
+ * \note If the read operation succeeds, the returned opendal_bytes is newly allocated on heap.
+ * After your usage of that, please call opendal_bytes_free() to free the space.
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_result_read opendal_operator_read_with(const struct opendal_operator *op,
+                                                      const char *path,
+                                                      const struct opendal_read_options *opts);
 
 /**
  * \brief Blocking read the data from `path`.
@@ -1896,6 +2024,84 @@ void opendal_write_options_set_chunk(struct opendal_write_options *opts, uintptr
 void opendal_write_options_set_user_metadata(struct opendal_write_options *opts,
                                              const struct opendal_write_user_metadata_pair *pairs,
                                              uintptr_t len);
+
+/**
+ * \brief Construct a heap-allocated opendal_read_options with default values.
+ */
+struct opendal_read_options *opendal_read_options_new(void);
+
+/**
+ * \brief Free the heap memory used by opendal_read_options.
+ */
+void opendal_read_options_free(struct opendal_read_options *opts);
+
+/**
+ * \brief Set the read range offset and length.
+ */
+void opendal_read_options_set_range(struct opendal_read_options *opts,
+                                    uint64_t offset,
+                                    uint64_t length);
+
+/**
+ * \brief Set the version of the object to read.
+ */
+void opendal_read_options_set_version(struct opendal_read_options *opts, const char *version);
+
+/**
+ * \brief Set If-Match.
+ */
+void opendal_read_options_set_if_match(struct opendal_read_options *opts, const char *if_match);
+
+/**
+ * \brief Set If-None-Match.
+ */
+void opendal_read_options_set_if_none_match(struct opendal_read_options *opts,
+                                            const char *if_none_match);
+
+/**
+ * \brief Set If-Modified-Since, in Unix milliseconds.
+ */
+void opendal_read_options_set_if_modified_since(struct opendal_read_options *opts,
+                                                int64_t if_modified_since);
+
+/**
+ * \brief Set If-Unmodified-Since, in Unix milliseconds.
+ */
+void opendal_read_options_set_if_unmodified_since(struct opendal_read_options *opts,
+                                                  int64_t if_unmodified_since);
+
+/**
+ * \brief Set concurrent read operations.
+ */
+void opendal_read_options_set_concurrent(struct opendal_read_options *opts, uintptr_t concurrent);
+
+/**
+ * \brief Set chunk size.
+ */
+void opendal_read_options_set_chunk(struct opendal_read_options *opts, uintptr_t chunk);
+
+/**
+ * \brief Set gap size.
+ */
+void opendal_read_options_set_gap(struct opendal_read_options *opts, uintptr_t gap);
+
+/**
+ * \brief Set the override Content-Type (presign only).
+ */
+void opendal_read_options_set_override_content_type(struct opendal_read_options *opts,
+                                                    const char *override_content_type);
+
+/**
+ * \brief Set the override Cache-Control (presign only).
+ */
+void opendal_read_options_set_override_cache_control(struct opendal_read_options *opts,
+                                                     const char *override_cache_control);
+
+/**
+ * \brief Set the override Content-Disposition (presign only).
+ */
+void opendal_read_options_set_override_content_disposition(struct opendal_read_options *opts,
+                                                           const char *override_content_disposition);
 
 /**
  * \brief Construct a heap-allocated opendal_operator_options

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -74,6 +74,7 @@ mod types;
 pub use types::opendal_bytes;
 pub use types::opendal_list_options;
 pub use types::opendal_operator_options;
+pub use types::opendal_read_options;
 pub use types::opendal_write_options;
 pub use types::opendal_write_user_metadata_pair;
 

--- a/bindings/c/src/operator.rs
+++ b/bindings/c/src/operator.rs
@@ -364,6 +364,62 @@ pub unsafe extern "C" fn opendal_operator_read(
     }
 }
 
+/// \brief Blocking read the data from `path` with options.
+///
+/// Read the data out from `path` blocking by operator, using the provided
+/// `opendal_read_options` to control the behavior, e.g. range, version, or
+/// conditional headers.
+///
+/// @param op The opendal_operator created previously
+/// @param path The path you want to read the data out
+/// @param opts The options for the read operation; pass NULL to use defaults
+/// @see opendal_operator
+/// @see opendal_result_read
+/// @see opendal_read_options
+/// @see opendal_error
+/// @return Returns opendal_result_read, the `data` field is a pointer to a newly allocated
+/// opendal_bytes, the `error` field contains the error. If the `error` is not NULL, then
+/// the operation failed and the `data` field is a nullptr.
+///
+/// \note If the read operation succeeds, the returned opendal_bytes is newly allocated on heap.
+/// After your usage of that, please call opendal_bytes_free() to free the space.
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_read_with(
+    op: &opendal_operator,
+    path: *const c_char,
+    opts: *const opendal_read_options,
+) -> opendal_result_read {
+    assert!(!path.is_null());
+    let path = std::ffi::CStr::from_ptr(path)
+        .to_str()
+        .expect("malformed path");
+    let opts = if opts.is_null() {
+        core::options::ReadOptions::default()
+    } else {
+        (&*opts).into()
+    };
+    match op.deref().read_options(path, opts) {
+        Ok(b) => opendal_result_read {
+            data: opendal_bytes::new(b),
+            error: std::ptr::null_mut(),
+        },
+        Err(e) => opendal_result_read {
+            data: opendal_bytes::empty(),
+            error: opendal_error::new(e),
+        },
+    }
+}
+
 /// \brief Blocking read the data from `path`.
 ///
 /// Read the data out from `path` blocking by operator, returns

--- a/bindings/c/src/operator_info.rs
+++ b/bindings/c/src/operator_info.rs
@@ -62,6 +62,12 @@ pub struct opendal_capability {
     pub read_with_override_content_disposition: bool,
     /// if operator supports read with override content type.
     pub read_with_override_content_type: bool,
+    /// If operator supports read with if modified since.
+    pub read_with_if_modified_since: bool,
+    /// If operator supports read with if unmodified since.
+    pub read_with_if_unmodified_since: bool,
+    /// If operator supports read with version.
+    pub read_with_version: bool,
 
     /// If operator supports write.
     pub write: bool,
@@ -243,6 +249,9 @@ impl From<core::Capability> for opendal_capability {
             read_with_override_content_type: value.read_with_override_content_type,
             read_with_override_cache_control: value.read_with_override_cache_control,
             read_with_override_content_disposition: value.read_with_override_content_disposition,
+            read_with_if_modified_since: value.read_with_if_modified_since,
+            read_with_if_unmodified_since: value.read_with_if_unmodified_since,
+            read_with_version: value.read_with_version,
             write: value.write,
             write_can_multi: value.write_can_multi,
             write_can_empty: value.write_can_empty,

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -20,6 +20,7 @@ use std::ffi::{c_void, CStr, CString};
 use std::os::raw::c_char;
 
 use opendal::options;
+use opendal::raw::{BytesRange, Timestamp};
 use opendal::Buffer;
 
 /// \brief Frees a heap-allocated string returned by OpenDAL C APIs.
@@ -449,6 +450,269 @@ impl From<&opendal_write_options> for options::WriteOptions {
             if_not_exists: value.if_not_exists,
             concurrent: value.concurrent,
             chunk: value.has_chunk.then_some(value.chunk),
+        }
+    }
+}
+
+/// \brief The options for read operations.
+///
+/// Use `opendal_read_options_new()` to construct and
+/// `opendal_read_options_free()` to free.
+#[repr(C)]
+pub struct opendal_read_options {
+    /// The start offset of the range to read; default 0.
+    pub offset: u64,
+    /// Whether `length` has been set.
+    pub has_length: bool,
+    /// The number of bytes to read starting from `offset`.
+    pub length: u64,
+    /// The version of the object to read; NULL means unset.
+    pub version: *const c_char,
+    /// If-Match header value; NULL means unset.
+    pub if_match: *const c_char,
+    /// If-None-Match header value; NULL means unset.
+    pub if_none_match: *const c_char,
+    /// Whether `if_modified_since` has been set.
+    pub has_if_modified_since: bool,
+    /// If-Modified-Since condition, in Unix milliseconds.
+    pub if_modified_since: i64,
+    /// Whether `if_unmodified_since` has been set.
+    pub has_if_unmodified_since: bool,
+    /// If-Unmodified-Since condition, in Unix milliseconds.
+    pub if_unmodified_since: i64,
+    /// Concurrent read operations. `0` means sequential reads.
+    pub concurrent: usize,
+    /// Whether `chunk` has been set.
+    pub has_chunk: bool,
+    /// Chunk size for each read request.
+    pub chunk: usize,
+    /// Whether `gap` has been set.
+    pub has_gap: bool,
+    /// Gap size for merging nearby range reads.
+    pub gap: usize,
+    /// Override the response Content-Type header (presign only); NULL means unset.
+    pub override_content_type: *const c_char,
+    /// Override the response Cache-Control header (presign only); NULL means unset.
+    pub override_cache_control: *const c_char,
+    /// Override the response Content-Disposition header (presign only); NULL means unset.
+    pub override_content_disposition: *const c_char,
+}
+
+impl Default for opendal_read_options {
+    fn default() -> Self {
+        Self {
+            offset: 0,
+            has_length: false,
+            length: 0,
+            version: std::ptr::null(),
+            if_match: std::ptr::null(),
+            if_none_match: std::ptr::null(),
+            has_if_modified_since: false,
+            if_modified_since: 0,
+            has_if_unmodified_since: false,
+            if_unmodified_since: 0,
+            concurrent: 0,
+            has_chunk: false,
+            chunk: 0,
+            has_gap: false,
+            gap: 0,
+            override_content_type: std::ptr::null(),
+            override_cache_control: std::ptr::null(),
+            override_content_disposition: std::ptr::null(),
+        }
+    }
+}
+
+impl opendal_read_options {
+    /// \brief Construct a heap-allocated opendal_read_options with default values.
+    #[no_mangle]
+    pub extern "C" fn opendal_read_options_new() -> *mut Self {
+        Box::into_raw(Box::new(Self::default()))
+    }
+
+    /// \brief Free the heap memory used by opendal_read_options.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_free(opts: *mut opendal_read_options) {
+        if !opts.is_null() {
+            drop(Box::from_raw(opts));
+        }
+    }
+
+    /// \brief Set the read range offset and length.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_range(
+        opts: *mut opendal_read_options,
+        offset: u64,
+        length: u64,
+    ) {
+        if !opts.is_null() {
+            (*opts).offset = offset;
+            (*opts).has_length = true;
+            (*opts).length = length;
+        }
+    }
+
+    /// \brief Set the version of the object to read.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_version(
+        opts: *mut opendal_read_options,
+        version: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).version = version;
+        }
+    }
+
+    /// \brief Set If-Match.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_if_match(
+        opts: *mut opendal_read_options,
+        if_match: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).if_match = if_match;
+        }
+    }
+
+    /// \brief Set If-None-Match.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_if_none_match(
+        opts: *mut opendal_read_options,
+        if_none_match: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).if_none_match = if_none_match;
+        }
+    }
+
+    /// \brief Set If-Modified-Since, in Unix milliseconds.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_if_modified_since(
+        opts: *mut opendal_read_options,
+        if_modified_since: i64,
+    ) {
+        if !opts.is_null() {
+            (*opts).has_if_modified_since = true;
+            (*opts).if_modified_since = if_modified_since;
+        }
+    }
+
+    /// \brief Set If-Unmodified-Since, in Unix milliseconds.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_if_unmodified_since(
+        opts: *mut opendal_read_options,
+        if_unmodified_since: i64,
+    ) {
+        if !opts.is_null() {
+            (*opts).has_if_unmodified_since = true;
+            (*opts).if_unmodified_since = if_unmodified_since;
+        }
+    }
+
+    /// \brief Set concurrent read operations.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_concurrent(
+        opts: *mut opendal_read_options,
+        concurrent: usize,
+    ) {
+        if !opts.is_null() {
+            (*opts).concurrent = concurrent;
+        }
+    }
+
+    /// \brief Set chunk size.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_chunk(
+        opts: *mut opendal_read_options,
+        chunk: usize,
+    ) {
+        if !opts.is_null() {
+            (*opts).has_chunk = true;
+            (*opts).chunk = chunk;
+        }
+    }
+
+    /// \brief Set gap size.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_gap(
+        opts: *mut opendal_read_options,
+        gap: usize,
+    ) {
+        if !opts.is_null() {
+            (*opts).has_gap = true;
+            (*opts).gap = gap;
+        }
+    }
+
+    /// \brief Set the override Content-Type (presign only).
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_override_content_type(
+        opts: *mut opendal_read_options,
+        override_content_type: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).override_content_type = override_content_type;
+        }
+    }
+
+    /// \brief Set the override Cache-Control (presign only).
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_override_cache_control(
+        opts: *mut opendal_read_options,
+        override_cache_control: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).override_cache_control = override_cache_control;
+        }
+    }
+
+    /// \brief Set the override Content-Disposition (presign only).
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_override_content_disposition(
+        opts: *mut opendal_read_options,
+        override_content_disposition: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).override_content_disposition = override_content_disposition;
+        }
+    }
+}
+
+impl From<&opendal_read_options> for options::ReadOptions {
+    fn from(value: &opendal_read_options) -> Self {
+        let range = if value.offset > 0 || value.has_length {
+            let size = if value.has_length {
+                Some(value.length)
+            } else {
+                None
+            };
+            BytesRange::new(value.offset, size)
+        } else {
+            BytesRange::default()
+        };
+
+        Self {
+            range,
+            version: unsafe { optional_cstr(value.version) },
+            if_match: unsafe { optional_cstr(value.if_match) },
+            if_none_match: unsafe { optional_cstr(value.if_none_match) },
+            if_modified_since: value
+                .has_if_modified_since
+                .then(|| Timestamp::from_millisecond(value.if_modified_since).ok())
+                .flatten(),
+            if_unmodified_since: value
+                .has_if_unmodified_since
+                .then(|| Timestamp::from_millisecond(value.if_unmodified_since).ok())
+                .flatten(),
+            content_length_hint: None,
+            concurrent: value.concurrent,
+            chunk: value.has_chunk.then_some(value.chunk),
+            gap: value.has_gap.then_some(value.gap),
+            override_content_type: unsafe { optional_cstr(value.override_content_type) },
+            override_cache_control: unsafe { optional_cstr(value.override_cache_control) },
+            override_content_disposition: unsafe {
+                optional_cstr(value.override_content_disposition)
+            },
         }
     }
 }

--- a/bindings/go/operator_info.go
+++ b/bindings/go/operator_info.go
@@ -112,12 +112,12 @@ func (c *Capability) Read() bool {
 	return c.inner.read == 1
 }
 
-func (c *Capability) ReadWithIfmatch() bool {
-	return c.inner.readWithIfmatch == 1
+func (c *Capability) ReadWithIfMatch() bool {
+	return c.inner.readWithIfMatch == 1
 }
 
-func (c *Capability) ReadWithIfMatchNone() bool {
-	return c.inner.readWithIfMatchNone == 1
+func (c *Capability) ReadWithIfNoneMatch() bool {
+	return c.inner.readWithIfNoneMatch == 1
 }
 
 func (c *Capability) ReadWithOverrideCacheControl() bool {
@@ -130,6 +130,18 @@ func (c *Capability) ReadWithOverrideContentDisposition() bool {
 
 func (c *Capability) ReadWithOverrideContentType() bool {
 	return c.inner.readWithOverrideContentType == 1
+}
+
+func (c *Capability) ReadWithIfModifiedSince() bool {
+	return c.inner.readWithIfModifiedSince == 1
+}
+
+func (c *Capability) ReadWithIfUnmodifiedSince() bool {
+	return c.inner.readWithIfUnmodifiedSince == 1
+}
+
+func (c *Capability) ReadWithVersion() bool {
+	return c.inner.readWithVersion == 1
 }
 
 func (c *Capability) Write() bool {

--- a/bindings/go/reader.go
+++ b/bindings/go/reader.go
@@ -22,6 +22,8 @@ package opendal
 import (
 	"context"
 	"io"
+	"runtime"
+	"time"
 	"unsafe"
 
 	"github.com/jupiterrider/ffi"
@@ -29,11 +31,13 @@ import (
 
 // Read reads the entire contents of the file at the specified path into a byte slice.
 //
-// This function is a wrapper around the C-binding function `opendal_operator_read`.
+// Read is a wrapper around the C-binding function `opendal_operator_read`.
+// When options are provided, it uses `opendal_operator_read_with`.
 //
 // # Parameters
 //
 //   - path: The path of the file to read.
+//   - opts: Optional read options.
 //
 // # Returns
 //
@@ -42,7 +46,6 @@ import (
 //
 // # Notes
 //
-//   - This implementation does not support the `read_with` functionality.
 //   - Read allocates a new byte slice internally. For more precise memory control
 //     or lazy reading, consider using the Reader() method instead.
 //
@@ -57,8 +60,8 @@ import (
 //	}
 //
 // Note: This example assumes proper error handling and import statements.
-func (op *Operator) Read(path string) ([]byte, error) {
-	bytes, err := ffiOperatorRead.symbol(op.ctx)(op.inner, path)
+func (op *Operator) Read(path string, opts ...WithReadFn) ([]byte, error) {
+	bytes, err := op.read(path, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -68,6 +71,206 @@ func (op *Operator) Read(path string) ([]byte, error) {
 		ffiBytesFree.symbol(op.ctx)(&bytes)
 	}
 	return data, nil
+}
+
+func (op *Operator) read(path string, opts ...WithReadFn) (opendalBytes, error) {
+	if len(opts) == 0 {
+		return ffiOperatorRead.symbol(op.ctx)(op.inner, path)
+	}
+
+	o := parseReadOptions(opts...)
+	cOpts, keepAlive, err := newOpendalReadOptions(op.ctx, o)
+	if err != nil {
+		return opendalBytes{}, err
+	}
+	defer ffiReadOptionsFree.symbol(op.ctx)(cOpts)
+	bytes, err := ffiOperatorReadWith.symbol(op.ctx)(op.inner, path, cOpts)
+	runtime.KeepAlive(keepAlive)
+	return bytes, err
+}
+
+// WithReadFn is a functional option for read operations.
+type WithReadFn func(*readOptions)
+
+// ReadWithRange sets the byte range to read, starting at offset and reading
+// length bytes. To read a file with size n, offset must be in [0, n) and the
+// effective range is [offset, offset+length).
+func ReadWithRange(offset, length uint64) WithReadFn {
+	return func(o *readOptions) {
+		o.hasRange = true
+		o.rangeOffset = offset
+		o.rangeLength = length
+	}
+}
+
+// ReadWithVersion sets the version of the object to read.
+func ReadWithVersion(version string) WithReadFn {
+	return func(o *readOptions) {
+		o.version = version
+	}
+}
+
+// ReadWithIfMatch sets the If-Match condition for the read operation.
+func ReadWithIfMatch(ifMatch string) WithReadFn {
+	return func(o *readOptions) {
+		o.ifMatch = ifMatch
+	}
+}
+
+// ReadWithIfNoneMatch sets the If-None-Match condition for the read operation.
+func ReadWithIfNoneMatch(ifNoneMatch string) WithReadFn {
+	return func(o *readOptions) {
+		o.ifNoneMatch = ifNoneMatch
+	}
+}
+
+// ReadWithIfModifiedSince sets the If-Modified-Since condition for the read operation.
+func ReadWithIfModifiedSince(t time.Time) WithReadFn {
+	return func(o *readOptions) {
+		millis := t.UnixMilli()
+		o.ifModifiedSince = &millis
+	}
+}
+
+// ReadWithIfUnmodifiedSince sets the If-Unmodified-Since condition for the read operation.
+func ReadWithIfUnmodifiedSince(t time.Time) WithReadFn {
+	return func(o *readOptions) {
+		millis := t.UnixMilli()
+		o.ifUnmodifiedSince = &millis
+	}
+}
+
+// ReadWithConcurrent sets the number of concurrent read tasks.
+func ReadWithConcurrent(concurrent uint) WithReadFn {
+	return func(o *readOptions) {
+		o.concurrent = concurrent
+	}
+}
+
+// ReadWithChunk sets the chunk size for each read request.
+func ReadWithChunk(chunk uint) WithReadFn {
+	return func(o *readOptions) {
+		o.chunk = chunk
+	}
+}
+
+// ReadWithGap sets the gap size for merging nearby range reads.
+func ReadWithGap(gap uint) WithReadFn {
+	return func(o *readOptions) {
+		o.gap = gap
+	}
+}
+
+// ReadWithOverrideContentType sets the Content-Type to send back (presign only).
+func ReadWithOverrideContentType(contentType string) WithReadFn {
+	return func(o *readOptions) {
+		o.overrideContentType = contentType
+	}
+}
+
+// ReadWithOverrideCacheControl sets the Cache-Control to send back (presign only).
+func ReadWithOverrideCacheControl(cacheControl string) WithReadFn {
+	return func(o *readOptions) {
+		o.overrideCacheControl = cacheControl
+	}
+}
+
+// ReadWithOverrideContentDisposition sets the Content-Disposition to send back (presign only).
+func ReadWithOverrideContentDisposition(contentDisposition string) WithReadFn {
+	return func(o *readOptions) {
+		o.overrideContentDisposition = contentDisposition
+	}
+}
+
+type readOptions struct {
+	hasRange                   bool
+	rangeOffset                uint64
+	rangeLength                uint64
+	version                    string
+	ifMatch                    string
+	ifNoneMatch                string
+	ifModifiedSince            *int64
+	ifUnmodifiedSince          *int64
+	concurrent                 uint
+	chunk                      uint
+	gap                        uint
+	overrideContentType        string
+	overrideCacheControl       string
+	overrideContentDisposition string
+}
+
+func parseReadOptions(opts ...WithReadFn) *readOptions {
+	o := &readOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+type readOptionsKeepAlive struct {
+	strings [][]byte
+}
+
+func newOpendalReadOptions(ctx context.Context, o *readOptions) (*opendalReadOptions, readOptionsKeepAlive, error) {
+	cOpts := ffiReadOptionsNew.symbol(ctx)()
+	keepAlive := readOptionsKeepAlive{}
+
+	// fail frees the C-allocated options before returning
+	fail := func(err error) (*opendalReadOptions, readOptionsKeepAlive, error) {
+		ffiReadOptionsFree.symbol(ctx)(cOpts)
+		return nil, readOptionsKeepAlive{}, err
+	}
+
+	setString := func(value string, set func(*opendalReadOptions, string) ([]byte, error)) error {
+		if value == "" {
+			return nil
+		}
+		data, err := set(cOpts, value)
+		if err != nil {
+			return err
+		}
+		keepAlive.strings = append(keepAlive.strings, data)
+		return nil
+	}
+
+	if o.hasRange {
+		ffiReadOptionsSetRange.symbol(ctx)(cOpts, o.rangeOffset, o.rangeLength)
+	}
+	if err := setString(o.version, ffiReadOptionsSetVersion.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if err := setString(o.ifMatch, ffiReadOptionsSetIfMatch.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if err := setString(o.ifNoneMatch, ffiReadOptionsSetIfNoneMatch.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if o.ifModifiedSince != nil {
+		ffiReadOptionsSetIfModifiedSince.symbol(ctx)(cOpts, *o.ifModifiedSince)
+	}
+	if o.ifUnmodifiedSince != nil {
+		ffiReadOptionsSetIfUnmodifiedSince.symbol(ctx)(cOpts, *o.ifUnmodifiedSince)
+	}
+	if o.concurrent != 0 {
+		ffiReadOptionsSetConcurrent.symbol(ctx)(cOpts, o.concurrent)
+	}
+	if o.chunk != 0 {
+		ffiReadOptionsSetChunk.symbol(ctx)(cOpts, o.chunk)
+	}
+	if o.gap != 0 {
+		ffiReadOptionsSetGap.symbol(ctx)(cOpts, o.gap)
+	}
+	if err := setString(o.overrideContentType, ffiReadOptionsSetOverrideContentType.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if err := setString(o.overrideCacheControl, ffiReadOptionsSetOverrideCacheControl.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if err := setString(o.overrideContentDisposition, ffiReadOptionsSetOverrideContentDisposition.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+
+	return cOpts, keepAlive, nil
 }
 
 // Reader creates a new Reader for reading the contents of a file at the specified path.
@@ -261,6 +464,133 @@ var ffiOperatorRead = newFFI(ffiOpts{
 			unsafe.Pointer(&bytePath),
 		)
 		return result.data, parseError(ctx, result.error)
+	}
+})
+
+var ffiOperatorReadWith = newFFI(ffiOpts{
+	sym:    "opendal_operator_read_with",
+	rType:  &typeResultRead,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(op *opendalOperator, path string, opts *opendalReadOptions) (opendalBytes, error) {
+	return func(op *opendalOperator, path string, opts *opendalReadOptions) (opendalBytes, error) {
+		bytePath, err := BytePtrFromString(path)
+		if err != nil {
+			return opendalBytes{}, err
+		}
+		var result resultRead
+		ffiCall(
+			unsafe.Pointer(&result),
+			unsafe.Pointer(&op),
+			unsafe.Pointer(&bytePath),
+			unsafe.Pointer(&opts),
+		)
+		return result.data, parseError(ctx, result.error)
+	}
+})
+
+var ffiReadOptionsNew = newFFI(ffiOpts{
+	sym:   "opendal_read_options_new",
+	rType: &ffi.TypePointer,
+}, func(_ context.Context, ffiCall ffiCall) func() *opendalReadOptions {
+	return func() *opendalReadOptions {
+		var opts *opendalReadOptions
+		ffiCall(unsafe.Pointer(&opts))
+		return opts
+	}
+})
+
+var ffiReadOptionsFree = newFFI(ffiOpts{
+	sym:    "opendal_read_options_free",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReadOptions) {
+	return func(opts *opendalReadOptions) {
+		ffiCall(nil, unsafe.Pointer(&opts))
+	}
+})
+
+var ffiReadOptionsSetRange = newFFI(ffiOpts{
+	sym:    "opendal_read_options_set_range",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypeUint64, &ffi.TypeUint64},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReadOptions, offset, length uint64) {
+	return func(opts *opendalReadOptions, offset, length uint64) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&offset), unsafe.Pointer(&length))
+	}
+})
+
+func newReadOptionsSetStringFFI(sym string) *FFI[func(*opendalReadOptions, string) ([]byte, error)] {
+	return newFFI(ffiOpts{
+		sym:    contextKey(sym),
+		rType:  &ffi.TypeVoid,
+		aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
+	}, func(_ context.Context, ffiCall ffiCall) func(*opendalReadOptions, string) ([]byte, error) {
+		return func(opts *opendalReadOptions, value string) ([]byte, error) {
+			data, err := byteSliceFromString(value)
+			if err != nil {
+				return nil, err
+			}
+			byteValue := &data[0]
+			ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&byteValue))
+			return data, nil
+		}
+	})
+}
+
+var ffiReadOptionsSetVersion = newReadOptionsSetStringFFI("opendal_read_options_set_version")
+var ffiReadOptionsSetIfMatch = newReadOptionsSetStringFFI("opendal_read_options_set_if_match")
+var ffiReadOptionsSetIfNoneMatch = newReadOptionsSetStringFFI("opendal_read_options_set_if_none_match")
+var ffiReadOptionsSetOverrideContentType = newReadOptionsSetStringFFI("opendal_read_options_set_override_content_type")
+var ffiReadOptionsSetOverrideCacheControl = newReadOptionsSetStringFFI("opendal_read_options_set_override_cache_control")
+var ffiReadOptionsSetOverrideContentDisposition = newReadOptionsSetStringFFI("opendal_read_options_set_override_content_disposition")
+
+var ffiReadOptionsSetIfModifiedSince = newFFI(ffiOpts{
+	sym:    "opendal_read_options_set_if_modified_since",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypeSint64},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReadOptions, millis int64) {
+	return func(opts *opendalReadOptions, millis int64) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&millis))
+	}
+})
+
+var ffiReadOptionsSetIfUnmodifiedSince = newFFI(ffiOpts{
+	sym:    "opendal_read_options_set_if_unmodified_since",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypeSint64},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReadOptions, millis int64) {
+	return func(opts *opendalReadOptions, millis int64) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&millis))
+	}
+})
+
+var ffiReadOptionsSetConcurrent = newFFI(ffiOpts{
+	sym:    "opendal_read_options_set_concurrent",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReadOptions, concurrent uint) {
+	return func(opts *opendalReadOptions, concurrent uint) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&concurrent))
+	}
+})
+
+var ffiReadOptionsSetChunk = newFFI(ffiOpts{
+	sym:    "opendal_read_options_set_chunk",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReadOptions, chunk uint) {
+	return func(opts *opendalReadOptions, chunk uint) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&chunk))
+	}
+})
+
+var ffiReadOptionsSetGap = newFFI(ffiOpts{
+	sym:    "opendal_read_options_set_gap",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReadOptions, gap uint) {
+	return func(opts *opendalReadOptions, gap uint) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&gap))
 	}
 })
 

--- a/bindings/go/string_ownership_test.go
+++ b/bindings/go/string_ownership_test.go
@@ -22,6 +22,7 @@ package opendal
 import (
 	"context"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/jupiterrider/ffi"
@@ -845,5 +846,146 @@ func TestFfiOperatorListWithArgTypes(t *testing.T) {
 		if at != &ffi.TypePointer {
 			t.Fatalf("ffiOperatorListWith aTypes[%d] = %v, want TypePointer", i, at)
 		}
+	}
+}
+
+func TestReadWithOptions(t *testing.T) {
+	modified := time.Unix(1700000000, 0)
+	unmodified := time.Unix(1700000123, 0)
+
+	o := &readOptions{}
+	ReadWithRange(1024, 2048)(o)
+	ReadWithVersion("v1")(o)
+	ReadWithIfMatch("etag-a")(o)
+	ReadWithIfNoneMatch("etag-b")(o)
+	ReadWithIfModifiedSince(modified)(o)
+	ReadWithIfUnmodifiedSince(unmodified)(o)
+	ReadWithConcurrent(4)(o)
+	ReadWithChunk(1024)(o)
+	ReadWithGap(512)(o)
+	ReadWithOverrideContentType("text/plain")(o)
+	ReadWithOverrideCacheControl("max-age=60")(o)
+	ReadWithOverrideContentDisposition("attachment")(o)
+
+	if !o.hasRange {
+		t.Fatalf("hasRange = false, want true")
+	}
+	if o.rangeOffset != 1024 {
+		t.Fatalf("rangeOffset = %d, want 1024", o.rangeOffset)
+	}
+	if o.rangeLength != 2048 {
+		t.Fatalf("rangeLength = %d, want 2048", o.rangeLength)
+	}
+	if o.version != "v1" {
+		t.Fatalf("version = %q, want v1", o.version)
+	}
+	if o.ifMatch != "etag-a" {
+		t.Fatalf("ifMatch = %q, want etag-a", o.ifMatch)
+	}
+	if o.ifNoneMatch != "etag-b" {
+		t.Fatalf("ifNoneMatch = %q, want etag-b", o.ifNoneMatch)
+	}
+	if o.ifModifiedSince == nil || *o.ifModifiedSince != modified.UnixMilli() {
+		t.Fatalf("ifModifiedSince = %v, want %d", o.ifModifiedSince, modified.UnixMilli())
+	}
+	if o.ifUnmodifiedSince == nil || *o.ifUnmodifiedSince != unmodified.UnixMilli() {
+		t.Fatalf("ifUnmodifiedSince = %v, want %d", o.ifUnmodifiedSince, unmodified.UnixMilli())
+	}
+	if o.concurrent != 4 {
+		t.Fatalf("concurrent = %d, want 4", o.concurrent)
+	}
+	if o.chunk != 1024 {
+		t.Fatalf("chunk = %d, want 1024", o.chunk)
+	}
+	if o.gap != 512 {
+		t.Fatalf("gap = %d, want 512", o.gap)
+	}
+	if o.overrideContentType != "text/plain" {
+		t.Fatalf("overrideContentType = %q, want text/plain", o.overrideContentType)
+	}
+	if o.overrideCacheControl != "max-age=60" {
+		t.Fatalf("overrideCacheControl = %q, want max-age=60", o.overrideCacheControl)
+	}
+	if o.overrideContentDisposition != "attachment" {
+		t.Fatalf("overrideContentDisposition = %q, want attachment", o.overrideContentDisposition)
+	}
+}
+
+func TestFfiOperatorReadWithReturnType(t *testing.T) {
+	if ffiOperatorReadWith.opts.rType != &typeResultRead {
+		t.Fatalf("ffiOperatorReadWith rType = %v, want typeResultRead", ffiOperatorReadWith.opts.rType)
+	}
+}
+
+func TestFfiOperatorReadWithArgTypes(t *testing.T) {
+	aTypes := ffiOperatorReadWith.opts.aTypes
+	if len(aTypes) != 3 {
+		t.Fatalf("ffiOperatorReadWith aTypes len = %d, want 3", len(aTypes))
+	}
+	for i, at := range aTypes {
+		if at != &ffi.TypePointer {
+			t.Fatalf("ffiOperatorReadWith aTypes[%d] = %v, want TypePointer", i, at)
+		}
+	}
+}
+
+func TestReadOptionsSetterArgTypes(t *testing.T) {
+	stringSetters := []*FFI[func(*opendalReadOptions, string) ([]byte, error)]{
+		ffiReadOptionsSetVersion,
+		ffiReadOptionsSetIfMatch,
+		ffiReadOptionsSetIfNoneMatch,
+		ffiReadOptionsSetOverrideContentType,
+		ffiReadOptionsSetOverrideCacheControl,
+		ffiReadOptionsSetOverrideContentDisposition,
+	}
+	for _, setter := range stringSetters {
+		aTypes := setter.opts.aTypes
+		if len(aTypes) != 2 {
+			t.Fatalf("%s aTypes len = %d, want 2", setter.opts.sym, len(aTypes))
+		}
+		for i, at := range aTypes {
+			if at != &ffi.TypePointer {
+				t.Fatalf("%s aTypes[%d] = %v, want TypePointer", setter.opts.sym, i, at)
+			}
+		}
+	}
+
+	int64Setters := []*FFI[func(*opendalReadOptions, int64)]{
+		ffiReadOptionsSetIfModifiedSince,
+		ffiReadOptionsSetIfUnmodifiedSince,
+	}
+	for _, setter := range int64Setters {
+		aTypes := setter.opts.aTypes
+		if len(aTypes) != 2 {
+			t.Fatalf("%s aTypes len = %d, want 2", setter.opts.sym, len(aTypes))
+		}
+		if aTypes[0] != &ffi.TypePointer || aTypes[1] != &ffi.TypeSint64 {
+			t.Fatalf("%s aTypes = %v, want TypePointer, TypeSint64", setter.opts.sym, aTypes)
+		}
+	}
+
+	uintSetters := []*FFI[func(*opendalReadOptions, uint)]{
+		ffiReadOptionsSetConcurrent,
+		ffiReadOptionsSetChunk,
+		ffiReadOptionsSetGap,
+	}
+	for _, setter := range uintSetters {
+		aTypes := setter.opts.aTypes
+		if len(aTypes) != 2 {
+			t.Fatalf("%s aTypes len = %d, want 2", setter.opts.sym, len(aTypes))
+		}
+		for i, at := range aTypes {
+			if at != &ffi.TypePointer {
+				t.Fatalf("%s aTypes[%d] = %v, want TypePointer", setter.opts.sym, i, at)
+			}
+		}
+	}
+
+	rangeATypes := ffiReadOptionsSetRange.opts.aTypes
+	if len(rangeATypes) != 3 {
+		t.Fatalf("ffiReadOptionsSetRange aTypes len = %d, want 3", len(rangeATypes))
+	}
+	if rangeATypes[0] != &ffi.TypePointer || rangeATypes[1] != &ffi.TypeUint64 || rangeATypes[2] != &ffi.TypeUint64 {
+		t.Fatalf("ffiReadOptionsSetRange aTypes = %v, want TypePointer, TypeUint64, TypeUint64", rangeATypes)
 	}
 }

--- a/bindings/go/tests/behavior_tests/benchmark_test.go
+++ b/bindings/go/tests/behavior_tests/benchmark_test.go
@@ -140,6 +140,10 @@ func (rw *OpenDALReadWriter) Write(path string, data []byte) error {
 	return rw.Operator.Write(path, data)
 }
 
+func (rw *OpenDALReadWriter) Read(path string) ([]byte, error) {
+	return rw.Operator.Read(path)
+}
+
 func (rw *OpenDALReadWriter) Name() string {
 	return "OpenDAL"
 }

--- a/bindings/go/tests/behavior_tests/read_test.go
+++ b/bindings/go/tests/behavior_tests/read_test.go
@@ -21,6 +21,7 @@ package opendal_test
 
 import (
 	"io"
+	"time"
 
 	"github.com/apache/opendal/bindings/go"
 	"github.com/google/uuid"
@@ -38,11 +39,175 @@ func testsRead(cap *opendal.Capability) []behaviorTest {
 		testReadWithDirPath,
 		testReadWithSpecialChars,
 		testReaderSeek,
+		testReadWithRange,
+		testReadWithConcurrentChunkGap,
 	}
 	if cap.WriteCanMulti() {
 		tests = append(tests, testIOCopy)
+		tests = append(tests, testReadWithWriteOptions)
+	}
+	if cap.ReadWithIfMatch() {
+		tests = append(tests, testReadWithIfMatch)
+	}
+	if cap.ReadWithIfNoneMatch() {
+		tests = append(tests, testReadWithIfNoneMatch)
+	}
+	if cap.ReadWithIfModifiedSince() {
+		tests = append(tests, testReadWithIfModifiedSince)
+	}
+	if cap.ReadWithIfUnmodifiedSince() {
+		tests = append(tests, testReadWithIfUnmodifiedSince)
+	}
+	if cap.ReadWithVersion() {
+		tests = append(tests, testReadWithVersion)
 	}
 	return tests
+}
+
+func testReadWithConcurrentChunkGap(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, size := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	bs, err := op.Read(path,
+		opendal.ReadWithConcurrent(2),
+		opendal.ReadWithChunk(1024*1024),
+		opendal.ReadWithGap(4096),
+	)
+	assert.Nil(err)
+	assert.Equal(size, uint(len(bs)), "read size")
+	assert.Equal(content, bs, "read content")
+}
+
+func testReadWithWriteOptions(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path := fixture.NewFilePath()
+	content := genFixedBytes(1024 * 1024)
+	offset, length := genOffsetLength(uint(len(content)))
+
+	assert.Nil(op.Write(path, content, opendal.WriteWithChunk(256*1024), opendal.WriteWithConcurrent(2)))
+
+	bs, err := op.Read(path,
+		opendal.ReadWithRange(uint64(offset), uint64(length)),
+		opendal.ReadWithConcurrent(2),
+		opendal.ReadWithChunk(128*1024),
+		opendal.ReadWithGap(4096),
+	)
+	assert.Nil(err)
+	assert.Equal(length, int64(len(bs)), "read range size")
+	assert.Equal(content[offset:offset+length], bs, "read range content")
+}
+
+func testReadWithIfModifiedSince(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, _ := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	meta, err := op.Stat(path)
+	assert.Nil(err)
+	lastModified := meta.LastModified()
+
+	bs, err := op.Read(path, opendal.ReadWithIfModifiedSince(lastModified.Add(-time.Second)))
+	assert.Nil(err, "read with if-modified-since before last modified must succeed")
+	assert.Equal(content, bs, "read content")
+
+	_, err = op.Read(path, opendal.ReadWithIfModifiedSince(lastModified.Add(time.Second)))
+	assert.NotNil(err)
+	assert.Equal(opendal.CodeConditionNotMatch, assertErrorCode(err))
+}
+
+func testReadWithIfUnmodifiedSince(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, _ := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	meta, err := op.Stat(path)
+	assert.Nil(err)
+	lastModified := meta.LastModified()
+
+	bs, err := op.Read(path, opendal.ReadWithIfUnmodifiedSince(lastModified.Add(time.Second)))
+	assert.Nil(err, "read with if-unmodified-since after last modified must succeed")
+	assert.Equal(content, bs, "read content")
+
+	_, err = op.Read(path, opendal.ReadWithIfUnmodifiedSince(lastModified.Add(-time.Second)))
+	assert.NotNil(err)
+	assert.Equal(opendal.CodeConditionNotMatch, assertErrorCode(err))
+}
+
+func testReadWithVersion(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, _ := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	meta, err := op.Stat(path)
+	assert.Nil(err)
+	version, ok := meta.Version()
+	if !ok {
+		return
+	}
+
+	data, err := op.Read(path, opendal.ReadWithVersion(version))
+	assert.Nil(err)
+	assert.Equal(content, data, "read content")
+
+	// After overwriting, the previous version data is still readable.
+	assert.Nil(op.Write(path, []byte("1")), "overwrite must succeed")
+	second, err := op.Read(path, opendal.ReadWithVersion(version))
+	assert.Nil(err)
+	assert.Equal(content, second, "read old version content")
+}
+
+func testReadWithRange(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, size := fixture.NewFile()
+	offset, length := genOffsetLength(size)
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	bs, err := op.Read(path, opendal.ReadWithRange(uint64(offset), uint64(length)))
+	assert.Nil(err)
+	assert.Equal(length, int64(len(bs)), "read range size")
+	assert.Equal(content[offset:offset+length], bs, "read range content")
+}
+
+func testReadWithIfMatch(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, _ := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	meta, err := op.Stat(path)
+	assert.Nil(err)
+	etag, ok := meta.ETag()
+	if !ok {
+		return
+	}
+
+	_, err = op.Read(path, opendal.ReadWithIfMatch("\"invalid_etag\""))
+	assert.NotNil(err)
+	assert.Equal(opendal.CodeConditionNotMatch, assertErrorCode(err))
+
+	bs, err := op.Read(path, opendal.ReadWithIfMatch(etag))
+	assert.Nil(err, "read with matching etag must succeed")
+	assert.Equal(content, bs, "read content")
+}
+
+func testReadWithIfNoneMatch(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, _ := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	meta, err := op.Stat(path)
+	assert.Nil(err)
+	etag, ok := meta.ETag()
+	if !ok {
+		return
+	}
+
+	_, err = op.Read(path, opendal.ReadWithIfNoneMatch(etag))
+	assert.NotNil(err)
+	assert.Equal(opendal.CodeConditionNotMatch, assertErrorCode(err))
+
+	bs, err := op.Read(path, opendal.ReadWithIfNoneMatch("\"invalid_etag\""))
+	assert.Nil(err, "read with non-matching etag must succeed")
+	assert.Equal(content, bs, "read content")
 }
 
 func testReadFull(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -156,6 +156,9 @@ var (
 			&ffi.TypeUint8,   // read_with_override_cache_control
 			&ffi.TypeUint8,   // read_with_override_content_disposition
 			&ffi.TypeUint8,   // read_with_override_content_type
+			&ffi.TypeUint8,   // read_with_if_modified_since
+			&ffi.TypeUint8,   // read_with_if_unmodified_since
+			&ffi.TypeUint8,   // read_with_version
 			&ffi.TypeUint8,   // write
 			&ffi.TypeUint8,   // write_can_multi
 			&ffi.TypeUint8,   // write_can_empty
@@ -195,11 +198,14 @@ type opendalCapability struct {
 	statWithIfmatch                    uint8
 	statWithIfNoneMatch                uint8
 	read                               uint8
-	readWithIfmatch                    uint8
-	readWithIfMatchNone                uint8
+	readWithIfMatch                    uint8
+	readWithIfNoneMatch                uint8
 	readWithOverrideCacheControl       uint8
 	readWithOverrideContentDisposition uint8
 	readWithOverrideContentType        uint8
+	readWithIfModifiedSince            uint8
+	readWithIfUnmodifiedSince          uint8
+	readWithVersion                    uint8
 	write                              uint8
 	writeCanMulti                      uint8
 	writeCanEmpty                      uint8
@@ -324,6 +330,8 @@ type opendalResultList struct {
 type opendalLister struct{}
 
 type opendalListOptions struct{}
+
+type opendalReadOptions struct{}
 
 type opendalWriteOptions struct{}
 


### PR DESCRIPTION
# Rationale for this change

C and go binding should be compatible with rust core functionality-wise.

# What changes are included in this PR?

This PR exposes all read options in C and go binding.

# Are there any user-facing changes?

Yes, new read options are added.

# AI Usage Statement

Opus-4.8 helped me make the code change, with GPT-5.5 reviewed it.