### PR TITLE
feat(services/obs): support if_modified_since and if_unmodified_since…

### DIFF
--- a/core/services/obs/src/backend.rs
+++ b/core/services/obs/src/backend.rs
@@ -206,6 +206,8 @@ impl Builder for ObsBuilder {
 
             read_with_if_match: true,
             read_with_if_none_match: true,
+            read_with_if_modified_since: true,
+            read_with_if_unmodified_since: true,
 
             write: true,
             write_can_empty: true,

--- a/core/services/obs/src/core.rs
+++ b/core/services/obs/src/core.rs
@@ -25,7 +25,9 @@ use http::header::CONTENT_DISPOSITION;
 use http::header::CONTENT_LENGTH;
 use http::header::CONTENT_TYPE;
 use http::header::IF_MATCH;
+use http::header::IF_MODIFIED_SINCE;
 use http::header::IF_NONE_MATCH;
+use http::header::IF_UNMODIFIED_SINCE;
 use opendal_core::raw::*;
 use opendal_core::*;
 use reqsign_core::{Context, Signer};
@@ -142,6 +144,14 @@ impl ObsCore {
 
         if let Some(if_none_match) = args.if_none_match() {
             req = req.header(IF_NONE_MATCH, if_none_match);
+        }
+
+        if let Some(if_modified_since) = args.if_modified_since() {
+            req = req.header(IF_MODIFIED_SINCE, if_modified_since.format_http_date());
+        }
+
+        if let Some(if_unmodified_since) = args.if_unmodified_since() {
+            req = req.header(IF_UNMODIFIED_SINCE, if_unmodified_since.format_http_date());
         }
 
         let req = req


### PR DESCRIPTION
# Which issue does this PR close?

Part of #5486.

# Rationale for this change

OBS read already wires `if_match` / `if_none_match` but ignores the date-based conditionals. OBS is S3-compatible and honors `If-Modified-Since` / `If-Unmodified-Since` on GET per RFC 7232. Other backends (s3, azblob, oss, cos, tos, swift, http, webdav, azdls) already wire them.

# What changes are included in this PR?

- Inject `If-Modified-Since` / `If-Unmodified-Since` in `obs_get_object_request`.
- Declare `read_with_if_modified_since`, `read_with_if_unmodified_since` on the obs service capability.

# Are there any user-facing changes?

`op.reader_with(...)` conditionals now work on obs backends. No breaking changes; existing capability-gated behavior tests auto-cover the new flags.

# AI Usage Statement

AI-assisted implementation.