### PR TITLE
fix(services/fs): preserve backslash in filenames on Unix during list

### DIFF
--- a/core/services/fs/src/lister.rs
+++ b/core/services/fs/src/lister.rs
@@ -66,13 +66,13 @@ impl oio::List for FsLister<tokio::fs::ReadDir> {
             };
 
             let entry_path = de.path();
-            let rel_path = normalize_path(
-                &entry_path
-                    .strip_prefix(&self.root)
-                    .expect("cannot fail because the prefix is iterated")
-                    .to_string_lossy()
-                    .replace('\\', "/"),
-            );
+            let raw = entry_path
+                .strip_prefix(&self.root)
+                .expect("cannot fail because the prefix is iterated")
+                .to_string_lossy();
+            #[cfg(windows)]
+            let raw = raw.replace('\\', "/");
+            let rel_path = normalize_path(&raw);
 
             let ft = match de.file_type().await {
                 Ok(ft) => ft,
@@ -112,5 +112,36 @@ impl oio::List for FsLister<tokio::fs::ReadDir> {
 
             return Ok(Some(oio::Entry::new(path, metadata)));
         }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use opendal_core::raw::oio::List;
+
+    #[tokio::test]
+    async fn list_file_with_backslash_in_name() {
+        let root = std::env::temp_dir().join("opendal-test-fs-lister-backslash");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        std::fs::write(root.join("has\\slash"), b"data").unwrap();
+
+        let rd = tokio::fs::read_dir(&root).await.unwrap();
+        let mut lister = FsLister::new(&root, "/", rd);
+
+        let first = lister.next().await.unwrap().unwrap();
+        assert_eq!(first.mode(), EntryMode::DIR);
+
+        let file_entry = lister.next().await.unwrap().unwrap();
+        assert_eq!(file_entry.mode(), EntryMode::FILE);
+        assert!(
+            !file_entry.path().ends_with('/'),
+            "file path must not end with /: {}",
+            file_entry.path()
+        );
+
+        std::fs::remove_dir_all(&root).unwrap();
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

N/A — discovered via fuzz testing.

# Rationale for this change

On Unix systems `\` (backslash) is a valid character in filenames. The
fs lister unconditionally replaced every `\` with `/` when converting
OS paths to OpenDAL paths. This turned a file named `has\slash` into
the path `has/slash` — a trailing `/` makes it look like a directory,
so `oio::Entry::with` hit a `debug_assert!` panic (mode `FILE` vs
path ending with `/`). In release builds the inconsistency was
silently returned to callers, giving them a wrong `EntryMode`.

The replacement is only needed on Windows where `\` is the path
separator. On Unix it must be preserved.

# What changes are included in this PR?

- Guard the `replace('\\', "/")` call in `FsLister` with
  `#[cfg(windows)]` so it only runs where `\` is a path separator.
- Add a `#[cfg(unix)]` regression test that creates a file with a
  backslash in its name and asserts the lister reports it as `FILE`.

# Are there any user-facing changes?

Files whose names contain backslashes are now listed with the correct
`EntryMode` on Unix/macOS. Previously they could be misreported as
directories.

# AI Usage Statement

Claude was used for assistance with fuzz target development that led to
discovering this bug.