### PR TITLE
feat(core): Add copy source version support

### DIFF
--- a/.github/services/s3/0_minio_s3/action.yml
+++ b/.github/services/s3/0_minio_s3/action.yml
@@ -43,5 +43,5 @@ runs:
         OPENDAL_S3_ACCESS_KEY_ID=minioadmin
         OPENDAL_S3_SECRET_ACCESS_KEY=minioadmin
         OPENDAL_S3_REGION=us-east-1
-        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false,copy_with_if_not_exists=false,copy_with_if_match=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,copy_with_source_version=false,write_can_append=false,copy_with_if_not_exists=false,copy_with_if_match=false
         EOF

--- a/.github/services/s3/aws_s3/action.yml
+++ b/.github/services/s3/aws_s3/action.yml
@@ -36,4 +36,4 @@ runs:
     - name: Add capability overrides
       shell: bash
       run: |
-        echo "OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false" >> $GITHUB_ENV
+        echo "OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,copy_with_source_version=false,write_can_append=false" >> $GITHUB_ENV

--- a/.github/services/s3/aws_s3_with_list_objects_v1/action.yml
+++ b/.github/services/s3/aws_s3_with_list_objects_v1/action.yml
@@ -37,4 +37,4 @@ runs:
       shell: bash
       run: |
         echo "OPENDAL_S3_DISABLE_LIST_OBJECTS_V2=true" >> $GITHUB_ENV
-        echo "OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false" >> $GITHUB_ENV
+        echo "OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,copy_with_source_version=false,write_can_append=false" >> $GITHUB_ENV

--- a/.github/services/s3/aws_s3_with_sse_c/action.yml
+++ b/.github/services/s3/aws_s3_with_sse_c/action.yml
@@ -40,5 +40,5 @@ runs:
         OPENDAL_S3_SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM=AES256
         OPENDAL_S3_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY=MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=
         OPENDAL_S3_SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5=zZ5FnqcIqUjVwvWmyog4zw==
-        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,copy_with_source_version=false,write_can_append=false
         EOF

--- a/.github/services/s3/aws_s3_with_virtual_host/action.yml
+++ b/.github/services/s3/aws_s3_with_virtual_host/action.yml
@@ -37,4 +37,4 @@ runs:
       shell: bash
       run: |
         echo "OPENDAL_S3_ENABLE_VIRTUAL_HOST_STYLE=on" >> $GITHUB_ENV
-        echo "OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false" >> $GITHUB_ENV
+        echo "OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,copy_with_source_version=false,write_can_append=false" >> $GITHUB_ENV

--- a/.github/services/s3/ceph_rados_s3/disable_action.yml
+++ b/.github/services/s3/ceph_rados_s3/disable_action.yml
@@ -41,5 +41,5 @@ runs:
         OPENDAL_S3_ACCESS_KEY_ID=demo
         OPENDAL_S3_SECRET_ACCESS_KEY=demo
         OPENDAL_S3_REGION=us-east-1
-        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_with_if_match=false,write_can_append=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,copy_with_source_version=false,write_with_if_match=false,write_can_append=false
         EOF

--- a/.github/services/s3/minio_s3_with_anonymous/action.yml
+++ b/.github/services/s3/minio_s3_with_anonymous/action.yml
@@ -49,5 +49,5 @@ runs:
         OPENDAL_S3_REGION=us-east-1
         OPENDAL_S3_ALLOW_ANONYMOUS=on
         OPENDAL_S3_DISABLE_EC2_METADATA=on
-        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false,copy_with_if_not_exists=false,copy_with_if_match=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,copy_with_source_version=false,write_can_append=false,copy_with_if_not_exists=false,copy_with_if_match=false
         EOF

--- a/.github/services/s3/minio_s3_with_list_objects_v1/action.yml
+++ b/.github/services/s3/minio_s3_with_list_objects_v1/action.yml
@@ -44,5 +44,5 @@ runs:
         OPENDAL_S3_SECRET_ACCESS_KEY=minioadmin
         OPENDAL_S3_REGION=us-east-1
         OPENDAL_S3_DISABLE_LIST_OBJECTS_V2=true
-        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false,copy_with_if_not_exists=false,copy_with_if_match=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,copy_with_source_version=false,write_can_append=false,copy_with_if_not_exists=false,copy_with_if_match=false
         EOF

--- a/.github/services/s3/r2/disabled_action.yml
+++ b/.github/services/s3/r2/disabled_action.yml
@@ -38,5 +38,5 @@ runs:
       run: |
         cat << EOF >> $GITHUB_ENV
         OPENDAL_S3_REGION=auto
-        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,write_can_append=false,delete_max_size=700,stat_with_override_cache_control=false,stat_with_override_content_disposition=false,stat_with_override_content_type=false
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,copy_with_source_version=false,write_can_append=false,delete_max_size=700,stat_with_override_cache_control=false,stat_with_override_content_disposition=false,stat_with_override_content_type=false
         EOF

--- a/bindings/dotnet/OpenDAL/Capability.cs
+++ b/bindings/dotnet/OpenDAL/Capability.cs
@@ -77,6 +77,7 @@ public struct Capability
 
         Copy = native.copy != 0;
         CopyWithIfNotExists = native.copyWithIfNotExists != 0;
+        CopyWithSourceVersion = native.copyWithSourceVersion != 0;
         Rename = native.rename != 0;
 
         List = native.list != 0;
@@ -294,6 +295,11 @@ public struct Capability
     /// If operator supports copy with if not exists.
     /// </summary>
     public bool CopyWithIfNotExists { get; private set; }
+
+    /// <summary>
+    /// If operator supports copy with source version.
+    /// </summary>
+    public bool CopyWithSourceVersion { get; private set; }
 
     /// <summary>
     /// If operator supports rename.

--- a/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALCapability.cs
+++ b/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALCapability.cs
@@ -69,6 +69,7 @@ internal struct OpenDALCapability
 
     [MarshalAs(UnmanagedType.U1)] internal byte copy;
     [MarshalAs(UnmanagedType.U1)] internal byte copyWithIfNotExists;
+    [MarshalAs(UnmanagedType.U1)] internal byte copyWithSourceVersion;
     [MarshalAs(UnmanagedType.U1)] internal byte rename;
 
     [MarshalAs(UnmanagedType.U1)] internal byte list;

--- a/bindings/dotnet/src/capability.rs
+++ b/bindings/dotnet/src/capability.rs
@@ -70,6 +70,7 @@ pub struct Capability {
 
     pub copy: bool,
     pub copy_with_if_not_exists: bool,
+    pub copy_with_source_version: bool,
     pub rename: bool,
 
     pub list: bool,
@@ -132,6 +133,7 @@ impl Capability {
             delete_max_size: cap.delete_max_size.unwrap_or(usize::MIN),
             copy: cap.copy,
             copy_with_if_not_exists: cap.copy_with_if_not_exists,
+            copy_with_source_version: cap.copy_with_source_version,
             rename: cap.rename,
             list: cap.list,
             list_with_limit: cap.list_with_limit,

--- a/core/core/src/layers/correctness_check.rs
+++ b/core/core/src/layers/correctness_check.rs
@@ -240,6 +240,13 @@ impl<A: Access> LayeredAccess for CorrectnessAccessor<A> {
                 "if_match",
             ));
         }
+        if args.source_version().is_some() && !capability.copy_with_source_version {
+            return Err(new_unsupported_error(
+                &self.info,
+                Operation::Copy,
+                "source_version",
+            ));
+        }
 
         self.inner.copy(from, to, args, opts).await
     }

--- a/core/core/src/raw/ops.rs
+++ b/core/core/src/raw/ops.rs
@@ -895,6 +895,7 @@ impl From<options::WriteOptions> for (OpWrite, OpWriter) {
 pub struct OpCopy {
     if_not_exists: bool,
     if_match: Option<String>,
+    source_version: Option<String>,
 }
 
 impl OpCopy {
@@ -929,6 +930,19 @@ impl OpCopy {
     /// Get if_match condition.
     pub fn if_match(&self) -> Option<&str> {
         self.if_match.as_deref()
+    }
+
+    /// Set source version for the operation.
+    ///
+    /// When set, the copy operation will copy from the specified source version.
+    pub fn with_source_version(mut self, version: impl Into<String>) -> Self {
+        self.source_version = Some(version.into());
+        self
+    }
+
+    /// Get source version from the operation.
+    pub fn source_version(&self) -> Option<&str> {
+        self.source_version.as_deref()
     }
 }
 
@@ -986,6 +1000,7 @@ impl From<options::CopyOptions> for (OpCopy, OpCopier) {
             OpCopy {
                 if_not_exists: value.if_not_exists,
                 if_match: value.if_match,
+                source_version: value.source_version,
             },
             OpCopier {
                 concurrent: value.concurrent.max(1),

--- a/core/core/src/types/capability.rs
+++ b/core/core/src/types/capability.rs
@@ -158,6 +158,8 @@ pub struct Capability {
     pub copy_with_if_not_exists: bool,
     /// Indicates if conditional copy operations with if-match are supported.
     pub copy_with_if_match: bool,
+    /// Indicates if copy operations from a specific source version are supported.
+    pub copy_with_source_version: bool,
     /// Indicates if copy operations can be split into multiple server-side tasks.
     pub copy_can_multi: bool,
     /// Maximum size supported for segmented copy tasks.

--- a/core/core/src/types/operator/operator.rs
+++ b/core/core/src/types/operator/operator.rs
@@ -1005,7 +1005,8 @@ impl Operator {
     /// # Notes
     ///
     /// - `from` and `to` must be a file.
-    /// - If `from` and `to` are the same, an `IsSameFile` error will occur.
+    /// - If `from` and `to` are the same and `source_version` is not set,
+    ///   an `IsSameFile` error will occur.
     /// - `copy` is idempotent. For same `from` and `to` input, the result will be the same.
     ///
     /// # Options
@@ -1065,7 +1066,8 @@ impl Operator {
     /// # Notes
     ///
     /// - `from` and `to` must be a file.
-    /// - If `from` and `to` are the same, an `IsSameFile` error will occur.
+    /// - If `from` and `to` are the same and `source_version` is not set,
+    ///   an `IsSameFile` error will occur.
     /// - `copy` is idempotent. For same `from` and `to` input, the result will be the same.
     ///
     /// # Options
@@ -1138,7 +1140,7 @@ impl Operator {
             );
         }
 
-        if from == to {
+        if from == to && opts.source_version.is_none() {
             return Err(
                 Error::new(ErrorKind::IsSameFile, "from and to paths are same")
                     .with_operation("Operator::copy")

--- a/core/core/src/types/operator/operator.rs
+++ b/core/core/src/types/operator/operator.rs
@@ -1181,7 +1181,7 @@ impl Operator {
             );
         }
 
-        if from == to {
+        if from == to && opts.source_version.is_none() {
             return Err(
                 Error::new(ErrorKind::IsSameFile, "from and to paths are same")
                     .with_operation("Operator::copier")

--- a/core/core/src/types/operator/operator_futures.rs
+++ b/core/core/src/types/operator/operator_futures.rs
@@ -1446,6 +1446,14 @@ impl<F: Future<Output = Result<Metadata>>> FutureCopy<F> {
         self
     }
 
+    /// Sets source version for this copy operation.
+    ///
+    /// Refer to [`options::CopyOptions::source_version`] for more details.
+    pub fn source_version(mut self, version: impl Into<String>) -> Self {
+        self.args.0.source_version = Some(version.into());
+        self
+    }
+
     /// Sets concurrent copy operations for this copy.
     ///
     /// Refer to [`options::CopyOptions::concurrent`] for more details.
@@ -1491,6 +1499,14 @@ impl<F: Future<Output = Result<Copier>>> FutureCopier<F> {
     /// Refer to [`options::CopyOptions::if_match`] for more details.
     pub fn if_match(mut self, etag: &str) -> Self {
         self.args.0.if_match = Some(etag.to_string());
+        self
+    }
+
+    /// Sets source version for this copier operation.
+    ///
+    /// Refer to [`options::CopyOptions::source_version`] for more details.
+    pub fn source_version(mut self, version: impl Into<String>) -> Self {
+        self.args.0.source_version = Some(version.into());
         self
     }
 

--- a/core/core/src/types/options.rs
+++ b/core/core/src/types/options.rs
@@ -560,6 +560,19 @@ pub struct CopyOptions {
     ///   destination object's ETag matches the given value.
     pub if_match: Option<String>,
 
+    /// Copy from a specific source object version.
+    ///
+    /// ### Capability
+    ///
+    /// Check [`Capability::copy_with_source_version`] before using this feature.
+    ///
+    /// ### Behavior
+    ///
+    /// - If supported, the copy operation will read from the specified source
+    ///   version instead of the current source object.
+    /// - Destination behavior follows normal copy semantics.
+    pub source_version: Option<String>,
+
     /// Known content length of the source object.
     ///
     /// This is an execution hint that allows OpenDAL to avoid extra metadata

--- a/core/layers/capability-check/src/lib.rs
+++ b/core/layers/capability-check/src/lib.rs
@@ -169,6 +169,13 @@ impl<A: Access> LayeredAccess for CapabilityAccessor<A> {
                 "if_match",
             ));
         }
+        if args.source_version().is_some() && !capability.copy_with_source_version {
+            return Err(new_unsupported_error(
+                self.info.as_ref(),
+                Operation::Copy,
+                "source_version",
+            ));
+        }
 
         self.inner.copy(from, to, args, opts).await
     }

--- a/core/services/azblob/src/copier.rs
+++ b/core/services/azblob/src/copier.rs
@@ -74,9 +74,14 @@ pub struct AzblobCopier {
 
 impl oio::BlockCopy for AzblobCopier {
     async fn source_metadata(&self) -> Result<Metadata> {
+        let mut args = OpStat::default();
+        if let Some(version) = self.args.source_version() {
+            args = args.with_version(version);
+        }
+
         let resp = self
             .core
-            .azblob_get_blob_properties(&self.from, &OpStat::default())
+            .azblob_get_blob_properties(&self.from, &args)
             .await?;
 
         match resp.status() {
@@ -107,7 +112,13 @@ impl oio::BlockCopy for AzblobCopier {
     async fn copy_block(&self, block_id: Uuid, range: BytesRange) -> Result<()> {
         let resp = self
             .core
-            .azblob_put_block_from_url(&self.from, &self.to, block_id, range)
+            .azblob_put_block_from_url(
+                &self.from,
+                &self.to,
+                self.args.source_version(),
+                block_id,
+                range,
+            )
             .await?;
 
         match resp.status() {

--- a/core/services/azblob/src/core.rs
+++ b/core/services/azblob/src/core.rs
@@ -524,10 +524,18 @@ impl AzblobCore {
         &self,
         from: &str,
         to: &str,
+        source_version: Option<&str>,
         block_id: Uuid,
         range: BytesRange,
     ) -> Result<Response<Buffer>> {
-        let source = Request::get(self.build_path_url(from))
+        let mut source_url = self.build_path_url(from);
+        if let Some(version) = source_version {
+            source_url = QueryPairsWriter::new(&source_url)
+                .push("versionid", &percent_encode_path(version))
+                .finish();
+        }
+
+        let source = Request::get(source_url)
             .extension(Operation::Copy)
             .extension(ServiceOperation("GetBlob"))
             .body(Buffer::new())
@@ -634,7 +642,14 @@ impl AzblobCore {
     }
 
     pub fn azblob_head_blob_request(&self, path: &str, args: &OpStat) -> Result<Request<Buffer>> {
-        let mut req = Request::head(self.build_path_url(path));
+        let mut url = self.build_path_url(path);
+        if let Some(version) = args.version() {
+            url = QueryPairsWriter::new(&url)
+                .push("versionid", &percent_encode_path(version))
+                .finish();
+        }
+
+        let mut req = Request::head(url);
 
         // Set SSE headers.
         req = self.insert_sse_headers(req);
@@ -687,7 +702,12 @@ impl AzblobCore {
         to: &str,
         args: OpCopy,
     ) -> Result<Response<Buffer>> {
-        let source = self.build_path_url(from);
+        let mut source = self.build_path_url(from);
+        if let Some(version) = args.source_version() {
+            source = QueryPairsWriter::new(&source)
+                .push("versionid", &percent_encode_path(version))
+                .finish();
+        }
         let target = self.build_path_url(to);
 
         let mut req = Request::put(&target)

--- a/core/services/gcs/src/core.rs
+++ b/core/services/gcs/src/core.rs
@@ -489,6 +489,9 @@ impl GcsCore {
 
         let mut url = QueryPairsWriter::new(&url);
 
+        if let Some(version) = args.source_version() {
+            url = url.push("sourceGeneration", &percent_encode_path(version));
+        }
         if args.if_not_exists() {
             url = url.push("ifGenerationMatch", "0");
         }

--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -983,6 +983,7 @@ impl Builder for S3Builder {
                             copy_can_multi: true,
                             copy_with_if_not_exists: true,
                             copy_with_if_match: true,
+                            copy_with_source_version: true,
                             // The min multipart size of S3 is 5 MiB.
                             //
                             // ref: <https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html>

--- a/core/services/s3/src/copier.rs
+++ b/core/services/s3/src/copier.rs
@@ -85,10 +85,12 @@ pub struct S3Copier {
 
 impl oio::MultipartCopy for S3Copier {
     async fn source_metadata(&self) -> Result<Metadata> {
-        let resp = self
-            .core
-            .s3_head_object(&self.from, OpStat::default())
-            .await?;
+        let mut args = OpStat::default();
+        if let Some(version) = self.args.source_version() {
+            args = args.with_version(version);
+        }
+
+        let resp = self.core.s3_head_object(&self.from, args).await?;
 
         match resp.status() {
             StatusCode::OK => {
@@ -173,6 +175,7 @@ impl oio::MultipartCopy for S3Copier {
             .s3_upload_part_copy_request(S3UploadPartCopyRequest {
                 from: &self.from,
                 to: &self.to,
+                source_version: self.args.source_version(),
                 upload_id,
                 part_number,
                 range,

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -111,6 +111,7 @@ pub struct S3Core {
 pub(crate) struct S3UploadPartCopyRequest<'a> {
     pub(crate) from: &'a str,
     pub(crate) to: &'a str,
+    pub(crate) source_version: Option<&'a str>,
     pub(crate) upload_id: &'a str,
     pub(crate) part_number: usize,
     pub(crate) range: BytesRange,
@@ -663,6 +664,16 @@ impl S3Core {
         let to = build_abs_path(&self.root, to);
 
         let source = format!("{}/{}", self.bucket, percent_encode_path(&from));
+        let source = if let Some(version) = args.source_version() {
+            QueryPairsWriter::new(&source)
+                .push(
+                    constants::S3_QUERY_VERSION_ID,
+                    &percent_encode_path(version),
+                )
+                .finish()
+        } else {
+            source
+        };
         let target = format!("{}/{}", self.endpoint, percent_encode_path(&to));
 
         let mut req = Request::put(&target);
@@ -930,6 +941,16 @@ impl S3Core {
         let to = build_abs_path(&self.root, input.to);
 
         let source = format!("{}/{}", self.bucket, percent_encode_path(&from));
+        let source = if let Some(version) = input.source_version {
+            QueryPairsWriter::new(&source)
+                .push(
+                    constants::S3_QUERY_VERSION_ID,
+                    &percent_encode_path(version),
+                )
+                .finish()
+        } else {
+            source
+        };
 
         let url = format!(
             "{}/{}?partNumber={}&uploadId={}",

--- a/core/tests/behavior/async_copy.rs
+++ b/core/tests/behavior/async_copy.rs
@@ -64,6 +64,14 @@ pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
             test_copy_with_if_match_mismatch
         ))
     }
+
+    if cap.read && cap.write && cap.stat && cap.copy && cap.copy_with_source_version {
+        tests.extend(async_trials!(
+            op,
+            test_copy_with_source_version_to_new_file,
+            test_copy_with_source_version_to_same_file
+        ))
+    }
 }
 
 fn copy_multi_chunk_size(cap: Capability) -> Option<(usize, usize)> {
@@ -431,6 +439,86 @@ pub async fn test_copy_with_if_match_mismatch(op: Operator) -> Result<()> {
 
     op.delete(&source_path).await.expect("delete must succeed");
     op.delete(&target_path).await.expect("delete must succeed");
+    Ok(())
+}
+
+/// Copy with source_version should copy a specific source version to a new file.
+pub async fn test_copy_with_source_version_to_new_file(op: Operator) -> Result<()> {
+    if !op.info().full_capability().copy_with_source_version {
+        return Ok(());
+    }
+
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (new_content, _) = gen_bytes(op.info().full_capability());
+    assert_ne!(source_content, new_content);
+
+    op.write(&source_path, source_content.clone()).await?;
+    let version = op
+        .stat(&source_path)
+        .await?
+        .version()
+        .expect("must have version")
+        .to_string();
+
+    op.write(&source_path, new_content).await?;
+
+    let target_path = uuid::Uuid::new_v4().to_string();
+    op.copy_with(&source_path, &target_path)
+        .source_version(version)
+        .await?;
+
+    let target_content = op
+        .read(&target_path)
+        .await
+        .expect("read must succeed")
+        .to_bytes();
+    assert_eq!(
+        sha256_digest(target_content),
+        sha256_digest(&source_content),
+    );
+
+    op.delete(&source_path).await.expect("delete must succeed");
+    op.delete(&target_path).await.expect("delete must succeed");
+    Ok(())
+}
+
+/// Copy with source_version should allow copying a specific source version to itself.
+pub async fn test_copy_with_source_version_to_same_file(op: Operator) -> Result<()> {
+    if !op.info().full_capability().copy_with_source_version {
+        return Ok(());
+    }
+
+    let source_path = uuid::Uuid::new_v4().to_string();
+    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (new_content, _) = gen_bytes(op.info().full_capability());
+    assert_ne!(source_content, new_content);
+
+    op.write(&source_path, source_content.clone()).await?;
+    let version = op
+        .stat(&source_path)
+        .await?
+        .version()
+        .expect("must have version")
+        .to_string();
+
+    op.write(&source_path, new_content).await?;
+
+    op.copy_with(&source_path, &source_path)
+        .source_version(version)
+        .await?;
+
+    let current_content = op
+        .read(&source_path)
+        .await
+        .expect("read must succeed")
+        .to_bytes();
+    assert_eq!(
+        sha256_digest(current_content),
+        sha256_digest(&source_content),
+    );
+
+    op.delete(&source_path).await.expect("delete must succeed");
     Ok(())
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of #7182.

# Rationale for this change

RFC-7182 needs a zero-overhead primitive that can copy from a specific source version. Exposing this on copy lets higher-level restore APIs reuse the existing copy abstraction instead of requiring every backend to implement a separate restore path.

# What changes are included in this PR?

This PR adds `copy_with_source_version` capability and `CopyOptions::source_version`, wires the option through `copy_with` and `copier_with`, and validates the capability in correctness and capability-check layers.

S3 enables the capability and sends `versionId` in copy-source requests. GCS and AzBlob request builders are prepared to carry source versions, but their capabilities are not enabled yet. The S3 non-versioning CI configurations explicitly disable the new capability, and behavior tests cover copying an older source version to a new path and back to the same path.

# Are there any user-facing changes?

Yes. Rust users can call `.source_version(...)` on `copy_with` and `copier_with` when `Capability::copy_with_source_version` is true.

# AI Usage Statement

AI-assisted implementation and review were used for this PR.
