### PR TITLE
fix(services): bound batch-delete result allocation against malformed server responses

### DIFF
--- a/core/services/cloudflare-kv/src/deleter.rs
+++ b/core/services/cloudflare-kv/src/deleter.rs
@@ -95,7 +95,11 @@ impl oio::BatchDelete for CloudflareKvDeleter {
         };
 
         let mut batched_result = BatchDeleteResult {
-            succeeded: Vec::with_capacity(result.successful_key_count),
+            // `successful_key_count` is taken verbatim from the server response; cap it to
+            // the number of keys we actually requested so a malicious/compromised endpoint
+            // cannot drive `Vec::with_capacity` to an abort/OOM. (`unsuccessful_keys` is an
+            // already-parsed Vec, so its length is inherently bounded.)
+            succeeded: Vec::with_capacity(result.successful_key_count.min(batch.len())),
             failed: Vec::with_capacity(result.unsuccessful_keys.len()),
         };
 

--- a/core/services/oss/src/deleter.rs
+++ b/core/services/oss/src/deleter.rs
@@ -79,7 +79,10 @@ impl oio::BatchDelete for OssDeleter {
 
         let mut batched_result = BatchDeleteResult {
             succeeded: Vec::with_capacity(result.deleted.len()),
-            failed: Vec::with_capacity(keys.len() - result.deleted.len()),
+            // `result.deleted.len()` is server-controlled and may exceed `keys.len()`; use
+            // `saturating_sub` (mirroring services/tos) to avoid an unsigned underflow that
+            // wraps to a huge `with_capacity` (release: abort).
+            failed: Vec::with_capacity(keys.len().saturating_sub(result.deleted.len())),
         };
 
         for i in result.deleted {

--- a/core/services/s3/src/deleter.rs
+++ b/core/services/s3/src/deleter.rs
@@ -73,7 +73,10 @@ impl oio::BatchDelete for S3Deleter {
 
         let mut errors = result.error;
         let mut batched_result = BatchDeleteResult {
-            succeeded: Vec::with_capacity(batch.len() - errors.len()),
+            // `errors.len()` is server-controlled and may exceed `batch.len()`; use
+            // `saturating_sub` (mirroring services/tos) to avoid an unsigned underflow
+            // that wraps to a huge `with_capacity` (release: abort).
+            succeeded: Vec::with_capacity(batch.len().saturating_sub(errors.len())),
             failed: Vec::with_capacity(errors.len()),
         };
         for (path, op) in batch {

--- a/core/services/swift/src/deleter.rs
+++ b/core/services/swift/src/deleter.rs
@@ -60,7 +60,10 @@ impl oio::BatchDelete for SwiftDeleter {
             serde_json::from_slice(&bs).map_err(new_json_deserialize_error)?;
 
         let mut batched_result = oio::BatchDeleteResult {
-            succeeded: Vec::with_capacity(batch.len() - result.errors.len()),
+            // `result.errors.len()` is server-controlled and may exceed `batch.len()`; use
+            // `saturating_sub` (mirroring services/tos) to avoid an unsigned underflow that
+            // wraps to a huge `with_capacity` (release: abort).
+            succeeded: Vec::with_capacity(batch.len().saturating_sub(result.errors.len())),
             failed: Vec::with_capacity(result.errors.len()),
         };
 


### PR DESCRIPTION
# Which issue does this PR close?

This was discussed on the OpenDAL security list with the PMC; no public issue was filed. Happy to open one if preferred.

# Rationale for this change

Four batch-delete implementations size the result `Vec`s directly from counts taken out of the parsed server response, then feed those counts to `Vec::with_capacity`:

- `services/s3`: `batch.len() - errors.len()`
- `services/oss`: `keys.len() - result.deleted.len()`
- `services/swift`: `batch.len() - result.errors.len()`
- `services/cloudflare-kv`: `Vec::with_capacity(result.successful_key_count)` where `successful_key_count` is an integer copied verbatim from the response

For the three subtraction sites, a malformed or compromised storage endpoint that returns more error/deleted entries than were requested makes the unsigned subtraction underflow and wrap to a near-`usize::MAX` capacity, which `Vec::with_capacity` turns into an allocation abort (capacity-overflow panic / OOM abort in release). For cloudflare-kv, an inflated `successful_key_count` does the same thing directly, with no subtraction needed.

`services/tos` already guards exactly this in the same place with `saturating_sub`:

```rust
succeeded: Vec::with_capacity(batch.len().saturating_sub(errors.len())),
```

This PR brings the other four backends in line. It is purely defensive: under a well-behaved server the computed capacity is unchanged, so there is no behavioral difference on the normal path.

# What changes are included in this PR?

- `services/s3`, `services/oss`, `services/swift`: replace the bare unsigned subtraction with `saturating_sub`, mirroring `services/tos`.
- `services/cloudflare-kv`: cap `successful_key_count` with `.min(batch.len())` (the number of keys actually requested) before passing it to `with_capacity`.

A short comment at each site explains why the clamp is there.

# Are there any user-facing changes?

No. No public API or behavior change on well-formed responses; only the failure mode on a malformed response changes (graceful instead of an allocation abort).

# AI Usage Statement

Drafted with assistance from an AI coding tool (Claude). All changes were reviewed by me, and the touched service crates were verified locally: `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` (s3 22, swift 10 including the `parse_bulk_delete_response` tests, oss 7, cloudflare-kv 2) all pass.
