### PR TITLE
feat(binding/go): add missing read options

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -469,6 +469,15 @@ typedef struct opendal_read_options {
    */
   uintptr_t gap;
   /**
+   * Whether `content_length_hint` has been set.
+   */
+  bool has_content_length_hint;
+  /**
+   * Known content length of the object, used as an execution hint to avoid
+   * extra metadata requests while planning reads.
+   */
+  uint64_t content_length_hint;
+  /**
    * Override the response Content-Type header (presign only); NULL means unset.
    */
   const char *override_content_type;
@@ -2453,6 +2462,11 @@ void opendal_read_options_set_range(struct opendal_read_options *opts,
                                     uint64_t length);
 
 /**
+ * \brief Set the read range to start at `offset` and extend to the end of the file.
+ */
+void opendal_read_options_set_range_from(struct opendal_read_options *opts, uint64_t offset);
+
+/**
  * \brief Set the version of the object to read.
  */
 void opendal_read_options_set_version(struct opendal_read_options *opts, const char *version);
@@ -2494,6 +2508,16 @@ void opendal_read_options_set_chunk(struct opendal_read_options *opts, uintptr_t
  * \brief Set gap size.
  */
 void opendal_read_options_set_gap(struct opendal_read_options *opts, uintptr_t gap);
+
+/**
+ * \brief Set the known content length of the object.
+ *
+ * This is an execution hint that allows OpenDAL to avoid extra metadata
+ * requests while planning reads. It must not be used as an object identity
+ * or consistency condition.
+ */
+void opendal_read_options_set_content_length_hint(struct opendal_read_options *opts,
+                                                  uint64_t content_length_hint);
 
 /**
  * \brief Set the override Content-Type (presign only).

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -791,6 +791,11 @@ pub struct opendal_read_options {
     pub has_gap: bool,
     /// Gap size for merging nearby range reads.
     pub gap: usize,
+    /// Whether `content_length_hint` has been set.
+    pub has_content_length_hint: bool,
+    /// Known content length of the object, used as an execution hint to avoid
+    /// extra metadata requests while planning reads.
+    pub content_length_hint: u64,
     /// Override the response Content-Type header (presign only); NULL means unset.
     pub override_content_type: *const c_char,
     /// Override the response Cache-Control header (presign only); NULL means unset.
@@ -817,6 +822,8 @@ impl Default for opendal_read_options {
             chunk: 0,
             has_gap: false,
             gap: 0,
+            has_content_length_hint: false,
+            content_length_hint: 0,
             override_content_type: std::ptr::null(),
             override_cache_control: std::ptr::null(),
             override_content_disposition: std::ptr::null(),
@@ -850,6 +857,19 @@ impl opendal_read_options {
             (*opts).offset = offset;
             (*opts).has_length = true;
             (*opts).length = length;
+        }
+    }
+
+    /// \brief Set the read range to start at `offset` and extend to the end of the file.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_range_from(
+        opts: *mut opendal_read_options,
+        offset: u64,
+    ) {
+        if !opts.is_null() {
+            (*opts).offset = offset;
+            (*opts).has_length = false;
+            (*opts).length = 0;
         }
     }
 
@@ -945,6 +965,22 @@ impl opendal_read_options {
         }
     }
 
+    /// \brief Set the known content length of the object.
+    ///
+    /// This is an execution hint that allows OpenDAL to avoid extra metadata
+    /// requests while planning reads. It must not be used as an object identity
+    /// or consistency condition.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_read_options_set_content_length_hint(
+        opts: *mut opendal_read_options,
+        content_length_hint: u64,
+    ) {
+        if !opts.is_null() {
+            (*opts).has_content_length_hint = true;
+            (*opts).content_length_hint = content_length_hint;
+        }
+    }
+
     /// \brief Set the override Content-Type (presign only).
     #[no_mangle]
     pub unsafe extern "C" fn opendal_read_options_set_override_content_type(
@@ -1005,7 +1041,9 @@ impl From<&opendal_read_options> for options::ReadOptions {
                 .has_if_unmodified_since
                 .then(|| Timestamp::from_millisecond(value.if_unmodified_since).ok())
                 .flatten(),
-            content_length_hint: None,
+            content_length_hint: value
+                .has_content_length_hint
+                .then_some(value.content_length_hint),
             concurrent: value.concurrent,
             chunk: value.has_chunk.then_some(value.chunk),
             gap: value.has_gap.then_some(value.gap),

--- a/bindings/go/reader.go
+++ b/bindings/go/reader.go
@@ -98,8 +98,20 @@ type WithReadFn func(*readOptions)
 func ReadWithRange(offset, length uint64) WithReadFn {
 	return func(o *readOptions) {
 		o.hasRange = true
+		o.hasRangeLength = true
 		o.rangeOffset = offset
 		o.rangeLength = length
+	}
+}
+
+// ReadWithRangeFrom sets the byte range to start at offset and read until the
+// end of the file, i.e. the range [offset, n) for a file of size n.
+func ReadWithRangeFrom(offset uint64) WithReadFn {
+	return func(o *readOptions) {
+		o.hasRange = true
+		o.hasRangeLength = false
+		o.rangeOffset = offset
+		o.rangeLength = 0
 	}
 }
 
@@ -161,6 +173,17 @@ func ReadWithGap(gap uint) WithReadFn {
 	}
 }
 
+// ReadWithContentLengthHint sets the known content length of the object.
+//
+// This is an execution hint that allows OpenDAL to avoid extra metadata
+// requests while planning reads. It must not be used as an object identity
+// or consistency condition.
+func ReadWithContentLengthHint(length uint64) WithReadFn {
+	return func(o *readOptions) {
+		o.contentLengthHint = &length
+	}
+}
+
 // ReadWithOverrideContentType sets the Content-Type to send back (presign only).
 func ReadWithOverrideContentType(contentType string) WithReadFn {
 	return func(o *readOptions) {
@@ -184,6 +207,7 @@ func ReadWithOverrideContentDisposition(contentDisposition string) WithReadFn {
 
 type readOptions struct {
 	hasRange                   bool
+	hasRangeLength             bool
 	rangeOffset                uint64
 	rangeLength                uint64
 	version                    string
@@ -194,6 +218,7 @@ type readOptions struct {
 	concurrent                 uint
 	chunk                      uint
 	gap                        uint
+	contentLengthHint          *uint64
 	overrideContentType        string
 	overrideCacheControl       string
 	overrideContentDisposition string
@@ -234,7 +259,11 @@ func newOpendalReadOptions(ctx context.Context, o *readOptions) (*opendalReadOpt
 	}
 
 	if o.hasRange {
-		ffiReadOptionsSetRange.symbol(ctx)(cOpts, o.rangeOffset, o.rangeLength)
+		if o.hasRangeLength {
+			ffiReadOptionsSetRange.symbol(ctx)(cOpts, o.rangeOffset, o.rangeLength)
+		} else {
+			ffiReadOptionsSetRangeFrom.symbol(ctx)(cOpts, o.rangeOffset)
+		}
 	}
 	if err := setString(o.version, ffiReadOptionsSetVersion.symbol(ctx)); err != nil {
 		return fail(err)
@@ -259,6 +288,9 @@ func newOpendalReadOptions(ctx context.Context, o *readOptions) (*opendalReadOpt
 	}
 	if o.gap != 0 {
 		ffiReadOptionsSetGap.symbol(ctx)(cOpts, o.gap)
+	}
+	if o.contentLengthHint != nil {
+		ffiReadOptionsSetContentLengthHint.symbol(ctx)(cOpts, *o.contentLengthHint)
 	}
 	if err := setString(o.overrideContentType, ffiReadOptionsSetOverrideContentType.symbol(ctx)); err != nil {
 		return fail(err)
@@ -519,6 +551,16 @@ var ffiReadOptionsSetRange = newFFI(ffiOpts{
 	}
 })
 
+var ffiReadOptionsSetRangeFrom = newFFI(ffiOpts{
+	sym:    "opendal_read_options_set_range_from",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypeUint64},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReadOptions, offset uint64) {
+	return func(opts *opendalReadOptions, offset uint64) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&offset))
+	}
+})
+
 func newReadOptionsSetStringFFI(sym string) *FFI[func(*opendalReadOptions, string) ([]byte, error)] {
 	return newFFI(ffiOpts{
 		sym:    contextKey(sym),
@@ -591,6 +633,16 @@ var ffiReadOptionsSetGap = newFFI(ffiOpts{
 }, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReadOptions, gap uint) {
 	return func(opts *opendalReadOptions, gap uint) {
 		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&gap))
+	}
+})
+
+var ffiReadOptionsSetContentLengthHint = newFFI(ffiOpts{
+	sym:    "opendal_read_options_set_content_length_hint",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypeUint64},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReadOptions, length uint64) {
+	return func(opts *opendalReadOptions, length uint64) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&length))
 	}
 })
 

--- a/bindings/go/string_ownership_test.go
+++ b/bindings/go/string_ownership_test.go
@@ -897,12 +897,16 @@ func TestReadWithOptions(t *testing.T) {
 	ReadWithConcurrent(4)(o)
 	ReadWithChunk(1024)(o)
 	ReadWithGap(512)(o)
+	ReadWithContentLengthHint(4096)(o)
 	ReadWithOverrideContentType("text/plain")(o)
 	ReadWithOverrideCacheControl("max-age=60")(o)
 	ReadWithOverrideContentDisposition("attachment")(o)
 
 	if !o.hasRange {
 		t.Fatalf("hasRange = false, want true")
+	}
+	if !o.hasRangeLength {
+		t.Fatalf("hasRangeLength = false, want true")
 	}
 	if o.rangeOffset != 1024 {
 		t.Fatalf("rangeOffset = %d, want 1024", o.rangeOffset)
@@ -934,6 +938,9 @@ func TestReadWithOptions(t *testing.T) {
 	if o.gap != 512 {
 		t.Fatalf("gap = %d, want 512", o.gap)
 	}
+	if o.contentLengthHint == nil || *o.contentLengthHint != 4096 {
+		t.Fatalf("contentLengthHint = %v, want 4096", o.contentLengthHint)
+	}
 	if o.overrideContentType != "text/plain" {
 		t.Fatalf("overrideContentType = %q, want text/plain", o.overrideContentType)
 	}
@@ -942,6 +949,30 @@ func TestReadWithOptions(t *testing.T) {
 	}
 	if o.overrideContentDisposition != "attachment" {
 		t.Fatalf("overrideContentDisposition = %q, want attachment", o.overrideContentDisposition)
+	}
+}
+
+func TestReadWithRangeFrom(t *testing.T) {
+	o := &readOptions{}
+	ReadWithRangeFrom(1024)(o)
+
+	if !o.hasRange {
+		t.Fatalf("hasRange = false, want true")
+	}
+	if o.hasRangeLength {
+		t.Fatalf("hasRangeLength = true, want false")
+	}
+	if o.rangeOffset != 1024 {
+		t.Fatalf("rangeOffset = %d, want 1024", o.rangeOffset)
+	}
+
+	// ReadWithRangeFrom overrides a previously set bounded range.
+	o = &readOptions{}
+	ReadWithRange(0, 2048)(o)
+	ReadWithRangeFrom(512)(o)
+	if o.hasRangeLength || o.rangeOffset != 512 || o.rangeLength != 0 {
+		t.Fatalf("after override: hasRangeLength=%v offset=%d length=%d, want false 512 0",
+			o.hasRangeLength, o.rangeOffset, o.rangeLength)
 	}
 }
 
@@ -1015,11 +1046,27 @@ func TestReadOptionsSetterArgTypes(t *testing.T) {
 		}
 	}
 
+	hintATypes := ffiReadOptionsSetContentLengthHint.opts.aTypes
+	if len(hintATypes) != 2 {
+		t.Fatalf("ffiReadOptionsSetContentLengthHint aTypes len = %d, want 2", len(hintATypes))
+	}
+	if hintATypes[0] != &ffi.TypePointer || hintATypes[1] != &ffi.TypeUint64 {
+		t.Fatalf("ffiReadOptionsSetContentLengthHint aTypes = %v, want TypePointer, TypeUint64", hintATypes)
+	}
+
 	rangeATypes := ffiReadOptionsSetRange.opts.aTypes
 	if len(rangeATypes) != 3 {
 		t.Fatalf("ffiReadOptionsSetRange aTypes len = %d, want 3", len(rangeATypes))
 	}
 	if rangeATypes[0] != &ffi.TypePointer || rangeATypes[1] != &ffi.TypeUint64 || rangeATypes[2] != &ffi.TypeUint64 {
 		t.Fatalf("ffiReadOptionsSetRange aTypes = %v, want TypePointer, TypeUint64, TypeUint64", rangeATypes)
+	}
+
+	rangeFromATypes := ffiReadOptionsSetRangeFrom.opts.aTypes
+	if len(rangeFromATypes) != 2 {
+		t.Fatalf("ffiReadOptionsSetRangeFrom aTypes len = %d, want 2", len(rangeFromATypes))
+	}
+	if rangeFromATypes[0] != &ffi.TypePointer || rangeFromATypes[1] != &ffi.TypeUint64 {
+		t.Fatalf("ffiReadOptionsSetRangeFrom aTypes = %v, want TypePointer, TypeUint64", rangeFromATypes)
 	}
 }

--- a/bindings/go/tests/behavior_tests/read_test.go
+++ b/bindings/go/tests/behavior_tests/read_test.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/apache/opendal/bindings/go"
+	opendal "github.com/apache/opendal/bindings/go"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -40,6 +40,8 @@ func testsRead(cap *opendal.Capability) []behaviorTest {
 		testReadWithSpecialChars,
 		testReaderSeek,
 		testReadWithRange,
+		testReadWithRangeFrom,
+		testReadWithContentLengthHint,
 		testReadWithConcurrentChunkGap,
 	}
 	if cap.WriteCanMulti() {
@@ -163,6 +165,40 @@ func testReadWithRange(assert *require.Assertions, op *opendal.Operator, fixture
 	assert.Nil(op.Write(path, content), "write must succeed")
 
 	bs, err := op.Read(path, opendal.ReadWithRange(uint64(offset), uint64(length)))
+	assert.Nil(err)
+	assert.Equal(length, int64(len(bs)), "read range size")
+	assert.Equal(content[offset:offset+length], bs, "read range content")
+}
+
+func testReadWithRangeFrom(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, size := fixture.NewFile()
+	offset, _ := genOffsetLength(size)
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	bs, err := op.Read(path, opendal.ReadWithRangeFrom(uint64(offset)))
+	assert.Nil(err)
+	assert.Equal(int64(size)-offset, int64(len(bs)), "read range-from size")
+	assert.Equal(content[offset:], bs, "read range-from content")
+}
+
+func testReadWithContentLengthHint(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, size := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	// An accurate hint must not change the result of a full read.
+	bs, err := op.Read(path, opendal.ReadWithContentLengthHint(uint64(size)))
+	assert.Nil(err)
+	assert.Equal(size, uint(len(bs)), "read size")
+	assert.Equal(content, bs, "read content")
+
+	// The hint is an execution hint only; it must also work combined with a range.
+	offset, length := genOffsetLength(size)
+	bs, err = op.Read(path,
+		opendal.ReadWithRange(uint64(offset), uint64(length)),
+		opendal.ReadWithContentLengthHint(uint64(size)),
+	)
 	assert.Nil(err)
 	assert.Equal(length, int64(len(bs)), "read range size")
 	assert.Equal(content[offset:offset+length], bs, "read range content")


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

golang binding should provide the same functionality as rust core

# What changes are included in this PR?

This PR exposes all missing read options to go binding

# Are there any user-facing changes?

Yes, new options are exposed.

# AI Usage Statement

fable-5 helped me detect feature gap and made the code change