### PR TITLE
feat(operator.go): use c binding check

### DIFF
--- a/bindings/go/lister.go
+++ b/bindings/go/lister.go
@@ -26,52 +26,6 @@ import (
 	"github.com/jupiterrider/ffi"
 )
 
-// Check verifies if the operator is functioning correctly.
-//
-// This function performs a health check on the operator by sending a `list` request
-// to the root path. It returns any errors encountered during this process.
-//
-// # Returns
-//
-//   - error: An error if the check fails, or nil if the operator is working correctly.
-//
-// # Details
-//
-// The check is performed by attempting to list the contents of the root directory.
-// This operation tests the basic functionality of the operator, including
-// connectivity and permissions.
-//
-// # Example
-//
-//	func exampleCheck(op *opendal.Operator) {
-//		err = op.Check()
-//		if err != nil {
-//			log.Printf("Operator check failed: %v", err)
-//		} else {
-//			log.Println("Operator is functioning correctly")
-//		}
-//	}
-//
-// Note: This example assumes proper error handling and import statements.
-func (op *Operator) Check() (err error) {
-	ds, err := op.List("/")
-	if err != nil {
-		return
-	}
-	defer func() {
-		closeErr := ds.Close()
-		if err == nil {
-			err = closeErr
-		}
-	}()
-	ds.Next()
-	err = ds.Error()
-	if err, ok := err.(*Error); ok && err.Code() == CodeNotFound {
-		return nil
-	}
-	return
-}
-
 // List returns a Lister to iterate over entries that start with the given path in the parent directory.
 //
 // WithListFn is a functional option for the List operation.

--- a/bindings/go/operator.go
+++ b/bindings/go/operator.go
@@ -62,6 +62,32 @@ func (op *Operator) Rename(src, dest string) error {
 	return ffiOperatorRename.symbol(op.ctx)(op.inner, src, dest)
 }
 
+// Check verifies if the operator is functioning correctly.
+//
+// Check is a wrapper around the C-binding function `opendal_operator_check`.
+// It performs a health check against the underlying backend, returning any
+// error encountered while reaching it.
+//
+// # Returns
+//
+//   - error: An error if the check fails, or nil if the operator is working correctly.
+//
+// # Example
+//
+//	func exampleCheck(op *opendal.Operator) {
+//		err = op.Check()
+//		if err != nil {
+//			log.Printf("Operator check failed: %v", err)
+//		} else {
+//			log.Println("Operator is functioning correctly")
+//		}
+//	}
+//
+// Note: This example assumes proper error handling and import statements.
+func (op *Operator) Check() error {
+	return ffiOperatorCheck.symbol(op.ctx)(op.inner)
+}
+
 func normalizeScheme(scheme Scheme) (*byte, error) {
 	return BytePtrFromString(strings.ReplaceAll(scheme.Name(), "_", "-"))
 }
@@ -212,6 +238,21 @@ var ffiOperatorRename = newFFI(ffiOpts{
 			unsafe.Pointer(&op),
 			unsafe.Pointer(&byteSrc),
 			unsafe.Pointer(&byteDest),
+		)
+		return parseError(ctx, e)
+	}
+})
+
+var ffiOperatorCheck = newFFI(ffiOpts{
+	sym:    "opendal_operator_check",
+	rType:  &ffi.TypePointer,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(op *opendalOperator) error {
+	return func(op *opendalOperator) error {
+		var e *opendalError
+		ffiCall(
+			unsafe.Pointer(&e),
+			unsafe.Pointer(&op),
 		)
 		return parseError(ctx, e)
 	}


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
This PR wires Go's `Check()` to the native function, removing the duplicated logic and matching the behavior of the other bindings.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add an FFI binding `ffiOperatorCheck` for `opendal_operator_check`.
- Refactor `Operator.Check()` as a thin wrapper over the native call and move it from `lister.go` to `operator.go`, since it is no longer list-related.

# Are there any user-facing changes?

N/A

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
Claude Code with Opus 4.8