### PR TITLE
fix(services/webdav): handle invalid propfind metadata

### DIFF
--- a/core/services/webdav/src/core.rs
+++ b/core/services/webdav/src/core.rs
@@ -747,7 +747,8 @@ pub fn parse_propstat(propstat: &Propstat) -> Result<Metadata> {
         )
     })?;
 
-    // As defined in https://tools.ietf.org/html/rfc2068#section-6.1
+    // read status definition at https://tools.ietf.org/html/rfc2068#section-6.1
+    let mut status_parts = status.split_whitespace();
     let code = code.parse::<u16>().map_err(|err| {
         Error::new(ErrorKind::Unexpected, "parse webdav propfind status code").set_source(err)
     })?;

--- a/core/services/webdav/src/core.rs
+++ b/core/services/webdav/src/core.rs
@@ -736,15 +736,27 @@ pub fn parse_propstat(propstat: &Propstat) -> Result<Metadata> {
         status,
     } = propstat;
 
-    if let [_, code, text] = status.splitn(3, ' ').collect::<Vec<_>>()[..3] {
-        // As defined in https://tools.ietf.org/html/rfc2068#section-6.1
-        let code = code.parse::<u16>().unwrap();
-        if code >= 400 {
-            return Err(Error::new(
-                ErrorKind::Unexpected,
-                format!("propfind response is unexpected: {code} {text}"),
-            ));
-        }
+    let mut status_parts = status.split_whitespace();
+    status_parts
+        .next()
+        .ok_or_else(|| Error::new(ErrorKind::Unexpected, "propfind response status is missing"))?;
+    let code = status_parts.next().ok_or_else(|| {
+        Error::new(
+            ErrorKind::Unexpected,
+            "propfind response status code is missing",
+        )
+    })?;
+
+    // As defined in https://tools.ietf.org/html/rfc2068#section-6.1
+    let code = code.parse::<u16>().map_err(|err| {
+        Error::new(ErrorKind::Unexpected, "parse webdav propfind status code").set_source(err)
+    })?;
+    if code >= 400 {
+        let text = status_parts.collect::<Vec<_>>().join(" ");
+        return Err(Error::new(
+            ErrorKind::Unexpected,
+            format!("propfind response is unexpected: {code} {text}"),
+        ));
     }
 
     let mode: EntryMode = if resourcetype.value == Some(ResourceType::Collection) {
@@ -755,7 +767,10 @@ pub fn parse_propstat(propstat: &Propstat) -> Result<Metadata> {
     let mut m = Metadata::new(mode);
 
     if let Some(v) = getcontentlength {
-        m.set_content_length(v.parse::<u64>().unwrap());
+        let content_length = v.parse::<u64>().map_err(|err| {
+            Error::new(ErrorKind::Unexpected, "parse webdav content length").set_source(err)
+        })?;
+        m.set_content_length(content_length);
     }
 
     if let Some(v) = getcontenttype {
@@ -818,6 +833,19 @@ mod tests {
 
     use super::*;
 
+    fn new_propstat(status: &str, getcontentlength: Option<&str>) -> Propstat {
+        Propstat {
+            status: status.to_string(),
+            prop: Prop {
+                getlastmodified: "Tue, 01 May 2022 06:39:47 GMT".to_string(),
+                getetag: None,
+                getcontentlength: getcontentlength.map(str::to_string),
+                getcontenttype: None,
+                resourcetype: ResourceTypeContainer { value: None },
+            },
+        }
+    }
+
     #[test]
     fn test_propstat() {
         let xml = r#"<D:propstat>
@@ -847,6 +875,22 @@ mod tests {
         );
 
         assert_eq!(propstat.status, "HTTP/1.1 200 OK");
+    }
+
+    #[test]
+    fn test_parse_propstat_rejects_invalid_status_code() {
+        for status in ["HTTP/1.1 abc OK", "HTTP/1.1 99999 OK", "HTTP/1.1", "broken"] {
+            assert!(parse_propstat(&new_propstat(status, None)).is_err());
+        }
+    }
+
+    #[test]
+    fn test_parse_propstat_rejects_invalid_content_length() {
+        for content_length in ["abc", "18446744073709551616"] {
+            assert!(
+                parse_propstat(&new_propstat("HTTP/1.1 200 OK", Some(content_length))).is_err()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

WebDAV PROPFIND responses can contain malformed metadata fields. The parser should surface malformed status codes and content lengths as OpenDAL errors instead of panicking while building metadata.

# What changes are included in this PR?

This PR updates WebDAV `parse_propstat` to validate the PROPFIND status line and content length with fallible parsing. It also adds unit tests for invalid status codes, truncated status lines, and invalid content lengths.

# Are there any user-facing changes?

Invalid WebDAV PROPFIND metadata now returns an error instead of panicking. There are no public API changes.

# AI Usage Statement

AI tools were used to assist with implementation and validation.
