### PR TITLE
fix(layer/foyers): support suffix read

### DIFF
--- a/core/layers/foyer/src/full.rs
+++ b/core/layers/foyer/src/full.rs
@@ -69,8 +69,8 @@ impl<A: Access> FullReader<A> {
         RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(buffer.len() as _))
     }
 
-    fn slice_full_object(buffer: &Buffer, range: BytesRange) -> Buffer {
-        buffer.slice(range.to_range_as_usize())
+    fn slice_full_object(buffer: &Buffer, range: BytesRange) -> Result<Buffer> {
+        Ok(buffer.slice(range.to_content_range(buffer.len())?))
     }
 
     fn is_deleted(&self, key: &FoyerKey) -> bool {
@@ -178,7 +178,7 @@ impl<A: Access> FullReader<A> {
         match self.read_full_object().await? {
             Some(buffer) => {
                 let rp = Self::full_object_rp(&buffer);
-                let buffer = Self::slice_full_object(&buffer, range);
+                let buffer = Self::slice_full_object(&buffer, range)?;
                 Ok((rp, buffer))
             }
             None => self.fallback_read(range).await,
@@ -191,7 +191,7 @@ impl<A: Access> oio::Read for FullReader<A> {
         match self.read_full_object().await? {
             Some(buffer) => {
                 let rp = Self::full_object_rp(&buffer);
-                let buffer = Self::slice_full_object(&buffer, range);
+                let buffer = Self::slice_full_object(&buffer, range)?;
                 Ok((rp, Box::new(buffer) as Box<dyn oio::ReadStreamDyn>))
             }
             None => self.fallback_open(range).await,

--- a/core/layers/foyer/src/lib.rs
+++ b/core/layers/foyer/src/lib.rs
@@ -411,6 +411,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_full_reader_open_suffix_range() {
+        let cache = memory_cache().await;
+        let accessor = FoyerLayer::new(cache)
+            .with_size_limit(0..100)
+            .layer(MockReadAccessor::new("0123456789"));
+        let state = accessor.inner.accessor.state.clone();
+
+        let (_, reader) = LayeredAccess::read(&accessor, "test", OpRead::default())
+            .await
+            .unwrap();
+        let (_, mut stream) = reader.open(BytesRange::suffix(4)).await.unwrap();
+        let buffer = stream.read_all().await.unwrap();
+
+        assert_eq!(buffer.to_vec(), b"6789");
+        assert_eq!(state.stat_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(state.open_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(state.read_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
     async fn test_full_reader_open_fallback_preserves_stream() {
         let cache = memory_cache().await;
         let accessor = FoyerLayer::new(cache)

--- a/core/layers/foyer/src/lib.rs
+++ b/core/layers/foyer/src/lib.rs
@@ -395,6 +395,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_full_reader_suffix_range() {
+        let cache = memory_cache().await;
+
+        let op = Operator::new(Memory::default())
+            .unwrap()
+            .layer(FoyerLayer::new(cache))
+            .finish();
+        op.write("test", Buffer::from("0123456789")).await.unwrap();
+
+        let reader = op.reader("test").await.unwrap();
+        let buf = reader.read(BytesRange::suffix(4)).await.unwrap();
+
+        assert_eq!(buf.to_vec(), b"6789");
+    }
+
+    #[tokio::test]
     async fn test_full_reader_open_fallback_preserves_stream() {
         let cache = memory_cache().await;
         let accessor = FoyerLayer::new(cache)


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7736

# Rationale for this change

The support for suffix read feature should be decided by storage backends, and layers should panic on this feature.

# What changes are included in this PR?

Change the way how full object is sliced with suffix read involved.

# Are there any user-facing changes?

No.

# AI Usage Statement

fable-5 helped me make the code change for me, opus-4.6 and me doing code review.