### PR TITLE
fix(bindings/go): keep FFI call arguments alive

### DIFF
--- a/bindings/go/ffi.go
+++ b/bindings/go/ffi.go
@@ -22,6 +22,7 @@ package opendal
 import (
 	"context"
 	"errors"
+	"runtime"
 	"sync"
 	"unsafe"
 
@@ -79,6 +80,11 @@ func (f *FFI[T]) withFFI(ctx context.Context, lib uintptr) (context.Context, err
 	}
 	val := f.withFunc(ctx, func(rValue unsafe.Pointer, aValues ...unsafe.Pointer) {
 		ffi.Call(&cif, fn, rValue, aValues...)
+		// ffi.Call passes pointers through uintptr internally, so keep the Go
+		// objects alive until the native call has returned.
+		runtime.KeepAlive(&cif)
+		runtime.KeepAlive(rValue)
+		runtime.KeepAlive(aValues)
 	})
 	return context.WithValue(ctx, f.opts.sym, val), nil
 }


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

Go binding behavior tests can crash with `SIGSEGV` on Go 1.24.10 while executing native calls through `jupiterrider/ffi`/`purego`. The root cause is that `ffi.Call` passes Go pointers through `uintptr` internally, so the Go runtime cannot prove the FFI call interface and argument slice remain live until the native call returns.

# What changes are included in this PR?

This PR keeps the FFI call interface, return value pointer, and argument pointer slice alive after each native FFI call returns.

# Are there any user-facing changes?

No API changes. This fixes a crash in Go bindings under GC pressure.

# AI Usage Statement

Used OpenAI GPT-5 for investigation and patch preparation.
