### PR TITLE
fix(services/azdls): load Azure credentials from environment

### DIFF
--- a/core/services/azdls/src/backend.rs
+++ b/core/services/azdls/src/backend.rs
@@ -233,11 +233,8 @@ impl AzdlsBuilder {
     }
 }
 
-/// Build the credential environment, seeding from the process environment.
-///
-/// Seeding from `env` is what lets OS-supplied credentials (e.g. AKS Workload
-/// Identity: AZURE_FEDERATED_TOKEN_FILE, AZURE_CLIENT_ID) reach the credential
-/// providers; explicitly configured values then override them.
+/// Build the credential env map, seeded from the process environment so OS-supplied
+/// credentials (e.g. AKS Workload Identity) reach the providers; explicit config wins.
 fn merge_credential_envs(
     env: &impl Env,
     account_name: Option<&str>,
@@ -305,10 +302,6 @@ impl Builder for AzdlsBuilder {
             .or_else(|| azure_account_name_from_endpoint(endpoint.as_str()));
 
         let os_env = OsEnv;
-
-        // Seed from the process environment so credential providers can read
-        // OS-supplied variables (e.g. AKS Workload Identity:
-        // AZURE_FEDERATED_TOKEN_FILE, AZURE_CLIENT_ID); explicit config wins.
         let envs = merge_credential_envs(&os_env, account_name.as_deref(), &self.config);
 
         let info = Arc::new(AccessorInfo::default());
@@ -535,8 +528,6 @@ mod tests {
 
     #[test]
     fn merge_credential_envs_passes_through_os_env() {
-        // OS-supplied Workload Identity variables must survive into the env map
-        // even when no explicit credentials are configured (the #7224 bug).
         let env = env_with(&[
             ("AZURE_FEDERATED_TOKEN_FILE", "/var/run/token"),
             ("AZURE_CLIENT_ID", "os-client"),
@@ -572,7 +563,6 @@ mod tests {
 
         let envs = merge_credential_envs(&env, Some("cfg-account"), &config);
 
-        // Explicit config wins.
         assert_eq!(
             envs.get("AZURE_CLIENT_ID").map(String::as_str),
             Some("cfg-client")
@@ -581,7 +571,6 @@ mod tests {
             envs.get("AZURE_STORAGE_ACCOUNT_NAME").map(String::as_str),
             Some("cfg-account")
         );
-        // Untouched OS variables remain available.
         assert_eq!(
             envs.get("AZURE_FEDERATED_TOKEN_FILE").map(String::as_str),
             Some("/var/run/token")

--- a/core/services/azdls/src/backend.rs
+++ b/core/services/azdls/src/backend.rs
@@ -25,7 +25,7 @@ use reqsign_azure_storage::DefaultCredentialProvider;
 use reqsign_azure_storage::RequestSigner;
 use reqsign_azure_storage::StaticCredentialProvider;
 use reqsign_core::Context;
-use reqsign_core::Env as _;
+use reqsign_core::Env;
 use reqsign_core::OsEnv;
 use reqsign_core::Signer;
 use reqsign_core::StaticEnv;
@@ -233,13 +233,52 @@ impl AzdlsBuilder {
     }
 }
 
+/// Build the credential environment, seeding from the process environment.
+///
+/// Seeding from `env` is what lets OS-supplied credentials (e.g. AKS Workload
+/// Identity: AZURE_FEDERATED_TOKEN_FILE, AZURE_CLIENT_ID) reach the credential
+/// providers; explicitly configured values then override them.
+fn merge_credential_envs(
+    env: &impl Env,
+    account_name: Option<&str>,
+    config: &AzdlsConfig,
+) -> std::collections::HashMap<String, String> {
+    let mut envs = env.vars();
+
+    if let Some(v) = account_name {
+        envs.insert("AZBLOB_ACCOUNT_NAME".to_string(), v.to_string());
+        envs.insert("AZURE_STORAGE_ACCOUNT_NAME".to_string(), v.to_string());
+    }
+    if let Some(v) = &config.account_key {
+        envs.insert("AZBLOB_ACCOUNT_KEY".to_string(), v.clone());
+        envs.insert("AZURE_STORAGE_ACCOUNT_KEY".to_string(), v.clone());
+    }
+    if let Some(v) = &config.sas_token {
+        envs.insert("AZURE_STORAGE_SAS_TOKEN".to_string(), v.clone());
+    }
+    if let Some(v) = &config.client_id {
+        envs.insert("AZURE_CLIENT_ID".to_string(), v.clone());
+    }
+    if let Some(v) = &config.client_secret {
+        envs.insert("AZURE_CLIENT_SECRET".to_string(), v.clone());
+    }
+    if let Some(v) = &config.tenant_id {
+        envs.insert("AZURE_TENANT_ID".to_string(), v.clone());
+    }
+    if let Some(v) = &config.authority_host {
+        envs.insert("AZURE_AUTHORITY_HOST".to_string(), v.clone());
+    }
+
+    envs
+}
+
 impl Builder for AzdlsBuilder {
     type Config = AzdlsConfig;
 
     fn build(self) -> Result<impl Access> {
         debug!("backend build started: {:?}", &self);
 
-        let root = normalize_root(&self.config.root.unwrap_or_default());
+        let root = normalize_root(&self.config.root.clone().unwrap_or_default());
         debug!("backend use root {root}");
 
         // Handle endpoint, region and container name.
@@ -265,33 +304,13 @@ impl Builder for AzdlsBuilder {
             .clone()
             .or_else(|| azure_account_name_from_endpoint(endpoint.as_str()));
 
-        let mut envs = std::collections::HashMap::new();
-
-        if let Some(v) = &account_name {
-            envs.insert("AZBLOB_ACCOUNT_NAME".to_string(), v.clone());
-            envs.insert("AZURE_STORAGE_ACCOUNT_NAME".to_string(), v.clone());
-        }
-        if let Some(v) = &self.config.account_key {
-            envs.insert("AZBLOB_ACCOUNT_KEY".to_string(), v.clone());
-            envs.insert("AZURE_STORAGE_ACCOUNT_KEY".to_string(), v.clone());
-        }
-        if let Some(v) = &self.config.sas_token {
-            envs.insert("AZURE_STORAGE_SAS_TOKEN".to_string(), v.clone());
-        }
-        if let Some(v) = &self.config.client_id {
-            envs.insert("AZURE_CLIENT_ID".to_string(), v.clone());
-        }
-        if let Some(v) = &self.config.client_secret {
-            envs.insert("AZURE_CLIENT_SECRET".to_string(), v.clone());
-        }
-        if let Some(v) = &self.config.tenant_id {
-            envs.insert("AZURE_TENANT_ID".to_string(), v.clone());
-        }
-        if let Some(v) = &self.config.authority_host {
-            envs.insert("AZURE_AUTHORITY_HOST".to_string(), v.clone());
-        }
-
         let os_env = OsEnv;
+
+        // Seed from the process environment so credential providers can read
+        // OS-supplied variables (e.g. AKS Workload Identity:
+        // AZURE_FEDERATED_TOKEN_FILE, AZURE_CLIENT_ID); explicit config wins.
+        let envs = merge_credential_envs(&os_env, account_name.as_deref(), &self.config);
+
         let info = Arc::new(AccessorInfo::default());
 
         let ctx = Context::new()
@@ -497,5 +516,75 @@ impl Access for AzdlsBackend {
             StatusCode::CREATED => Ok(RpRename::default()),
             _ => Err(parse_error(resp)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env_with(pairs: &[(&str, &str)]) -> StaticEnv {
+        StaticEnv {
+            home_dir: None,
+            envs: pairs
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn merge_credential_envs_passes_through_os_env() {
+        // OS-supplied Workload Identity variables must survive into the env map
+        // even when no explicit credentials are configured (the #7224 bug).
+        let env = env_with(&[
+            ("AZURE_FEDERATED_TOKEN_FILE", "/var/run/token"),
+            ("AZURE_CLIENT_ID", "os-client"),
+            ("AZURE_TENANT_ID", "os-tenant"),
+        ]);
+
+        let envs = merge_credential_envs(&env, None, &AzdlsConfig::default());
+
+        assert_eq!(
+            envs.get("AZURE_FEDERATED_TOKEN_FILE").map(String::as_str),
+            Some("/var/run/token")
+        );
+        assert_eq!(
+            envs.get("AZURE_CLIENT_ID").map(String::as_str),
+            Some("os-client")
+        );
+        assert_eq!(
+            envs.get("AZURE_TENANT_ID").map(String::as_str),
+            Some("os-tenant")
+        );
+    }
+
+    #[test]
+    fn merge_credential_envs_explicit_config_overrides_os_env() {
+        let env = env_with(&[
+            ("AZURE_CLIENT_ID", "os-client"),
+            ("AZURE_FEDERATED_TOKEN_FILE", "/var/run/token"),
+        ]);
+        let config = AzdlsConfig {
+            client_id: Some("cfg-client".to_string()),
+            ..Default::default()
+        };
+
+        let envs = merge_credential_envs(&env, Some("cfg-account"), &config);
+
+        // Explicit config wins.
+        assert_eq!(
+            envs.get("AZURE_CLIENT_ID").map(String::as_str),
+            Some("cfg-client")
+        );
+        assert_eq!(
+            envs.get("AZURE_STORAGE_ACCOUNT_NAME").map(String::as_str),
+            Some("cfg-account")
+        );
+        // Untouched OS variables remain available.
+        assert_eq!(
+            envs.get("AZURE_FEDERATED_TOKEN_FILE").map(String::as_str),
+            Some("/var/run/token")
+        );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7224.

# Rationale for this change

The `azdls` builder seeded its credential environment from an empty `HashMap`,
so OS-supplied variables (e.g. AKS Workload Identity:
`AZURE_FEDERATED_TOKEN_FILE`, `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,
`AZURE_AUTHORITY_HOST`) never reached the credential providers. Authentication
then fell back to IMDS, which does not work in AKS. The `azblob` builder
already passes the process environment through, so the two backends behaved
inconsistently.

# What changes are included in this PR?

- Seed the `azdls` credential environment from the process environment before
  overlaying explicitly configured values, mirroring `azblob`. Explicit config
  still takes precedence over environment variables.
- Extract the env-map construction into a small `merge_credential_envs` helper
  so the override precedence can be unit-tested without mutating process state.
- Add unit tests covering both directions: OS environment variables pass
  through, and explicit config overrides them.

# Are there any user-facing changes?

No public API change. Behaviorally, `azdls` now picks up Azure credentials from
environment variables (matching its documented behavior and `azblob`), which is
required for Workload Identity in AKS.

# AI Usage Statement

I used Anthropic's Claude (via the Claude Code CLI) to assist with drafting and
reviewing this change. I reviewed every line myself and verified it locally: a
clean `--all-features` build plus the new `merge_credential_envs` unit tests.
