### PR TITLE
fix(services/webdav): remove unnecessary mut

### DIFF
--- a/core/services/webdav/src/core.rs
+++ b/core/services/webdav/src/core.rs
@@ -748,7 +748,7 @@ pub fn parse_propstat(propstat: &Propstat) -> Result<Metadata> {
     })?;
 
     // read status definition at https://tools.ietf.org/html/rfc2068#section-6.1
-    let mut status_parts = status.split_whitespace();
+    let status_parts = status.split_whitespace();
     let code = code.parse::<u16>().map_err(|err| {
         Error::new(ErrorKind::Unexpected, "parse webdav propfind status code").set_source(err)
     })?;


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

The latest `check_clippy` CI fails with `unused_mut` in WebDAV PROPFIND status parsing. The second `status_parts` iterator is only consumed by `collect()` to build error text, so the binding does not need to be mutable.

# What changes are included in this PR?

Remove the unnecessary `mut` from the second `status_parts` binding in the WebDAV service.

# Are there any user-facing changes?

No.

# AI Usage Statement

AI assistance was used to prepare this PR.

# Tests

- `cargo clippy -p opendal-service-webdav --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
