### PR TITLE
feat(delete.go): add options version and recursive

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -543,6 +543,30 @@ typedef struct opendal_result_operator_writer {
 } opendal_result_operator_writer;
 
 /**
+ * \brief The options for the delete operation.
+ *
+ * This struct carries the options for the delete operation, including an optional
+ * version string and whether to delete recursively.
+ * Use `opendal_delete_options_new()` to construct and `opendal_delete_options_free()` to free.
+ *
+ * @see opendal_operator_delete_with
+ * @see opendal_delete_options_new
+ * @see opendal_delete_options_free
+ * @see opendal_delete_options_set_version
+ * @see opendal_delete_options_set_recursive
+ */
+typedef struct opendal_delete_options {
+  /**
+   * Optional version string to delete a specific version; NULL means unset.
+   */
+  char *version;
+  /**
+   * Whether to delete recursively; default false.
+   */
+  bool recursive;
+} opendal_delete_options;
+
+/**
  * \brief The result type returned by opendal_operator_is_exist().
  *
  * The result type for opendal_operator_is_exist(), the field `is_exist`
@@ -794,6 +818,14 @@ typedef struct opendal_capability {
    * If operator supports delete.
    */
   bool delete_;
+  /**
+   * If operator supports delete with version.
+   */
+  bool delete_with_version;
+  /**
+   * If operator supports delete with recursive.
+   */
+  bool delete_with_recursive;
   /**
    * If operator supports copy.
    */
@@ -1449,6 +1481,32 @@ struct opendal_result_operator_writer opendal_operator_writer_with(const struct 
 struct opendal_error *opendal_operator_delete(const struct opendal_operator *op, const char *path);
 
 /**
+ * \brief Blocking delete the object in `path` with options.
+ *
+ * Delete the object in `path` blocking by `op`, using the provided `opendal_delete_options`.
+ * This is similar to `opendal_operator_delete` but allows specifying a version or
+ * requesting a recursive delete.
+ *
+ * @param op The opendal_operator created previously
+ * @param path The designated path you want to delete
+ * @param opts The options for the delete operation; pass NULL to use defaults
+ * @see opendal_delete_options
+ * @return NULL if succeeds, otherwise it contains the error code and error message.
+ *
+ * # Safety
+ *
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_error *opendal_operator_delete_with(const struct opendal_operator *op,
+                                                   const char *path,
+                                                   const struct opendal_delete_options *opts);
+
+/**
  * \brief Check whether the path exists.
  *
  * If the operation succeeds, no matter the path exists or not,
@@ -1951,6 +2009,38 @@ void opendal_list_options_set_start_after(struct opendal_list_options *opts,
  * @param opts The opendal_list_options to free.
  */
 void opendal_list_options_free(struct opendal_list_options *opts);
+
+/**
+ * \brief Construct a heap-allocated opendal_delete_options with default values.
+ *
+ * @return A new opendal_delete_options with all options set to their defaults.
+ *
+ * @see opendal_delete_options_free
+ */
+struct opendal_delete_options *opendal_delete_options_new(void);
+
+/**
+ * \brief Set the version option.
+ *
+ * @param opts The opendal_delete_options to modify.
+ * @param version The version string to delete; NULL to unset.
+ */
+void opendal_delete_options_set_version(struct opendal_delete_options *opts, const char *version);
+
+/**
+ * \brief Set the recursive option.
+ *
+ * @param opts The opendal_delete_options to modify.
+ * @param recursive Whether to delete recursively.
+ */
+void opendal_delete_options_set_recursive(struct opendal_delete_options *opts, bool recursive);
+
+/**
+ * \brief Free the heap memory used by opendal_delete_options.
+ *
+ * @param opts The opendal_delete_options to free.
+ */
+void opendal_delete_options_free(struct opendal_delete_options *opts);
 
 /**
  * \brief Construct a heap-allocated opendal_write_options with default values.

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -72,6 +72,7 @@ pub use result::opendal_result_writer_write;
 
 mod types;
 pub use types::opendal_bytes;
+pub use types::opendal_delete_options;
 pub use types::opendal_list_options;
 pub use types::opendal_operator_options;
 pub use types::opendal_read_options;

--- a/bindings/c/src/operator.rs
+++ b/bindings/c/src/operator.rs
@@ -635,6 +635,61 @@ pub unsafe extern "C" fn opendal_operator_delete(
     }
 }
 
+/// \brief Blocking delete the object in `path` with options.
+///
+/// Delete the object in `path` blocking by `op`, using the provided `opendal_delete_options`.
+/// This is similar to `opendal_operator_delete` but allows specifying a version or
+/// requesting a recursive delete.
+///
+/// @param op The opendal_operator created previously
+/// @param path The designated path you want to delete
+/// @param opts The options for the delete operation; pass NULL to use defaults
+/// @see opendal_delete_options
+/// @return NULL if succeeds, otherwise it contains the error code and error message.
+///
+/// # Safety
+///
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_delete_with(
+    op: &opendal_operator,
+    path: *const c_char,
+    opts: *const opendal_delete_options,
+) -> *mut opendal_error {
+    assert!(!path.is_null());
+    let path = std::ffi::CStr::from_ptr(path)
+        .to_str()
+        .expect("malformed path");
+    let delete_opts = if opts.is_null() {
+        core::options::DeleteOptions::default()
+    } else {
+        let o = &*opts;
+        let version = if o.version.is_null() {
+            None
+        } else {
+            Some(
+                std::ffi::CStr::from_ptr(o.version)
+                    .to_str()
+                    .expect("malformed version")
+                    .to_owned(),
+            )
+        };
+        core::options::DeleteOptions {
+            version,
+            recursive: o.recursive,
+        }
+    };
+    match op.deref().delete_options(path, delete_opts) {
+        Ok(_) => std::ptr::null_mut(),
+        Err(e) => opendal_error::new(e),
+    }
+}
+
 /// \brief Check whether the path exists.
 ///
 /// If the operation succeeds, no matter the path exists or not,

--- a/bindings/c/src/operator_info.rs
+++ b/bindings/c/src/operator_info.rs
@@ -117,6 +117,10 @@ pub struct opendal_capability {
 
     /// If operator supports delete.
     pub delete: bool,
+    /// If operator supports delete with version.
+    pub delete_with_version: bool,
+    /// If operator supports delete with recursive.
+    pub delete_with_recursive: bool,
 
     /// If operator supports copy.
     pub copy: bool,
@@ -269,6 +273,8 @@ impl From<core::Capability> for opendal_capability {
             write_total_max_size: value.write_total_max_size.unwrap_or(0),
             create_dir: value.create_dir,
             delete: value.delete,
+            delete_with_version: value.delete_with_version,
+            delete_with_recursive: value.delete_with_recursive,
             copy: value.copy,
             rename: value.rename,
             list: value.list,

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -197,6 +197,95 @@ impl opendal_list_options {
     }
 }
 
+/// \brief The options for the delete operation.
+///
+/// This struct carries the options for the delete operation, including an optional
+/// version string and whether to delete recursively.
+/// Use `opendal_delete_options_new()` to construct and `opendal_delete_options_free()` to free.
+///
+/// @see opendal_operator_delete_with
+/// @see opendal_delete_options_new
+/// @see opendal_delete_options_free
+/// @see opendal_delete_options_set_version
+/// @see opendal_delete_options_set_recursive
+#[repr(C)]
+pub struct opendal_delete_options {
+    /// Optional version string to delete a specific version; NULL means unset.
+    pub version: *mut c_char,
+    /// Whether to delete recursively; default false.
+    pub recursive: bool,
+}
+
+impl opendal_delete_options {
+    /// \brief Construct a heap-allocated opendal_delete_options with default values.
+    ///
+    /// @return A new opendal_delete_options with all options set to their defaults.
+    ///
+    /// @see opendal_delete_options_free
+    #[no_mangle]
+    pub extern "C" fn opendal_delete_options_new() -> *mut Self {
+        Box::into_raw(Box::new(Self {
+            version: std::ptr::null_mut(),
+            recursive: false,
+        }))
+    }
+
+    /// \brief Set the version option.
+    ///
+    /// @param opts The opendal_delete_options to modify.
+    /// @param version The version string to delete; NULL to unset.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_delete_options_set_version(
+        opts: *mut opendal_delete_options,
+        version: *const c_char,
+    ) {
+        if opts.is_null() {
+            return;
+        }
+        let o = &mut *opts;
+        if !o.version.is_null() {
+            drop(CString::from_raw(o.version));
+            o.version = std::ptr::null_mut();
+        }
+        if !version.is_null() {
+            let s = CStr::from_ptr(version)
+                .to_str()
+                .expect("malformed version")
+                .to_owned();
+            o.version = CString::new(s).unwrap().into_raw();
+        }
+    }
+
+    /// \brief Set the recursive option.
+    ///
+    /// @param opts The opendal_delete_options to modify.
+    /// @param recursive Whether to delete recursively.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_delete_options_set_recursive(
+        opts: *mut opendal_delete_options,
+        recursive: bool,
+    ) {
+        if !opts.is_null() {
+            (*opts).recursive = recursive;
+        }
+    }
+
+    /// \brief Free the heap memory used by opendal_delete_options.
+    ///
+    /// @param opts The opendal_delete_options to free.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_delete_options_free(opts: *mut opendal_delete_options) {
+        if !opts.is_null() {
+            let o = &mut *opts;
+            if !o.version.is_null() {
+                drop(CString::from_raw(o.version));
+                o.version = std::ptr::null_mut();
+            }
+            drop(Box::from_raw(opts));
+        }
+    }
+}
+
 /// \brief A key-value pair for write user metadata.
 #[repr(C)]
 pub struct opendal_write_user_metadata_pair {

--- a/bindings/go/delete.go
+++ b/bindings/go/delete.go
@@ -26,21 +26,84 @@ import (
 	"github.com/jupiterrider/ffi"
 )
 
+// WithDeleteFn is a functional option for the Delete operation.
+type WithDeleteFn func(*deleteOptions)
+
+// DeleteWithVersion sets the version for the delete operation.
+//
+// When version is set, only the specified version of the object will be deleted.
+// This is useful for versioned storage backends such as S3 versioning or GCS object versioning.
+func DeleteWithVersion(version string) WithDeleteFn {
+	return func(o *deleteOptions) {
+		o.version = &version
+	}
+}
+
+// DeleteWithRecursive sets the recursive flag for the delete operation.
+//
+// When recursive is true, all entries under the path (or sharing the prefix for
+// file-like paths) will be removed.
+func DeleteWithRecursive(recursive bool) WithDeleteFn {
+	return func(o *deleteOptions) {
+		o.recursive = recursive
+	}
+}
+
+// deleteOptions holds the options for a delete operation.
+type deleteOptions struct {
+	version   *string
+	recursive bool
+}
+
 // Delete removes the file or directory at the specified path.
 //
 // # Parameters
 //
 //   - path: The path of the file or directory to delete.
+//   - opts: Optional functional options to configure the delete operation.
 //
 // # Returns
 //
 //   - error: An error if the deletion fails, or nil if successful.
 //
-// # Note
+// # Example
 //
-// Use with caution as this operation is irreversible.
-func (op *Operator) Delete(path string) error {
-	return ffiOperatorDelete.symbol(op.ctx)(op.inner, path)
+//	func exampleDelete(op *opendal.Operator) {
+//		// Delete without options
+//		err := op.Delete("file.txt")
+//		if err != nil {
+//			log.Printf("Delete operation failed: %v", err)
+//		}
+//
+//		// Delete with recursive option
+//		err = op.Delete("dir/", opendal.DeleteWithRecursive(true))
+//		if err != nil {
+//			log.Printf("Delete operation failed: %v", err)
+//		}
+//
+//		// Delete a specific version
+//		err = op.Delete("file.txt", opendal.DeleteWithVersion("v1"))
+//		if err != nil {
+//			log.Printf("Delete operation failed: %v", err)
+//		}
+//	}
+//
+// Note: This example assumes proper error handling and import statements.
+func (op *Operator) Delete(path string, opts ...WithDeleteFn) error {
+	if len(opts) == 0 {
+		return ffiOperatorDelete.symbol(op.ctx)(op.inner, path)
+	}
+	o := &deleteOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	cOpts := ffiDeleteOptionsNew.symbol(op.ctx)()
+	defer ffiDeleteOptionsFree.symbol(op.ctx)(cOpts)
+	ffiDeleteOptionsSetRecursive.symbol(op.ctx)(cOpts, o.recursive)
+	if o.version != nil {
+		ffiDeleteOptionsSetVersion.symbol(op.ctx)(cOpts, *o.version)
+	}
+	return ffiOperatorDeleteWith.symbol(op.ctx)(op.inner, path, cOpts)
 }
 
 var ffiOperatorDelete = newFFI(ffiOpts{
@@ -58,6 +121,87 @@ var ffiOperatorDelete = newFFI(ffiOpts{
 			unsafe.Pointer(&e),
 			unsafe.Pointer(&op),
 			unsafe.Pointer(&bytePath),
+		)
+		return parseError(ctx, e)
+	}
+})
+
+var ffiDeleteOptionsNew = newFFI(ffiOpts{
+	sym:   "opendal_delete_options_new",
+	rType: &ffi.TypePointer,
+}, func(_ context.Context, ffiCall ffiCall) func() *opendalDeleteOptions {
+	return func() *opendalDeleteOptions {
+		var opts *opendalDeleteOptions
+		ffiCall(unsafe.Pointer(&opts))
+		return opts
+	}
+})
+
+var ffiDeleteOptionsSetVersion = newFFI(ffiOpts{
+	sym:    "opendal_delete_options_set_version",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalDeleteOptions, version string) {
+	return func(opts *opendalDeleteOptions, version string) {
+		bytePtr, err := BytePtrFromString(version)
+		if err != nil {
+			return
+		}
+		ffiCall(
+			nil,
+			unsafe.Pointer(&opts),
+			unsafe.Pointer(&bytePtr),
+		)
+	}
+})
+
+var ffiDeleteOptionsSetRecursive = newFFI(ffiOpts{
+	sym:    "opendal_delete_options_set_recursive",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypeUint8},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalDeleteOptions, recursive bool) {
+	return func(opts *opendalDeleteOptions, recursive bool) {
+		var r uint8
+		if recursive {
+			r = 1
+		}
+		ffiCall(
+			nil,
+			unsafe.Pointer(&opts),
+			unsafe.Pointer(&r),
+		)
+	}
+})
+
+var ffiDeleteOptionsFree = newFFI(ffiOpts{
+	sym:    "opendal_delete_options_free",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalDeleteOptions) {
+	return func(opts *opendalDeleteOptions) {
+		ffiCall(
+			nil,
+			unsafe.Pointer(&opts),
+		)
+	}
+})
+
+var ffiOperatorDeleteWith = newFFI(ffiOpts{
+	sym:    "opendal_operator_delete_with",
+	rType:  &ffi.TypePointer,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(op *opendalOperator, path string, opts *opendalDeleteOptions) error {
+	return func(op *opendalOperator, path string, opts *opendalDeleteOptions) error {
+		bytePath, err := BytePtrFromString(path)
+		if err != nil {
+			return err
+		}
+		var e *opendalError
+		ffiCall(
+			unsafe.Pointer(&e),
+			unsafe.Pointer(&op),
+			unsafe.Pointer(&bytePath),
+			unsafe.Pointer(&opts),
 		)
 		return parseError(ctx, e)
 	}

--- a/bindings/go/operator_info.go
+++ b/bindings/go/operator_info.go
@@ -211,6 +211,14 @@ func (c *Capability) Delete() bool {
 	return c.inner.delete == 1
 }
 
+func (c *Capability) DeleteWithVersion() bool {
+	return c.inner.deleteWithVersion == 1
+}
+
+func (c *Capability) DeleteWithRecursive() bool {
+	return c.inner.deleteWithRecursive == 1
+}
+
 func (c *Capability) Copy() bool {
 	return c.inner.copy == 1
 }

--- a/bindings/go/tests/behavior_tests/delete_test.go
+++ b/bindings/go/tests/behavior_tests/delete_test.go
@@ -20,6 +20,8 @@
 package opendal_test
 
 import (
+	"fmt"
+
 	"github.com/apache/opendal/bindings/go"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -34,6 +36,12 @@ func testsDelete(cap *opendal.Capability) []behaviorTest {
 		testDeleteEmptyDir,
 		testDeleteWithSpecialChars,
 		testDeleteNotExisting,
+	}
+	if cap.DeleteWithRecursive() {
+		tests = append(tests, testDeleteWithRecursive)
+	}
+	if cap.DeleteWithVersion() {
+		tests = append(tests, testDeleteWithVersion)
 	}
 	return tests
 }
@@ -75,4 +83,45 @@ func testDeleteNotExisting(assert *require.Assertions, op *opendal.Operator, fix
 	path := uuid.NewString()
 
 	assert.Nil(op.Delete(path))
+}
+
+func testDeleteWithRecursive(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	if !op.Info().GetFullCapability().CreateDir() {
+		return
+	}
+
+	dir := fixture.NewDirPath()
+	assert.Nil(op.CreateDir(dir), "create dir must succeed")
+
+	// Write a few files under the directory.
+	var filePaths []string
+	for i := range 3 {
+		path, content, _ := fixture.NewFileWithPath(fmt.Sprintf("%sfile-%d.txt", dir, i))
+		assert.Nil(op.Write(path, content), "write must succeed")
+		filePaths = append(filePaths, path)
+	}
+
+	assert.Nil(op.Delete(dir, opendal.DeleteWithRecursive(true)))
+
+	assert.False(op.IsExist(dir))
+	for _, p := range filePaths {
+		assert.False(op.IsExist(p))
+	}
+}
+
+func testDeleteWithVersion(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, _ := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	meta, err := op.Stat(path)
+	assert.Nil(err)
+	version, ok := meta.Version()
+	if !ok {
+		return
+	}
+
+	assert.Nil(op.Delete(path, opendal.DeleteWithVersion(version)))
+
+	assert.False(op.IsExist(path))
 }

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -176,6 +176,8 @@ var (
 			&ffi.TypePointer, // write_total_max_size
 			&ffi.TypeUint8,   // create_dir
 			&ffi.TypeUint8,   // delete
+			&ffi.TypeUint8,   // delete_with_version
+			&ffi.TypeUint8,   // delete_with_recursive
 			&ffi.TypeUint8,   // copy
 			&ffi.TypeUint8,   // rename
 			&ffi.TypeUint8,   // list
@@ -223,6 +225,8 @@ type opendalCapability struct {
 	writeTotalMaxSize                  uint
 	createDir                          uint8
 	delete                             uint8
+	deleteWithVersion                  uint8
+	deleteWithRecursive                uint8
 	copy                               uint8
 	rename                             uint8
 	list                               uint8
@@ -330,6 +334,8 @@ type opendalResultList struct {
 type opendalLister struct{}
 
 type opendalListOptions struct{}
+
+type opendalDeleteOptions struct{}
 
 type opendalReadOptions struct{}
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7663

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
The Go binding's `Delete` operation currently only accepts a path, lacking support for version-specific and recursive deletion that the Rust core already supports via `DeleteOptions`. Users working with versioned storage backends cannot delete a specific version, and cannot perform recursive deletion without manual listing and deleting.


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
C Binding

- Add `opendal_delete_options` struct with version and recursive fields
- Expose `delete_with_version` and `delete_with_recursive` capabilities

Go Binding

- Change `Delete(path string)` to `Delete(path string, opts ...WithDeleteFn)`
- Add `DeleteWithVersion(version string) WithDeleteFn` option
- Add `DeleteWithRecursive(recursive bool) WithDeleteFn` option

# Are there any user-facing changes?

The Go binding's Delete method now accepts optional `WithDeleteFn` arguments.

```
// Old
op.Delete("path")

// New
op.Delete("path")
op.Delete("dir/", opendal.DeleteWithRecursive(true))
op.Delete("file.txt", opendal.DeleteWithVersion("v1"))
```

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

OpenCode with claude-sonnect-4.6
<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
