### PR TITLE
feat(ci): add golang package into dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -160,6 +160,36 @@ updates:
         patterns:
           - "*"
 
+  # Go bindings
+  - package-ecosystem: "gomod"
+    directory: "/bindings/go"
+    open-pull-requests-limit: 1
+    schedule:
+      interval: "monthly"
+    groups:
+      others:
+        patterns:
+          - "*"
+    cooldown:
+      semver-patch-days: 90
+      include:
+        - "*"
+
+  # Go bindings behavior tests
+  - package-ecosystem: "gomod"
+    directory: "/bindings/go/tests/behavior_tests"
+    open-pull-requests-limit: 1
+    schedule:
+      interval: "monthly"
+    groups:
+      others:
+        patterns:
+          - "*"
+    cooldown:
+      semver-patch-days: 90
+      include:
+        - "*"
+
   # Website npm dependencies
   - package-ecosystem: "npm"
     directory: "/website"


### PR DESCRIPTION
# Rationale for this change

Dependabot should be setup properly to automatically upgrade stale dependencies. 

# What changes are included in this PR?

Followup for https://github.com/apache/opendal/pull/7681, this PR sets dependabot for our golang packages.

# Are there any user-facing changes?

No

# AI Usage Statement

opus-4.8 made the code change for me