### PR TITLE
fix(fuzz): fall back to fs operator so fuzz targets produce real coverage

### DIFF
--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -89,6 +89,11 @@ opendal = { path = "..", features = ["tests", "services-fs"] }
 uuid = { workspace = true, features = ["v4"] }
 
 [[bin]]
+name = "fuzz_path"
+path = "fuzz_path.rs"
+test = false
+
+[[bin]]
 name = "fuzz_reader"
 path = "fuzz_reader.rs"
 test = false

--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -85,7 +85,7 @@ arbitrary = { version = "1.4.2", features = ["derive"] }
 libfuzzer-sys = "0.4"
 log = { workspace = true }
 logforth = { workspace = true }
-opendal = { path = "..", features = ["tests"] }
+opendal = { path = "..", features = ["tests", "services-fs"] }
 uuid = { workspace = true, features = ["v4"] }
 
 [[bin]]

--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -89,6 +89,11 @@ opendal = { path = "..", features = ["tests", "services-fs"] }
 uuid = { workspace = true, features = ["v4"] }
 
 [[bin]]
+name = "fuzz_from_uri"
+path = "fuzz_from_uri.rs"
+test = false
+
+[[bin]]
 name = "fuzz_path"
 path = "fuzz_path.rs"
 test = false

--- a/core/fuzz/fuzz_from_uri.rs
+++ b/core/fuzz/fuzz_from_uri.rs
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![no_main]
+
+use libfuzzer_sys::arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use opendal::Operator;
+use opendal::OperatorUri;
+
+#[derive(Debug, Clone, Arbitrary)]
+struct FuzzInput {
+    uri: String,
+    options: Vec<(String, String)>,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let _ = logforth::starter_log::stderr().try_apply();
+
+    let _ = OperatorUri::new(&input.uri, input.options.clone());
+    let _ = Operator::from_uri(input.uri.as_str());
+    let _ = Operator::via_iter(&input.uri, input.options);
+});

--- a/core/fuzz/fuzz_path.rs
+++ b/core/fuzz/fuzz_path.rs
@@ -36,6 +36,7 @@ static OPERATOR: LazyLock<Operator> = LazyLock::new(|| {
         return op;
     }
 
+    log::warn!("OPENDAL_TEST is not set; falling back to a temporary fs operator");
     let root = std::env::temp_dir().join(format!("opendal-fuzz-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&root).expect("create fuzz root dir must succeed");
     Operator::new(opendal::services::Fs::default().root(&root.to_string_lossy()))

--- a/core/fuzz/fuzz_path.rs
+++ b/core/fuzz/fuzz_path.rs
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![no_main]
+
+use std::sync::LazyLock;
+
+use libfuzzer_sys::arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use opendal::Operator;
+use opendal::tests::TEST_RUNTIME;
+use opendal::tests::init_test_service;
+
+#[derive(Debug, Clone, Arbitrary)]
+struct FuzzInput {
+    path: String,
+    target: String,
+}
+
+static OPERATOR: LazyLock<Operator> = LazyLock::new(|| {
+    if let Some(op) = init_test_service().expect("operator init must succeed") {
+        return op;
+    }
+
+    let root = std::env::temp_dir().join(format!("opendal-fuzz-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&root).expect("create fuzz root dir must succeed");
+    Operator::new(opendal::services::Fs::default().root(&root.to_string_lossy()))
+        .expect("operator init must succeed")
+        .finish()
+});
+
+async fn fuzz_path(op: Operator, input: FuzzInput) {
+    let _ = op.write(&input.path, "data".as_bytes()).await;
+    let _ = op.stat(&input.path).await;
+    let _ = op.list(&input.path).await;
+    let _ = op.create_dir(&input.path).await;
+    let _ = op.copy(&input.path, &input.target).await;
+    let _ = op.rename(&input.path, &input.target).await;
+    let _ = op.delete(&input.target).await;
+    let _ = op.delete(&input.path).await;
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let _ = logforth::starter_log::stderr().try_apply();
+
+    let op = OPERATOR.clone();
+    TEST_RUNTIME.block_on(async {
+        fuzz_path(op, input.clone()).await;
+    })
+});

--- a/core/fuzz/fuzz_reader.rs
+++ b/core/fuzz/fuzz_reader.rs
@@ -94,6 +94,7 @@ static OPERATOR: LazyLock<Operator> = LazyLock::new(|| {
         return op;
     }
 
+    log::warn!("OPENDAL_TEST is not set; falling back to a temporary fs operator");
     let root = std::env::temp_dir().join(format!("opendal-fuzz-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&root).expect("create fuzz root dir must succeed");
     Operator::new(opendal::services::Fs::default().root(&root.to_string_lossy()))

--- a/core/fuzz/fuzz_reader.rs
+++ b/core/fuzz/fuzz_reader.rs
@@ -89,8 +89,6 @@ async fn fuzz_reader(op: Operator, input: FuzzInput) -> Result<()> {
     Ok(())
 }
 
-// Fall back to an fs operator in a temporary directory when no test service is
-// configured, so fuzz targets exercise real code out of the box (e.g. on OSS-Fuzz).
 static OPERATOR: LazyLock<Operator> = LazyLock::new(|| {
     if let Some(op) = init_test_service().expect("operator init must succeed") {
         return op;

--- a/core/fuzz/fuzz_reader.rs
+++ b/core/fuzz/fuzz_reader.rs
@@ -19,6 +19,7 @@
 
 use std::fmt::Debug;
 use std::fmt::Formatter;
+use std::sync::LazyLock;
 
 use libfuzzer_sys::arbitrary::Arbitrary;
 use libfuzzer_sys::arbitrary::Unstructured;
@@ -88,15 +89,27 @@ async fn fuzz_reader(op: Operator, input: FuzzInput) -> Result<()> {
     Ok(())
 }
 
+// Fall back to an fs operator in a temporary directory when no test service is
+// configured, so fuzz targets exercise real code out of the box (e.g. on OSS-Fuzz).
+static OPERATOR: LazyLock<Operator> = LazyLock::new(|| {
+    if let Some(op) = init_test_service().expect("operator init must succeed") {
+        return op;
+    }
+
+    let root = std::env::temp_dir().join(format!("opendal-fuzz-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&root).expect("create fuzz root dir must succeed");
+    Operator::new(opendal::services::Fs::default().root(&root.to_string_lossy()))
+        .expect("operator init must succeed")
+        .finish()
+});
+
 fuzz_target!(|input: FuzzInput| {
     let _ = logforth::starter_log::stderr().try_apply();
 
-    let op = init_test_service().expect("operator init must succeed");
-    if let Some(op) = op {
-        TEST_RUNTIME.block_on(async {
-            fuzz_reader(op, input.clone())
-                .await
-                .unwrap_or_else(|err| panic!("fuzz reader must succeed: {err:?}"));
-        })
-    }
+    let op = OPERATOR.clone();
+    TEST_RUNTIME.block_on(async {
+        fuzz_reader(op, input.clone())
+            .await
+            .unwrap_or_else(|err| panic!("fuzz reader must succeed: {err:?}"));
+    })
 });

--- a/core/fuzz/fuzz_writer.rs
+++ b/core/fuzz/fuzz_writer.rs
@@ -111,6 +111,7 @@ static OPERATOR: LazyLock<Operator> = LazyLock::new(|| {
         return op;
     }
 
+    log::warn!("OPENDAL_TEST is not set; falling back to a temporary fs operator");
     let root = std::env::temp_dir().join(format!("opendal-fuzz-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&root).expect("create fuzz root dir must succeed");
     Operator::new(opendal::services::Fs::default().root(&root.to_string_lossy()))

--- a/core/fuzz/fuzz_writer.rs
+++ b/core/fuzz/fuzz_writer.rs
@@ -106,8 +106,6 @@ async fn fuzz_writer(op: Operator, input: FuzzInput) -> Result<()> {
     Ok(())
 }
 
-// Fall back to an fs operator in a temporary directory when no test service is
-// configured, so fuzz targets exercise real code out of the box (e.g. on OSS-Fuzz).
 static OPERATOR: LazyLock<Operator> = LazyLock::new(|| {
     if let Some(op) = init_test_service().expect("operator init must succeed") {
         return op;

--- a/core/fuzz/fuzz_writer.rs
+++ b/core/fuzz/fuzz_writer.rs
@@ -17,6 +17,8 @@
 
 #![no_main]
 
+use std::sync::LazyLock;
+
 use libfuzzer_sys::arbitrary::Arbitrary;
 use libfuzzer_sys::arbitrary::Unstructured;
 use libfuzzer_sys::fuzz_target;
@@ -104,20 +106,32 @@ async fn fuzz_writer(op: Operator, input: FuzzInput) -> Result<()> {
     Ok(())
 }
 
+// Fall back to an fs operator in a temporary directory when no test service is
+// configured, so fuzz targets exercise real code out of the box (e.g. on OSS-Fuzz).
+static OPERATOR: LazyLock<Operator> = LazyLock::new(|| {
+    if let Some(op) = init_test_service().expect("operator init must succeed") {
+        return op;
+    }
+
+    let root = std::env::temp_dir().join(format!("opendal-fuzz-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&root).expect("create fuzz root dir must succeed");
+    Operator::new(opendal::services::Fs::default().root(&root.to_string_lossy()))
+        .expect("operator init must succeed")
+        .finish()
+});
+
 fuzz_target!(|input: FuzzInput| {
     let _ = logforth::starter_log::stderr().try_apply();
 
-    let op = init_test_service().expect("operator init must succeed");
-    if let Some(op) = op {
-        if !op.info().full_capability().write_can_multi {
-            log::warn!("service doesn't support write multi, skip fuzzing");
-            return;
-        }
-
-        TEST_RUNTIME.block_on(async {
-            fuzz_writer(op, input.clone())
-                .await
-                .unwrap_or_else(|err| panic!("fuzz reader must succeed: {err:?}"));
-        })
+    let op = OPERATOR.clone();
+    if !op.info().full_capability().write_can_multi {
+        log::warn!("service doesn't support write multi, skip fuzzing");
+        return;
     }
+
+    TEST_RUNTIME.block_on(async {
+        fuzz_writer(op, input.clone())
+            .await
+            .unwrap_or_else(|err| panic!("fuzz writer must succeed: {err:?}"));
+    })
 });


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7722.

# Rationale for this change

All OSS-Fuzz targets exit immediately when `OPENDAL_TEST` is unset because `init_test_service()` returns `None`. OSS-Fuzz never sets this variable, so coverage has been stuck at 0.26% (harness startup only) since integration.

# What changes are included in this PR?

- `fuzz_reader.rs` / `fuzz_writer.rs`: replace the `if let Some(op)` early-return with a `LazyLock<Operator>` that falls back to a local `Fs` operator in a temp directory when no test service is configured.
- `fuzz/Cargo.toml`: enable `services-fs` feature so the fallback compiles.
- New `fuzz_path.rs` target: feeds arbitrary strings as paths through `write`/`stat`/`list`/`copy`/`rename`/`delete` — already found a real bug (#7721) within 2 minutes of running.

# Are there any user-facing changes?

No. Changes are limited to the `core/fuzz/` directory which is only used by `cargo fuzz` and OSS-Fuzz.

# AI Usage Statement

Claude was used for assistance with fuzz target development.