### PR TITLE
feat(binding/go): Add Copier

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -876,6 +876,53 @@ typedef struct opendal_copy_options {
 } opendal_copy_options;
 
 /**
+ * \brief opendal_copier completes a long-running copy operation to
+ * completion in a blocking manner. opendal_copier repeatedly calls a
+ * copy operation until completion.
+ *
+ * Internally, each copy step performs a unit of work and reports progress.
+ * When copy completes, `has_next` returns false.
+ *
+ * A "step" is one backend-defined unit of work. For backends that copy in
+ * multiple requests (e.g. multipart copy), one step typically copies one chunk;
+ * for backends that only support single-request copy, the entire copy happens
+ * in a single step. The reported byte count is best-effort: a step may report
+ * 0 bytes when the backend advances its state without a reliable byte delta.
+ *
+ * Users can construct a copier by `opendal_operator_copier` or
+ * `opendal_operator_copier_with`.
+ *
+ * @see opendal_operator_copier()
+ * @see opendal_copier_next()
+ */
+typedef struct opendal_copier {
+  /**
+   * The pointer to the opendal::blocking::Copier in the Rust code.
+   * Only used to check whether the copier is NULL.
+   */
+  void *inner;
+} opendal_copier;
+
+/**
+ * \brief The result type returned by opendal_operator_copier().
+ *
+ * Fields:
+ * * `copier`: the copier used to drive a long-running copy operation by calling
+ *   opendal_copier_next() repeatedly; only valid when `error` is null.
+ * * `error`: the error of the operation; null when the operation succeeds.
+ */
+typedef struct opendal_result_operator_copier {
+  /**
+   * The pointer for opendal_copier
+   */
+  struct opendal_copier *copier;
+  /**
+   * The error, if ok, it is null
+   */
+  struct opendal_error *error;
+} opendal_result_operator_copier;
+
+/**
  * \brief Metadata for **operator**, users can use this metadata to get information
  * of operator.
  */
@@ -1221,6 +1268,34 @@ typedef struct opendal_result_writer_write {
    */
   struct opendal_error *error;
 } opendal_result_writer_write;
+
+/**
+ * \brief The result type returned by opendal_copier_next().
+ *
+ * A copy is driven by calling opendal_copier_next() repeatedly: each call
+ * performs one step of the copy until the copy reports completion.
+ *
+ * Fields:
+ * * `size`: the number of bytes copied in this step; zero on error or completion.
+ * * `has_next`: true when the copy made progress and should be driven again by
+ *   another opendal_copier_next() call; when false and `error` is null, the copy
+ *   has completed.
+ * * `error`: the error code and message; null when the step succeeds.
+ */
+typedef struct opendal_result_copier_next {
+  /**
+   * The number of bytes copied in this step.
+   */
+  uintptr_t size;
+  /**
+   * Whether the copy operation made progress and should be driven again.
+   */
+  bool has_next;
+  /**
+   * The error, if ok, it is null
+   */
+  struct opendal_error *error;
+} opendal_result_copier_next;
 
 #ifdef __cplusplus
 extern "C" {
@@ -2262,6 +2337,56 @@ struct opendal_error *opendal_operator_copy_with(const struct opendal_operator *
 struct opendal_error *opendal_operator_check(const struct opendal_operator *op);
 
 /**
+ * \brief Blocking create a copier to copy a file from `src` to `dest`.
+ *
+ * The returned copier is used to complete a long-running copy operation. Call
+ * `opendal_copier_next` repeatedly to make progress, and `opendal_copier_free`
+ * to release it once finished.
+ *
+ * @param op The opendal_operator created previously
+ * @param src The designated source path you want to copy
+ * @param dest The designated destination path you want to copy
+ * @see opendal_operator
+ * @see opendal_copier
+ * @see opendal_result_operator_copier
+ * @return opendal_result_operator_copier, containing a copier and an opendal_error.
+ * If the operation succeeds, the `copier` field holds a valid copier and the `error`
+ * field is null. Otherwise, the `copier` will be null and the `error` will be set
+ * correspondingly.
+ *
+ * # Safety
+ *
+ * * The memory pointed to by `src` and `dest` must contain a valid nul terminator at the
+ *   end of the string.
+ *
+ * # Panic
+ *
+ * * If the `src` or `dest` points to NULL, this function panics
+ */
+struct opendal_result_operator_copier opendal_operator_copier(const struct opendal_operator *op,
+                                                              const char *src,
+                                                              const char *dest);
+
+/**
+ * \brief Blocking create a copier to copy a file from `src` to `dest` with options.
+ *
+ * This is the same as `opendal_operator_copier` but accepts an `opendal_copy_options`
+ * to control the behavior, e.g. `concurrent` or `chunk`. Pass NULL to use defaults.
+ *
+ * @param op The opendal_operator created previously
+ * @param src The designated source path you want to copy
+ * @param dest The designated destination path you want to copy
+ * @param opts The options for the copy operation; pass NULL to use defaults
+ * @see opendal_operator_copier
+ * @see opendal_copy_options
+ * @return opendal_result_operator_copier, containing a copier and an opendal_error.
+ */
+struct opendal_result_operator_copier opendal_operator_copier_with(const struct opendal_operator *op,
+                                                                   const char *src,
+                                                                   const char *dest,
+                                                                   const struct opendal_copy_options *opts);
+
+/**
  * \brief Get information of underlying accessor.
  *
  * # Example
@@ -2954,6 +3079,35 @@ struct opendal_result_write opendal_writer_close_with_metadata(struct opendal_wr
  * \brief Frees the heap memory used by the opendal_writer.
  */
 void opendal_writer_free(struct opendal_writer *ptr);
+
+/**
+ * \brief Perform one step of the copy operation.
+ *
+ * One step performs one backend-defined unit of work: typically one chunk for
+ * backends that copy in multiple requests, or the entire copy for backends that
+ * only support single-request copy.
+ *
+ * Returns the number of bytes copied in this step (best-effort; may be 0 when
+ * the backend advances without a reliable byte delta). When `has_next` is true
+ * the caller should call this function again to continue the copy. When
+ * `has_next` is false and `error` is null the copy has completed.
+ *
+ * @see opendal_operator_copier()
+ */
+struct opendal_result_copier_next opendal_copier_next(struct opendal_copier *self);
+
+/**
+ * \brief Abort the pending copy operation.
+ *
+ * Returns NULL if the abort succeeds, otherwise it contains the error code and
+ * error message.
+ */
+struct opendal_error *opendal_copier_abort(struct opendal_copier *self);
+
+/**
+ * \brief Free the heap memory used by the opendal_copier.
+ */
+void opendal_copier_free(struct opendal_copier *ptr);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/bindings/c/src/copier.rs
+++ b/bindings/c/src/copier.rs
@@ -1,0 +1,121 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use ::opendal as core;
+use std::ffi::c_void;
+
+use super::*;
+
+/// \brief opendal_copier completes a long-running copy operation to
+/// completion in a blocking manner. opendal_copier repeatedly calls a
+/// copy operation until completion.
+///
+/// Internally, each copy step performs a unit of work and reports progress.
+/// When copy completes, `has_next` returns false.
+///
+/// A "step" is one backend-defined unit of work. For backends that copy in
+/// multiple requests (e.g. multipart copy), one step typically copies one chunk;
+/// for backends that only support single-request copy, the entire copy happens
+/// in a single step. The reported byte count is best-effort: a step may report
+/// 0 bytes when the backend advances its state without a reliable byte delta.
+///
+/// Users can construct a copier by `opendal_operator_copier` or
+/// `opendal_operator_copier_with`.
+///
+/// @see opendal_operator_copier()
+/// @see opendal_copier_next()
+#[repr(C)]
+pub struct opendal_copier {
+    /// The pointer to the opendal::blocking::Copier in the Rust code.
+    /// Only used to check whether the copier is NULL.
+    inner: *mut c_void,
+}
+
+impl opendal_copier {
+    fn deref_mut(&mut self) -> &mut core::blocking::Copier {
+        // Safety: the inner should never be null once constructed
+        // The use-after-free is undefined behavior
+        unsafe { &mut *(self.inner as *mut core::blocking::Copier) }
+    }
+}
+
+impl opendal_copier {
+    pub(crate) fn new(copier: core::blocking::Copier) -> Self {
+        Self {
+            inner: Box::into_raw(Box::new(copier)) as _,
+        }
+    }
+
+    /// \brief Perform one step of the copy operation.
+    ///
+    /// One step performs one backend-defined unit of work: typically one chunk for
+    /// backends that copy in multiple requests, or the entire copy for backends that
+    /// only support single-request copy.
+    ///
+    /// Returns the number of bytes copied in this step (best-effort; may be 0 when
+    /// the backend advances without a reliable byte delta). When `has_next` is true
+    /// the caller should call this function again to continue the copy. When
+    /// `has_next` is false and `error` is null the copy has completed.
+    ///
+    /// @see opendal_operator_copier()
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_copier_next(&mut self) -> opendal_result_copier_next {
+        match self.deref_mut().next() {
+            Some(Ok(n)) => opendal_result_copier_next {
+                size: n,
+                has_next: true,
+                error: std::ptr::null_mut(),
+            },
+            None => opendal_result_copier_next {
+                size: 0,
+                has_next: false,
+                error: std::ptr::null_mut(),
+            },
+            Some(Err(e)) => opendal_result_copier_next {
+                size: 0,
+                has_next: false,
+                error: opendal_error::new(e),
+            },
+        }
+    }
+
+    /// \brief Abort the pending copy operation.
+    ///
+    /// Returns NULL if the abort succeeds, otherwise it contains the error code and
+    /// error message.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_copier_abort(&mut self) -> *mut opendal_error {
+        if let Err(e) = self.deref_mut().abort() {
+            opendal_error::new(e)
+        } else {
+            std::ptr::null_mut()
+        }
+    }
+
+    /// \brief Free the heap memory used by the opendal_copier.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_copier_free(ptr: *mut opendal_copier) {
+        unsafe {
+            if !ptr.is_null() {
+                drop(Box::from_raw((*ptr).inner as *mut core::blocking::Copier));
+                // A use-after-free crashes on NULL instead of reading stale memory.
+                (*ptr).inner = std::ptr::null_mut();
+                drop(Box::from_raw(ptr));
+            }
+        }
+    }
+}

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -58,10 +58,12 @@ pub use presign::opendal_presigned_request;
 pub use presign::opendal_result_presign;
 
 mod result;
+pub use result::opendal_result_copier_next;
 pub use result::opendal_result_exists;
 pub use result::opendal_result_is_exist;
 pub use result::opendal_result_list;
 pub use result::opendal_result_lister_next;
+pub use result::opendal_result_operator_copier;
 pub use result::opendal_result_operator_new;
 pub use result::opendal_result_operator_reader;
 pub use result::opendal_result_operator_writer;
@@ -91,3 +93,6 @@ pub use reader::opendal_reader;
 
 mod writer;
 pub use writer::opendal_writer;
+
+mod copier;
+pub use copier::opendal_copier;

--- a/bindings/c/src/operator.rs
+++ b/bindings/c/src/operator.rs
@@ -1444,3 +1444,98 @@ pub unsafe extern "C" fn opendal_operator_check(op: &opendal_operator) -> *mut o
         std::ptr::null_mut()
     }
 }
+
+/// \brief Blocking create a copier to copy a file from `src` to `dest`.
+///
+/// The returned copier is used to complete a long-running copy operation. Call
+/// `opendal_copier_next` repeatedly to make progress, and `opendal_copier_free`
+/// to release it once finished.
+///
+/// @param op The opendal_operator created previously
+/// @param src The designated source path you want to copy
+/// @param dest The designated destination path you want to copy
+/// @see opendal_operator
+/// @see opendal_copier
+/// @see opendal_result_operator_copier
+/// @return opendal_result_operator_copier, containing a copier and an opendal_error.
+/// If the operation succeeds, the `copier` field holds a valid copier and the `error`
+/// field is null. Otherwise, the `copier` will be null and the `error` will be set
+/// correspondingly.
+///
+/// # Safety
+///
+/// * The memory pointed to by `src` and `dest` must contain a valid nul terminator at the
+///   end of the string.
+///
+/// # Panic
+///
+/// * If the `src` or `dest` points to NULL, this function panics
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_copier(
+    op: &opendal_operator,
+    src: *const c_char,
+    dest: *const c_char,
+) -> opendal_result_operator_copier {
+    assert!(!src.is_null());
+    assert!(!dest.is_null());
+    let src = std::ffi::CStr::from_ptr(src)
+        .to_str()
+        .expect("malformed src");
+    let dest = std::ffi::CStr::from_ptr(dest)
+        .to_str()
+        .expect("malformed dest");
+    match op.deref().copier(src, dest) {
+        Ok(copier) => opendal_result_operator_copier {
+            copier: Box::into_raw(Box::new(opendal_copier::new(copier))),
+            error: std::ptr::null_mut(),
+        },
+        Err(err) => opendal_result_operator_copier {
+            copier: std::ptr::null_mut(),
+            error: opendal_error::new(err),
+        },
+    }
+}
+
+/// \brief Blocking create a copier to copy a file from `src` to `dest` with options.
+///
+/// This is the same as `opendal_operator_copier` but accepts an `opendal_copy_options`
+/// to control the behavior, e.g. `concurrent` or `chunk`. Pass NULL to use defaults.
+///
+/// @param op The opendal_operator created previously
+/// @param src The designated source path you want to copy
+/// @param dest The designated destination path you want to copy
+/// @param opts The options for the copy operation; pass NULL to use defaults
+/// @see opendal_operator_copier
+/// @see opendal_copy_options
+/// @return opendal_result_operator_copier, containing a copier and an opendal_error.
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_copier_with(
+    op: &opendal_operator,
+    src: *const c_char,
+    dest: *const c_char,
+    opts: *const opendal_copy_options,
+) -> opendal_result_operator_copier {
+    assert!(!src.is_null());
+    assert!(!dest.is_null());
+    let src = std::ffi::CStr::from_ptr(src)
+        .to_str()
+        .expect("malformed src");
+    let dest = std::ffi::CStr::from_ptr(dest)
+        .to_str()
+        .expect("malformed dest");
+    let copy_opts = if opts.is_null() {
+        core::options::CopyOptions::default()
+    } else {
+        core::options::CopyOptions::from(&*opts)
+    };
+    match op.deref().copier_options(src, dest, copy_opts) {
+        Ok(copier) => opendal_result_operator_copier {
+            copier: Box::into_raw(Box::new(opendal_copier::new(copier))),
+            error: std::ptr::null_mut(),
+        },
+        Err(err) => opendal_result_operator_copier {
+            copier: std::ptr::null_mut(),
+            error: opendal_error::new(err),
+        },
+    }
+}

--- a/bindings/c/src/result.rs
+++ b/bindings/c/src/result.rs
@@ -194,3 +194,38 @@ pub struct opendal_result_write {
     /// The error, if ok, it is null
     pub error: *mut opendal_error,
 }
+
+/// \brief The result type returned by opendal_operator_copier().
+///
+/// Fields:
+/// * `copier`: the copier used to drive a long-running copy operation by calling
+///   opendal_copier_next() repeatedly; only valid when `error` is null.
+/// * `error`: the error of the operation; null when the operation succeeds.
+#[repr(C)]
+pub struct opendal_result_operator_copier {
+    /// The pointer for opendal_copier
+    pub copier: *mut opendal_copier,
+    /// The error, if ok, it is null
+    pub error: *mut opendal_error,
+}
+
+/// \brief The result type returned by opendal_copier_next().
+///
+/// A copy is driven by calling opendal_copier_next() repeatedly: each call
+/// performs one step of the copy until the copy reports completion.
+///
+/// Fields:
+/// * `size`: the number of bytes copied in this step; zero on error or completion.
+/// * `has_next`: true when the copy made progress and should be driven again by
+///   another opendal_copier_next() call; when false and `error` is null, the copy
+///   has completed.
+/// * `error`: the error code and message; null when the step succeeds.
+#[repr(C)]
+pub struct opendal_result_copier_next {
+    /// The number of bytes copied in this step.
+    pub size: usize,
+    /// Whether the copy operation made progress and should be driven again.
+    pub has_next: bool,
+    /// The error, if ok, it is null
+    pub error: *mut opendal_error,
+}

--- a/bindings/go/copier.go
+++ b/bindings/go/copier.go
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package opendal
+
+import (
+	"context"
+	"runtime"
+	"unsafe"
+
+	"github.com/jupiterrider/ffi"
+)
+
+// Copier drives a long-running copy operation from a source to a destination.
+//
+// Unlike Copy, which performs the whole copy in a single call, a Copier lets the
+// caller advance the copy step by step via Next, which is useful for reporting
+// progress on large copies. The copy is complete once Next reports that no more
+// progress is available. Always call Close to release the resources held by the
+// Copier.
+//
+// # Example
+//
+//	func exampleCopier(op *opendal.Operator) {
+//		copier, err := op.Copier("path/from/file", "path/to/file")
+//		if err != nil {
+//			log.Fatal(err)
+//		}
+//		defer copier.Close()
+//		for {
+//			n, ok, err := copier.Next()
+//			if err != nil {
+//				log.Fatal(err)
+//			}
+//			if !ok {
+//				break
+//			}
+//			log.Printf("copied %d bytes", n)
+//		}
+//	}
+type Copier struct {
+	inner *opendalCopier
+	ctx   context.Context
+}
+
+// Copier creates a Copier to copy a file from src to dest.
+//
+// Copier is a wrapper around the C-binding function `opendal_operator_copier`.
+// When options are provided, it uses `opendal_operator_copier_with`.
+//
+// # Parameters
+//
+//   - src: The source file path.
+//   - dest: The destination file path.
+//   - opts: Optional copy options (shared with Copy).
+//
+// # Returns
+//
+//   - *Copier: A Copier used to drive the copy, or an error if the operation fails.
+//
+// # Behavior
+//
+//   - Both src and dest must be file paths, not directories.
+//   - The returned Copier must be released with Close.
+func (op *Operator) Copier(src, dest string, opts ...WithCopyFn) (*Copier, error) {
+	if len(opts) == 0 {
+		inner, err := ffiOperatorCopier.symbol(op.ctx)(op.inner, src, dest)
+		if err != nil {
+			return nil, err
+		}
+		return &Copier{inner: inner, ctx: op.ctx}, nil
+	}
+
+	o := parseCopyOptions(opts...)
+	cOpts, keepAlive, err := newOpendalCopyOptions(op.ctx, o)
+	if err != nil {
+		return nil, err
+	}
+	defer ffiCopyOptionsFree.symbol(op.ctx)(cOpts)
+	inner, err := ffiOperatorCopierWith.symbol(op.ctx)(op.inner, src, dest, cOpts)
+	// cOpts holds raw pointers into the Go buffers tracked by keepAlive.
+	// Keep them reachable until the native call above has returned.
+	runtime.KeepAlive(keepAlive)
+	if err != nil {
+		return nil, err
+	}
+	return &Copier{inner: inner, ctx: op.ctx}, nil
+}
+
+// Next drives the copy forward by one step.
+//
+// It returns the number of bytes copied in this step. ok is false when the copy
+// has completed; once that happens, further calls keep returning (0, false, nil).
+// A non-nil error reports a failed copy. Calling Next on a closed Copier also
+// returns (0, false, nil).
+func (c *Copier) Next() (size uint, ok bool, err error) {
+	if c.inner == nil {
+		return 0, false, nil
+	}
+	return ffiCopierNext.symbol(c.ctx)(c.inner)
+}
+
+// Abort aborts the pending copy operation.
+//
+// After Abort, the Copier should still be released with Close. Calling Abort
+// on a closed Copier is a no-op.
+func (c *Copier) Abort() error {
+	if c.inner == nil {
+		return nil
+	}
+	return ffiCopierAbort.symbol(c.ctx)(c.inner)
+}
+
+// Close releases the resources held by the Copier. It must be called once the
+// Copier is no longer needed. Close is safe to call more than once; subsequent
+// calls are no-ops.
+func (c *Copier) Close() error {
+	if c.inner == nil {
+		return nil
+	}
+	ffiCopierFree.symbol(c.ctx)(c.inner)
+	c.inner = nil
+	return nil
+}
+
+var ffiOperatorCopier = newFFI(ffiOpts{
+	sym:    "opendal_operator_copier",
+	rType:  &typeResultOperatorCopier,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(op *opendalOperator, src, dest string) (*opendalCopier, error) {
+	return func(op *opendalOperator, src, dest string) (*opendalCopier, error) {
+		byteSrc, err := BytePtrFromString(src)
+		if err != nil {
+			return nil, err
+		}
+		byteDest, err := BytePtrFromString(dest)
+		if err != nil {
+			return nil, err
+		}
+		var result resultOperatorCopier
+		ffiCall(
+			unsafe.Pointer(&result),
+			unsafe.Pointer(&op),
+			unsafe.Pointer(&byteSrc),
+			unsafe.Pointer(&byteDest),
+		)
+		if result.error != nil {
+			return nil, parseError(ctx, result.error)
+		}
+		return result.copier, nil
+	}
+})
+
+var ffiOperatorCopierWith = newFFI(ffiOpts{
+	sym:    "opendal_operator_copier_with",
+	rType:  &typeResultOperatorCopier,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(op *opendalOperator, src, dest string, opts *opendalCopyOptions) (*opendalCopier, error) {
+	return func(op *opendalOperator, src, dest string, opts *opendalCopyOptions) (*opendalCopier, error) {
+		byteSrc, err := BytePtrFromString(src)
+		if err != nil {
+			return nil, err
+		}
+		byteDest, err := BytePtrFromString(dest)
+		if err != nil {
+			return nil, err
+		}
+		var result resultOperatorCopier
+		ffiCall(
+			unsafe.Pointer(&result),
+			unsafe.Pointer(&op),
+			unsafe.Pointer(&byteSrc),
+			unsafe.Pointer(&byteDest),
+			unsafe.Pointer(&opts),
+		)
+		if result.error != nil {
+			return nil, parseError(ctx, result.error)
+		}
+		return result.copier, nil
+	}
+})
+
+var ffiCopierNext = newFFI(ffiOpts{
+	sym:    "opendal_copier_next",
+	rType:  &typeResultCopierNext,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(c *opendalCopier) (uint, bool, error) {
+	return func(c *opendalCopier) (uint, bool, error) {
+		var result resultCopierNext
+		ffiCall(
+			unsafe.Pointer(&result),
+			unsafe.Pointer(&c),
+		)
+		if result.error != nil {
+			return 0, false, parseError(ctx, result.error)
+		}
+		return result.size, result.has_next == 1, nil
+	}
+})
+
+var ffiCopierAbort = newFFI(ffiOpts{
+	sym:    "opendal_copier_abort",
+	rType:  &ffi.TypePointer,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(c *opendalCopier) error {
+	return func(c *opendalCopier) error {
+		var e *opendalError
+		ffiCall(
+			unsafe.Pointer(&e),
+			unsafe.Pointer(&c),
+		)
+		return parseError(ctx, e)
+	}
+})
+
+var ffiCopierFree = newFFI(ffiOpts{
+	sym:    "opendal_copier_free",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(c *opendalCopier) {
+	return func(c *opendalCopier) {
+		ffiCall(
+			nil,
+			unsafe.Pointer(&c),
+		)
+	}
+})

--- a/bindings/go/copy.go
+++ b/bindings/go/copy.go
@@ -126,46 +126,75 @@ func (op *Operator) Copy(src, dest string, opts ...WithCopyFn) error {
 		return ffiOperatorCopy.symbol(op.ctx)(op.inner, src, dest)
 	}
 
+	o := parseCopyOptions(opts...)
+	cOpts, keepAlive, err := newOpendalCopyOptions(op.ctx, o)
+	if err != nil {
+		return err
+	}
+	defer ffiCopyOptionsFree.symbol(op.ctx)(cOpts)
+	err = ffiOperatorCopyWith.symbol(op.ctx)(op.inner, src, dest, cOpts)
+	// cOpts holds raw pointers into the Go buffers tracked by keepAlive; keep
+	// them reachable until the native call above has returned.
+	runtime.KeepAlive(keepAlive)
+	return err
+}
+
+func parseCopyOptions(opts ...WithCopyFn) *copyOptions {
 	o := &copyOptions{}
 	for _, opt := range opts {
 		opt(o)
 	}
-	cOpts := ffiCopyOptionsNew.symbol(op.ctx)()
-	free := ffiCopyOptionsFree.symbol(op.ctx)
+	return o
+}
 
-	ffiCopyOptionsSetIfNotExists.symbol(op.ctx)(cOpts, o.ifNotExists)
-	var ifMatchData []byte
-	if o.ifMatch != "" {
-		data, err := ffiCopyOptionsSetIfMatch.symbol(op.ctx)(cOpts, o.ifMatch)
-		if err != nil {
-			free(cOpts)
-			return err
-		}
-		ifMatchData = data
+// copyOptionsKeepAlive holds byte slices that must outlive the FFI call that
+// references them, since the C side borrows the underlying memory.
+type copyOptionsKeepAlive struct {
+	strings [][]byte
+}
+
+// newOpendalCopyOptions builds a C-side opendal_copy_options from o. On error it
+// frees the allocated options before returning. The caller is responsible for
+// freeing the returned options and for keeping keepAlive reachable until after
+// the FFI call that consumes the options.
+func newOpendalCopyOptions(ctx context.Context, o *copyOptions) (*opendalCopyOptions, copyOptionsKeepAlive, error) {
+	cOpts := ffiCopyOptionsNew.symbol(ctx)()
+	keepAlive := copyOptionsKeepAlive{}
+
+	fail := func(err error) (*opendalCopyOptions, copyOptionsKeepAlive, error) {
+		ffiCopyOptionsFree.symbol(ctx)(cOpts)
+		return nil, copyOptionsKeepAlive{}, err
 	}
-	var sourceVersionData []byte
-	if o.sourceVersion != "" {
-		data, err := ffiCopyOptionsSetSourceVersion.symbol(op.ctx)(cOpts, o.sourceVersion)
+
+	setString := func(value string, set func(*opendalCopyOptions, string) ([]byte, error)) error {
+		if value == "" {
+			return nil
+		}
+		data, err := set(cOpts, value)
 		if err != nil {
-			free(cOpts)
 			return err
 		}
-		sourceVersionData = data
+		keepAlive.strings = append(keepAlive.strings, data)
+		return nil
+	}
+
+	ffiCopyOptionsSetIfNotExists.symbol(ctx)(cOpts, o.ifNotExists)
+	if err := setString(o.ifMatch, ffiCopyOptionsSetIfMatch.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if err := setString(o.sourceVersion, ffiCopyOptionsSetSourceVersion.symbol(ctx)); err != nil {
+		return fail(err)
 	}
 	if o.sourceContentLengthHint != 0 {
-		ffiCopyOptionsSetSourceContentLengthHint.symbol(op.ctx)(cOpts, o.sourceContentLengthHint)
+		ffiCopyOptionsSetSourceContentLengthHint.symbol(ctx)(cOpts, o.sourceContentLengthHint)
 	}
 	if o.concurrent != 0 {
-		ffiCopyOptionsSetConcurrent.symbol(op.ctx)(cOpts, o.concurrent)
+		ffiCopyOptionsSetConcurrent.symbol(ctx)(cOpts, o.concurrent)
 	}
 	if o.chunk != 0 {
-		ffiCopyOptionsSetChunk.symbol(op.ctx)(cOpts, o.chunk)
+		ffiCopyOptionsSetChunk.symbol(ctx)(cOpts, o.chunk)
 	}
-	err := ffiOperatorCopyWith.symbol(op.ctx)(op.inner, src, dest, cOpts)
-	free(cOpts)
-	runtime.KeepAlive(ifMatchData)
-	runtime.KeepAlive(sourceVersionData)
-	return err
+	return cOpts, keepAlive, nil
 }
 
 var ffiCopyOptionsNew = newFFI(ffiOpts{

--- a/bindings/go/tests/behavior_tests/copy_test.go
+++ b/bindings/go/tests/behavior_tests/copy_test.go
@@ -38,12 +38,17 @@ func testsCopy(cap *opendal.Capability) []behaviorTest {
 		testCopySelf,
 		testCopyNested,
 		testCopyOverwrite,
+		testCopierFile,
+		testCopierCompletion,
+		testCopierAbort,
+		testCopierClosed,
 	}
 	if cap.CreateDir() {
 		tests = append(tests, testCopySourceDir, testCopyTargetDir)
 	}
 	if isCapEnabled(cap.CopyWithIfNotExists, "copy_with_if_not_exists") {
-		tests = append(tests, testCopyWithIfNotExistsToNewFile, testCopyWithIfNotExistsToExistingFile)
+		tests = append(tests, testCopyWithIfNotExistsToNewFile, testCopyWithIfNotExistsToExistingFile,
+			testCopierWithIfNotExistsToNewFile, testCopierWithIfNotExistsToExistingFile)
 	}
 	if isCapEnabled(cap.CopyWithIfMatch, "copy_with_if_match") {
 		tests = append(tests, testCopyWithIfMatchMatch, testCopyWithIfMatchMismatch)
@@ -52,7 +57,7 @@ func testsCopy(cap *opendal.Capability) []behaviorTest {
 		tests = append(tests, testCopyWithSourceVersionToNewFile, testCopyWithSourceVersionToSameFile)
 	}
 	if isCapEnabled(cap.CopyCanMulti, "copy_can_multi") {
-		tests = append(tests, testCopyWithChunk, testCopyWithChunkAndConcurrent)
+		tests = append(tests, testCopyWithChunk, testCopyWithChunkAndConcurrent, testCopierMultipart)
 	}
 	return tests
 }
@@ -168,6 +173,122 @@ func testCopyOverwrite(assert *require.Assertions, op *opendal.Operator, fixture
 	targetContent, err = op.Read(targetPath)
 	assert.Nil(err, "read must succeed")
 	assert.Equal(sourceContent, targetContent)
+}
+
+func driveCopier(copier *opendal.Copier) error {
+	for {
+		_, ok, err := copier.Next()
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return nil
+		}
+	}
+}
+
+func testCopierFile(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	sourcePath, sourceContent, _ := fixture.NewFile()
+	_, err := op.Write(sourcePath, sourceContent)
+	assert.Nil(err)
+
+	targetPath := fixture.NewFilePath()
+	copier, err := op.Copier(sourcePath, targetPath)
+	assert.Nil(err, "create copier must succeed")
+	defer copier.Close()
+
+	assert.Nil(driveCopier(copier), "copier must drive to completion")
+
+	targetContent, err := op.Read(targetPath)
+	assert.Nil(err, "read must succeed")
+	assert.Equal(sourceContent, targetContent)
+}
+
+func testCopierCompletion(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	sourcePath, sourceContent, _ := fixture.NewFile()
+	_, err := op.Write(sourcePath, sourceContent)
+	assert.Nil(err)
+
+	targetPath := fixture.NewFilePath()
+	copier, err := op.Copier(sourcePath, targetPath)
+	assert.Nil(err, "create copier must succeed")
+	defer copier.Close()
+
+	assert.Nil(driveCopier(copier), "copier must drive to completion")
+
+	_, ok, err := copier.Next()
+	assert.Nil(err, "next on completed copier must not error")
+	assert.False(ok, "completed copier must keep reporting no progress")
+}
+
+func testCopierAbort(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	sourcePath, sourceContent, _ := fixture.NewFile()
+	_, err := op.Write(sourcePath, sourceContent)
+	assert.Nil(err)
+
+	targetPath := fixture.NewFilePath()
+	copier, err := op.Copier(sourcePath, targetPath)
+	assert.Nil(err, "create copier must succeed")
+	defer copier.Close()
+
+	assert.Nil(copier.Abort(), "abort must succeed")
+}
+
+func testCopierClosed(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	sourcePath, sourceContent, _ := fixture.NewFile()
+	_, err := op.Write(sourcePath, sourceContent)
+	assert.Nil(err)
+
+	targetPath := fixture.NewFilePath()
+	copier, err := op.Copier(sourcePath, targetPath)
+	assert.Nil(err, "create copier must succeed")
+
+	assert.Nil(copier.Close(), "close must succeed")
+	assert.Nil(copier.Close(), "close must be idempotent")
+
+	_, ok, err := copier.Next()
+	assert.Nil(err, "next on a closed copier must not error")
+	assert.False(ok, "closed copier must report no progress")
+	assert.Nil(copier.Abort(), "abort on a closed copier must be a no-op")
+}
+
+func testCopierWithIfNotExistsToNewFile(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	sourcePath, sourceContent, _ := fixture.NewFile()
+	_, err := op.Write(sourcePath, sourceContent)
+	assert.Nil(err)
+
+	targetPath := fixture.NewFilePath()
+	copier, err := op.Copier(sourcePath, targetPath, opendal.CopyWithIfNotExists(true))
+	assert.Nil(err, "create copier must succeed")
+	defer copier.Close()
+
+	assert.Nil(driveCopier(copier), "copier must drive to completion")
+
+	bs, err := op.Read(targetPath)
+	assert.Nil(err, "read must succeed")
+	assert.Equal(sourceContent, bs)
+}
+
+func testCopierWithIfNotExistsToExistingFile(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	sourcePath, sourceContent, _ := fixture.NewFile()
+	_, err := op.Write(sourcePath, sourceContent)
+	assert.Nil(err)
+
+	targetPath, targetContent, _ := fixture.NewFile()
+	_, err = op.Write(targetPath, targetContent)
+	assert.Nil(err)
+
+	copier, err := op.Copier(sourcePath, targetPath, opendal.CopyWithIfNotExists(true))
+	assert.Nil(err, "create copier must succeed")
+	defer copier.Close()
+
+	err = driveCopier(copier)
+	assert.NotNil(err, "copier must fail when target exists")
+	assert.Equal(opendal.CodeConditionNotMatch, assertErrorCode(err))
+
+	bs, err := op.Read(targetPath)
+	assert.Nil(err, "read must succeed")
+	assert.Equal(targetContent, bs, "target must not be overwritten")
 }
 
 func testCopyWithIfNotExistsToNewFile(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
@@ -332,6 +453,42 @@ func testCopyWithChunkAndConcurrent(assert *require.Assertions, op *opendal.Oper
 
 	targetPath := fixture.NewFilePath()
 	assert.Nil(op.Copy(sourcePath, targetPath, opendal.CopyWithChunk(uint(chunk)), opendal.CopyWithConcurrent(4)))
+
+	bs, err := op.Read(targetPath)
+	assert.Nil(err, "read must succeed")
+	assert.Equal(sourceContent, bs)
+}
+
+func testCopierMultipart(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	chunk, sourceSize := copyMultiChunkSize(op.Info().GetCapability())
+	if sourceSize == 0 {
+		return
+	}
+
+	sourcePath := fixture.NewFilePath()
+	sourceContent := genFixedBytes(sourceSize)
+	_, err := op.Write(sourcePath, sourceContent)
+	assert.Nil(err)
+
+	targetPath := fixture.NewFilePath()
+	copier, err := op.Copier(sourcePath, targetPath, opendal.CopyWithChunk(uint(chunk)))
+	assert.Nil(err, "create copier must succeed")
+	defer copier.Close()
+
+	var steps int
+	var total uint
+	for {
+		n, ok, err := copier.Next()
+		assert.Nil(err, "copier next must succeed")
+		if !ok {
+			break
+		}
+		steps++
+		total += n
+	}
+
+	assert.Greater(steps, 0, "multipart copier must report incremental progress")
+	assert.Equal(uint(sourceSize), total, "reported progress must sum to source size")
 
 	bs, err := op.Read(targetPath)
 	assert.Nil(err, "read must succeed")

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -117,6 +117,25 @@ var (
 		}[0],
 	}
 
+	typeResultOperatorCopier = ffi.Type{
+		Type: ffi.Struct,
+		Elements: &[]*ffi.Type{
+			&ffi.TypePointer,
+			&ffi.TypePointer,
+			nil,
+		}[0],
+	}
+
+	typeResultCopierNext = ffi.Type{
+		Type: ffi.Struct,
+		Elements: &[]*ffi.Type{
+			&ffi.TypePointer, // size (usize)
+			&ffi.TypeUint8,   // has_next (bool)
+			&ffi.TypePointer, // error
+			nil,
+		}[0],
+	}
+
 	typeResultReaderRead = ffi.Type{
 		Type: ffi.Struct,
 		Elements: &[]*ffi.Type{
@@ -307,6 +326,19 @@ type resultOperatorWriter struct {
 type resultWriterWrite struct {
 	size  uint
 	error *opendalError
+}
+
+type opendalCopier struct{}
+
+type resultOperatorCopier struct {
+	copier *opendalCopier
+	error  *opendalError
+}
+
+type resultCopierNext struct {
+	size     uint
+	has_next uint8
+	error    *opendalError
 }
 
 type resultReaderRead struct {


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7731

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->
Rust core exposes `Operator::copier()` (a `Copier` handle that drives a long-running copy step by step), but it was missing from both the C and Go bindings, so Go users only had the one-shot `Operator.Copy`. This adds it.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- C binding: `opendal_operator_copier` / `opendal_operator_copier_with`, plus an `opendal_copier` handle with `opendal_copier_next` / `_abort` / `_free` and matching result types.
- Go binding: a `Copier` type with `Operator.Copier(src, dest, ...)`, `Next() (uint, bool, error)`, `Abort()` and `Close()`. Copy-option building is refactored into a shared helper reused by both `Copy` and `Copier`.

# Are there any user-facing changes?

New `Operator.Copier` API in the Go binding (and the underlying `opendal_operator_copier*` C functions). No breaking changes.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
Claude Code with Opus 4.8.
