### PR TITLE
Implement capability API rename

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -2014,6 +2014,11 @@ char *opendal_operator_info_get_root(const struct opendal_operator_info *self);
 char *opendal_operator_info_get_name(const struct opendal_operator_info *self);
 
 /**
+ * \brief Return the operator's capability
+ */
+struct opendal_capability opendal_operator_info_get_capability(const struct opendal_operator_info *self);
+
+/**
  * \brief Return the operator's full capability
  */
 struct opendal_capability opendal_operator_info_get_full_capability(const struct opendal_operator_info *self);

--- a/bindings/c/src/operator_info.rs
+++ b/bindings/c/src/operator_info.rs
@@ -238,12 +238,19 @@ impl opendal_operator_info {
             .into_raw()
     }
 
+    /// \brief Return the operator's capability
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_operator_info_get_capability(&self) -> opendal_capability {
+        let cap = self.deref().capability();
+        cap.into()
+    }
+
     /// \brief Return the operator's full capability
     #[no_mangle]
     pub unsafe extern "C" fn opendal_operator_info_get_full_capability(
         &self,
     ) -> opendal_capability {
-        let cap = self.deref().full_capability();
+        let cap = self.deref().capability();
         cap.into()
     }
 
@@ -252,6 +259,7 @@ impl opendal_operator_info {
     pub unsafe extern "C" fn opendal_operator_info_get_native_capability(
         &self,
     ) -> opendal_capability {
+        #[allow(deprecated)]
         let cap = self.deref().native_capability();
         cap.into()
     }

--- a/bindings/c/tests/example_test.cpp
+++ b/bindings/c/tests/example_test.cpp
@@ -56,7 +56,7 @@ void simple_test()
     // Test basic write/read if supported
     opendal_operator_info* info = opendal_operator_info_new(config->operator_instance);
     if (info) {
-        opendal_capability cap = opendal_operator_info_get_full_capability(info);
+        opendal_capability cap = opendal_operator_info_get_capability(info);
 
         if (cap.write && cap.read) {
             printf("Testing write/read operations...\n");

--- a/bindings/c/tests/opinfo.cpp
+++ b/bindings/c/tests/opinfo.cpp
@@ -60,7 +60,7 @@ protected:
 // We test the capability set by **memory** service.
 TEST_F(OpendalOperatorInfoTest, CapabilityTest)
 {
-    opendal_capability full_cap = opendal_operator_info_get_full_capability(this->info);
+    opendal_capability full_cap = opendal_operator_info_get_capability(this->info);
     opendal_capability native_cap = opendal_operator_info_get_native_capability(this->info);
 
     EXPECT_TRUE(full_cap.read);

--- a/bindings/c/tests/test_framework.cpp
+++ b/bindings/c/tests/test_framework.cpp
@@ -164,7 +164,7 @@ bool opendal_check_capability(const opendal_operator* op,
     if (!info)
         return false;
 
-    opendal_capability cap = opendal_operator_info_get_full_capability(info);
+    opendal_capability cap = opendal_operator_info_get_capability(info);
 
     bool result = true;
     if (required.stat && !cap.stat)

--- a/bindings/c/tests/test_runner.cpp
+++ b/bindings/c/tests/test_runner.cpp
@@ -169,7 +169,7 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    opendal_capability cap = opendal_operator_info_get_full_capability(info);
+    opendal_capability cap = opendal_operator_info_get_capability(info);
 
     // Check operator availability - only perform list-based check if list is supported
     if (cap.list) {

--- a/bindings/c/tests/test_suites_basic.cpp
+++ b/bindings/c/tests/test_suites_basic.cpp
@@ -26,7 +26,7 @@ void test_check(opendal_test_context* ctx)
     opendal_operator_info* info = opendal_operator_info_new(ctx->config->operator_instance);
     OPENDAL_ASSERT_NOT_NULL(info, "Should be able to get operator info");
 
-    opendal_capability cap = opendal_operator_info_get_full_capability(info);
+    opendal_capability cap = opendal_operator_info_get_capability(info);
 
     if (cap.list) {
         // Only perform the standard check if list operations are supported

--- a/bindings/c/tests/test_suites_presign.cpp
+++ b/bindings/c/tests/test_suites_presign.cpp
@@ -661,7 +661,7 @@ void test_presign_delete(opendal_test_context* ctx)
 {
     opendal_operator_info* info = opendal_operator_info_new(ctx->config->operator_instance);
     OPENDAL_ASSERT_NOT_NULL(info, "Operator info should not be null");
-    opendal_capability cap = opendal_operator_info_get_full_capability(info);
+    opendal_capability cap = opendal_operator_info_get_capability(info);
     opendal_operator_info_free(info);
     if (!cap.presign_delete) {
         return;

--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -259,7 +259,7 @@ impl Operator {
 
     fn info(&self) -> Result<ffi::Capability> {
         let info = self.0.info();
-        let cap = info.full_capability();
+        let cap = info.capability();
 
         Ok(ffi::Capability {
             stat: cap.stat,

--- a/bindings/dotnet/OpenDAL.Tests/Behavior/BehaviorOperatorFixture.cs
+++ b/bindings/dotnet/OpenDAL.Tests/Behavior/BehaviorOperatorFixture.cs
@@ -57,7 +57,7 @@ public sealed class BehaviorOperatorFixture : IDisposable
             op = op.WithLayer(new CapabilityOverrideLayer(capabilityOverrides));
         }
 
-        capability = op.Info.FullCapability;
+        capability = op.Info.Capability;
     }
 
     public bool IsEnabled => op is not null;

--- a/bindings/dotnet/OpenDAL.Tests/OperatorInfoTest.cs
+++ b/bindings/dotnet/OpenDAL.Tests/OperatorInfoTest.cs
@@ -35,8 +35,8 @@ public class OperatorInfoTest
         var info = op.Info;
 
         Assert.Equal("memory", info.Scheme);
-        Assert.True(info.FullCapability.Read);
-        Assert.True(info.FullCapability.Write);
+        Assert.True(info.Capability.Read);
+        Assert.True(info.Capability.Write);
     }
 
     [Fact]
@@ -56,8 +56,8 @@ public class OperatorInfoTest
             var info = op.Info;
 
             Assert.Equal("fs", info.Scheme);
-            Assert.True(info.FullCapability.Read);
-            Assert.True(info.FullCapability.Write);
+            Assert.True(info.Capability.Read);
+            Assert.True(info.Capability.Write);
         }
         finally
         {

--- a/bindings/dotnet/OpenDAL/Interop/Marshalling/OperatorInfoMarshaller.cs
+++ b/bindings/dotnet/OpenDAL/Interop/Marshalling/OperatorInfoMarshaller.cs
@@ -55,7 +55,7 @@ internal static class OperatorInfoMarshaller
             Utilities.ReadUtf8(payload.Scheme),
             Utilities.ReadUtf8(payload.Root),
             Utilities.ReadUtf8(payload.Name),
-            new Capability(payload.FullCapability),
+            new Capability(payload.Capability),
             new Capability(payload.NativeCapability)
         );
     }

--- a/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALOperatorInfo.cs
+++ b/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALOperatorInfo.cs
@@ -33,7 +33,7 @@ internal struct OpenDALOperatorInfo
 
     public IntPtr Name;
 
-    public OpenDALCapability FullCapability;
+    public OpenDALCapability Capability;
 
     public OpenDALCapability NativeCapability;
 }

--- a/bindings/dotnet/OpenDAL/Layer/CapabilityOverrideLayer.cs
+++ b/bindings/dotnet/OpenDAL/Layer/CapabilityOverrideLayer.cs
@@ -22,7 +22,7 @@ using OpenDAL.Layer.Abstractions;
 namespace OpenDAL.Layer;
 
 /// <summary>
-/// Layer that overrides the full capability exposed by an operator.
+/// Layer that overrides the effective capability exposed by an operator.
 /// </summary>
 public sealed class CapabilityOverrideLayer : ILayer
 {

--- a/bindings/dotnet/OpenDAL/OperatorInfo.cs
+++ b/bindings/dotnet/OpenDAL/OperatorInfo.cs
@@ -40,21 +40,28 @@ public sealed class OperatorInfo
     public string Name { get; }
 
     /// <summary>
+    /// Gets the capability of this operator.
+    /// </summary>
+    public Capability Capability { get; }
+
+    /// <summary>
     /// Gets the full capability of this operator.
     /// </summary>
-    public Capability FullCapability { get; }
+    [Obsolete("Use Capability.")]
+    public Capability FullCapability => Capability;
 
     /// <summary>
     /// Gets the native capability of this operator.
     /// </summary>
+    [Obsolete("NativeCapability is not intended for availability checks. Use Capability.")]
     public Capability NativeCapability { get; }
 
-    internal OperatorInfo(string scheme, string root, string name, Capability fullCapability, Capability nativeCapability)
+    internal OperatorInfo(string scheme, string root, string name, Capability capability, Capability nativeCapability)
     {
         Scheme = scheme;
         Root = root;
         Name = name;
-        FullCapability = fullCapability;
+        Capability = capability;
         NativeCapability = nativeCapability;
     }
 }

--- a/bindings/dotnet/README.md
+++ b/bindings/dotnet/README.md
@@ -235,10 +235,10 @@ catch (OpenDALException ex) when (ex.Code == ErrorCode.NotFound)
 }
 ```
 
-Some features depend on backend capability. Check `op.Info.FullCapability` before using optional options/features:
+Some features depend on backend capability. Check `op.Info.Capability` before using optional options/features:
 
 ```csharp
-var cap = op.Info.FullCapability;
+var cap = op.Info.Capability;
 if (cap.PresignRead)
 {
 	var req = await op.PresignReadAsync("a.txt", TimeSpan.FromMinutes(5));

--- a/bindings/dotnet/src/operator_info.rs
+++ b/bindings/dotnet/src/operator_info.rs
@@ -25,16 +25,19 @@ pub struct OpendalOperatorInfo {
     pub scheme: *mut c_char,
     pub root: *mut c_char,
     pub name: *mut c_char,
-    pub full_capability: Capability,
+    pub capability: Capability,
     pub native_capability: Capability,
 }
 
 pub fn into_operator_info(info: opendal::OperatorInfo) -> OpendalOperatorInfo {
+    #[allow(deprecated)]
+    let native_capability = info.native_capability();
+
     OpendalOperatorInfo {
         scheme: into_string_ptr(info.scheme().to_string()),
         root: into_string_ptr(info.root()),
         name: into_string_ptr(info.name()),
-        full_capability: Capability::new(info.full_capability()),
-        native_capability: Capability::new(info.native_capability()),
+        capability: Capability::new(info.capability()),
+        native_capability: Capability::new(native_capability),
     }
 }

--- a/bindings/go/operator_info.go
+++ b/bindings/go/operator_info.go
@@ -41,7 +41,7 @@ func (op *Operator) Info() *OperatorInfo {
 		scheme:    ffiOperatorInfoGetScheme.symbol(op.ctx)(inner),
 		root:      ffiOperatorInfoGetRoot.symbol(op.ctx)(inner),
 		name:      ffiOperatorInfoGetName.symbol(op.ctx)(inner),
-		fullCap:   &Capability{inner: ffiOperatorInfoGetFullCapability.symbol(op.ctx)(inner)},
+		cap:       &Capability{inner: ffiOperatorInfoGetCapability.symbol(op.ctx)(inner)},
 		nativeCap: &Capability{inner: ffiOperatorInfoGetNativeCapability.symbol(op.ctx)(inner)},
 	}
 }
@@ -55,12 +55,16 @@ type OperatorInfo struct {
 	scheme    string
 	root      string
 	name      string
-	fullCap   *Capability
+	cap       *Capability
 	nativeCap *Capability
 }
 
+func (i *OperatorInfo) GetCapability() *Capability {
+	return i.cap
+}
+
 func (i *OperatorInfo) GetFullCapability() *Capability {
-	return i.fullCap
+	return i.cap
 }
 
 func (i *OperatorInfo) GetNativeCapability() *Capability {
@@ -335,8 +339,8 @@ var ffiOperatorInfoFree = newFFI(ffiOpts{
 	}
 })
 
-var ffiOperatorInfoGetFullCapability = newFFI(ffiOpts{
-	sym:    "opendal_operator_info_get_full_capability",
+var ffiOperatorInfoGetCapability = newFFI(ffiOpts{
+	sym:    "opendal_operator_info_get_capability",
 	rType:  &typeCapability,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
 }, func(ctx context.Context, ffiCall ffiCall) func(info *opendalOperatorInfo) *opendalCapability {
@@ -349,6 +353,8 @@ var ffiOperatorInfoGetFullCapability = newFFI(ffiOpts{
 		return &cap
 	}
 })
+
+var ffiOperatorInfoGetFullCapability = ffiOperatorInfoGetCapability
 
 var ffiOperatorInfoGetNativeCapability = newFFI(ffiOpts{
 	sym:    "opendal_operator_info_get_native_capability",

--- a/bindings/go/operator_info.go
+++ b/bindings/go/operator_info.go
@@ -354,8 +354,6 @@ var ffiOperatorInfoGetCapability = newFFI(ffiOpts{
 	}
 })
 
-var ffiOperatorInfoGetFullCapability = ffiOperatorInfoGetCapability
-
 var ffiOperatorInfoGetNativeCapability = newFFI(ffiOpts{
 	sym:    "opendal_operator_info_get_native_capability",
 	rType:  &typeCapability,

--- a/bindings/go/string_ownership_test.go
+++ b/bindings/go/string_ownership_test.go
@@ -89,7 +89,7 @@ func TestOperatorInfoCopiesAndFreesOwnedStrings(t *testing.T) {
 		assertOperatorInfoPointer(t, infoInner, aValues...)
 		*(**byte)(rValue) = namePtr
 	}))
-	ctx = context.WithValue(ctx, ffiOperatorInfoGetFullCapability.opts.sym, func(info *opendalOperatorInfo) *opendalCapability {
+	ctx = context.WithValue(ctx, ffiOperatorInfoGetCapability.opts.sym, func(info *opendalOperatorInfo) *opendalCapability {
 		if info != infoInner {
 			t.Fatalf("Info() requested full capability for unexpected operator info: %p", info)
 		}
@@ -117,8 +117,8 @@ func TestOperatorInfoCopiesAndFreesOwnedStrings(t *testing.T) {
 	if info.GetName() != "namespace" {
 		t.Fatalf("Info().GetName() = %q, want namespace", info.GetName())
 	}
-	if !info.GetFullCapability().Stat() {
-		t.Fatal("Info().GetFullCapability().Stat() = false, want true")
+	if !info.GetCapability().Stat() {
+		t.Fatal("Info().GetCapability().Stat() = false, want true")
 	}
 	if !info.GetNativeCapability().List() {
 		t.Fatal("Info().GetNativeCapability().List() = false, want true")

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -73,8 +73,10 @@ fn make_operator_info<'a>(env: &mut JNIEnv<'a>, info: OperatorInfo) -> Result<JO
     let scheme = env.new_string(info.scheme().to_string())?;
     let root = env.new_string(info.root().to_string())?;
     let name = env.new_string(info.name().to_string())?;
-    let full_capability_obj = make_capability(env, info.full_capability())?;
-    let native_capability_obj = make_capability(env, info.native_capability())?;
+    let capability_obj = make_capability(env, info.capability())?;
+    #[allow(deprecated)]
+    let native_capability = info.native_capability();
+    let native_capability_obj = make_capability(env, native_capability)?;
 
     let result = env
         .new_object(
@@ -84,7 +86,7 @@ fn make_operator_info<'a>(env: &mut JNIEnv<'a>, info: OperatorInfo) -> Result<JO
                 JValue::Object(&scheme),
                 JValue::Object(&root),
                 JValue::Object(&name),
-                JValue::Object(&full_capability_obj),
+                JValue::Object(&capability_obj),
                 JValue::Object(&native_capability_obj),
             ],
         )?;

--- a/bindings/java/src/main/java/org/apache/opendal/OperatorInfo.java
+++ b/bindings/java/src/main/java/org/apache/opendal/OperatorInfo.java
@@ -28,8 +28,10 @@ public class OperatorInfo {
     public final String root;
     public final String name;
     public final Capability capability;
+
     @Deprecated
     public final Capability fullCapability;
+
     @Deprecated
     public final Capability nativeCapability;
 

--- a/bindings/java/src/main/java/org/apache/opendal/OperatorInfo.java
+++ b/bindings/java/src/main/java/org/apache/opendal/OperatorInfo.java
@@ -27,19 +27,23 @@ public class OperatorInfo {
     public final String scheme;
     public final String root;
     public final String name;
+    public final Capability capability;
+    @Deprecated
     public final Capability fullCapability;
+    @Deprecated
     public final Capability nativeCapability;
 
     public OperatorInfo(
             @NonNull String scheme,
             @NonNull String root,
             @NonNull String name,
-            @NonNull Capability fullCapability,
+            @NonNull Capability capability,
             @NonNull Capability nativeCapability) {
         this.scheme = scheme;
         this.root = root;
         this.name = name;
-        this.fullCapability = fullCapability;
+        this.capability = capability;
+        this.fullCapability = capability;
         this.nativeCapability = nativeCapability;
     }
 }

--- a/bindings/java/src/test/java/org/apache/opendal/test/OperatorInfoTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/OperatorInfoTest.java
@@ -43,13 +43,13 @@ public class OperatorInfoTest {
             assertThat(info).isNotNull();
             assertThat(info.scheme).isEqualTo("fs");
 
-            assertThat(info.fullCapability).isNotNull();
-            assertThat(info.fullCapability.read).isTrue();
-            assertThat(info.fullCapability.write).isTrue();
-            assertThat(info.fullCapability.delete).isTrue();
-            assertThat(info.fullCapability.writeCanAppend).isTrue();
-            assertThat(info.fullCapability.writeMultiMaxSize).isEqualTo(-1);
-            assertThat(info.fullCapability.writeMultiMinSize).isEqualTo(-1);
+            assertThat(info.capability).isNotNull();
+            assertThat(info.capability.read).isTrue();
+            assertThat(info.capability.write).isTrue();
+            assertThat(info.capability.delete).isTrue();
+            assertThat(info.capability.writeCanAppend).isTrue();
+            assertThat(info.capability.writeMultiMaxSize).isEqualTo(-1);
+            assertThat(info.capability.writeMultiMinSize).isEqualTo(-1);
 
             assertThat(info.nativeCapability).isNotNull();
         }
@@ -64,13 +64,13 @@ public class OperatorInfoTest {
             assertThat(info).isNotNull();
             assertThat(info.scheme).isEqualTo("memory");
 
-            assertThat(info.fullCapability).isNotNull();
-            assertThat(info.fullCapability.read).isTrue();
-            assertThat(info.fullCapability.write).isTrue();
-            assertThat(info.fullCapability.delete).isTrue();
-            assertThat(info.fullCapability.writeCanAppend).isFalse();
-            assertThat(info.fullCapability.writeMultiMaxSize).isEqualTo(-1);
-            assertThat(info.fullCapability.writeMultiMinSize).isEqualTo(-1);
+            assertThat(info.capability).isNotNull();
+            assertThat(info.capability.read).isTrue();
+            assertThat(info.capability.write).isTrue();
+            assertThat(info.capability.delete).isTrue();
+            assertThat(info.capability.writeCanAppend).isFalse();
+            assertThat(info.capability.writeMultiMaxSize).isEqualTo(-1);
+            assertThat(info.capability.writeMultiMinSize).isEqualTo(-1);
 
             assertThat(info.nativeCapability).isNotNull();
         }

--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -99,7 +99,7 @@ impl Operator {
     #[napi]
     pub fn capability(&self) -> Result<capability::Capability> {
         Ok(capability::Capability::new(
-            self.async_op.info().full_capability(),
+            self.async_op.info().capability(),
         ))
     }
 

--- a/bindings/ocaml/src/operator/mod.rs
+++ b/bindings/ocaml/src/operator/mod.rs
@@ -173,5 +173,5 @@ pub fn operator_info(operator: &mut Operator) -> ocaml::Pointer<OperatorInfo> {
 #[ocaml::func]
 #[ocaml::sig("operator_info -> capability ")]
 pub fn operator_info_capability(info: &mut OperatorInfo) -> ocaml::Pointer<Capability> {
-    Capability(info.0.full_capability()).into()
+    Capability(info.0.capability()).into()
 }

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -673,7 +673,7 @@ impl Operator {
     ///     The capability of the operator.
     pub fn capability(&self) -> PyResult<capability::Capability> {
         Ok(capability::Capability::new(
-            self.core.info().full_capability(),
+            self.core.info().capability(),
         ))
     }
 
@@ -1783,7 +1783,7 @@ impl AsyncOperator {
     ///     The capability of the operator.
     pub fn capability(&self) -> PyResult<Capability> {
         Ok(capability::Capability::new(
-            self.core.info().full_capability(),
+            self.core.info().capability(),
         ))
     }
 

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -672,9 +672,7 @@ impl Operator {
     /// Capability
     ///     The capability of the operator.
     pub fn capability(&self) -> PyResult<capability::Capability> {
-        Ok(capability::Capability::new(
-            self.core.info().capability(),
-        ))
+        Ok(capability::Capability::new(self.core.info().capability()))
     }
 
     /// Check if the operator is able to work correctly.
@@ -1782,9 +1780,7 @@ impl AsyncOperator {
     /// Capability
     ///     The capability of the operator.
     pub fn capability(&self) -> PyResult<Capability> {
-        Ok(capability::Capability::new(
-            self.core.info().capability(),
-        ))
+        Ok(capability::Capability::new(self.core.info().capability()))
     }
 
     /// Create a new blocking `Operator` from this async operator.

--- a/bindings/ruby/src/operator.rs
+++ b/bindings/ruby/src/operator.rs
@@ -140,7 +140,7 @@ impl Operator {
     /// Gets capabilities of the current operator
     /// @return [Capability]
     fn capability(&self) -> Result<Capability, Error> {
-        let capability = self.blocking_op.info().full_capability();
+        let capability = self.blocking_op.info().capability();
         Ok(Capability::new(capability))
     }
 

--- a/bindings/ruby/src/operator_info.rs
+++ b/bindings/ruby/src/operator_info.rs
@@ -68,7 +68,7 @@ impl OperatorInfo {
     /// Returns the [`Full Capability`] of the operator.
     /// @return [Capability]
     pub fn capability(&self) -> Capability {
-        Capability::new(self.0.full_capability())
+        Capability::new(self.0.capability())
     }
 }
 

--- a/bindings/zig/src/opendal.zig
+++ b/bindings/zig/src/opendal.zig
@@ -145,8 +145,12 @@ pub const OperatorInfo = struct {
         return std.mem.span(ptr);
     }
 
+    pub fn capability(self: *const OperatorInfo) c.opendal_capability {
+        return c.opendal_operator_info_get_capability(self.inner);
+    }
+
     pub fn fullCapability(self: *const OperatorInfo) c.opendal_capability {
-        return c.opendal_operator_info_get_full_capability(self.inner);
+        return self.capability();
     }
 
     pub fn nativeCapability(self: *const OperatorInfo) c.opendal_capability {

--- a/core/core/src/docs/internals/accessor.rs
+++ b/core/core/src/docs/internals/accessor.rs
@@ -92,13 +92,13 @@
 //! - Most APIs accept `path` and `OpXxx`, and returns `RpXxx`.
 //! - Most APIs have `async` and `blocking` variants, they share the same semantics but may have different underlying implementations.
 //!
-//! [`Access`] can declare their capabilities via [`AccessorInfo`]'s `set_native_capability`:
+//! [`Access`] can declare their capabilities via [`AccessorInfo`]'s `set_service_capability`:
 //!
 //! ```ignore
 //! impl Access for MyBackend {
 //!     fn info(&self) -> Arc<AccessorInfo> {
 //!         let am = AccessorInfo::default();
-//!         am.set_native_capability(
+//!         am.set_service_capability(
 //!             Capability {
 //!                 read: true,
 //!                 write: true,
@@ -274,7 +274,7 @@
 //!         let am = AccessorInfo::default();
 //!         am.set_scheme(DUCK_SCHEME)
 //!             .set_root(&self.root)
-//!             .set_native_capability(
+//!             .set_service_capability(
 //!                 Capability {
 //!                     read: true,
 //!                     ..Default::default()

--- a/core/core/src/docs/upgrade.md
+++ b/core/core/src/docs/upgrade.md
@@ -26,6 +26,27 @@ Out-of-tree raw services and layers that implement copy must migrate to the new 
 
 HTTP metrics emitted by the metrics layers now include a `service_operation` label for backend-specific request names such as `GetObject` or `UploadPart`. Metrics consumers and dashboards that assume the previous HTTP metric label set must be updated.
 
+### Capability APIs renamed
+
+`OperatorInfo::capability()` now returns the effective capability of the current operator. Use it to decide whether an operation or option is available.
+
+```diff
+- let cap = op.info().full_capability();
++ let cap = op.info().capability();
+```
+
+`full_capability()` remains as a deprecated compatibility alias. `native_capability()` is also deprecated for user-facing availability checks.
+
+Raw service and layer implementations should use the new service/effective capability names:
+
+```diff
+- info.set_native_capability(cap);
++ info.set_service_capability(cap);
+
+- info.update_full_capability(|cap| cap);
++ info.update_capability(|cap| cap);
+```
+
 ## Raw API
 
 ### `RpRead` carries optional `Metadata`
@@ -169,8 +190,8 @@ op.write_options("path/to/file", data, options).await?;
 All `stat_has_*` and `list_has_*` capability check APIs have been removed. Instead, check capabilities directly on the `Capability` struct:
 
 ```diff
-- if op.info().full_capability().stat_has_content_length() {
-+ if op.info().full_capability().stat.content_length {
+- if op.info().capability().stat_has_content_length() {
++ if op.info().capability().stat.content_length {
     // ...
 }
 ```

--- a/core/core/src/layers/capability_override.rs
+++ b/core/core/src/layers/capability_override.rs
@@ -25,13 +25,13 @@ use serde_json::Value;
 use crate::raw::*;
 use crate::*;
 
-/// Layer for overriding an accessor's full capability.
+/// Layer for overriding an accessor's effective capability.
 ///
 /// This layer updates [`Capability`] exposed by
-/// [`OperatorInfo::full_capability`][crate::OperatorInfo::full_capability]
-/// without changing the accessor's native capability. It is useful when the
-/// backend implementation supports a capability, but the specific endpoint or
-/// test setup needs to disable or tune it.
+/// [`OperatorInfo::capability`][crate::OperatorInfo::capability] without
+/// changing the accessor's service capability. It is useful when the service
+/// implementation supports a capability, but the specific endpoint or test
+/// setup needs to disable or tune it.
 ///
 /// # Examples
 ///
@@ -92,7 +92,7 @@ impl<A: Access> Layer<A> for CapabilityOverrideLayer {
     fn layer(&self, inner: A) -> Self::LayeredAccess {
         let info = inner.info();
         let apply = self.apply.clone();
-        info.update_full_capability(|cap| apply(cap));
+        info.update_capability(|cap| apply(cap));
         inner
     }
 }
@@ -192,7 +192,7 @@ mod tests {
     use crate::services;
 
     #[test]
-    fn capability_override_updates_full_capability_only() -> Result<()> {
+    fn capability_override_updates_capability_only() -> Result<()> {
         let op = Operator::new(services::Memory::default())?
             .layer(CapabilityOverrideLayer::new(|mut cap| {
                 cap.read = false;
@@ -200,14 +200,15 @@ mod tests {
                 cap
             }))
             .finish();
+        let info = op.inner().info();
 
-        assert!(!op.info().full_capability().read);
-        assert_eq!(op.info().full_capability().delete_max_size, Some(7));
+        assert!(!op.info().capability().read);
+        assert_eq!(op.info().capability().delete_max_size, Some(7));
 
-        assert!(op.info().native_capability().read);
+        assert!(info.service_capability().read);
         assert_ne!(
-            op.info().native_capability().delete_max_size,
-            op.info().full_capability().delete_max_size
+            info.service_capability().delete_max_size,
+            op.info().capability().delete_max_size
         );
 
         Ok(())
@@ -222,9 +223,9 @@ mod tests {
             .layer(layer)
             .finish();
 
-        assert!(!op.info().full_capability().read);
-        assert!(op.info().full_capability().write_can_append);
-        assert_eq!(op.info().full_capability().delete_max_size, Some(7));
+        assert!(!op.info().capability().read);
+        assert!(op.info().capability().write_can_append);
+        assert_eq!(op.info().capability().delete_max_size, Some(7));
 
         Ok(())
     }
@@ -237,9 +238,9 @@ mod tests {
             .layer(layer)
             .finish();
 
-        assert!(!op.info().full_capability().read);
-        assert!(op.info().full_capability().write);
-        assert_eq!(op.info().full_capability().delete_max_size, None);
+        assert!(!op.info().capability().read);
+        assert!(op.info().capability().write);
+        assert_eq!(op.info().capability().delete_max_size, None);
 
         Ok(())
     }

--- a/core/core/src/layers/correctness_check.rs
+++ b/core/core/src/layers/correctness_check.rs
@@ -92,7 +92,7 @@ impl<A: Access> LayeredAccess for CorrectnessAccessor<A> {
     }
 
     async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
-        let capability = self.info.full_capability();
+        let capability = self.info.capability();
         if !capability.read_with_version && args.version().is_some() {
             return Err(new_unsupported_error(
                 self.info.as_ref(),
@@ -133,7 +133,7 @@ impl<A: Access> LayeredAccess for CorrectnessAccessor<A> {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        let capability = self.info.full_capability();
+        let capability = self.info.capability();
         if args.append() && !capability.write_can_append {
             return Err(new_unsupported_error(
                 &self.info,
@@ -171,7 +171,7 @@ impl<A: Access> LayeredAccess for CorrectnessAccessor<A> {
     }
 
     async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        let capability = self.info.full_capability();
+        let capability = self.info.capability();
         if !capability.stat_with_version && args.version().is_some() {
             return Err(new_unsupported_error(
                 self.info.as_ref(),
@@ -225,7 +225,7 @@ impl<A: Access> LayeredAccess for CorrectnessAccessor<A> {
         args: OpCopy,
         opts: OpCopier,
     ) -> Result<(RpCopy, Self::Copier)> {
-        let capability = self.info.full_capability();
+        let capability = self.info.capability();
         if args.if_not_exists() && !capability.copy_with_if_not_exists {
             return Err(new_unsupported_error(
                 &self.info,
@@ -267,7 +267,7 @@ impl<T> CheckWrapper<T> {
     }
 
     fn check_delete(&self, args: &OpDelete) -> Result<()> {
-        if args.version().is_some() && !self.info.full_capability().delete_with_version {
+        if args.version().is_some() && !self.info.capability().delete_with_version {
             return Err(new_unsupported_error(
                 &self.info,
                 Operation::Delete,
@@ -275,7 +275,7 @@ impl<T> CheckWrapper<T> {
             ));
         }
 
-        if args.recursive() && !self.info.full_capability().delete_with_recursive {
+        if args.recursive() && !self.info.capability().delete_with_recursive {
             return Err(new_unsupported_error(
                 &self.info,
                 Operation::Delete,
@@ -322,7 +322,7 @@ mod tests {
         fn info(&self) -> Arc<AccessorInfo> {
             let info = AccessorInfo::default();
             info.set_scheme("memory");
-            info.set_native_capability(self.capability);
+            info.set_service_capability(self.capability);
 
             info.into()
         }

--- a/core/core/src/layers/simulate.rs
+++ b/core/core/src/layers/simulate.rs
@@ -76,7 +76,7 @@ impl<A: Access> Layer<A> for SimulateLayer {
 
     fn layer(&self, inner: A) -> Self::LayeredAccess {
         let info = inner.info();
-        info.update_full_capability(|mut cap| {
+        info.update_capability(|mut cap| {
             if self.create_dir && cap.list && cap.write_can_empty {
                 cap.create_dir = true;
             }
@@ -109,7 +109,7 @@ impl<A: Access> Debug for SimulateAccessor<A> {
 
 impl<A: Access> SimulateAccessor<A> {
     async fn simulate_create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
-        let capability = self.info.native_capability();
+        let capability = self.info.service_capability();
 
         if capability.create_dir || !self.config.create_dir {
             return self.inner().create_dir(path, args).await;
@@ -125,7 +125,7 @@ impl<A: Access> SimulateAccessor<A> {
     }
 
     async fn simulate_stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
-        let capability = self.info.native_capability();
+        let capability = self.info.service_capability();
 
         if path == "/" {
             return Ok(RpStat::new(Metadata::new(EntryMode::DIR)));
@@ -170,7 +170,7 @@ impl<A: Access> SimulateAccessor<A> {
         path: &str,
         args: OpList,
     ) -> Result<(RpList, SimulateLister<A, A::Lister>)> {
-        let cap = self.info.native_capability();
+        let cap = self.info.service_capability();
 
         let recursive = args.recursive();
         let forward = args;
@@ -225,7 +225,7 @@ impl<A: Access> SimulateAccessor<A> {
         path: &str,
         args: OpDelete,
     ) -> Result<()> {
-        if !self.info.full_capability().delete_with_recursive {
+        if !self.info.capability().delete_with_recursive {
             return Err(Error::new(
                 ErrorKind::Unsupported,
                 "recursive delete is not supported",
@@ -331,7 +331,7 @@ impl<A: Access, D> SimulateDeleter<A, D> {
 impl<A: Access, D: oio::Delete> oio::Delete for SimulateDeleter<A, D> {
     async fn delete(&mut self, path: &str, args: OpDelete) -> Result<()> {
         if args.recursive() {
-            let cap = self.accessor.info.native_capability();
+            let cap = self.accessor.info.service_capability();
 
             if cap.delete_with_recursive {
                 return self.deleter.delete(path, args).await;

--- a/core/core/src/raw/accessor.rs
+++ b/core/core/src/raw/accessor.rs
@@ -467,7 +467,7 @@ impl Access for () {
         ai.set_scheme("dummy")
             .set_root("")
             .set_name("dummy")
-            .set_native_capability(Capability::default());
+            .set_service_capability(Capability::default());
         ai.into()
     }
 }
@@ -565,8 +565,8 @@ struct AccessorInfoInner {
     root: Arc<str>,
     name: Arc<str>,
 
-    native_capability: Capability,
-    full_capability: Capability,
+    service_capability: Capability,
+    capability: Capability,
 
     http_client: HttpClient,
     executor: Executor,
@@ -578,8 +578,8 @@ impl Default for AccessorInfoInner {
             scheme: "unknown",
             root: Arc::from(""),
             name: Arc::from(""),
-            native_capability: Capability::default(),
-            full_capability: Capability::default(),
+            service_capability: Capability::default(),
+            capability: Capability::default(),
             http_client: HttpClient::default(),
             executor: Executor::default(),
         }
@@ -744,66 +744,90 @@ impl AccessorInfo {
         self
     }
 
-    /// Get backend's native capabilities.
+    /// Get service-declared capabilities.
     ///
     /// # Panic Safety
     ///
     /// This method safely handles lock poisoning scenarios. If the inner `RwLock` is poisoned,
-    /// this method will gracefully continue execution by simply returning the current native capability.
-    pub fn native_capability(&self) -> Capability {
+    /// this method will gracefully continue execution by simply returning the current service capability.
+    pub fn service_capability(&self) -> Capability {
         match self.inner.read() {
-            Ok(v) => v.native_capability,
-            Err(err) => err.get_ref().native_capability,
+            Ok(v) => v.service_capability,
+            Err(err) => err.get_ref().service_capability,
         }
     }
 
-    /// Set native capabilities for service.
+    /// Set service-declared capabilities.
     ///
     /// # NOTES
     ///
-    /// Set native capability will also flush the full capability. The only way to change
-    /// full_capability is via `update_full_capability`.
+    /// Setting service capability will also reset the effective capability. The only way to
+    /// change effective capability after this is via `update_capability`.
     ///
     /// # Panic Safety
     ///
     /// This method safely handles lock poisoning scenarios. If the inner `RwLock` is poisoned,
     /// this method will gracefully continue execution by simply skipping the update operation
     /// rather than propagating the panic.
-    pub fn set_native_capability(&self, capability: Capability) -> &Self {
+    pub fn set_service_capability(&self, capability: Capability) -> &Self {
         if let Ok(mut v) = self.inner.write() {
-            v.native_capability = capability;
-            v.full_capability = capability;
+            v.service_capability = capability;
+            v.capability = capability;
         }
 
         self
+    }
+
+    /// Get effective capabilities.
+    ///
+    /// # Panic Safety
+    ///
+    /// This method safely handles lock poisoning scenarios. If the inner `RwLock` is poisoned,
+    /// this method will gracefully continue execution by simply returning the current capability.
+    pub fn capability(&self) -> Capability {
+        match self.inner.read() {
+            Ok(v) => v.capability,
+            Err(err) => err.get_ref().capability,
+        }
+    }
+
+    /// Update effective capabilities.
+    ///
+    /// # Panic Safety
+    ///
+    /// This method safely handles lock poisoning scenarios. If the inner `RwLock` is poisoned,
+    /// this method will gracefully continue execution by simply skipping the update operation
+    /// rather than propagating the panic.
+    pub fn update_capability(&self, f: impl FnOnce(Capability) -> Capability) -> &Self {
+        if let Ok(mut v) = self.inner.write() {
+            v.capability = f(v.capability);
+        }
+
+        self
+    }
+
+    /// Get backend's native capabilities.
+    #[deprecated(note = "use service_capability()")]
+    pub fn native_capability(&self) -> Capability {
+        self.service_capability()
+    }
+
+    /// Set native capabilities for service.
+    #[deprecated(note = "use set_service_capability()")]
+    pub fn set_native_capability(&self, capability: Capability) -> &Self {
+        self.set_service_capability(capability)
     }
 
     /// Get service's full capabilities.
-    ///
-    /// # Panic Safety
-    ///
-    /// This method safely handles lock poisoning scenarios. If the inner `RwLock` is poisoned,
-    /// this method will gracefully continue execution by simply returning the current native capability.
+    #[deprecated(note = "use capability()")]
     pub fn full_capability(&self) -> Capability {
-        match self.inner.read() {
-            Ok(v) => v.full_capability,
-            Err(err) => err.get_ref().full_capability,
-        }
+        self.capability()
     }
 
     /// Update service's full capabilities.
-    ///
-    /// # Panic Safety
-    ///
-    /// This method safely handles lock poisoning scenarios. If the inner `RwLock` is poisoned,
-    /// this method will gracefully continue execution by simply skipping the update operation
-    /// rather than propagating the panic.
+    #[deprecated(note = "use update_capability()")]
     pub fn update_full_capability(&self, f: impl FnOnce(Capability) -> Capability) -> &Self {
-        if let Ok(mut v) = self.inner.write() {
-            v.full_capability = f(v.full_capability);
-        }
-
-        self
+        self.update_capability(f)
     }
 
     /// Get http client from the context.

--- a/core/core/src/raw/oio/copy/multipart_copy.rs
+++ b/core/core/src/raw/oio/copy/multipart_copy.rs
@@ -189,7 +189,7 @@ impl<C: MultipartCopy> MultipartCopier<C> {
     ///
     /// This is called before `initiate_copy` so we fail a copy operation before we make any IO.
     fn validate_part_count(&self, source_size: u64) -> Result<()> {
-        let capability = self.info.full_capability();
+        let capability = self.info.capability();
         let (Some(max_total_size), Some(max_part_size)) = (
             capability.write_total_max_size,
             capability.write_multi_max_size,
@@ -439,7 +439,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_part_count_rejects_before_initiate() -> Result<()> {
         let info = Arc::new(AccessorInfo::default());
-        info.update_full_capability(|cap| Capability {
+        info.update_capability(|cap| Capability {
             write_total_max_size: Some(2),
             write_multi_max_size: Some(1),
             ..cap

--- a/core/core/src/services/memory/backend.rs
+++ b/core/core/src/services/memory/backend.rs
@@ -68,7 +68,7 @@ impl MemoryBackend {
         info.set_scheme(MEMORY_SCHEME);
         info.set_name(&format!("{:p}", Arc::as_ptr(&core.data)));
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             write: true,
             write_can_empty: true,

--- a/core/core/src/types/capability.rs
+++ b/core/core/src/types/capability.rs
@@ -31,16 +31,17 @@ use serde::Serialize;
 /// - Advanced operation variants (conditional operations, metadata handling)
 /// - Operational constraints (size limits, batch limitations)
 ///
-/// # Capability Types
+/// # Capability Sources
 ///
-/// Every operator maintains two capability sets:
+/// Every accessor maintains two capability sets internally:
 ///
-/// 1. [`OperatorInfo::native_capability`][crate::OperatorInfo::native_capability]:
-///    Represents operations natively supported by the storage backend.
+/// 1. [`OperatorInfo::capability`][crate::OperatorInfo::capability]:
+///    Represents all available operations on the current operator, including
+///    those implemented through layers or alternative mechanisms.
 ///
-/// 2. [`OperatorInfo::full_capability`][crate::OperatorInfo::full_capability]:
-///    Represents all available operations, including those implemented through
-///    alternative mechanisms.
+/// 2. `AccessorInfo::service_capability`:
+///    Represents operations declared by the service implementation. This is used
+///    by service and layer internals and is not the user-facing availability check.
 ///
 /// # Implementation Details
 ///
@@ -50,8 +51,10 @@ use serde::Serialize;
 /// - Blocking operations are provided through the BlockingLayer
 ///
 /// Developers should:
-/// - Use `full_capability` to determine available operations
-/// - Use `native_capability` to identify optimized operations
+/// - Use [`OperatorInfo::capability`][crate::OperatorInfo::capability] to
+///   determine available operations.
+/// - Use service capability only inside service and layer implementations that
+///   need the service-declared baseline.
 ///
 /// # Field Naming Conventions
 ///

--- a/core/core/src/types/context/write.rs
+++ b/core/core/src/types/context/write.rs
@@ -73,7 +73,7 @@ impl WriteContext {
     ///
     /// Returns the chunk size and if the chunk size is exact.
     fn calculate_chunk_size(&self) -> (Option<usize>, bool) {
-        let cap = self.accessor().info().full_capability();
+        let cap = self.accessor().info().capability();
 
         let exact = self.options().chunk().is_some();
         let chunk_size = self

--- a/core/core/src/types/operator/info.rs
+++ b/core/core/src/types/operator/info.rs
@@ -49,13 +49,20 @@ impl OperatorInfo {
         self.0.name().to_string()
     }
 
+    /// Get [`Capability`] of operator.
+    pub fn capability(&self) -> Capability {
+        self.0.capability()
+    }
+
     /// Get [`Full Capability`] of operator.
+    #[deprecated(note = "use capability()")]
     pub fn full_capability(&self) -> Capability {
-        self.0.full_capability()
+        self.0.capability()
     }
 
     /// Get [`Native Capability`] of operator.
+    #[deprecated(note = "service capability is not intended for availability checks")]
     pub fn native_capability(&self) -> Capability {
-        self.0.native_capability()
+        self.0.service_capability()
     }
 }

--- a/core/fuzz/fuzz_writer.rs
+++ b/core/fuzz/fuzz_writer.rs
@@ -81,7 +81,7 @@ async fn fuzz_writer(op: Operator, input: FuzzInput) -> Result<()> {
     let mut writer = op.writer_with(&path);
     if let Some(buffer) = input.buffer {
         writer = writer.chunk(buffer);
-    } else if let Some(min_size) = op.info().full_capability().write_multi_min_size {
+    } else if let Some(min_size) = op.info().capability().write_multi_min_size {
         writer = writer.chunk(min_size);
     }
     if let Some(concurrent) = input.concurrent {
@@ -109,7 +109,7 @@ fuzz_target!(|input: FuzzInput| {
 
     let op = init_test_service().expect("operator init must succeed");
     if let Some(op) = op {
-        if !op.info().full_capability().write_can_multi {
+        if !op.info().capability().write_can_multi {
             log::warn!("service doesn't support write multi, skip fuzzing");
             return;
         }

--- a/core/layers/capability-check/src/lib.rs
+++ b/core/layers/capability-check/src/lib.rs
@@ -121,7 +121,7 @@ impl<A: Access> LayeredAccess for CapabilityAccessor<A> {
     }
 
     async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
-        let capability = self.info.full_capability();
+        let capability = self.info.capability();
         if !capability.write_with_content_type && args.content_type().is_some() {
             return Err(new_unsupported_error(
                 self.info.as_ref(),
@@ -154,7 +154,7 @@ impl<A: Access> LayeredAccess for CapabilityAccessor<A> {
         args: OpCopy,
         opts: OpCopier,
     ) -> Result<(RpCopy, Self::Copier)> {
-        let capability = self.info.full_capability();
+        let capability = self.info.capability();
         if args.if_not_exists() && !capability.copy_with_if_not_exists {
             return Err(new_unsupported_error(
                 self.info.as_ref(),
@@ -185,7 +185,7 @@ impl<A: Access> LayeredAccess for CapabilityAccessor<A> {
     }
 
     async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
-        let capability = self.info.full_capability();
+        let capability = self.info.capability();
         if !capability.list_with_versions && args.versions() {
             return Err(new_unsupported_error(
                 self.info.as_ref(),
@@ -216,7 +216,7 @@ mod tests {
 
         fn info(&self) -> Arc<AccessorInfo> {
             let info = AccessorInfo::default();
-            info.set_native_capability(self.capability);
+            info.set_service_capability(self.capability);
 
             info.into()
         }

--- a/core/layers/concurrent-limit/src/lib.rs
+++ b/core/layers/concurrent-limit/src/lib.rs
@@ -511,7 +511,7 @@ mod tests {
         let semaphore = Arc::new(Semaphore::new(1));
         let layer = ConcurrentLimitLayer::with_semaphore(semaphore.clone());
         let info = Arc::new(AccessorInfo::default());
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             copy: true,
             rename: true,
             ..Default::default()
@@ -579,7 +579,7 @@ mod tests {
         let semaphore = Arc::new(Semaphore::new(1));
         let layer = ConcurrentLimitLayer::with_semaphore(semaphore.clone());
         let info = Arc::new(AccessorInfo::default());
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             copy: true,
             stat: true,
             ..Default::default()

--- a/core/layers/foyer/src/lib.rs
+++ b/core/layers/foyer/src/lib.rs
@@ -370,7 +370,7 @@ mod tests {
 
         fn info(&self) -> Arc<AccessorInfo> {
             let am = AccessorInfo::default();
-            am.set_scheme("mock").set_native_capability(Capability {
+            am.set_scheme("mock").set_service_capability(Capability {
                 read: true,
                 stat: true,
                 ..Default::default()

--- a/core/layers/immutable-index/src/lib.rs
+++ b/core/layers/immutable-index/src/lib.rs
@@ -85,7 +85,7 @@ impl<A: Access> Layer<A> for ImmutableIndexLayer {
 
     fn layer(&self, inner: A) -> Self::LayeredAccess {
         let info = inner.info();
-        info.update_full_capability(|mut cap| {
+        info.update_capability(|mut cap| {
             cap.list = true;
             cap.list_with_recursive = true;
             cap

--- a/core/layers/retry/src/lib.rs
+++ b/core/layers/retry/src/lib.rs
@@ -1045,7 +1045,7 @@ mod tests {
 
         fn info(&self) -> Arc<AccessorInfo> {
             let am = AccessorInfo::default();
-            am.set_scheme("mock").set_native_capability(Capability {
+            am.set_scheme("mock").set_service_capability(Capability {
                 read: true,
                 write: true,
                 write_can_multi: true,

--- a/core/layers/timeout/src/lib.rs
+++ b/core/layers/timeout/src/lib.rs
@@ -433,7 +433,7 @@ mod tests {
 
         fn info(&self) -> Arc<AccessorInfo> {
             let am = AccessorInfo::default();
-            am.set_native_capability(Capability {
+            am.set_service_capability(Capability {
                 read: true,
                 delete: true,
                 ..Default::default()

--- a/core/services/aliyun-drive/src/backend.rs
+++ b/core/services/aliyun-drive/src/backend.rs
@@ -148,7 +148,7 @@ impl Builder for AliyunDriveBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(ALIYUN_DRIVE_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
                             create_dir: true,
                             read: true,

--- a/core/services/alluxio/src/backend.rs
+++ b/core/services/alluxio/src/backend.rs
@@ -98,7 +98,7 @@ impl Builder for AlluxioBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(ALLUXIO_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             // FIXME:

--- a/core/services/azblob/src/backend.rs
+++ b/core/services/azblob/src/backend.rs
@@ -398,7 +398,7 @@ impl Builder for AzblobBuilder {
                     info.set_scheme(AZBLOB_SCHEME)
                         .set_root(&root)
                         .set_name(container)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
                             stat_with_if_match: true,
                             stat_with_if_none_match: true,
@@ -566,7 +566,7 @@ impl Access for AzblobBackend {
             RpDelete::default(),
             oio::BatchDeleter::new(
                 AzblobDeleter::new(self.core.clone()),
-                self.core.info.full_capability().delete_max_size,
+                self.core.info.capability().delete_max_size,
             ),
         ))
     }

--- a/core/services/azdls/src/backend.rs
+++ b/core/services/azdls/src/backend.rs
@@ -323,7 +323,7 @@ impl Builder for AzdlsBuilder {
                     info.set_scheme(AZDLS_SCHEME)
                         .set_root(&root)
                         .set_name(filesystem)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             read: true,

--- a/core/services/azfile/src/backend.rs
+++ b/core/services/azfile/src/backend.rs
@@ -235,7 +235,7 @@ impl Builder for AzfileBuilder {
                 info: {
                     info.set_scheme(AZFILE_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             read: true,

--- a/core/services/b2/src/backend.rs
+++ b/core/services/b2/src/backend.rs
@@ -164,7 +164,7 @@ impl Builder for B2Builder {
                     let am = AccessorInfo::default();
                     am.set_scheme(B2_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             read: true,

--- a/core/services/cacache/src/backend.rs
+++ b/core/services/cacache/src/backend.rs
@@ -57,7 +57,7 @@ impl Builder for CacacheBuilder {
         info.set_scheme(CACACHE_SCHEME);
         info.set_name(&datadir_path);
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             write: true,
             delete: true,

--- a/core/services/cloudflare-kv/src/backend.rs
+++ b/core/services/cloudflare-kv/src/backend.rs
@@ -147,7 +147,7 @@ impl Builder for CloudflareKvBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(CLOUDFLARE_KV_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             create_dir: true,
 
                             stat: true,
@@ -495,7 +495,7 @@ impl Access for CloudflareKvBackend {
             RpDelete::default(),
             oio::BatchDeleter::new(
                 CloudflareKvDeleter::new(self.core.clone()),
-                self.core.info.full_capability().delete_max_size,
+                self.core.info.capability().delete_max_size,
             ),
         ))
     }

--- a/core/services/compfs/src/backend.rs
+++ b/core/services/compfs/src/backend.rs
@@ -89,7 +89,7 @@ impl Builder for CompfsBuilder {
                 let am = AccessorInfo::default();
                 am.set_scheme(COMPFS_SCHEME)
                     .set_root(&root)
-                    .set_native_capability(Capability {
+                    .set_service_capability(Capability {
                         stat: true,
 
                         read: true,

--- a/core/services/cos/src/backend.rs
+++ b/core/services/cos/src/backend.rs
@@ -239,7 +239,7 @@ impl Builder for CosBuilder {
                     info.set_scheme(COS_SCHEME)
                         .set_root(&root)
                         .set_name(&bucket)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
                             stat_with_if_match: true,
                             stat_with_if_none_match: true,

--- a/core/services/d1/src/backend.rs
+++ b/core/services/d1/src/backend.rs
@@ -195,7 +195,7 @@ impl D1Backend {
         info.set_scheme(D1_SCHEME);
         info.set_name(&core.table);
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             stat: true,
             write: true,

--- a/core/services/dashmap/src/backend.rs
+++ b/core/services/dashmap/src/backend.rs
@@ -86,7 +86,7 @@ impl DashmapBackend {
         info.set_scheme(DASHMAP_SCHEME);
         info.set_name("dashmap");
         info.set_root(&root);
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
 
             write: true,

--- a/core/services/dbfs/src/backend.rs
+++ b/core/services/dbfs/src/backend.rs
@@ -134,7 +134,7 @@ impl Access for DbfsBackend {
         let am = AccessorInfo::default();
         am.set_scheme(DBFS_SCHEME)
             .set_root(&self.core.root)
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 stat: true,
 
                 write: true,

--- a/core/services/dropbox/src/builder.rs
+++ b/core/services/dropbox/src/builder.rs
@@ -153,7 +153,7 @@ impl Builder for DropboxBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(DROPBOX_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             read: true,

--- a/core/services/etcd/src/backend.rs
+++ b/core/services/etcd/src/backend.rs
@@ -181,7 +181,7 @@ impl EtcdBackend {
         info.set_scheme(ETCD_SCHEME);
         info.set_name("etcd");
         info.set_root(root);
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
 
             write: true,

--- a/core/services/foundationdb/src/backend.rs
+++ b/core/services/foundationdb/src/backend.rs
@@ -96,7 +96,7 @@ impl FoundationdbBackend {
         info.set_scheme(FOUNDATIONDB_SCHEME);
         info.set_name("foundationdb");
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             stat: true,
             write: true,

--- a/core/services/foyer/src/backend.rs
+++ b/core/services/foyer/src/backend.rs
@@ -215,7 +215,7 @@ impl FoyerBackend {
         info.set_scheme(FOYER_SCHEME);
         info.set_name(core.name().unwrap_or("foyer"));
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             write: true,
             write_can_empty: true,

--- a/core/services/fs/src/backend.rs
+++ b/core/services/fs/src/backend.rs
@@ -140,7 +140,7 @@ impl Builder for FsBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(FS_SCHEME)
                         .set_root(&root.to_string_lossy())
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             read: true,

--- a/core/services/ftp/src/backend.rs
+++ b/core/services/ftp/src/backend.rs
@@ -146,7 +146,7 @@ impl Builder for FtpBuilder {
         accessor_info
             .set_scheme(FTP_SCHEME)
             .set_root(&root)
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/services/gcs/src/backend.rs
+++ b/core/services/gcs/src/backend.rs
@@ -347,7 +347,7 @@ impl Builder for GcsBuilder {
                     info.set_scheme(GCS_SCHEME)
                         .set_root(&root)
                         .set_name(bucket)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
                             stat_with_if_match: true,
                             stat_with_if_none_match: true,
@@ -513,7 +513,7 @@ impl Access for GcsBackend {
             RpDelete::default(),
             oio::BatchDeleter::new(
                 GcsDeleter::new(self.core.clone()),
-                self.core.info.full_capability().delete_max_size,
+                self.core.info.capability().delete_max_size,
             ),
         ))
     }

--- a/core/services/gdrive/src/builder.rs
+++ b/core/services/gdrive/src/builder.rs
@@ -110,7 +110,7 @@ impl Builder for GdriveBuilder {
         let info = AccessorInfo::default();
         info.set_scheme(GDRIVE_SCHEME)
             .set_root(&root)
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/services/ghac/src/backend.rs
+++ b/core/services/ghac/src/backend.rs
@@ -158,7 +158,7 @@ impl Builder for GhacBuilder {
                 am.set_scheme(GHAC_SCHEME)
                     .set_root(&root)
                     .set_name(&version)
-                    .set_native_capability(Capability {
+                    .set_service_capability(Capability {
                         stat: true,
 
                         read: true,

--- a/core/services/ghac/src/writer.rs
+++ b/core/services/ghac/src/writer.rs
@@ -81,7 +81,7 @@ impl GhacWriter {
                         am.set_scheme("azblob")
                             .set_root("/")
                             .set_name(container)
-                            .set_native_capability(Capability {
+                            .set_service_capability(Capability {
                                 stat: true,
                                 stat_with_if_match: true,
                                 stat_with_if_none_match: true,

--- a/core/services/github/src/backend.rs
+++ b/core/services/github/src/backend.rs
@@ -123,7 +123,7 @@ impl Builder for GithubBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(GITHUB_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             read: true,

--- a/core/services/goosefs/src/backend.rs
+++ b/core/services/goosefs/src/backend.rs
@@ -272,7 +272,7 @@ impl Builder for GoosefsBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(GOOSEFS_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
                             read: true,
                             write: true,

--- a/core/services/gridfs/src/backend.rs
+++ b/core/services/gridfs/src/backend.rs
@@ -162,7 +162,7 @@ impl GridfsBackend {
         info.set_scheme(GRIDFS_SCHEME);
         info.set_name(&format!("{}/{}", core.database, core.bucket));
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             stat: true,
             write: true,

--- a/core/services/hdfs-native/src/backend.rs
+++ b/core/services/hdfs-native/src/backend.rs
@@ -124,7 +124,7 @@ impl Builder for HdfsNativeBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(HDFS_NATIVE_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             read: true,

--- a/core/services/hdfs/src/backend.rs
+++ b/core/services/hdfs/src/backend.rs
@@ -160,7 +160,7 @@ impl Builder for HdfsBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(HDFS_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             read: true,

--- a/core/services/hf/src/backend.rs
+++ b/core/services/hf/src/backend.rs
@@ -221,7 +221,7 @@ impl Builder for HfBuilder {
 
         let info: Arc<AccessorInfo> = {
             let am = AccessorInfo::default();
-            am.set_scheme(HF_SCHEME).set_native_capability(Capability {
+            am.set_scheme(HF_SCHEME).set_service_capability(Capability {
                 stat: true,
                 read: true,
                 write: token.is_some(),
@@ -325,7 +325,7 @@ impl Access for HfBackend {
 
     async fn delete(&self) -> Result<(RpDelete, Self::Deleter)> {
         let deleter = HfDeleter::new(self.core.clone());
-        let max_batch_size = self.core.info.full_capability().delete_max_size;
+        let max_batch_size = self.core.info.capability().delete_max_size;
         Ok((
             RpDelete::default(),
             oio::BatchDeleter::new(deleter, max_batch_size),
@@ -378,7 +378,7 @@ pub(super) mod test_utils {
         let token = std::env::var("HF_OPENDAL_TOKEN").expect("HF_OPENDAL_TOKEN must be set");
 
         let info = AccessorInfo::default();
-        info.set_scheme("hf").set_native_capability(Capability {
+        info.set_scheme("hf").set_service_capability(Capability {
             read: true,
             write: true,
             delete: true,

--- a/core/services/hf/src/core.rs
+++ b/core/services/hf/src/core.rs
@@ -643,7 +643,7 @@ pub(crate) mod test_utils {
 
         let info = AccessorInfo::default();
         info.set_scheme("hf")
-            .set_native_capability(Capability::default());
+            .set_service_capability(Capability::default());
         info.update_http_client(|_| http_client);
 
         let xet_session = XetSessionBuilder::new()

--- a/core/services/http/src/backend.rs
+++ b/core/services/http/src/backend.rs
@@ -131,7 +131,7 @@ impl Builder for HttpBuilder {
         let info = AccessorInfo::default();
         info.set_scheme(HTTP_SCHEME)
             .set_root(&root)
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 stat: true,
                 stat_with_if_match: true,
                 stat_with_if_none_match: true,

--- a/core/services/ipfs/src/backend.rs
+++ b/core/services/ipfs/src/backend.rs
@@ -113,7 +113,7 @@ impl Builder for IpfsBuilder {
         let info = AccessorInfo::default();
         info.set_scheme(IPFS_SCHEME)
             .set_root(&root)
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/services/ipmfs/src/builder.rs
+++ b/core/services/ipmfs/src/builder.rs
@@ -118,7 +118,7 @@ impl Builder for IpmfsBuilder {
         let info = AccessorInfo::default();
         info.set_scheme(IPMFS_SCHEME)
             .set_root(&root)
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/services/koofr/src/backend.rs
+++ b/core/services/koofr/src/backend.rs
@@ -147,7 +147,7 @@ impl Builder for KoofrBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(KOOFR_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             create_dir: true,

--- a/core/services/lakefs/src/backend.rs
+++ b/core/services/lakefs/src/backend.rs
@@ -157,7 +157,7 @@ impl Builder for LakefsBuilder {
                 info: {
                     let am = AccessorInfo::default();
                     am.set_scheme(LAKEFS_SCHEME)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             list: true,

--- a/core/services/memcached/src/backend.rs
+++ b/core/services/memcached/src/backend.rs
@@ -191,7 +191,7 @@ impl MemcachedBackend {
         info.set_scheme(MEMCACHED_SCHEME);
         info.set_name("memcached");
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             stat: true,
             write: true,

--- a/core/services/mini_moka/src/backend.rs
+++ b/core/services/mini_moka/src/backend.rs
@@ -180,7 +180,7 @@ impl Access for MiniMokaBackend {
         let info = AccessorInfo::default();
         info.set_scheme(MINI_MOKA_SCHEME)
             .set_root(&self.root)
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 stat: true,
                 read: true,
                 write: true,

--- a/core/services/moka/src/backend.rs
+++ b/core/services/moka/src/backend.rs
@@ -193,7 +193,7 @@ impl MokaBackend {
         info.set_scheme(MOKA_SCHEME);
         info.set_name(core.cache.name().unwrap_or("moka"));
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             write: true,
             write_can_empty: true,

--- a/core/services/mongodb/src/backend.rs
+++ b/core/services/mongodb/src/backend.rs
@@ -180,7 +180,7 @@ impl MongodbBackend {
         info.set_scheme(MONGODB_SCHEME);
         info.set_name(&format!("{}/{}", core.database, core.collection));
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             stat: true,
             write: true,

--- a/core/services/monoiofs/src/core.rs
+++ b/core/services/monoiofs/src/core.rs
@@ -71,7 +71,7 @@ impl MonoiofsCore {
                 let am = AccessorInfo::default();
                 am.set_scheme(MONOIOFS_SCHEME)
                     .set_root(&root.to_string_lossy())
-                    .set_native_capability(Capability {
+                    .set_service_capability(Capability {
                         stat: true,
 
                         read: true,

--- a/core/services/mysql/src/backend.rs
+++ b/core/services/mysql/src/backend.rs
@@ -163,7 +163,7 @@ impl MysqlBackend {
         info.set_scheme(MYSQL_SCHEME);
         info.set_name(&core.table);
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             list: true,
             list_with_recursive: true,

--- a/core/services/obs/src/backend.rs
+++ b/core/services/obs/src/backend.rs
@@ -207,7 +207,7 @@ impl Builder for ObsBuilder {
                     info.set_scheme(OBS_SCHEME)
                         .set_root(&root)
                         .set_name(&bucket)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
                             stat_with_if_match: true,
                             stat_with_if_none_match: true,

--- a/core/services/onedrive/src/builder.rs
+++ b/core/services/onedrive/src/builder.rs
@@ -119,7 +119,7 @@ impl Builder for OnedriveBuilder {
         let info = AccessorInfo::default();
         info.set_scheme(ONEDRIVE_SCHEME)
             .set_root(&root)
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 read: true,
                 read_with_if_none_match: true,
 

--- a/core/services/onedrive/src/lister.rs
+++ b/core/services/onedrive/src/lister.rs
@@ -79,7 +79,7 @@ impl oio::PageList for OneDriveLister {
         let decoded_response: GraphApiOneDriveListResponse =
             serde_json::from_reader(bytes.reader()).map_err(new_json_deserialize_error)?;
 
-        let list_with_versions = self.core.info.native_capability().list_with_versions;
+        let list_with_versions = self.core.info.service_capability().list_with_versions;
 
         // Include the current directory itself when handling the first page of the listing.
         if ctx.token.is_empty() && !ctx.done {

--- a/core/services/opfs/src/core.rs
+++ b/core/services/opfs/src/core.rs
@@ -33,7 +33,7 @@ impl OpfsCore {
         info.set_scheme(OPFS_SCHEME);
         info.set_name("opfs");
         info.set_root(&root);
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             stat: true,
 
             read: true,

--- a/core/services/oss/src/backend.rs
+++ b/core/services/oss/src/backend.rs
@@ -557,7 +557,7 @@ impl Builder for OssBuilder {
                     info.set_scheme(OSS_SCHEME)
                         .set_root(&root)
                         .set_name(bucket)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
                             stat_with_if_match: true,
                             stat_with_if_none_match: true,
@@ -740,7 +740,7 @@ impl Access for OssBackend {
             RpDelete::default(),
             oio::BatchDeleter::new(
                 OssDeleter::new(self.core.clone()),
-                self.core.info.full_capability().delete_max_size,
+                self.core.info.capability().delete_max_size,
             ),
         ))
     }

--- a/core/services/pcloud/src/backend.rs
+++ b/core/services/pcloud/src/backend.rs
@@ -141,7 +141,7 @@ impl Builder for PcloudBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(PCLOUD_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             create_dir: true,

--- a/core/services/persy/src/backend.rs
+++ b/core/services/persy/src/backend.rs
@@ -131,7 +131,7 @@ impl PersyBackend {
         info.set_scheme(PERSY_SCHEME);
         info.set_name(&core.datafile);
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             stat: true,
             write: true,

--- a/core/services/postgresql/src/backend.rs
+++ b/core/services/postgresql/src/backend.rs
@@ -157,7 +157,7 @@ impl PostgresqlBackend {
         info.set_scheme(POSTGRESQL_SCHEME);
         info.set_name(&core.table);
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             stat: true,
             write: true,

--- a/core/services/redb/src/backend.rs
+++ b/core/services/redb/src/backend.rs
@@ -143,7 +143,7 @@ impl RedbBackend {
         info.set_scheme(REDB_SCHEME);
         info.set_name(&core.table);
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             stat: true,
             write: true,

--- a/core/services/redis/src/backend.rs
+++ b/core/services/redis/src/backend.rs
@@ -283,7 +283,7 @@ impl RedisBackend {
         info.set_scheme(REDIS_SCHEME);
         info.set_name(core.addr());
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             write: true,
             delete: true,

--- a/core/services/rocksdb/src/backend.rs
+++ b/core/services/rocksdb/src/backend.rs
@@ -91,7 +91,7 @@ impl RocksdbBackend {
         info.set_scheme(ROCKSDB_SCHEME)
             .set_name(&core.db.path().to_string_lossy())
             .set_root("/")
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 read: true,
                 stat: true,
                 write: true,

--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -920,7 +920,7 @@ impl Builder for S3Builder {
                     info.set_scheme(S3_SCHEME)
                         .set_root(&root)
                         .set_name(bucket)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
                             stat_with_if_match: true,
                             stat_with_if_none_match: true,
@@ -1146,7 +1146,7 @@ impl Access for S3Backend {
             RpDelete::default(),
             oio::BatchDeleter::new(
                 S3Deleter::new(self.core.clone()),
-                self.core.info.full_capability().delete_max_size,
+                self.core.info.capability().delete_max_size,
             ),
         ))
     }

--- a/core/services/s3/src/copier.rs
+++ b/core/services/s3/src/copier.rs
@@ -36,7 +36,7 @@ pub fn new_s3_copier(
     args: OpCopy,
     opts: OpCopier,
 ) -> Result<S3Copiers> {
-    let capability = core.info.full_capability();
+    let capability = core.info.capability();
     let max_part_size = capability.copy_multi_max_size.ok_or_else(|| {
         Error::new(
             ErrorKind::Unexpected,

--- a/core/services/seafile/src/backend.rs
+++ b/core/services/seafile/src/backend.rs
@@ -161,7 +161,7 @@ impl Builder for SeafileBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(SEAFILE_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             create_dir: true,
                             stat: true,
 

--- a/core/services/sftp/src/backend.rs
+++ b/core/services/sftp/src/backend.rs
@@ -167,7 +167,7 @@ impl Builder for SftpBuilder {
         let info = AccessorInfo::default();
         info.set_root(root.as_str())
             .set_scheme(SFTP_SCHEME)
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/services/sled/src/backend.rs
+++ b/core/services/sled/src/backend.rs
@@ -115,7 +115,7 @@ impl SledBackend {
         info.set_scheme(SLED_SCHEME)
             .set_name(&core.datadir)
             .set_root("/")
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 read: true,
                 stat: true,
                 write: true,

--- a/core/services/sqlite/src/backend.rs
+++ b/core/services/sqlite/src/backend.rs
@@ -181,7 +181,7 @@ impl SqliteBackend {
         info.set_scheme(SQLITE_SCHEME);
         info.set_name(&core.table);
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             write: true,
             create_dir: true,
@@ -387,10 +387,10 @@ mod test {
         // Verify basic properties
         assert_eq!(accessor.root, "/");
         assert_eq!(accessor.info.scheme(), SQLITE_SCHEME);
-        assert!(accessor.info.native_capability().read);
-        assert!(accessor.info.native_capability().write);
-        assert!(accessor.info.native_capability().delete);
-        assert!(accessor.info.native_capability().stat);
+        assert!(accessor.info.service_capability().read);
+        assert!(accessor.info.service_capability().write);
+        assert!(accessor.info.service_capability().delete);
+        assert!(accessor.info.service_capability().stat);
     }
 
     #[tokio::test]

--- a/core/services/surrealdb/src/backend.rs
+++ b/core/services/surrealdb/src/backend.rs
@@ -211,7 +211,7 @@ impl SurrealdbBackend {
         info.set_scheme(SURREALDB_SCHEME);
         info.set_name(&core.table);
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             stat: true,
             write: true,

--- a/core/services/swift/src/backend.rs
+++ b/core/services/swift/src/backend.rs
@@ -172,7 +172,7 @@ impl Builder for SwiftBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(SWIFT_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
                             stat_with_if_match: true,
                             stat_with_if_none_match: true,
@@ -326,7 +326,7 @@ impl Access for SwiftBackend {
             RpDelete::default(),
             oio::BatchDeleter::new(
                 SwiftDeleter::new(self.core.clone()),
-                self.core.info.full_capability().delete_max_size,
+                self.core.info.capability().delete_max_size,
             ),
         ))
     }

--- a/core/services/tikv/src/backend.rs
+++ b/core/services/tikv/src/backend.rs
@@ -125,7 +125,7 @@ impl TikvBackend {
         info.set_scheme(TIKV_SCHEME);
         info.set_name("TiKV");
         info.set_root("/");
-        info.set_native_capability(Capability {
+        info.set_service_capability(Capability {
             read: true,
             stat: true,
             write: true,

--- a/core/services/tos/src/backend.rs
+++ b/core/services/tos/src/backend.rs
@@ -174,7 +174,7 @@ impl Builder for TosBuilder {
             am.set_scheme(TOS_SCHEME)
                 .set_root(&root)
                 .set_name(&bucket)
-                .set_native_capability(Capability {
+                .set_service_capability(Capability {
                     stat_with_version: true,
 
                     read: true,
@@ -374,7 +374,7 @@ impl Access for TosBackend {
 
     async fn delete(&self) -> Result<(RpDelete, Self::Deleter)> {
         let info = self.core.info.clone();
-        let capability = info.full_capability();
+        let capability = info.capability();
         let deleter = TosDeleter::new(self.core.clone());
         Ok((
             RpDelete::default(),

--- a/core/services/tos/src/copier.rs
+++ b/core/services/tos/src/copier.rs
@@ -35,7 +35,7 @@ pub fn new_tos_copier(
     args: OpCopy,
     opts: OpCopier,
 ) -> Result<TosCopiers> {
-    let capability = core.info.full_capability();
+    let capability = core.info.capability();
     let max_part_size = capability.copy_multi_max_size.ok_or_else(|| {
         Error::new(
             ErrorKind::Unexpected,

--- a/core/services/upyun/src/backend.rs
+++ b/core/services/upyun/src/backend.rs
@@ -142,7 +142,7 @@ impl Builder for UpyunBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(UPYUN_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             create_dir: true,

--- a/core/services/vercel-artifacts/src/builder.rs
+++ b/core/services/vercel-artifacts/src/builder.rs
@@ -86,7 +86,7 @@ impl Builder for VercelArtifactsBuilder {
     fn build(self) -> Result<impl Access> {
         let info = AccessorInfo::default();
         info.set_scheme(VERCEL_ARTIFACTS_SCHEME)
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/services/vercel-blob/src/backend.rs
+++ b/core/services/vercel-blob/src/backend.rs
@@ -100,7 +100,7 @@ impl Builder for VercelBlobBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(VERCEL_BLOB_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             read: true,

--- a/core/services/webdav/src/backend.rs
+++ b/core/services/webdav/src/backend.rs
@@ -198,7 +198,7 @@ impl Builder for WebdavBuilder {
                 let am = AccessorInfo::default();
                 am.set_scheme(WEBDAV_SCHEME)
                     .set_root(&root)
-                    .set_native_capability(Capability {
+                    .set_service_capability(Capability {
                         stat: true,
 
                         read: true,

--- a/core/services/webhdfs/src/backend.rs
+++ b/core/services/webhdfs/src/backend.rs
@@ -168,7 +168,7 @@ impl Builder for WebhdfsBuilder {
         let info = AccessorInfo::default();
         info.set_scheme(WEBHDFS_SCHEME)
             .set_root(&root)
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 stat: true,
 
                 read: true,

--- a/core/services/yandex-disk/src/backend.rs
+++ b/core/services/yandex-disk/src/backend.rs
@@ -99,7 +99,7 @@ impl Builder for YandexDiskBuilder {
                     let am = AccessorInfo::default();
                     am.set_scheme(YANDEX_DISK_SCHEME)
                         .set_root(&root)
-                        .set_native_capability(Capability {
+                        .set_service_capability(Capability {
                             stat: true,
 
                             create_dir: true,

--- a/core/tests/behavior/async_copy.rs
+++ b/core/tests/behavior/async_copy.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 use crate::*;
 
 pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
 
     if cap.read && cap.write && cap.copy {
         tests.extend(async_trials!(
@@ -101,7 +101,7 @@ fn copy_multi_chunk_size(cap: Capability) -> Option<(usize, usize)> {
 /// Copy a file with ascii name and test contents.
 pub async fn test_copy_file_with_ascii_name(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, source_content.clone()).await?;
 
@@ -134,7 +134,7 @@ pub async fn test_copy_file_with_non_ascii_name(op: Operator) -> Result<()> {
 
     let source_path = "🐂🍺中文.docx";
     let target_path = "😈🐅Français.docx";
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(source_path, source_content.clone()).await?;
     op.copy(source_path, target_path).await?;
@@ -169,7 +169,7 @@ pub async fn test_copy_non_existing_source(op: Operator) -> Result<()> {
 
 /// Copy a dir as source should return an error.
 pub async fn test_copy_source_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
 
@@ -188,12 +188,12 @@ pub async fn test_copy_source_dir(op: Operator) -> Result<()> {
 
 /// Copy to a dir should return an error.
 pub async fn test_copy_target_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
 
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (content, _) = gen_bytes(op.info().full_capability());
+    let (content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, content).await?;
 
@@ -215,7 +215,7 @@ pub async fn test_copy_target_dir(op: Operator) -> Result<()> {
 /// Copy a file to self should return an error.
 pub async fn test_copy_self(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (content, _) = gen_bytes(op.info().full_capability());
+    let (content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, content).await?;
 
@@ -232,7 +232,7 @@ pub async fn test_copy_self(op: Operator) -> Result<()> {
 /// Copy to a nested path, parent path should be created successfully.
 pub async fn test_copy_nested(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, source_content.clone()).await?;
 
@@ -263,12 +263,12 @@ pub async fn test_copy_nested(op: Operator) -> Result<()> {
 /// Copy to a exist path should overwrite successfully.
 pub async fn test_copy_overwrite(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, source_content.clone()).await?;
 
     let target_path = uuid::Uuid::new_v4().to_string();
-    let (target_content, _) = gen_bytes(op.info().full_capability());
+    let (target_content, _) = gen_bytes(op.info().capability());
     assert_ne!(source_content, target_content);
 
     op.write(&target_path, target_content).await?;
@@ -292,12 +292,12 @@ pub async fn test_copy_overwrite(op: Operator) -> Result<()> {
 
 /// Copy with if_not_exists to a new file should succeed.
 pub async fn test_copy_with_if_not_exists_to_new_file(op: Operator) -> Result<()> {
-    if !op.info().full_capability().copy_with_if_not_exists {
+    if !op.info().capability().copy_with_if_not_exists {
         return Ok(());
     }
 
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, source_content.clone()).await?;
 
@@ -325,17 +325,17 @@ pub async fn test_copy_with_if_not_exists_to_new_file(op: Operator) -> Result<()
 
 /// Copy with if_not_exists to an existing file should fail.
 pub async fn test_copy_with_if_not_exists_to_existing_file(op: Operator) -> Result<()> {
-    if !op.info().full_capability().copy_with_if_not_exists {
+    if !op.info().capability().copy_with_if_not_exists {
         return Ok(());
     }
 
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, source_content.clone()).await?;
 
     let target_path = uuid::Uuid::new_v4().to_string();
-    let (target_content, _) = gen_bytes(op.info().full_capability());
+    let (target_content, _) = gen_bytes(op.info().capability());
     assert_ne!(source_content, target_content);
 
     // Write to target file first
@@ -367,16 +367,16 @@ pub async fn test_copy_with_if_not_exists_to_existing_file(op: Operator) -> Resu
 
 /// Copy with if_match matching the destination ETag should overwrite it.
 pub async fn test_copy_with_if_match_match(op: Operator) -> Result<()> {
-    if !op.info().full_capability().copy_with_if_match {
+    if !op.info().capability().copy_with_if_match {
         return Ok(());
     }
 
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
     op.write(&source_path, source_content.clone()).await?;
 
     let target_path = uuid::Uuid::new_v4().to_string();
-    let (target_content, _) = gen_bytes(op.info().full_capability());
+    let (target_content, _) = gen_bytes(op.info().capability());
     assert_ne!(source_content, target_content);
     op.write(&target_path, target_content.clone()).await?;
 
@@ -407,16 +407,16 @@ pub async fn test_copy_with_if_match_match(op: Operator) -> Result<()> {
 
 /// Copy with if_match not matching the destination ETag should fail.
 pub async fn test_copy_with_if_match_mismatch(op: Operator) -> Result<()> {
-    if !op.info().full_capability().copy_with_if_match {
+    if !op.info().capability().copy_with_if_match {
         return Ok(());
     }
 
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
     op.write(&source_path, source_content.clone()).await?;
 
     let target_path = uuid::Uuid::new_v4().to_string();
-    let (target_content, _) = gen_bytes(op.info().full_capability());
+    let (target_content, _) = gen_bytes(op.info().capability());
     assert_ne!(source_content, target_content);
     op.write(&target_path, target_content.clone()).await?;
 
@@ -444,13 +444,13 @@ pub async fn test_copy_with_if_match_mismatch(op: Operator) -> Result<()> {
 
 /// Copy with source_version should copy a specific source version to a new file.
 pub async fn test_copy_with_source_version_to_new_file(op: Operator) -> Result<()> {
-    if !op.info().full_capability().copy_with_source_version {
+    if !op.info().capability().copy_with_source_version {
         return Ok(());
     }
 
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
-    let (new_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
+    let (new_content, _) = gen_bytes(op.info().capability());
     assert_ne!(source_content, new_content);
 
     op.write(&source_path, source_content.clone()).await?;
@@ -485,13 +485,13 @@ pub async fn test_copy_with_source_version_to_new_file(op: Operator) -> Result<(
 
 /// Copy with source_version should allow copying a specific source version to itself.
 pub async fn test_copy_with_source_version_to_same_file(op: Operator) -> Result<()> {
-    if !op.info().full_capability().copy_with_source_version {
+    if !op.info().capability().copy_with_source_version {
         return Ok(());
     }
 
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
-    let (new_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
+    let (new_content, _) = gen_bytes(op.info().capability());
     assert_ne!(source_content, new_content);
 
     op.write(&source_path, source_content.clone()).await?;
@@ -524,7 +524,7 @@ pub async fn test_copy_with_source_version_to_same_file(op: Operator) -> Result<
 
 /// Copy with chunk should copy a file successfully.
 pub async fn test_copy_with_chunk(op: Operator) -> Result<()> {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
     let Some((chunk, source_size)) = copy_multi_chunk_size(cap) else {
         return Ok(());
     };
@@ -558,7 +558,7 @@ pub async fn test_copy_with_chunk(op: Operator) -> Result<()> {
 /// Copier should copy a file and commit the target after completion.
 pub async fn test_copier_file(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, source_content.clone()).await?;
 
@@ -584,7 +584,7 @@ pub async fn test_copier_file(op: Operator) -> Result<()> {
 
 /// Copy with chunk and concurrent should copy a file successfully.
 pub async fn test_copy_with_chunk_and_concurrent(op: Operator) -> Result<()> {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
     let Some((chunk, source_size)) = copy_multi_chunk_size(cap) else {
         return Ok(());
     };
@@ -619,7 +619,7 @@ pub async fn test_copy_with_chunk_and_concurrent(op: Operator) -> Result<()> {
 /// Completed copier should keep returning `None`.
 pub async fn test_copier_completion(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, source_content).await?;
 
@@ -637,7 +637,7 @@ pub async fn test_copier_completion(op: Operator) -> Result<()> {
 /// Aborting a copier should be explicit and idempotent for completed one-shot copies.
 pub async fn test_copier_abort(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, source_content).await?;
 
@@ -653,7 +653,7 @@ pub async fn test_copier_abort(op: Operator) -> Result<()> {
 /// Copier with if_not_exists to a new file should succeed.
 pub async fn test_copier_with_if_not_exists_to_new_file(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, source_content.clone()).await?;
 
@@ -683,12 +683,12 @@ pub async fn test_copier_with_if_not_exists_to_new_file(op: Operator) -> Result<
 /// Copier with if_not_exists to an existing file should fail.
 pub async fn test_copier_with_if_not_exists_to_existing_file(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, source_content).await?;
 
     let target_path = uuid::Uuid::new_v4().to_string();
-    let (target_content, _) = gen_bytes(op.info().full_capability());
+    let (target_content, _) = gen_bytes(op.info().capability());
     op.write(&target_path, target_content.clone()).await?;
 
     let mut copier = op

--- a/core/tests/behavior/async_create_dir.rs
+++ b/core/tests/behavior/async_create_dir.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 use crate::*;
 
 pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
 
     if cap.create_dir && cap.stat {
         tests.extend(async_trials!(op, test_create_dir, test_create_dir_existing))

--- a/core/tests/behavior/async_delete.rs
+++ b/core/tests/behavior/async_delete.rs
@@ -23,7 +23,7 @@ use opendal::raw::OpDelete;
 use crate::*;
 
 pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
 
     if cap.stat && cap.delete && cap.write {
         tests.extend(async_trials!(
@@ -67,7 +67,7 @@ pub async fn test_delete_file(op: Operator) -> Result<()> {
 
 /// Delete empty dir should succeed.
 pub async fn test_delete_empty_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
 
@@ -131,7 +131,7 @@ pub async fn test_remove_one_file(op: Operator) -> Result<()> {
 
 /// Delete via stream.
 pub async fn test_delete_stream(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
     // Gdrive think that this test is an abuse of their service and redirect us
@@ -175,7 +175,7 @@ async fn test_blocking_remove_all_with_objects(
 ) -> Result<()> {
     for path in paths {
         let path = format!("{parent}/{path}");
-        let (content, _) = gen_bytes(op.info().full_capability());
+        let (content, _) = gen_bytes(op.info().capability());
         op.write(&path, content).await.expect("write must succeed");
     }
 
@@ -228,7 +228,7 @@ pub async fn test_remove_all_with_prefix_exists(op: Operator) -> Result<()> {
     }
 
     let parent = uuid::Uuid::new_v4().to_string();
-    let (content, _) = gen_bytes(op.info().full_capability());
+    let (content, _) = gen_bytes(op.info().capability());
     op.write(&parent, content)
         .await
         .expect("write must succeed");
@@ -237,7 +237,7 @@ pub async fn test_remove_all_with_prefix_exists(op: Operator) -> Result<()> {
 }
 
 pub async fn test_delete_with_version(op: Operator) -> Result<()> {
-    if !op.info().full_capability().delete_with_version {
+    if !op.info().capability().delete_with_version {
         return Ok(());
     }
 
@@ -273,7 +273,7 @@ pub async fn test_delete_with_version(op: Operator) -> Result<()> {
 }
 
 pub async fn test_delete_with_not_existing_version(op: Operator) -> Result<()> {
-    if !op.info().full_capability().delete_with_version {
+    if !op.info().capability().delete_with_version {
         return Ok(());
     }
 
@@ -304,7 +304,7 @@ pub async fn test_delete_with_not_existing_version(op: Operator) -> Result<()> {
 }
 
 pub async fn test_delete_with_recursive_basic(op: Operator) -> Result<()> {
-    if !op.info().full_capability().delete_with_recursive {
+    if !op.info().capability().delete_with_recursive {
         return Ok(());
     }
 
@@ -345,7 +345,7 @@ pub async fn test_delete_with_recursive_basic(op: Operator) -> Result<()> {
 }
 
 pub async fn test_batch_delete(op: Operator) -> Result<()> {
-    let mut cap = op.info().full_capability();
+    let mut cap = op.info().capability();
     if cap.delete_max_size.unwrap_or(1) <= 1 {
         return Ok(());
     }
@@ -376,7 +376,7 @@ pub async fn test_batch_delete(op: Operator) -> Result<()> {
 }
 
 pub async fn test_batch_delete_with_version(op: Operator) -> Result<()> {
-    let mut cap = op.info().full_capability();
+    let mut cap = op.info().capability();
     if !cap.delete_with_version {
         return Ok(());
     }

--- a/core/tests/behavior/async_list.rs
+++ b/core/tests/behavior/async_list.rs
@@ -27,7 +27,7 @@ use log::debug;
 use crate::*;
 
 pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
 
     if cap.read && cap.write && cap.list {
         tests.extend(async_trials!(
@@ -82,7 +82,7 @@ pub async fn test_list_dir(op: Operator) -> Result<()> {
     let parent = uuid::Uuid::new_v4().to_string();
     let path = format!("{parent}/{}", uuid::Uuid::new_v4());
     debug!("Generate a random file: {}", &path);
-    let (content, size) = gen_bytes(op.info().full_capability());
+    let (content, size) = gen_bytes(op.info().capability());
 
     op.write(&path, content).await.expect("write must succeed");
 
@@ -107,7 +107,7 @@ pub async fn test_list_dir(op: Operator) -> Result<()> {
 pub async fn test_list_prefix(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
     debug!("Generate a random file: {}", &path);
-    let (content, _) = gen_bytes(op.info().full_capability());
+    let (content, _) = gen_bytes(op.info().capability());
 
     op.write(&path, content).await.expect("write must succeed");
 
@@ -122,7 +122,7 @@ pub async fn test_list_prefix(op: Operator) -> Result<()> {
 
 /// listing a directory, which contains more objects than a single page can take.
 pub async fn test_list_rich_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
     if skip_cos_create_dir_list_check(&op) {
@@ -161,7 +161,7 @@ pub async fn test_list_rich_dir(op: Operator) -> Result<()> {
 
 /// List empty dir should return itself.
 pub async fn test_list_empty_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
     if skip_cos_create_dir_list_check(&op) {
@@ -259,7 +259,7 @@ pub async fn test_list_non_exist_dir(op: Operator) -> Result<()> {
 
 /// List dir should return correct sub dir.
 pub async fn test_list_sub_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
     if skip_cos_create_dir_list_check(&op) {
@@ -293,7 +293,7 @@ pub async fn test_list_sub_dir(op: Operator) -> Result<()> {
 
 /// List dir should also to list nested dir.
 pub async fn test_list_nested_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
     if skip_cos_create_dir_list_check(&op) {
@@ -381,7 +381,7 @@ pub async fn test_list_dir_with_file_path(op: Operator) -> Result<()> {
     let parent = uuid::Uuid::new_v4().to_string();
     let file = format!("{parent}/{}", uuid::Uuid::new_v4());
 
-    let (content, _) = gen_bytes(op.info().full_capability());
+    let (content, _) = gen_bytes(op.info().capability());
     op.write(&file, content).await?;
 
     let obs = op.list(&parent).await?;
@@ -396,7 +396,7 @@ pub async fn test_list_dir_with_file_path(op: Operator) -> Result<()> {
 
 /// List with start after should start listing after the specified key
 pub async fn test_list_with_start_after(op: Operator) -> Result<()> {
-    if !op.info().full_capability().list_with_start_after {
+    if !op.info().capability().list_with_start_after {
         return Ok(());
     }
 
@@ -452,7 +452,7 @@ pub async fn test_list_non_exist_dir_with_recursive(op: Operator) -> Result<()> 
 }
 
 pub async fn test_list_root_with_recursive(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
     if skip_cos_create_dir_list_check(&op) {
@@ -476,7 +476,7 @@ pub async fn test_list_root_with_recursive(op: Operator) -> Result<()> {
 
 // Walk top down should output as expected
 pub async fn test_list_dir_with_recursive(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
     if skip_cos_create_dir_list_check(&op) {
@@ -520,7 +520,7 @@ pub async fn test_list_dir_with_recursive(op: Operator) -> Result<()> {
 
 // same as test_list_dir_with_recursive except listing 'x' instead of 'x/'
 pub async fn test_list_dir_with_recursive_no_trailing_slash(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
     if skip_cos_create_dir_list_check(&op) {
@@ -595,7 +595,7 @@ pub async fn test_list_file_with_recursive(op: Operator) -> Result<()> {
 
 // Remove all should remove all in this path.
 pub async fn test_remove_all(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
     if skip_cos_create_dir_list_check(&op) {
@@ -652,7 +652,7 @@ pub async fn test_list_only(op: Operator) -> Result<()> {
 }
 
 pub async fn test_list_files_with_versions(op: Operator) -> Result<()> {
-    if !op.info().full_capability().list_with_versions {
+    if !op.info().capability().list_with_versions {
         return Ok(());
     }
 
@@ -677,7 +677,7 @@ pub async fn test_list_files_with_versions(op: Operator) -> Result<()> {
 }
 
 pub async fn test_list_files_with_deleted(op: Operator) -> Result<()> {
-    if !op.info().full_capability().list_with_deleted {
+    if !op.info().capability().list_with_deleted {
         return Ok(());
     }
 
@@ -718,7 +718,7 @@ pub async fn test_list_with_versions_and_limit(op: Operator) -> Result<()> {
     if op.info().scheme() == services::GDRIVE_SCHEME {
         return Ok(());
     }
-    if !op.info().full_capability().list_with_versions {
+    if !op.info().capability().list_with_versions {
         return Ok(());
     }
     if skip_cos_create_dir_list_check(&op) {
@@ -756,7 +756,7 @@ pub async fn test_list_with_versions_and_limit(op: Operator) -> Result<()> {
 }
 
 pub async fn test_list_with_versions_and_start_after(op: Operator) -> Result<()> {
-    if !op.info().full_capability().list_with_versions {
+    if !op.info().capability().list_with_versions {
         return Ok(());
     }
 

--- a/core/tests/behavior/async_presign.rs
+++ b/core/tests/behavior/async_presign.rs
@@ -27,7 +27,7 @@ use reqwest::Url;
 use crate::*;
 
 pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
 
     if cap.read && cap.write && cap.presign {
         tests.extend(async_trials!(
@@ -44,7 +44,7 @@ pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
 pub async fn test_presign_write(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
     debug!("Generate a random file: {}", &path);
-    let (content, size) = gen_bytes(op.info().full_capability());
+    let (content, size) = gen_bytes(op.info().capability());
 
     let signed_req = op.presign_write(&path, Duration::from_secs(3600)).await?;
     debug!("Generated request: {signed_req:?}");
@@ -76,7 +76,7 @@ pub async fn test_presign_write(op: Operator) -> Result<()> {
 pub async fn test_presign_stat(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
     debug!("Generate a random file: {}", &path);
-    let (content, size) = gen_bytes(op.info().full_capability());
+    let (content, size) = gen_bytes(op.info().capability());
     op.write(&path, content.clone())
         .await
         .expect("write must succeed");
@@ -106,7 +106,7 @@ pub async fn test_presign_stat(op: Operator) -> Result<()> {
 pub async fn test_presign_read(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
     debug!("Generate a random file: {}", &path);
-    let (content, size) = gen_bytes(op.info().full_capability());
+    let (content, size) = gen_bytes(op.info().capability());
 
     op.write(&path, content.clone())
         .await
@@ -136,14 +136,14 @@ pub async fn test_presign_read(op: Operator) -> Result<()> {
 
 /// Presign delete should succeed.
 pub async fn test_presign_delete(op: Operator) -> Result<()> {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
     if !cap.presign_delete {
         return Ok(());
     }
 
     let path = uuid::Uuid::new_v4().to_string();
     debug!("Generate a random file: {}", &path);
-    let (content, _size) = gen_bytes(op.info().full_capability());
+    let (content, _size) = gen_bytes(op.info().capability());
     // create a file
     op.write(&path, content.clone())
         .await

--- a/core/tests/behavior/async_read.rs
+++ b/core/tests/behavior/async_read.rs
@@ -27,7 +27,7 @@ use tokio::time::sleep;
 use crate::*;
 
 pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
 
     if cap.read && cap.write {
         tests.extend(async_trials!(
@@ -337,7 +337,7 @@ pub async fn test_read_not_exist(op: Operator) -> anyhow::Result<()> {
 
 /// Reader with if_match should match, else get a ConditionNotMatch error.
 pub async fn test_reader_with_if_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_match {
+    if !op.info().capability().read_with_if_match {
         return Ok(());
     }
 
@@ -367,7 +367,7 @@ pub async fn test_reader_with_if_match(op: Operator) -> anyhow::Result<()> {
 
 /// Read with if_match should match, else get a ConditionNotMatch error.
 pub async fn test_read_with_if_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_match {
+    if !op.info().capability().read_with_if_match {
         return Ok(());
     }
 
@@ -396,7 +396,7 @@ pub async fn test_read_with_if_match(op: Operator) -> anyhow::Result<()> {
 
 /// Reader with if_none_match should match, else get a ConditionNotMatch error.
 pub async fn test_reader_with_if_none_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_none_match {
+    if !op.info().capability().read_with_if_none_match {
         return Ok(());
     }
 
@@ -429,7 +429,7 @@ pub async fn test_reader_with_if_none_match(op: Operator) -> anyhow::Result<()> 
 
 /// Reader with if_modified_since should match, otherwise, a ConditionNotMatch error will be returned.
 pub async fn test_reader_with_if_modified_since(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_modified_since {
+    if !op.info().capability().read_with_if_modified_since {
         return Ok(());
     }
 
@@ -458,7 +458,7 @@ pub async fn test_reader_with_if_modified_since(op: Operator) -> anyhow::Result<
 
 /// Reader with if_unmodified_since should match, otherwise, a ConditionNotMatch error will be returned.
 pub async fn test_reader_with_if_unmodified_since(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_unmodified_since {
+    if !op.info().capability().read_with_if_unmodified_since {
         return Ok(());
     }
 
@@ -487,7 +487,7 @@ pub async fn test_reader_with_if_unmodified_since(op: Operator) -> anyhow::Resul
 
 /// Read with if_none_match should match, else get a ConditionNotMatch error.
 pub async fn test_read_with_if_none_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_none_match {
+    if !op.info().capability().read_with_if_none_match {
         return Ok(());
     }
 
@@ -519,7 +519,7 @@ pub async fn test_read_with_if_none_match(op: Operator) -> anyhow::Result<()> {
 
 /// Read with dir path should return an error.
 pub async fn test_read_with_dir_path(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
 
@@ -552,8 +552,7 @@ pub async fn test_read_with_special_chars(op: Operator) -> anyhow::Result<()> {
 
 /// Read file with override-cache-control should succeed.
 pub async fn test_read_with_override_cache_control(op: Operator) -> anyhow::Result<()> {
-    if !(op.info().full_capability().read_with_override_cache_control
-        && op.info().full_capability().presign)
+    if !(op.info().capability().read_with_override_cache_control && op.info().capability().presign)
     {
         return Ok(());
     }
@@ -599,9 +598,9 @@ pub async fn test_read_with_override_cache_control(op: Operator) -> anyhow::Resu
 pub async fn test_read_with_override_content_disposition(op: Operator) -> anyhow::Result<()> {
     if !(op
         .info()
-        .full_capability()
+        .capability()
         .read_with_override_content_disposition
-        && op.info().full_capability().presign)
+        && op.info().capability().presign)
     {
         return Ok(());
     }
@@ -647,9 +646,7 @@ pub async fn test_read_with_override_content_disposition(op: Operator) -> anyhow
 
 /// Read file with override_content_type should succeed.
 pub async fn test_read_with_override_content_type(op: Operator) -> anyhow::Result<()> {
-    if !(op.info().full_capability().read_with_override_content_type
-        && op.info().full_capability().presign)
-    {
+    if !(op.info().capability().read_with_override_content_type && op.info().capability().presign) {
         return Ok(());
     }
 
@@ -694,7 +691,7 @@ pub async fn test_read_with_override_content_type(op: Operator) -> anyhow::Resul
 
 /// Read with if_modified_since should match, otherwise, a ConditionNotMatch error will be returned.
 pub async fn test_read_with_if_modified_since(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_modified_since {
+    if !op.info().capability().read_with_if_modified_since {
         return Ok(());
     }
 
@@ -725,7 +722,7 @@ pub async fn test_read_with_if_modified_since(op: Operator) -> anyhow::Result<()
 
 /// Read with if_unmodified_since should match, otherwise, a ConditionNotMatch error will be returned.
 pub async fn test_read_with_if_unmodified_since(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_unmodified_since {
+    if !op.info().capability().read_with_if_unmodified_since {
         return Ok(());
     }
 
@@ -824,7 +821,7 @@ pub async fn test_read_only_read_with_dir_path(op: Operator) -> anyhow::Result<(
 
 /// Reader with if_match should match, else get a ConditionNotMatch error.
 pub async fn test_reader_only_read_with_if_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_match {
+    if !op.info().capability().read_with_if_match {
         return Ok(());
     }
 
@@ -856,7 +853,7 @@ pub async fn test_reader_only_read_with_if_match(op: Operator) -> anyhow::Result
 
 /// Read with if_match should match, else get a ConditionNotMatch error.
 pub async fn test_read_only_read_with_if_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_match {
+    if !op.info().capability().read_with_if_match {
         return Ok(());
     }
 
@@ -886,7 +883,7 @@ pub async fn test_read_only_read_with_if_match(op: Operator) -> anyhow::Result<(
 
 /// Reader with if_none_match should match, else get a ConditionNotMatch error.
 pub async fn test_reader_only_read_with_if_none_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_none_match {
+    if !op.info().capability().read_with_if_none_match {
         return Ok(());
     }
 
@@ -918,7 +915,7 @@ pub async fn test_reader_only_read_with_if_none_match(op: Operator) -> anyhow::R
 
 /// Read with if_none_match should match, else get a ConditionNotMatch error.
 pub async fn test_read_only_read_with_if_none_match(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_if_none_match {
+    if !op.info().capability().read_with_if_none_match {
         return Ok(());
     }
 
@@ -950,7 +947,7 @@ pub async fn test_read_only_read_with_if_none_match(op: Operator) -> anyhow::Res
 }
 
 pub async fn test_read_with_version(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_version {
+    if !op.info().capability().read_with_version {
         return Ok(());
     }
 
@@ -984,7 +981,7 @@ pub async fn test_read_with_version(op: Operator) -> anyhow::Result<()> {
 }
 
 pub async fn test_read_with_not_existing_version(op: Operator) -> anyhow::Result<()> {
-    if !op.info().full_capability().read_with_version {
+    if !op.info().capability().read_with_version {
         return Ok(());
     }
 

--- a/core/tests/behavior/async_rename.rs
+++ b/core/tests/behavior/async_rename.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 use crate::*;
 
 pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
 
     if cap.read && cap.write && cap.rename {
         tests.extend(async_trials!(
@@ -39,7 +39,7 @@ pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
 /// Rename a file and test with stat.
 pub async fn test_rename_file(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, source_content.clone()).await?;
 
@@ -80,7 +80,7 @@ pub async fn test_rename_non_existing_source(op: Operator) -> Result<()> {
 
 /// Rename a dir as source should return an error.
 pub async fn test_rename_source_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
 
@@ -99,12 +99,12 @@ pub async fn test_rename_source_dir(op: Operator) -> Result<()> {
 
 /// Rename to a dir should return an error.
 pub async fn test_rename_target_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
 
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (content, _) = gen_bytes(op.info().full_capability());
+    let (content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, content).await?;
 
@@ -126,7 +126,7 @@ pub async fn test_rename_target_dir(op: Operator) -> Result<()> {
 /// Rename a file to self should return an error.
 pub async fn test_rename_self(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (content, _) = gen_bytes(op.info().full_capability());
+    let (content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, content).await?;
 
@@ -143,7 +143,7 @@ pub async fn test_rename_self(op: Operator) -> Result<()> {
 /// Rename to a nested path, parent path should be created successfully.
 pub async fn test_rename_nested(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, source_content.clone()).await?;
 
@@ -177,12 +177,12 @@ pub async fn test_rename_nested(op: Operator) -> Result<()> {
 /// Rename to a exist path should overwrite successfully.
 pub async fn test_rename_overwrite(op: Operator) -> Result<()> {
     let source_path = uuid::Uuid::new_v4().to_string();
-    let (source_content, _) = gen_bytes(op.info().full_capability());
+    let (source_content, _) = gen_bytes(op.info().capability());
 
     op.write(&source_path, source_content.clone()).await?;
 
     let target_path = uuid::Uuid::new_v4().to_string();
-    let (target_content, _) = gen_bytes(op.info().full_capability());
+    let (target_content, _) = gen_bytes(op.info().capability());
     assert_ne!(source_content, target_content);
 
     op.write(&target_path, target_content).await?;

--- a/core/tests/behavior/async_stat.rs
+++ b/core/tests/behavior/async_stat.rs
@@ -26,7 +26,7 @@ use tokio::time::sleep;
 use crate::*;
 
 pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
 
     if cap.stat && cap.write {
         tests.extend(async_trials!(
@@ -75,7 +75,7 @@ pub async fn test_stat_file(op: Operator) -> Result<()> {
     assert_eq!(meta.content_length(), size as u64);
 
     // Stat a file with trailing slash should return `NotFound`.
-    if op.info().full_capability().create_dir {
+    if op.info().capability().create_dir {
         let result = op.stat(&format!("{path}/")).await;
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().kind(), ErrorKind::NotFound);
@@ -86,7 +86,7 @@ pub async fn test_stat_file(op: Operator) -> Result<()> {
 
 /// Stat existing file should return metadata
 pub async fn test_stat_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
 
@@ -109,7 +109,7 @@ pub async fn test_stat_dir(op: Operator) -> Result<()> {
 
 /// Stat the parent dir of existing dir should return metadata
 pub async fn test_stat_nested_parent_dir(op: Operator) -> Result<()> {
-    if !op.info().full_capability().create_dir {
+    if !op.info().capability().create_dir {
         return Ok(());
     }
 
@@ -165,7 +165,7 @@ pub async fn test_stat_not_exist(op: Operator) -> Result<()> {
     assert_eq!(meta.unwrap_err().kind(), ErrorKind::NotFound);
 
     // Stat not exist dir should also return NotFound.
-    if op.info().full_capability().create_dir {
+    if op.info().capability().create_dir {
         let meta = op.stat(&format!("{path}/")).await;
         assert!(meta.is_err());
         assert_eq!(meta.unwrap_err().kind(), ErrorKind::NotFound);
@@ -176,7 +176,7 @@ pub async fn test_stat_not_exist(op: Operator) -> Result<()> {
 
 /// Stat with if_match should succeed, else get a ConditionNotMatch error.
 pub async fn test_stat_with_if_match(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_if_match {
+    if !op.info().capability().stat_with_if_match {
         return Ok(());
     }
 
@@ -205,7 +205,7 @@ pub async fn test_stat_with_if_match(op: Operator) -> Result<()> {
 
 /// Stat with if_none_match should succeed, else get a ConditionNotMatch.
 pub async fn test_stat_with_if_none_match(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_if_none_match {
+    if !op.info().capability().stat_with_if_none_match {
         return Ok(());
     }
 
@@ -238,7 +238,7 @@ pub async fn test_stat_with_if_none_match(op: Operator) -> Result<()> {
 
 /// Stat file with if_modified_since should succeed, otherwise get a ConditionNotMatch error.
 pub async fn test_stat_with_if_modified_since(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_if_modified_since {
+    if !op.info().capability().stat_with_if_modified_since {
         return Ok(());
     }
 
@@ -268,7 +268,7 @@ pub async fn test_stat_with_if_modified_since(op: Operator) -> Result<()> {
 
 /// Stat file with if_unmodified_since should succeed, otherwise get a ConditionNotMatch error.
 pub async fn test_stat_with_if_unmodified_since(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_if_unmodified_since {
+    if !op.info().capability().stat_with_if_unmodified_since {
         return Ok(());
     }
 
@@ -298,8 +298,7 @@ pub async fn test_stat_with_if_unmodified_since(op: Operator) -> Result<()> {
 
 /// Stat file with override-cache-control should succeed.
 pub async fn test_stat_with_override_cache_control(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().stat_with_override_cache_control
-        && op.info().full_capability().presign)
+    if !(op.info().capability().stat_with_override_cache_control && op.info().capability().presign)
     {
         return Ok(());
     }
@@ -345,9 +344,9 @@ pub async fn test_stat_with_override_cache_control(op: Operator) -> Result<()> {
 pub async fn test_stat_with_override_content_disposition(op: Operator) -> Result<()> {
     if !(op
         .info()
-        .full_capability()
+        .capability()
         .stat_with_override_content_disposition
-        && op.info().full_capability().presign)
+        && op.info().capability().presign)
     {
         return Ok(());
     }
@@ -392,9 +391,7 @@ pub async fn test_stat_with_override_content_disposition(op: Operator) -> Result
 
 /// Stat file with override_content_type should succeed.
 pub async fn test_stat_with_override_content_type(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().stat_with_override_content_type
-        && op.info().full_capability().presign)
-    {
+    if !(op.info().capability().stat_with_override_content_type && op.info().capability().presign) {
         return Ok(());
     }
 
@@ -493,7 +490,7 @@ pub async fn test_read_only_stat_not_exist(op: Operator) -> Result<()> {
 
 /// Stat with if_match should succeed, else get a ConditionNotMatch error.
 pub async fn test_read_only_stat_with_if_match(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_if_match {
+    if !op.info().capability().stat_with_if_match {
         return Ok(());
     }
 
@@ -518,7 +515,7 @@ pub async fn test_read_only_stat_with_if_match(op: Operator) -> Result<()> {
 
 /// Stat with if_none_match should succeed, else get a ConditionNotMatch.
 pub async fn test_read_only_stat_with_if_none_match(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_if_none_match {
+    if !op.info().capability().stat_with_if_none_match {
         return Ok(());
     }
 
@@ -554,7 +551,7 @@ pub async fn test_read_only_stat_root(op: Operator) -> Result<()> {
 }
 
 pub async fn test_stat_with_version(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_version {
+    if !op.info().capability().stat_with_version {
         return Ok(());
     }
 
@@ -592,7 +589,7 @@ pub async fn test_stat_with_version(op: Operator) -> Result<()> {
 }
 
 pub async fn stat_with_not_existing_version(op: Operator) -> Result<()> {
-    if !op.info().full_capability().stat_with_version {
+    if !op.info().capability().stat_with_version {
         return Ok(());
     }
 

--- a/core/tests/behavior/async_write.rs
+++ b/core/tests/behavior/async_write.rs
@@ -29,7 +29,7 @@ use futures::stream;
 use crate::*;
 
 pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
 
     if cap.read && cap.write && cap.stat {
         tests.extend(async_trials!(
@@ -85,7 +85,7 @@ pub async fn test_write_only(op: Operator) -> Result<()> {
 
 /// Write a file with empty content.
 pub async fn test_write_with_empty_content(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_can_empty {
+    if !op.info().capability().write_can_empty {
         return Ok(());
     }
 
@@ -132,12 +132,12 @@ pub async fn test_write_with_special_chars(op: Operator) -> Result<()> {
 
 /// Write a single file with cache control should succeed.
 pub async fn test_write_with_cache_control(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_cache_control {
+    if !op.info().capability().write_with_cache_control {
         return Ok(());
     }
 
     let path = uuid::Uuid::new_v4().to_string();
-    let (content, _) = gen_bytes(op.info().full_capability());
+    let (content, _) = gen_bytes(op.info().capability());
 
     let target_cache_control = "no-cache, no-store, max-age=300";
     op.write_with(&path, content)
@@ -158,7 +158,7 @@ pub async fn test_write_with_cache_control(op: Operator) -> Result<()> {
 
 /// Write a single file with content type should succeed.
 pub async fn test_write_with_content_type(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_content_type {
+    if !op.info().capability().write_with_content_type {
         return Ok(());
     }
 
@@ -182,7 +182,7 @@ pub async fn test_write_with_content_type(op: Operator) -> Result<()> {
 
 /// Write a single file with content disposition should succeed.
 pub async fn test_write_with_content_disposition(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_content_disposition {
+    if !op.info().capability().write_with_content_disposition {
         return Ok(());
     }
 
@@ -206,7 +206,7 @@ pub async fn test_write_with_content_disposition(op: Operator) -> Result<()> {
 
 /// Write a single file with content encoding should succeed.
 pub async fn test_write_with_content_encoding(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_content_encoding {
+    if !op.info().capability().write_with_content_encoding {
         return Ok(());
     }
 
@@ -228,7 +228,7 @@ pub async fn test_write_with_content_encoding(op: Operator) -> Result<()> {
 
 /// write a single file with user defined metadata should succeed.
 pub async fn test_write_with_user_metadata(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_user_metadata {
+    if !op.info().capability().write_with_user_metadata {
         return Ok(());
     }
 
@@ -316,7 +316,7 @@ pub async fn test_writer_abort_with_concurrent(op: Operator) -> Result<()> {
 
 /// Append data into writer
 pub async fn test_writer_write(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().write_can_multi) {
+    if !(op.info().capability().write_can_multi) {
         return Ok(());
     }
 
@@ -351,7 +351,7 @@ pub async fn test_writer_write(op: Operator) -> Result<()> {
 
 /// Append data into writer
 pub async fn test_writer_write_with_concurrent(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().write_can_multi) {
+    if !(op.info().capability().write_can_multi) {
         return Ok(());
     }
 
@@ -393,7 +393,7 @@ pub async fn test_writer_write_with_concurrent(op: Operator) -> Result<()> {
 
 /// Streaming data into writer
 pub async fn test_writer_sink(op: Operator) -> Result<()> {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
     if !(cap.write && cap.write_can_multi) {
         return Ok(());
     }
@@ -437,7 +437,7 @@ pub async fn test_writer_sink(op: Operator) -> Result<()> {
 
 /// Streaming data into writer
 pub async fn test_writer_sink_with_concurrent(op: Operator) -> Result<()> {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
     if !(cap.write && cap.write_can_multi) {
         return Ok(());
     }
@@ -482,7 +482,7 @@ pub async fn test_writer_sink_with_concurrent(op: Operator) -> Result<()> {
 
 /// Copy data from reader to writer
 pub async fn test_writer_futures_copy(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().write_can_multi) {
+    if !(op.info().capability().write_can_multi) {
         return Ok(());
     }
 
@@ -517,7 +517,7 @@ pub async fn test_writer_futures_copy(op: Operator) -> Result<()> {
 
 /// Copy data from reader to writer
 pub async fn test_writer_futures_copy_with_concurrent(op: Operator) -> Result<()> {
-    if !(op.info().full_capability().write_can_multi) {
+    if !(op.info().capability().write_can_multi) {
         return Ok(());
     }
 
@@ -552,7 +552,7 @@ pub async fn test_writer_futures_copy_with_concurrent(op: Operator) -> Result<()
 }
 
 pub async fn test_writer_return_metadata(op: Operator) -> Result<()> {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
     if !cap.write_can_multi {
         return Ok(());
     }
@@ -577,8 +577,8 @@ pub async fn test_writer_return_metadata(op: Operator) -> Result<()> {
 /// Test append to a file must success.
 pub async fn test_write_with_append(op: Operator) -> Result<()> {
     let path = TEST_FIXTURE.new_file_path();
-    let (content_one, size_one) = gen_bytes(op.info().full_capability());
-    let (content_two, size_two) = gen_bytes(op.info().full_capability());
+    let (content_one, size_one) = gen_bytes(op.info().capability());
+    let (content_two, size_two) = gen_bytes(op.info().capability());
 
     op.write_with(&path, content_one.clone())
         .append(true)
@@ -607,7 +607,7 @@ pub async fn test_write_with_append(op: Operator) -> Result<()> {
 }
 
 pub async fn test_write_with_append_returns_metadata(op: Operator) -> Result<()> {
-    let cap = op.info().full_capability();
+    let cap = op.info().capability();
 
     let path = TEST_FIXTURE.new_file_path();
     let (content_one, _) = gen_bytes(cap);
@@ -695,8 +695,8 @@ pub async fn test_writer_write_with_overwrite(op: Operator) -> Result<()> {
     }
 
     let path = uuid::Uuid::new_v4().to_string();
-    let (content_one, _) = gen_bytes(op.info().full_capability());
-    let (content_two, _) = gen_bytes(op.info().full_capability());
+    let (content_one, _) = gen_bytes(op.info().capability());
+    let (content_two, _) = gen_bytes(op.info().capability());
 
     op.write(&path, content_one.clone()).await?;
     let bs = op.read(&path).await?.to_bytes();
@@ -726,7 +726,7 @@ pub async fn test_writer_write_with_overwrite(op: Operator) -> Result<()> {
 
 /// Write an exists file with if_none_match should match, else get a ConditionNotMatch error.
 pub async fn test_write_with_if_none_match(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_if_none_match {
+    if !op.info().capability().write_with_if_none_match {
         return Ok(());
     }
 
@@ -750,7 +750,7 @@ pub async fn test_write_with_if_none_match(op: Operator) -> Result<()> {
 
 /// Write a file with if_not_exists will get a ConditionNotMatch error if file exists.
 pub async fn test_write_with_if_not_exists(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_if_not_exists {
+    if !op.info().capability().write_with_if_not_exists {
         return Ok(());
     }
 
@@ -774,7 +774,7 @@ pub async fn test_write_with_if_not_exists(op: Operator) -> Result<()> {
 
 /// Write a file with if_match will get a ConditionNotMatch error if file's etag does not match.
 pub async fn test_write_with_if_match(op: Operator) -> Result<()> {
-    if !op.info().full_capability().write_with_if_match {
+    if !op.info().capability().write_with_if_match {
         return Ok(());
     }
 

--- a/core/tests/behavior/utils.rs
+++ b/core/tests/behavior/utils.rs
@@ -139,7 +139,7 @@ impl Fixture {
 
     /// Create a new file with random content
     pub fn new_file(&self, op: impl Into<Operator>) -> (String, Vec<u8>, usize) {
-        let max_size = content_max_size(op.into().info().full_capability());
+        let max_size = content_max_size(op.into().info().capability());
 
         self.new_file_with_range(uuid::Uuid::new_v4().to_string(), 1..max_size)
     }
@@ -149,7 +149,7 @@ impl Fixture {
         op: impl Into<Operator>,
         path: &str,
     ) -> (String, Vec<u8>, usize) {
-        let max_size = content_max_size(op.into().info().full_capability());
+        let max_size = content_max_size(op.into().info().capability());
 
         self.new_file_with_range(path, 1..max_size)
     }
@@ -176,7 +176,7 @@ impl Fixture {
     pub async fn cleanup(&self, op: impl Into<Operator>) {
         let op = op.into();
         // Don't cleanup data if delete is not supported
-        if !op.info().full_capability().delete {
+        if !op.info().capability().delete {
             return;
         }
 

--- a/integrations/object_store/src/service/mod.rs
+++ b/integrations/object_store/src/service/mod.rs
@@ -102,7 +102,7 @@ impl Access for ObjectStoreService {
         info.set_scheme(OBJECT_STORE_SCHEME)
             .set_root("/")
             .set_name("object_store")
-            .set_native_capability(Capability {
+            .set_service_capability(Capability {
                 stat: true,
                 stat_with_if_match: true,
                 stat_with_if_unmodified_since: true,
@@ -184,7 +184,7 @@ mod tests {
         assert_eq!(info.name(), "object_store".into());
         assert_eq!(info.root(), "/".into());
 
-        let cap = info.native_capability();
+        let cap = info.service_capability();
         assert!(cap.stat);
         assert!(cap.read);
         assert!(cap.write);

--- a/integrations/object_store/src/store.rs
+++ b/integrations/object_store/src/store.rs
@@ -378,7 +378,7 @@ impl Debug for OpendalStore {
             .field("scheme", &self.info.scheme())
             .field("name", &self.info.name())
             .field("root", &self.info.root())
-            .field("capability", &self.info.full_capability())
+            .field("capability", &self.info.capability())
             .finish()
     }
 }
@@ -630,7 +630,7 @@ impl ObjectStore for OpendalStore {
         let this = self.clone();
 
         let fut = async move {
-            let list_with_start_after = this.inner.info().full_capability().list_with_start_after;
+            let list_with_start_after = this.inner.info().capability().list_with_start_after;
             let mut fut = this.inner.lister_with(&path).recursive(true);
 
             // Use native start_after support if possible.

--- a/integrations/object_store/tests/behavior/get.rs
+++ b/integrations/object_store/tests/behavior/get.rs
@@ -185,7 +185,7 @@ pub async fn test_get_opts_with_invalid_range(store: OpendalStore) -> Result<()>
 }
 
 pub async fn test_get_opts_with_version(store: OpendalStore) -> Result<()> {
-    if !store.info().full_capability().read_with_version {
+    if !store.info().capability().read_with_version {
         return Ok(());
     }
 
@@ -228,7 +228,7 @@ pub async fn test_get_opts_with_version(store: OpendalStore) -> Result<()> {
 }
 
 async fn test_get_ops_with_if_match(store: OpendalStore) -> Result<()> {
-    if !store.info().full_capability().read_with_if_match {
+    if !store.info().capability().read_with_if_match {
         return Ok(());
     }
 
@@ -261,7 +261,7 @@ async fn test_get_ops_with_if_match(store: OpendalStore) -> Result<()> {
 }
 
 async fn test_get_ops_with_if_none_match(store: OpendalStore) -> Result<()> {
-    if !store.info().full_capability().read_with_if_none_match {
+    if !store.info().capability().read_with_if_none_match {
         return Ok(());
     }
 
@@ -294,7 +294,7 @@ async fn test_get_ops_with_if_none_match(store: OpendalStore) -> Result<()> {
 }
 
 async fn test_get_opts_with_if_modified_since(store: OpendalStore) -> Result<()> {
-    if !store.info().full_capability().read_with_if_modified_since {
+    if !store.info().capability().read_with_if_modified_since {
         return Ok(());
     }
 
@@ -327,7 +327,7 @@ async fn test_get_opts_with_if_modified_since(store: OpendalStore) -> Result<()>
 }
 
 async fn test_get_opts_with_if_unmodified_since(store: OpendalStore) -> Result<()> {
-    if !store.info().full_capability().read_with_if_unmodified_since {
+    if !store.info().capability().read_with_if_unmodified_since {
         return Ok(());
     }
 

--- a/integrations/object_store/tests/behavior/put.rs
+++ b/integrations/object_store/tests/behavior/put.rs
@@ -75,7 +75,7 @@ pub async fn test_put_opts_with_overwrite(store: OpendalStore) -> Result<()> {
 }
 
 pub async fn test_put_opts_with_create(store: OpendalStore) -> Result<()> {
-    if !store.info().full_capability().write_with_if_not_exists {
+    if !store.info().capability().write_with_if_not_exists {
         return Ok(());
     }
 
@@ -103,7 +103,7 @@ pub async fn test_put_opts_with_create(store: OpendalStore) -> Result<()> {
 }
 
 pub async fn test_put_opts_with_update(store: OpendalStore) -> Result<()> {
-    if !store.info().full_capability().write_with_if_match {
+    if !store.info().capability().write_with_if_match {
         return Ok(());
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A. Implements RFC #7700.

# Rationale for this change

RFC #7700 simplifies OpenDAL's capability model by making `Capability` the single user-facing type and `OperatorInfo::capability()` the recommended availability check. The previous `native_capability()` and `full_capability()` naming made users choose between backend-declared and effective capabilities even though most user code only needs the effective operator capability.

# What changes are included in this PR?

This PR adds `OperatorInfo::capability()` and renames raw internals to `service_capability()` / `set_service_capability()` and `capability()` / `update_capability()`. The old native/full APIs remain as deprecated compatibility aliases.

It also updates services, layers, behavior tests, the object_store integration, binding shims, binding docs, and upgrade notes to use the new effective capability terminology.

# Are there any user-facing changes?

Yes. Users should migrate from `OperatorInfo::full_capability()` to `OperatorInfo::capability()`. `full_capability()` and `native_capability()` remain available as deprecated compatibility APIs.

Bindings add matching capability accessors where applicable while keeping existing full/native APIs for compatibility.

# AI Usage Statement

AI assistance was used to implement and check this change.
