### PR TITLE
docs: add Noorle to users list

### DIFF
--- a/core/users.md
+++ b/core/users.md
@@ -6,6 +6,7 @@
 - [deepeth/mars](https://github.com/deepeth/mars): The powerful analysis platform to explore and visualize data from blockchain.
 - [GreptimeDB](https://github.com/GreptimeTeam/greptimedb): An open-source, cloud-native, distributed time-series database.
 - [mozilla/sccache](https://github.com/mozilla/sccache/): `sccache` is [`ccache`](https://github.com/ccache/ccache) with cloud storage
+- [Noorle](https://noorle.com/): A managed runtime for AI agents; OpenDAL backs agents' files and memories on different storage providers.
 - [OctoBase](https://github.com/toeverything/OctoBase): the open-source database behind [AFFiNE](https://github.com/toeverything/affine), local-first, yet collaborative.
 - [Pants](https://github.com/pantsbuild/pants): A fast, scalable, user-friendly build system for codebases of all sizes.
 - [QuestDB](https://github.com/questdb/questdb): An open-source time-series database for high throughput ingestion and fast SQL queries with operational simplicity.


### PR DESCRIPTION
# Which issue does this PR close?

No linked issue — this is a docs-only addition to the community users list
(`core/users.md`), not a bug fix or enhancement.

# Rationale for this change

Noorle uses OpenDAL in production and would like to be listed among its users,
as the docs invite. Noorle is a managed runtime for AI agents; OpenDAL backs
its workspace file storage and knowledge-base document storage on S3-compatible
object storage.

# What changes are included in this PR?

Adds one line to `core/users.md` (alphabetical order, between `mozilla/sccache`
and `OctoBase`). Note: existing entries link open-source repos — Noorle is a
commercial platform, so this entry links our website instead. Happy to adjust
the format if you'd prefer this listed differently.

# Are there any user-facing changes?

No — documentation list only.

# AI Usage Statement

The entry text and this PR description were drafted with Claude (Anthropic),
reviewed and submitted by a human. The change itself is a single documentation
line.