### PR TITLE
ci: update rustdoc toolchain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,8 +41,8 @@ concurrency:
 env:
   # This is the toolchain used by docs.rs
   #
-  # Check this page for updating: https://docs.rs/crate/opendal/0.54.1/builds
-  RUST_DOC_TOOLCHAIN: nightly-2025-10-12
+  # Check this page for updating: https://docs.rs/crate/opendal/latest/builds
+  RUST_DOC_TOOLCHAIN: nightly-2026-04-30
   # Enable cfg docsrs to make sure docs are built.
   RUSTDOCFLAGS: "--cfg docsrs"
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

The docs workflow currently pins `RUST_DOC_TOOLCHAIN` to `nightly-2025-10-12`, which can no longer build the updated `compio-buf` dependency because `MaybeUninit` slice initialization APIs were still unstable in that nightly.

This updates the pinned rustdoc toolchain to match the current docs.rs toolchain used by OpenDAL builds.

# What changes are included in this PR?

This PR updates the docs workflow rustdoc toolchain to `nightly-2026-04-30` and refreshes the docs.rs build reference URL.

# Are there any user-facing changes?

No.

# AI Usage Statement

AI-assisted by OpenAI GPT-5.
