### PR TITLE
feat(services/azdls): support conditional read headers

### DIFF
--- a/core/services/azdls/src/backend.rs
+++ b/core/services/azdls/src/backend.rs
@@ -327,6 +327,10 @@ impl Builder for AzdlsBuilder {
                             stat: true,
 
                             read: true,
+                            read_with_if_match: true,
+                            read_with_if_none_match: true,
+                            read_with_if_modified_since: true,
+                            read_with_if_unmodified_since: true,
 
                             write: true,
                             write_can_append: true,
@@ -403,7 +407,7 @@ impl Access for AzdlsBackend {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let resp = self.core.azdls_read(path, args.range()).await?;
+        let resp = self.core.azdls_read(path, args.range(), &args).await?;
 
         let status = resp.status();
         match status {

--- a/core/services/azdls/src/core.rs
+++ b/core/services/azdls/src/core.rs
@@ -29,7 +29,10 @@ use http::StatusCode;
 use http::header::CONTENT_DISPOSITION;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
+use http::header::IF_MATCH;
+use http::header::IF_MODIFIED_SINCE;
 use http::header::IF_NONE_MATCH;
+use http::header::IF_UNMODIFIED_SINCE;
 use reqsign_azure_storage::Credential;
 use reqsign_core::Signer;
 
@@ -98,7 +101,12 @@ impl AzdlsCore {
 }
 
 impl AzdlsCore {
-    pub async fn azdls_read(&self, path: &str, range: BytesRange) -> Result<Response<HttpBody>> {
+    pub async fn azdls_read(
+        &self,
+        path: &str,
+        range: BytesRange,
+        args: &OpRead,
+    ) -> Result<Response<HttpBody>> {
         let p = build_abs_path(&self.root, path);
 
         let url = format!(
@@ -112,6 +120,19 @@ impl AzdlsCore {
 
         if !range.is_full() {
             req = req.header(http::header::RANGE, range.to_header());
+        }
+
+        if let Some(if_match) = args.if_match() {
+            req = req.header(IF_MATCH, if_match);
+        }
+        if let Some(if_none_match) = args.if_none_match() {
+            req = req.header(IF_NONE_MATCH, if_none_match);
+        }
+        if let Some(if_modified_since) = args.if_modified_since() {
+            req = req.header(IF_MODIFIED_SINCE, if_modified_since.format_http_date());
+        }
+        if let Some(if_unmodified_since) = args.if_unmodified_since() {
+            req = req.header(IF_UNMODIFIED_SINCE, if_unmodified_since.format_http_date());
         }
 
         let req = req


### PR DESCRIPTION
# Which issue does this PR close?

Part of #5486.

# Rationale for this change

azdls supported read but ignored conditional headers. ADLS Gen2 Path Read honors `If-Match` / `If-None-Match` / `If-Modified-Since` / `If-Unmodified-Since` per RFC 7232. Other backends (s3, azblob, oss, cos, tos, swift, http, webdav) already wire them.

# What changes are included in this PR?

- Inject the four conditional headers in `azdls_read`.
- Declare `read_with_if_match`, `read_with_if_none_match`, `read_with_if_modified_since`, `read_with_if_unmodified_since` on the azdls capability.

# Are there any user-facing changes?

`op.reader_with(...)` conditionals now work on azdls backends. No breaking changes; existing capability-gated behavior tests auto-cover the new flags.

# AI Usage Statement

AI-assisted implementation.