### PR TITLE
ci: fix hadoop connector cache size

### DIFF
--- a/.github/actions/setup-hadoop/action.yaml
+++ b/.github/actions/setup-hadoop/action.yaml
@@ -41,12 +41,12 @@ runs:
         distribution: zulu
         java-version: 11
 
-    - name: Cache hadoop
+    - name: Restore hadoop cache
       id: cache-hadoop
-      uses: actions/cache@v5
+      uses: actions/cache/restore@v5
       with:
         path: ${{ runner.temp }}/hadoop-3.3.5
-        key: cache-hadoop-3.3.5
+        key: cache-hadoop-3.3.5-v1
 
     - name: Build hadoop if not cached
       if: steps.cache-hadoop.outputs.cache-hit != 'true'
@@ -56,18 +56,29 @@ runs:
           https://dlcdn.apache.org/hadoop/common/hadoop-3.3.5/hadoop-3.3.5.tar.gz \
           | tar --gzip --extract --file=- --directory=${{ runner.temp }}
 
+    - name: Store hadoop cache
+      if: steps.cache-hadoop.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ runner.temp }}/hadoop-3.3.5
+        key: cache-hadoop-3.3.5-v1
+
     - name: Cached hadoop connectors
       id: cache-hadoop-connectors
       uses: actions/cache@v5
       with:
         path: ${{ runner.temp }}/downloaded-connectors
-        key: cache-hadoop-connectors-${{ case(inputs.connector-aws == 'true', 'aws', '') }}-${{ case(inputs.connector-gcs == 'true', 'gcs', '') }}-${{ case(inputs.connector-azurite == 'true', 'azurite', '') }}
+        key: cache-hadoop-connectors-${{ case(inputs.connector-aws == 'true', 'aws', '') }}-${{ case(inputs.connector-gcs == 'true', 'gcs', '') }}-${{ case(inputs.connector-azurite == 'true', 'azurite', '') }}-v1
+
+    - name: Prepare folders for hadoop connectors
+      if: steps.cache-hadoop-connectors.outputs.cache-hit != 'true'
+      shell: bash
+      run: mkdir -p ${{ runner.temp }}/downloaded-connectors
 
     - name: Download Hadoop AWS connector
-      if: ${{ inputs.connector-aws }} == 'true' && steps.cache-hadoop-connectors.outputs.cache-hit != 'true'
+      if: inputs.connector-aws == 'true' && steps.cache-hadoop-connectors.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        mkdir -p ${{ runner.temp }}/downloaded-connectors
         curl --location \
           --silent \
           --show-error \
@@ -83,10 +94,9 @@ runs:
           https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.653/aws-java-sdk-bundle-1.12.653.jar
 
     - name: Download Hadoop GCS connector
-      if: ${{ inputs.connector-gcs }} == 'true' && steps.cache-hadoop-connectors.outputs.cache-hit != 'true'
+      if: inputs.connector-gcs == 'true' && steps.cache-hadoop-connectors.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        mkdir -p ${{ runner.temp }}/downloaded-connectors
         curl --location \
           --silent \
           --show-error \
@@ -95,10 +105,9 @@ runs:
           https://github.com/GoogleCloudDataproc/hadoop-connectors/releases/download/v2.2.19/gcs-connector-hadoop3-2.2.19-shaded.jar
 
     - name: Download Hadoop Azurite connector
-      if: ${{ inputs.connector-azurite }} == 'true' && steps.cache-hadoop-connectors.outputs.cache-hit != 'true'
+      if: inputs.connector-azurite == 'true' && steps.cache-hadoop-connectors.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        mkdir -p ${{ runner.temp }}/downloaded-connectors
         curl --location \
           --silent \
           --show-error \
@@ -113,12 +122,23 @@ runs:
           --output ${{ runner.temp }}/downloaded-connectors/azure-storage-7.0.1.jar \
           https://repo1.maven.org/maven2/com/microsoft/azure/azure-storage/7.0.1/azure-storage-7.0.1.jar
 
+    - name: Examine downloaded connectors
+      shell: bash
+      run: |
+        # useful for debugging downloads or cache
+        ls -alh ${{ runner.temp }}/downloaded-connectors
+
     - name: Setup hadoop env
       shell: bash
       run: |
         export HADOOP_HOME=${{ runner.temp }}/hadoop-3.3.5
-        cp -r ${{ runner.temp }}/downloaded-connectors/* ${HADOOP_HOME}/share/hadoop/common/lib/
+
+        if [ -n "$(ls -A "${{ runner.temp }}/downloaded-connectors" 2>/dev/null)" ]; then
+          cp "${{ runner.temp }}/downloaded-connectors"/* "${HADOOP_HOME}/share/hadoop/common/lib/"
+        fi
+
         echo "HADOOP_HOME=${HADOOP_HOME}" >> $GITHUB_ENV
         echo "CLASSPATH=$(${HADOOP_HOME}/bin/hadoop classpath --glob)" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=${{ env.JAVA_HOME }}/lib/server:${HADOOP_HOME}/lib/native" >> $GITHUB_ENV
+
         cp ${{ github.workspace }}/fixtures/hdfs/hdfs-site.xml ${HADOOP_HOME}/etc/hadoop/hdfs-site.xml

--- a/.github/services/azblob/azurite_azblob/action.yml
+++ b/.github/services/azblob/azurite_azblob/action.yml
@@ -25,15 +25,20 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: 20
+        cache: 'npm'
+        cache-dependency-path: fixtures/azblob/setup_azurite.sh
+
     - name: Setup azurite azblob service
       shell: bash
       run: ./fixtures/azblob/setup_azurite.sh
+
     - name: Setup test bucket
       shell: bash
       run: |
         az storage container create \
             --name test \
             --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;"
+
     - name: Setup
       shell: bash
       run: |

--- a/.github/services/hdfs/hdfs_default_on_azurite_azblob/action.yml
+++ b/.github/services/hdfs/hdfs_default_on_azurite_azblob/action.yml
@@ -21,15 +21,17 @@ description: 'Behavior test for hdfs default over azurite azblob'
 runs:
   using: "composite"
   steps:
-    - name: Setup node
-      uses: actions/setup-node@v6
-      with:
-        node-version: 20
-
     - name: Setup hadoop
       uses: ./.github/actions/setup-hadoop
       with:
         connector-azurite: true
+
+    - name: Setup node
+      uses: actions/setup-node@v6
+      with:
+        node-version: 20
+        cache: 'npm'
+        cache-dependency-path: fixtures/azblob/setup_azurite.sh
 
     - name: Setup azurite azblob service
       shell: bash


### PR DESCRIPTION
# Which issue does this PR close?

Fixes #7726.

# Rationale for this change

- Fix cache size increase. Now the main branch will have:
   - same cache size as hadoop' dump
   - independent hadoop connector cache
- Fine-grain control on what to cache

# What changes are included in this PR?

- Cache connectors in setup-hadoop with versions
- Cache azurite npm package.

# Are there any user-facing changes?

None

# AI Usage Statement

No