### PR TITLE
fix(layers): Align reader observability

### DIFF
--- a/core/core/src/docs/internals/accessor.rs
+++ b/core/core/src/docs/internals/accessor.rs
@@ -27,7 +27,7 @@
 //! ```ignore
 //! //                  <----------Trait Bound-------------->
 //! pub trait Access: Send + Sync + Debug + Unpin + 'static {
-//!     type Reader: oio::ReadStream;                    // --+
+//!     type Reader: oio::Read;                    // --+
 //!     type Writer: oio::Write;                   //   +--> Associated Type
 //!     type Lister: oio::List;                    //   +
 //!     type Deleter: oio::Delete;                 // --+

--- a/core/core/src/docs/rfcs/7660_move_read_range_to_reader.md
+++ b/core/core/src/docs/rfcs/7660_move_read_range_to_reader.md
@@ -220,11 +220,14 @@ they need for wrapping and cloning.
 - `read(range)` reads one bounded planner range and returns exactly one
   materialized `Buffer`.
 
-`read` is not a syscall-style partial read. Backends should not return a short
-buffer just because one underlying syscall or network read returned fewer bytes
-than requested. For a valid bounded planner range, `read` should either return
-the complete range content or return an error. The complete layer can still
-enforce the final length check.
+This is the adapter-level `oio::Read` contract. Native services usually
+implement either `StreamRead::open` or `PositionRead::read_at`; `StreamReader`
+and `PositionReader` then provide the full `oio::Read` contract.
+
+`read` is not a syscall-style partial read. `oio::Read` implementations should
+not return a short buffer just because one underlying syscall or network read
+returned fewer bytes than requested. For a valid bounded planner range, `read`
+should either return the complete range content or return an error.
 
 The public `Reader::read` can still accept a large user range. The core planner
 must not blindly pass that large range to raw `read`. It should choose between
@@ -313,13 +316,14 @@ pub struct ReadContext {
 
 `acc`, `path`, and `args` are still useful for planning, especially when
 OpenDAL needs `stat` to resolve unbounded ranges for chunked reads or
-`AsyncSeek` adapters. Actual range I/O should go through `reader.open`,
-`reader.read`, or `reader.fetch`, not through repeated `acc.read` calls.
+`AsyncSeek` adapters. Actual raw range I/O should go through `reader.open` or
+`reader.read`, not through repeated `acc.read` calls.
 
 `Reader::metadata()` remains cache-only. The cache is updated from `RpRead`
-returned by `Access::read`, `open`, `read`, or `fetch`. Lazy backends may return
-`RpRead::default()` from `Access::read` and fill metadata after the first range
-operation.
+returned by `Access::read`, `open`, or `read`. Lazy backends may return
+`RpRead::default()` from `Access::read` and fill metadata after the first raw
+range operation. Public `Reader::fetch` observes metadata from the planned raw
+`read` calls it executes.
 
 ## Layers
 
@@ -433,8 +437,9 @@ This keeps object-store behavior unchanged.
 
 ### Memory and database-like services
 
-Services that already have the data content in memory can store the content or
-lookup key in their raw reader. `read(range)` can slice bounded ranges directly.
+Services that already have the data content in memory can implement
+`StreamRead` by opening a stream over the selected slice. Their
+`StreamReader` adapter will provide bounded `read(range)`.
 
 ### Handle based services
 
@@ -571,9 +576,9 @@ can be implemented.
 
 `object_store` exposes both single-range and multi-range reads through
 `get_range` and `get_ranges`. OpenDAL's public `Reader::fetch` serves a similar
-user-facing purpose. This RFC places the raw batch primitive on the raw reader,
-where both object-store requests and file-handle positioned reads can be
-implemented.
+user-facing purpose. The accepted raw contract does not expose a batch
+primitive; public fetch is planned by core and executed through bounded raw
+`read(range)` calls.
 
 # Unresolved questions
 
@@ -581,8 +586,8 @@ implemented.
 
 The initial implementation can preserve current public behavior by batching
 merged ranges according to `OpReader::concurrent`. We should benchmark whether
-the default policy should prefer one large `raw.fetch` call, several batches, or
-one task per merged range for different backend classes.
+the default policy should prefer fewer larger bounded raw reads or one task per
+merged range for different backend classes.
 
 ## Native preferred read size
 

--- a/core/core/src/raw/accessor.rs
+++ b/core/core/src/raw/accessor.rs
@@ -121,15 +121,16 @@ pub trait Access: Send + Sync + Debug + Unpin + 'static {
         )))
     }
 
-    /// Invoke the `read` operation on the specified path, returns a
-    /// [`Reader`][crate::Reader] if operate successful.
+    /// Invoke the `read` operation on the specified path, returns a raw
+    /// reader if operate successful.
     ///
     /// Require [`Capability::read`]
     ///
     /// # Behavior
     ///
     /// - Input path MUST be file path, DON'T NEED to check mode.
-    /// - The returning content length may be smaller than the range specified.
+    /// - Range I/O is selected by the returned reader's `open` or `read`
+    ///   operation.
     fn read(
         &self,
         path: &str,

--- a/core/layers/dtrace/src/lib.rs
+++ b/core/layers/dtrace/src/lib.rs
@@ -58,9 +58,9 @@ use probe::probe_lazy;
 ///
 /// ### For Reader
 ///
-/// 1. reader_read_start, arguments: path
-/// 2. reader_read_ok, arguments: path, length
-/// 3. reader_read_error, arguments: path
+/// 1. reader_read_start, arguments: path, range
+/// 2. reader_read_ok, arguments: path, range, length
+/// 3. reader_read_error, arguments: path, range
 ///
 /// ### For Writer
 ///
@@ -249,28 +249,57 @@ impl<A: Access> LayeredAccess for DTraceAccessor<A> {
 pub struct DtraceLayerWrapper<R> {
     inner: R,
     path: String,
+    range: Option<BytesRange>,
 }
 
 impl<R> DtraceLayerWrapper<R> {
     fn new(inner: R, path: &String) -> Self {
+        Self::with_range(inner, path, None)
+    }
+
+    fn with_range(inner: R, path: &String, range: Option<BytesRange>) -> Self {
         Self {
             inner,
             path: path.to_string(),
+            range,
         }
+    }
+
+    fn range_label(&self) -> String {
+        self.range
+            .map(|range| range.to_string())
+            .unwrap_or_default()
     }
 }
 
 impl<R: oio::ReadStream> oio::ReadStream for DtraceLayerWrapper<R> {
     async fn read(&mut self) -> Result<Buffer> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, reader_read_start, c_path.as_ptr());
+        let c_range = CString::new(self.range_label()).unwrap();
+        probe_lazy!(
+            opendal,
+            reader_read_start,
+            c_path.as_ptr(),
+            c_range.as_ptr()
+        );
         match self.inner.read().await {
             Ok(bs) => {
-                probe_lazy!(opendal, reader_read_ok, c_path.as_ptr(), bs.remaining());
+                probe_lazy!(
+                    opendal,
+                    reader_read_ok,
+                    c_path.as_ptr(),
+                    c_range.as_ptr(),
+                    bs.remaining()
+                );
                 Ok(bs)
             }
             Err(e) => {
-                probe_lazy!(opendal, reader_read_error, c_path.as_ptr());
+                probe_lazy!(
+                    opendal,
+                    reader_read_error,
+                    c_path.as_ptr(),
+                    c_range.as_ptr()
+                );
                 Err(e)
             }
         }
@@ -280,18 +309,38 @@ impl<R: oio::ReadStream> oio::ReadStream for DtraceLayerWrapper<R> {
 impl<R: oio::Read> oio::Read for DtraceLayerWrapper<R> {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, reader_read_start, c_path.as_ptr());
+        let c_range = CString::new(range.to_string()).unwrap();
+        probe_lazy!(
+            opendal,
+            reader_read_start,
+            c_path.as_ptr(),
+            c_range.as_ptr()
+        );
         match self.inner.open(range).await {
             Ok((rp, stream)) => {
-                probe_lazy!(opendal, reader_read_ok, c_path.as_ptr(), 0);
+                probe_lazy!(
+                    opendal,
+                    reader_read_ok,
+                    c_path.as_ptr(),
+                    c_range.as_ptr(),
+                    0
+                );
                 Ok((
                     rp,
-                    Box::new(DtraceLayerWrapper::new(stream, &self.path))
-                        as Box<dyn oio::ReadStreamDyn>,
+                    Box::new(DtraceLayerWrapper::with_range(
+                        stream,
+                        &self.path,
+                        Some(range),
+                    )) as Box<dyn oio::ReadStreamDyn>,
                 ))
             }
             Err(e) => {
-                probe_lazy!(opendal, reader_read_error, c_path.as_ptr());
+                probe_lazy!(
+                    opendal,
+                    reader_read_error,
+                    c_path.as_ptr(),
+                    c_range.as_ptr()
+                );
                 Err(e)
             }
         }
@@ -299,14 +348,31 @@ impl<R: oio::Read> oio::Read for DtraceLayerWrapper<R> {
 
     async fn read(&self, range: BytesRange) -> Result<(RpRead, Buffer)> {
         let c_path = CString::new(self.path.clone()).unwrap();
-        probe_lazy!(opendal, reader_read_start, c_path.as_ptr());
+        let c_range = CString::new(range.to_string()).unwrap();
+        probe_lazy!(
+            opendal,
+            reader_read_start,
+            c_path.as_ptr(),
+            c_range.as_ptr()
+        );
         match self.inner.read(range).await {
             Ok((rp, buffer)) => {
-                probe_lazy!(opendal, reader_read_ok, c_path.as_ptr(), buffer.len());
+                probe_lazy!(
+                    opendal,
+                    reader_read_ok,
+                    c_path.as_ptr(),
+                    c_range.as_ptr(),
+                    buffer.len()
+                );
                 Ok((rp, buffer))
             }
             Err(e) => {
-                probe_lazy!(opendal, reader_read_error, c_path.as_ptr());
+                probe_lazy!(
+                    opendal,
+                    reader_read_error,
+                    c_path.as_ptr(),
+                    c_range.as_ptr()
+                );
                 Err(e)
             }
         }

--- a/core/layers/logging/src/lib.rs
+++ b/core/layers/logging/src/lib.rs
@@ -558,6 +558,7 @@ pub struct LoggingReader<R, I: LoggingInterceptor> {
     info: Arc<AccessorInfo>,
     logger: I,
     path: String,
+    range: Option<BytesRange>,
 
     read: u64,
     inner: R,
@@ -565,14 +566,31 @@ pub struct LoggingReader<R, I: LoggingInterceptor> {
 
 impl<R, I: LoggingInterceptor> LoggingReader<R, I> {
     fn new(info: Arc<AccessorInfo>, logger: I, path: &str, reader: R) -> Self {
+        Self::with_range(info, logger, path, None, reader)
+    }
+
+    fn with_range(
+        info: Arc<AccessorInfo>,
+        logger: I,
+        path: &str,
+        range: Option<BytesRange>,
+        reader: R,
+    ) -> Self {
         Self {
             info,
             logger,
             path: path.to_string(),
+            range,
 
             read: 0,
             inner: reader,
         }
+    }
+
+    fn range_label(&self) -> String {
+        self.range
+            .map(|range| range.to_string())
+            .unwrap_or_default()
     }
 }
 
@@ -580,11 +598,13 @@ impl<R: oio::ReadStream, I: LoggingInterceptor> oio::ReadStream for LoggingReade
     async fn read(&mut self) -> Result<Buffer> {
         match self.inner.read().await {
             Ok(bs) if bs.is_empty() => {
+                let range = self.range_label();
                 self.logger.log(
                     &self.info,
                     Operation::Read,
                     &[
                         ("path", &self.path),
+                        ("range", &range),
                         ("read", &self.read.to_string()),
                         ("size", &bs.len().to_string()),
                     ],
@@ -598,10 +618,15 @@ impl<R: oio::ReadStream, I: LoggingInterceptor> oio::ReadStream for LoggingReade
                 Ok(bs)
             }
             Err(err) => {
+                let range = self.range_label();
                 self.logger.log(
                     &self.info,
                     Operation::Read,
-                    &[("path", &self.path), ("read", &self.read.to_string())],
+                    &[
+                        ("path", &self.path),
+                        ("range", &range),
+                        ("read", &self.read.to_string()),
+                    ],
                     "failed",
                     Some(&err),
                 );
@@ -616,10 +641,11 @@ impl<R: oio::Read, I: LoggingInterceptor> oio::Read for LoggingReader<R, I> {
         match self.inner.open(range).await {
             Ok((rp, stream)) => Ok((
                 rp,
-                Box::new(LoggingReader::new(
+                Box::new(LoggingReader::with_range(
                     self.info.clone(),
                     self.logger.clone(),
                     &self.path,
+                    Some(range),
                     stream,
                 )) as Box<dyn oio::ReadStreamDyn>,
             )),

--- a/core/layers/oteltrace/src/lib.rs
+++ b/core/layers/oteltrace/src/lib.rs
@@ -28,7 +28,6 @@ use opendal_core::*;
 use opentelemetry::Context as TraceContext;
 use opentelemetry::KeyValue;
 use opentelemetry::global;
-use opentelemetry::global::BoxedSpan;
 use opentelemetry::trace::FutureExt as TraceFutureExt;
 use opentelemetry::trace::Span;
 use opentelemetry::trace::TraceContextExt;
@@ -109,10 +108,12 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         let mut span = tracer.start("read");
         span.set_attribute(KeyValue::new("path", path.to_string()));
         span.set_attribute(KeyValue::new("args", format!("{args:?}")));
+        let cx = TraceContext::current_with_span(span);
         self.inner
             .read(path, args)
+            .with_context(cx.clone())
             .await
-            .map(|(rp, r)| (rp, OtelTraceWrapper::new(span, r)))
+            .map(|(rp, r)| (rp, OtelTraceWrapper::new(cx, r)))
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
@@ -120,10 +121,12 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         let mut span = tracer.start("write");
         span.set_attribute(KeyValue::new("path", path.to_string()));
         span.set_attribute(KeyValue::new("args", format!("{args:?}")));
+        let cx = TraceContext::current_with_span(span);
         self.inner
             .write(path, args)
+            .with_context(cx.clone())
             .await
-            .map(|(rp, r)| (rp, OtelTraceWrapper::new(span, r)))
+            .map(|(rp, r)| (rp, OtelTraceWrapper::new(cx, r)))
     }
 
     async fn copy(
@@ -173,10 +176,12 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
         let mut span = tracer.start("list");
         span.set_attribute(KeyValue::new("path", path.to_string()));
         span.set_attribute(KeyValue::new("args", format!("{args:?}")));
+        let cx = TraceContext::current_with_span(span);
         self.inner
             .list(path, args)
+            .with_context(cx.clone())
             .await
-            .map(|(rp, s)| (rp, OtelTraceWrapper::new(span, s)))
+            .map(|(rp, s)| (rp, OtelTraceWrapper::new(cx, s)))
     }
 
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
@@ -191,36 +196,36 @@ impl<A: Access> LayeredAccess for OtelTraceAccessor<A> {
 
 #[doc(hidden)]
 pub struct OtelTraceWrapper<R> {
-    span: Arc<BoxedSpan>,
+    cx: TraceContext,
     inner: R,
 }
 
 impl<R> OtelTraceWrapper<R> {
-    fn new(span: BoxedSpan, inner: R) -> Self {
-        Self {
-            span: Arc::new(span),
-            inner,
-        }
+    fn new(cx: TraceContext, inner: R) -> Self {
+        Self { cx, inner }
     }
 
-    fn with_span(span: Arc<BoxedSpan>, inner: R) -> Self {
-        Self { span, inner }
+    fn child_context(&self, name: &'static str, range: BytesRange) -> TraceContext {
+        let tracer = global::tracer("opendal");
+        let mut span = tracer.start_with_context(name, &self.cx);
+        span.set_attribute(KeyValue::new("range", range.to_string()));
+        self.cx.with_span(span)
     }
 }
 
 impl<R: oio::ReadStream> oio::ReadStream for OtelTraceWrapper<R> {
     async fn read(&mut self) -> Result<Buffer> {
-        self.inner.read().await
+        self.inner.read().with_context(self.cx.clone()).await
     }
 }
 
 impl<R: oio::Read> oio::Read for OtelTraceWrapper<R> {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
-        let (rp, stream) = self.inner.open(range).await?;
+        let cx = self.child_context("reader.open", range);
+        let (rp, stream) = self.inner.open(range).with_context(cx.clone()).await?;
         Ok((
             rp,
-            Box::new(OtelTraceWrapper::with_span(self.span.clone(), stream))
-                as Box<dyn oio::ReadStreamDyn>,
+            Box::new(OtelTraceWrapper::new(cx, stream)) as Box<dyn oio::ReadStreamDyn>,
         ))
     }
 
@@ -228,26 +233,27 @@ impl<R: oio::Read> oio::Read for OtelTraceWrapper<R> {
         &self,
         range: BytesRange,
     ) -> impl Future<Output = Result<(RpRead, Buffer)>> + MaybeSend {
-        self.inner.read(range)
+        let cx = self.child_context("reader.read", range);
+        self.inner.read(range).with_context(cx)
     }
 }
 
 impl<R: oio::Write> oio::Write for OtelTraceWrapper<R> {
     fn write(&mut self, bs: Buffer) -> impl Future<Output = Result<()>> + MaybeSend {
-        self.inner.write(bs)
+        self.inner.write(bs).with_context(self.cx.clone())
     }
 
     fn abort(&mut self) -> impl Future<Output = Result<()>> + MaybeSend {
-        self.inner.abort()
+        self.inner.abort().with_context(self.cx.clone())
     }
 
     fn close(&mut self) -> impl Future<Output = Result<Metadata>> + MaybeSend {
-        self.inner.close()
+        self.inner.close().with_context(self.cx.clone())
     }
 }
 
 impl<R: oio::List> oio::List for OtelTraceWrapper<R> {
     async fn next(&mut self) -> Result<Option<oio::Entry>> {
-        self.inner.next().await
+        self.inner.next().with_context(self.cx.clone()).await
     }
 }

--- a/core/layers/tracing/src/lib.rs
+++ b/core/layers/tracing/src/lib.rs
@@ -296,15 +296,17 @@ impl<R: oio::ReadStream> oio::ReadStream for TracingWrapper<R> {
 
 impl<R: oio::Read> oio::Read for TracingWrapper<R> {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
-        let (rp, stream) = self.inner.open(range).instrument(self.span.clone()).await?;
+        let span = span!(parent: &self.span, Level::DEBUG, "reader.open", range = %range);
+        let (rp, stream) = self.inner.open(range).instrument(span.clone()).await?;
         Ok((
             rp,
-            Box::new(TracingWrapper::new(self.span.clone(), stream)) as Box<dyn oio::ReadStreamDyn>,
+            Box::new(TracingWrapper::new(span, stream)) as Box<dyn oio::ReadStreamDyn>,
         ))
     }
 
     async fn read(&self, range: BytesRange) -> Result<(RpRead, Buffer)> {
-        self.inner.read(range).instrument(self.span.clone()).await
+        let span = span!(parent: &self.span, Level::DEBUG, "reader.read", range = %range);
+        self.inner.read(range).instrument(span).await
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

After moving raw read ranges to readers, a few docs and observability layers still described or observed the old range-scoped read shape. This PR keeps raw fetch out of the backend contract and makes reader-side IO observable with range context.

# What changes are included in this PR?

This updates the raw accessor docs and RFC-7660 text to describe `oio::Read` plus `StreamRead` / `PositionRead` adapters. It also propagates range information through logging, tracing, dtrace, and oteltrace reader wrappers, including streaming reads opened via `open(range)`.

# Are there any user-facing changes?

No public API changes. Observability output for reader-side streaming reads now includes range context where supported.

# AI Usage Statement

AI-assisted with GPT-5.
