### PR TITLE
refactor(core): Rename oio::Read to ReadStream

### DIFF
--- a/core/core/src/docs/internals/accessor.rs
+++ b/core/core/src/docs/internals/accessor.rs
@@ -27,7 +27,7 @@
 //! ```ignore
 //! //                  <----------Trait Bound-------------->
 //! pub trait Access: Send + Sync + Debug + Unpin + 'static {
-//!     type Reader: oio::Read;                    // --+
+//!     type Reader: oio::ReadStream;                    // --+
 //!     type Writer: oio::Write;                   //   +--> Associated Type
 //!     type Lister: oio::List;                    //   +
 //!     type Deleter: oio::Delete;                 // --+

--- a/core/core/src/layers/complete.rs
+++ b/core/core/src/layers/complete.rs
@@ -213,7 +213,7 @@ impl<R> CompleteReader<R> {
     }
 }
 
-impl<R: oio::Read> oio::Read for CompleteReader<R> {
+impl<R: oio::ReadStream> oio::ReadStream for CompleteReader<R> {
     async fn read(&mut self) -> Result<Buffer> {
         let buf = self.inner.read().await?;
 

--- a/core/core/src/layers/error_context.rs
+++ b/core/core/src/layers/error_context.rs
@@ -228,7 +228,7 @@ impl<T> ErrorContextWrapper<T> {
     }
 }
 
-impl<T: oio::Read> oio::Read for ErrorContextWrapper<T> {
+impl<T: oio::ReadStream> oio::ReadStream for ErrorContextWrapper<T> {
     async fn read(&mut self) -> Result<Buffer> {
         self.inner
             .read()

--- a/core/core/src/layers/type_eraser.rs
+++ b/core/core/src/layers/type_eraser.rs
@@ -23,7 +23,7 @@ use crate::*;
 
 /// TypeEraseLayer will erase the types on internal accessor.
 ///
-/// For example, we will erase `Self::Reader` to `oio::Reader` (`Box<dyn oio::Read>`).
+/// For example, we will erase `Self::Reader` to `oio::Reader` (`Box<dyn oio::ReadStream>`).
 ///
 /// # Notes
 ///

--- a/core/core/src/raw/accessor.rs
+++ b/core/core/src/raw/accessor.rs
@@ -59,7 +59,7 @@ use crate::*;
 ///   - The default implementation should return [`ErrorKind::Unsupported`].
 pub trait Access: Send + Sync + Debug + Unpin + 'static {
     /// Reader is the associated reader returned in `read` operation.
-    type Reader: oio::Read;
+    type Reader: oio::ReadStream;
     /// Writer is the associated writer returned in `write` operation.
     type Writer: oio::Write;
     /// Lister is the associated lister returned in `list` operation.

--- a/core/core/src/raw/enum_utils.rs
+++ b/core/core/src/raw/enum_utils.rs
@@ -51,7 +51,7 @@ pub enum TwoWays<ONE, TWO> {
     Two(TWO),
 }
 
-impl<ONE: oio::Read, TWO: oio::Read> oio::Read for TwoWays<ONE, TWO> {
+impl<ONE: oio::ReadStream, TWO: oio::ReadStream> oio::ReadStream for TwoWays<ONE, TWO> {
     async fn read(&mut self) -> Result<Buffer> {
         match self {
             TwoWays::One(v) => v.read().await,
@@ -127,7 +127,9 @@ pub enum ThreeWays<ONE, TWO, THREE> {
     Three(THREE),
 }
 
-impl<ONE: oio::Read, TWO: oio::Read, THREE: oio::Read> oio::Read for ThreeWays<ONE, TWO, THREE> {
+impl<ONE: oio::ReadStream, TWO: oio::ReadStream, THREE: oio::ReadStream> oio::ReadStream
+    for ThreeWays<ONE, TWO, THREE>
+{
     async fn read(&mut self) -> Result<Buffer> {
         match self {
             ThreeWays::One(v) => v.read().await,
@@ -189,12 +191,12 @@ pub enum FourWays<ONE, TWO, THREE, FOUR> {
     Four(FOUR),
 }
 
-impl<ONE, TWO, THREE, FOUR> oio::Read for FourWays<ONE, TWO, THREE, FOUR>
+impl<ONE, TWO, THREE, FOUR> oio::ReadStream for FourWays<ONE, TWO, THREE, FOUR>
 where
-    ONE: oio::Read,
-    TWO: oio::Read,
-    THREE: oio::Read,
-    FOUR: oio::Read,
+    ONE: oio::ReadStream,
+    TWO: oio::ReadStream,
+    THREE: oio::ReadStream,
+    FOUR: oio::ReadStream,
 {
     async fn read(&mut self) -> Result<Buffer> {
         match self {

--- a/core/core/src/raw/http_util/body.rs
+++ b/core/core/src/raw/http_util/body.rs
@@ -19,14 +19,14 @@ use std::cmp::Ordering;
 
 use futures::Stream;
 use futures::StreamExt;
-use oio::Read;
+use oio::ReadStream;
 
 use crate::raw::*;
 use crate::*;
 
 /// The streaming body that OpenDAL's HttpClient returned.
 ///
-/// We implement [`oio::Read`] for the `HttpBody`. Services can use `HttpBody` as
+/// We implement [`oio::ReadStream`] for the `HttpBody`. Services can use `HttpBody` as
 /// [`Access::Read`].
 pub struct HttpBody {
     #[cfg(not(target_arch = "wasm32"))]
@@ -128,7 +128,7 @@ impl HttpBody {
     }
 }
 
-impl oio::Read for HttpBody {
+impl oio::ReadStream for HttpBody {
     async fn read(&mut self) -> Result<Buffer> {
         match self.stream.next().await.transpose()? {
             Some(buf) => {

--- a/core/core/src/raw/http_util/client.rs
+++ b/core/core/src/raw/http_util/client.rs
@@ -35,7 +35,7 @@ use http::Request;
 use http::Response;
 use http_body::Frame;
 use http_body::SizeHint;
-use raw::oio::Read;
+use raw::oio::ReadStream;
 
 use super::HttpBody;
 use super::parse_content_encoding;

--- a/core/core/src/raw/layer.rs
+++ b/core/core/src/raw/layer.rs
@@ -111,7 +111,7 @@ pub trait Layer<A: Access> {
 pub trait LayeredAccess: Send + Sync + Debug + Unpin + 'static {
     type Inner: Access;
 
-    type Reader: oio::Read;
+    type Reader: oio::ReadStream;
     type Writer: oio::Write;
     type Lister: oio::List;
     type Deleter: oio::Delete;

--- a/core/core/src/raw/oio/read/api.rs
+++ b/core/core/src/raw/oio/read/api.rs
@@ -24,10 +24,10 @@ use futures::Future;
 use crate::raw::*;
 use crate::*;
 
-/// Reader is a type erased [`Read`].
-pub type Reader = Box<dyn ReadDyn>;
+/// Reader is a type erased [`ReadStream`].
+pub type Reader = Box<dyn ReadStreamDyn>;
 
-/// Read is the internal trait used by OpenDAL to read data from storage.
+/// ReadStream is the internal trait used by OpenDAL to stream data from storage.
 ///
 /// Users should not use or import this trait unless they are implementing an `Accessor`.
 ///
@@ -35,14 +35,16 @@ pub type Reader = Box<dyn ReadDyn>;
 ///
 /// ## Object Safety
 ///
-/// `Read` uses `async in trait`, making it not object safe, preventing the use of `Box<dyn Read>`.
-/// To address this, we've introduced [`ReadDyn`] and its compatible type `Box<dyn ReadDyn>`.
+/// `ReadStream` uses `async in trait`, making it not object safe, preventing the use of
+/// `Box<dyn ReadStream>`.
+/// To address this, we've introduced [`ReadStreamDyn`] and its compatible type
+/// `Box<dyn ReadStreamDyn>`.
 ///
-/// `ReadDyn` uses `Box::pin()` to transform the returned future into a [`BoxedFuture`], introducing
-/// an additional layer of indirection and an extra allocation. Ideally, `ReadDyn` should occur only
-/// once, at the outermost level of our API.
-pub trait Read: Unpin + Send + Sync {
-    /// Read at the given offset with the given size.
+/// `ReadStreamDyn` uses `Box::pin()` to transform the returned future into a [`BoxedFuture`],
+/// introducing an additional layer of indirection and an extra allocation. Ideally,
+/// `ReadStreamDyn` should occur only once, at the outermost level of our API.
+pub trait ReadStream: Unpin + Send + Sync {
+    /// Read the next data chunk from the stream.
     fn read(&mut self) -> impl Future<Output = Result<Buffer>> + MaybeSend;
 
     /// Read all data from the reader.
@@ -61,7 +63,7 @@ pub trait Read: Unpin + Send + Sync {
     }
 }
 
-impl Read for () {
+impl ReadStream for () {
     async fn read(&mut self) -> Result<Buffer> {
         Err(Error::new(
             ErrorKind::Unsupported,
@@ -70,31 +72,31 @@ impl Read for () {
     }
 }
 
-impl Read for Bytes {
+impl ReadStream for Bytes {
     async fn read(&mut self) -> Result<Buffer> {
         Ok(Buffer::from(self.split_off(0)))
     }
 }
 
-impl Read for Buffer {
+impl ReadStream for Buffer {
     async fn read(&mut self) -> Result<Buffer> {
         Ok(mem::take(self))
     }
 }
 
-/// ReadDyn is the dyn version of [`Read`] make it possible to use as
-/// `Box<dyn ReadDyn>`.
-pub trait ReadDyn: Unpin + Send + Sync {
-    /// The dyn version of [`Read::read`].
+/// ReadStreamDyn is the dyn version of [`ReadStream`] make it possible to use as
+/// `Box<dyn ReadStreamDyn>`.
+pub trait ReadStreamDyn: Unpin + Send + Sync {
+    /// The dyn version of [`ReadStream::read`].
     ///
     /// This function returns a boxed future to make it object safe.
     fn read_dyn(&mut self) -> BoxedFuture<'_, Result<Buffer>>;
 
-    /// The dyn version of [`Read::read_all`]
+    /// The dyn version of [`ReadStream::read_all`].
     fn read_all_dyn(&mut self) -> BoxedFuture<'_, Result<Buffer>>;
 }
 
-impl<T: Read + ?Sized> ReadDyn for T {
+impl<T: ReadStream + ?Sized> ReadStreamDyn for T {
     fn read_dyn(&mut self) -> BoxedFuture<'_, Result<Buffer>> {
         Box::pin(self.read())
     }
@@ -108,7 +110,7 @@ impl<T: Read + ?Sized> ReadDyn for T {
 ///
 /// Take care about the `deref_mut()` here. This makes sure that we are calling functions
 /// upon `&mut T` instead of `&mut Box<T>`. The later could result in infinite recursion.
-impl<T: ReadDyn + ?Sized> Read for Box<T> {
+impl<T: ReadStreamDyn + ?Sized> ReadStream for Box<T> {
     async fn read(&mut self) -> Result<Buffer> {
         self.deref_mut().read_dyn().await
     }

--- a/core/core/src/raw/oio/read/mod.rs
+++ b/core/core/src/raw/oio/read/mod.rs
@@ -16,6 +16,6 @@
 // under the License.
 
 mod api;
-pub use api::Read;
-pub use api::ReadDyn;
+pub use api::ReadStream;
+pub use api::ReadStreamDyn;
 pub use api::Reader;

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -24,7 +24,7 @@ use std::task::Poll;
 use futures::Stream;
 use futures::ready;
 
-use crate::raw::oio::Read as _;
+use crate::raw::oio::ReadStream as _;
 use crate::raw::*;
 use crate::*;
 
@@ -70,7 +70,7 @@ impl StreamingReader {
     }
 }
 
-impl oio::Read for StreamingReader {
+impl oio::ReadStream for StreamingReader {
     async fn read(&mut self) -> Result<Buffer> {
         loop {
             if self.reader.is_none() {
@@ -217,7 +217,7 @@ impl ChunkedReader {
     }
 }
 
-impl oio::Read for ChunkedReader {
+impl oio::ReadStream for ChunkedReader {
     async fn read(&mut self) -> Result<Buffer> {
         while self.tasks.has_remaining() && !self.done {
             if let Some(input) = self.opened.take() {

--- a/core/layers/async-backtrace/src/lib.rs
+++ b/core/layers/async-backtrace/src/lib.rs
@@ -152,7 +152,7 @@ impl<R> AsyncBacktraceWrapper<R> {
     }
 }
 
-impl<R: oio::Read> oio::Read for AsyncBacktraceWrapper<R> {
+impl<R: oio::ReadStream> oio::ReadStream for AsyncBacktraceWrapper<R> {
     #[async_backtrace::framed]
     async fn read(&mut self) -> Result<Buffer> {
         self.inner.read().await

--- a/core/layers/await-tree/src/lib.rs
+++ b/core/layers/await-tree/src/lib.rs
@@ -164,7 +164,7 @@ impl<R> AwaitTreeWrapper<R> {
     }
 }
 
-impl<R: oio::Read> oio::Read for AwaitTreeWrapper<R> {
+impl<R: oio::ReadStream> oio::ReadStream for AwaitTreeWrapper<R> {
     async fn read(&mut self) -> Result<Buffer> {
         self.inner
             .read()

--- a/core/layers/chaos/src/lib.rs
+++ b/core/layers/chaos/src/lib.rs
@@ -176,7 +176,7 @@ impl<R> ChaosReader<R> {
     }
 }
 
-impl<R: oio::Read> oio::Read for ChaosReader<R> {
+impl<R: oio::ReadStream> oio::ReadStream for ChaosReader<R> {
     async fn read(&mut self) -> Result<Buffer> {
         if self.i_feel_lucky() {
             self.inner.read().await

--- a/core/layers/concurrent-limit/src/lib.rs
+++ b/core/layers/concurrent-limit/src/lib.rs
@@ -342,7 +342,9 @@ impl<R, P> ConcurrentLimitWrapper<R, P> {
     }
 }
 
-impl<R: oio::Read, P: Send + Sync + 'static + Unpin> oio::Read for ConcurrentLimitWrapper<R, P> {
+impl<R: oio::ReadStream, P: Send + Sync + 'static + Unpin> oio::ReadStream
+    for ConcurrentLimitWrapper<R, P>
+{
     async fn read(&mut self) -> Result<Buffer> {
         self.inner.read().await
     }

--- a/core/layers/dtrace/src/lib.rs
+++ b/core/layers/dtrace/src/lib.rs
@@ -260,7 +260,7 @@ impl<R> DtraceLayerWrapper<R> {
     }
 }
 
-impl<R: oio::Read> oio::Read for DtraceLayerWrapper<R> {
+impl<R: oio::ReadStream> oio::ReadStream for DtraceLayerWrapper<R> {
     async fn read(&mut self) -> Result<Buffer> {
         let c_path = CString::new(self.path.clone()).unwrap();
         probe_lazy!(opendal, reader_read_start, c_path.as_ptr());

--- a/core/layers/fastrace/src/lib.rs
+++ b/core/layers/fastrace/src/lib.rs
@@ -252,7 +252,7 @@ impl<R> FastraceWrapper<R> {
     }
 }
 
-impl<R: oio::Read> oio::Read for FastraceWrapper<R> {
+impl<R: oio::ReadStream> oio::ReadStream for FastraceWrapper<R> {
     #[trace(enter_on_poll = true)]
     async fn read(&mut self) -> Result<Buffer> {
         self.inner.read().await

--- a/core/layers/foyer/src/full.rs
+++ b/core/layers/foyer/src/full.rs
@@ -27,7 +27,7 @@ use opendal_core::raw::BytesRange;
 use opendal_core::raw::OpRead;
 use opendal_core::raw::OpStat;
 use opendal_core::raw::RpRead;
-use opendal_core::raw::oio::Read;
+use opendal_core::raw::oio::ReadStream;
 
 use crate::FoyerKey;
 use crate::FoyerValue;

--- a/core/layers/hotpath/src/lib.rs
+++ b/core/layers/hotpath/src/lib.rs
@@ -184,7 +184,7 @@ impl<R> HotpathWrapper<R> {
     }
 }
 
-impl<R: oio::Read> oio::Read for HotpathWrapper<R> {
+impl<R: oio::ReadStream> oio::ReadStream for HotpathWrapper<R> {
     async fn read(&mut self) -> Result<Buffer> {
         hotpath::measure_async(LABEL_READER_READ, self.inner.read()).await
     }

--- a/core/layers/logging/src/lib.rs
+++ b/core/layers/logging/src/lib.rs
@@ -576,7 +576,7 @@ impl<R, I: LoggingInterceptor> LoggingReader<R, I> {
     }
 }
 
-impl<R: oio::Read, I: LoggingInterceptor> oio::Read for LoggingReader<R, I> {
+impl<R: oio::ReadStream, I: LoggingInterceptor> oio::ReadStream for LoggingReader<R, I> {
     async fn read(&mut self) -> Result<Buffer> {
         match self.inner.read().await {
             Ok(bs) if bs.is_empty() => {

--- a/core/layers/observe-metrics-common/src/lib.rs
+++ b/core/layers/observe-metrics-common/src/lib.rs
@@ -1080,7 +1080,7 @@ impl<R, I: MetricsIntercept> MetricsWrapper<R, I> {
     }
 }
 
-impl<R: oio::Read, I: MetricsIntercept> oio::Read for MetricsWrapper<R, I> {
+impl<R: oio::ReadStream, I: MetricsIntercept> oio::ReadStream for MetricsWrapper<R, I> {
     async fn read(&mut self) -> Result<Buffer> {
         self.inner
             .read()

--- a/core/layers/oteltrace/src/lib.rs
+++ b/core/layers/oteltrace/src/lib.rs
@@ -201,7 +201,7 @@ impl<R> OtelTraceWrapper<R> {
     }
 }
 
-impl<R: oio::Read> oio::Read for OtelTraceWrapper<R> {
+impl<R: oio::ReadStream> oio::ReadStream for OtelTraceWrapper<R> {
     async fn read(&mut self) -> Result<Buffer> {
         self.inner.read().await
     }

--- a/core/layers/retry/src/lib.rs
+++ b/core/layers/retry/src/lib.rs
@@ -480,7 +480,7 @@ impl<A, R> RetryReader<A, R> {
     }
 }
 
-impl<A: Access> oio::Read for RetryReader<A, A::Reader> {
+impl<A: Access> oio::ReadStream for RetryReader<A, A::Reader> {
     async fn read(&mut self) -> Result<Buffer> {
         loop {
             match self.reader.take() {
@@ -527,7 +527,7 @@ impl<R, I> RetryWrapper<R, I> {
     }
 }
 
-impl<R: oio::Read, I: RetryInterceptor> oio::Read for RetryWrapper<R, I> {
+impl<R: oio::ReadStream, I: RetryInterceptor> oio::ReadStream for RetryWrapper<R, I> {
     async fn read(&mut self) -> Result<Buffer> {
         use backon::RetryableWithContext;
 
@@ -970,7 +970,7 @@ mod tests {
         attempt: Arc<Mutex<usize>>,
     }
 
-    impl oio::Read for MockReader {
+    impl oio::ReadStream for MockReader {
         async fn read(&mut self) -> Result<Buffer> {
             let mut attempt = self.attempt.lock().unwrap();
             *attempt += 1;

--- a/core/layers/tail-cut/src/lib.rs
+++ b/core/layers/tail-cut/src/lib.rs
@@ -536,7 +536,7 @@ impl<R> TailCutWrapper<R> {
     }
 }
 
-impl<R: oio::Read> oio::Read for TailCutWrapper<R> {
+impl<R: oio::ReadStream> oio::ReadStream for TailCutWrapper<R> {
     async fn read(&mut self) -> Result<Buffer> {
         let deadline = self.calculate_deadline(Operation::Read);
         Self::with_io_deadline(

--- a/core/layers/throttle/src/lib.rs
+++ b/core/layers/throttle/src/lib.rs
@@ -177,7 +177,7 @@ impl<R> ThrottleWrapper<R> {
     }
 }
 
-impl<R: oio::Read> oio::Read for ThrottleWrapper<R> {
+impl<R: oio::ReadStream> oio::ReadStream for ThrottleWrapper<R> {
     async fn read(&mut self) -> Result<Buffer> {
         self.inner.read().await
     }

--- a/core/layers/timeout/src/lib.rs
+++ b/core/layers/timeout/src/lib.rs
@@ -327,7 +327,7 @@ impl<R> TimeoutWrapper<R> {
     }
 }
 
-impl<R: oio::Read> oio::Read for TimeoutWrapper<R> {
+impl<R: oio::ReadStream> oio::ReadStream for TimeoutWrapper<R> {
     async fn read(&mut self) -> Result<Buffer> {
         let fut = self.inner.read();
         Self::io_timeout(self.timeout, Operation::Read.into_static(), fut).await
@@ -451,7 +451,7 @@ mod tests {
     #[derive(Debug, Clone, Default)]
     struct MockReader;
 
-    impl oio::Read for MockReader {
+    impl oio::ReadStream for MockReader {
         fn read(&mut self) -> impl Future<Output = Result<Buffer>> {
             pending()
         }

--- a/core/layers/tracing/src/lib.rs
+++ b/core/layers/tracing/src/lib.rs
@@ -288,7 +288,7 @@ impl<R> TracingWrapper<R> {
     }
 }
 
-impl<R: oio::Read> oio::Read for TracingWrapper<R> {
+impl<R: oio::ReadStream> oio::ReadStream for TracingWrapper<R> {
     async fn read(&mut self) -> Result<Buffer> {
         self.inner.read().instrument(self.span.clone()).await
     }

--- a/core/services/compfs/src/reader.rs
+++ b/core/services/compfs/src/reader.rs
@@ -45,7 +45,7 @@ impl CompfsReader {
     }
 }
 
-impl oio::Read for CompfsReader {
+impl oio::ReadStream for CompfsReader {
     async fn read(&mut self) -> Result<Buffer> {
         let pos = self.offset;
         if let Some(end) = self.end {

--- a/core/services/fs/src/reader.rs
+++ b/core/services/fs/src/reader.rs
@@ -45,7 +45,7 @@ impl<F> FsReader<F> {
     }
 }
 
-impl oio::Read for FsReader<tokio::fs::File> {
+impl oio::ReadStream for FsReader<tokio::fs::File> {
     async fn read(&mut self) -> Result<Buffer> {
         if self.read >= self.size {
             return Ok(Buffer::new());

--- a/core/services/ftp/src/reader.rs
+++ b/core/services/ftp/src/reader.rs
@@ -71,7 +71,7 @@ impl FtpReader {
     }
 }
 
-impl oio::Read for FtpReader {
+impl oio::ReadStream for FtpReader {
     async fn read(&mut self) -> Result<Buffer> {
         self.buf.resize(self.chunk, 0);
         let n = self

--- a/core/services/goosefs/src/reader.rs
+++ b/core/services/goosefs/src/reader.rs
@@ -24,7 +24,7 @@ use super::error::parse_error;
 use opendal_core::raw::*;
 use opendal_core::*;
 
-/// `GoosefsReader` implements [`oio::Read`] on top of the goosefs-sdk
+/// `GoosefsReader` implements [`oio::ReadStream`] on top of the goosefs-sdk
 /// high-level streaming reader (`GoosefsFileReader`).
 ///
 /// # Streaming semantics
@@ -42,7 +42,7 @@ use opendal_core::*;
 ///     first block lands, rather than stalling until the whole range
 ///     is materialised.
 ///   - When `read_next_block` returns `None` the reader returns an
-///     empty `Buffer`, which is OpenDAL's `oio::Read` EOF signal.
+///     empty `Buffer`, which is OpenDAL's `oio::ReadStream` EOF signal.
 ///
 /// # Range handling
 ///
@@ -137,7 +137,7 @@ impl GoosefsReader {
     }
 }
 
-impl oio::Read for GoosefsReader {
+impl oio::ReadStream for GoosefsReader {
     async fn read(&mut self) -> Result<Buffer> {
         if self.done {
             return Ok(Buffer::new());

--- a/core/services/hdfs-native/src/reader.rs
+++ b/core/services/hdfs-native/src/reader.rs
@@ -43,7 +43,7 @@ impl HdfsNativeReader {
     }
 }
 
-impl oio::Read for HdfsNativeReader {
+impl oio::ReadStream for HdfsNativeReader {
     async fn read(&mut self) -> Result<Buffer> {
         if self.read >= self.size {
             return Ok(Buffer::new());

--- a/core/services/hdfs/src/reader.rs
+++ b/core/services/hdfs/src/reader.rs
@@ -44,7 +44,7 @@ impl<F> HdfsReader<F> {
     }
 }
 
-impl oio::Read for HdfsReader<AsyncFile> {
+impl oio::ReadStream for HdfsReader<AsyncFile> {
     async fn read(&mut self) -> Result<Buffer> {
         if self.read >= self.size {
             return Ok(Buffer::new());

--- a/core/services/hf/src/reader.rs
+++ b/core/services/hf/src/reader.rs
@@ -80,7 +80,7 @@ fn map_session_error(e: SessionError) -> Error {
     Error::new(ErrorKind::Unexpected, "xet read error").set_source(e)
 }
 
-impl oio::Read for HfReader {
+impl oio::ReadStream for HfReader {
     async fn read(&mut self) -> Result<Buffer> {
         match self {
             Self::Http(body) => body.read().await,
@@ -101,7 +101,7 @@ mod tests {
     use super::super::uri::HfRepoType;
     use super::*;
     use bytes::Bytes;
-    use opendal_core::raw::oio::Read;
+    use opendal_core::raw::oio::ReadStream;
 
     /// Parquet magic bytes: "PAR1"
     const PARQUET_MAGIC: &[u8] = b"PAR1";

--- a/core/services/monoiofs/src/reader.rs
+++ b/core/services/monoiofs/src/reader.rs
@@ -105,7 +105,7 @@ impl MonoiofsReader {
     }
 }
 
-impl oio::Read for MonoiofsReader {
+impl oio::ReadStream for MonoiofsReader {
     /// Send read request to worker thread and wait for result. Actual
     /// read happens in [`MonoiofsReader::worker_entrypoint`] running
     /// on worker thread.

--- a/core/services/opfs/src/reader.rs
+++ b/core/services/opfs/src/reader.rs
@@ -40,7 +40,7 @@ impl OpfsReader {
     }
 }
 
-impl oio::Read for OpfsReader {
+impl oio::ReadStream for OpfsReader {
     async fn read(&mut self) -> Result<Buffer> {
         if self.done {
             return Ok(Buffer::new());

--- a/core/services/sftp/src/reader.rs
+++ b/core/services/sftp/src/reader.rs
@@ -48,7 +48,7 @@ impl SftpReader {
     }
 }
 
-impl oio::Read for SftpReader {
+impl oio::ReadStream for SftpReader {
     async fn read(&mut self) -> Result<Buffer> {
         if self.read >= self.size.unwrap_or(usize::MAX) {
             return Ok(Buffer::new());

--- a/integrations/object_store/src/service/mod.rs
+++ b/integrations/object_store/src/service/mod.rs
@@ -159,7 +159,7 @@ mod tests {
     use super::*;
     use object_store::memory::InMemory;
     use opendal::Buffer;
-    use opendal::raw::oio::{Delete, List, Read, Write};
+    use opendal::raw::oio::{Delete, List, ReadStream, Write};
 
     #[tokio::test]
     async fn test_object_store_backend_builder() {

--- a/integrations/object_store/src/service/reader.rs
+++ b/integrations/object_store/src/service/reader.rs
@@ -59,7 +59,7 @@ impl ObjectStoreReader {
 // `&mut self` and `rp()` is stateless.
 unsafe impl Sync for ObjectStoreReader {}
 
-impl oio::Read for ObjectStoreReader {
+impl oio::ReadStream for ObjectStoreReader {
     async fn read(&mut self) -> Result<Buffer> {
         let bs = self.bytes_stream.try_next().await.map_err(parse_error)?;
         Ok(bs.map(Buffer::from).unwrap_or_default())


### PR DESCRIPTION
# Which issue does this PR close?

Part of #7661.

# Rationale for this change

This is the first implementation step for RFC #7660. The current raw reader trait is range-scoped but named `Read`, which will conflict with moving the range to the returned reader.

Rename it to `ReadStream` so the existing object is explicitly a stream of data chunks while leaving behavior unchanged.

# What changes are included in this PR?

Rename raw `oio::Read` and `oio::ReadDyn` to `oio::ReadStream` and `oio::ReadStreamDyn`, then update `Access::Reader`, layers, services, and the object_store integration to use the new names.

# Are there any user-facing changes?

Yes. Backend and layer implementers that refer to raw `oio::Read` should use `oio::ReadStream` instead. Runtime behavior is unchanged.

# AI Usage Statement

AI-assisted implementation was used.
