### PR TITLE
fix(services/memcached): TCP address resolution

### DIFF
--- a/core/services/memcached/src/core.rs
+++ b/core/services/memcached/src/core.rs
@@ -219,3 +219,56 @@ impl MemcachedCore {
         conn.delete(&percent_encode_path(key)).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn connect_tcp_socket() -> std::io::Result<()> {
+        // Test both ip and localhost addresses to make sure that both can be parsed.
+        for addr in &["127.0.0.1:11211", "localhost:11211", "[::1]:11211"] {
+            let listener = TcpListener::bind(addr).await?;
+            let addr = listener.local_addr()?.to_string();
+
+            let accepted = tokio::spawn(async move {
+                let _ = listener.accept().await?;
+                Ok::<_, std::io::Error>(())
+            });
+
+            let _stream = SocketStream::connect_tcp(&addr).await?;
+            accepted.await.unwrap()?;
+        }
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn connect_unix_socket() -> std::io::Result<()> {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        use tokio::net::UnixListener;
+
+        let path = std::env::temp_dir().join(format!(
+            "opendal-memcached-{}.sock",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+
+        let listener = UnixListener::bind(&path)?;
+
+        let accepted = tokio::spawn(async move {
+            let _ = listener.accept().await?;
+            Ok::<_, std::io::Error>(())
+        });
+
+        let _stream = SocketStream::connect_unix(path.to_str().unwrap()).await?;
+        accepted.await.unwrap()?;
+
+        let _ = std::fs::remove_file(path);
+        Ok(())
+    }
+}

--- a/core/services/memcached/src/core.rs
+++ b/core/services/memcached/src/core.rs
@@ -23,7 +23,6 @@ use fastpool::bounded;
 use opendal_core::raw::*;
 use opendal_core::*;
 use std::io;
-use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
@@ -42,10 +41,7 @@ pub enum SocketStream {
 
 impl SocketStream {
     pub async fn connect_tcp(addr_str: &str) -> io::Result<Self> {
-        let socket_addr: SocketAddr = addr_str
-            .parse()
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-        let stream = TcpStream::connect(socket_addr).await?;
+        let stream = TcpStream::connect(addr_str).await?;
         Ok(SocketStream::Tcp(stream))
     }
 

--- a/core/services/memcached/src/core.rs
+++ b/core/services/memcached/src/core.rs
@@ -225,9 +225,11 @@ mod tests {
     use super::*;
     use tokio::net::TcpListener;
 
+    // regression test for connecting to a webdav server.
+    // Because setting up a dedicated behavior test is expensive, we choose to test `SocketStream::connect_tcp` instead.
+    // In the future, we could set up a webdav server to test TCP connection properly.
     #[tokio::test]
     async fn connect_tcp_socket() -> std::io::Result<()> {
-        // Test both ip and localhost addresses to make sure that both can be parsed.
         for addr in &["127.0.0.1:11211", "localhost:11211", "[::1]:11211"] {
             let listener = TcpListener::bind(addr).await?;
             let addr = listener.local_addr()?.to_string();
@@ -244,6 +246,9 @@ mod tests {
         Ok(())
     }
 
+    // regression test for connecting to a webdav server.
+    // Because setting up a dedicated behavior test is expensive, we choose to test `SocketStream::connect_unix` instead.
+    // In the future, we could set up a webdav server to test UNIX socket connection properly.
     #[cfg(unix)]
     #[tokio::test]
     async fn connect_unix_socket() -> std::io::Result<()> {


### PR DESCRIPTION
# Which issue does this PR close?

PR #7112 added support for Unix sockets to the memcached backend. As a side effect, it switched the TCP address parsing from being done inside of `TcpStream::connect` to `SocketAddr::parse`. The major difference is that `SocketAddr::parse` cannot resolve addresses like `localhost:1234`, as it errors out if it sees non-octal numbers in the address.

I didn't create an issue, but can do so if required. 

cc @zenyanle @tisonkun 

# Rationale for this change

#7112 claimed:

> Existing TCP configurations (e.g., `127.0.0.1:11211`) remain unaffected.

But it broke TCP configurations like `tcp://localhost:11211`.

So, this seemed like an unintended breaking change to me. I also can't see the benefit of doing that, as `TcpStream::connect` already calls `to_socket_addrs` internally.

# What changes are included in this PR?

Remove the additional and more restrictive `SocketAddr` parsing.

# Are there any user-facing changes?

This restores the behavior from before the 0.56.0 release. This is required to bump the opendal dependency in `sccache`: 

- https://github.com/mozilla/sccache/pull/2715, 

which fixes a transitive GCS issue that was fixed in opendal in version 0.56.0: 

- https://github.com/apache/opendal/issues/6553

# AI Usage Statement

I used Gemini to find the PR #7112 that introduced this change, but came up and implemented the fix myself.
