### PR TITLE
docs: update PMC member nomination process

### DIFF
--- a/website/community/pmc_members/nominate-pmc-member.md
+++ b/website/community/pmc_members/nominate-pmc-member.md
@@ -76,24 +76,6 @@ Thanks for everyone's support!
 ${your_name}
 ```
 
-## Send NOTICE to Board after VOTE PASSED
-
-The nominating PMC member should send a message to the Board <board@apache.org> with a reference to the vote result in the following form:
-
-Title:
-
-```
-[NOTICE] ${candidate_name} for Apache OpenDAL PMC
-```
-
-Content:
-
-```
-${candidate_name} has been voted as a new member of the Apache OpenDAL PMC. the vote thread is at: 
-
-https://lists.apache.org/thread/yg2gz2tof3cvbrgp1wxzk6mf9o858h7t
-```
-
 ## Send invitation to the candidate
 
 Send an invitation to the candidate and cc <private@opendal.apache.org>:


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

ASF PMC membership guidance no longer requires projects to send a separate Board NOTICE before updating the roster. OpenDAL's nomination guide still included the old Board NOTICE step.

# What changes are included in this PR?

Remove the Board NOTICE section from the PMC member nomination guide so the documented flow proceeds from vote result to candidate invitation and then roster update after acceptance.

# Are there any user-facing changes?

No public API changes. This updates community governance documentation.

# AI Usage Statement

Used AI-assisted editing.
