### PR TITLE
feat(binding/go): expose all stats options

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -522,6 +522,57 @@ typedef struct opendal_result_stat {
 } opendal_result_stat;
 
 /**
+ * \brief The options for stat operations.
+ *
+ * Use `opendal_stat_options_new()` to construct and
+ * `opendal_stat_options_free()` to free.
+ *
+ * @see opendal_operator_stat_with
+ */
+typedef struct opendal_stat_options {
+  /**
+   * The version of the object to stat; NULL means unset.
+   */
+  const char *version;
+  /**
+   * If-Match header value; NULL means unset.
+   */
+  const char *if_match;
+  /**
+   * If-None-Match header value; NULL means unset.
+   */
+  const char *if_none_match;
+  /**
+   * Whether `if_modified_since` has been set.
+   */
+  bool has_if_modified_since;
+  /**
+   * If-Modified-Since timestamp in milliseconds since the Unix epoch.
+   */
+  int64_t if_modified_since;
+  /**
+   * Whether `if_unmodified_since` has been set.
+   */
+  bool has_if_unmodified_since;
+  /**
+   * If-Unmodified-Since timestamp in milliseconds since the Unix epoch.
+   */
+  int64_t if_unmodified_since;
+  /**
+   * Override the response Content-Type header; NULL means unset.
+   */
+  const char *override_content_type;
+  /**
+   * Override the response Cache-Control header; NULL means unset.
+   */
+  const char *override_cache_control;
+  /**
+   * Override the response Content-Disposition header; NULL means unset.
+   */
+  const char *override_content_disposition;
+} opendal_stat_options;
+
+/**
  * \brief The result type returned by opendal_operator_list().
  *
  * The result type for opendal_operator_list(), the field `lister` contains the lister
@@ -597,6 +648,30 @@ typedef struct opendal_capability {
    * If operator supports stat with if none match.
    */
   bool stat_with_if_none_match;
+  /**
+   * If operator supports stat with if modified since.
+   */
+  bool stat_with_if_modified_since;
+  /**
+   * If operator supports stat with if unmodified since.
+   */
+  bool stat_with_if_unmodified_since;
+  /**
+   * if operator supports stat with override cache control.
+   */
+  bool stat_with_override_cache_control;
+  /**
+   * if operator supports stat with override content disposition.
+   */
+  bool stat_with_override_content_disposition;
+  /**
+   * if operator supports stat with override content type.
+   */
+  bool stat_with_override_content_type;
+  /**
+   * If operator supports stat with version.
+   */
+  bool stat_with_version;
   /**
    * If operator supports read.
    */
@@ -1446,6 +1521,34 @@ struct opendal_result_stat opendal_operator_stat(const struct opendal_operator *
                                                  const char *path);
 
 /**
+ * \brief Blocking stat the object in `path` with options.
+ *
+ * Stat the object in `path` with the provided `opendal_stat_options`. This is
+ * similar to `opendal_operator_stat` but allows passing options such as
+ * `version`, `if_match`, `if_none_match`, or response header overrides.
+ *
+ * @param op The opendal_operator created previously
+ * @param path The path you want to stat
+ * @param opts The options for the stat operation; pass NULL to use defaults
+ * @see opendal_operator
+ * @see opendal_result_stat
+ * @see opendal_stat_options
+ * @return Returns opendal_result_stat, containing a metadata and an opendal_error.
+ *
+ * # Safety
+ *
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_result_stat opendal_operator_stat_with(const struct opendal_operator *op,
+                                                      const char *path,
+                                                      const struct opendal_stat_options *opts);
+
+/**
  * \brief Blocking list the objects in `path`.
  *
  * List the object in `path` blocking by `op_ptr`, return a result with an
@@ -1896,6 +1999,62 @@ void opendal_write_options_set_chunk(struct opendal_write_options *opts, uintptr
 void opendal_write_options_set_user_metadata(struct opendal_write_options *opts,
                                              const struct opendal_write_user_metadata_pair *pairs,
                                              uintptr_t len);
+
+/**
+ * \brief Construct a heap-allocated opendal_stat_options with default values.
+ */
+struct opendal_stat_options *opendal_stat_options_new(void);
+
+/**
+ * \brief Free the heap memory used by opendal_stat_options.
+ */
+void opendal_stat_options_free(struct opendal_stat_options *opts);
+
+/**
+ * \brief Set the version.
+ */
+void opendal_stat_options_set_version(struct opendal_stat_options *opts, const char *version);
+
+/**
+ * \brief Set If-Match.
+ */
+void opendal_stat_options_set_if_match(struct opendal_stat_options *opts, const char *if_match);
+
+/**
+ * \brief Set If-None-Match.
+ */
+void opendal_stat_options_set_if_none_match(struct opendal_stat_options *opts,
+                                            const char *if_none_match);
+
+/**
+ * \brief Set If-Modified-Since in milliseconds since the Unix epoch.
+ */
+void opendal_stat_options_set_if_modified_since(struct opendal_stat_options *opts,
+                                                int64_t if_modified_since);
+
+/**
+ * \brief Set If-Unmodified-Since in milliseconds since the Unix epoch.
+ */
+void opendal_stat_options_set_if_unmodified_since(struct opendal_stat_options *opts,
+                                                  int64_t if_unmodified_since);
+
+/**
+ * \brief Set the override Content-Type.
+ */
+void opendal_stat_options_set_override_content_type(struct opendal_stat_options *opts,
+                                                    const char *override_content_type);
+
+/**
+ * \brief Set the override Cache-Control.
+ */
+void opendal_stat_options_set_override_cache_control(struct opendal_stat_options *opts,
+                                                     const char *override_cache_control);
+
+/**
+ * \brief Set the override Content-Disposition.
+ */
+void opendal_stat_options_set_override_content_disposition(struct opendal_stat_options *opts,
+                                                           const char *override_content_disposition);
 
 /**
  * \brief Construct a heap-allocated opendal_operator_options

--- a/bindings/c/src/error.rs
+++ b/bindings/c/src/error.rs
@@ -115,7 +115,8 @@ impl opendal_error {
     pub unsafe extern "C" fn opendal_error_free(ptr: *mut opendal_error) {
         unsafe {
             if !ptr.is_null() {
-                drop(Box::from_raw(ptr));
+                let mut err = Box::from_raw(ptr);
+                opendal_bytes::opendal_bytes_free(&mut err.message);
             }
         }
     }

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -74,6 +74,7 @@ mod types;
 pub use types::opendal_bytes;
 pub use types::opendal_list_options;
 pub use types::opendal_operator_options;
+pub use types::opendal_stat_options;
 pub use types::opendal_write_options;
 pub use types::opendal_write_user_metadata_pair;
 

--- a/bindings/c/src/operator.rs
+++ b/bindings/c/src/operator.rs
@@ -753,6 +753,55 @@ pub unsafe extern "C" fn opendal_operator_stat(
     }
 }
 
+/// \brief Blocking stat the object in `path` with options.
+///
+/// Stat the object in `path` with the provided `opendal_stat_options`. This is
+/// similar to `opendal_operator_stat` but allows passing options such as
+/// `version`, `if_match`, `if_none_match`, or response header overrides.
+///
+/// @param op The opendal_operator created previously
+/// @param path The path you want to stat
+/// @param opts The options for the stat operation; pass NULL to use defaults
+/// @see opendal_operator
+/// @see opendal_result_stat
+/// @see opendal_stat_options
+/// @return Returns opendal_result_stat, containing a metadata and an opendal_error.
+///
+/// # Safety
+///
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_stat_with(
+    op: &opendal_operator,
+    path: *const c_char,
+    opts: *const opendal_stat_options,
+) -> opendal_result_stat {
+    assert!(!path.is_null());
+    let path = std::ffi::CStr::from_ptr(path)
+        .to_str()
+        .expect("malformed path");
+    let opts = if opts.is_null() {
+        core::options::StatOptions::default()
+    } else {
+        (&*opts).into()
+    };
+    match op.deref().stat_options(path, opts) {
+        Ok(m) => opendal_result_stat {
+            meta: Box::into_raw(Box::new(opendal_metadata::new(m))),
+            error: std::ptr::null_mut(),
+        },
+        Err(e) => opendal_result_stat {
+            meta: std::ptr::null_mut(),
+            error: opendal_error::new(e),
+        },
+    }
+}
+
 /// \brief Blocking list the objects in `path`.
 ///
 /// List the object in `path` blocking by `op_ptr`, return a result with an

--- a/bindings/c/src/operator_info.rs
+++ b/bindings/c/src/operator_info.rs
@@ -49,6 +49,18 @@ pub struct opendal_capability {
     pub stat_with_if_match: bool,
     /// If operator supports stat with if none match.
     pub stat_with_if_none_match: bool,
+    /// If operator supports stat with if modified since.
+    pub stat_with_if_modified_since: bool,
+    /// If operator supports stat with if unmodified since.
+    pub stat_with_if_unmodified_since: bool,
+    /// if operator supports stat with override cache control.
+    pub stat_with_override_cache_control: bool,
+    /// if operator supports stat with override content disposition.
+    pub stat_with_override_content_disposition: bool,
+    /// if operator supports stat with override content type.
+    pub stat_with_override_content_type: bool,
+    /// If operator supports stat with version.
+    pub stat_with_version: bool,
 
     /// If operator supports read.
     pub read: bool,
@@ -237,6 +249,12 @@ impl From<core::Capability> for opendal_capability {
             stat: value.stat,
             stat_with_if_match: value.stat_with_if_match,
             stat_with_if_none_match: value.stat_with_if_none_match,
+            stat_with_if_modified_since: value.stat_with_if_modified_since,
+            stat_with_if_unmodified_since: value.stat_with_if_unmodified_since,
+            stat_with_override_content_type: value.stat_with_override_content_type,
+            stat_with_override_cache_control: value.stat_with_override_cache_control,
+            stat_with_override_content_disposition: value.stat_with_override_content_disposition,
+            stat_with_version: value.stat_with_version,
             read: value.read,
             read_with_if_match: value.read_with_if_match,
             read_with_if_none_match: value.read_with_if_none_match,

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -453,6 +453,182 @@ impl From<&opendal_write_options> for options::WriteOptions {
     }
 }
 
+/// \brief The options for stat operations.
+///
+/// Use `opendal_stat_options_new()` to construct and
+/// `opendal_stat_options_free()` to free.
+///
+/// @see opendal_operator_stat_with
+#[repr(C)]
+pub struct opendal_stat_options {
+    /// The version of the object to stat; NULL means unset.
+    pub version: *const c_char,
+    /// If-Match header value; NULL means unset.
+    pub if_match: *const c_char,
+    /// If-None-Match header value; NULL means unset.
+    pub if_none_match: *const c_char,
+    /// Whether `if_modified_since` has been set.
+    pub has_if_modified_since: bool,
+    /// If-Modified-Since timestamp in milliseconds since the Unix epoch.
+    pub if_modified_since: i64,
+    /// Whether `if_unmodified_since` has been set.
+    pub has_if_unmodified_since: bool,
+    /// If-Unmodified-Since timestamp in milliseconds since the Unix epoch.
+    pub if_unmodified_since: i64,
+    /// Override the response Content-Type header; NULL means unset.
+    pub override_content_type: *const c_char,
+    /// Override the response Cache-Control header; NULL means unset.
+    pub override_cache_control: *const c_char,
+    /// Override the response Content-Disposition header; NULL means unset.
+    pub override_content_disposition: *const c_char,
+}
+
+impl opendal_stat_options {
+    /// \brief Construct a heap-allocated opendal_stat_options with default values.
+    #[no_mangle]
+    pub extern "C" fn opendal_stat_options_new() -> *mut Self {
+        Box::into_raw(Box::new(Self::default()))
+    }
+
+    /// \brief Free the heap memory used by opendal_stat_options.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_stat_options_free(opts: *mut opendal_stat_options) {
+        if !opts.is_null() {
+            drop(Box::from_raw(opts));
+        }
+    }
+
+    /// \brief Set the version.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_stat_options_set_version(
+        opts: *mut opendal_stat_options,
+        version: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).version = version;
+        }
+    }
+
+    /// \brief Set If-Match.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_stat_options_set_if_match(
+        opts: *mut opendal_stat_options,
+        if_match: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).if_match = if_match;
+        }
+    }
+
+    /// \brief Set If-None-Match.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_stat_options_set_if_none_match(
+        opts: *mut opendal_stat_options,
+        if_none_match: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).if_none_match = if_none_match;
+        }
+    }
+
+    /// \brief Set If-Modified-Since in milliseconds since the Unix epoch.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_stat_options_set_if_modified_since(
+        opts: *mut opendal_stat_options,
+        if_modified_since: i64,
+    ) {
+        if !opts.is_null() {
+            (*opts).has_if_modified_since = true;
+            (*opts).if_modified_since = if_modified_since;
+        }
+    }
+
+    /// \brief Set If-Unmodified-Since in milliseconds since the Unix epoch.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_stat_options_set_if_unmodified_since(
+        opts: *mut opendal_stat_options,
+        if_unmodified_since: i64,
+    ) {
+        if !opts.is_null() {
+            (*opts).has_if_unmodified_since = true;
+            (*opts).if_unmodified_since = if_unmodified_since;
+        }
+    }
+
+    /// \brief Set the override Content-Type.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_stat_options_set_override_content_type(
+        opts: *mut opendal_stat_options,
+        override_content_type: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).override_content_type = override_content_type;
+        }
+    }
+
+    /// \brief Set the override Cache-Control.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_stat_options_set_override_cache_control(
+        opts: *mut opendal_stat_options,
+        override_cache_control: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).override_cache_control = override_cache_control;
+        }
+    }
+
+    /// \brief Set the override Content-Disposition.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_stat_options_set_override_content_disposition(
+        opts: *mut opendal_stat_options,
+        override_content_disposition: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).override_content_disposition = override_content_disposition;
+        }
+    }
+}
+
+impl Default for opendal_stat_options {
+    fn default() -> Self {
+        Self {
+            version: std::ptr::null(),
+            if_match: std::ptr::null(),
+            if_none_match: std::ptr::null(),
+            has_if_modified_since: false,
+            if_modified_since: 0,
+            has_if_unmodified_since: false,
+            if_unmodified_since: 0,
+            override_content_type: std::ptr::null(),
+            override_cache_control: std::ptr::null(),
+            override_content_disposition: std::ptr::null(),
+        }
+    }
+}
+
+impl From<&opendal_stat_options> for options::StatOptions {
+    fn from(value: &opendal_stat_options) -> Self {
+        Self {
+            version: unsafe { optional_cstr(value.version) },
+            if_match: unsafe { optional_cstr(value.if_match) },
+            if_none_match: unsafe { optional_cstr(value.if_none_match) },
+            if_modified_since: value
+                .has_if_modified_since
+                .then(|| opendal::raw::Timestamp::from_millisecond(value.if_modified_since).ok())
+                .flatten(),
+            if_unmodified_since: value
+                .has_if_unmodified_since
+                .then(|| opendal::raw::Timestamp::from_millisecond(value.if_unmodified_since).ok())
+                .flatten(),
+            override_content_type: unsafe { optional_cstr(value.override_content_type) },
+            override_cache_control: unsafe { optional_cstr(value.override_cache_control) },
+            override_content_disposition: unsafe {
+                optional_cstr(value.override_content_disposition)
+            },
+        }
+    }
+}
+
 impl Drop for opendal_bytes {
     fn drop(&mut self) {
         unsafe {

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -893,15 +893,6 @@ impl From<&opendal_read_options> for options::ReadOptions {
     }
 }
 
-impl Drop for opendal_bytes {
-    fn drop(&mut self) {
-        unsafe {
-            // Safety: the pointer is always valid
-            Self::opendal_bytes_free(self);
-        }
-    }
-}
-
 impl From<&opendal_bytes> for Buffer {
     fn from(v: &opendal_bytes) -> Self {
         let slice = unsafe { std::slice::from_raw_parts(v.data, v.len) };

--- a/bindings/go/operator_info.go
+++ b/bindings/go/operator_info.go
@@ -100,12 +100,40 @@ func (c *Capability) Stat() bool {
 	return c.inner.stat == 1
 }
 
+func (c *Capability) StatWithIfMatch() bool {
+	return c.inner.statWithIfMatch == 1
+}
+
 func (c *Capability) StatWithIfmatch() bool {
-	return c.inner.statWithIfmatch == 1
+	return c.StatWithIfMatch()
 }
 
 func (c *Capability) StatWithIfNoneMatch() bool {
 	return c.inner.statWithIfNoneMatch == 1
+}
+
+func (c *Capability) StatWithIfModifiedSince() bool {
+	return c.inner.statWithIfModifiedSince == 1
+}
+
+func (c *Capability) StatWithIfUnmodifiedSince() bool {
+	return c.inner.statWithIfUnmodifiedSince == 1
+}
+
+func (c *Capability) StatWithOverrideCacheControl() bool {
+	return c.inner.statWithOverrideCacheControl == 1
+}
+
+func (c *Capability) StatWithOverrideContentDisposition() bool {
+	return c.inner.statWithOverrideContentDisposition == 1
+}
+
+func (c *Capability) StatWithOverrideContentType() bool {
+	return c.inner.statWithOverrideContentType == 1
+}
+
+func (c *Capability) StatWithVersion() bool {
+	return c.inner.statWithVersion == 1
 }
 
 func (c *Capability) Read() bool {

--- a/bindings/go/stat.go
+++ b/bindings/go/stat.go
@@ -21,6 +21,8 @@ package opendal
 
 import (
 	"context"
+	"runtime"
+	"time"
 	"unsafe"
 
 	"github.com/jupiterrider/ffi"
@@ -28,11 +30,13 @@ import (
 
 // Stat retrieves metadata for the specified path.
 //
-// This function is a wrapper around the C-binding function `opendal_operator_stat`.
+// Stat is a wrapper around the C-binding function `opendal_operator_stat`.
+// When options are provided, it uses `opendal_operator_stat_with`.
 //
 // # Parameters
 //
 //   - path: The path of the file or directory to get metadata for.
+//   - opts: Optional stat options.
 //
 // # Returns
 //
@@ -41,7 +45,6 @@ import (
 //
 // # Notes
 //
-//   - The current implementation does not support `stat_with` functionality.
 //   - If the path does not exist, an error with code opendal.CodeNotFound will be returned.
 //
 // # Example
@@ -60,12 +63,159 @@ import (
 //	}
 //
 // Note: This example assumes proper error handling and import statements.
-func (op *Operator) Stat(path string) (*Metadata, error) {
-	meta, err := ffiOperatorStat.symbol(op.ctx)(op.inner, path)
+func (op *Operator) Stat(path string, opts ...WithStatFn) (*Metadata, error) {
+	if len(opts) == 0 {
+		meta, err := ffiOperatorStat.symbol(op.ctx)(op.inner, path)
+		if err != nil {
+			return nil, err
+		}
+		return newMetadata(op.ctx, meta), nil
+	}
+
+	o := parseStatOptions(opts...)
+	cOpts, keepAlive, err := newOpendalStatOptions(op.ctx, o)
+	if err != nil {
+		return nil, err
+	}
+	defer ffiStatOptionsFree.symbol(op.ctx)(cOpts)
+	meta, err := ffiOperatorStatWith.symbol(op.ctx)(op.inner, path, cOpts)
+	runtime.KeepAlive(keepAlive)
 	if err != nil {
 		return nil, err
 	}
 	return newMetadata(op.ctx, meta), nil
+}
+
+// WithStatFn is a functional option for stat operations.
+type WithStatFn func(*statOptions)
+
+// StatWithVersion sets the version of the object to stat.
+func StatWithVersion(version string) WithStatFn {
+	return func(o *statOptions) {
+		o.version = version
+	}
+}
+
+// StatWithIfMatch sets the If-Match condition for the stat operation.
+func StatWithIfMatch(ifMatch string) WithStatFn {
+	return func(o *statOptions) {
+		o.ifMatch = ifMatch
+	}
+}
+
+// StatWithIfNoneMatch sets the If-None-Match condition for the stat operation.
+func StatWithIfNoneMatch(ifNoneMatch string) WithStatFn {
+	return func(o *statOptions) {
+		o.ifNoneMatch = ifNoneMatch
+	}
+}
+
+// StatWithIfModifiedSince sets the If-Modified-Since condition for the stat operation.
+func StatWithIfModifiedSince(t time.Time) WithStatFn {
+	return func(o *statOptions) {
+		o.ifModifiedSince = &t
+	}
+}
+
+// StatWithIfUnmodifiedSince sets the If-Unmodified-Since condition for the stat operation.
+func StatWithIfUnmodifiedSince(t time.Time) WithStatFn {
+	return func(o *statOptions) {
+		o.ifUnmodifiedSince = &t
+	}
+}
+
+// StatWithOverrideContentType sets the response Content-Type header override.
+//
+// This option is only meaningful when used along with presign.
+func StatWithOverrideContentType(contentType string) WithStatFn {
+	return func(o *statOptions) {
+		o.overrideContentType = contentType
+	}
+}
+
+// StatWithOverrideCacheControl sets the response Cache-Control header override.
+//
+// This option is only meaningful when used along with presign.
+func StatWithOverrideCacheControl(cacheControl string) WithStatFn {
+	return func(o *statOptions) {
+		o.overrideCacheControl = cacheControl
+	}
+}
+
+// StatWithOverrideContentDisposition sets the response Content-Disposition header override.
+//
+// This option is only meaningful when used along with presign.
+func StatWithOverrideContentDisposition(contentDisposition string) WithStatFn {
+	return func(o *statOptions) {
+		o.overrideContentDisposition = contentDisposition
+	}
+}
+
+type statOptions struct {
+	version                    string
+	ifMatch                    string
+	ifNoneMatch                string
+	ifModifiedSince            *time.Time
+	ifUnmodifiedSince          *time.Time
+	overrideContentType        string
+	overrideCacheControl       string
+	overrideContentDisposition string
+}
+
+func parseStatOptions(opts ...WithStatFn) *statOptions {
+	o := &statOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+func newOpendalStatOptions(ctx context.Context, o *statOptions) (*opendalStatOptions, [][]byte, error) {
+	cOpts := ffiStatOptionsNew.symbol(ctx)()
+	var keepAlive [][]byte
+
+	fail := func(err error) (*opendalStatOptions, [][]byte, error) {
+		ffiStatOptionsFree.symbol(ctx)(cOpts)
+		return nil, nil, err
+	}
+
+	setString := func(value string, set func(*opendalStatOptions, string) ([]byte, error)) error {
+		if value == "" {
+			return nil
+		}
+		data, err := set(cOpts, value)
+		if err != nil {
+			return err
+		}
+		keepAlive = append(keepAlive, data)
+		return nil
+	}
+
+	if err := setString(o.version, ffiStatOptionsSetVersion.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if err := setString(o.ifMatch, ffiStatOptionsSetIfMatch.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if err := setString(o.ifNoneMatch, ffiStatOptionsSetIfNoneMatch.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if err := setString(o.overrideContentType, ffiStatOptionsSetOverrideContentType.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if err := setString(o.overrideCacheControl, ffiStatOptionsSetOverrideCacheControl.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if err := setString(o.overrideContentDisposition, ffiStatOptionsSetOverrideContentDisposition.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if o.ifModifiedSince != nil {
+		ffiStatOptionsSetIfModifiedSince.symbol(ctx)(cOpts, o.ifModifiedSince.UnixMilli())
+	}
+	if o.ifUnmodifiedSince != nil {
+		ffiStatOptionsSetIfUnmodifiedSince.symbol(ctx)(cOpts, o.ifUnmodifiedSince.UnixMilli())
+	}
+	return cOpts, keepAlive, nil
 }
 
 // IsExist checks if a file or directory exists at the specified path.
@@ -121,6 +271,30 @@ var ffiOperatorStat = newFFI(ffiOpts{
 	}
 })
 
+var ffiOperatorStatWith = newFFI(ffiOpts{
+	sym:    "opendal_operator_stat_with",
+	rType:  &typeResultStat,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(op *opendalOperator, path string, opts *opendalStatOptions) (*opendalMetadata, error) {
+	return func(op *opendalOperator, path string, opts *opendalStatOptions) (*opendalMetadata, error) {
+		bytePath, err := BytePtrFromString(path)
+		if err != nil {
+			return nil, err
+		}
+		var result resultStat
+		ffiCall(
+			unsafe.Pointer(&result),
+			unsafe.Pointer(&op),
+			unsafe.Pointer(&bytePath),
+			unsafe.Pointer(&opts),
+		)
+		if result.error != nil {
+			return nil, parseError(ctx, result.error)
+		}
+		return result.meta, nil
+	}
+})
+
 var ffiOperatorIsExist = newFFI(ffiOpts{
 	sym:    "opendal_operator_is_exist",
 	rType:  &typeResultIsExist,
@@ -141,5 +315,71 @@ var ffiOperatorIsExist = newFFI(ffiOpts{
 			return false, parseError(ctx, result.error)
 		}
 		return result.is_exist == 1, nil
+	}
+})
+
+var ffiStatOptionsNew = newFFI(ffiOpts{
+	sym:   "opendal_stat_options_new",
+	rType: &ffi.TypePointer,
+}, func(_ context.Context, ffiCall ffiCall) func() *opendalStatOptions {
+	return func() *opendalStatOptions {
+		var opts *opendalStatOptions
+		ffiCall(unsafe.Pointer(&opts))
+		return opts
+	}
+})
+
+var ffiStatOptionsFree = newFFI(ffiOpts{
+	sym:    "opendal_stat_options_free",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalStatOptions) {
+	return func(opts *opendalStatOptions) {
+		ffiCall(nil, unsafe.Pointer(&opts))
+	}
+})
+
+func newStatOptionsSetStringFFI(sym string) *FFI[func(*opendalStatOptions, string) ([]byte, error)] {
+	return newFFI(ffiOpts{
+		sym:    contextKey(sym),
+		rType:  &ffi.TypeVoid,
+		aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
+	}, func(_ context.Context, ffiCall ffiCall) func(*opendalStatOptions, string) ([]byte, error) {
+		return func(opts *opendalStatOptions, value string) ([]byte, error) {
+			data, err := byteSliceFromString(value)
+			if err != nil {
+				return nil, err
+			}
+			byteValue := &data[0]
+			ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&byteValue))
+			return data, nil
+		}
+	})
+}
+
+var ffiStatOptionsSetVersion = newStatOptionsSetStringFFI("opendal_stat_options_set_version")
+var ffiStatOptionsSetIfMatch = newStatOptionsSetStringFFI("opendal_stat_options_set_if_match")
+var ffiStatOptionsSetIfNoneMatch = newStatOptionsSetStringFFI("opendal_stat_options_set_if_none_match")
+var ffiStatOptionsSetOverrideContentType = newStatOptionsSetStringFFI("opendal_stat_options_set_override_content_type")
+var ffiStatOptionsSetOverrideCacheControl = newStatOptionsSetStringFFI("opendal_stat_options_set_override_cache_control")
+var ffiStatOptionsSetOverrideContentDisposition = newStatOptionsSetStringFFI("opendal_stat_options_set_override_content_disposition")
+
+var ffiStatOptionsSetIfModifiedSince = newFFI(ffiOpts{
+	sym:    "opendal_stat_options_set_if_modified_since",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypeSint64},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalStatOptions, ms int64) {
+	return func(opts *opendalStatOptions, ms int64) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&ms))
+	}
+})
+
+var ffiStatOptionsSetIfUnmodifiedSince = newFFI(ffiOpts{
+	sym:    "opendal_stat_options_set_if_unmodified_since",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypeSint64},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalStatOptions, ms int64) {
+	return func(opts *opendalStatOptions, ms int64) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&ms))
 	}
 })

--- a/bindings/go/tests/behavior_tests/stat_test.go
+++ b/bindings/go/tests/behavior_tests/stat_test.go
@@ -43,6 +43,10 @@ func testsStat(cap *opendal.Capability) []behaviorTest {
 		testStatRoot,
 		testStatFileMetadata,
 		testStatDirMetadata,
+		testStatWithIfMatch,
+		testStatWithIfNoneMatch,
+		testStatWithIfModifiedSince,
+		testStatWithIfUnmodifiedSince,
 	}
 }
 
@@ -246,6 +250,117 @@ func testStatFileMetadata(assert *require.Assertions, op *opendal.Operator, fixt
 	} else if um := meta.UserMetadata(); um != nil {
 		assert.Equal(um, meta.UserMetadata(), "user metadata accessor must return equal copies")
 	}
+}
+
+func testStatWithIfMatch(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	cap := op.Info().GetFullCapability()
+	if !isCapEnabled(cap.StatWithIfMatch, "stat_with_if_match") {
+		return
+	}
+
+	path, content, _ := fixture.NewFile()
+
+	// Write with options to exercise the write-with-options path.
+	writeOpts := make([]opendal.WithWriteFn, 0, 1)
+	if isCapEnabled(cap.WriteWithContentType, "write_with_content_type") {
+		writeOpts = append(writeOpts, opendal.WriteWithContentType("text/plain"))
+	}
+	assert.Nil(op.Write(path, content, writeOpts...), "write must succeed")
+
+	meta, err := op.Stat(path)
+	assert.Nil(err, "stat must succeed")
+	etag, ok := meta.ETag()
+	assert.True(ok, "etag must exist")
+
+	// Stat with a matching ETag must succeed.
+	meta, err = op.Stat(path, opendal.StatWithIfMatch(etag))
+	assert.Nil(err, "stat with matching if_match must succeed")
+	assert.Equal(uint64(len(content)), meta.ContentLength())
+
+	// Stat with a non-matching ETag must fail with ConditionNotMatch.
+	_, err = op.Stat(path, opendal.StatWithIfMatch("\"invalid_etag\""))
+	assert.NotNil(err)
+	assert.Equal(opendal.CodeConditionNotMatch, assertErrorCode(err))
+}
+
+func testStatWithIfNoneMatch(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	cap := op.Info().GetFullCapability()
+	if !isCapEnabled(cap.StatWithIfNoneMatch, "stat_with_if_none_match") {
+		return
+	}
+
+	path, content, size := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	meta, err := op.Stat(path)
+	assert.Nil(err, "stat must succeed")
+	etag, ok := meta.ETag()
+	assert.True(ok, "etag must exist")
+
+	// Stat with a non-matching ETag must succeed and return metadata.
+	meta, err = op.Stat(path, opendal.StatWithIfNoneMatch("\"invalid_etag\""))
+	assert.Nil(err, "stat with non-matching if_none_match must succeed")
+	assert.Equal(uint64(size), meta.ContentLength())
+
+	// Stat with a matching ETag must fail with ConditionNotMatch.
+	_, err = op.Stat(path, opendal.StatWithIfNoneMatch(etag))
+	assert.NotNil(err)
+	assert.Equal(opendal.CodeConditionNotMatch, assertErrorCode(err))
+}
+
+func testStatWithIfModifiedSince(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	cap := op.Info().GetFullCapability()
+	if !isCapEnabled(cap.StatWithIfModifiedSince, "stat_with_if_modified_since") {
+		return
+	}
+
+	path, content, _ := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	meta, err := op.Stat(path)
+	assert.Nil(err, "stat must succeed")
+	assert.True(meta.IsFile(), "written object must be a file")
+	assert.Equal(uint64(len(content)), meta.ContentLength())
+
+	lastModified := meta.LastModified()
+	assert.False(lastModified.IsZero(), "last_modified must exist")
+
+	meta, err = op.Stat(path, opendal.StatWithIfModifiedSince(lastModified.Add(-time.Second)))
+	assert.Nil(err, "stat with older if_modified_since must succeed")
+	assert.Equal(lastModified, meta.LastModified())
+
+	_, err = op.Stat(path, opendal.StatWithIfModifiedSince(lastModified.Add(time.Second)))
+	assert.NotNil(err)
+	assert.Equal(opendal.CodeConditionNotMatch, assertErrorCode(err))
+}
+
+func testStatWithIfUnmodifiedSince(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	cap := op.Info().GetFullCapability()
+	if !isCapEnabled(cap.StatWithIfUnmodifiedSince, "stat_with_if_unmodified_since") {
+		return
+	}
+
+	path, content, _ := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	meta, err := op.Stat(path)
+	assert.Nil(err, "stat must succeed")
+	assert.True(meta.IsFile(), "written object must be a file")
+	assert.Equal(uint64(len(content)), meta.ContentLength())
+
+	lastModified := meta.LastModified()
+	assert.False(lastModified.IsZero(), "last_modified must exist")
+
+	_, err = op.Stat(path, opendal.StatWithIfUnmodifiedSince(lastModified.Add(-time.Second)))
+	assert.NotNil(err)
+	assert.Equal(opendal.CodeConditionNotMatch, assertErrorCode(err))
+
+	meta, err = op.Stat(path, opendal.StatWithIfUnmodifiedSince(lastModified.Add(time.Second)))
+	assert.Nil(err, "stat with newer if_unmodified_since must succeed")
+	assert.Equal(lastModified, meta.LastModified())
 }
 
 func testStatDirMetadata(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {

--- a/bindings/go/tests/behavior_tests/stat_test.go
+++ b/bindings/go/tests/behavior_tests/stat_test.go
@@ -33,7 +33,7 @@ func testsStat(cap *opendal.Capability) []behaviorTest {
 	if !cap.Write() || !cap.Stat() {
 		return nil
 	}
-	return []behaviorTest{
+	tests := []behaviorTest{
 		testStatFile,
 		testStatDir,
 		testStatNestedParentDir,
@@ -43,11 +43,20 @@ func testsStat(cap *opendal.Capability) []behaviorTest {
 		testStatRoot,
 		testStatFileMetadata,
 		testStatDirMetadata,
-		testStatWithIfMatch,
-		testStatWithIfNoneMatch,
-		testStatWithIfModifiedSince,
-		testStatWithIfUnmodifiedSince,
 	}
+	if isCapEnabled(cap.StatWithIfMatch, "stat_with_if_match") {
+		tests = append(tests, testStatWithIfMatch)
+	}
+	if isCapEnabled(cap.StatWithIfNoneMatch, "stat_with_if_none_match") {
+		tests = append(tests, testStatWithIfNoneMatch)
+	}
+	if isCapEnabled(cap.StatWithIfModifiedSince, "stat_with_if_modified_since") {
+		tests = append(tests, testStatWithIfModifiedSince)
+	}
+	if isCapEnabled(cap.StatWithIfUnmodifiedSince, "stat_with_if_unmodified_since") {
+		tests = append(tests, testStatWithIfUnmodifiedSince)
+	}
+	return tests
 }
 
 func assertOptionalMetaString(assert *require.Assertions, name string, accessor func() (string, bool)) {

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -150,6 +150,12 @@ var (
 			&ffi.TypeUint8,   // stat
 			&ffi.TypeUint8,   // stat_with_if_match
 			&ffi.TypeUint8,   // stat_with_if_none_match
+			&ffi.TypeUint8,   // stat_with_if_modified_since
+			&ffi.TypeUint8,   // stat_with_if_unmodified_since
+			&ffi.TypeUint8,   // stat_with_override_cache_control
+			&ffi.TypeUint8,   // stat_with_override_content_disposition
+			&ffi.TypeUint8,   // stat_with_override_content_type
+			&ffi.TypeUint8,   // stat_with_version
 			&ffi.TypeUint8,   // read
 			&ffi.TypeUint8,   // read_with_if_match
 			&ffi.TypeUint8,   // read_with_if_match_none
@@ -192,8 +198,14 @@ var (
 
 type opendalCapability struct {
 	stat                               uint8
-	statWithIfmatch                    uint8
+	statWithIfMatch                    uint8
 	statWithIfNoneMatch                uint8
+	statWithIfModifiedSince            uint8
+	statWithIfUnmodifiedSince          uint8
+	statWithOverrideCacheControl       uint8
+	statWithOverrideContentDisposition uint8
+	statWithOverrideContentType        uint8
+	statWithVersion                    uint8
 	read                               uint8
 	readWithIfmatch                    uint8
 	readWithIfMatchNone                uint8
@@ -326,6 +338,8 @@ type opendalLister struct{}
 type opendalListOptions struct{}
 
 type opendalWriteOptions struct{}
+
+type opendalStatOptions struct{}
 
 type opendalWriteUserMetadataPair struct {
 	key   *byte


### PR DESCRIPTION
# Rationale for this change

C and golang binding should be compatible with rust core functionality-wise.

# What changes are included in this PR?

This PR exposes all left stats options to C and go binding.
Disclaimer: some options are related to `presign`, I will work on it in the followup PRs.

# Are there any user-facing changes?

Yes, new stats options are exposed.

# AI Usage Statement

Opus-4.8 helped me make the code change, and I used GPT-5.5 for code review.