### PR TITLE
fix(services/azdls): Handle not modified as condition mismatch

### DIFF
--- a/core/services/azdls/src/error.rs
+++ b/core/services/azdls/src/error.rs
@@ -65,7 +65,7 @@ pub(super) fn parse_error(resp: Response<Buffer>) -> Error {
     let (kind, retryable) = match parts.status {
         StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
         StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
-        StatusCode::PRECONDITION_FAILED | StatusCode::CONFLICT => {
+        StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED | StatusCode::CONFLICT => {
             (ErrorKind::ConditionNotMatch, false)
         }
         StatusCode::INTERNAL_SERVER_ERROR


### PR DESCRIPTION
# Which issue does this PR close?

No issue.

# Rationale for this change

Azdls conditional reads can return `304 Not Modified` when `If-None-Match` or `If-Modified-Since` prevents the read. OpenDAL expects conditional read failures to surface as `ConditionNotMatch`, but azdls currently maps `304` to `Unexpected`.

# What changes are included in this PR?

Map `304 Not Modified` to `ConditionNotMatch` in the azdls error parser, matching the conditional read contract and other HTTP-based services.

# Are there any user-facing changes?

Azdls conditional reads now return `ConditionNotMatch` instead of `Unexpected` when the object is not modified.

# AI Usage Statement

Used AI assistance.
