### PR TITLE
fix(ci): release dotnet workflow

### DIFF
--- a/.github/workflows/release_dotnet.yml
+++ b/.github/workflows/release_dotnet.yml
@@ -155,7 +155,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    environment: production
 
     steps:
       - name: Setup dotnet toolchain
@@ -170,27 +169,10 @@ jobs:
           path: bindings/dotnet/artifacts/package
 
       - name: NuGet login
+        uses: NuGet/login@v1
         id: login
-        shell: bash
-        env:
-          NUGET_USERNAME: Apache.OpenDAL
-        run: |
-          oidc_token="$(curl -fsSL \
-            -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https%3A%2F%2Fwww.nuget.org" \
-            | python3 -c 'import json, sys; print(json.load(sys.stdin)["value"])')"
-          echo "::add-mask::${oidc_token}"
-
-          request_body="$(python3 -c 'import json, os; print(json.dumps({"username": os.environ["NUGET_USERNAME"], "tokenType": "ApiKey"}))')"
-          api_key="$(curl -fsSL \
-            -X POST https://www.nuget.org/api/v2/token \
-            -H "Content-Type: application/json" \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H "User-Agent: apache-opendal-release" \
-            --data "${request_body}" \
-            | python3 -c 'import json, sys; print(json.load(sys.stdin)["apiKey"])')"
-          echo "::add-mask::${api_key}"
-          echo "NUGET_API_KEY=${api_key}" >> "${GITHUB_OUTPUT}"
+        with:
+          user: ${{ secrets.NUGET_USER }}
 
       - name: Publish package
         run: dotnet nuget push bindings/dotnet/artifacts/package/*.nupkg --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/release_dotnet.yml
+++ b/.github/workflows/release_dotnet.yml
@@ -169,10 +169,27 @@ jobs:
           path: bindings/dotnet/artifacts/package
 
       - name: NuGet login
-        uses: NuGet/login@v1
         id: login
-        with:
-          user: ${{ secrets.NUGET_USER }}
+        shell: bash
+        env:
+          NUGET_USERNAME: Apache.OpenDAL
+        run: |
+          oidc_token="$(curl -fsSL \
+            -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https%3A%2F%2Fwww.nuget.org" \
+            | python3 -c 'import json, sys; print(json.load(sys.stdin)["value"])')"
+          echo "::add-mask::${oidc_token}"
+
+          request_body="$(python3 -c 'import json, os; print(json.dumps({"username": os.environ["NUGET_USERNAME"], "tokenType": "ApiKey"}))')"
+          api_key="$(curl -fsSL \
+            -X POST https://www.nuget.org/api/v2/token \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H "User-Agent: apache-opendal-release" \
+            --data "${request_body}" \
+            | python3 -c 'import json, sys; print(json.load(sys.stdin)["apiKey"])')"
+          echo "::add-mask::${api_key}"
+          echo "NUGET_API_KEY=${api_key}" >> "${GITHUB_OUTPUT}"
 
       - name: Publish package
         run: dotnet nuget push bindings/dotnet/artifacts/package/*.nupkg --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

The current dotnet release workflow failed in the publish stage because it referenced a non-existent environment parameter in the repository settings.

# What changes are included in this PR?

Removed the non-existent environment parameter from release script.

# Are there any user-facing changes?

None

# AI Usage Statement

None
