### PR TITLE
refactor!: simplify stateful operation factories

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -6818,6 +6818,7 @@ dependencies = [
  "bytes",
  "http 1.4.1",
  "log",
+ "mea",
  "opendal-core",
  "opendal-service-azure-common",
  "quick-xml",

--- a/core/core/src/docs/internals/accessor.rs
+++ b/core/core/src/docs/internals/accessor.rs
@@ -41,7 +41,7 @@
 //!         ctx: &OperationContext,
 //!         path: &str,
 //!         args: OpRead,
-//!     ) -> impl Future<Output = Result<(RpRead, Self::Reader)>> + MaybeSend;
+//!     ) -> impl Future<Output = Result<Self::Reader>> + MaybeSend;
 //! }
 //! ```
 //!
@@ -307,7 +307,7 @@
 //!         }
 //!     }
 //!
-//!     async fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+//!     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
 //!         gagaga!()
 //!     }
 //! }

--- a/core/core/src/layers/capability_override.rs
+++ b/core/core/src/layers/capability_override.rs
@@ -141,46 +141,31 @@ impl Service for CapabilityOverrideService {
         self.inner.stat(ctx, path, args).await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        self.inner.read(ctx, path, args).await
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        self.inner.read(ctx, path, args)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        self.inner.write(ctx, path, args).await
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        self.inner.write(ctx, path, args)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.inner.delete(ctx).await
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner.delete(ctx)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        self.inner.list(ctx, path, args).await
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        self.inner.list(ctx, path, args)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        self.inner.copy(ctx, from, to, args, opts).await
+    ) -> Result<Self::Copier> {
+        self.inner.copy(ctx, from, to, args, opts)
     }
 
     async fn rename(

--- a/core/core/src/layers/complete.rs
+++ b/core/core/src/layers/complete.rs
@@ -79,37 +79,26 @@ impl Service for CompleteService {
         self.inner.create_dir(ctx, path, args).await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, reader) = self.inner.read(ctx, path, args).await?;
-        let reader = CompleteReader::new(reader);
-        Ok((rp, reader))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let reader = self.inner.read(ctx, path, args)?;
+        Ok(CompleteReader::new(reader))
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let append = args.append();
-        let (rp, w) = self.inner.write(ctx, path, args).await?;
-        Ok((rp, CompleteWriter::new(w, append)))
+        let w = self.inner.write(ctx, path, args)?;
+        Ok(CompleteWriter::new(w, append))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        self.inner.copy(ctx, from, to, args, opts).await
+    ) -> Result<Self::Copier> {
+        self.inner.copy(ctx, from, to, args, opts)
     }
 
     async fn rename(
@@ -126,19 +115,13 @@ impl Service for CompleteService {
         self.inner.stat(ctx, path, args).await
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.inner.delete(ctx).await
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner.delete(ctx)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, lister) = self.inner.list(ctx, path, args).await?;
-        let lister = CompleteLister::new(ctx.clone(), self.inner.clone(), lister);
-        Ok((rp, lister))
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let lister = self.inner.list(ctx, path, args)?;
+        Ok(CompleteLister::new(ctx.clone(), self.inner.clone(), lister))
     }
 
     async fn presign(
@@ -454,7 +437,12 @@ mod tests {
         }
 
         async fn read(&self, _: BytesRange) -> Result<(RpRead, Buffer)> {
-            Ok((RpRead::default(), self.buffer.clone()))
+            Ok((
+                RpRead::new(
+                    Metadata::new(EntryMode::FILE).with_content_length(self.buffer.len() as u64),
+                ),
+                self.buffer.clone(),
+            ))
         }
     }
 

--- a/core/core/src/layers/correctness_check.rs
+++ b/core/core/src/layers/correctness_check.rs
@@ -93,12 +93,7 @@ impl Service for CorrectnessService {
         self.inner.capability()
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
         let capability = self.capability();
         let scheme = self.info().scheme();
         if !capability.read_with_version && args.version().is_some() {
@@ -129,15 +124,10 @@ impl Service for CorrectnessService {
             ));
         }
 
-        self.inner.read(ctx, path, args).await
+        self.inner.read(ctx, path, args)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let capability = self.capability();
         let scheme = self.info().scheme();
         if args.append() && !capability.write_can_append {
@@ -164,7 +154,7 @@ impl Service for CorrectnessService {
             }
         }
 
-        self.inner.write(ctx, path, args).await
+        self.inner.write(ctx, path, args)
     }
 
     async fn stat(&self, ctx: &OperationContext, path: &str, args: OpStat) -> Result<RpStat> {
@@ -201,21 +191,20 @@ impl Service for CorrectnessService {
         self.inner.stat(ctx, path, args).await
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.inner.delete(ctx).await.map(|(rp, deleter)| {
-            let deleter = CheckWrapper::new(deleter, self.info().scheme(), self.capability());
-            (rp, deleter)
-        })
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner
+            .delete(ctx)
+            .map(|deleter| CheckWrapper::new(deleter, self.info().scheme(), self.capability()))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         let capability = self.capability();
         let scheme = self.info().scheme();
         if args.if_not_exists() && !capability.copy_with_if_not_exists {
@@ -236,16 +225,11 @@ impl Service for CorrectnessService {
             ));
         }
 
-        self.inner.copy(ctx, from, to, args, opts).await
+        self.inner.copy(ctx, from, to, args, opts)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        self.inner.list(ctx, path, args).await
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        self.inner.list(ctx, path, args)
     }
 
     async fn create_dir(
@@ -369,48 +353,30 @@ mod tests {
             Ok(RpStat::new(Metadata::new(EntryMode::Unknown)))
         }
 
-        async fn read(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpRead,
-        ) -> Result<(RpRead, Self::Reader)> {
-            Ok((
-                RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(0)),
-                MockReader,
-            ))
+        fn read(&self, _ctx: &OperationContext, _: &str, _: OpRead) -> Result<Self::Reader> {
+            Ok(MockReader)
         }
 
-        async fn write(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpWrite,
-        ) -> Result<(RpWrite, Self::Writer)> {
-            Ok((RpWrite::new(), MockWriter))
+        fn write(&self, _ctx: &OperationContext, _: &str, _: OpWrite) -> Result<Self::Writer> {
+            Ok(MockWriter)
         }
 
-        async fn list(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpList,
-        ) -> Result<(RpList, Self::Lister)> {
-            Ok((RpList::default(), ()))
+        fn list(&self, _ctx: &OperationContext, _: &str, _: OpList) -> Result<Self::Lister> {
+            Ok(())
         }
 
-        async fn delete(&self, _: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-            Ok((RpDelete::default(), MockDeleter))
+        fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+            Ok(MockDeleter)
         }
 
-        async fn copy(
+        fn copy(
             &self,
             _: &OperationContext,
             _: &str,
             _: &str,
             _: OpCopy,
             _: OpCopier,
-        ) -> Result<(RpCopy, Self::Copier)> {
+        ) -> Result<Self::Copier> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
@@ -443,13 +409,16 @@ mod tests {
     impl oio::Read for MockReader {
         async fn open(&self, _: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
             Ok((
-                RpRead::default(),
+                RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(0)),
                 Box::new(Buffer::new()) as Box<dyn oio::ReadStreamDyn>,
             ))
         }
 
         async fn read(&self, _: BytesRange) -> Result<(RpRead, Buffer)> {
-            Ok((RpRead::default(), Buffer::new()))
+            Ok((
+                RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(0)),
+                Buffer::new(),
+            ))
         }
     }
 

--- a/core/core/src/layers/error_context.rs
+++ b/core/core/src/layers/error_context.rs
@@ -98,16 +98,10 @@ impl Service for ErrorContextService {
         })
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
         self.inner
             .read(ctx, path, args)
-            .await
-            .map(|(rp, r)| (rp, ErrorContextWrapper::new(self.info().scheme(), path, r)))
+            .map(|r| ErrorContextWrapper::new(self.info().scheme(), path, r))
             .map_err(|err| {
                 err.with_operation(Operation::Read)
                     .with_context("service", self.info().scheme())
@@ -115,16 +109,10 @@ impl Service for ErrorContextService {
             })
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         self.inner
             .write(ctx, path, args)
-            .await
-            .map(|(rp, w)| (rp, ErrorContextWrapper::new(self.info().scheme(), path, w)))
+            .map(|w| ErrorContextWrapper::new(self.info().scheme(), path, w))
             .map_err(|err| {
                 err.with_operation(Operation::Write)
                     .with_context("service", self.info().scheme())
@@ -132,18 +120,17 @@ impl Service for ErrorContextService {
             })
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         self.inner
             .copy(ctx, from, to, args, opts)
-            .await
-            .map(|(rp, p)| (rp, ErrorContextWrapper::new(self.info().scheme(), to, p)))
+            .map(|p| ErrorContextWrapper::new(self.info().scheme(), to, p))
             .map_err(|err| {
                 err.with_operation(Operation::Copy)
                     .with_context("service", self.info().scheme())
@@ -175,27 +162,20 @@ impl Service for ErrorContextService {
         })
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
         self.inner
             .delete(ctx)
-            .await
-            .map(|(rp, w)| (rp, ErrorContextWrapper::new(self.info().scheme(), "", w)))
+            .map(|w| ErrorContextWrapper::new(self.info().scheme(), "", w))
             .map_err(|err| {
                 err.with_operation(Operation::Delete)
                     .with_context("service", self.info().scheme())
             })
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         self.inner
             .list(ctx, path, args)
-            .await
-            .map(|(rp, p)| (rp, ErrorContextWrapper::new(self.info().scheme(), path, p)))
+            .map(|p| ErrorContextWrapper::new(self.info().scheme(), path, p))
             .map_err(|err| {
                 err.with_operation(Operation::List)
                     .with_context("service", self.info().scheme())

--- a/core/core/src/layers/simulate.rs
+++ b/core/core/src/layers/simulate.rs
@@ -133,7 +133,7 @@ impl SimulateService {
         }
 
         if capability.write_can_empty && capability.list {
-            let (_, mut w) = self.srv.write(ctx, path, OpWrite::default()).await?;
+            let mut w = self.srv.write(ctx, path, OpWrite::default())?;
             oio::Write::close(&mut w).await?;
             return Ok(RpCreateDir::default());
         }
@@ -172,14 +172,11 @@ impl SimulateService {
             }
 
             if self.config.stat_dir && capability.list_with_recursive {
-                let (_, mut l) = self
-                    .srv
-                    .list(
-                        ctx,
-                        path,
-                        OpList::default().with_recursive(true).with_limit(1),
-                    )
-                    .await?;
+                let mut l = self.srv.list(
+                    ctx,
+                    path,
+                    OpList::default().with_recursive(true).with_limit(1),
+                )?;
 
                 return if l.next().await?.is_some() {
                     Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
@@ -195,59 +192,59 @@ impl SimulateService {
         self.srv.stat(ctx, path, args).await
     }
 
-    async fn simulate_list(
+    fn simulate_list(
         &self,
         ctx: &OperationContext,
         path: &str,
         args: OpList,
-    ) -> Result<(RpList, SimulateLister)> {
+    ) -> Result<SimulateLister> {
         let cap = self.srv.capability();
 
         let recursive = args.recursive();
         let forward = args;
 
-        let (rp, lister) = match (
+        let lister = match (
             recursive,
             cap.list_with_recursive,
             self.config.list_recursive,
         ) {
             // Backend supports recursive list, forward directly.
             (_, true, _) => {
-                let (rp, p) = self.srv.list(ctx, path, forward).await?;
-                (rp, SimulateLister::One(p))
+                let p = self.srv.list(ctx, path, forward)?;
+                SimulateLister::One(p)
             }
             // Simulate recursive via flat list when enabled.
             (true, false, true) => {
                 if path.ends_with('/') {
                     let p = ServicerFlatLister::new(ctx.clone(), self.srv.clone(), path);
-                    (RpList::default(), SimulateLister::Two(p))
+                    SimulateLister::Two(p)
                 } else {
                     let parent = get_parent(path);
                     let p = ServicerFlatLister::new(ctx.clone(), self.srv.clone(), parent);
                     let p = PrefixLister::new(p, path);
-                    (RpList::default(), SimulateLister::Four(p))
+                    SimulateLister::Four(p)
                 }
             }
             // Recursive requested but simulation disabled; rely on backend and propagate errors.
             (true, false, false) => {
-                let (rp, p) = self.srv.list(ctx, path, forward).await?;
-                (rp, SimulateLister::One(p))
+                let p = self.srv.list(ctx, path, forward)?;
+                SimulateLister::One(p)
             }
             // Non-recursive list: keep existing prefix handling semantics.
             (false, false, _) => {
                 if path.ends_with('/') {
-                    let (rp, p) = self.srv.list(ctx, path, forward).await?;
-                    (rp, SimulateLister::One(p))
+                    let p = self.srv.list(ctx, path, forward)?;
+                    SimulateLister::One(p)
                 } else {
                     let parent = get_parent(path);
-                    let (rp, p) = self.srv.list(ctx, parent, forward).await?;
+                    let p = self.srv.list(ctx, parent, forward)?;
                     let p = PrefixLister::new(p, path);
-                    (rp, SimulateLister::Three(p))
+                    SimulateLister::Three(p)
                 }
             }
         };
 
-        Ok((rp, lister))
+        Ok(lister)
     }
 
     async fn simulate_delete_with_recursive(
@@ -266,9 +263,7 @@ impl SimulateService {
 
         let non_recursive = args.clone().with_recursive(false);
 
-        let (_rp, mut lister) = self
-            .simulate_list(ctx, path, OpList::new().with_recursive(true))
-            .await?;
+        let mut lister = self.simulate_list(ctx, path, OpList::new().with_recursive(true))?;
 
         while let Some(entry) = lister.next().await? {
             let entry = entry.into_entry();
@@ -307,16 +302,11 @@ impl Service for SimulateService {
         self.simulate_create_dir(ctx, path, args).await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
         let capability = self.srv.capability();
         let simulate_read_with_suffix =
             self.config.read_with_suffix && capability.read && !capability.read_with_suffix;
-        let (rp, reader) = self.srv.read(ctx, path, args.clone()).await?;
+        let reader = self.srv.read(ctx, path, args.clone())?;
         let reader = SimulateReader::new(
             ctx.clone(),
             self.srv.clone(),
@@ -325,27 +315,22 @@ impl Service for SimulateService {
             reader,
             simulate_read_with_suffix,
         );
-        Ok((rp, reader))
+        Ok(reader)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        self.srv.write(ctx, path, args).await
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        self.srv.write(ctx, path, args)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        self.srv.copy(ctx, from, to, args, opts).await
+    ) -> Result<Self::Copier> {
+        self.srv.copy(ctx, from, to, args, opts)
     }
 
     async fn rename(
@@ -362,21 +347,18 @@ impl Service for SimulateService {
         self.simulate_stat(ctx, path, args).await
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, deleter) = self.srv.delete(ctx).await?;
-        Ok((
-            rp,
-            SimulateDeleter::new(ctx.clone(), self.srv.clone(), self.config.clone(), deleter),
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let deleter = self.srv.delete(ctx)?;
+        Ok(SimulateDeleter::new(
+            ctx.clone(),
+            self.srv.clone(),
+            self.config.clone(),
+            deleter,
         ))
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        self.simulate_list(ctx, path, args).await
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        self.simulate_list(ctx, path, args)
     }
 
     async fn presign(
@@ -491,7 +473,7 @@ impl oio::List for ServicerFlatLister {
     async fn next(&mut self) -> Result<Option<oio::Entry>> {
         loop {
             if let Some(de) = self.next_dir.take() {
-                let (_, mut l) = match self.srv.list(&self.ctx, de.path(), OpList::new()).await {
+                let mut l = match self.srv.list(&self.ctx, de.path(), OpList::new()) {
                     Ok(v) => v,
                     Err(e) if e.kind() == ErrorKind::PermissionDenied => {
                         log::warn!(
@@ -677,57 +659,42 @@ mod tests {
             ))
         }
 
-        async fn read(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpRead,
-        ) -> Result<(RpRead, Self::Reader)> {
+        fn read(&self, _ctx: &OperationContext, _: &str, _: OpRead) -> Result<Self::Reader> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn write(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpWrite,
-        ) -> Result<(RpWrite, Self::Writer)> {
+        fn write(&self, _ctx: &OperationContext, _: &str, _: OpWrite) -> Result<Self::Writer> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn delete(&self, _: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+        fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn list(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpList,
-        ) -> Result<(RpList, Self::Lister)> {
+        fn list(&self, _ctx: &OperationContext, _: &str, _: OpList) -> Result<Self::Lister> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn copy(
+        fn copy(
             &self,
             _: &OperationContext,
             _: &str,
             _: &str,
             _: OpCopy,
             _: OpCopier,
-        ) -> Result<(RpCopy, Self::Copier)> {
+        ) -> Result<Self::Copier> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
@@ -762,12 +729,18 @@ mod tests {
     impl oio::Read for MockReader {
         async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
             *self.observed_range.lock().expect("mutex must not poison") = Some(range);
-            Ok((RpRead::default(), Box::new(Buffer::new())))
+            Ok((
+                RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(0)),
+                Box::new(Buffer::new()),
+            ))
         }
 
         async fn read(&self, range: BytesRange) -> Result<(RpRead, Buffer)> {
             *self.observed_range.lock().expect("mutex must not poison") = Some(range);
-            Ok((RpRead::default(), Buffer::new()))
+            Ok((
+                RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(0)),
+                Buffer::new(),
+            ))
         }
     }
 

--- a/core/core/src/raw/accessor.rs
+++ b/core/core/src/raw/accessor.rs
@@ -217,12 +217,7 @@ pub trait Service: Send + Sync + Debug + Unpin + 'static {
     ///
     /// - `path` is a normalized file path.
     /// - Range I/O is handled by the returned reader.
-    fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> impl Future<Output = Result<(RpRead, Self::Reader)>> + MaybeSend;
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader>;
 
     /// Invoke the `write` operation on the specified path.
     ///
@@ -231,12 +226,7 @@ pub trait Service: Send + Sync + Debug + Unpin + 'static {
     /// # Behavior
     ///
     /// - `path` is a normalized file path.
-    fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> impl Future<Output = Result<(RpWrite, Self::Writer)>> + MaybeSend;
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer>;
 
     /// Invoke the `delete` operation.
     ///
@@ -246,10 +236,7 @@ pub trait Service: Send + Sync + Debug + Unpin + 'static {
     ///
     /// - The returned deleter handles one or more delete requests.
     /// - Deleting a missing path should succeed.
-    fn delete(
-        &self,
-        ctx: &OperationContext,
-    ) -> impl Future<Output = Result<(RpDelete, Self::Deleter)>> + MaybeSend;
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter>;
 
     /// Invoke the `list` operation on the specified path.
     ///
@@ -259,12 +246,7 @@ pub trait Service: Send + Sync + Debug + Unpin + 'static {
     ///
     /// - `path` is a normalized directory path or prefix.
     /// - Listing a non-existing directory should return an empty stream.
-    fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> impl Future<Output = Result<(RpList, Self::Lister)>> + MaybeSend;
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister>;
 
     /// Invoke the `copy` operation on the specified `from` path and `to` path.
     ///
@@ -281,7 +263,7 @@ pub trait Service: Send + Sync + Debug + Unpin + 'static {
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> impl Future<Output = Result<(RpCopy, Self::Copier)>> + MaybeSend;
+    ) -> Result<Self::Copier>;
 
     /// Invoke the `rename` operation on the specified `from` path and `to` path.
     ///
@@ -340,7 +322,7 @@ pub trait ServiceDyn: Send + Sync + Debug + Unpin + 'static {
         ctx: &'a OperationContext,
         path: &'a str,
         args: OpRead,
-    ) -> BoxedFuture<'a, Result<(RpRead, oio::Reader)>>;
+    ) -> Result<oio::Reader>;
 
     /// Dyn version of [`Service::write`].
     fn write_dyn<'a>(
@@ -348,13 +330,10 @@ pub trait ServiceDyn: Send + Sync + Debug + Unpin + 'static {
         ctx: &'a OperationContext,
         path: &'a str,
         args: OpWrite,
-    ) -> BoxedFuture<'a, Result<(RpWrite, oio::Writer)>>;
+    ) -> Result<oio::Writer>;
 
     /// Dyn version of [`Service::delete`].
-    fn delete_dyn<'a>(
-        &'a self,
-        ctx: &'a OperationContext,
-    ) -> BoxedFuture<'a, Result<(RpDelete, oio::Deleter)>>;
+    fn delete_dyn<'a>(&'a self, ctx: &'a OperationContext) -> Result<oio::Deleter>;
 
     /// Dyn version of [`Service::list`].
     fn list_dyn<'a>(
@@ -362,7 +341,7 @@ pub trait ServiceDyn: Send + Sync + Debug + Unpin + 'static {
         ctx: &'a OperationContext,
         path: &'a str,
         args: OpList,
-    ) -> BoxedFuture<'a, Result<(RpList, oio::Lister)>>;
+    ) -> Result<oio::Lister>;
 
     /// Dyn version of [`Service::copy`].
     fn copy_dyn<'a>(
@@ -372,7 +351,7 @@ pub trait ServiceDyn: Send + Sync + Debug + Unpin + 'static {
         to: &'a str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> BoxedFuture<'a, Result<(RpCopy, oio::Copier)>>;
+    ) -> Result<oio::Copier>;
 
     /// Dyn version of [`Service::rename`].
     fn rename_dyn<'a>(
@@ -427,11 +406,8 @@ impl<S: Service + ?Sized> ServiceDyn for S {
         ctx: &'a OperationContext,
         path: &'a str,
         args: OpRead,
-    ) -> BoxedFuture<'a, Result<(RpRead, oio::Reader)>> {
-        Box::pin(async move {
-            let (rp, reader) = self.read(ctx, path, args).await?;
-            Ok((rp, Box::new(reader) as oio::Reader))
-        })
+    ) -> Result<oio::Reader> {
+        Ok(Box::new(self.read(ctx, path, args)?) as oio::Reader)
     }
 
     fn write_dyn<'a>(
@@ -439,21 +415,12 @@ impl<S: Service + ?Sized> ServiceDyn for S {
         ctx: &'a OperationContext,
         path: &'a str,
         args: OpWrite,
-    ) -> BoxedFuture<'a, Result<(RpWrite, oio::Writer)>> {
-        Box::pin(async move {
-            let (rp, writer) = self.write(ctx, path, args).await?;
-            Ok((rp, Box::new(writer) as oio::Writer))
-        })
+    ) -> Result<oio::Writer> {
+        Ok(Box::new(self.write(ctx, path, args)?) as oio::Writer)
     }
 
-    fn delete_dyn<'a>(
-        &'a self,
-        ctx: &'a OperationContext,
-    ) -> BoxedFuture<'a, Result<(RpDelete, oio::Deleter)>> {
-        Box::pin(async move {
-            let (rp, deleter) = self.delete(ctx).await?;
-            Ok((rp, Box::new(deleter) as oio::Deleter))
-        })
+    fn delete_dyn<'a>(&'a self, ctx: &'a OperationContext) -> Result<oio::Deleter> {
+        Ok(Box::new(self.delete(ctx)?) as oio::Deleter)
     }
 
     fn list_dyn<'a>(
@@ -461,11 +428,8 @@ impl<S: Service + ?Sized> ServiceDyn for S {
         ctx: &'a OperationContext,
         path: &'a str,
         args: OpList,
-    ) -> BoxedFuture<'a, Result<(RpList, oio::Lister)>> {
-        Box::pin(async move {
-            let (rp, lister) = self.list(ctx, path, args).await?;
-            Ok((rp, Box::new(lister) as oio::Lister))
-        })
+    ) -> Result<oio::Lister> {
+        Ok(Box::new(self.list(ctx, path, args)?) as oio::Lister)
     }
 
     fn copy_dyn<'a>(
@@ -475,11 +439,8 @@ impl<S: Service + ?Sized> ServiceDyn for S {
         to: &'a str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> BoxedFuture<'a, Result<(RpCopy, oio::Copier)>> {
-        Box::pin(async move {
-            let (rp, copier) = self.copy(ctx, from, to, args, opts).await?;
-            Ok((rp, Box::new(copier) as oio::Copier))
-        })
+    ) -> Result<oio::Copier> {
+        Ok(Box::new(self.copy(ctx, from, to, args, opts)?) as oio::Copier)
     }
 
     fn rename_dyn<'a>(
@@ -531,46 +492,31 @@ impl<T: ServiceDyn + ?Sized> Service for Arc<T> {
         self.as_ref().stat_dyn(ctx, path, args).await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, oio::Reader)> {
-        self.as_ref().read_dyn(ctx, path, args).await
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<oio::Reader> {
+        self.as_ref().read_dyn(ctx, path, args)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, oio::Writer)> {
-        self.as_ref().write_dyn(ctx, path, args).await
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<oio::Writer> {
+        self.as_ref().write_dyn(ctx, path, args)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, oio::Deleter)> {
-        self.as_ref().delete_dyn(ctx).await
+    fn delete(&self, ctx: &OperationContext) -> Result<oio::Deleter> {
+        self.as_ref().delete_dyn(ctx)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, oio::Lister)> {
-        self.as_ref().list_dyn(ctx, path, args).await
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<oio::Lister> {
+        self.as_ref().list_dyn(ctx, path, args)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, oio::Copier)> {
-        self.as_ref().copy_dyn(ctx, from, to, args, opts).await
+    ) -> Result<oio::Copier> {
+        self.as_ref().copy_dyn(ctx, from, to, args, opts)
     }
 
     async fn rename(
@@ -628,57 +574,42 @@ impl Service for () {
         ))
     }
 
-    async fn read(
-        &self,
-        _: &OperationContext,
-        _: &str,
-        _: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, _: &OperationContext, _: &str, _: OpRead) -> Result<Self::Reader> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn write(
-        &self,
-        _: &OperationContext,
-        _: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, _: &OperationContext, _: &str, _: OpWrite) -> Result<Self::Writer> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn delete(&self, _: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+    fn delete(&self, _: &OperationContext) -> Result<Self::Deleter> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn list(
-        &self,
-        _: &OperationContext,
-        _: &str,
-        _: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _: &OperationContext, _: &str, _: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _: &OperationContext,
         _: &str,
         _: &str,
         _: OpCopy,
         _: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/core/src/raw/enum_utils.rs
+++ b/core/core/src/raw/enum_utils.rs
@@ -20,7 +20,7 @@
 //!
 //! ```txt
 //! impl Service for S3Backend {
-//!     fn write(...) -> Result<(RpWrite, oio::Writer)>;
+//!     fn write(...) -> Result<oio::Writer>;
 //! }
 //! ```
 //!

--- a/core/core/src/raw/oio/copy/api.rs
+++ b/core/core/src/raw/oio/copy/api.rs
@@ -55,8 +55,10 @@ impl Copy for () {
 
 /// OneShotCopier drives a single asynchronous copy step.
 pub struct OneShotCopier {
+    factory: Option<Box<dyn FnMut() -> BoxedStaticFuture<Result<Metadata>>>>,
     fut: Option<BoxedStaticFuture<Result<Metadata>>>,
     meta: Option<Metadata>,
+    consumed: bool,
 }
 
 /// # Safety
@@ -73,16 +75,39 @@ impl OneShotCopier {
     /// Create a new one-shot copier.
     pub fn new(fut: impl Future<Output = Result<Metadata>> + MaybeSend + 'static) -> Self {
         Self {
+            factory: None,
             fut: Some(Box::pin(fut)),
             meta: None,
+            consumed: false,
+        }
+    }
+
+    /// Create a new one-shot copier with a future factory.
+    ///
+    /// The factory will be called again if the previous future fails, allowing
+    /// upper layers like retry to rerun the one-shot copy body.
+    pub fn new_with<F, Fut>(mut factory: F) -> Self
+    where
+        F: FnMut() -> Fut + 'static,
+        Fut: Future<Output = Result<Metadata>> + MaybeSend + 'static,
+    {
+        Self {
+            factory: Some(Box::new(move || {
+                Box::pin(factory()) as BoxedStaticFuture<Result<Metadata>>
+            })),
+            fut: None,
+            meta: None,
+            consumed: false,
         }
     }
 
     /// Create a one-shot copier that has already completed.
     pub fn completed() -> Self {
         Self {
+            factory: None,
             fut: None,
             meta: Some(Metadata::default()),
+            consumed: true,
         }
     }
 }
@@ -97,16 +122,55 @@ impl Copy for OneShotCopier {
     }
 
     async fn close(&mut self) -> Result<Metadata> {
-        if let Some(fut) = self.fut.take() {
-            self.meta = Some(fut.await?);
+        if let Some(meta) = self.meta.clone() {
+            return Ok(meta);
         }
 
-        Ok(self.meta.clone().unwrap_or_default())
+        if self.consumed {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "one-shot copier has already been consumed",
+            )
+            .set_persistent());
+        }
+
+        if self.fut.is_none() {
+            if let Some(factory) = self.factory.as_mut() {
+                self.fut = Some(factory());
+            }
+        }
+
+        if let Some(fut) = self.fut.take() {
+            match fut.await {
+                Ok(meta) => {
+                    self.consumed = true;
+                    self.meta = Some(meta.clone());
+                    return Ok(meta);
+                }
+                Err(err) => {
+                    if self.factory.is_none() {
+                        self.consumed = true;
+                        return Err(err.set_persistent());
+                    }
+
+                    return Err(err);
+                }
+            }
+        }
+
+        self.consumed = true;
+        Err(Error::new(
+            ErrorKind::Unexpected,
+            "one-shot copier has no future to drive",
+        )
+        .set_persistent())
     }
 
     async fn abort(&mut self) -> Result<()> {
+        self.factory = None;
         self.fut = None;
         self.meta = None;
+        self.consumed = true;
         Ok(())
     }
 }
@@ -148,5 +212,53 @@ impl<T: CopyDyn + ?Sized> Copy for Box<T> {
 
     async fn abort(&mut self) -> Result<()> {
         self.deref_mut().abort_dyn().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn one_shot_copier_rebuilds_future_after_error() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let retry_attempts = attempts.clone();
+
+        let mut copier = OneShotCopier::new_with(move || {
+            let attempts = retry_attempts.clone();
+
+            async move {
+                if attempts.fetch_add(1, Ordering::Relaxed) == 0 {
+                    return Err(
+                        Error::new(ErrorKind::Unexpected, "temporary copy failure").set_temporary()
+                    );
+                }
+
+                Ok(Metadata::new(EntryMode::FILE))
+            }
+        });
+
+        assert!(copier.close().await.unwrap_err().is_temporary());
+        assert_eq!(copier.close().await.unwrap().mode(), EntryMode::FILE);
+        assert_eq!(attempts.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn one_shot_copier_does_not_succeed_after_consumed_error() {
+        let mut copier = OneShotCopier::new(async {
+            Err(Error::new(ErrorKind::Unexpected, "copy failure").set_temporary())
+        });
+
+        let err = copier.close().await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Unexpected);
+        assert!(err.is_persistent());
+
+        let err = copier.close().await.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::Unexpected);
+        assert!(err.is_persistent());
     }
 }

--- a/core/core/src/raw/oio/list/flat_list.rs
+++ b/core/core/src/raw/oio/list/flat_list.rs
@@ -89,11 +89,10 @@ impl<S: Service> oio::List for FlatLister<S> {
     async fn next(&mut self) -> Result<Option<oio::Entry>> {
         loop {
             if let Some(de) = self.next_dir.take() {
-                let (_, mut l) = match self
+                let mut l = match self
                     .service
                     .as_ref()
                     .list(&self.ctx, de.path(), OpList::new())
-                    .await
                 {
                     Ok(v) => v,
                     Err(e) if e.kind() == ErrorKind::PermissionDenied => {

--- a/core/core/src/services/memory/backend.rs
+++ b/core/core/src/services/memory/backend.rs
@@ -141,60 +141,43 @@ impl Service for MemoryBackend {
         }
     }
 
-    async fn read(
-        &self,
-        _: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        Ok((
-            RpRead::default(),
-            oio::StreamReader::new(MemoryReader::new(self.clone(), path, args)),
-        ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        Ok(oio::StreamReader::new(MemoryReader::new(
+            self.clone(),
+            path,
+            args,
+        )))
     }
 
-    async fn write(
-        &self,
-        _: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, _ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let p = build_abs_path(&self.root, path);
-        Ok((
-            RpWrite::new(),
-            MemoryWriter::new(self.core.clone(), p, args),
-        ))
+        Ok(MemoryWriter::new(self.core.clone(), p, args))
     }
 
-    async fn delete(&self, _: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        Ok((
-            RpDelete::default(),
-            oio::OneShotDeleter::new(MemoryDeleter::new(self.core.clone(), self.root.clone())),
-        ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        Ok(oio::OneShotDeleter::new(MemoryDeleter::new(
+            self.core.clone(),
+            self.root.clone(),
+        )))
     }
 
-    async fn list(
-        &self,
-        _: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         let p = build_abs_path(&self.root, path);
         let keys = self.core.scan(&p)?;
         let lister = MemoryLister::new(&self.root, keys);
         let lister = oio::HierarchyLister::new(lister, path, args.recursive());
 
-        Ok((RpList::default(), lister))
+        Ok(lister)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _: &OperationContext,
         _: &str,
         _: &str,
         _: OpCopy,
         _: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/core/src/types/context/read.rs
+++ b/core/core/src/types/context/read.rs
@@ -251,23 +251,23 @@ mod tests {
 
     use super::*;
 
-    async fn new_read_context(
+    fn new_read_context(
         ctx: OperationContext,
         srv: Servicer,
         path: &str,
         options: crate::raw::OpReader,
     ) -> crate::Result<ReadContext> {
-        new_read_context_with_args(ctx, srv, path, crate::raw::OpRead::new(), options).await
+        new_read_context_with_args(ctx, srv, path, crate::raw::OpRead::new(), options)
     }
 
-    async fn new_read_context_with_args(
+    fn new_read_context_with_args(
         ctx: OperationContext,
         srv: Servicer,
         path: &str,
         args: crate::raw::OpRead,
         options: crate::raw::OpReader,
     ) -> crate::Result<ReadContext> {
-        let (_, reader) = srv.read(&ctx, path, args.clone()).await?;
+        let reader = srv.read(&ctx, path, args.clone())?;
         Ok(ReadContext::new(
             ctx,
             srv,
@@ -289,8 +289,12 @@ mod tests {
 
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx =
-            Arc::new(new_read_context(ctx, srv, "test", OpReader::new().with_chunk(3)).await?);
+        let ctx = Arc::new(new_read_context(
+            ctx,
+            srv,
+            "test",
+            OpReader::new().with_chunk(3),
+        )?);
         let mut generator = ReadGenerator::new(ctx, BytesRange::new(0, Some(10)));
         let mut readers = vec![];
         while let Some(r) = generator.next_reader().await? {
@@ -312,8 +316,12 @@ mod tests {
 
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx =
-            Arc::new(new_read_context(ctx, srv, "test", OpReader::new().with_chunk(3)).await?);
+        let ctx = Arc::new(new_read_context(
+            ctx,
+            srv,
+            "test",
+            OpReader::new().with_chunk(3),
+        )?);
         let mut generator = ReadGenerator::new(ctx, BytesRange::new(0, None));
         let mut readers = vec![];
         while let Some(r) = generator.next_reader().await? {
@@ -331,7 +339,7 @@ mod tests {
 
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = new_read_context(ctx, srv, "test", OpReader::new()).await?;
+        let ctx = new_read_context(ctx, srv, "test", OpReader::new())?;
 
         let result = ctx
             .parse_into_range(BytesRange::new(u64::MAX, Some(1)))
@@ -355,7 +363,7 @@ mod tests {
 
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = new_read_context_with_args(ctx, srv, "test", args, options).await?;
+        let ctx = new_read_context_with_args(ctx, srv, "test", args, options)?;
 
         let range = ctx.parse_into_range(10..).await?;
 
@@ -374,7 +382,7 @@ mod tests {
 
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = new_read_context_with_args(ctx, srv, "test", args, options).await?;
+        let ctx = new_read_context_with_args(ctx, srv, "test", args, options)?;
 
         let range = ctx.parse_into_range(BytesRange::suffix(10)).await?;
 

--- a/core/core/src/types/context/write.rs
+++ b/core/core/src/types/context/write.rs
@@ -111,12 +111,9 @@ pub struct WriteGenerator<W> {
 
 impl WriteGenerator<oio::Writer> {
     /// Create a new exact buf writer.
-    pub async fn create(ctx: Arc<WriteContext>) -> Result<Self> {
+    pub fn create(ctx: Arc<WriteContext>) -> Result<Self> {
         let (chunk_size, exact) = ctx.calculate_chunk_size();
-        let (_, w) = ctx
-            .srv
-            .write(&ctx.ctx, ctx.path(), ctx.args().clone())
-            .await?;
+        let w = ctx.srv.write(&ctx.ctx, ctx.path(), ctx.args().clone())?;
 
         Ok(Self {
             w,

--- a/core/core/src/types/copy.rs
+++ b/core/core/src/types/copy.rs
@@ -55,7 +55,7 @@ unsafe impl Sync for Copier {}
 
 impl Copier {
     /// Create a new copier.
-    pub(crate) async fn create(
+    pub(crate) fn create(
         ctx: OperationContext,
         srv: Servicer,
         from: &str,
@@ -63,7 +63,7 @@ impl Copier {
         args: OpCopy,
         opts: OpCopier,
     ) -> Result<Self> {
-        let (_, copier) = srv.copy(&ctx, from, to, args, opts).await?;
+        let copier = srv.copy(&ctx, from, to, args, opts)?;
 
         Ok(Self {
             copier: Some(copier),

--- a/core/core/src/types/delete/deleter.rs
+++ b/core/core/src/types/delete/deleter.rs
@@ -86,8 +86,8 @@ pub struct Deleter {
 }
 
 impl Deleter {
-    pub(crate) async fn create(ctx: OperationContext, srv: Servicer) -> Result<Self> {
-        let (_, deleter) = srv.delete(&ctx).await?;
+    pub(crate) fn create(ctx: OperationContext, srv: Servicer) -> Result<Self> {
+        let deleter = srv.delete(&ctx)?;
 
         Ok(Self { deleter })
     }

--- a/core/core/src/types/list.rs
+++ b/core/core/src/types/list.rs
@@ -44,13 +44,13 @@ unsafe impl Sync for Lister {}
 
 impl Lister {
     /// Create a new lister.
-    pub(crate) async fn create(
+    pub(crate) fn create(
         ctx: OperationContext,
         srv: Servicer,
         path: &str,
         args: OpList,
     ) -> Result<Self> {
-        let (_, lister) = srv.list(&ctx, path, args).await?;
+        let lister = srv.list(&ctx, path, args)?;
 
         Ok(Self {
             lister: Some(lister),

--- a/core/core/src/types/operator/operator.rs
+++ b/core/core/src/types/operator/operator.rs
@@ -638,7 +638,7 @@ impl Operator {
         }
 
         let (range, args, opts) = opts.into();
-        let (_, reader) = srv.read(&ctx, &path, args.clone()).await?;
+        let reader = srv.read(&ctx, &path, args.clone())?;
         let read_context = ReadContext::new(ctx, srv, path, args, opts, reader);
         let r = Reader::new(read_context);
         let buf = r.read(range).await?;
@@ -749,7 +749,7 @@ impl Operator {
         }
 
         let (args, opts) = options.into();
-        let (_, reader) = srv.read(&ctx, &path, args.clone()).await?;
+        let reader = srv.read(&ctx, &path, args.clone())?;
         let read_context = ReadContext::new(ctx, srv, path, args, opts, reader);
         Ok(Reader::new(read_context))
     }
@@ -1335,7 +1335,7 @@ impl Operator {
         }
 
         let (args, opts) = opts.into();
-        Copier::create(ctx, srv, &from, &to, args, opts).await
+        std::future::ready(Copier::create(ctx, srv, &from, &to, args, opts)).await
     }
 
     /// Rename a file from `from` to `to`.
@@ -1488,7 +1488,7 @@ impl Operator {
         path: String,
         opts: options::DeleteOptions,
     ) -> Result<()> {
-        let (_, mut deleter) = srv.delete(&ctx).await?;
+        let mut deleter = srv.delete(&ctx)?;
         let args = opts.into();
         deleter.delete_dyn(&path, args).await?;
         deleter.close_dyn().await?;
@@ -1573,7 +1573,11 @@ impl Operator {
     ///
     /// Users can have more control over the deletion process by using [`Deleter`] directly.
     pub async fn deleter(&self) -> Result<Deleter> {
-        Deleter::create(self.context().clone(), self.service().clone()).await
+        std::future::ready(Deleter::create(
+            self.context().clone(),
+            self.service().clone(),
+        ))
+        .await
     }
 
     /// Remove the path and all nested dirs and files recursively.
@@ -1772,7 +1776,7 @@ impl Operator {
         opts: options::ListOptions,
     ) -> Result<Vec<Entry>> {
         let args = opts.into();
-        let lister = Lister::create(ctx, srv, &path, args).await?;
+        let lister = Lister::create(ctx, srv, &path, args)?;
         lister.try_collect().await
     }
 
@@ -1911,8 +1915,7 @@ impl Operator {
         opts: options::ListOptions,
     ) -> Result<Lister> {
         let args = opts.into();
-        let lister = Lister::create(ctx, srv, &path, args).await?;
-        Ok(lister)
+        std::future::ready(Lister::create(ctx, srv, &path, args)).await
     }
 }
 

--- a/core/core/src/types/read/buffer_stream.rs
+++ b/core/core/src/types/read/buffer_stream.rs
@@ -378,14 +378,14 @@ mod tests {
 
     use super::*;
 
-    async fn new_read_context(
+    fn new_read_context(
         ctx: OperationContext,
         srv: Servicer,
         path: &str,
         options: crate::raw::OpReader,
     ) -> crate::Result<ReadContext> {
         let args = crate::raw::OpRead::new();
-        let (_, reader) = srv.read(&ctx, path, args.clone()).await?;
+        let reader = srv.read(&ctx, path, args.clone())?;
         Ok(ReadContext::new(
             ctx,
             srv,
@@ -401,7 +401,7 @@ mod tests {
         let op = Operator::via_iter(services::MEMORY_SCHEME, [])?;
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new()).await?);
+        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new())?);
         let v = BufferStream::create(ctx, 4..8).await?;
 
         let _: Box<dyn Unpin + MaybeSend + 'static> = Box::new(v);
@@ -420,7 +420,7 @@ mod tests {
 
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new()).await?);
+        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new())?);
 
         let s = BufferStream::create(ctx, 4..8).await?;
         let bufs: Vec<_> = s.try_collect().await.unwrap();

--- a/core/core/src/types/read/futures_async_reader.rs
+++ b/core/core/src/types/read/futures_async_reader.rs
@@ -190,14 +190,14 @@ mod tests {
 
     use super::*;
 
-    async fn new_read_context(
+    fn new_read_context(
         ctx: OperationContext,
         srv: Servicer,
         path: &str,
         options: crate::raw::OpReader,
     ) -> crate::Result<ReadContext> {
         let args = crate::raw::OpRead::new();
-        let (_, reader) = srv.read(&ctx, path, args.clone()).await?;
+        let reader = srv.read(&ctx, path, args.clone())?;
         Ok(ReadContext::new(
             ctx,
             srv,
@@ -213,7 +213,7 @@ mod tests {
         let op = Operator::via_iter(services::MEMORY_SCHEME, [])?;
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new()).await?);
+        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new())?);
 
         let v = FuturesAsyncReader::new(ctx, 4..8);
 
@@ -232,7 +232,7 @@ mod tests {
 
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new()).await?);
+        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new())?);
 
         let mut fr = FuturesAsyncReader::new(ctx, 4..8);
         let mut bs = vec![];
@@ -259,15 +259,12 @@ mod tests {
 
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = Arc::new(
-            new_read_context(
-                ctx,
-                srv,
-                "test",
-                OpReader::new().with_concurrent(3).with_chunk(1),
-            )
-            .await?,
-        );
+        let ctx = Arc::new(new_read_context(
+            ctx,
+            srv,
+            "test",
+            OpReader::new().with_concurrent(3).with_chunk(1),
+        )?);
 
         let mut fr = FuturesAsyncReader::new(ctx, 4..8);
         let mut bs = vec![];
@@ -294,15 +291,12 @@ mod tests {
 
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = Arc::new(
-            new_read_context(
-                ctx,
-                srv,
-                "test",
-                OpReader::new().with_concurrent(3).with_chunk(1),
-            )
-            .await?,
-        );
+        let ctx = Arc::new(new_read_context(
+            ctx,
+            srv,
+            "test",
+            OpReader::new().with_concurrent(3).with_chunk(1),
+        )?);
 
         let mut fr = FuturesAsyncReader::new(ctx, 4..8);
         let chunk = fr.fill_buf().await.unwrap();
@@ -326,7 +320,7 @@ mod tests {
 
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new()).await?);
+        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new())?);
 
         // Range 4..8, in total 4 bytes of logical data.
         let mut fr = FuturesAsyncReader::new(ctx, 4..8);

--- a/core/core/src/types/read/futures_bytes_stream.rs
+++ b/core/core/src/types/read/futures_bytes_stream.rs
@@ -95,14 +95,14 @@ mod tests {
 
     use super::*;
 
-    async fn new_read_context(
+    fn new_read_context(
         ctx: OperationContext,
         srv: Servicer,
         path: &str,
         options: crate::raw::OpReader,
     ) -> crate::Result<ReadContext> {
         let args = crate::raw::OpRead::new();
-        let (_, reader) = srv.read(&ctx, path, args.clone()).await?;
+        let reader = srv.read(&ctx, path, args.clone())?;
         Ok(ReadContext::new(
             ctx,
             srv,
@@ -118,7 +118,7 @@ mod tests {
         let op = Operator::via_iter(services::MEMORY_SCHEME, [])?;
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new()).await?);
+        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new())?);
         let v = FuturesBytesStream::new(ctx, 4..8).await?;
 
         let _: Box<dyn Unpin + MaybeSend + Sync + 'static> = Box::new(v);
@@ -137,7 +137,7 @@ mod tests {
 
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new()).await?);
+        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new())?);
 
         let s = FuturesBytesStream::new(ctx, 4..8).await?;
         let bufs: Vec<Bytes> = s.try_collect().await.unwrap();
@@ -158,15 +158,12 @@ mod tests {
 
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = Arc::new(
-            new_read_context(
-                ctx,
-                srv,
-                "test",
-                OpReader::new().with_concurrent(3).with_chunk(1),
-            )
-            .await?,
-        );
+        let ctx = Arc::new(new_read_context(
+            ctx,
+            srv,
+            "test",
+            OpReader::new().with_concurrent(3).with_chunk(1),
+        )?);
 
         let s = FuturesBytesStream::new(ctx, 4..8).await?;
         let bufs: Vec<Bytes> = s.try_collect().await.unwrap();

--- a/core/core/src/types/read/reader.rs
+++ b/core/core/src/types/read/reader.rs
@@ -552,14 +552,14 @@ mod tests {
     use crate::services;
     use crate::*;
 
-    async fn new_read_context(
+    fn new_read_context(
         ctx: OperationContext,
         srv: Servicer,
         path: &str,
         options: crate::raw::OpReader,
     ) -> crate::Result<ReadContext> {
         let args = crate::raw::OpRead::new();
-        let (_, reader) = srv.read(&ctx, path, args.clone()).await?;
+        let reader = srv.read(&ctx, path, args.clone())?;
         Ok(ReadContext::new(
             ctx,
             srv,
@@ -612,7 +612,9 @@ mod tests {
             }
 
             Ok((
-                RpRead::default(),
+                RpRead::new(
+                    Metadata::new(EntryMode::FILE).with_content_length(self.content.len() as u64),
+                ),
                 Buffer::from(self.content.slice(start..end)),
             ))
         }
@@ -645,7 +647,7 @@ mod tests {
 
         let ctx = op.context().clone();
         let srv = op.service().clone();
-        let ctx = new_read_context(ctx, srv, "test", OpReader::new()).await?;
+        let ctx = new_read_context(ctx, srv, "test", OpReader::new())?;
 
         let _: Box<dyn Unpin + MaybeSend + Sync + 'static> = Box::new(Reader::new(ctx));
 

--- a/core/core/src/types/write/buffer_sink.rs
+++ b/core/core/src/types/write/buffer_sink.rs
@@ -181,7 +181,7 @@ mod tests {
             OpWrite::new(),
             OpWriter::new().with_chunk(1),
         ));
-        let write_gen = WriteGenerator::create(ctx).await.unwrap();
+        let write_gen = WriteGenerator::create(ctx).unwrap();
 
         let v = BufferSink::new(write_gen);
 

--- a/core/core/src/types/write/futures_async_writer.rs
+++ b/core/core/src/types/write/futures_async_writer.rs
@@ -129,7 +129,7 @@ mod tests {
             OpWrite::new(),
             OpWriter::new().with_chunk(1),
         ));
-        let write_gen = WriteGenerator::create(ctx).await.unwrap();
+        let write_gen = WriteGenerator::create(ctx).unwrap();
 
         let v = FuturesAsyncWriter::new(write_gen);
 

--- a/core/core/src/types/write/futures_bytes_sink.rs
+++ b/core/core/src/types/write/futures_bytes_sink.rs
@@ -96,7 +96,7 @@ mod tests {
             OpWrite::new(),
             OpWriter::new().with_chunk(1),
         ));
-        let write_gen = WriteGenerator::create(ctx).await.unwrap();
+        let write_gen = WriteGenerator::create(ctx).unwrap();
 
         let v = FuturesBytesSink::new(write_gen);
 

--- a/core/core/src/types/write/writer.rs
+++ b/core/core/src/types/write/writer.rs
@@ -107,7 +107,7 @@ impl Writer {
     /// Create a new writer from an `oio::Writer`.
     pub(crate) async fn new(ctx: WriteContext) -> Result<Self> {
         let ctx = Arc::new(ctx);
-        let inner = WriteGenerator::create(ctx.clone()).await?;
+        let inner = std::future::ready(WriteGenerator::create(ctx.clone())).await?;
 
         Ok(Self { _ctx: ctx, inner })
     }

--- a/core/layers/async-backtrace/src/lib.rs
+++ b/core/layers/async-backtrace/src/lib.rs
@@ -100,42 +100,27 @@ impl Service for AsyncBacktraceAccessor {
         self.inner.create_dir(ctx, path, args).await
     }
 
-    #[async_backtrace::framed]
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
         self.inner
             .read(ctx, path, args)
-            .await
-            .map(|(rp, r)| (rp, AsyncBacktraceWrapper::new(r)))
+            .map(AsyncBacktraceWrapper::new)
     }
 
-    #[async_backtrace::framed]
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         self.inner
             .write(ctx, path, args)
-            .await
-            .map(|(rp, r)| (rp, AsyncBacktraceWrapper::new(r)))
+            .map(AsyncBacktraceWrapper::new)
     }
 
-    #[async_backtrace::framed]
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        self.inner.copy(ctx, from, to, args, opts).await
+    ) -> Result<Self::Copier> {
+        self.inner.copy(ctx, from, to, args, opts)
     }
 
     #[async_backtrace::framed]
@@ -154,25 +139,14 @@ impl Service for AsyncBacktraceAccessor {
         self.inner.stat(ctx, path, args).await
     }
 
-    #[async_backtrace::framed]
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.inner
-            .delete(ctx)
-            .await
-            .map(|(rp, r)| (rp, AsyncBacktraceWrapper::new(r)))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner.delete(ctx).map(AsyncBacktraceWrapper::new)
     }
 
-    #[async_backtrace::framed]
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         self.inner
             .list(ctx, path, args)
-            .await
-            .map(|(rp, r)| (rp, AsyncBacktraceWrapper::new(r)))
+            .map(AsyncBacktraceWrapper::new)
     }
 
     #[async_backtrace::framed]

--- a/core/layers/await-tree/src/lib.rs
+++ b/core/layers/await-tree/src/lib.rs
@@ -104,45 +104,25 @@ impl Service for AwaitTreeAccessor {
             .await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        self.inner
-            .read(ctx, path, args)
-            .instrument_await(format!("opendal::{}", Operation::Read))
-            .await
-            .map(|(rp, r)| (rp, AwaitTreeWrapper::new(r)))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        self.inner.read(ctx, path, args).map(AwaitTreeWrapper::new)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        self.inner
-            .write(ctx, path, args)
-            .instrument_await(format!("opendal::{}", Operation::Write))
-            .await
-            .map(|(rp, r)| (rp, AwaitTreeWrapper::new(r)))
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        self.inner.write(ctx, path, args).map(AwaitTreeWrapper::new)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         self.inner
             .copy(ctx, from, to, args, opts)
-            .instrument_await(format!("opendal::{}", Operation::Copy))
-            .await
-            .map(|(rp, r)| (rp, AwaitTreeWrapper::new(r)))
+            .map(AwaitTreeWrapper::new)
     }
 
     async fn rename(
@@ -165,25 +145,12 @@ impl Service for AwaitTreeAccessor {
             .await
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.inner
-            .delete(ctx)
-            .instrument_await(format!("opendal::{}", Operation::Delete))
-            .await
-            .map(|(rp, r)| (rp, AwaitTreeWrapper::new(r)))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner.delete(ctx).map(AwaitTreeWrapper::new)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        self.inner
-            .list(ctx, path, args)
-            .instrument_await(format!("opendal::{}", Operation::List))
-            .await
-            .map(|(rp, r)| (rp, AwaitTreeWrapper::new(r)))
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        self.inner.list(ctx, path, args).map(AwaitTreeWrapper::new)
     }
 
     async fn presign(

--- a/core/layers/capability-check/src/lib.rs
+++ b/core/layers/capability-check/src/lib.rs
@@ -123,21 +123,11 @@ impl Service for CapabilityCheckService {
         self.inner.stat(ctx, path, args).await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        self.inner.read(ctx, path, args).await
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        self.inner.read(ctx, path, args)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let capability = self.capability();
         let info = self.info();
         if !capability.write_with_content_type && args.content_type().is_some() {
@@ -162,17 +152,17 @@ impl Service for CapabilityCheckService {
             ));
         }
 
-        self.inner.write(ctx, path, args).await
+        self.inner.write(ctx, path, args)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         let capability = self.capability();
         let info = self.info();
         if args.if_not_exists() && !capability.copy_with_if_not_exists {
@@ -193,26 +183,21 @@ impl Service for CapabilityCheckService {
             ));
         }
 
-        self.inner.copy(ctx, from, to, args, opts).await
+        self.inner.copy(ctx, from, to, args, opts)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.inner.delete(ctx).await
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner.delete(ctx)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         let capability = self.capability();
         if !capability.list_with_versions && args.versions() {
             let info = self.info();
             return Err(new_unsupported_error(&info, Operation::List, "version"));
         }
 
-        self.inner.list(ctx, path, args).await
+        self.inner.list(ctx, path, args)
     }
 
     async fn rename(
@@ -278,51 +263,36 @@ mod tests {
             ))
         }
 
-        async fn read(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpRead,
-        ) -> Result<(RpRead, Self::Reader)> {
+        fn read(&self, _ctx: &OperationContext, _: &str, _: OpRead) -> Result<Self::Reader> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn write(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpWrite,
-        ) -> Result<(RpWrite, Self::Writer)> {
-            Ok((RpWrite::new(), ()))
+        fn write(&self, _ctx: &OperationContext, _: &str, _: OpWrite) -> Result<Self::Writer> {
+            Ok(())
         }
 
-        async fn list(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpList,
-        ) -> Result<(RpList, Self::Lister)> {
-            Ok((RpList {}, ()))
+        fn list(&self, _ctx: &OperationContext, _: &str, _: OpList) -> Result<Self::Lister> {
+            Ok(())
         }
 
-        async fn delete(&self, _: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+        fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn copy(
+        fn copy(
             &self,
             _: &OperationContext,
             _: &str,
             _: &str,
             _: OpCopy,
             _: OpCopier,
-        ) -> Result<(RpCopy, Self::Copier)> {
+        ) -> Result<Self::Copier> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",

--- a/core/layers/chaos/src/lib.rs
+++ b/core/layers/chaos/src/lib.rs
@@ -135,51 +135,33 @@ impl Service for ChaosService {
         self.inner.stat(ctx, path, args).await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        self.inner.read(ctx, path, args).await.map(|(rp, r)| {
-            (
-                rp,
-                ChaosReader::new(r, Arc::clone(&self.rng), self.error_ratio),
-            )
-        })
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        self.inner
+            .read(ctx, path, args)
+            .map(|r| ChaosReader::new(r, Arc::clone(&self.rng), self.error_ratio))
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        self.inner.write(ctx, path, args).await
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        self.inner.write(ctx, path, args)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        self.inner.copy(ctx, from, to, args, opts).await
+    ) -> Result<Self::Copier> {
+        self.inner.copy(ctx, from, to, args, opts)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        self.inner.list(ctx, path, args).await
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        self.inner.list(ctx, path, args)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.inner.delete(ctx).await
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner.delete(ctx)
     }
 
     async fn rename(

--- a/core/layers/concurrent-limit/src/lib.rs
+++ b/core/layers/concurrent-limit/src/lib.rs
@@ -504,6 +504,7 @@ mod tests {
     use super::*;
     use opendal_core::Operator;
     use opendal_core::services;
+    use std::future::pending;
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::time::timeout;
@@ -679,6 +680,23 @@ mod tests {
 
     #[tokio::test]
     async fn operation_semaphore_held_until_copier_dropped() {
+        #[derive(Debug)]
+        struct PendingCopier;
+
+        impl oio::Copy for PendingCopier {
+            async fn next(&mut self) -> Result<Option<usize>> {
+                pending().await
+            }
+
+            async fn close(&mut self) -> Result<Metadata> {
+                pending().await
+            }
+
+            async fn abort(&mut self) -> Result<()> {
+                Ok(())
+            }
+        }
+
         #[derive(Clone, Debug)]
         struct CopierBackend {
             info: ServiceInfo,
@@ -690,7 +708,7 @@ mod tests {
             type Writer = ();
             type Lister = ();
             type Deleter = ();
-            type Copier = ();
+            type Copier = PendingCopier;
 
             fn info(&self) -> ServiceInfo {
                 self.info.clone()
@@ -748,7 +766,7 @@ mod tests {
                 _: OpCopy,
                 _: OpCopier,
             ) -> Result<Self::Copier> {
-                Ok(())
+                Ok(PendingCopier)
             }
 
             async fn stat(&self, _: &OperationContext, _: &str, _: OpStat) -> Result<RpStat> {
@@ -794,12 +812,15 @@ mod tests {
         }))
         .layer(layer);
 
-        let copier = timeout(Duration::from_millis(50), op.copier("from", "to"))
+        let mut copier = timeout(Duration::from_millis(50), op.copier("from", "to"))
             .await
             .expect("copier setup should not block")
             .expect("copier should be created");
 
-        // The permit is held by the live copier, so concurrent operations
+        let copy = timeout(Duration::from_millis(50), copier.next()).await;
+        assert!(copy.is_err(), "copy body should remain pending");
+
+        // The permit is held by the active copy body, so concurrent operations
         // must time out until the copier is dropped.
         let blocked = timeout(Duration::from_millis(50), op.stat("any")).await;
         assert!(

--- a/core/layers/concurrent-limit/src/lib.rs
+++ b/core/layers/concurrent-limit/src/lib.rs
@@ -256,10 +256,10 @@ where
     S::Permit: Send + Sync + 'static + Unpin,
 {
     type Reader = ConcurrentLimitReader<oio::Reader, S>;
-    type Writer = ConcurrentLimitWrapper<oio::Writer, S::Permit>;
-    type Lister = ConcurrentLimitWrapper<oio::Lister, S::Permit>;
-    type Deleter = ConcurrentLimitWrapper<oio::Deleter, S::Permit>;
-    type Copier = ConcurrentLimitWrapper<oio::Copier, S::Permit>;
+    type Writer = ConcurrentLimitWrapper<oio::Writer, S>;
+    type Lister = ConcurrentLimitWrapper<oio::Lister, S>;
+    type Deleter = ConcurrentLimitWrapper<oio::Deleter, S>;
+    type Copier = ConcurrentLimitWrapper<oio::Copier, S>;
 
     fn info(&self) -> ServiceInfo {
         self.inner.info()
@@ -279,44 +279,29 @@ where
         self.inner.create_dir(ctx, path, args).await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
         self.inner
             .read(ctx, path, args)
-            .await
-            .map(|(rp, r)| (rp, ConcurrentLimitReader::new(r, self.semaphore.clone())))
+            .map(|r| ConcurrentLimitReader::new(r, self.semaphore.clone()))
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let permit = self.semaphore.acquire().await;
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         self.inner
             .write(ctx, path, args)
-            .await
-            .map(|(rp, w)| (rp, ConcurrentLimitWrapper::new(w, permit)))
+            .map(|w| ConcurrentLimitWrapper::new(w, self.semaphore.clone()))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let permit = self.semaphore.acquire().await;
+    ) -> Result<Self::Copier> {
         self.inner
             .copy(ctx, from, to, args, opts)
-            .await
-            .map(|(rp, c)| (rp, ConcurrentLimitWrapper::new(c, permit)))
+            .map(|c| ConcurrentLimitWrapper::new(c, self.semaphore.clone()))
     }
 
     async fn rename(
@@ -335,25 +320,16 @@ where
         self.inner.stat(ctx, path, args).await
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let permit = self.semaphore.acquire().await;
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
         self.inner
             .delete(ctx)
-            .await
-            .map(|(rp, w)| (rp, ConcurrentLimitWrapper::new(w, permit)))
+            .map(|w| ConcurrentLimitWrapper::new(w, self.semaphore.clone()))
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let permit = self.semaphore.acquire().await;
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         self.inner
             .list(ctx, path, args)
-            .await
-            .map(|(rp, s)| (rp, ConcurrentLimitWrapper::new(s, permit)))
+            .map(|s| ConcurrentLimitWrapper::new(s, self.semaphore.clone()))
     }
 
     async fn presign(
@@ -388,7 +364,11 @@ where
         let (rp, stream) = self.inner.open(range).await?;
         Ok((
             rp,
-            Box::new(ConcurrentLimitWrapper::new(stream, permit)) as Box<dyn oio::ReadStreamDyn>,
+            Box::new(ConcurrentLimitWrapper::new_with_permit(
+                stream,
+                self.semaphore.clone(),
+                permit,
+            )) as Box<dyn oio::ReadStreamDyn>,
         ))
     }
 
@@ -399,31 +379,52 @@ where
 }
 
 #[doc(hidden)]
-pub struct ConcurrentLimitWrapper<R, P> {
+pub struct ConcurrentLimitWrapper<R, S: ConcurrentLimitSemaphore> {
     inner: R,
-
+    semaphore: S,
     // Hold this permit until the wrapped operation body is dropped.
-    _permit: P,
+    permit: Option<S::Permit>,
 }
 
-impl<R, P> ConcurrentLimitWrapper<R, P> {
-    fn new(inner: R, permit: P) -> Self {
+impl<R, S: ConcurrentLimitSemaphore> ConcurrentLimitWrapper<R, S> {
+    fn new(inner: R, semaphore: S) -> Self {
         Self {
             inner,
-            _permit: permit,
+            semaphore,
+            permit: None,
+        }
+    }
+
+    fn new_with_permit(inner: R, semaphore: S, permit: S::Permit) -> Self {
+        Self {
+            inner,
+            semaphore,
+            permit: Some(permit),
+        }
+    }
+
+    async fn acquire(&mut self) {
+        if self.permit.is_none() {
+            self.permit = Some(self.semaphore.acquire().await);
         }
     }
 }
 
-impl<R: oio::ReadStream, P: Send + Sync + 'static + Unpin> oio::ReadStream
-    for ConcurrentLimitWrapper<R, P>
+impl<R: oio::ReadStream, S: ConcurrentLimitSemaphore> oio::ReadStream
+    for ConcurrentLimitWrapper<R, S>
+where
+    S::Permit: Send + Sync + 'static + Unpin,
 {
     async fn read(&mut self) -> Result<Buffer> {
+        self.acquire().await;
         self.inner.read().await
     }
 }
 
-impl<R: oio::Read, P: Send + Sync + 'static + Unpin> oio::Read for ConcurrentLimitWrapper<R, P> {
+impl<R: oio::Read, S: ConcurrentLimitSemaphore> oio::Read for ConcurrentLimitWrapper<R, S>
+where
+    S::Permit: Send + Sync + 'static + Unpin,
+{
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         self.inner.open(range).await
     }
@@ -433,48 +434,67 @@ impl<R: oio::Read, P: Send + Sync + 'static + Unpin> oio::Read for ConcurrentLim
     }
 }
 
-impl<R: oio::Write, P: Send + Sync + 'static + Unpin> oio::Write for ConcurrentLimitWrapper<R, P> {
+impl<R: oio::Write, S: ConcurrentLimitSemaphore> oio::Write for ConcurrentLimitWrapper<R, S>
+where
+    S::Permit: Send + Sync + 'static + Unpin,
+{
     async fn write(&mut self, bs: Buffer) -> Result<()> {
+        self.acquire().await;
         self.inner.write(bs).await
     }
 
     async fn close(&mut self) -> Result<Metadata> {
+        self.acquire().await;
         self.inner.close().await
     }
 
     async fn abort(&mut self) -> Result<()> {
+        self.acquire().await;
         self.inner.abort().await
     }
 }
 
-impl<R: oio::List, P: Send + Sync + 'static + Unpin> oio::List for ConcurrentLimitWrapper<R, P> {
+impl<R: oio::List, S: ConcurrentLimitSemaphore> oio::List for ConcurrentLimitWrapper<R, S>
+where
+    S::Permit: Send + Sync + 'static + Unpin,
+{
     async fn next(&mut self) -> Result<Option<oio::Entry>> {
+        self.acquire().await;
         self.inner.next().await
     }
 }
 
-impl<R: oio::Delete, P: Send + Sync + 'static + Unpin> oio::Delete
-    for ConcurrentLimitWrapper<R, P>
+impl<R: oio::Delete, S: ConcurrentLimitSemaphore> oio::Delete for ConcurrentLimitWrapper<R, S>
+where
+    S::Permit: Send + Sync + 'static + Unpin,
 {
     async fn delete(&mut self, path: &str, args: OpDelete) -> Result<()> {
+        self.acquire().await;
         self.inner.delete(path, args).await
     }
 
     async fn close(&mut self) -> Result<()> {
+        self.acquire().await;
         self.inner.close().await
     }
 }
 
-impl<C: oio::Copy, P: Send + Sync + 'static + Unpin> oio::Copy for ConcurrentLimitWrapper<C, P> {
+impl<C: oio::Copy, S: ConcurrentLimitSemaphore> oio::Copy for ConcurrentLimitWrapper<C, S>
+where
+    S::Permit: Send + Sync + 'static + Unpin,
+{
     async fn next(&mut self) -> Result<Option<usize>> {
+        self.acquire().await;
         self.inner.next().await
     }
 
     async fn close(&mut self) -> Result<Metadata> {
+        self.acquire().await;
         self.inner.close().await
     }
 
     async fn abort(&mut self) -> Result<()> {
+        self.acquire().await;
         self.inner.abort().await
     }
 }
@@ -559,58 +579,43 @@ mod tests {
                 ))
             }
 
-            async fn read(
-                &self,
-                _: &OperationContext,
-                _: &str,
-                _: OpRead,
-            ) -> Result<(RpRead, Self::Reader)> {
+            fn read(&self, _ctx: &OperationContext, _: &str, _: OpRead) -> Result<Self::Reader> {
                 Err(Error::new(
                     ErrorKind::Unsupported,
                     "operation is not supported",
                 ))
             }
 
-            async fn write(
-                &self,
-                _: &OperationContext,
-                _: &str,
-                _: OpWrite,
-            ) -> Result<(RpWrite, Self::Writer)> {
+            fn write(&self, _: &OperationContext, _: &str, _: OpWrite) -> Result<Self::Writer> {
                 Err(Error::new(
                     ErrorKind::Unsupported,
                     "operation is not supported",
                 ))
             }
 
-            async fn delete(&self, _: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+            fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
                 Err(Error::new(
                     ErrorKind::Unsupported,
                     "operation is not supported",
                 ))
             }
 
-            async fn list(
-                &self,
-                _: &OperationContext,
-                _: &str,
-                _: OpList,
-            ) -> Result<(RpList, Self::Lister)> {
+            fn list(&self, _ctx: &OperationContext, _: &str, _: OpList) -> Result<Self::Lister> {
                 Err(Error::new(
                     ErrorKind::Unsupported,
                     "operation is not supported",
                 ))
             }
 
-            async fn copy(
+            fn copy(
                 &self,
                 _: &OperationContext,
                 _: &str,
                 _: &str,
                 _: OpCopy,
                 _: OpCopier,
-            ) -> Result<(RpCopy, Self::Copier)> {
-                Ok((RpCopy::default(), ()))
+            ) -> Result<Self::Copier> {
+                Ok(())
             }
 
             async fn rename(
@@ -707,58 +712,43 @@ mod tests {
                 ))
             }
 
-            async fn read(
-                &self,
-                _: &OperationContext,
-                _: &str,
-                _: OpRead,
-            ) -> Result<(RpRead, Self::Reader)> {
+            fn read(&self, _ctx: &OperationContext, _: &str, _: OpRead) -> Result<Self::Reader> {
                 Err(Error::new(
                     ErrorKind::Unsupported,
                     "operation is not supported",
                 ))
             }
 
-            async fn write(
-                &self,
-                _: &OperationContext,
-                _: &str,
-                _: OpWrite,
-            ) -> Result<(RpWrite, Self::Writer)> {
+            fn write(&self, _: &OperationContext, _: &str, _: OpWrite) -> Result<Self::Writer> {
                 Err(Error::new(
                     ErrorKind::Unsupported,
                     "operation is not supported",
                 ))
             }
 
-            async fn delete(&self, _: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+            fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
                 Err(Error::new(
                     ErrorKind::Unsupported,
                     "operation is not supported",
                 ))
             }
 
-            async fn list(
-                &self,
-                _: &OperationContext,
-                _: &str,
-                _: OpList,
-            ) -> Result<(RpList, Self::Lister)> {
+            fn list(&self, _ctx: &OperationContext, _: &str, _: OpList) -> Result<Self::Lister> {
                 Err(Error::new(
                     ErrorKind::Unsupported,
                     "operation is not supported",
                 ))
             }
 
-            async fn copy(
+            fn copy(
                 &self,
                 _: &OperationContext,
                 _: &str,
                 _: &str,
                 _: OpCopy,
                 _: OpCopier,
-            ) -> Result<(RpCopy, Self::Copier)> {
-                Ok((RpCopy::default(), ()))
+            ) -> Result<Self::Copier> {
+                Ok(())
             }
 
             async fn stat(&self, _: &OperationContext, _: &str, _: OpStat) -> Result<RpStat> {
@@ -910,16 +900,18 @@ mod tests {
                 ))
             }
 
-            async fn read(
+            fn read(
                 &self,
                 ctx: &OperationContext,
                 path: &str,
                 args: OpRead,
-            ) -> Result<(RpRead, Self::Reader)> {
-                Ok((
-                    RpRead::default(),
-                    oio::StreamReader::new(HttpReader::new(self.clone(), ctx.clone(), path, args)),
-                ))
+            ) -> Result<Self::Reader> {
+                Ok(oio::StreamReader::new(HttpReader::new(
+                    self.clone(),
+                    ctx.clone(),
+                    path,
+                    args,
+                )))
             }
 
             async fn stat(&self, _: &OperationContext, _: &str, _: OpStat) -> Result<RpStat> {
@@ -928,45 +920,35 @@ mod tests {
                 ))
             }
 
-            async fn write(
-                &self,
-                _: &OperationContext,
-                _: &str,
-                _: OpWrite,
-            ) -> Result<(RpWrite, Self::Writer)> {
+            fn write(&self, _: &OperationContext, _: &str, _: OpWrite) -> Result<Self::Writer> {
                 Err(Error::new(
                     ErrorKind::Unsupported,
                     "operation is not supported",
                 ))
             }
 
-            async fn delete(&self, _: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+            fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
                 Err(Error::new(
                     ErrorKind::Unsupported,
                     "operation is not supported",
                 ))
             }
 
-            async fn list(
-                &self,
-                _: &OperationContext,
-                _: &str,
-                _: OpList,
-            ) -> Result<(RpList, Self::Lister)> {
+            fn list(&self, _ctx: &OperationContext, _: &str, _: OpList) -> Result<Self::Lister> {
                 Err(Error::new(
                     ErrorKind::Unsupported,
                     "operation is not supported",
                 ))
             }
 
-            async fn copy(
+            fn copy(
                 &self,
                 _: &OperationContext,
                 _: &str,
                 _: &str,
                 _: OpCopy,
                 _: OpCopier,
-            ) -> Result<(RpCopy, Self::Copier)> {
+            ) -> Result<Self::Copier> {
                 Err(Error::new(
                     ErrorKind::Unsupported,
                     "operation is not supported",

--- a/core/layers/dtrace/src/lib.rs
+++ b/core/layers/dtrace/src/lib.rs
@@ -181,52 +181,40 @@ impl Service for DTraceService {
         result
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
         let c_path = CString::new(path).unwrap();
         probe_lazy!(opendal, read_start, c_path.as_ptr());
         let result = self
             .inner
             .read(ctx, path, args)
-            .await
-            .map(|(rp, r)| (rp, DtraceLayerWrapper::new(r, path)));
+            .map(|r| DtraceLayerWrapper::new(r, path));
         probe_lazy!(opendal, read_end, c_path.as_ptr());
         result
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let c_path = CString::new(path).unwrap();
         probe_lazy!(opendal, write_start, c_path.as_ptr());
         let result = self
             .inner
             .write(ctx, path, args)
-            .await
-            .map(|(rp, r)| (rp, DtraceLayerWrapper::new(r, path)));
+            .map(|r| DtraceLayerWrapper::new(r, path));
 
         probe_lazy!(opendal, write_end, c_path.as_ptr());
         result
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         let c_from = CString::new(from).unwrap();
         probe_lazy!(opendal, copy_start, c_from.as_ptr());
-        let result = self.inner.copy(ctx, from, to, args, opts).await;
+        let result = self.inner.copy(ctx, from, to, args, opts);
         probe_lazy!(opendal, copy_end, c_from.as_ptr());
         result
     }
@@ -249,19 +237,14 @@ impl Service for DTraceService {
         result
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.inner.delete(ctx).await
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner.delete(ctx)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         let c_path = CString::new(path).unwrap();
         probe_lazy!(opendal, list_start, c_path.as_ptr());
-        let result = self.inner.list(ctx, path, args).await;
+        let result = self.inner.list(ctx, path, args);
         probe_lazy!(opendal, list_end, c_path.as_ptr());
         result
     }

--- a/core/layers/fastrace/src/lib.rs
+++ b/core/layers/fastrace/src/lib.rs
@@ -160,63 +160,41 @@ impl Service for FastraceAccessor {
         self.inner.create_dir(ctx, path, args).await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
         let _guard = Span::enter_with_local_parent(Operation::Read.into_static());
-        self.inner.read(ctx, path, args).await.map(|(rp, r)| {
-            (
-                rp,
-                FastraceWrapper::new(
-                    Span::enter_with_local_parent(Operation::Read.into_static()),
-                    r,
-                ),
+        self.inner.read(ctx, path, args).map(|r| {
+            FastraceWrapper::new(
+                Span::enter_with_local_parent(Operation::Read.into_static()),
+                r,
             )
         })
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let _guard = Span::enter_with_local_parent(Operation::Write.into_static());
-        self.inner.write(ctx, path, args).await.map(|(rp, r)| {
-            (
-                rp,
-                FastraceWrapper::new(
-                    Span::enter_with_local_parent(Operation::Write.into_static()),
-                    r,
-                ),
+        self.inner.write(ctx, path, args).map(|r| {
+            FastraceWrapper::new(
+                Span::enter_with_local_parent(Operation::Write.into_static()),
+                r,
             )
         })
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         let _guard = Span::enter_with_local_parent(Operation::Copy.into_static());
-        self.inner
-            .copy(ctx, from, to, args, opts)
-            .await
-            .map(|(rp, c)| {
-                (
-                    rp,
-                    FastraceWrapper::new(
-                        Span::enter_with_local_parent(Operation::Copy.into_static()),
-                        c,
-                    ),
-                )
-            })
+        self.inner.copy(ctx, from, to, args, opts).map(|c| {
+            FastraceWrapper::new(
+                Span::enter_with_local_parent(Operation::Copy.into_static()),
+                c,
+            )
+        })
     }
 
     async fn rename(
@@ -235,33 +213,22 @@ impl Service for FastraceAccessor {
         self.inner.stat(ctx, path, args).await
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
         let _guard = Span::enter_with_local_parent(Operation::Delete.into_static());
-        self.inner.delete(ctx).await.map(|(rp, r)| {
-            (
-                rp,
-                FastraceWrapper::new(
-                    Span::enter_with_local_parent(Operation::Delete.into_static()),
-                    r,
-                ),
+        self.inner.delete(ctx).map(|r| {
+            FastraceWrapper::new(
+                Span::enter_with_local_parent(Operation::Delete.into_static()),
+                r,
             )
         })
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         let _guard = Span::enter_with_local_parent(Operation::List.into_static());
-        self.inner.list(ctx, path, args).await.map(|(rp, s)| {
-            (
-                rp,
-                FastraceWrapper::new(
-                    Span::enter_with_local_parent(Operation::List.into_static()),
-                    s,
-                ),
+        self.inner.list(ctx, path, args).map(|s| {
+            FastraceWrapper::new(
+                Span::enter_with_local_parent(Operation::List.into_static()),
+                s,
             )
         })
     }

--- a/core/layers/foyer/src/full.rs
+++ b/core/layers/foyer/src/full.rs
@@ -85,25 +85,19 @@ impl FullReader {
         &self,
         range: BytesRange,
     ) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
-        let (rp, reader) = self
+        let reader = self
             .inner
             .srv
-            .read(&self.inner.ctx, &self.path, self.args.clone())
-            .await?;
-        let (rp_open, stream) = reader.open(range).await?;
-        let rp = rp_open.into_metadata().map(RpRead::new).unwrap_or(rp);
-        Ok((rp, stream))
+            .read(&self.inner.ctx, &self.path, self.args.clone())?;
+        reader.open(range).await
     }
 
     async fn fallback_read(&self, range: BytesRange) -> Result<(RpRead, Buffer)> {
-        let (rp, reader) = self
+        let reader = self
             .inner
             .srv
-            .read(&self.inner.ctx, &self.path, self.args.clone())
-            .await?;
-        let (rp_read, buffer) = reader.read(range).await?;
-        let rp = rp_read.into_metadata().map(RpRead::new).unwrap_or(rp);
-        Ok((rp, buffer))
+            .read(&self.inner.ctx, &self.path, self.args.clone())?;
+        reader.read(range).await
     }
 
     async fn read_full_object(&self) -> Result<Option<Buffer>> {
@@ -144,10 +138,9 @@ impl FullReader {
                     }
 
                     // fetch the ENTIRE object from remote.
-                    let (_, reader) = inner
+                    let reader = inner
                         .srv
                         .read(&inner.ctx, &path_clone, OpRead::default())
-                        .await
                         .map_err(FetchError::from_error)?;
                     let (_, mut stream) = reader
                         .open(BytesRange::new(0, None))

--- a/core/layers/foyer/src/lib.rs
+++ b/core/layers/foyer/src/lib.rs
@@ -212,60 +212,42 @@ impl Service for FoyerService {
         self.inner.capability()
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        Ok((
-            RpRead::default(),
-            full::FullReader::new(
-                self.operation_inner(ctx),
-                self.size_limit.clone(),
-                path.to_string(),
-                args,
-            ),
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        Ok(full::FullReader::new(
+            self.operation_inner(ctx),
+            self.size_limit.clone(),
+            path.to_string(),
+            args,
         ))
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let inner = self.operation_inner(ctx);
         let size_limit = self.size_limit.clone();
         let path = path.to_string();
-        let (rp, w) = inner.srv.write(&inner.ctx, &path, args).await?;
-        Ok((rp, Writer::new(w, path, inner, size_limit)))
+        let w = inner.srv.write(&inner.ctx, &path, args)?;
+        Ok(Writer::new(w, path, inner, size_limit))
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
         let inner = self.operation_inner(ctx);
-        let (rp, d) = inner.srv.delete(&inner.ctx).await?;
-        Ok((rp, Deleter::new(d, inner)))
+        let d = inner.srv.delete(&inner.ctx)?;
+        Ok(Deleter::new(d, inner))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        self.inner.copy(ctx, from, to, args, opts).await
+    ) -> Result<Self::Copier> {
+        self.inner.copy(ctx, from, to, args, opts)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        self.inner.list(ctx, path, args).await
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        self.inner.list(ctx, path, args)
     }
 
     async fn create_dir(
@@ -449,59 +431,41 @@ mod tests {
             Ok(RpStat::new(self.state.metadata()))
         }
 
-        async fn read(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpRead,
-        ) -> Result<(RpRead, Self::Reader)> {
-            Ok((
-                self.state.rp_read(),
-                MockReadReader {
-                    state: self.state.clone(),
-                },
-            ))
+        fn read(&self, _ctx: &OperationContext, _: &str, _: OpRead) -> Result<Self::Reader> {
+            Ok(MockReadReader {
+                state: self.state.clone(),
+            })
         }
 
-        async fn write(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpWrite,
-        ) -> Result<(RpWrite, Self::Writer)> {
+        fn write(&self, _ctx: &OperationContext, _: &str, _: OpWrite) -> Result<Self::Writer> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn delete(&self, _: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+        fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn list(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpList,
-        ) -> Result<(RpList, Self::Lister)> {
+        fn list(&self, _ctx: &OperationContext, _: &str, _: OpList) -> Result<Self::Lister> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn copy(
+        fn copy(
             &self,
             _: &OperationContext,
             _: &str,
             _: &str,
             _: OpCopy,
             _: OpCopier,
-        ) -> Result<(RpCopy, Self::Copier)> {
+        ) -> Result<Self::Copier> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
@@ -543,7 +507,7 @@ mod tests {
             .apply_service(source);
         let ctx = service_context(&service);
 
-        let (_, reader) = service.read(&ctx, "test", OpRead::default()).await.unwrap();
+        let reader = service.read(&ctx, "test", OpRead::default()).unwrap();
         let (_, mut stream) = reader.open(BytesRange::new(0, None)).await.unwrap();
         let buffer = stream.read_all().await.unwrap();
 
@@ -563,7 +527,7 @@ mod tests {
             .apply_service(source);
         let ctx = service_context(&service);
 
-        let (_, reader) = service.read(&ctx, "test", OpRead::default()).await.unwrap();
+        let reader = service.read(&ctx, "test", OpRead::default()).unwrap();
         let (_, mut stream) = reader.open(BytesRange::from(0_u64..2)).await.unwrap();
         let buffer = stream.read_all().await.unwrap();
 
@@ -572,7 +536,7 @@ mod tests {
         assert_eq!(state.open_calls.load(Ordering::Relaxed), 1);
         assert_eq!(state.read_calls.load(Ordering::Relaxed), 0);
 
-        let (_, reader) = service.read(&ctx, "test", OpRead::default()).await.unwrap();
+        let reader = service.read(&ctx, "test", OpRead::default()).unwrap();
         let (_, mut stream) = reader.open(BytesRange::from(4_u64..7)).await.unwrap();
         let buffer = stream.read_all().await.unwrap();
 

--- a/core/layers/hotpath/src/lib.rs
+++ b/core/layers/hotpath/src/lib.rs
@@ -32,12 +32,8 @@ use opendal_core::*;
 
 const LABEL_CREATE_DIR: &str = "opendal.create_dir";
 const LABEL_READ: &str = "opendal.read";
-const LABEL_WRITE: &str = "opendal.write";
-const LABEL_COPY: &str = "opendal.copy";
 const LABEL_RENAME: &str = "opendal.rename";
 const LABEL_STAT: &str = "opendal.stat";
-const LABEL_DELETE: &str = "opendal.delete";
-const LABEL_LIST: &str = "opendal.list";
 const LABEL_PRESIGN: &str = "opendal.presign";
 
 const LABEL_READER_READ: &str = "opendal.reader.read";
@@ -135,39 +131,25 @@ impl Service for HotpathAccessor {
         hotpath::measure_async(LABEL_CREATE_DIR, self.inner.create_dir(ctx, path, args)).await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, reader) =
-            hotpath::measure_async(LABEL_READ, self.inner.read(ctx, path, args)).await?;
-        Ok((rp, HotpathWrapper::new(reader)))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        self.inner.read(ctx, path, args).map(HotpathWrapper::new)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, writer) =
-            hotpath::measure_async(LABEL_WRITE, self.inner.write(ctx, path, args)).await?;
-        Ok((rp, HotpathWrapper::new(writer)))
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        self.inner.write(ctx, path, args).map(HotpathWrapper::new)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, copier) =
-            hotpath::measure_async(LABEL_COPY, self.inner.copy(ctx, from, to, args, opts)).await?;
-        Ok((rp, HotpathWrapper::new(copier)))
+    ) -> Result<Self::Copier> {
+        self.inner
+            .copy(ctx, from, to, args, opts)
+            .map(HotpathWrapper::new)
     }
 
     async fn rename(
@@ -184,20 +166,12 @@ impl Service for HotpathAccessor {
         hotpath::measure_async(LABEL_STAT, self.inner.stat(ctx, path, args)).await
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, deleter) = hotpath::measure_async(LABEL_DELETE, self.inner.delete(ctx)).await?;
-        Ok((rp, HotpathWrapper::new(deleter)))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner.delete(ctx).map(HotpathWrapper::new)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, lister) =
-            hotpath::measure_async(LABEL_LIST, self.inner.list(ctx, path, args)).await?;
-        Ok((rp, HotpathWrapper::new(lister)))
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        self.inner.list(ctx, path, args).map(HotpathWrapper::new)
     }
 
     async fn presign(

--- a/core/layers/immutable-index/src/lib.rs
+++ b/core/layers/immutable-index/src/lib.rs
@@ -181,41 +181,26 @@ impl Service for ImmutableIndexService {
         self.inner.stat(ctx, path, args).await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        self.inner.read(ctx, path, args).await
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        self.inner.read(ctx, path, args)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        self.inner.write(ctx, path, args).await
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        self.inner.write(ctx, path, args)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        self.inner.copy(ctx, from, to, args, opts).await
+    ) -> Result<Self::Copier> {
+        self.inner.copy(ctx, from, to, args, opts)
     }
 
-    async fn list(
-        &self,
-        _: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         let mut path = path;
         if path == "/" {
             path = ""
@@ -227,11 +212,11 @@ impl Service for ImmutableIndexService {
             self.children_hierarchy(path)
         };
 
-        Ok((RpList::default(), ImmutableDir::new(idx)))
+        Ok(ImmutableDir::new(idx))
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.inner.delete(ctx).await
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner.delete(ctx)
     }
 
     async fn rename(
@@ -338,57 +323,42 @@ mod tests {
             ))
         }
 
-        async fn read(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpRead,
-        ) -> Result<(RpRead, Self::Reader)> {
+        fn read(&self, _ctx: &OperationContext, _: &str, _: OpRead) -> Result<Self::Reader> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn write(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpWrite,
-        ) -> Result<(RpWrite, Self::Writer)> {
+        fn write(&self, _ctx: &OperationContext, _: &str, _: OpWrite) -> Result<Self::Writer> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn delete(&self, _: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+        fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn list(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpList,
-        ) -> Result<(RpList, Self::Lister)> {
+        fn list(&self, _ctx: &OperationContext, _: &str, _: OpList) -> Result<Self::Lister> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn copy(
+        fn copy(
             &self,
             _: &OperationContext,
             _: &str,
             _: &str,
             _: OpCopy,
             _: OpCopier,
-        ) -> Result<(RpCopy, Self::Copier)> {
+        ) -> Result<Self::Copier> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",

--- a/core/layers/logging/src/lib.rs
+++ b/core/layers/logging/src/lib.rs
@@ -292,17 +292,11 @@ impl<I: LoggingInterceptor> Service for LoggingService<I> {
         result
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
         self.log_start(Operation::Read, &[("path", path)]);
         self.inner
             .read(ctx, path, args)
-            .await
-            .map(|(rp, r)| {
+            .map(|r| {
                 self.logger.log(
                     &self.info,
                     Operation::Read,
@@ -310,10 +304,7 @@ impl<I: LoggingInterceptor> Service for LoggingService<I> {
                     "created reader",
                     None,
                 );
-                (
-                    rp,
-                    LoggingReader::new(self.info.clone(), self.logger.clone(), path, r),
-                )
+                LoggingReader::new(self.info.clone(), self.logger.clone(), path, r)
             })
             .inspect_err(|err| {
                 self.logger.log(
@@ -326,17 +317,11 @@ impl<I: LoggingInterceptor> Service for LoggingService<I> {
             })
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         self.log_start(Operation::Write, &[("path", path)]);
         self.inner
             .write(ctx, path, args)
-            .await
-            .map(|(rp, w)| {
+            .map(|w| {
                 self.logger.log(
                     &self.info,
                     Operation::Write,
@@ -344,10 +329,7 @@ impl<I: LoggingInterceptor> Service for LoggingService<I> {
                     "created writer",
                     None,
                 );
-                (
-                    rp,
-                    LoggingWriter::new(self.info.clone(), self.logger.clone(), path, w),
-                )
+                LoggingWriter::new(self.info.clone(), self.logger.clone(), path, w)
             })
             .inspect_err(|err| {
                 self.logger.log(
@@ -367,18 +349,14 @@ impl<I: LoggingInterceptor> Service for LoggingService<I> {
         result
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
         self.log_start(Operation::Delete, &[]);
         self.inner
             .delete(ctx)
-            .await
-            .map(|(rp, d)| {
+            .map(|d| {
                 self.logger
                     .log(&self.info, Operation::Delete, &[], "finished", None);
-                (
-                    rp,
-                    LoggingDeleter::new(self.info.clone(), self.logger.clone(), d),
-                )
+                LoggingDeleter::new(self.info.clone(), self.logger.clone(), d)
             })
             .inspect_err(|err| {
                 self.logger
@@ -386,19 +364,18 @@ impl<I: LoggingInterceptor> Service for LoggingService<I> {
             })
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         self.log_start(Operation::Copy, &[("from", from), ("to", to)]);
         self.inner
             .copy(ctx, from, to, args, opts)
-            .await
-            .map(|(rp, c)| {
+            .map(|c| {
                 self.logger.log(
                     &self.info,
                     Operation::Copy,
@@ -406,10 +383,7 @@ impl<I: LoggingInterceptor> Service for LoggingService<I> {
                     "created copier",
                     None,
                 );
-                (
-                    rp,
-                    LoggingCopier::new(self.info.clone(), self.logger.clone(), from, to, c),
-                )
+                LoggingCopier::new(self.info.clone(), self.logger.clone(), from, to, c)
             })
             .inspect_err(|err| {
                 self.logger.log(
@@ -439,17 +413,11 @@ impl<I: LoggingInterceptor> Service for LoggingService<I> {
         result
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         self.log_start(Operation::List, &[("path", path)]);
         self.inner
             .list(ctx, path, args)
-            .await
-            .map(|(rp, v)| {
+            .map(|v| {
                 self.logger.log(
                     &self.info,
                     Operation::List,
@@ -457,10 +425,7 @@ impl<I: LoggingInterceptor> Service for LoggingService<I> {
                     "created lister",
                     None,
                 );
-                (
-                    rp,
-                    LoggingLister::new(self.info.clone(), self.logger.clone(), path, v),
-                )
+                LoggingLister::new(self.info.clone(), self.logger.clone(), path, v)
             })
             .inspect_err(|err| {
                 self.logger.log(

--- a/core/layers/mime-guess/src/lib.rs
+++ b/core/layers/mime-guess/src/lib.rs
@@ -144,33 +144,23 @@ impl Service for MimeGuessAccessor {
         self.0.create_dir(ctx, path, args).await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        self.0.read(ctx, path, args).await
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        self.0.read(ctx, path, args)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        self.0.write(ctx, path, opwrite_with_mime(path, args)).await
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        self.0.write(ctx, path, opwrite_with_mime(path, args))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        self.0.copy(ctx, from, to, args, opts).await
+    ) -> Result<Self::Copier> {
+        self.0.copy(ctx, from, to, args, opts)
     }
 
     async fn stat(&self, ctx: &OperationContext, path: &str, args: OpStat) -> Result<RpStat> {
@@ -190,17 +180,12 @@ impl Service for MimeGuessAccessor {
         self.0.rename(ctx, from, to, args).await
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.0.delete(ctx).await
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.0.delete(ctx)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        self.0.list(ctx, path, args).await
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        self.0.list(ctx, path, args)
     }
 
     async fn presign(

--- a/core/layers/observe-metrics-common/src/lib.rs
+++ b/core/layers/observe-metrics-common/src/lib.rs
@@ -772,12 +772,7 @@ impl<I: MetricsIntercept> Service for MetricsAccessor<I> {
         res
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
         let labels = MetricLabels::new(self.info.clone(), Operation::Read.into_static());
 
         let start = Instant::now();
@@ -787,13 +782,10 @@ impl<I: MetricsIntercept> Service for MetricsAccessor<I> {
         let mut guard =
             ExecutingGuard::new_operation(self.interceptor.clone(), labels.clone(), start);
 
-        match self.inner.read(ctx, path, args).await {
-            Ok((rp, reader)) => {
+        match self.inner.read(ctx, path, args) {
+            Ok(reader) => {
                 guard.complete();
-                Ok((
-                    rp,
-                    MetricsReader::new(reader, self.interceptor.clone(), labels),
-                ))
+                Ok(MetricsReader::new(reader, self.interceptor.clone(), labels))
             }
             Err(err) => {
                 self.interceptor.observe(
@@ -806,12 +798,7 @@ impl<I: MetricsIntercept> Service for MetricsAccessor<I> {
         }
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let labels = MetricLabels::new(self.info.clone(), Operation::Write.into_static());
 
         let start = Instant::now();
@@ -821,12 +808,14 @@ impl<I: MetricsIntercept> Service for MetricsAccessor<I> {
         let mut guard =
             ExecutingGuard::new_operation(self.interceptor.clone(), labels.clone(), start);
 
-        match self.inner.write(ctx, path, args).await {
-            Ok((rp, writer)) => {
+        match self.inner.write(ctx, path, args) {
+            Ok(writer) => {
                 guard.defuse();
-                Ok((
-                    rp,
-                    MetricsWrapper::new(writer, self.interceptor.clone(), labels, start),
+                Ok(MetricsWrapper::new(
+                    writer,
+                    self.interceptor.clone(),
+                    labels,
+                    start,
                 ))
             }
             Err(err) => {
@@ -840,14 +829,14 @@ impl<I: MetricsIntercept> Service for MetricsAccessor<I> {
         }
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         let labels = MetricLabels::new(self.info.clone(), Operation::Copy.into_static());
 
         let start = Instant::now();
@@ -857,12 +846,14 @@ impl<I: MetricsIntercept> Service for MetricsAccessor<I> {
         let mut guard =
             ExecutingGuard::new_operation(self.interceptor.clone(), labels.clone(), start);
 
-        match self.inner.copy(ctx, from, to, args, opts.clone()).await {
-            Ok((rp, copier)) => {
+        match self.inner.copy(ctx, from, to, args, opts.clone()) {
+            Ok(copier) => {
                 guard.defuse();
-                Ok((
-                    rp,
-                    MetricsWrapper::new(copier, self.interceptor.clone(), labels, start),
+                Ok(MetricsWrapper::new(
+                    copier,
+                    self.interceptor.clone(),
+                    labels,
+                    start,
                 ))
             }
             Err(err) => {
@@ -944,7 +935,7 @@ impl<I: MetricsIntercept> Service for MetricsAccessor<I> {
         res
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
         let labels = MetricLabels::new(self.info.clone(), Operation::Delete.into_static());
 
         let start = Instant::now();
@@ -954,12 +945,14 @@ impl<I: MetricsIntercept> Service for MetricsAccessor<I> {
         let mut guard =
             ExecutingGuard::new_operation(self.interceptor.clone(), labels.clone(), start);
 
-        match self.inner.delete(ctx).await {
-            Ok((rp, deleter)) => {
+        match self.inner.delete(ctx) {
+            Ok(deleter) => {
                 guard.defuse();
-                Ok((
-                    rp,
-                    MetricsWrapper::new(deleter, self.interceptor.clone(), labels, start),
+                Ok(MetricsWrapper::new(
+                    deleter,
+                    self.interceptor.clone(),
+                    labels,
+                    start,
                 ))
             }
             Err(err) => {
@@ -973,12 +966,7 @@ impl<I: MetricsIntercept> Service for MetricsAccessor<I> {
         }
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         let labels = MetricLabels::new(self.info.clone(), Operation::List.into_static());
 
         let start = Instant::now();
@@ -988,12 +976,14 @@ impl<I: MetricsIntercept> Service for MetricsAccessor<I> {
         let mut guard =
             ExecutingGuard::new_operation(self.interceptor.clone(), labels.clone(), start);
 
-        match self.inner.list(ctx, path, args).await {
-            Ok((rp, lister)) => {
+        match self.inner.list(ctx, path, args) {
+            Ok(lister) => {
                 guard.defuse();
-                Ok((
-                    rp,
-                    MetricsWrapper::new(lister, self.interceptor.clone(), labels, start),
+                Ok(MetricsWrapper::new(
+                    lister,
+                    self.interceptor.clone(),
+                    labels,
+                    start,
                 ))
             }
             Err(err) => {

--- a/core/layers/oteltrace/src/lib.rs
+++ b/core/layers/oteltrace/src/lib.rs
@@ -112,12 +112,7 @@ impl Service for OtelTraceService {
             .await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
         let tracer = global::tracer("opendal");
         let mut span = tracer.start("read");
         span.set_attribute(KeyValue::new("path", path.to_string()));
@@ -125,17 +120,10 @@ impl Service for OtelTraceService {
         let cx = TraceContext::current_with_span(span);
         self.inner
             .read(ctx, path, args)
-            .with_context(cx.clone())
-            .await
-            .map(|(rp, r)| (rp, OtelTraceWrapper::new(cx, r)))
+            .map(|r| OtelTraceWrapper::new(cx, r))
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let tracer = global::tracer("opendal");
         let mut span = tracer.start("write");
         span.set_attribute(KeyValue::new("path", path.to_string()));
@@ -143,29 +131,25 @@ impl Service for OtelTraceService {
         let cx = TraceContext::current_with_span(span);
         self.inner
             .write(ctx, path, args)
-            .with_context(cx.clone())
-            .await
-            .map(|(rp, r)| (rp, OtelTraceWrapper::new(cx, r)))
+            .map(|r| OtelTraceWrapper::new(cx, r))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         let tracer = global::tracer("opendal");
         let mut span = tracer.start("copy");
         span.set_attribute(KeyValue::new("from", from.to_string()));
         span.set_attribute(KeyValue::new("to", to.to_string()));
         span.set_attribute(KeyValue::new("args", format!("{args:?}")));
         let cx = TraceContext::current_with_span(span);
-        self.inner
-            .copy(ctx, from, to, args, opts)
-            .with_context(cx)
-            .await
+        let _guard = cx.attach();
+        self.inner.copy(ctx, from, to, args, opts)
     }
 
     async fn rename(
@@ -196,16 +180,11 @@ impl Service for OtelTraceService {
         self.inner.stat(ctx, path, args).with_context(cx).await
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.inner.delete(ctx).await
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner.delete(ctx)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         let tracer = global::tracer("opendal");
         let mut span = tracer.start("list");
         span.set_attribute(KeyValue::new("path", path.to_string()));
@@ -213,9 +192,7 @@ impl Service for OtelTraceService {
         let cx = TraceContext::current_with_span(span);
         self.inner
             .list(ctx, path, args)
-            .with_context(cx.clone())
-            .await
-            .map(|(rp, s)| (rp, OtelTraceWrapper::new(cx, s)))
+            .map(|s| OtelTraceWrapper::new(cx, s))
     }
 
     async fn presign(

--- a/core/layers/retry/src/lib.rs
+++ b/core/layers/retry/src/lib.rs
@@ -23,6 +23,7 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use backon::BlockingRetryable;
 use backon::ExponentialBuilder;
 use backon::Retryable;
 use opendal_core::raw::*;
@@ -330,14 +331,9 @@ impl<I: RetryInterceptor> Service for RetryService<I> {
             .map_err(|err| err.set_persistent())
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
         let mut attempt: u32 = 0;
-        let (rp, reader) = { || self.inner.read(ctx, path, args.clone()) }
+        let reader = { || self.inner.read(ctx, path, args.clone()) }
             .retry(self.builder)
             .when(|e| e.is_temporary())
             .notify(|err, dur| {
@@ -349,23 +345,15 @@ impl<I: RetryInterceptor> Service for RetryService<I> {
                     attempt,
                 })
             })
-            .await
+            .call()
             .map_err(|err| err.set_persistent())?;
 
-        Ok((
-            rp,
-            RetryReader::new(reader, self.notify.clone(), self.builder),
-        ))
+        Ok(RetryReader::new(reader, self.notify.clone(), self.builder))
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let mut attempt: u32 = 0;
-        let (rp, writer) = { || self.inner.write(ctx, path, args.clone()) }
+        let writer = { || self.inner.write(ctx, path, args.clone()) }
             .retry(self.builder)
             .when(|e| e.is_temporary())
             .notify(|err, dur| {
@@ -377,13 +365,10 @@ impl<I: RetryInterceptor> Service for RetryService<I> {
                     attempt,
                 })
             })
-            .await
+            .call()
             .map_err(|err| err.set_persistent())?;
 
-        Ok((
-            rp,
-            RetryWrapper::new(writer, self.notify.clone(), self.builder),
-        ))
+        Ok(RetryWrapper::new(writer, self.notify.clone(), self.builder))
     }
 
     async fn stat(&self, ctx: &OperationContext, path: &str, args: OpStat) -> Result<RpStat> {
@@ -404,9 +389,9 @@ impl<I: RetryInterceptor> Service for RetryService<I> {
             .map_err(|err| err.set_persistent())
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
         let mut attempt: u32 = 0;
-        let (rp, deleter) = { || self.inner.delete(ctx) }
+        let deleter = { || self.inner.delete(ctx) }
             .retry(self.builder)
             .when(|e| e.is_temporary())
             .notify(|err, dur| {
@@ -418,25 +403,26 @@ impl<I: RetryInterceptor> Service for RetryService<I> {
                     attempt,
                 })
             })
-            .await
+            .call()
             .map_err(|err| err.set_persistent())?;
 
-        Ok((
-            rp,
-            RetryWrapper::new(deleter, self.notify.clone(), self.builder),
+        Ok(RetryWrapper::new(
+            deleter,
+            self.notify.clone(),
+            self.builder,
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         let mut attempt: u32 = 0;
-        let (rp, copier) = { || self.inner.copy(ctx, from, to, args.clone(), opts.clone()) }
+        let copier = { || self.inner.copy(ctx, from, to, args.clone(), opts.clone()) }
             .retry(self.builder)
             .when(|e| e.is_temporary())
             .notify(|err, dur| {
@@ -448,13 +434,10 @@ impl<I: RetryInterceptor> Service for RetryService<I> {
                     attempt,
                 })
             })
-            .await
+            .call()
             .map_err(|err| err.set_persistent())?;
 
-        Ok((
-            rp,
-            RetryWrapper::new(copier, self.notify.clone(), self.builder),
-        ))
+        Ok(RetryWrapper::new(copier, self.notify.clone(), self.builder))
     }
 
     async fn rename(
@@ -481,14 +464,9 @@ impl<I: RetryInterceptor> Service for RetryService<I> {
             .map_err(|err| err.set_persistent())
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         let mut attempt: u32 = 0;
-        let (rp, lister) = { || self.inner.list(ctx, path, args.clone()) }
+        let lister = { || self.inner.list(ctx, path, args.clone()) }
             .retry(self.builder)
             .when(|e| e.is_temporary())
             .notify(|err, dur| {
@@ -500,13 +478,10 @@ impl<I: RetryInterceptor> Service for RetryService<I> {
                     attempt,
                 })
             })
-            .await
+            .call()
             .map_err(|err| err.set_persistent())?;
 
-        Ok((
-            rp,
-            RetryWrapper::new(lister, self.notify.clone(), self.builder),
-        ))
+        Ok(RetryWrapper::new(lister, self.notify.clone(), self.builder))
     }
 
     async fn presign(
@@ -1154,61 +1129,41 @@ mod tests {
             ))
         }
 
-        async fn read(
-            &self,
-            _: &OperationContext,
-            path: &str,
-            args: OpRead,
-        ) -> Result<(RpRead, Self::Reader)> {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(MockReader::new(self.clone(), path, args)),
-            ))
+        fn read(&self, _: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+            Ok(oio::StreamReader::new(MockReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }
 
-        async fn delete(&self, _: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-            Ok((
-                RpDelete::default(),
-                MockDeleter {
-                    size: 0,
-                    attempt: self.attempt.clone(),
-                },
-            ))
+        fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+            Ok(MockDeleter {
+                size: 0,
+                attempt: self.attempt.clone(),
+            })
         }
 
-        async fn write(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpWrite,
-        ) -> Result<(RpWrite, Self::Writer)> {
-            Ok((RpWrite::new(), MockWriter {}))
+        fn write(&self, _ctx: &OperationContext, _: &str, _: OpWrite) -> Result<Self::Writer> {
+            Ok(MockWriter {})
         }
 
-        async fn list(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpList,
-        ) -> Result<(RpList, Self::Lister)> {
+        fn list(&self, _ctx: &OperationContext, _: &str, _: OpList) -> Result<Self::Lister> {
             let lister = MockLister::default();
-            Ok((RpList::default(), lister))
+            Ok(lister)
         }
 
-        async fn copy(
+        fn copy(
             &self,
             _: &OperationContext,
             _: &str,
             _: &str,
             _: OpCopy,
             _: OpCopier,
-        ) -> Result<(RpCopy, Self::Copier)> {
-            Ok((
-                RpCopy::default(),
-                MockCopier {
-                    attempt: self.attempt.clone(),
-                },
-            ))
+        ) -> Result<Self::Copier> {
+            Ok(MockCopier {
+                attempt: self.attempt.clone(),
+            })
         }
 
         async fn rename(

--- a/core/layers/route/src/lib.rs
+++ b/core/layers/route/src/lib.rs
@@ -187,43 +187,31 @@ impl Service for RouteAccessor {
         }
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, oio::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<oio::Reader> {
         match self.select(path) {
-            RouteSelected::Default(srv) => srv.read(ctx, path, args).await,
-            RouteSelected::Target(target) => target.srv.read(&target.ctx, path, args).await,
+            RouteSelected::Default(srv) => srv.read(ctx, path, args),
+            RouteSelected::Target(target) => target.srv.read(&target.ctx, path, args),
         }
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, oio::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<oio::Writer> {
         match self.select(path) {
-            RouteSelected::Default(srv) => srv.write(ctx, path, args).await,
-            RouteSelected::Target(target) => target.srv.write(&target.ctx, path, args).await,
+            RouteSelected::Default(srv) => srv.write(ctx, path, args),
+            RouteSelected::Target(target) => target.srv.write(&target.ctx, path, args),
         }
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, oio::Copier)> {
+    ) -> Result<oio::Copier> {
         match self.select(from) {
-            RouteSelected::Default(srv) => srv.copy(ctx, from, to, args, opts).await,
-            RouteSelected::Target(target) => {
-                target.srv.copy(&target.ctx, from, to, args, opts).await
-            }
+            RouteSelected::Default(srv) => srv.copy(ctx, from, to, args, opts),
+            RouteSelected::Target(target) => target.srv.copy(&target.ctx, from, to, args, opts),
         }
     }
 
@@ -247,26 +235,18 @@ impl Service for RouteAccessor {
         }
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, oio::Deleter)> {
-        Ok((
-            RpDelete::default(),
-            Box::new(RouteDeleter::new(
-                self.inner.clone(),
-                self.router.clone(),
-                ctx.clone(),
-            )) as oio::Deleter,
-        ))
+    fn delete(&self, ctx: &OperationContext) -> Result<oio::Deleter> {
+        Ok(Box::new(RouteDeleter::new(
+            self.inner.clone(),
+            self.router.clone(),
+            ctx.clone(),
+        )) as oio::Deleter)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, oio::Lister)> {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<oio::Lister> {
         match self.select(path) {
-            RouteSelected::Default(srv) => srv.list(ctx, path, args).await,
-            RouteSelected::Target(target) => target.srv.list(&target.ctx, path, args).await,
+            RouteSelected::Default(srv) => srv.list(ctx, path, args),
+            RouteSelected::Target(target) => target.srv.list(&target.ctx, path, args),
         }
     }
 
@@ -309,7 +289,7 @@ impl RouteDeleter {
         match key {
             RouteKey::Default => {
                 if self.default_deleter.is_none() {
-                    let (_, deleter) = self.default.delete(&self.ctx).await?;
+                    let deleter = self.default.delete(&self.ctx)?;
                     self.default_deleter = Some(deleter);
                 }
                 Ok(self
@@ -320,7 +300,7 @@ impl RouteDeleter {
             RouteKey::Target(idx) => {
                 if idx >= self.target_deleters.len() {
                     if self.default_deleter.is_none() {
-                        let (_, deleter) = self.default.delete(&self.ctx).await?;
+                        let deleter = self.default.delete(&self.ctx)?;
                         self.default_deleter = Some(deleter);
                     }
                     return Ok(self
@@ -330,14 +310,14 @@ impl RouteDeleter {
                 }
                 if self.target_deleters[idx].is_none() {
                     let Some(target) = self.router.target(idx) else {
-                        let (_, deleter) = self.default.delete(&self.ctx).await?;
+                        let deleter = self.default.delete(&self.ctx)?;
                         self.default_deleter = Some(deleter);
                         return Ok(self
                             .default_deleter
                             .as_mut()
                             .expect("default deleter must exist"));
                     };
-                    let (_, deleter) = target.srv.delete(&target.ctx).await?;
+                    let deleter = target.srv.delete(&target.ctx)?;
                     self.target_deleters[idx] = Some(deleter);
                 }
                 Ok(self.target_deleters[idx]
@@ -489,65 +469,47 @@ mod tests {
             }
         }
 
-        async fn read(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpRead,
-        ) -> Result<(RpRead, Self::Reader)> {
+        fn read(&self, _ctx: &OperationContext, _: &str, _: OpRead) -> Result<Self::Reader> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn write(
-            &self,
-            _: &OperationContext,
-            path: &str,
-            _: OpWrite,
-        ) -> Result<(RpWrite, Self::Writer)> {
-            Ok((
-                RpWrite::default(),
-                MockWriter {
-                    paths: self.paths.clone(),
-                    path: path.to_string(),
-                },
-            ))
+        fn write(&self, _: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+            Ok(MockWriter {
+                paths: self.paths.clone(),
+                path: path.to_string(),
+            })
         }
 
-        async fn delete(&self, _: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+        fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn list(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpList,
-        ) -> Result<(RpList, Self::Lister)> {
+        fn list(&self, _ctx: &OperationContext, _: &str, _: OpList) -> Result<Self::Lister> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        async fn copy(
+        fn copy(
             &self,
             _: &OperationContext,
             from: &str,
             to: &str,
             _: OpCopy,
             _: OpCopier,
-        ) -> Result<(RpCopy, Self::Copier)> {
+        ) -> Result<Self::Copier> {
             if !self.paths.lock().unwrap().contains(from) {
                 return Err(Error::new(ErrorKind::NotFound, "source not found"));
             }
             self.paths.lock().unwrap().insert(to.to_string());
-            Ok((RpCopy::default(), ()))
+            Ok(())
         }
 
         async fn rename(

--- a/core/layers/tail-cut/src/lib.rs
+++ b/core/layers/tail-cut/src/lib.rs
@@ -396,58 +396,29 @@ impl Service for TailCutService {
         .await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        self.with_deadline(Operation::Read, None, self.inner.read(ctx, path, args))
-            .await
-            .map(|(rp, r)| {
-                (
-                    rp,
-                    TailCutWrapper::new(r, None, self.config.clone(), self.stats.clone()),
-                )
-            })
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        self.inner
+            .read(ctx, path, args)
+            .map(|r| TailCutWrapper::new(r, None, self.config.clone(), self.stats.clone()))
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        self.with_deadline(Operation::Write, None, self.inner.write(ctx, path, args))
-            .await
-            .map(|(rp, w)| {
-                (
-                    rp,
-                    TailCutWrapper::new(w, None, self.config.clone(), self.stats.clone()),
-                )
-            })
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        self.inner
+            .write(ctx, path, args)
+            .map(|w| TailCutWrapper::new(w, None, self.config.clone(), self.stats.clone()))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        self.with_deadline(
-            Operation::Copy,
-            None,
-            self.inner.copy(ctx, from, to, args, opts),
-        )
-        .await
-        .map(|(rp, c)| {
-            (
-                rp,
-                TailCutWrapper::new(c, None, self.config.clone(), self.stats.clone()),
-            )
-        })
+    ) -> Result<Self::Copier> {
+        self.inner
+            .copy(ctx, from, to, args, opts)
+            .map(|c| TailCutWrapper::new(c, None, self.config.clone(), self.stats.clone()))
     }
 
     async fn rename(
@@ -470,31 +441,16 @@ impl Service for TailCutService {
             .await
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.with_deadline(Operation::Delete, None, self.inner.delete(ctx))
-            .await
-            .map(|(rp, d)| {
-                (
-                    rp,
-                    TailCutWrapper::new(d, None, self.config.clone(), self.stats.clone()),
-                )
-            })
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner
+            .delete(ctx)
+            .map(|d| TailCutWrapper::new(d, None, self.config.clone(), self.stats.clone()))
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        self.with_deadline(Operation::List, None, self.inner.list(ctx, path, args))
-            .await
-            .map(|(rp, l)| {
-                (
-                    rp,
-                    TailCutWrapper::new(l, None, self.config.clone(), self.stats.clone()),
-                )
-            })
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        self.inner
+            .list(ctx, path, args)
+            .map(|l| TailCutWrapper::new(l, None, self.config.clone(), self.stats.clone()))
     }
 
     async fn presign(

--- a/core/layers/throttle/src/lib.rs
+++ b/core/layers/throttle/src/lib.rs
@@ -142,47 +142,35 @@ impl Service for ThrottleAccessor {
         self.inner.stat(ctx, path, args).await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
         let limiter = self.rate_limiter.clone();
 
         self.inner
             .read(ctx, path, args)
-            .await
-            .map(|(rp, r)| (rp, ThrottleWrapper::new(r, limiter)))
+            .map(|r| ThrottleWrapper::new(r, limiter))
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let limiter = self.rate_limiter.clone();
 
         self.inner
             .write(ctx, path, args)
-            .await
-            .map(|(rp, w)| (rp, ThrottleWrapper::new(w, limiter)))
+            .map(|w| ThrottleWrapper::new(w, limiter))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        self.inner.copy(ctx, from, to, args, opts).await
+    ) -> Result<Self::Copier> {
+        self.inner.copy(ctx, from, to, args, opts)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.inner.delete(ctx).await
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner.delete(ctx)
     }
 
     async fn rename(
@@ -195,13 +183,8 @@ impl Service for ThrottleAccessor {
         self.inner.rename(ctx, from, to, args).await
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        self.inner.list(ctx, path, args).await
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        self.inner.list(ctx, path, args)
     }
 
     async fn presign(

--- a/core/layers/timeout/src/lib.rs
+++ b/core/layers/timeout/src/lib.rs
@@ -38,7 +38,7 @@ use opendal_core::*;
 /// `TimeoutLayer` applies two timeout budgets:
 ///
 /// - `timeout` bounds control operations such as `stat`, `create_dir`, `rename`,
-///   `copy`, `delete`, and `presign`.
+///   and `presign`.
 /// - `io_timeout` bounds operations that open IO bodies, such as `read`, `write`,
 ///   and `list`, and every method call on returned readers, writers, listers,
 ///   deleters, and copiers.
@@ -576,10 +576,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_operation_timeout() {
+    async fn test_delete_timeout() {
         let srv = MockService;
         let op = Operator::from_inner(Arc::new(srv))
-            .layer(TimeoutLayer::default().with_timeout(Duration::from_secs(1)));
+            .layer(TimeoutLayer::default().with_io_timeout(Duration::from_secs(1)));
 
         let fut = async {
             let res = op.delete("test").await;

--- a/core/layers/timeout/src/lib.rs
+++ b/core/layers/timeout/src/lib.rs
@@ -195,21 +195,6 @@ impl TimeoutService {
                 .set_temporary()
         })?
     }
-
-    async fn io_timeout<F: Future<Output = Result<T>>, T>(
-        &self,
-        op: Operation,
-        fut: F,
-    ) -> Result<T> {
-        tokio::time::timeout(self.io_timeout, fut)
-            .await
-            .map_err(|_| {
-                Error::new(ErrorKind::Unexpected, "io timeout reached")
-                    .with_operation(op)
-                    .with_context("timeout", self.io_timeout.as_secs_f64().to_string())
-                    .set_temporary()
-            })?
-    }
 }
 
 impl Service for TimeoutService {
@@ -237,39 +222,29 @@ impl Service for TimeoutService {
             .await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        self.io_timeout(Operation::Read, self.inner.read(ctx, path, args))
-            .await
-            .map(|(rp, r)| (rp, TimeoutWrapper::new(r, self.io_timeout)))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        self.inner
+            .read(ctx, path, args)
+            .map(|r| TimeoutWrapper::new(r, self.io_timeout))
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        self.io_timeout(Operation::Write, self.inner.write(ctx, path, args))
-            .await
-            .map(|(rp, r)| (rp, TimeoutWrapper::new(r, self.io_timeout)))
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        self.inner
+            .write(ctx, path, args)
+            .map(|r| TimeoutWrapper::new(r, self.io_timeout))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        self.timeout(Operation::Copy, self.inner.copy(ctx, from, to, args, opts))
-            .await
-            .map(|(rp, c)| (rp, TimeoutWrapper::new(c, self.io_timeout)))
+    ) -> Result<Self::Copier> {
+        self.inner
+            .copy(ctx, from, to, args, opts)
+            .map(|c| TimeoutWrapper::new(c, self.io_timeout))
     }
 
     async fn rename(
@@ -288,21 +263,16 @@ impl Service for TimeoutService {
             .await
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        self.timeout(Operation::Delete, self.inner.delete(ctx))
-            .await
-            .map(|(rp, r)| (rp, TimeoutWrapper::new(r, self.io_timeout)))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        self.inner
+            .delete(ctx)
+            .map(|r| TimeoutWrapper::new(r, self.io_timeout))
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        self.io_timeout(Operation::List, self.inner.list(ctx, path, args))
-            .await
-            .map(|(rp, r)| (rp, TimeoutWrapper::new(r, self.io_timeout)))
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        self.inner
+            .list(ctx, path, args)
+            .map(|r| TimeoutWrapper::new(r, self.io_timeout))
     }
 
     async fn presign(
@@ -453,7 +423,6 @@ mod tests {
     use std::future::pending;
 
     use futures::StreamExt;
-    use tokio::time::sleep;
     use tokio::time::timeout;
 
     use super::*;
@@ -465,7 +434,7 @@ mod tests {
         type Reader = MockReader;
         type Writer = ();
         type Lister = MockLister;
-        type Deleter = ();
+        type Deleter = MockDeleter;
         type Copier = MockCopier;
 
         fn info(&self) -> ServiceInfo {
@@ -502,55 +471,35 @@ mod tests {
         }
 
         /// Return a reader whose operations never complete.
-        async fn read(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpRead,
-        ) -> Result<(RpRead, Self::Reader)> {
-            Ok((
-                RpRead::new(Metadata::new(EntryMode::FILE).with_content_length(0)),
-                MockReader,
-            ))
+        fn read(&self, _ctx: &OperationContext, _: &str, _: OpRead) -> Result<Self::Reader> {
+            Ok(MockReader)
         }
 
-        async fn write(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpWrite,
-        ) -> Result<(RpWrite, Self::Writer)> {
+        fn write(&self, _ctx: &OperationContext, _: &str, _: OpWrite) -> Result<Self::Writer> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",
             ))
         }
 
-        /// Never return, so the service-level timeout can fire.
-        async fn delete(&self, _: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-            sleep(Duration::from_secs(u64::MAX)).await;
-
-            Ok((RpDelete::default(), ()))
+        /// Return a deleter whose operations never complete.
+        fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+            Ok(MockDeleter)
         }
 
-        async fn list(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: OpList,
-        ) -> Result<(RpList, Self::Lister)> {
-            Ok((RpList::default(), MockLister))
+        fn list(&self, _ctx: &OperationContext, _: &str, _: OpList) -> Result<Self::Lister> {
+            Ok(MockLister)
         }
 
-        async fn copy(
+        fn copy(
             &self,
             _: &OperationContext,
             _: &str,
             _: &str,
             _: OpCopy,
             _: OpCopier,
-        ) -> Result<(RpCopy, Self::Copier)> {
-            Ok((RpCopy::default(), MockCopier))
+        ) -> Result<Self::Copier> {
+            Ok(MockCopier)
         }
 
         async fn rename(
@@ -699,9 +648,8 @@ mod tests {
             .with_io_timeout(Duration::from_millis(100))
             .apply_service(Arc::new(MockService));
         let ctx = OperationContext::new(HttpClient::default(), Executor::default());
-        let (_, mut copier) = service
+        let mut copier = service
             .copy(&ctx, "f", "t", OpCopy::default(), OpCopier::default())
-            .await
             .unwrap();
 
         let err = copier.next().await.unwrap_err();
@@ -718,7 +666,7 @@ mod tests {
         let service = timeout_layer.apply_service(Arc::new(MockService));
         let ctx = OperationContext::new(HttpClient::default(), Executor::default());
 
-        let (_, mut lister) = service.list(&ctx, "test", OpList::default()).await.unwrap();
+        let mut lister = service.list(&ctx, "test", OpList::default()).unwrap();
 
         let res = lister.next().await;
         assert!(res.is_err());

--- a/core/layers/tracing/src/lib.rs
+++ b/core/layers/tracing/src/lib.rs
@@ -224,52 +224,31 @@ impl Service for TracingService {
             .await
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
         let span = span!(Level::DEBUG, "read", path, ?args);
-
-        let (rp, r) = self
-            .inner
+        self.inner
             .read(ctx, path, args)
-            .instrument(span.clone())
-            .await?;
-        Ok((rp, TracingWrapper::new(span, r)))
+            .map(|r| TracingWrapper::new(span, r))
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let span = span!(Level::DEBUG, "write", path, ?args);
-
-        let (rp, r) = self
-            .inner
+        self.inner
             .write(ctx, path, args)
-            .instrument(span.clone())
-            .await?;
-
-        Ok((rp, TracingWrapper::new(span, r)))
+            .map(|r| TracingWrapper::new(span, r))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         let span = span!(Level::DEBUG, "copy", from, to, ?args, ?opts);
-        self.inner
-            .copy(ctx, from, to, args, opts)
-            .instrument(span)
-            .await
+        let _guard = span.enter();
+        self.inner.copy(ctx, from, to, args, opts)
     }
 
     async fn rename(
@@ -291,29 +270,16 @@ impl Service for TracingService {
         self.inner.stat(ctx, path, args).instrument(span).await
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
         let span = span!(Level::DEBUG, "delete");
-
-        let (rp, r) = self.inner.delete(ctx).instrument(span.clone()).await?;
-
-        Ok((rp, TracingWrapper::new(span, r)))
+        self.inner.delete(ctx).map(|r| TracingWrapper::new(span, r))
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         let span = span!(Level::DEBUG, "list", path, ?args);
-
-        let (rp, r) = self
-            .inner
+        self.inner
             .list(ctx, path, args)
-            .instrument(span.clone())
-            .await?;
-
-        Ok((rp, TracingWrapper::new(span, r)))
+            .map(|r| TracingWrapper::new(span, r))
     }
 
     async fn presign(

--- a/core/services/aliyun-drive/src/backend.rs
+++ b/core/services/aliyun-drive/src/backend.rs
@@ -30,8 +30,7 @@ use super::core::*;
 use super::deleter::AliyunDriveDeleter;
 use super::error::parse_error;
 use super::lister::AliyunDriveLister;
-use super::lister::AliyunDriveParent;
-use super::writer::AliyunDriveWriter;
+use super::writer::AliyunDriveLazyWriter;
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -234,10 +233,10 @@ impl oio::StreamRead for AliyunDriveReader {
 
 impl Service for AliyunDriveBackend {
     type Reader = oio::StreamReader<AliyunDriveReader>;
-    type Writer = AliyunDriveWriter;
+    type Writer = AliyunDriveLazyWriter;
     type Lister = oio::PageLister<AliyunDriveLister>;
     type Deleter = oio::OneShotDeleter<AliyunDriveDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -297,60 +296,62 @@ impl Service for AliyunDriveBackend {
         Ok(RpRename::default())
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
+
+        Ok(oio::OneShotCopier::new(async move {
             if from == to {
-                Ok((RpCopy::default(), ()))
+                Ok(Metadata::default())
             } else {
-                let res = self.core.get_by_path(ctx, from).await?;
+                let res = core.get_by_path(&ctx, &from).await?;
                 let file: AliyunDriveFile =
                     serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
                 // copy can overwrite.
-                match self.core.get_by_path(ctx, to).await {
+                match core.get_by_path(&ctx, &to).await {
                     Err(err) if err.kind() == ErrorKind::NotFound => {}
                     Err(err) => Err(err)?,
                     Ok(res) => {
                         let file: AliyunDriveFile = serde_json::from_reader(res.reader())
                             .map_err(new_json_serialize_error)?;
-                        self.core.delete_path(ctx, &file.file_id).await?;
+                        core.delete_path(&ctx, &file.file_id).await?;
                     }
                 }
                 // there is no direct copy in AliyunDrive.
                 // so we need to copy the path first and then rename it.
-                let parent_path = get_parent(to);
-                let parent_file_id = self.core.ensure_dir_exists(ctx, parent_path).await?;
+                let parent_path = get_parent(&to);
+                let parent_file_id = core.ensure_dir_exists(&ctx, parent_path).await?;
 
                 // if from and to are going to be placed in the same folder,
                 // copy_path will fail as we cannot change the name during this action.
                 // it has to be auto renamed.
                 let auto_rename = file.parent_file_id == parent_file_id;
-                let res = self
-                    .core
-                    .copy_path(ctx, &file.file_id, &parent_file_id, auto_rename)
+                let res = core
+                    .copy_path(&ctx, &file.file_id, &parent_file_id, auto_rename)
                     .await?;
                 let file: CopyResponse =
                     serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
                 let file_id = file.file_id;
 
-                let from_name = get_basename(from);
-                let to_name = get_basename(to);
+                let from_name = get_basename(&from);
+                let to_name = get_basename(&to);
 
                 if from_name != to_name {
-                    self.core.update_path(ctx, &file_id, to_name).await?;
+                    core.update_path(&ctx, &file_id, to_name).await?;
                 }
 
-                Ok((RpCopy::default(), ()))
+                Ok(Metadata::default())
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
     async fn stat(&self, ctx: &OperationContext, path: &str, _args: OpStat) -> Result<RpStat> {
@@ -382,100 +383,52 @@ impl Service for AliyunDriveBackend {
 
         Ok(RpStat::new(meta))
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<AliyunDriveReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(AliyunDriveReader::new(
-                    self.clone(),
-                    ctx.clone(),
-                    path,
-                    args,
-                )),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<AliyunDriveReader> = {
+            Ok(oio::StreamReader::new(AliyunDriveReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<AliyunDriveDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(AliyunDriveDeleter::new(self.core.clone(), ctx.clone())),
-            ))
-        }?;
-
-        Ok((rp, output))
-    }
-
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<AliyunDriveLister>) = {
-            let parent = match self.core.get_by_path(ctx, path).await {
-                Err(err) if err.kind() == ErrorKind::NotFound => None,
-                Err(err) => return Err(err),
-                Ok(res) => {
-                    let file: AliyunDriveFile =
-                        serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
-                    Some(AliyunDriveParent {
-                        file_id: file.file_id,
-                        path: path.to_string(),
-                        updated_at: file.updated_at,
-                    })
-                }
-            };
-
-            let l = AliyunDriveLister::new(self.core.clone(), ctx.clone(), parent, args.limit());
-
-            Ok((RpList::default(), oio::PageLister::new(l)))
-        }?;
-
-        Ok((rp, output))
-    }
-
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, AliyunDriveWriter) = {
-            let parent_path = get_parent(path);
-            let parent_file_id = self.core.ensure_dir_exists(ctx, parent_path).await?;
-
-            // write can overwrite
-            match self.core.get_by_path(ctx, path).await {
-                Err(err) if err.kind() == ErrorKind::NotFound => {}
-                Err(err) => return Err(err),
-                Ok(res) => {
-                    let file: AliyunDriveFile =
-                        serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
-                    self.core.delete_path(ctx, &file.file_id).await?;
-                }
-            };
-
-            let writer = AliyunDriveWriter::new(
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<AliyunDriveDeleter> = {
+            Ok(oio::OneShotDeleter::new(AliyunDriveDeleter::new(
                 self.core.clone(),
                 ctx.clone(),
-                &parent_file_id,
-                get_basename(path),
-                args,
-            );
-
-            Ok((RpWrite::default(), writer))
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
+    }
+
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<AliyunDriveLister> = {
+            let l = AliyunDriveLister::new_with_path(
+                self.core.clone(),
+                ctx.clone(),
+                path.to_string(),
+                args.limit(),
+            );
+
+            Ok(oio::PageLister::new(l))
+        }?;
+
+        Ok(output)
+    }
+
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        Ok(AliyunDriveLazyWriter::new(
+            self.core.clone(),
+            ctx.clone(),
+            path.to_string(),
+            args,
+        ))
     }
 
     async fn presign(

--- a/core/services/aliyun-drive/src/lister.rs
+++ b/core/services/aliyun-drive/src/lister.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 use self::oio::Entry;
 use super::core::AliyunDriveCore;
+use super::core::AliyunDriveFile;
 use super::core::AliyunDriveFileList;
 use bytes::Buf;
 use opendal_core::EntryMode;
@@ -33,9 +34,11 @@ pub struct AliyunDriveLister {
     ctx: OperationContext,
 
     parent: Option<AliyunDriveParent>,
+    path: Option<String>,
     limit: Option<usize>,
 }
 
+#[derive(Clone)]
 pub struct AliyunDriveParent {
     pub file_id: String,
     pub path: String,
@@ -43,24 +46,49 @@ pub struct AliyunDriveParent {
 }
 
 impl AliyunDriveLister {
-    pub fn new(
+    pub fn new_with_path(
         core: Arc<AliyunDriveCore>,
         ctx: OperationContext,
-        parent: Option<AliyunDriveParent>,
+        path: String,
         limit: Option<usize>,
     ) -> Self {
         AliyunDriveLister {
             core,
             ctx,
-            parent,
+            parent: None,
+            path: Some(path),
             limit,
+        }
+    }
+
+    async fn parent(&self) -> Result<Option<AliyunDriveParent>> {
+        if let Some(parent) = &self.parent {
+            return Ok(Some(parent.clone()));
+        }
+
+        let Some(path) = &self.path else {
+            return Ok(None);
+        };
+
+        match self.core.get_by_path(&self.ctx, path).await {
+            Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+            Err(err) => Err(err),
+            Ok(res) => {
+                let file: AliyunDriveFile =
+                    serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
+                Ok(Some(AliyunDriveParent {
+                    file_id: file.file_id,
+                    path: path.to_string(),
+                    updated_at: file.updated_at,
+                }))
+            }
         }
     }
 }
 
 impl oio::PageList for AliyunDriveLister {
     async fn next_page(&self, ctx: &mut oio::PageContext) -> Result<()> {
-        let Some(parent) = &self.parent else {
+        let Some(parent) = self.parent().await? else {
             ctx.done = true;
             return Ok(());
         };

--- a/core/services/aliyun-drive/src/writer.rs
+++ b/core/services/aliyun-drive/src/writer.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use bytes::Buf;
 
 use super::core::AliyunDriveCore;
+use super::core::AliyunDriveFile;
 use super::core::CheckNameMode;
 use super::core::CreateResponse;
 use super::core::CreateType;
@@ -37,6 +38,82 @@ pub struct AliyunDriveWriter {
     file_id: Option<String>,
     upload_id: Option<String>,
     part_number: usize,
+}
+
+pub struct AliyunDriveLazyWriter {
+    core: Arc<AliyunDriveCore>,
+    ctx: OperationContext,
+    path: String,
+    args: OpWrite,
+    inner: Option<AliyunDriveWriter>,
+}
+
+impl AliyunDriveLazyWriter {
+    pub fn new(
+        core: Arc<AliyunDriveCore>,
+        ctx: OperationContext,
+        path: String,
+        args: OpWrite,
+    ) -> Self {
+        Self {
+            core,
+            ctx,
+            path,
+            args,
+            inner: None,
+        }
+    }
+
+    async fn inner(&mut self) -> Result<&mut AliyunDriveWriter> {
+        if self.inner.is_none() {
+            let parent_path = get_parent(&self.path);
+            let parent_file_id = self.core.ensure_dir_exists(&self.ctx, parent_path).await?;
+
+            // write can overwrite
+            match self.core.get_by_path(&self.ctx, &self.path).await {
+                Err(err) if err.kind() == ErrorKind::NotFound => {}
+                Err(err) => return Err(err),
+                Ok(res) => {
+                    let file: AliyunDriveFile =
+                        serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
+                    self.core.delete_path(&self.ctx, &file.file_id).await?;
+                }
+            };
+
+            self.inner = Some(AliyunDriveWriter::new(
+                self.core.clone(),
+                self.ctx.clone(),
+                &parent_file_id,
+                get_basename(&self.path),
+                self.args.clone(),
+            ));
+        }
+
+        Ok(self
+            .inner
+            .as_mut()
+            .expect("aliyun drive writer must be initialized"))
+    }
+}
+
+impl oio::Write for AliyunDriveLazyWriter {
+    async fn write(&mut self, bs: Buffer) -> Result<()> {
+        self.inner().await?.write(bs).await
+    }
+
+    async fn close(&mut self) -> Result<Metadata> {
+        match &mut self.inner {
+            Some(w) => w.close().await,
+            None => Ok(Metadata::default()),
+        }
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        match &mut self.inner {
+            Some(w) => w.abort().await,
+            None => Ok(()),
+        }
+    }
 }
 
 impl AliyunDriveWriter {

--- a/core/services/alluxio/src/backend.rs
+++ b/core/services/alluxio/src/backend.rs
@@ -195,29 +195,21 @@ impl Service for AlluxioBackend {
 
         Ok(RpStat::new(file_info.try_into()?))
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<AlluxioReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(AlluxioReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<AlluxioReader> = {
+            Ok(oio::StreamReader::new(AlluxioReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, AlluxioWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: AlluxioWriters = {
             let w = AlluxioWriter::new(
                 self.core.clone(),
                 ctx.clone(),
@@ -225,45 +217,40 @@ impl Service for AlluxioBackend {
                 path.to_string(),
             );
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<AlluxioDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(AlluxioDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<AlluxioDeleter> = {
+            Ok(oio::OneShotDeleter::new(AlluxioDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<AlluxioLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, _args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<AlluxioLister> = {
             let l = AlluxioLister::new(self.core.clone(), ctx.clone(), path);
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/azblob/src/backend.rs
+++ b/core/services/azblob/src/backend.rs
@@ -555,29 +555,21 @@ impl Service for AzblobBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<AzblobReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(AzblobReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<AzblobReader> = {
+            Ok(oio::StreamReader::new(AzblobReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, AzblobWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: AzblobWriters = {
             let w = AzblobWriter::new(
                 self.core.clone(),
                 ctx.clone(),
@@ -594,33 +586,25 @@ impl Service for AzblobBackend {
                 ))
             };
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::BatchDeleter<AzblobDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::BatchDeleter::new(
-                    AzblobDeleter::new(self.core.clone(), ctx.clone()),
-                    self.core.capability.delete_max_size,
-                ),
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::BatchDeleter<AzblobDeleter> = {
+            Ok(oio::BatchDeleter::new(
+                AzblobDeleter::new(self.core.clone(), ctx.clone()),
+                self.core.capability.delete_max_size,
             ))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<AzblobLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<AzblobLister> = {
             let l = AzblobLister::new(
                 self.core.clone(),
                 ctx.clone(),
@@ -629,26 +613,26 @@ impl Service for AzblobBackend {
                 args.limit(),
             );
 
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, AzblobCopiers) = {
+    ) -> Result<Self::Copier> {
+        let output: AzblobCopiers = {
             let copier = new_azblob_copier(self.core.clone(), ctx, from, to, args, opts)?;
-            Ok((RpCopy::default(), copier))
+            Ok(copier)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
     async fn rename(

--- a/core/services/azdls/Cargo.toml
+++ b/core/services/azdls/Cargo.toml
@@ -35,6 +35,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
+mea = { workspace = true }
 opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 opendal-service-azure-common = { path = "../azure-common", version = "0.57.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/azdls/src/backend.rs
+++ b/core/services/azdls/src/backend.rs
@@ -38,6 +38,7 @@ use super::core::DIRECTORY;
 use super::deleter::AzdlsDeleter;
 use super::error::parse_error;
 use super::lister::AzdlsLister;
+use super::writer::AzdlsLazyPositionWriter;
 use super::writer::AzdlsWriter;
 use super::writer::AzdlsWriters;
 use opendal_core::raw::*;
@@ -457,29 +458,21 @@ impl Service for AzdlsBackend {
         let metadata = self.core.azdls_stat_metadata(ctx, path).await?;
         Ok(RpStat::new(metadata))
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<AzdlsReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(AzdlsReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<AzdlsReader> = {
+            Ok(oio::StreamReader::new(AzdlsReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, AzdlsWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: AzdlsWriters = {
             if args.append() {
                 let w = AzdlsWriter::new(
                     self.core.clone(),
@@ -487,44 +480,39 @@ impl Service for AzdlsBackend {
                     args.clone(),
                     path.to_string(),
                 );
-                Ok((
-                    RpWrite::default(),
-                    AzdlsWriters::Two(oio::AppendWriter::new(w)),
-                ))
+                Ok(AzdlsWriters::Two(oio::AppendWriter::new(w)))
             } else {
-                let w = AzdlsWriter::create(
+                let w = AzdlsWriter::new(
                     self.core.clone(),
                     ctx.clone(),
                     args.clone(),
                     path.to_string(),
-                )
-                .await?;
-                let w = oio::PositionWriter::new(ctx.executor().clone(), w, args.concurrent());
-                Ok((RpWrite::default(), AzdlsWriters::One(w)))
+                );
+                let w = oio::PositionWriter::new(
+                    ctx.executor().clone(),
+                    AzdlsLazyPositionWriter::new(w),
+                    args.concurrent(),
+                );
+                Ok(AzdlsWriters::One(w))
             }
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<AzdlsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(AzdlsDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<AzdlsDeleter> = {
+            Ok(oio::OneShotDeleter::new(AzdlsDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<AzdlsLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<AzdlsLister> = {
             let l = AzdlsLister::new(
                 self.core.clone(),
                 ctx.clone(),
@@ -532,20 +520,20 @@ impl Service for AzdlsBackend {
                 args.limit(),
             );
 
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/azdls/src/writer.rs
+++ b/core/services/azdls/src/writer.rs
@@ -18,6 +18,7 @@
 use std::sync::Arc;
 
 use http::StatusCode;
+use mea::once::OnceCell;
 
 use super::core::AzdlsCore;
 use super::core::FILE;
@@ -27,7 +28,29 @@ use opendal_core::raw::*;
 use opendal_core::*;
 
 /// Writer type for azdls: non-append uses PositionWriter, append uses AppendWriter.
-pub type AzdlsWriters = TwoWays<oio::PositionWriter<AzdlsWriter>, oio::AppendWriter<AzdlsWriter>>;
+pub type AzdlsWriters =
+    TwoWays<oio::PositionWriter<AzdlsLazyPositionWriter>, oio::AppendWriter<AzdlsWriter>>;
+
+pub struct AzdlsLazyPositionWriter {
+    inner: AzdlsWriter,
+    created: OnceCell<()>,
+}
+
+impl AzdlsLazyPositionWriter {
+    pub fn new(inner: AzdlsWriter) -> Self {
+        Self {
+            inner,
+            created: OnceCell::new(),
+        }
+    }
+
+    async fn ensure_created(&self) -> Result<()> {
+        self.created
+            .get_or_try_init(async || self.inner.create_if_needed().await)
+            .await?;
+        Ok(())
+    }
+}
 
 #[derive(Clone)]
 pub struct AzdlsWriter {
@@ -45,17 +68,6 @@ impl AzdlsWriter {
             op,
             path,
         }
-    }
-
-    pub async fn create(
-        core: Arc<AzdlsCore>,
-        ctx: OperationContext,
-        op: OpWrite,
-        path: String,
-    ) -> Result<Self> {
-        let writer = Self::new(core, ctx, op, path);
-        writer.create_if_needed().await?;
-        Ok(writer)
     }
 
     async fn create_if_needed(&self) -> Result<()> {
@@ -127,6 +139,22 @@ impl oio::PositionWrite for AzdlsWriter {
             ErrorKind::Unsupported,
             "Abort is not supported for azdls writer",
         ))
+    }
+}
+
+impl oio::PositionWrite for AzdlsLazyPositionWriter {
+    async fn write_all_at(&self, offset: u64, buf: Buffer) -> Result<()> {
+        self.ensure_created().await?;
+        self.inner.write_all_at(offset, buf).await
+    }
+
+    async fn close(&self, size: u64) -> Result<Metadata> {
+        self.ensure_created().await?;
+        self.inner.close(size).await
+    }
+
+    async fn abort(&self) -> Result<()> {
+        self.inner.abort().await
     }
 }
 

--- a/core/services/azfile/src/backend.rs
+++ b/core/services/azfile/src/backend.rs
@@ -378,30 +378,21 @@ impl Service for AzfileBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<AzfileReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(AzfileReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<AzfileReader> = {
+            Ok(oio::StreamReader::new(AzfileReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, AzfileWriters) = {
-            self.core.ensure_parent_dir_exists(ctx, path).await?;
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: AzfileWriters = {
             let w = AzfileWriter::new(
                 self.core.clone(),
                 ctx.clone(),
@@ -413,30 +404,25 @@ impl Service for AzfileBackend {
             } else {
                 AzfileWriters::One(oio::OneShotWriter::new(w))
             };
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<AzfileDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(AzfileDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<AzfileDeleter> = {
+            Ok(oio::OneShotDeleter::new(AzfileDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<AzfileLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<AzfileLister> = {
             let l = AzfileLister::new(
                 self.core.clone(),
                 ctx.clone(),
@@ -444,20 +430,20 @@ impl Service for AzfileBackend {
                 args.limit(),
             );
 
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/azfile/src/writer.rs
+++ b/core/services/azfile/src/writer.rs
@@ -43,6 +43,12 @@ impl AzfileWriter {
         }
     }
 
+    async fn ensure_parent_dir_exists(&self) -> Result<()> {
+        self.core
+            .ensure_parent_dir_exists(&self.ctx, &self.path)
+            .await
+    }
+
     fn parse_metadata(headers: &http::HeaderMap) -> Result<Metadata> {
         let mut metadata = Metadata::default();
 
@@ -60,6 +66,8 @@ impl AzfileWriter {
 
 impl oio::OneShotWrite for AzfileWriter {
     async fn write_once(&self, bs: Buffer) -> Result<Metadata> {
+        self.ensure_parent_dir_exists().await?;
+
         let size = bs.len();
         let resp = self
             .core
@@ -90,6 +98,8 @@ impl oio::OneShotWrite for AzfileWriter {
 
 impl oio::AppendWrite for AzfileWriter {
     async fn offset(&self) -> Result<u64> {
+        self.ensure_parent_dir_exists().await?;
+
         let resp = self
             .core
             .azfile_get_file_properties(&self.ctx, &self.path)

--- a/core/services/b2/src/backend.rs
+++ b/core/services/b2/src/backend.rs
@@ -269,7 +269,7 @@ impl Service for B2Backend {
     type Writer = B2Writers;
     type Lister = oio::PageLister<B2Lister>;
     type Deleter = oio::OneShotDeleter<B2Deleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -305,102 +305,88 @@ impl Service for B2Backend {
         let meta = parse_file_info(&file_info);
         Ok(RpStat::new(meta))
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<B2Reader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(B2Reader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<B2Reader> = {
+            Ok(oio::StreamReader::new(B2Reader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, B2Writers) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: B2Writers = {
             let concurrent = args.concurrent();
             let writer = B2Writer::new(self.core.clone(), ctx.clone(), path, args);
 
             let w = oio::MultipartWriter::new(ctx.executor().clone(), writer, concurrent);
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<B2Deleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(B2Deleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<B2Deleter> = {
+            Ok(oio::OneShotDeleter::new(B2Deleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<B2Lister>) = {
-            Ok((
-                RpList::default(),
-                oio::PageLister::new(B2Lister::new(
-                    self.core.clone(),
-                    ctx.clone(),
-                    path,
-                    args.recursive(),
-                    args.limit(),
-                    args.start_after(),
-                )),
-            ))
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<B2Lister> = {
+            Ok(oio::PageLister::new(B2Lister::new(
+                self.core.clone(),
+                ctx.clone(),
+                path,
+                args.recursive(),
+                args.limit(),
+                args.start_after(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let file_info = self.core.get_file_info(ctx, from, None).await?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
 
+        Ok(oio::OneShotCopier::new(async move {
+            let file_info = core.get_file_info(&ctx, &from, None).await?;
             let source_file_id = file_info.file_id;
 
             let Some(source_file_id) = source_file_id else {
                 return Err(Error::new(ErrorKind::IsADirectory, "is a directory"));
             };
 
-            let resp = self.core.copy_file(ctx, source_file_id, to).await?;
+            let resp = core.copy_file(&ctx, source_file_id, &to).await?;
 
             let status = resp.status();
 
             match status {
-                StatusCode::OK => Ok((RpCopy::default(), ())),
+                StatusCode::OK => Ok(Metadata::default()),
                 _ => Err(parse_error(resp)),
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
     async fn rename(

--- a/core/services/cacache/src/backend.rs
+++ b/core/services/cacache/src/backend.rs
@@ -161,69 +161,50 @@ impl Service for CacacheBackend {
             None => Err(Error::new(ErrorKind::NotFound, "entry not found")),
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<CacacheReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(CacacheReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<CacacheReader> = {
+            Ok(oio::StreamReader::new(CacacheReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, CacacheWriter) = {
-            Ok((
-                RpWrite::new(),
-                CacacheWriter::new(self.core.clone(), path.to_string()),
-            ))
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: CacacheWriter =
+            { Ok(CacacheWriter::new(self.core.clone(), path.to_string())) }?;
+
+        Ok(output)
+    }
+
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<CacacheDeleter> = {
+            Ok(oio::OneShotDeleter::new(CacacheDeleter::new(
+                self.core.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<CacacheDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(CacacheDeleter::new(self.core.clone())),
-            ))
-        }?;
-
-        Ok((rp, output))
-    }
-
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/cloudflare-kv/src/backend.rs
+++ b/core/services/cloudflare-kv/src/backend.rs
@@ -479,66 +479,45 @@ impl Service for CloudflareKvBackend {
 
         Ok(RpStat::new(meta))
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<CloudflareKvReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(CloudflareKvReader::new(
-                    self.clone(),
-                    ctx.clone(),
-                    path,
-                    args,
-                )),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<CloudflareKvReader> = {
+            Ok(oio::StreamReader::new(CloudflareKvReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, oio::OneShotWriter<CloudflareWriter>) = {
+    fn write(&self, ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: oio::OneShotWriter<CloudflareWriter> = {
             let path = build_abs_path(&self.core.info.root(), path);
             let writer = CloudflareWriter::new(self.core.clone(), ctx.clone(), path);
 
             let w = oio::OneShotWriter::new(writer);
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::BatchDeleter<CloudflareKvDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::BatchDeleter::new(
-                    CloudflareKvDeleter::new(self.core.clone(), ctx.clone()),
-                    self.core.capability.delete_max_size,
-                ),
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::BatchDeleter<CloudflareKvDeleter> = {
+            Ok(oio::BatchDeleter::new(
+                CloudflareKvDeleter::new(self.core.clone(), ctx.clone()),
+                self.core.capability.delete_max_size,
             ))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<CloudflareKvLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<CloudflareKvLister> = {
             let path = build_abs_path(&self.core.info.root(), path);
 
             let limit = match args.limit() {
@@ -561,20 +540,20 @@ impl Service for CloudflareKvBackend {
                 Some(limit),
             );
 
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/compfs/src/backend.rs
+++ b/core/services/compfs/src/backend.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::io::Cursor;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use compio::buf::IntoInner;
@@ -158,12 +159,158 @@ impl oio::PositionRead for CompfsReader {
     }
 }
 
+pub struct CompfsLazyReader {
+    core: Arc<CompfsCore>,
+    path: PathBuf,
+}
+
+impl CompfsLazyReader {
+    fn new(core: Arc<CompfsCore>, path: PathBuf) -> Self {
+        Self { core, path }
+    }
+
+    async fn reader(&self) -> Result<oio::PositionReader<CompfsReader>> {
+        let path = self.path.clone();
+        let file = self
+            .core
+            .exec(move || async move {
+                let file = compio::fs::OpenOptions::new()
+                    .read(true)
+                    .open(&path)
+                    .await?;
+                Ok(file)
+            })
+            .await?;
+
+        Ok(oio::PositionReader::new(CompfsReader::new(
+            self.core.clone(),
+            file,
+        )))
+    }
+}
+
+impl oio::Read for CompfsLazyReader {
+    async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
+        self.reader().await?.open(range).await
+    }
+
+    async fn read(&self, range: BytesRange) -> Result<(RpRead, Buffer)> {
+        self.reader().await?.read(range).await
+    }
+}
+
+pub struct CompfsLazyWriter {
+    core: Arc<CompfsCore>,
+    path: PathBuf,
+    args: OpWrite,
+    inner: Option<CompfsWriter>,
+}
+
+impl CompfsLazyWriter {
+    fn new(core: Arc<CompfsCore>, path: PathBuf, args: OpWrite) -> Self {
+        Self {
+            core,
+            path,
+            args,
+            inner: None,
+        }
+    }
+
+    async fn inner(&mut self) -> Result<&mut CompfsWriter> {
+        if self.inner.is_none() {
+            let path = self.path.clone();
+            let append = self.args.append();
+            let file = self
+                .core
+                .exec(move || async move {
+                    if let Some(parent) = path.parent() {
+                        compio::fs::create_dir_all(parent).await?;
+                    }
+                    let file = compio::fs::OpenOptions::new()
+                        .create(true)
+                        .write(true)
+                        .truncate(!append)
+                        .open(path)
+                        .await?;
+                    let mut file = Cursor::new(file);
+                    if append {
+                        let len = file.get_ref().metadata().await?.len();
+                        file.set_position(len);
+                    }
+                    Ok(file)
+                })
+                .await?;
+
+            self.inner = Some(CompfsWriter::new(self.core.clone(), file));
+        }
+
+        Ok(self.inner.as_mut().expect("writer must be initialized"))
+    }
+}
+
+impl oio::Write for CompfsLazyWriter {
+    async fn write(&mut self, bs: Buffer) -> Result<()> {
+        self.inner().await?.write(bs).await
+    }
+
+    async fn close(&mut self) -> Result<Metadata> {
+        self.inner().await?.close().await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        self.inner().await?.abort().await
+    }
+}
+
+pub struct CompfsLazyLister {
+    core: Arc<CompfsCore>,
+    path: PathBuf,
+    inner: Option<Option<CompfsLister>>,
+}
+
+impl CompfsLazyLister {
+    fn new(core: Arc<CompfsCore>, path: PathBuf) -> Self {
+        Self {
+            core,
+            path,
+            inner: None,
+        }
+    }
+}
+
+impl oio::List for CompfsLazyLister {
+    async fn next(&mut self) -> Result<Option<oio::Entry>> {
+        if self.inner.is_none() {
+            let path = self.path.clone();
+            self.inner = Some(
+                match self
+                    .core
+                    .exec_blocking({
+                        let path = path.clone();
+                        move || std::fs::read_dir(path)
+                    })
+                    .await?
+                {
+                    Ok(read_dir) => Some(CompfsLister::new(self.core.clone(), &path, read_dir)),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+                    Err(e) => return Err(new_std_io_error(e)),
+                },
+            );
+        }
+
+        match self.inner.as_mut().expect("lister must be initialized") {
+            Some(lister) => lister.next().await,
+            None => Ok(None),
+        }
+    }
+}
+
 impl Service for CompfsBackend {
-    type Reader = oio::PositionReader<CompfsReader>;
-    type Writer = CompfsWriter;
-    type Lister = Option<CompfsLister>;
+    type Reader = CompfsLazyReader;
+    type Writer = CompfsLazyWriter;
+    type Lister = CompfsLazyLister;
     type Deleter = oio::OneShotDeleter<CompfsDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -209,53 +356,48 @@ impl Service for CompfsBackend {
         Ok(RpStat::new(ret))
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<CompfsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(CompfsDeleter::new(self.core.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<CompfsDeleter> = {
+            Ok(oio::OneShotDeleter::new(CompfsDeleter::new(
+                self.core.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         from: &str,
         to: &str,
         _: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let from = self.core.prepare_path(from)?;
-            let to = self.core.prepare_path(to)?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let from = self.core.prepare_path(from)?;
+        let to = self.core.prepare_path(to)?;
 
-            self.core
-                .exec(move || async move {
-                    let from = OpenOptions::new().read(true).open(from).await?;
-                    if let Some(parent) = to.parent() {
-                        compio::fs::create_dir_all(parent).await?;
-                    }
-                    let to = OpenOptions::new()
-                        .write(true)
-                        .create(true)
-                        .truncate(true)
-                        .open(to)
-                        .await?;
+        Ok(oio::OneShotCopier::new(async move {
+            core.exec(move || async move {
+                let from = OpenOptions::new().read(true).open(from).await?;
+                if let Some(parent) = to.parent() {
+                    compio::fs::create_dir_all(parent).await?;
+                }
+                let to = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(to)
+                    .await?;
 
-                    let (mut from, mut to) = (Cursor::new(from), Cursor::new(to));
-                    compio::io::copy(&mut from, &mut to).await?;
+                let (mut from, mut to) = (Cursor::new(from), Cursor::new(to));
+                compio::io::copy(&mut from, &mut to).await?;
 
-                    Ok(())
-                })
-                .await?;
-
-            Ok((RpCopy::default(), ()))
-        }?;
-
-        Ok((rp, output))
+                Ok(Metadata::default())
+            })
+            .await
+        }))
     }
 
     async fn rename(
@@ -279,98 +421,26 @@ impl Service for CompfsBackend {
 
         Ok(RpRename::default())
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::PositionReader<CompfsReader>) = {
-            let path = self.core.prepare_path(path)?;
-            let file = self
-                .core
-                .exec(move || async move {
-                    let file = compio::fs::OpenOptions::new()
-                        .read(true)
-                        .open(&path)
-                        .await?;
-                    Ok(file)
-                })
-                .await?;
-
-            Ok((
-                RpRead::default(),
-                oio::PositionReader::new(CompfsReader::new(self.core.clone(), file)),
-            ))
-        }?;
-
-        Ok((rp, output))
+    fn read(&self, _ctx: &OperationContext, path: &str, _: OpRead) -> Result<Self::Reader> {
+        Ok(CompfsLazyReader::new(
+            self.core.clone(),
+            self.core.prepare_path(path)?,
+        ))
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, CompfsWriter) = {
-            let path = self.core.prepare_path(path)?;
-            let append = args.append();
-            let file = self
-                .core
-                .exec(move || async move {
-                    if let Some(parent) = path.parent() {
-                        compio::fs::create_dir_all(parent).await?;
-                    }
-                    let file = compio::fs::OpenOptions::new()
-                        .create(true)
-                        .write(true)
-                        .truncate(!append)
-                        .open(path)
-                        .await?;
-                    let mut file = Cursor::new(file);
-                    if append {
-                        let len = file.get_ref().metadata().await?.len();
-                        file.set_position(len);
-                    }
-                    Ok(file)
-                })
-                .await?;
-
-            let w = CompfsWriter::new(self.core.clone(), file);
-            Ok((RpWrite::new(), w))
-        }?;
-
-        Ok((rp, output))
+    fn write(&self, _ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        Ok(CompfsLazyWriter::new(
+            self.core.clone(),
+            self.core.prepare_path(path)?,
+            args,
+        ))
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, Option<CompfsLister>) = {
-            let path = self.core.prepare_path(path)?;
-
-            match self
-                .core
-                .exec_blocking({
-                    let path = path.clone();
-                    move || std::fs::read_dir(path)
-                })
-                .await?
-            {
-                Ok(read_dir) => {
-                    let lister = CompfsLister::new(self.core.clone(), &path, read_dir);
-                    Ok((RpList::default(), Some(lister)))
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok((RpList::default(), None)),
-                Err(e) => Err(new_std_io_error(e)),
-            }
-        }?;
-
-        Ok((rp, output))
+    fn list(&self, _ctx: &OperationContext, path: &str, _: OpList) -> Result<Self::Lister> {
+        Ok(CompfsLazyLister::new(
+            self.core.clone(),
+            self.core.prepare_path(path)?,
+        ))
     }
 
     async fn presign(

--- a/core/services/cos/src/backend.rs
+++ b/core/services/cos/src/backend.rs
@@ -359,7 +359,7 @@ impl Service for CosBackend {
     type Writer = CosWriters;
     type Lister = CosListers;
     type Deleter = oio::OneShotDeleter<CosDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -407,29 +407,21 @@ impl Service for CosBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<CosReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(CosReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<CosReader> = {
+            Ok(oio::StreamReader::new(CosReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, CosWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: CosWriters = {
             let writer = CosWriter::new(self.core.clone(), ctx.clone(), path, args.clone());
 
             let w = if args.append() {
@@ -442,30 +434,25 @@ impl Service for CosBackend {
                 ))
             };
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<CosDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(CosDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<CosDeleter> = {
+            Ok(oio::OneShotDeleter::new(CosDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, CosListers) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: CosListers = {
             let l = if args.versions() || args.deleted() {
                 TwoWays::Two(oio::PageLister::new(CosObjectVersionsLister::new(
                     self.core.clone(),
@@ -483,32 +470,34 @@ impl Service for CosBackend {
                 )))
             };
 
-            Ok((RpList::default(), l))
+            Ok(l)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let resp = self.core.cos_copy_object(ctx, from, to, &args).await?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
+        Ok(oio::OneShotCopier::new(async move {
+            let resp = core.cos_copy_object(&ctx, &from, &to, &args).await?;
 
             let status = resp.status();
 
             match status {
-                StatusCode::OK => Ok((RpCopy::default(), ())),
+                StatusCode::OK => Ok(Metadata::default()),
                 _ => Err(parse_error(resp)),
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
     async fn rename(

--- a/core/services/d1/src/backend.rs
+++ b/core/services/d1/src/backend.rs
@@ -294,74 +294,55 @@ impl Service for D1Backend {
             }
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<D1Reader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(D1Reader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<D1Reader> = {
+            Ok(oio::StreamReader::new(D1Reader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, D1Writer) = {
+    fn write(&self, ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: D1Writer = {
             let p = build_abs_path(&self.root, path);
-            Ok((
-                RpWrite::new(),
-                D1Writer::new(self.core.clone(), ctx.clone(), p),
-            ))
+            Ok(D1Writer::new(self.core.clone(), ctx.clone(), p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<D1Deleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(D1Deleter::new(
-                    self.core.clone(),
-                    ctx.clone(),
-                    self.root.clone(),
-                )),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<D1Deleter> = {
+            Ok(oio::OneShotDeleter::new(D1Deleter::new(
+                self.core.clone(),
+                ctx.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/dashmap/src/backend.rs
+++ b/core/services/dashmap/src/backend.rs
@@ -194,73 +194,56 @@ impl Service for DashmapBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<DashmapReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(DashmapReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<DashmapReader> = {
+            Ok(oio::StreamReader::new(DashmapReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, DashmapWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: DashmapWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((
-                RpWrite::new(),
-                DashmapWriter::new(self.core.clone(), p, args),
-            ))
+            Ok(DashmapWriter::new(self.core.clone(), p, args))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<DashmapDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(DashmapDeleter::new(self.core.clone(), self.root.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<DashmapDeleter> = {
+            Ok(oio::OneShotDeleter::new(DashmapDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::HierarchyLister<DashmapLister>) = {
+    fn list(&self, _ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::HierarchyLister<DashmapLister> = {
             let lister = DashmapLister::new(self.core.clone(), self.root.clone(), path.to_string());
             let lister = oio::HierarchyLister::new(lister, path, args.recursive());
-            Ok((RpList::default(), lister))
+            Ok(lister)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/dbfs/src/backend.rs
+++ b/core/services/dbfs/src/backend.rs
@@ -204,63 +204,45 @@ impl Service for DbfsBackend {
         }
     }
 
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
+    fn read(&self, _ctx: &OperationContext, _path: &str, _args: OpRead) -> Result<Self::Reader> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, oio::OneShotWriter<DbfsWriter>) = {
-            Ok((
-                RpWrite::default(),
-                oio::OneShotWriter::new(DbfsWriter::new(
-                    self.core.clone(),
-                    ctx.clone(),
-                    args,
-                    path.to_string(),
-                )),
-            ))
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: oio::OneShotWriter<DbfsWriter> = {
+            Ok(oio::OneShotWriter::new(DbfsWriter::new(
+                self.core.clone(),
+                ctx.clone(),
+                args,
+                path.to_string(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<DbfsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(DbfsDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<DbfsDeleter> = {
+            Ok(oio::OneShotDeleter::new(DbfsDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<DbfsLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, _args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<DbfsLister> = {
             let l = DbfsLister::new(self.core.clone(), ctx.clone(), path.to_string());
 
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
     async fn rename(
@@ -282,14 +264,14 @@ impl Service for DbfsBackend {
         }
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/dropbox/src/backend.rs
+++ b/core/services/dropbox/src/backend.rs
@@ -85,7 +85,7 @@ impl Service for DropboxBackend {
     type Writer = oio::OneShotWriter<DropboxWriter>;
     type Lister = oio::PageLister<DropboxLister>;
     type Deleter = oio::OneShotDeleter<DropboxDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -159,102 +159,85 @@ impl Service for DropboxBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<DropboxReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(DropboxReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<DropboxReader> = {
+            Ok(oio::StreamReader::new(DropboxReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, oio::OneShotWriter<DropboxWriter>) = {
-            Ok((
-                RpWrite::default(),
-                oio::OneShotWriter::new(DropboxWriter::new(
-                    self.core.clone(),
-                    ctx.clone(),
-                    args,
-                    String::from(path),
-                )),
-            ))
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: oio::OneShotWriter<DropboxWriter> = {
+            Ok(oio::OneShotWriter::new(DropboxWriter::new(
+                self.core.clone(),
+                ctx.clone(),
+                args,
+                String::from(path),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<DropboxDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(DropboxDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<DropboxDeleter> = {
+            Ok(oio::OneShotDeleter::new(DropboxDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<DropboxLister>) = {
-            Ok((
-                RpList::default(),
-                oio::PageLister::new(DropboxLister::new(
-                    self.core.clone(),
-                    ctx.clone(),
-                    path.to_string(),
-                    args.recursive(),
-                    args.limit(),
-                )),
-            ))
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<DropboxLister> = {
+            Ok(oio::PageLister::new(DropboxLister::new(
+                self.core.clone(),
+                ctx.clone(),
+                path.to_string(),
+                args.recursive(),
+                args.limit(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let resp = self.core.dropbox_copy(ctx, from, to).await?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
 
+        Ok(oio::OneShotCopier::new(async move {
+            let resp = core.dropbox_copy(&ctx, &from, &to).await?;
             let status = resp.status();
 
             match status {
-                StatusCode::OK => Ok((RpCopy::default(), ())),
+                StatusCode::OK => Ok(Metadata::default()),
                 _ => {
                     let err = parse_error(resp);
                     match err.kind() {
-                        ErrorKind::NotFound => Ok((RpCopy::default(), ())),
+                        ErrorKind::NotFound => Ok(Metadata::default()),
                         _ => Err(err),
                     }
                 }
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
     async fn rename(

--- a/core/services/etcd/src/backend.rs
+++ b/core/services/etcd/src/backend.rs
@@ -27,7 +27,7 @@ use super::config::EtcdConfig;
 use super::core::EtcdCore;
 use super::core::constants::DEFAULT_ETCD_ENDPOINTS;
 use super::deleter::EtcdDeleter;
-use super::lister::EtcdLister;
+use super::lister::EtcdLazyLister;
 use super::writer::EtcdWriter;
 use opendal_core::raw::*;
 use opendal_core::*;
@@ -242,7 +242,7 @@ impl oio::StreamRead for EtcdReader {
 impl Service for EtcdBackend {
     type Reader = oio::StreamReader<EtcdReader>;
     type Writer = EtcdWriter;
-    type Lister = oio::HierarchyLister<EtcdLister>;
+    type Lister = oio::HierarchyLister<EtcdLazyLister>;
     type Deleter = oio::OneShotDeleter<EtcdDeleter>;
     type Copier = ();
 
@@ -306,77 +306,62 @@ impl Service for EtcdBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        op: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<EtcdReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(EtcdReader::new(self.clone(), path, op)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, op: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<EtcdReader> = {
+            Ok(oio::StreamReader::new(EtcdReader::new(
+                self.clone(),
+                path,
+                op,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _op: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, EtcdWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _op: OpWrite) -> Result<Self::Writer> {
+        let output: EtcdWriter = {
             let abs_path = build_abs_path(&self.info.root(), path);
             let writer = EtcdWriter::new(self.core.clone(), abs_path);
-            Ok((RpWrite::new(), writer))
+            Ok(writer)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<EtcdDeleter>) = {
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<EtcdDeleter> = {
             let deleter = oio::OneShotDeleter::new(EtcdDeleter::new(
                 self.core.clone(),
                 self.info.root().to_string(),
             ));
-            Ok((RpDelete::default(), deleter))
+            Ok(deleter)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::HierarchyLister<EtcdLister>) = {
-            let lister = EtcdLister::new(
+    fn list(&self, _ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::HierarchyLister<EtcdLazyLister> = {
+            let lister = EtcdLazyLister::new(
                 self.core.clone(),
                 self.info.root().to_string(),
                 path.to_string(),
-            )
-            .await?;
+            );
             let lister = oio::HierarchyLister::new(lister, path, args.recursive());
-            Ok((RpList::default(), lister))
+            Ok(lister)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/etcd/src/lister.rs
+++ b/core/services/etcd/src/lister.rs
@@ -77,3 +77,37 @@ impl oio::List for EtcdLister {
         Ok(None)
     }
 }
+
+pub struct EtcdLazyLister {
+    core: Arc<EtcdCore>,
+    root: String,
+    path: String,
+    inner: Option<EtcdLister>,
+}
+
+impl EtcdLazyLister {
+    pub fn new(core: Arc<EtcdCore>, root: String, path: String) -> Self {
+        Self {
+            core,
+            root,
+            path,
+            inner: None,
+        }
+    }
+}
+
+impl oio::List for EtcdLazyLister {
+    async fn next(&mut self) -> Result<Option<Entry>> {
+        if self.inner.is_none() {
+            self.inner = Some(
+                EtcdLister::new(self.core.clone(), self.root.clone(), self.path.clone()).await?,
+            );
+        }
+
+        self.inner
+            .as_mut()
+            .expect("lister must be initialized")
+            .next()
+            .await
+    }
+}

--- a/core/services/foundationdb/src/backend.rs
+++ b/core/services/foundationdb/src/backend.rs
@@ -202,73 +202,53 @@ impl Service for FoundationdbBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<FoundationdbReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(FoundationdbReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<FoundationdbReader> = {
+            Ok(oio::StreamReader::new(FoundationdbReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, FoundationdbWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: FoundationdbWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((
-                RpWrite::new(),
-                FoundationdbWriter::new(self.core.clone(), p),
-            ))
+            Ok(FoundationdbWriter::new(self.core.clone(), p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<FoundationdbDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(FoundationdbDeleter::new(
-                    self.core.clone(),
-                    self.root.clone(),
-                )),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<FoundationdbDeleter> = {
+            Ok(oio::OneShotDeleter::new(FoundationdbDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/foyer/src/backend.rs
+++ b/core/services/foyer/src/backend.rs
@@ -316,67 +316,53 @@ impl Service for FoyerBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<FoyerReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(FoyerReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<FoyerReader> = {
+            Ok(oio::StreamReader::new(FoyerReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, FoyerWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: FoyerWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((RpWrite::new(), FoyerWriter::new(self.core.clone(), p)))
+            Ok(FoyerWriter::new(self.core.clone(), p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<FoyerDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(FoyerDeleter::new(self.core.clone(), self.root.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<FoyerDeleter> = {
+            Ok(oio::OneShotDeleter::new(FoyerDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/fs/src/backend.rs
+++ b/core/services/fs/src/backend.rs
@@ -216,12 +216,131 @@ impl oio::PositionRead for FsReader {
     }
 }
 
+pub struct FsLazyReader {
+    core: Arc<FsCore>,
+    path: String,
+}
+
+impl FsLazyReader {
+    fn new(core: Arc<FsCore>, path: &str) -> Self {
+        Self {
+            core,
+            path: path.to_string(),
+        }
+    }
+
+    async fn reader(&self) -> Result<oio::PositionReader<FsReader>> {
+        let file = self.core.fs_open(&self.path).await?;
+        Ok(oio::PositionReader::new(FsReader::new(
+            self.core.clone(),
+            file,
+        )))
+    }
+}
+
+impl oio::Read for FsLazyReader {
+    async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
+        self.reader().await?.open(range).await
+    }
+
+    async fn read(&self, range: BytesRange) -> Result<(RpRead, Buffer)> {
+        self.reader().await?.read(range).await
+    }
+}
+
+pub struct FsLazyWriter {
+    core: Arc<FsCore>,
+    executor: Executor,
+    path: String,
+    op: OpWrite,
+    inner: Option<FsWriters>,
+}
+
+impl FsLazyWriter {
+    fn new(core: Arc<FsCore>, executor: Executor, path: &str, op: OpWrite) -> Self {
+        Self {
+            core,
+            executor,
+            path: path.to_string(),
+            op,
+            inner: None,
+        }
+    }
+
+    async fn inner(&mut self) -> Result<&mut FsWriters> {
+        if self.inner.is_none() {
+            let is_append = self.op.append();
+            let concurrent = self.op.concurrent();
+            let writer = FsWriter::create(self.core.clone(), &self.path, self.op.clone()).await?;
+            let writer = if is_append {
+                FsWriters::One(writer)
+            } else {
+                FsWriters::Two(oio::PositionWriter::new(
+                    self.executor.clone(),
+                    writer,
+                    concurrent,
+                ))
+            };
+
+            self.inner = Some(writer);
+        }
+
+        Ok(self.inner.as_mut().expect("writer must be initialized"))
+    }
+}
+
+impl oio::Write for FsLazyWriter {
+    async fn write(&mut self, bs: Buffer) -> Result<()> {
+        self.inner().await?.write(bs).await
+    }
+
+    async fn close(&mut self) -> Result<Metadata> {
+        self.inner().await?.close().await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        self.inner().await?.abort().await
+    }
+}
+
+pub struct FsLazyLister {
+    core: Arc<FsCore>,
+    path: String,
+    inner: Option<Option<FsLister<tokio::fs::ReadDir>>>,
+}
+
+impl FsLazyLister {
+    fn new(core: Arc<FsCore>, path: &str) -> Self {
+        Self {
+            core,
+            path: path.to_string(),
+            inner: None,
+        }
+    }
+}
+
+impl oio::List for FsLazyLister {
+    async fn next(&mut self) -> Result<Option<oio::Entry>> {
+        if self.inner.is_none() {
+            self.inner = Some(match self.core.fs_list(&self.path).await? {
+                Some(rd) => Some(FsLister::new(&self.core.root, &self.path, rd)),
+                None => None,
+            });
+        }
+
+        match self.inner.as_mut().expect("lister must be initialized") {
+            Some(lister) => lister.next().await,
+            None => Ok(None),
+        }
+    }
+}
+
 impl Service for FsBackend {
-    type Reader = oio::PositionReader<FsReader>;
-    type Writer = FsWriters;
-    type Lister = Option<FsLister<tokio::fs::ReadDir>>;
+    type Reader = FsLazyReader;
+    type Writer = FsLazyWriter;
+    type Lister = FsLazyLister;
     type Deleter = oio::OneShotDeleter<FsDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -246,95 +365,42 @@ impl Service for FsBackend {
         Ok(RpStat::new(m))
     }
 
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::PositionReader<FsReader>) = {
-            let file = self.core.fs_open(path).await?;
-            Ok((
-                RpRead::default(),
-                oio::PositionReader::new(FsReader::new(self.core.clone(), file)),
-            ))
-        }?;
-
-        Ok((rp, output))
+    fn read(&self, _ctx: &OperationContext, path: &str, _: OpRead) -> Result<Self::Reader> {
+        Ok(FsLazyReader::new(self.core.clone(), path))
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        op: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, FsWriters) = {
-            let is_append = op.append();
-            let concurrent = op.concurrent();
-
-            let writer = FsWriter::create(self.core.clone(), path, op).await?;
-
-            let writer = if is_append {
-                FsWriters::One(writer)
-            } else {
-                FsWriters::Two(oio::PositionWriter::new(
-                    ctx.executor().clone(),
-                    writer,
-                    concurrent,
-                ))
-            };
-
-            Ok((RpWrite::default(), writer))
-        }?;
-
-        Ok((rp, output))
+    fn write(&self, ctx: &OperationContext, path: &str, op: OpWrite) -> Result<Self::Writer> {
+        Ok(FsLazyWriter::new(
+            self.core.clone(),
+            ctx.executor().clone(),
+            path,
+            op,
+        ))
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<FsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(FsDeleter::new(self.core.clone())),
-            ))
-        }?;
-
-        Ok((rp, output))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        Ok(oio::OneShotDeleter::new(FsDeleter::new(self.core.clone())))
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, Option<FsLister<tokio::fs::ReadDir>>) = {
-            match self.core.fs_list(path).await? {
-                Some(f) => {
-                    let rd = FsLister::new(&self.core.root, path, f);
-                    Ok((RpList::default(), Some(rd)))
-                }
-                None => Ok((RpList::default(), None)),
-            }
-        }?;
-
-        Ok((rp, output))
+    fn list(&self, _ctx: &OperationContext, path: &str, _: OpList) -> Result<Self::Lister> {
+        Ok(FsLazyLister::new(self.core.clone(), path))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            self.core.fs_copy(from, to).await?;
-            Ok((RpCopy::default(), ()))
-        }?;
-
-        Ok((rp, output))
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let from = from.to_string();
+        let to = to.to_string();
+        Ok(oio::OneShotCopier::new(async move {
+            core.fs_copy(&from, &to).await?;
+            Ok(Metadata::default())
+        }))
     }
 
     async fn rename(

--- a/core/services/ftp/src/backend.rs
+++ b/core/services/ftp/src/backend.rs
@@ -201,6 +201,125 @@ impl FtpReader {
     }
 }
 
+pub struct FtpLazyWriter {
+    core: Arc<FtpCore>,
+    path: String,
+    append: bool,
+    inner: Option<FtpWriter>,
+}
+
+impl FtpLazyWriter {
+    fn new(core: Arc<FtpCore>, path: &str, op: OpWrite) -> Self {
+        Self {
+            core,
+            path: path.to_string(),
+            append: op.append(),
+            inner: None,
+        }
+    }
+
+    async fn inner(&mut self) -> Result<&mut FtpWriter> {
+        if self.inner.is_none() {
+            let parent = get_parent(&self.path);
+            let paths: Vec<&str> = parent.split('/').collect();
+
+            // TODO: we can optimize this by checking dir existence first.
+            let mut ftp_stream = self.core.ftp_connect(Operation::Write).await?;
+            let mut curr_path = String::new();
+
+            for path in paths {
+                if path.is_empty() {
+                    continue;
+                }
+                curr_path.push_str(path);
+                curr_path.push('/');
+                match ftp_stream.mkdir(&curr_path).await {
+                    // Do nothing if status is FileUnavailable or OK(()) is return.
+                    Err(FtpError::UnexpectedResponse(Response {
+                        status: Status::FileUnavailable,
+                        ..
+                    }))
+                    | Ok(()) => (),
+                    Err(e) => {
+                        return Err(format_ftp_error(e));
+                    }
+                }
+            }
+
+            let tmp_path = (!self.append).then_some(build_tmp_path_of(&self.path));
+            let w = FtpWriter::new(ftp_stream, self.path.clone(), tmp_path);
+            self.inner = Some(w);
+        }
+
+        Ok(self.inner.as_mut().expect("ftp writer must be initialized"))
+    }
+}
+
+impl oio::Write for FtpLazyWriter {
+    async fn write(&mut self, bs: Buffer) -> Result<()> {
+        self.inner().await?.write(bs).await
+    }
+
+    async fn close(&mut self) -> Result<Metadata> {
+        match &mut self.inner {
+            Some(w) => w.close().await,
+            None => Ok(Metadata::default()),
+        }
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        match &mut self.inner {
+            Some(w) => w.abort().await,
+            None => Err(Error::new(
+                ErrorKind::Unsupported,
+                "FtpWriter doesn't support abort",
+            )),
+        }
+    }
+}
+
+pub struct FtpLazyLister {
+    core: Arc<FtpCore>,
+    path: String,
+    inner: Option<FtpLister>,
+}
+
+impl FtpLazyLister {
+    fn new(core: Arc<FtpCore>, path: &str) -> Self {
+        Self {
+            core,
+            path: path.to_string(),
+            inner: None,
+        }
+    }
+
+    async fn inner(&mut self) -> Result<&mut FtpLister> {
+        if self.inner.is_none() {
+            let mut ftp_stream = self.core.ftp_connect(Operation::List).await?;
+
+            let pathname = if self.path == "/" {
+                None
+            } else {
+                Some(self.path.as_str())
+            };
+            let files = ftp_stream.list(pathname).await.map_err(format_ftp_error)?;
+
+            self.inner = Some(FtpLister::new(
+                if self.path == "/" { "" } else { &self.path },
+                files,
+            ));
+        }
+
+        Ok(self.inner.as_mut().expect("ftp lister must be initialized"))
+    }
+}
+
+impl oio::List for FtpLazyLister {
+    async fn next(&mut self) -> Result<Option<oio::Entry>> {
+        self.inner().await?.next().await
+    }
+}
+
 impl oio::StreamRead for FtpReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
@@ -216,8 +335,8 @@ impl oio::StreamRead for FtpReader {
 
 impl Service for FtpBackend {
     type Reader = oio::StreamReader<FtpReader>;
-    type Writer = FtpWriter;
-    type Lister = FtpLister;
+    type Writer = FtpLazyWriter;
+    type Lister = FtpLazyLister;
     type Deleter = oio::OneShotDeleter<FtpDeleter>;
     type Copier = ();
 
@@ -276,105 +395,41 @@ impl Service for FtpBackend {
 
         Ok(RpStat::new(meta))
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<FtpReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(FtpReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<FtpReader> = {
+            Ok(oio::StreamReader::new(FtpReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        op: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, FtpWriter) = {
-            // Ensure the parent dir exists.
-            let parent = get_parent(path);
-            let paths: Vec<&str> = parent.split('/').collect();
-
-            // TODO: we can optimize this by checking dir existence first.
-            let mut ftp_stream = self.core.ftp_connect(Operation::Write).await?;
-            let mut curr_path = String::new();
-
-            for path in paths {
-                if path.is_empty() {
-                    continue;
-                }
-                curr_path.push_str(path);
-                curr_path.push('/');
-                match ftp_stream.mkdir(&curr_path).await {
-                    // Do nothing if status is FileUnavailable or OK(()) is return.
-                    Err(FtpError::UnexpectedResponse(Response {
-                        status: Status::FileUnavailable,
-                        ..
-                    }))
-                    | Ok(()) => (),
-                    Err(e) => {
-                        return Err(format_ftp_error(e));
-                    }
-                }
-            }
-
-            let tmp_path = (!op.append()).then_some(build_tmp_path_of(path));
-            let w = FtpWriter::new(ftp_stream, path.to_string(), tmp_path);
-
-            Ok((RpWrite::new(), w))
-        }?;
-
-        Ok((rp, output))
+    fn write(&self, _ctx: &OperationContext, path: &str, op: OpWrite) -> Result<Self::Writer> {
+        Ok(FtpLazyWriter::new(self.core.clone(), path, op))
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<FtpDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(FtpDeleter::new(self.core.clone())),
-            ))
-        }?;
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<FtpDeleter> =
+            { Ok(oio::OneShotDeleter::new(FtpDeleter::new(self.core.clone()))) }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, FtpLister) = {
-            let mut ftp_stream = self.core.ftp_connect(Operation::List).await?;
-
-            let pathname = if path == "/" { None } else { Some(path) };
-            let files = ftp_stream.list(pathname).await.map_err(format_ftp_error)?;
-
-            Ok((
-                RpList::default(),
-                FtpLister::new(if path == "/" { "" } else { path }, files),
-            ))
-        }?;
-
-        Ok((rp, output))
+    fn list(&self, _ctx: &OperationContext, path: &str, _: OpList) -> Result<Self::Lister> {
+        Ok(FtpLazyLister::new(self.core.clone(), path))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/gcs/src/backend.rs
+++ b/core/services/gcs/src/backend.rs
@@ -513,62 +513,46 @@ impl Service for GcsBackend {
 
         Ok(RpStat::new(m))
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<GcsReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(GcsReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<GcsReader> = {
+            Ok(oio::StreamReader::new(GcsReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, GcsWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: GcsWriters = {
             let concurrent = args.concurrent();
             let w = GcsWriter::new(self.core.clone(), ctx.clone(), path, args);
             // Multipart uploads schedule work through the operation executor
             // supplied by the caller.
             let w = oio::MultipartWriter::new(ctx.executor().clone(), w, concurrent);
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::BatchDeleter<GcsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::BatchDeleter::new(
-                    GcsDeleter::new(self.core.clone(), ctx.clone()),
-                    self.core.capability.delete_max_size,
-                ),
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::BatchDeleter<GcsDeleter> = {
+            Ok(oio::BatchDeleter::new(
+                GcsDeleter::new(self.core.clone(), ctx.clone()),
+                self.core.capability.delete_max_size,
             ))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<GcsLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<GcsLister> = {
             let l = GcsLister::new(
                 self.core.clone(),
                 ctx.clone(),
@@ -578,26 +562,26 @@ impl Service for GcsBackend {
                 args.start_after(),
             );
 
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, GcsCopier) = {
+    ) -> Result<Self::Copier> {
+        let output: GcsCopier = {
             let copier = GcsCopier::new(self.core.clone(), ctx.clone(), from, to, args, opts);
-            Ok((RpCopy::default(), copier))
+            Ok(copier)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
     async fn rename(

--- a/core/services/gdrive/src/backend.rs
+++ b/core/services/gdrive/src/backend.rs
@@ -111,7 +111,7 @@ impl Service for GdriveBackend {
     type Writer = oio::OneShotWriter<GdriveWriter>;
     type Lister = GdriveListers;
     type Deleter = oio::OneShotDeleter<GdriveDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -207,98 +207,80 @@ impl Service for GdriveBackend {
         }
         Ok(RpStat::new(meta))
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<GdriveReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(GdriveReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<GdriveReader> = {
+            Ok(oio::StreamReader::new(GdriveReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, oio::OneShotWriter<GdriveWriter>) = {
+    fn write(&self, ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: oio::OneShotWriter<GdriveWriter> = {
             let path = build_abs_path(&self.core.root, path);
 
-            // As Google Drive allows files have the same name, we need to check if the file exists.
-            // If the file exists, we will keep its ID and update it.
-            let file_id = match self.core.resolve_path(ctx, &path).await? {
-                Some(id) => Some(id),
-                None => self.core.resolve_path_after_refresh(ctx, &path).await?,
-            };
-
-            Ok((
-                RpWrite::default(),
-                oio::OneShotWriter::new(GdriveWriter::new(
-                    self.core.clone(),
-                    ctx.clone(),
-                    path,
-                    file_id,
-                )),
-            ))
+            Ok(oio::OneShotWriter::new(GdriveWriter::new(
+                self.core.clone(),
+                ctx.clone(),
+                path,
+                None,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<GdriveDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(GdriveDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<GdriveDeleter> = {
+            Ok(oio::OneShotDeleter::new(GdriveDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, GdriveListers) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: GdriveListers = {
             let path = build_abs_path(&self.core.root, path);
 
             if args.recursive() {
                 // Use optimized batch-query recursive lister
                 let l = GdriveFlatLister::new(path, self.core.clone(), ctx.clone());
-                Ok((RpList::default(), TwoWays::Two(l)))
+                Ok(TwoWays::Two(l))
             } else {
                 // Use standard page-based lister for non-recursive
                 let l = GdriveLister::new(path, self.core.clone(), ctx.clone());
-                Ok((RpList::default(), TwoWays::One(oio::PageLister::new(l))))
+                Ok(TwoWays::One(oio::PageLister::new(l)))
             }
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let source = build_abs_path(&self.core.root, from);
-            let target = build_abs_path(&self.core.root, to);
-            let resp = self.core.gdrive_copy(ctx, from, to).await?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
+
+        Ok(oio::OneShotCopier::new(async move {
+            let source = build_abs_path(&core.root, &from);
+            let target = build_abs_path(&core.root, &to);
+            let resp = core.gdrive_copy(&ctx, &from, &to).await?;
 
             match resp.status() {
                 StatusCode::OK => {
@@ -306,7 +288,7 @@ impl Service for GdriveBackend {
                     let meta: GdriveFile = serde_json::from_reader(body.reader())
                         .map_err(new_json_deserialize_error)?;
 
-                    let to_path = build_abs_path(&self.core.root, to);
+                    let to_path = build_abs_path(&core.root, &to);
                     let mut metadata = if meta.mime_type == "application/vnd.google-apps.folder" {
                         Metadata::new(EntryMode::DIR)
                     } else {
@@ -321,25 +303,25 @@ impl Service for GdriveBackend {
                     }
 
                     if metadata.mode().is_dir() {
-                        self.core.cache_dir_id(&to_path, &meta.id).await;
+                        core.cache_dir_id(&to_path, &meta.id).await;
                     } else {
-                        self.core.cache_file_id(&to_path, &meta.id).await;
+                        core.cache_file_id(&to_path, &meta.id).await;
                     }
-                    self.core.record_recent_upsert(&to_path, metadata).await;
+                    core.record_recent_upsert(&to_path, metadata).await;
 
-                    Ok((RpCopy::default(), ()))
+                    Ok(Metadata::default())
                 }
                 StatusCode::NOT_FOUND => {
-                    self.core.refresh_path(&source).await;
-                    self.core.refresh_path(&target).await;
-                    let resp = self.core.gdrive_copy(ctx, from, to).await?;
+                    core.refresh_path(&source).await;
+                    core.refresh_path(&target).await;
+                    let resp = core.gdrive_copy(&ctx, &from, &to).await?;
                     match resp.status() {
                         StatusCode::OK => {
                             let body = resp.into_body();
                             let meta: GdriveFile = serde_json::from_reader(body.reader())
                                 .map_err(new_json_deserialize_error)?;
 
-                            let to_path = build_abs_path(&self.core.root, to);
+                            let to_path = build_abs_path(&core.root, &to);
                             let mut metadata =
                                 if meta.mime_type == "application/vnd.google-apps.folder" {
                                     Metadata::new(EntryMode::DIR)
@@ -356,22 +338,20 @@ impl Service for GdriveBackend {
                             }
 
                             if metadata.mode().is_dir() {
-                                self.core.cache_dir_id(&to_path, &meta.id).await;
+                                core.cache_dir_id(&to_path, &meta.id).await;
                             } else {
-                                self.core.cache_file_id(&to_path, &meta.id).await;
+                                core.cache_file_id(&to_path, &meta.id).await;
                             }
-                            self.core.record_recent_upsert(&to_path, metadata).await;
+                            core.record_recent_upsert(&to_path, metadata).await;
 
-                            Ok((RpCopy::default(), ()))
+                            Ok(Metadata::default())
                         }
                         _ => Err(parse_error(resp)),
                     }
                 }
                 _ => Err(parse_error(resp)),
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
     async fn rename(

--- a/core/services/gdrive/src/writer.rs
+++ b/core/services/gdrive/src/writer.rs
@@ -56,7 +56,17 @@ impl oio::OneShotWrite for GdriveWriter {
     async fn write_once(&self, bs: Buffer) -> Result<Metadata> {
         let size = bs.len();
 
-        let mut current_file_id = self.file_id.clone();
+        let mut current_file_id = match &self.file_id {
+            Some(file_id) => Some(file_id.clone()),
+            None => match self.core.resolve_path(&self.ctx, &self.path).await? {
+                Some(id) => Some(id),
+                None => {
+                    self.core
+                        .resolve_path_after_refresh(&self.ctx, &self.path)
+                        .await?
+                }
+            },
+        };
         let mut retried = false;
 
         loop {

--- a/core/services/ghac/src/backend.rs
+++ b/core/services/ghac/src/backend.rs
@@ -29,7 +29,7 @@ use super::config::GhacConfig;
 use super::core::GhacCore;
 use super::core::*;
 use super::error::parse_error;
-use super::writer::GhacWriter;
+use super::writer::GhacLazyWriter;
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -244,7 +244,7 @@ impl oio::StreamRead for GhacReader {
 
 impl Service for GhacBackend {
     type Reader = oio::StreamReader<GhacReader>;
-    type Writer = GhacWriter;
+    type Writer = GhacLazyWriter;
     type Lister = ();
     type Deleter = ();
     type Copier = ();
@@ -286,73 +286,50 @@ impl Service for GhacBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<GhacReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(GhacReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<GhacReader> = {
+            Ok(oio::StreamReader::new(GhacReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, GhacWriter) = {
-            let url = self.core.ghac_get_upload_url(ctx, path).await?;
-
-            Ok((
-                RpWrite::default(),
-                GhacWriter::new(
-                    self.core.clone(),
-                    ctx.clone(),
-                    ctx.executor().clone(),
-                    path.to_string(),
-                    url,
-                )?,
-            ))
-        }?;
-
-        Ok((rp, output))
+    fn write(&self, ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        Ok(GhacLazyWriter::new(
+            self.core.clone(),
+            ctx.clone(),
+            ctx.executor().clone(),
+            path.to_string(),
+        ))
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/ghac/src/writer.rs
+++ b/core/services/ghac/src/writer.rs
@@ -144,6 +144,60 @@ impl GhacWriter {
     }
 }
 
+pub struct GhacLazyWriter {
+    core: Arc<GhacCore>,
+    ctx: OperationContext,
+    executor: Executor,
+    path: String,
+    inner: Option<GhacWriter>,
+}
+
+impl GhacLazyWriter {
+    pub fn new(
+        core: Arc<GhacCore>,
+        ctx: OperationContext,
+        executor: Executor,
+        path: String,
+    ) -> Self {
+        Self {
+            core,
+            ctx,
+            executor,
+            path,
+            inner: None,
+        }
+    }
+
+    async fn inner(&mut self) -> Result<&mut GhacWriter> {
+        if self.inner.is_none() {
+            let url = self.core.ghac_get_upload_url(&self.ctx, &self.path).await?;
+            self.inner = Some(GhacWriter::new(
+                self.core.clone(),
+                self.ctx.clone(),
+                self.executor.clone(),
+                self.path.clone(),
+                url,
+            )?);
+        }
+
+        Ok(self.inner.as_mut().expect("writer must be initialized"))
+    }
+}
+
+impl oio::Write for GhacLazyWriter {
+    async fn write(&mut self, bs: Buffer) -> Result<()> {
+        self.inner().await?.write(bs).await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        self.inner().await?.abort().await
+    }
+
+    async fn close(&mut self) -> Result<Metadata> {
+        self.inner().await?.close().await
+    }
+}
+
 impl oio::Write for GhacWriter {
     async fn write(&mut self, bs: Buffer) -> Result<()> {
         self.0.write(bs).await

--- a/core/services/github/src/backend.rs
+++ b/core/services/github/src/backend.rs
@@ -256,72 +256,59 @@ impl Service for GithubBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<GithubReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(GithubReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<GithubReader> = {
+            Ok(oio::StreamReader::new(GithubReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, GithubWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, _args: OpWrite) -> Result<Self::Writer> {
+        let output: GithubWriters = {
             let writer = GithubWriter::new(self.core.clone(), ctx.clone(), path.to_string());
 
             let w = oio::OneShotWriter::new(writer);
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<GithubDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(GithubDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<GithubDeleter> = {
+            Ok(oio::OneShotDeleter::new(GithubDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<GithubLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<GithubLister> = {
             let l = GithubLister::new(self.core.clone(), ctx.clone(), path, args.recursive());
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/goosefs/src/backend.rs
+++ b/core/services/goosefs/src/backend.rs
@@ -369,69 +369,54 @@ impl Service for GoosefsBackend {
         let file_info = self.core.get_status(path).await?;
         Ok(RpStat::new(self.core.file_info_to_metadata(&file_info)))
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<GoosefsReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(GoosefsReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<GoosefsReader> = {
+            Ok(oio::StreamReader::new(GoosefsReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, GoosefsWriters) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: GoosefsWriters = {
             let w = GoosefsWriter::new(self.core.clone(), args.clone(), path.to_string());
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<GoosefsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(GoosefsDeleter::new(self.core.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<GoosefsDeleter> = {
+            Ok(oio::OneShotDeleter::new(GoosefsDeleter::new(
+                self.core.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<GoosefsLister>) = {
+    fn list(&self, _ctx: &OperationContext, path: &str, _args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<GoosefsLister> = {
             let l = GoosefsLister::new(self.core.clone(), path);
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/gridfs/src/backend.rs
+++ b/core/services/gridfs/src/backend.rs
@@ -266,67 +266,53 @@ impl Service for GridfsBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<GridfsReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(GridfsReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<GridfsReader> = {
+            Ok(oio::StreamReader::new(GridfsReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, GridfsWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: GridfsWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((RpWrite::new(), GridfsWriter::new(self.core.clone(), p)))
+            Ok(GridfsWriter::new(self.core.clone(), p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<GridfsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(GridfsDeleter::new(self.core.clone(), self.root.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<GridfsDeleter> = {
+            Ok(oio::OneShotDeleter::new(GridfsDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/hdfs-native/src/backend.rs
+++ b/core/services/hdfs-native/src/backend.rs
@@ -198,10 +198,117 @@ impl oio::PositionRead for HdfsNativeReader {
     }
 }
 
+pub struct HdfsNativeLazyReader {
+    core: Arc<HdfsNativeCore>,
+    path: String,
+}
+
+impl HdfsNativeLazyReader {
+    fn new(core: Arc<HdfsNativeCore>, path: &str) -> Self {
+        Self {
+            core,
+            path: path.to_string(),
+        }
+    }
+
+    async fn reader(&self) -> Result<oio::PositionReader<HdfsNativeReader>> {
+        let file = self.core.hdfs_open(&self.path).await?;
+        Ok(oio::PositionReader::new(HdfsNativeReader::new(file)))
+    }
+}
+
+impl oio::Read for HdfsNativeLazyReader {
+    async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
+        self.reader().await?.open(range).await
+    }
+
+    async fn read(&self, range: BytesRange) -> Result<(RpRead, Buffer)> {
+        self.reader().await?.read(range).await
+    }
+}
+
+pub struct HdfsNativeLazyWriter {
+    core: Arc<HdfsNativeCore>,
+    path: String,
+    args: OpWrite,
+    inner: Option<HdfsNativeWriter>,
+}
+
+impl HdfsNativeLazyWriter {
+    fn new(core: Arc<HdfsNativeCore>, path: &str, args: OpWrite) -> Self {
+        Self {
+            core,
+            path: path.to_string(),
+            args,
+            inner: None,
+        }
+    }
+
+    async fn inner(&mut self) -> Result<&mut HdfsNativeWriter> {
+        if self.inner.is_none() {
+            let (f, initial_size) = self.core.hdfs_write(&self.path, &self.args).await?;
+            self.inner = Some(HdfsNativeWriter::new(f, initial_size));
+        }
+
+        Ok(self.inner.as_mut().expect("writer must be initialized"))
+    }
+}
+
+impl oio::Write for HdfsNativeLazyWriter {
+    async fn write(&mut self, bs: Buffer) -> Result<()> {
+        self.inner().await?.write(bs).await
+    }
+
+    async fn close(&mut self) -> Result<Metadata> {
+        self.inner().await?.close().await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        self.inner().await?.abort().await
+    }
+}
+
+pub struct HdfsNativeLazyLister {
+    core: Arc<HdfsNativeCore>,
+    path: String,
+    inner: Option<Option<HdfsNativeLister>>,
+}
+
+impl HdfsNativeLazyLister {
+    fn new(core: Arc<HdfsNativeCore>, path: &str) -> Self {
+        Self {
+            core,
+            path: path.to_string(),
+            inner: None,
+        }
+    }
+}
+
+impl oio::List for HdfsNativeLazyLister {
+    async fn next(&mut self) -> Result<Option<oio::Entry>> {
+        if self.inner.is_none() {
+            self.inner = Some(match self.core.hdfs_list(&self.path).await? {
+                Some((p, current_path)) => Some(HdfsNativeLister::new(
+                    &self.core.root,
+                    &self.core.client,
+                    &p,
+                    current_path,
+                )),
+                None => None,
+            });
+        }
+
+        match self.inner.as_mut().expect("lister must be initialized") {
+            Some(lister) => lister.next().await,
+            None => Ok(None),
+        }
+    }
+}
+
 impl Service for HdfsNativeBackend {
-    type Reader = oio::PositionReader<HdfsNativeReader>;
-    type Writer = HdfsNativeWriter;
-    type Lister = Option<HdfsNativeLister>;
+    type Reader = HdfsNativeLazyReader;
+    type Writer = HdfsNativeLazyWriter;
+    type Lister = HdfsNativeLazyLister;
     type Deleter = oio::OneShotDeleter<HdfsNativeDeleter>;
     type Copier = ();
 
@@ -227,81 +334,36 @@ impl Service for HdfsNativeBackend {
         let m = self.core.hdfs_stat(path).await?;
         Ok(RpStat::new(m))
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::PositionReader<HdfsNativeReader>) = {
-            let file = self.core.hdfs_open(path).await?;
-            Ok((
-                RpRead::default(),
-                oio::PositionReader::new(HdfsNativeReader::new(file)),
-            ))
-        }?;
-
-        Ok((rp, output))
+    fn read(&self, _ctx: &OperationContext, path: &str, _: OpRead) -> Result<Self::Reader> {
+        Ok(HdfsNativeLazyReader::new(self.core.clone(), path))
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, HdfsNativeWriter) = {
-            let (f, initial_size) = self.core.hdfs_write(path, &args).await?;
-
-            Ok((RpWrite::new(), HdfsNativeWriter::new(f, initial_size)))
-        }?;
-
-        Ok((rp, output))
+    fn write(&self, _ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        Ok(HdfsNativeLazyWriter::new(self.core.clone(), path, args))
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<HdfsNativeDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(HdfsNativeDeleter::new(Arc::clone(&self.core))),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<HdfsNativeDeleter> = {
+            Ok(oio::OneShotDeleter::new(HdfsNativeDeleter::new(
+                Arc::clone(&self.core),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, Option<HdfsNativeLister>) = {
-            match self.core.hdfs_list(path).await? {
-                Some((p, current_path)) => Ok((
-                    RpList::default(),
-                    Some(HdfsNativeLister::new(
-                        &self.core.root,
-                        &self.core.client,
-                        &p,
-                        current_path,
-                    )),
-                )),
-                None => Ok((RpList::default(), None)),
-            }
-        }?;
-
-        Ok((rp, output))
+    fn list(&self, _ctx: &OperationContext, path: &str, _args: OpList) -> Result<Self::Lister> {
+        Ok(HdfsNativeLazyLister::new(self.core.clone(), path))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/hdfs/src/backend.rs
+++ b/core/services/hdfs/src/backend.rs
@@ -219,9 +219,59 @@ impl oio::StreamRead for HdfsReader {
     }
 }
 
+pub struct HdfsLazyWriter {
+    core: Arc<HdfsCore>,
+    path: String,
+    op: OpWrite,
+    inner: Option<HdfsWriter<hdrs::AsyncFile>>,
+}
+
+impl HdfsLazyWriter {
+    fn new(core: Arc<HdfsCore>, path: &str, op: OpWrite) -> Self {
+        Self {
+            core,
+            path: path.to_string(),
+            op,
+            inner: None,
+        }
+    }
+
+    async fn inner(&mut self) -> Result<&mut HdfsWriter<hdrs::AsyncFile>> {
+        if self.inner.is_none() {
+            let (target_path, tmp_path, f, target_exists, initial_size) =
+                self.core.hdfs_write(&self.path, &self.op).await?;
+
+            self.inner = Some(HdfsWriter::new(
+                target_path,
+                tmp_path,
+                f,
+                Arc::clone(&self.core.client),
+                target_exists,
+                initial_size,
+            ));
+        }
+
+        Ok(self.inner.as_mut().expect("writer must be initialized"))
+    }
+}
+
+impl oio::Write for HdfsLazyWriter {
+    async fn write(&mut self, bs: Buffer) -> Result<()> {
+        self.inner().await?.write(bs).await
+    }
+
+    async fn close(&mut self) -> Result<Metadata> {
+        self.inner().await?.close().await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        self.inner().await?.abort().await
+    }
+}
+
 impl Service for HdfsBackend {
     type Reader = oio::StreamReader<HdfsReader>;
-    type Writer = HdfsWriter<hdrs::AsyncFile>;
+    type Writer = HdfsLazyWriter;
     type Lister = Option<HdfsLister>;
     type Deleter = oio::OneShotDeleter<HdfsDeleter>;
     type Copier = ();
@@ -248,86 +298,54 @@ impl Service for HdfsBackend {
         let m = self.core.hdfs_stat(path)?;
         Ok(RpStat::new(m))
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<HdfsReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(HdfsReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<HdfsReader> = {
+            Ok(oio::StreamReader::new(HdfsReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        op: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, HdfsWriter<hdrs::AsyncFile>) = {
-            let (target_path, tmp_path, f, target_exists, initial_size) =
-                self.core.hdfs_write(path, &op).await?;
+    fn write(&self, _ctx: &OperationContext, path: &str, op: OpWrite) -> Result<Self::Writer> {
+        Ok(HdfsLazyWriter::new(self.core.clone(), path, op))
+    }
 
-            Ok((
-                RpWrite::new(),
-                HdfsWriter::new(
-                    target_path,
-                    tmp_path,
-                    f,
-                    Arc::clone(&self.core.client),
-                    target_exists,
-                    initial_size,
-                ),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<HdfsDeleter> = {
+            Ok(oio::OneShotDeleter::new(HdfsDeleter::new(Arc::clone(
+                &self.core,
+            ))))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<HdfsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(HdfsDeleter::new(Arc::clone(&self.core))),
-            ))
-        }?;
-
-        Ok((rp, output))
-    }
-
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, Option<HdfsLister>) = {
+    fn list(&self, _ctx: &OperationContext, path: &str, _: OpList) -> Result<Self::Lister> {
+        let output: Option<HdfsLister> = {
             match self.core.hdfs_list(path)? {
                 Some(f) => {
                     let rd = HdfsLister::new(&self.core.root, f, path);
-                    Ok((RpList::default(), Some(rd)))
+                    Ok(Some(rd))
                 }
-                None => Ok((RpList::default(), None)),
+                None => Ok(None),
             }
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/hf/src/backend.rs
+++ b/core/services/hf/src/backend.rs
@@ -28,7 +28,7 @@ use super::deleter::HfDeleter;
 use super::lister::HfLister;
 use super::reader::HfReadStream;
 use super::uri::{HfRepo, HfRepoType};
-use super::writer::HfWriter;
+use super::writer::HfLazyWriter;
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -283,7 +283,7 @@ impl oio::StreamRead for HfReader {
 
 impl Service for HfBackend {
     type Reader = oio::StreamReader<HfReader>;
-    type Writer = HfWriter;
+    type Writer = HfLazyWriter;
     type Lister = oio::PageLister<HfLister>;
     type Deleter = oio::BatchDeleter<HfDeleter>;
     type Copier = ();
@@ -322,77 +322,59 @@ impl Service for HfBackend {
         let info = self.core.path_info(ctx, path).await?;
         Ok(RpStat::new(info.metadata()?))
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<HfReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(HfReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<HfReader> = {
+            Ok(oio::StreamReader::new(HfReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<HfLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<HfLister> = {
             let lister = HfLister::new(
                 self.core.clone(),
                 ctx.clone(),
                 path.to_string(),
                 args.recursive(),
             );
-            Ok((RpList::default(), oio::PageLister::new(lister)))
+            Ok(oio::PageLister::new(lister))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, HfWriter) = {
-            let writer =
-                HfWriter::try_new(self.core.clone(), ctx.clone(), path.to_string()).await?;
-            Ok((RpWrite::default(), writer))
-        }?;
-
-        Ok((rp, output))
+    fn write(&self, ctx: &OperationContext, path: &str, _args: OpWrite) -> Result<Self::Writer> {
+        Ok(HfLazyWriter::new(
+            self.core.clone(),
+            ctx.clone(),
+            path.to_string(),
+        ))
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::BatchDeleter<HfDeleter>) = {
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::BatchDeleter<HfDeleter> = {
             let deleter = HfDeleter::new(self.core.clone(), ctx.clone());
             let max_batch_size = self.core.capability.delete_max_size;
-            Ok((
-                RpDelete::default(),
-                oio::BatchDeleter::new(deleter, max_batch_size),
-            ))
+            Ok(oio::BatchDeleter::new(deleter, max_batch_size))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/hf/src/writer.rs
+++ b/core/services/hf/src/writer.rs
@@ -35,6 +35,52 @@ pub struct HfWriter {
     finished_info: Option<XetFileInfo>,
 }
 
+/// Lazily creates [`HfWriter`] so `Service::write` can stay synchronous.
+pub struct HfLazyWriter {
+    core: Arc<HfCore>,
+    ctx: OperationContext,
+    path: String,
+    inner: Option<HfWriter>,
+}
+
+impl HfLazyWriter {
+    pub fn new(core: Arc<HfCore>, ctx: OperationContext, path: String) -> Self {
+        Self {
+            core,
+            ctx,
+            path,
+            inner: None,
+        }
+    }
+
+    async fn inner(&mut self) -> Result<&mut HfWriter> {
+        if self.inner.is_none() {
+            let writer =
+                HfWriter::try_new(self.core.clone(), self.ctx.clone(), self.path.clone()).await?;
+            self.inner = Some(writer);
+        }
+
+        Ok(self.inner.as_mut().expect("hf writer must be initialized"))
+    }
+}
+
+impl oio::Write for HfLazyWriter {
+    async fn write(&mut self, bs: Buffer) -> Result<()> {
+        self.inner().await?.write(bs).await
+    }
+
+    async fn close(&mut self) -> Result<Metadata> {
+        self.inner().await?.close().await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        match &mut self.inner {
+            Some(w) => w.abort().await,
+            None => Ok(()),
+        }
+    }
+}
+
 impl HfWriter {
     /// Create a new writer for the given path.
     ///

--- a/core/services/http/src/backend.rs
+++ b/core/services/http/src/backend.rs
@@ -260,61 +260,48 @@ impl Service for HttpBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<HttpReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(HttpReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<HttpReader> = {
+            Ok(oio::StreamReader::new(HttpReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, _ctx: &OperationContext, _path: &str, _args: OpWrite) -> Result<Self::Writer> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/ipfs/src/backend.rs
+++ b/core/services/ipfs/src/backend.rs
@@ -215,63 +215,50 @@ impl Service for IpfsBackend {
         Ok(RpStat::new(metadata))
     }
 
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<IpfsReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(IpfsReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<IpfsReader> = {
+            Ok(oio::StreamReader::new(IpfsReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, _ctx: &OperationContext, _path: &str, _args: OpWrite) -> Result<Self::Writer> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<DirStream>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, _: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<DirStream> = {
             let l = DirStream::new(self.core.clone(), ctx.clone(), path);
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/ipmfs/src/backend.rs
+++ b/core/services/ipmfs/src/backend.rs
@@ -137,75 +137,59 @@ impl Service for IpmfsBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<IpmfsReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(IpmfsReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<IpmfsReader> = {
+            Ok(oio::StreamReader::new(IpmfsReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, oio::OneShotWriter<IpmfsWriter>) = {
-            Ok((
-                RpWrite::default(),
-                oio::OneShotWriter::new(IpmfsWriter::new(
-                    self.core.clone(),
-                    ctx.clone(),
-                    path.to_string(),
-                )),
-            ))
+    fn write(&self, ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: oio::OneShotWriter<IpmfsWriter> = {
+            Ok(oio::OneShotWriter::new(IpmfsWriter::new(
+                self.core.clone(),
+                ctx.clone(),
+                path.to_string(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<IpmfsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(IpmfsDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<IpmfsDeleter> = {
+            Ok(oio::OneShotDeleter::new(IpmfsDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<IpmfsLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, _: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<IpmfsLister> = {
             let l = IpmfsLister::new(self.core.clone(), ctx.clone(), &self.core.root, path);
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/koofr/src/backend.rs
+++ b/core/services/koofr/src/backend.rs
@@ -229,7 +229,7 @@ impl Service for KoofrBackend {
     type Writer = KoofrWriters;
     type Lister = oio::PageLister<KoofrLister>;
     type Deleter = oio::OneShotDeleter<KoofrDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -282,98 +282,87 @@ impl Service for KoofrBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<KoofrReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(KoofrReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<KoofrReader> = {
+            Ok(oio::StreamReader::new(KoofrReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, KoofrWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, _args: OpWrite) -> Result<Self::Writer> {
+        let output: KoofrWriters = {
             let writer = KoofrWriter::new(self.core.clone(), ctx.clone(), path.to_string());
 
             let w = oio::OneShotWriter::new(writer);
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<KoofrDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(KoofrDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<KoofrDeleter> = {
+            Ok(oio::OneShotDeleter::new(KoofrDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<KoofrLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, _args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<KoofrLister> = {
             let l = KoofrLister::new(self.core.clone(), ctx.clone(), path);
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            self.core.ensure_dir_exists(ctx, to).await?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
 
+        Ok(oio::OneShotCopier::new(async move {
+            core.ensure_dir_exists(&ctx, &to).await?;
             if from == to {
-                Ok((RpCopy::default(), ()))
+                Ok(Metadata::default())
             } else {
-                let resp = self.core.remove(ctx, to).await?;
+                let resp = core.remove(&ctx, &to).await?;
 
                 let status = resp.status();
 
                 if status != StatusCode::OK && status != StatusCode::NOT_FOUND {
                     Err(parse_error(resp))
                 } else {
-                    let resp = self.core.copy(ctx, from, to).await?;
+                    let resp = core.copy(&ctx, &from, &to).await?;
 
                     let status = resp.status();
 
                     match status {
-                        StatusCode::OK => Ok((RpCopy::default(), ())),
+                        StatusCode::OK => Ok(Metadata::default()),
                         _ => Err(parse_error(resp)),
                     }
                 }
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
     async fn rename(

--- a/core/services/lakefs/src/backend.rs
+++ b/core/services/lakefs/src/backend.rs
@@ -237,7 +237,7 @@ impl Service for LakefsBackend {
     type Writer = oio::OneShotWriter<LakefsWriter>;
     type Lister = oio::PageLister<LakefsLister>;
     type Deleter = oio::OneShotDeleter<LakefsDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -284,29 +284,21 @@ impl Service for LakefsBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<LakefsReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(LakefsReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<LakefsReader> = {
+            Ok(oio::StreamReader::new(LakefsReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<LakefsLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<LakefsLister> = {
             let l = LakefsLister::new(
                 self.core.clone(),
                 ctx.clone(),
@@ -316,64 +308,58 @@ impl Service for LakefsBackend {
                 args.recursive(),
             );
 
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, oio::OneShotWriter<LakefsWriter>) = {
-            Ok((
-                RpWrite::default(),
-                oio::OneShotWriter::new(LakefsWriter::new(
-                    self.core.clone(),
-                    ctx.clone(),
-                    path.to_string(),
-                    args,
-                )),
-            ))
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: oio::OneShotWriter<LakefsWriter> = {
+            Ok(oio::OneShotWriter::new(LakefsWriter::new(
+                self.core.clone(),
+                ctx.clone(),
+                path.to_string(),
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<LakefsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(LakefsDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<LakefsDeleter> = {
+            Ok(oio::OneShotDeleter::new(LakefsDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let resp = self.core.copy_object(ctx, from, to).await?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
 
+        Ok(oio::OneShotCopier::new(async move {
+            let resp = core.copy_object(&ctx, &from, &to).await?;
             let status = resp.status();
 
             match status {
-                StatusCode::CREATED => Ok((RpCopy::default(), ())),
+                StatusCode::CREATED => Ok(Metadata::default()),
                 _ => Err(parse_error(resp)),
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
     async fn rename(

--- a/core/services/memcached/src/backend.rs
+++ b/core/services/memcached/src/backend.rs
@@ -289,70 +289,53 @@ impl Service for MemcachedBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<MemcachedReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(MemcachedReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<MemcachedReader> = {
+            Ok(oio::StreamReader::new(MemcachedReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, MemcachedWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: MemcachedWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((RpWrite::new(), MemcachedWriter::new(self.core.clone(), p)))
+            Ok(MemcachedWriter::new(self.core.clone(), p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<MemcachedDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(MemcachedDeleter::new(
-                    self.core.clone(),
-                    self.root.clone(),
-                )),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<MemcachedDeleter> = {
+            Ok(oio::OneShotDeleter::new(MemcachedDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/mini_moka/src/backend.rs
+++ b/core/services/mini_moka/src/backend.rs
@@ -245,75 +245,61 @@ impl Service for MiniMokaBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        op: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<MiniMokaReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(MiniMokaReader::new(self.clone(), path, op)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, op: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<MiniMokaReader> = {
+            Ok(oio::StreamReader::new(MiniMokaReader::new(
+                self.clone(),
+                path,
+                op,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        op: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, MiniMokaWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, op: OpWrite) -> Result<Self::Writer> {
+        let output: MiniMokaWriter = {
             let p = build_abs_path(&self.root, path);
             let writer = MiniMokaWriter::new(self.core.clone(), p, op);
-            Ok((RpWrite::new(), writer))
+            Ok(writer)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<MiniMokaDeleter>) = {
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<MiniMokaDeleter> = {
             let deleter = oio::OneShotDeleter::new(MiniMokaDeleter::new(
                 self.core.clone(),
                 self.root.clone(),
             ));
-            Ok((RpDelete::default(), deleter))
+            Ok(deleter)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        op: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::HierarchyLister<MiniMokaLister>) = {
+    fn list(&self, _ctx: &OperationContext, path: &str, op: OpList) -> Result<Self::Lister> {
+        let output: oio::HierarchyLister<MiniMokaLister> = {
             let p = build_abs_path(&self.root, path);
 
             let mini_moka_lister = MiniMokaLister::new(self.core.clone(), self.root.clone(), p);
             let lister = oio::HierarchyLister::new(mini_moka_lister, path, op.recursive());
 
-            Ok((RpList::default(), lister))
+            Ok(lister)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/moka/src/backend.rs
+++ b/core/services/moka/src/backend.rs
@@ -324,72 +324,58 @@ impl Service for MokaBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<MokaReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(MokaReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<MokaReader> = {
+            Ok(oio::StreamReader::new(MokaReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, MokaWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: MokaWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((RpWrite::new(), MokaWriter::new(self.core.clone(), p, args)))
+            Ok(MokaWriter::new(self.core.clone(), p, args))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<MokaDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(MokaDeleter::new(self.core.clone(), self.root.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<MokaDeleter> = {
+            Ok(oio::OneShotDeleter::new(MokaDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::HierarchyLister<MokaLister>) = {
+    fn list(&self, _ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::HierarchyLister<MokaLister> = {
             // For moka, we don't distinguish between files and directories
             // Just return the lister to iterate through all matching keys
             let lister = MokaLister::new(self.core.clone(), self.root.clone(), path.to_string());
             let lister = oio::HierarchyLister::new(lister, path, args.recursive());
-            Ok((RpList::default(), lister))
+            Ok(lister)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/mongodb/src/backend.rs
+++ b/core/services/mongodb/src/backend.rs
@@ -284,67 +284,53 @@ impl Service for MongodbBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<MongodbReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(MongodbReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<MongodbReader> = {
+            Ok(oio::StreamReader::new(MongodbReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, MongodbWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: MongodbWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((RpWrite::new(), MongodbWriter::new(self.core.clone(), p)))
+            Ok(MongodbWriter::new(self.core.clone(), p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<MongodbDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(MongodbDeleter::new(self.core.clone(), self.root.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<MongodbDeleter> = {
+            Ok(oio::OneShotDeleter::new(MongodbDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/monoiofs/src/backend.rs
+++ b/core/services/monoiofs/src/backend.rs
@@ -92,12 +92,89 @@ pub struct MonoiofsBackend {
     core: Arc<MonoiofsCore>,
 }
 
+pub struct MonoiofsLazyReader {
+    core: Arc<MonoiofsCore>,
+    path: PathBuf,
+}
+
+impl MonoiofsLazyReader {
+    fn new(core: Arc<MonoiofsCore>, path: PathBuf) -> Self {
+        Self { core, path }
+    }
+
+    async fn reader(&self) -> Result<oio::PositionReader<MonoiofsReader>> {
+        let reader = MonoiofsReader::new(self.core.clone(), self.path.clone()).await?;
+        Ok(oio::PositionReader::new(reader))
+    }
+}
+
+impl oio::Read for MonoiofsLazyReader {
+    async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
+        self.reader().await?.open(range).await
+    }
+
+    async fn read(&self, range: BytesRange) -> Result<(RpRead, Buffer)> {
+        self.reader().await?.read(range).await
+    }
+}
+
+pub struct MonoiofsLazyWriter {
+    core: Arc<MonoiofsCore>,
+    path: String,
+    append: bool,
+    inner: Option<MonoiofsWriter>,
+}
+
+impl MonoiofsLazyWriter {
+    fn new(core: Arc<MonoiofsCore>, path: &str, args: OpWrite) -> Self {
+        Self {
+            core,
+            path: path.to_string(),
+            append: args.append(),
+            inner: None,
+        }
+    }
+
+    async fn inner(&mut self) -> Result<&mut MonoiofsWriter> {
+        if self.inner.is_none() {
+            let path = self.core.prepare_write_path(&self.path).await?;
+            let writer = MonoiofsWriter::new(self.core.clone(), path, self.append).await?;
+            self.inner = Some(writer);
+        }
+
+        Ok(self
+            .inner
+            .as_mut()
+            .expect("monoiofs writer must be initialized"))
+    }
+}
+
+impl oio::Write for MonoiofsLazyWriter {
+    async fn write(&mut self, bs: Buffer) -> Result<()> {
+        self.inner().await?.write(bs).await
+    }
+
+    async fn close(&mut self) -> Result<Metadata> {
+        self.inner().await?.close().await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        match &mut self.inner {
+            Some(w) => w.abort().await,
+            None => Err(Error::new(
+                ErrorKind::Unsupported,
+                "Monoiofs doesn't support abort",
+            )),
+        }
+    }
+}
+
 impl Service for MonoiofsBackend {
-    type Reader = oio::PositionReader<MonoiofsReader>;
-    type Writer = MonoiofsWriter;
+    type Reader = MonoiofsLazyReader;
+    type Writer = MonoiofsLazyWriter;
     type Lister = ();
     type Deleter = oio::OneShotDeleter<MonoiofsDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -128,53 +205,26 @@ impl Service for MonoiofsBackend {
             )?);
         Ok(RpStat::new(m))
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::PositionReader<MonoiofsReader>) = {
-            let path = self.core.prepare_path(path)?;
-            let reader = MonoiofsReader::new(self.core.clone(), path).await?;
-            Ok((RpRead::default(), oio::PositionReader::new(reader)))
-        }?;
-
-        Ok((rp, output))
+    fn read(&self, _ctx: &OperationContext, path: &str, _args: OpRead) -> Result<Self::Reader> {
+        let path = self.core.prepare_path(path)?;
+        Ok(MonoiofsLazyReader::new(self.core.clone(), path))
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, MonoiofsWriter) = {
-            let path = self.core.prepare_write_path(path).await?;
-            let writer = MonoiofsWriter::new(self.core.clone(), path, args.append()).await?;
-            Ok((RpWrite::default(), writer))
-        }?;
-
-        Ok((rp, output))
+    fn write(&self, _ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        Ok(MonoiofsLazyWriter::new(self.core.clone(), path, args))
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<MonoiofsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(MonoiofsDeleter::new(self.core.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<MonoiofsDeleter> = {
+            Ok(oio::OneShotDeleter::new(MonoiofsDeleter::new(
+                self.core.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
@@ -219,71 +269,72 @@ impl Service for MonoiofsBackend {
         Ok(RpCreateDir::default())
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let from = self.core.prepare_path(from)?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let from = self.core.prepare_path(from)?;
+        let to = to.to_string();
+
+        let copier = oio::OneShotCopier::new(async move {
             // ensure file exists
-            self.core
-                .dispatch({
-                    let from = from.clone();
-                    move || monoio::fs::metadata(from)
-                })
-                .await
-                .map_err(new_std_io_error)?;
-            let to = self.core.prepare_write_path(to).await?;
-            self.core
-                .dispatch({
-                    let core = self.core.clone();
-                    move || async move {
-                        let from = OpenOptions::new().read(true).open(from).await?;
-                        let to = OpenOptions::new()
-                            .write(true)
-                            .create(true)
-                            .truncate(true)
-                            .open(to)
-                            .await?;
+            core.dispatch({
+                let from = from.clone();
+                move || monoio::fs::metadata(from)
+            })
+            .await
+            .map_err(new_std_io_error)?;
+            let to = core.prepare_write_path(&to).await?;
+            core.dispatch({
+                let core = core.clone();
+                move || async move {
+                    let from = OpenOptions::new().read(true).open(from).await?;
+                    let to = OpenOptions::new()
+                        .write(true)
+                        .create(true)
+                        .truncate(true)
+                        .open(to)
+                        .await?;
 
-                        // AsyncReadRent and AsyncWriteRent is not implemented
-                        // for File, so we can't write this:
-                        // monoio::io::copy(&mut from, &mut to).await?;
+                    // AsyncReadRent and AsyncWriteRent is not implemented
+                    // for File, so we can't write this:
+                    // monoio::io::copy(&mut from, &mut to).await?;
 
-                        let mut pos = 0;
-                        // allocate and resize buffer
-                        let mut buf = core.buf_pool.get();
-                        // set capacity of buf to exact size to avoid excessive read
-                        buf.reserve(BUFFER_SIZE);
-                        let _ = buf.split_off(BUFFER_SIZE);
+                    let mut pos = 0;
+                    // allocate and resize buffer
+                    let mut buf = core.buf_pool.get();
+                    // set capacity of buf to exact size to avoid excessive read
+                    buf.reserve(BUFFER_SIZE);
+                    let _ = buf.split_off(BUFFER_SIZE);
 
-                        loop {
-                            let result;
-                            (result, buf) = from.read_at(buf, pos).await;
-                            if result? == 0 {
-                                // EOF
-                                break;
-                            }
-                            let result;
-                            (result, buf) = to.write_all_at(buf, pos).await;
-                            result?;
-                            pos += buf.len() as u64;
-                            buf.clear();
+                    loop {
+                        let result;
+                        (result, buf) = from.read_at(buf, pos).await;
+                        if result? == 0 {
+                            // EOF
+                            break;
                         }
-                        core.buf_pool.put(buf);
-                        Ok(())
+                        let result;
+                        (result, buf) = to.write_all_at(buf, pos).await;
+                        result?;
+                        pos += buf.len() as u64;
+                        buf.clear();
                     }
-                })
-                .await
-                .map_err(new_std_io_error)?;
-            Ok((RpCopy::default(), ()))
-        }?;
+                    core.buf_pool.put(buf);
+                    Ok(())
+                }
+            })
+            .await
+            .map_err(new_std_io_error)?;
+            Ok(Metadata::default())
+        });
 
-        Ok((rp, output))
+        Ok(copier)
     }
 
     async fn presign(

--- a/core/services/mysql/src/backend.rs
+++ b/core/services/mysql/src/backend.rs
@@ -25,7 +25,7 @@ use super::MYSQL_SCHEME;
 use super::config::MysqlConfig;
 use super::core::*;
 use super::deleter::MysqlDeleter;
-use super::lister::MysqlLister;
+use super::lister::MysqlLazyLister;
 use super::writer::MysqlWriter;
 use opendal_core::raw::oio;
 use opendal_core::raw::*;
@@ -224,7 +224,7 @@ impl oio::StreamRead for MysqlReader {
 impl Service for MysqlBackend {
     type Reader = oio::StreamReader<MysqlReader>;
     type Writer = MysqlWriter;
-    type Lister = oio::HierarchyLister<MysqlLister>;
+    type Lister = oio::HierarchyLister<MysqlLazyLister>;
     type Deleter = oio::OneShotDeleter<MysqlDeleter>;
     type Copier = ();
 
@@ -263,71 +263,57 @@ impl Service for MysqlBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<MysqlReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(MysqlReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<MysqlReader> = {
+            Ok(oio::StreamReader::new(MysqlReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, MysqlWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: MysqlWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((RpWrite::new(), MysqlWriter::new(self.core.clone(), p)))
+            Ok(MysqlWriter::new(self.core.clone(), p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<MysqlDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(MysqlDeleter::new(self.core.clone(), self.root.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<MysqlDeleter> = {
+            Ok(oio::OneShotDeleter::new(MysqlDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::HierarchyLister<MysqlLister>) = {
+    fn list(&self, _ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::HierarchyLister<MysqlLazyLister> = {
             let lister =
-                MysqlLister::new(self.core.clone(), self.root.clone(), path.to_string()).await?;
+                MysqlLazyLister::new(self.core.clone(), self.root.clone(), path.to_string());
             let lister = oio::HierarchyLister::new(lister, path, args.recursive());
-            Ok((RpList::default(), lister))
+            Ok(lister)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/mysql/src/lister.rs
+++ b/core/services/mysql/src/lister.rs
@@ -51,3 +51,37 @@ impl List for MysqlLister {
         Ok(Some(Entry::new(&path, meta)))
     }
 }
+
+pub struct MysqlLazyLister {
+    core: Arc<MysqlCore>,
+    root: String,
+    path: String,
+    inner: Option<MysqlLister>,
+}
+
+impl MysqlLazyLister {
+    pub fn new(core: Arc<MysqlCore>, root: String, path: String) -> Self {
+        Self {
+            core,
+            root,
+            path,
+            inner: None,
+        }
+    }
+}
+
+impl List for MysqlLazyLister {
+    async fn next(&mut self) -> Result<Option<Entry>> {
+        if self.inner.is_none() {
+            self.inner = Some(
+                MysqlLister::new(self.core.clone(), self.root.clone(), self.path.clone()).await?,
+            );
+        }
+
+        self.inner
+            .as_mut()
+            .expect("lister must be initialized")
+            .next()
+            .await
+    }
+}

--- a/core/services/obs/src/backend.rs
+++ b/core/services/obs/src/backend.rs
@@ -315,7 +315,7 @@ impl Service for ObsBackend {
     type Writer = ObsWriters;
     type Lister = oio::PageLister<ObsLister>;
     type Deleter = oio::OneShotDeleter<ObsDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -376,29 +376,21 @@ impl Service for ObsBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<ObsReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(ObsReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<ObsReader> = {
+            Ok(oio::StreamReader::new(ObsReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, ObsWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: ObsWriters = {
             let writer = ObsWriter::new(self.core.clone(), ctx.clone(), path, args.clone());
 
             let w = if args.append() {
@@ -411,30 +403,25 @@ impl Service for ObsBackend {
                 ))
             };
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<ObsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(ObsDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<ObsDeleter> = {
+            Ok(oio::OneShotDeleter::new(ObsDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<ObsLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<ObsLister> = {
             let l = ObsLister::new(
                 self.core.clone(),
                 ctx.clone(),
@@ -442,32 +429,34 @@ impl Service for ObsBackend {
                 args.recursive(),
                 args.limit(),
             );
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let resp = self.core.obs_copy_object(ctx, from, to).await?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
+        Ok(oio::OneShotCopier::new(async move {
+            let resp = core.obs_copy_object(&ctx, &from, &to).await?;
 
             let status = resp.status();
 
             match status {
-                StatusCode::OK => Ok((RpCopy::default(), ())),
+                StatusCode::OK => Ok(Metadata::default()),
                 _ => Err(parse_error(resp)),
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
     async fn rename(

--- a/core/services/onedrive/src/backend.rs
+++ b/core/services/onedrive/src/backend.rs
@@ -83,7 +83,7 @@ impl Service for OnedriveBackend {
     type Writer = oio::OneShotWriter<OneDriveWriter>;
     type Lister = oio::PageLister<OneDriveLister>;
     type Deleter = oio::OneShotDeleter<OneDriveDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -116,69 +116,61 @@ impl Service for OnedriveBackend {
 
         Ok(RpStat::new(meta))
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<OnedriveReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(OnedriveReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<OnedriveReader> = {
+            Ok(oio::StreamReader::new(OnedriveReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, oio::OneShotWriter<OneDriveWriter>) = {
-            Ok((
-                RpWrite::default(),
-                oio::OneShotWriter::new(OneDriveWriter::new(
-                    self.core.clone(),
-                    ctx.clone(),
-                    args,
-                    path.to_string(),
-                )),
-            ))
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: oio::OneShotWriter<OneDriveWriter> = {
+            Ok(oio::OneShotWriter::new(OneDriveWriter::new(
+                self.core.clone(),
+                ctx.clone(),
+                args,
+                path.to_string(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<OneDriveDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(OneDriveDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<OneDriveDeleter> = {
+            Ok(oio::OneShotDeleter::new(OneDriveDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let monitor_url = self.core.initialize_copy(ctx, from, to).await?;
-            self.core.wait_until_complete(ctx, monitor_url).await?;
-            Ok((RpCopy::default(), ()))
-        }?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
 
-        Ok((rp, output))
+        Ok(oio::OneShotCopier::new(async move {
+            let monitor_url = core.initialize_copy(&ctx, &from, &to).await?;
+            core.wait_until_complete(&ctx, monitor_url).await?;
+            Ok(Metadata::default())
+        }))
     }
 
     async fn rename(
@@ -197,13 +189,8 @@ impl Service for OnedriveBackend {
         Ok(RpRename::default())
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<OneDriveLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<OneDriveLister> = {
             let l = OneDriveLister::new(
                 path.to_string(),
                 self.core.clone(),
@@ -211,10 +198,10 @@ impl Service for OnedriveBackend {
                 self.core.capability,
                 &args,
             );
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
     async fn presign(

--- a/core/services/opfs/src/backend.rs
+++ b/core/services/opfs/src/backend.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::File;
-use web_sys::FileSystemWritableFileStream;
 
 use super::config::OpfsConfig;
 use super::core::OpfsCore;
@@ -147,12 +146,7 @@ impl Service for OpfsBackend {
     }
 
     fn list(&self, _ctx: &OperationContext, path: &str, _args: OpList) -> Result<Self::Lister> {
-        let output: OpfsLister = {
-            let p = build_abs_path(&self.core.root, path);
-            let dir = get_directory_handle(&p, false).await?;
-
-            Ok(OpfsLister::new(dir, path.to_string()))
-        }?;
+        let output: OpfsLister = { Ok(OpfsLister::new(self.core.clone(), path.to_string())) }?;
 
         Ok(output)
     }
@@ -171,21 +165,12 @@ impl Service for OpfsBackend {
     }
 
     fn write(&self, _ctx: &OperationContext, path: &str, _args: OpWrite) -> Result<Self::Writer> {
-        let output: OpfsWriter = {
-            let p = build_abs_path(&self.core.root, path);
-            let handle = get_file_handle(&p, true).await?;
-            let stream: FileSystemWritableFileStream = JsFuture::from(handle.create_writable())
-                .await
-                .and_then(JsCast::dyn_into)
-                .map_err(parse_js_error)?;
-
-            Ok(OpfsWriter::new(stream))
-        }?;
+        let output: OpfsWriter = { Ok(OpfsWriter::new(self.core.clone(), path.to_string())) }?;
 
         Ok(output)
     }
 
-    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
         let output: oio::OneShotDeleter<OpfsDeleter> = {
             Ok(oio::OneShotDeleter::new(OpfsDeleter::new(
                 self.core.clone(),

--- a/core/services/opfs/src/backend.rs
+++ b/core/services/opfs/src/backend.rs
@@ -134,36 +134,27 @@ impl Service for OpfsBackend {
 
         Ok(RpStat::new(meta))
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<OpfsReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(OpfsReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<OpfsReader> = {
+            Ok(oio::StreamReader::new(OpfsReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, OpfsLister) = {
+    fn list(&self, _ctx: &OperationContext, path: &str, _args: OpList) -> Result<Self::Lister> {
+        let output: OpfsLister = {
             let p = build_abs_path(&self.core.root, path);
             let dir = get_directory_handle(&p, false).await?;
 
-            Ok((RpList::default(), OpfsLister::new(dir, path.to_string())))
+            Ok(OpfsLister::new(dir, path.to_string()))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
     async fn create_dir(
@@ -179,13 +170,8 @@ impl Service for OpfsBackend {
         Ok(RpCreateDir::default())
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, OpfsWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _args: OpWrite) -> Result<Self::Writer> {
+        let output: OpfsWriter = {
             let p = build_abs_path(&self.core.root, path);
             let handle = get_file_handle(&p, true).await?;
             let stream: FileSystemWritableFileStream = JsFuture::from(handle.create_writable())
@@ -193,31 +179,30 @@ impl Service for OpfsBackend {
                 .and_then(JsCast::dyn_into)
                 .map_err(parse_js_error)?;
 
-            Ok((RpWrite::default(), OpfsWriter::new(stream)))
+            Ok(OpfsWriter::new(stream))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<OpfsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(OpfsDeleter::new(self.core.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<OpfsDeleter> = {
+            Ok(oio::OneShotDeleter::new(OpfsDeleter::new(
+                self.core.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _: &OperationContext,
         _: &str,
         _: &str,
         _: OpCopy,
         _: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/opfs/src/lister.rs
+++ b/core/services/opfs/src/lister.rs
@@ -15,35 +15,58 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use send_wrapper::SendWrapper;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
-use web_sys::FileSystemDirectoryHandle;
 
+use super::core::OpfsCore;
 use super::error::*;
+use super::utils::*;
 use opendal_core::raw::*;
 use opendal_core::*;
 
 pub struct OpfsLister {
-    iter: SendWrapper<js_sys::AsyncIterator>,
+    core: Arc<OpfsCore>,
+    iter: Option<SendWrapper<js_sys::AsyncIterator>>,
     path: String,
 }
 
 impl OpfsLister {
-    pub fn new(dir: FileSystemDirectoryHandle, path: String) -> Self {
+    pub fn new(core: Arc<OpfsCore>, path: String) -> Self {
         // Entry paths must not start with '/'.
         // For root listing, path is "/" — normalize to "".
         let path = if path == "/" { String::new() } else { path };
         Self {
-            iter: SendWrapper::new(dir.entries()),
+            core,
+            iter: None,
             path,
         }
+    }
+
+    async fn init_iter(&mut self) -> Result<()> {
+        if self.iter.is_some() {
+            return Ok(());
+        }
+
+        let p = build_abs_path(&self.core.root, &self.path);
+        let dir = get_directory_handle(&p, false).await?;
+        self.iter = Some(SendWrapper::new(dir.entries()));
+
+        Ok(())
     }
 }
 
 impl oio::List for OpfsLister {
     async fn next(&mut self) -> Result<Option<oio::Entry>> {
-        let result = JsFuture::from(self.iter.next().map_err(parse_js_error)?)
+        self.init_iter().await?;
+
+        let iter = self
+            .iter
+            .as_ref()
+            .expect("opfs list iterator must be initialized");
+        let result = JsFuture::from(iter.next().map_err(parse_js_error)?)
             .await
             .map_err(parse_js_error)?;
 

--- a/core/services/opfs/src/writer.rs
+++ b/core/services/opfs/src/writer.rs
@@ -15,7 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::sync::Arc;
+
 use send_wrapper::SendWrapper;
+use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::FileSystemWritableFileStream;
@@ -25,31 +28,59 @@ use web_sys::WriteParams;
 use opendal_core::raw::*;
 use opendal_core::*;
 
+use super::core::OpfsCore;
 use super::error::*;
+use super::utils::*;
 
 pub struct OpfsWriter {
-    stream: SendWrapper<FileSystemWritableFileStream>,
+    core: Arc<OpfsCore>,
+    path: String,
+    stream: Option<SendWrapper<FileSystemWritableFileStream>>,
     bytes_written: u64,
 }
 
 impl OpfsWriter {
-    pub fn new(stream: FileSystemWritableFileStream) -> Self {
+    pub fn new(core: Arc<OpfsCore>, path: String) -> Self {
         Self {
-            stream: SendWrapper::new(stream),
+            core,
+            path,
+            stream: None,
             bytes_written: 0,
         }
+    }
+
+    async fn init_stream(&mut self) -> Result<()> {
+        if self.stream.is_some() {
+            return Ok(());
+        }
+
+        let p = build_abs_path(&self.core.root, &self.path);
+        let handle = get_file_handle(&p, true).await?;
+        let stream: FileSystemWritableFileStream = JsFuture::from(handle.create_writable())
+            .await
+            .and_then(JsCast::dyn_into)
+            .map_err(parse_js_error)?;
+        self.stream = Some(SendWrapper::new(stream));
+
+        Ok(())
     }
 }
 
 impl oio::Write for OpfsWriter {
     async fn write(&mut self, bs: Buffer) -> Result<()> {
+        self.init_stream().await?;
+
         let bytes = bs.to_bytes();
         let params = WriteParams::new(WriteCommandType::Write);
         params.set_size(Some(bytes.len() as f64));
         let data: JsValue = js_sys::Uint8Array::from(bytes.as_ref()).into();
         params.set_data(&data);
+        let stream = self
+            .stream
+            .as_ref()
+            .expect("opfs writable stream must be initialized");
         JsFuture::from(
-            self.stream
+            stream
                 .write_with_write_params(&params.into())
                 .map_err(parse_js_error)?,
         )
@@ -61,9 +92,13 @@ impl oio::Write for OpfsWriter {
     }
 
     async fn close(&mut self) -> Result<Metadata> {
-        JsFuture::from(self.stream.close())
-            .await
-            .map_err(parse_js_error)?;
+        self.init_stream().await?;
+
+        if let Some(stream) = self.stream.take() {
+            JsFuture::from(stream.close())
+                .await
+                .map_err(parse_js_error)?;
+        }
 
         // We cannot set LastModified here - stream does not have such metadata
         let mut meta = Metadata::new(EntryMode::FILE);
@@ -72,9 +107,11 @@ impl oio::Write for OpfsWriter {
     }
 
     async fn abort(&mut self) -> Result<()> {
-        JsFuture::from(self.stream.abort())
-            .await
-            .map_err(parse_js_error)?;
+        if let Some(stream) = self.stream.take() {
+            JsFuture::from(stream.abort())
+                .await
+                .map_err(parse_js_error)?;
+        }
         Ok(())
     }
 }

--- a/core/services/oss/src/backend.rs
+++ b/core/services/oss/src/backend.rs
@@ -689,7 +689,7 @@ impl Service for OssBackend {
     type Writer = OssWriters;
     type Lister = OssListers;
     type Deleter = oio::BatchDeleter<OssDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -730,29 +730,21 @@ impl Service for OssBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<OssReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(OssReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<OssReader> = {
+            Ok(oio::StreamReader::new(OssReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, OssWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: OssWriters = {
             let writer = OssWriter::new(self.core.clone(), ctx.clone(), path, args.clone());
 
             let w = if args.append() {
@@ -765,33 +757,25 @@ impl Service for OssBackend {
                 ))
             };
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::BatchDeleter<OssDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::BatchDeleter::new(
-                    OssDeleter::new(self.core.clone(), ctx.clone()),
-                    self.core.capability.delete_max_size,
-                ),
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::BatchDeleter<OssDeleter> = {
+            Ok(oio::BatchDeleter::new(
+                OssDeleter::new(self.core.clone(), ctx.clone()),
+                self.core.capability.delete_max_size,
             ))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, OssListers) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: OssListers = {
             let l = if args.versions() || args.deleted() {
                 TwoWays::Two(oio::PageLister::new(OssObjectVersionsLister::new(
                     self.core.clone(),
@@ -810,31 +794,33 @@ impl Service for OssBackend {
                 )))
             };
 
-            Ok((RpList::default(), l))
+            Ok(l)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let resp = self.core.oss_copy_object(ctx, from, to).await?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
+        Ok(oio::OneShotCopier::new(async move {
+            let resp = core.oss_copy_object(&ctx, &from, &to).await?;
             let status = resp.status();
 
             match status {
-                StatusCode::OK => Ok((RpCopy::default(), ())),
+                StatusCode::OK => Ok(Metadata::default()),
                 _ => Err(parse_error(resp)),
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
     async fn rename(

--- a/core/services/pcloud/src/backend.rs
+++ b/core/services/pcloud/src/backend.rs
@@ -221,7 +221,7 @@ impl Service for PcloudBackend {
     type Writer = PcloudWriters;
     type Lister = oio::PageLister<PcloudLister>;
     type Deleter = oio::OneShotDeleter<PcloudDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -269,79 +269,71 @@ impl Service for PcloudBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<PcloudReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(PcloudReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<PcloudReader> = {
+            Ok(oio::StreamReader::new(PcloudReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, PcloudWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, _args: OpWrite) -> Result<Self::Writer> {
+        let output: PcloudWriters = {
             let writer = PcloudWriter::new(self.core.clone(), ctx.clone(), path.to_string());
 
             let w = oio::OneShotWriter::new(writer);
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<PcloudDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(PcloudDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<PcloudDeleter> = {
+            Ok(oio::OneShotDeleter::new(PcloudDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<PcloudLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, _args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<PcloudLister> = {
             let l = PcloudLister::new(self.core.clone(), ctx.clone(), path);
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            self.core.ensure_dir_exists(ctx, to).await?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
+
+        Ok(oio::OneShotCopier::new(async move {
+            core.ensure_dir_exists(&ctx, &to).await?;
 
             let resp = if from.ends_with('/') {
-                self.core.copy_folder(ctx, from, to).await?
+                core.copy_folder(&ctx, &from, &to).await?
             } else {
-                self.core.copy_file(ctx, from, to).await?
+                core.copy_file(&ctx, &from, &to).await?
             };
 
             let status = resp.status();
@@ -357,14 +349,12 @@ impl Service for PcloudBackend {
                     } else if result != 0 {
                         Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")))
                     } else {
-                        Ok((RpCopy::default(), ()))
+                        Ok(Metadata::default())
                     }
                 }
                 _ => Err(parse_error(resp)),
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
     async fn rename(

--- a/core/services/persy/src/backend.rs
+++ b/core/services/persy/src/backend.rs
@@ -225,67 +225,53 @@ impl Service for PersyBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<PersyReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(PersyReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<PersyReader> = {
+            Ok(oio::StreamReader::new(PersyReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, PersyWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: PersyWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((RpWrite::new(), PersyWriter::new(self.core.clone(), p)))
+            Ok(PersyWriter::new(self.core.clone(), p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<PersyDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(PersyDeleter::new(self.core.clone(), self.root.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<PersyDeleter> = {
+            Ok(oio::OneShotDeleter::new(PersyDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/postgresql/src/backend.rs
+++ b/core/services/postgresql/src/backend.rs
@@ -263,70 +263,53 @@ impl Service for PostgresqlBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<PostgresqlReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(PostgresqlReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<PostgresqlReader> = {
+            Ok(oio::StreamReader::new(PostgresqlReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, PostgresqlWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: PostgresqlWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((RpWrite::new(), PostgresqlWriter::new(self.core.clone(), p)))
+            Ok(PostgresqlWriter::new(self.core.clone(), p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<PostgresqlDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(PostgresqlDeleter::new(
-                    self.core.clone(),
-                    self.root.clone(),
-                )),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<PostgresqlDeleter> = {
+            Ok(oio::OneShotDeleter::new(PostgresqlDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/redb/src/backend.rs
+++ b/core/services/redb/src/backend.rs
@@ -243,67 +243,53 @@ impl Service for RedbBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<RedbReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(RedbReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<RedbReader> = {
+            Ok(oio::StreamReader::new(RedbReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, RedbWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: RedbWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((RpWrite::new(), RedbWriter::new(self.core.clone(), p)))
+            Ok(RedbWriter::new(self.core.clone(), p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<RedbDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(RedbDeleter::new(self.core.clone(), self.root.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<RedbDeleter> = {
+            Ok(oio::OneShotDeleter::new(RedbDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/redis/src/backend.rs
+++ b/core/services/redis/src/backend.rs
@@ -415,67 +415,53 @@ impl Service for RedisBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<RedisReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(RedisReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<RedisReader> = {
+            Ok(oio::StreamReader::new(RedisReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, RedisWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: RedisWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((RpWrite::new(), RedisWriter::new(self.core.clone(), p)))
+            Ok(RedisWriter::new(self.core.clone(), p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<RedisDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(RedisDeleter::new(self.core.clone(), self.root.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<RedisDeleter> = {
+            Ok(oio::OneShotDeleter::new(RedisDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/rocksdb/src/backend.rs
+++ b/core/services/rocksdb/src/backend.rs
@@ -193,72 +193,55 @@ impl Service for RocksdbBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<RocksdbReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(RocksdbReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<RocksdbReader> = {
+            Ok(oio::StreamReader::new(RocksdbReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, RocksdbWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: RocksdbWriter = {
             let p = build_abs_path(&self.root, path);
             let writer = RocksdbWriter::new(self.core.clone(), p);
-            Ok((RpWrite::new(), writer))
+            Ok(writer)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<RocksdbDeleter>) = {
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<RocksdbDeleter> = {
             let deleter = RocksdbDeleter::new(self.core.clone(), self.root.clone());
-            Ok((RpDelete::default(), oio::OneShotDeleter::new(deleter)))
+            Ok(oio::OneShotDeleter::new(deleter))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::HierarchyLister<RocksdbLister>) = {
+    fn list(&self, _ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::HierarchyLister<RocksdbLister> = {
             let p = build_abs_path(&self.root, path);
             let lister = RocksdbLister::new(self.core.clone(), self.root.clone(), p)?;
-            Ok((
-                RpList::default(),
-                oio::HierarchyLister::new(lister, path, args.recursive()),
-            ))
+            Ok(oio::HierarchyLister::new(lister, path, args.recursive()))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -1140,29 +1140,21 @@ impl Service for S3Backend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<S3Reader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(S3Reader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<S3Reader> = {
+            Ok(oio::StreamReader::new(S3Reader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, S3Writers) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: S3Writers = {
             let writer = S3Writer::new(self.core.clone(), ctx.clone(), path, args.clone());
 
             let w = if args.append() {
@@ -1177,33 +1169,25 @@ impl Service for S3Backend {
                 ))
             };
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::BatchDeleter<S3Deleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::BatchDeleter::new(
-                    S3Deleter::new(self.core.clone(), ctx.clone()),
-                    self.core.capability.delete_max_size,
-                ),
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::BatchDeleter<S3Deleter> = {
+            Ok(oio::BatchDeleter::new(
+                S3Deleter::new(self.core.clone(), ctx.clone()),
+                self.core.capability.delete_max_size,
             ))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, S3Listers) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: S3Listers = {
             let l = if args.versions() || args.deleted() {
                 ThreeWays::Three(oio::PageLister::new(S3ObjectVersionsLister::new(
                     self.core.clone(),
@@ -1227,26 +1211,26 @@ impl Service for S3Backend {
                 )))
             };
 
-            Ok((RpList::default(), l))
+            Ok(l)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, S3Copiers) = {
+    ) -> Result<Self::Copier> {
+        let output: S3Copiers = {
             let copier = new_s3_copier(self.core.clone(), ctx, from, to, args, opts)?;
-            Ok((RpCopy::default(), copier))
+            Ok(copier)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
     async fn rename(

--- a/core/services/seafile/src/backend.rs
+++ b/core/services/seafile/src/backend.rs
@@ -274,71 +274,58 @@ impl Service for SeafileBackend {
 
         metadata.map(RpStat::new)
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<SeafileReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(SeafileReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<SeafileReader> = {
+            Ok(oio::StreamReader::new(SeafileReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, SeafileWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: SeafileWriters = {
             let w = SeafileWriter::new(self.core.clone(), ctx.clone(), args, path.to_string());
             let w = oio::OneShotWriter::new(w);
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<SeafileDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(SeafileDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<SeafileDeleter> = {
+            Ok(oio::OneShotDeleter::new(SeafileDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<SeafileLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, _args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<SeafileLister> = {
             let l = SeafileLister::new(self.core.clone(), ctx.clone(), path);
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/sftp/src/backend.rs
+++ b/core/services/sftp/src/backend.rs
@@ -253,12 +253,137 @@ impl oio::StreamRead for SftpReader {
     }
 }
 
+pub struct SftpLazyWriter {
+    backend: SftpBackend,
+    ctx: OperationContext,
+    path: String,
+    op: OpWrite,
+    inner: Option<SftpWriter>,
+}
+
+impl SftpLazyWriter {
+    fn new(backend: SftpBackend, ctx: OperationContext, path: &str, op: OpWrite) -> Self {
+        Self {
+            backend,
+            ctx,
+            path: path.to_string(),
+            op,
+            inner: None,
+        }
+    }
+
+    async fn inner(&mut self) -> Result<&mut SftpWriter> {
+        if self.inner.is_none() {
+            if let Some((dir, _)) = self.path.rsplit_once('/') {
+                self.backend
+                    .create_dir(&self.ctx, dir, OpCreateDir::default())
+                    .await?;
+            }
+
+            let client = self.backend.core.connect().await?;
+
+            let mut fs = client.fs();
+            fs.set_cwd(&self.backend.core.root);
+            let path = fs
+                .canonicalize(&self.path)
+                .await
+                .map_err(parse_sftp_error)?;
+
+            let mut option = client.options();
+            if self.op.if_not_exists() {
+                option.create_new(true);
+            } else {
+                option.create(true);
+            }
+
+            if self.op.append() {
+                option.append(true);
+            } else {
+                option.write(true).truncate(true);
+            }
+
+            let res = option.open(&path).await;
+            let file = match res {
+                Ok(f) => f,
+                Err(e) if self.op.if_not_exists() && is_sftp_failure(&e) => {
+                    if fs.metadata(&path).await.is_ok() {
+                        return Err(Error::new(
+                            ErrorKind::ConditionNotMatch,
+                            "file already exists, doesn't match the condition if_not_exists",
+                        )
+                        .set_source(e));
+                    }
+                    return Err(parse_sftp_error(e));
+                }
+                Err(e) => return Err(parse_sftp_error(e)),
+            };
+
+            self.inner = Some(SftpWriter::new(file));
+        }
+
+        Ok(self.inner.as_mut().expect("writer must be initialized"))
+    }
+}
+
+impl oio::Write for SftpLazyWriter {
+    async fn write(&mut self, bs: Buffer) -> Result<()> {
+        self.inner().await?.write(bs).await
+    }
+
+    async fn close(&mut self) -> Result<Metadata> {
+        self.inner().await?.close().await
+    }
+
+    async fn abort(&mut self) -> Result<()> {
+        self.inner().await?.abort().await
+    }
+}
+
+pub struct SftpLazyLister {
+    backend: SftpBackend,
+    path: String,
+    inner: Option<Option<SftpLister>>,
+}
+
+impl SftpLazyLister {
+    fn new(backend: SftpBackend, path: &str) -> Self {
+        Self {
+            backend,
+            path: path.to_string(),
+            inner: None,
+        }
+    }
+}
+
+impl oio::List for SftpLazyLister {
+    async fn next(&mut self) -> Result<Option<oio::Entry>> {
+        if self.inner.is_none() {
+            let client = self.backend.core.connect().await?;
+            let mut fs = client.fs();
+            fs.set_cwd(&self.backend.core.root);
+
+            let file_path = format!("./{}", self.path);
+
+            self.inner = Some(match fs.open_dir(&file_path).await {
+                Ok(dir) => Some(SftpLister::new(dir.read_dir(), self.path.clone())),
+                Err(e) if is_not_found(&e) => None,
+                Err(e) => return Err(parse_sftp_error(e)),
+            });
+        }
+
+        match self.inner.as_mut().expect("lister must be initialized") {
+            Some(lister) => lister.next().await,
+            None => Ok(None),
+        }
+    }
+}
+
 impl Service for SftpBackend {
     type Reader = oio::StreamReader<SftpReader>;
-    type Writer = SftpWriter;
-    type Lister = Option<SftpLister>;
+    type Writer = SftpLazyWriter;
+    type Lister = SftpLazyLister;
     type Deleter = oio::OneShotDeleter<SftpDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -305,136 +430,62 @@ impl Service for SftpBackend {
 
         Ok(RpStat::new(meta))
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<SftpReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(SftpReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<SftpReader> = {
+            Ok(oio::StreamReader::new(SftpReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        op: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, SftpWriter) = {
-            if let Some((dir, _)) = path.rsplit_once('/') {
-                self.create_dir(ctx, dir, OpCreateDir::default()).await?;
-            }
+    fn write(&self, ctx: &OperationContext, path: &str, op: OpWrite) -> Result<Self::Writer> {
+        Ok(SftpLazyWriter::new(self.clone(), ctx.clone(), path, op))
+    }
 
-            let client = self.core.connect().await?;
-
-            let mut fs = client.fs();
-            fs.set_cwd(&self.core.root);
-            let path = fs.canonicalize(path).await.map_err(parse_sftp_error)?;
-
-            let mut option = client.options();
-            if op.if_not_exists() {
-                option.create_new(true);
-            } else {
-                option.create(true);
-            }
-
-            if op.append() {
-                option.append(true);
-            } else {
-                option.write(true).truncate(true);
-            }
-
-            let res = option.open(&path).await;
-            let file = match res {
-                Ok(f) => f,
-                Err(e) if op.if_not_exists() && is_sftp_failure(&e) => {
-                    // OpenSSH returns Failure for create_new if file exists.
-                    // We perform a post-check to confirm if it was a ConditionNotMatch.
-                    if fs.metadata(&path).await.is_ok() {
-                        return Err(Error::new(
-                            ErrorKind::ConditionNotMatch,
-                            "file already exists, doesn't match the condition if_not_exists",
-                        )
-                        .set_source(e));
-                    }
-                    return Err(parse_sftp_error(e));
-                }
-                Err(e) => return Err(parse_sftp_error(e)),
-            };
-
-            Ok((RpWrite::new(), SftpWriter::new(file)))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<SftpDeleter> = {
+            Ok(oio::OneShotDeleter::new(SftpDeleter::new(
+                self.core.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<SftpDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(SftpDeleter::new(self.core.clone())),
-            ))
-        }?;
-
-        Ok((rp, output))
+    fn list(&self, _ctx: &OperationContext, path: &str, _: OpList) -> Result<Self::Lister> {
+        Ok(SftpLazyLister::new(self.clone(), path))
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, Option<SftpLister>) = {
-            let client = self.core.connect().await?;
-            let mut fs = client.fs();
-            fs.set_cwd(&self.core.root);
-
-            let file_path = format!("./{path}");
-
-            match fs.open_dir(&file_path).await {
-                Ok(dir) => {
-                    let dir = dir.read_dir();
-                    Ok((
-                        RpList::default(),
-                        Some(SftpLister::new(dir, path.to_owned())),
-                    ))
-                }
-                Err(e) if is_not_found(&e) => Ok((RpList::default(), None)),
-                Err(e) => Err(parse_sftp_error(e)),
-            }
-        }?;
-
-        Ok((rp, output))
-    }
-
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let client = self.core.connect().await?;
+    ) -> Result<Self::Copier> {
+        let backend = self.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
+        Ok(oio::OneShotCopier::new(async move {
+            let client = backend.core.connect().await?;
 
             let mut fs = client.fs();
-            fs.set_cwd(&self.core.root);
+            fs.set_cwd(&backend.core.root);
 
             if let Some((dir, _)) = to.rsplit_once('/') {
-                self.create_dir(ctx, dir, OpCreateDir::default()).await?;
+                backend
+                    .create_dir(&ctx, dir, OpCreateDir::default())
+                    .await?;
             }
 
-            let src = fs.canonicalize(from).await.map_err(parse_sftp_error)?;
-            let dst = fs.canonicalize(to).await.map_err(parse_sftp_error)?;
+            let src = fs.canonicalize(&from).await.map_err(parse_sftp_error)?;
+            let dst = fs.canonicalize(&to).await.map_err(parse_sftp_error)?;
             let mut src_file = client.open(&src).await.map_err(parse_sftp_error)?;
             let mut dst_file = client.create(dst).await.map_err(parse_sftp_error)?;
 
@@ -443,10 +494,8 @@ impl Service for SftpBackend {
                 .await
                 .map_err(parse_sftp_error)?;
 
-            Ok((RpCopy::default(), ()))
-        }?;
-
-        Ok((rp, output))
+            Ok(Metadata::default())
+        }))
     }
 
     async fn rename(

--- a/core/services/sled/src/backend.rs
+++ b/core/services/sled/src/backend.rs
@@ -217,72 +217,55 @@ impl Service for SledBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<SledReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(SledReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<SledReader> = {
+            Ok(oio::StreamReader::new(SledReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, SledWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: SledWriter = {
             let p = build_abs_path(&self.root, path);
             let writer = SledWriter::new(self.core.clone(), p);
-            Ok((RpWrite::new(), writer))
+            Ok(writer)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<SledDeleter>) = {
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<SledDeleter> = {
             let deleter = SledDeleter::new(self.core.clone(), self.root.clone());
-            Ok((RpDelete::default(), oio::OneShotDeleter::new(deleter)))
+            Ok(oio::OneShotDeleter::new(deleter))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::HierarchyLister<SledLister>) = {
+    fn list(&self, _ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::HierarchyLister<SledLister> = {
             let p = build_abs_path(&self.root, path);
             let lister = SledLister::new(self.core.clone(), self.root.clone(), p)?;
-            Ok((
-                RpList::default(),
-                oio::HierarchyLister::new(lister, path, args.recursive()),
-            ))
+            Ok(oio::HierarchyLister::new(lister, path, args.recursive()))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/sqlite/src/backend.rs
+++ b/core/services/sqlite/src/backend.rs
@@ -325,45 +325,36 @@ impl Service for SqliteBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<SqliteReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(SqliteReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<SqliteReader> = {
+            Ok(oio::StreamReader::new(SqliteReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, SqliteWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: SqliteWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((RpWrite::new(), SqliteWriter::new(self.core.clone(), &p)))
+            Ok(SqliteWriter::new(self.core.clone(), &p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<SqliteDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(SqliteDeleter::new(self.core.clone(), self.root.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<SqliteDeleter> = {
+            Ok(oio::OneShotDeleter::new(SqliteDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
     async fn create_dir(
@@ -387,26 +378,21 @@ impl Service for SqliteBackend {
         Ok(RpCreateDir::default())
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
@@ -507,17 +493,11 @@ mod test {
 
         let accessor = SqliteBackend::new(core);
         let ctx = OperationContext::new(HttpClient::default(), Executor::default());
-        let (_, mut writer) = accessor
-            .write(&ctx, "hello", OpWrite::default())
-            .await
-            .unwrap();
+        let mut writer = accessor.write(&ctx, "hello", OpWrite::default()).unwrap();
         writer.write(Buffer::from("hello world")).await.unwrap();
         writer.close().await.unwrap();
 
-        let (_, reader) = accessor
-            .read(&ctx, "hello", OpRead::default())
-            .await
-            .unwrap();
+        let reader = accessor.read(&ctx, "hello", OpRead::default()).unwrap();
         let (_, mut stream) = reader.open(BytesRange::from(6_u64..)).await.unwrap();
         let buffer = stream.read_all().await.unwrap();
 

--- a/core/services/surrealdb/src/backend.rs
+++ b/core/services/surrealdb/src/backend.rs
@@ -311,70 +311,53 @@ impl Service for SurrealdbBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<SurrealdbReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(SurrealdbReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<SurrealdbReader> = {
+            Ok(oio::StreamReader::new(SurrealdbReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, SurrealdbWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: SurrealdbWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((RpWrite::new(), SurrealdbWriter::new(self.core.clone(), p)))
+            Ok(SurrealdbWriter::new(self.core.clone(), p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<SurrealdbDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(SurrealdbDeleter::new(
-                    self.core.clone(),
-                    self.root.clone(),
-                )),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<SurrealdbDeleter> = {
+            Ok(oio::OneShotDeleter::new(SurrealdbDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/swift/src/backend.rs
+++ b/core/services/swift/src/backend.rs
@@ -284,7 +284,7 @@ impl Service for SwiftBackend {
     type Writer = oio::MultipartWriter<SwiftWriter>;
     type Lister = oio::PageLister<SwiftLister>;
     type Deleter = oio::BatchDeleter<SwiftDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -323,29 +323,21 @@ impl Service for SwiftBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<SwiftReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(SwiftReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<SwiftReader> = {
+            Ok(oio::StreamReader::new(SwiftReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, oio::MultipartWriter<SwiftWriter>) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: oio::MultipartWriter<SwiftWriter> = {
             let concurrent = args.concurrent();
             let writer = SwiftWriter::new(
                 self.core.clone(),
@@ -355,33 +347,25 @@ impl Service for SwiftBackend {
             );
             let w = oio::MultipartWriter::new(ctx.executor().clone(), writer, concurrent);
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::BatchDeleter<SwiftDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::BatchDeleter::new(
-                    SwiftDeleter::new(self.core.clone(), ctx.clone()),
-                    self.core.capability.delete_max_size,
-                ),
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::BatchDeleter<SwiftDeleter> = {
+            Ok(oio::BatchDeleter::new(
+                SwiftDeleter::new(self.core.clone(), ctx.clone()),
+                self.core.capability.delete_max_size,
             ))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<SwiftLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<SwiftLister> = {
             let l = SwiftLister::new(
                 self.core.clone(),
                 ctx.clone(),
@@ -390,10 +374,10 @@ impl Service for SwiftBackend {
                 args.limit(),
             );
 
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
     async fn presign(
@@ -428,28 +412,31 @@ impl Service for SwiftBackend {
         )))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
+
+        Ok(oio::OneShotCopier::new(async move {
             // cannot copy objects larger than 5 GB.
             // Reference: https://docs.openstack.org/api-ref/object-store/#copy-object
-            let resp = self.core.swift_copy(ctx, from, to).await?;
+            let resp = core.swift_copy(&ctx, &from, &to).await?;
 
             let status = resp.status();
 
             match status {
-                StatusCode::CREATED | StatusCode::OK => Ok((RpCopy::default(), ())),
+                StatusCode::CREATED | StatusCode::OK => Ok(Metadata::default()),
                 _ => Err(parse_error(resp)),
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
     async fn rename(

--- a/core/services/tikv/src/backend.rs
+++ b/core/services/tikv/src/backend.rs
@@ -217,67 +217,53 @@ impl Service for TikvBackend {
             }
         }
     }
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<TikvReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(TikvReader::new(self.clone(), path, args)),
-            ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<TikvReader> = {
+            Ok(oio::StreamReader::new(TikvReader::new(
+                self.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        _: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, TikvWriter) = {
+    fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
+        let output: TikvWriter = {
             let p = build_abs_path(&self.root, path);
-            Ok((RpWrite::new(), TikvWriter::new(self.core.clone(), p)))
+            Ok(TikvWriter::new(self.core.clone(), p))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<TikvDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(TikvDeleter::new(self.core.clone(), self.root.clone())),
-            ))
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<TikvDeleter> = {
+            Ok(oio::OneShotDeleter::new(TikvDeleter::new(
+                self.core.clone(),
+                self.root.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/tos/src/backend.rs
+++ b/core/services/tos/src/backend.rs
@@ -371,58 +371,45 @@ impl Service for TosBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<TosReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(TosReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<TosReader> = {
+            Ok(oio::StreamReader::new(TosReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, oio::MultipartWriter<TosWriter>) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: oio::MultipartWriter<TosWriter> = {
             let writer = TosWriter::new(self.core.clone(), ctx.clone(), path, args.clone());
 
             let w = oio::MultipartWriter::new(ctx.executor().clone(), writer, args.concurrent());
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::BatchDeleter<TosDeleter>) = {
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::BatchDeleter<TosDeleter> = {
             let deleter = TosDeleter::new(self.core.clone(), ctx.clone());
-            Ok((
-                RpDelete::default(),
-                oio::BatchDeleter::new(deleter, self.core.capability.delete_max_size),
+            Ok(oio::BatchDeleter::new(
+                deleter,
+                self.core.capability.delete_max_size,
             ))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, TosListers) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: TosListers = {
             let lister = if args.versions() || args.deleted() {
                 TwoWays::Two(oio::PageLister::new(TosObjectVersionsLister::new(
                     self.core.clone(),
@@ -438,26 +425,26 @@ impl Service for TosBackend {
                     args,
                 )))
             };
-            Ok((RpList::default(), lister))
+            Ok(lister)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         args: OpCopy,
         opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, TosCopiers) = {
+    ) -> Result<Self::Copier> {
+        let output: TosCopiers = {
             let copier = new_tos_copier(self.core.clone(), ctx, from, to, args, opts)?;
-            Ok((RpCopy::default(), copier))
+            Ok(copier)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
     async fn rename(

--- a/core/services/upyun/src/backend.rs
+++ b/core/services/upyun/src/backend.rs
@@ -229,7 +229,7 @@ impl Service for UpyunBackend {
     type Writer = UpyunWriters;
     type Lister = oio::PageLister<UpyunLister>;
     type Deleter = oio::OneShotDeleter<UpyunDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -265,85 +265,74 @@ impl Service for UpyunBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<UpyunReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(UpyunReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<UpyunReader> = {
+            Ok(oio::StreamReader::new(UpyunReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, UpyunWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: UpyunWriters = {
             let concurrent = args.concurrent();
             let writer = UpyunWriter::new(self.core.clone(), ctx.clone(), args, path.to_string());
 
             let w = oio::MultipartWriter::new(ctx.executor().clone(), writer, concurrent);
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<UpyunDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(UpyunDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<UpyunDeleter> = {
+            Ok(oio::OneShotDeleter::new(UpyunDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<UpyunLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<UpyunLister> = {
             let l = UpyunLister::new(self.core.clone(), ctx.clone(), path, args.limit());
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let resp = self.core.copy(ctx, from, to).await?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
 
+        Ok(oio::OneShotCopier::new(async move {
+            let resp = core.copy(&ctx, &from, &to).await?;
             let status = resp.status();
 
             match status {
-                StatusCode::OK => Ok((RpCopy::default(), ())),
+                StatusCode::OK => Ok(Metadata::default()),
                 _ => Err(parse_error(resp)),
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
     async fn rename(

--- a/core/services/vercel-artifacts/src/backend.rs
+++ b/core/services/vercel-artifacts/src/backend.rs
@@ -125,75 +125,54 @@ impl Service for VercelArtifactsBackend {
             _ => Err(parse_error(response)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<VercelArtifactsReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(VercelArtifactsReader::new(
-                    self.clone(),
-                    ctx.clone(),
-                    path,
-                    args,
-                )),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<VercelArtifactsReader> = {
+            Ok(oio::StreamReader::new(VercelArtifactsReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, oio::OneShotWriter<VercelArtifactsWriter>) = {
-            Ok((
-                RpWrite::default(),
-                oio::OneShotWriter::new(VercelArtifactsWriter::new(
-                    self.core.clone(),
-                    ctx.clone(),
-                    args,
-                    path.to_string(),
-                )),
-            ))
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: oio::OneShotWriter<VercelArtifactsWriter> = {
+            Ok(oio::OneShotWriter::new(VercelArtifactsWriter::new(
+                self.core.clone(),
+                ctx.clone(),
+                args,
+                path.to_string(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        _path: &str,
-        _args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
+    fn list(&self, _ctx: &OperationContext, _path: &str, _args: OpList) -> Result<Self::Lister> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/vercel-blob/src/backend.rs
+++ b/core/services/vercel-blob/src/backend.rs
@@ -181,7 +181,7 @@ impl Service for VercelBlobBackend {
     type Writer = VercelBlobWriters;
     type Lister = oio::PageLister<VercelBlobLister>;
     type Deleter = oio::OneShotDeleter<VercelBlobDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -220,91 +220,75 @@ impl Service for VercelBlobBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<VercelBlobReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(VercelBlobReader::new(
-                    self.clone(),
-                    ctx.clone(),
-                    path,
-                    args,
-                )),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<VercelBlobReader> = {
+            Ok(oio::StreamReader::new(VercelBlobReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, VercelBlobWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: VercelBlobWriters = {
             let concurrent = args.concurrent();
             let writer =
                 VercelBlobWriter::new(self.core.clone(), ctx.clone(), args, path.to_string());
 
             let w = oio::MultipartWriter::new(ctx.executor().clone(), writer, concurrent);
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let resp = self.core.copy(ctx, from, to).await?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
 
+        Ok(oio::OneShotCopier::new(async move {
+            let resp = core.copy(&ctx, &from, &to).await?;
             let status = resp.status();
 
             match status {
-                StatusCode::OK => Ok((RpCopy::default(), ())),
+                StatusCode::OK => Ok(Metadata::default()),
                 _ => Err(parse_error(resp)),
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<VercelBlobLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<VercelBlobLister> = {
             let l = VercelBlobLister::new(self.core.clone(), ctx.clone(), path, args.limit());
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<VercelBlobDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(VercelBlobDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<VercelBlobDeleter> = {
+            Ok(oio::OneShotDeleter::new(VercelBlobDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
     async fn rename(

--- a/core/services/webdav/src/backend.rs
+++ b/core/services/webdav/src/backend.rs
@@ -295,7 +295,7 @@ impl Service for WebdavBackend {
     type Writer = oio::OneShotWriter<WebdavWriter>;
     type Lister = oio::PageLister<WebdavLister>;
     type Deleter = oio::OneShotDeleter<WebdavDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -319,100 +319,78 @@ impl Service for WebdavBackend {
         let metadata = self.core.webdav_stat(ctx, path).await?;
         Ok(RpStat::new(metadata))
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<WebdavReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(WebdavReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<WebdavReader> = {
+            Ok(oio::StreamReader::new(WebdavReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, oio::OneShotWriter<WebdavWriter>) = {
-            // Ensure parent path exists (unless disabled for servers that don't support PROPFIND)
-            if !self.core.disable_create_dir {
-                self.core.webdav_mkcol(ctx, get_parent(path)).await?;
-            }
-
-            Ok((
-                RpWrite::default(),
-                oio::OneShotWriter::new(WebdavWriter::new(
-                    self.core.clone(),
-                    ctx.clone(),
-                    args,
-                    path.to_string(),
-                )),
-            ))
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: oio::OneShotWriter<WebdavWriter> = {
+            Ok(oio::OneShotWriter::new(WebdavWriter::new(
+                self.core.clone(),
+                ctx.clone(),
+                args,
+                path.to_string(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<WebdavDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(WebdavDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<WebdavDeleter> = {
+            Ok(oio::OneShotDeleter::new(WebdavDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<WebdavLister>) = {
-            Ok((
-                RpList::default(),
-                oio::PageLister::new(WebdavLister::new(
-                    self.core.clone(),
-                    ctx.clone(),
-                    path,
-                    args,
-                )),
-            ))
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<WebdavLister> = {
+            Ok(oio::PageLister::new(WebdavLister::new(
+                self.core.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            let resp = self.core.webdav_copy(ctx, from, to).await?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
 
+        Ok(oio::OneShotCopier::new(async move {
+            let resp = core.webdav_copy(&ctx, &from, &to).await?;
             let status = resp.status();
 
             match status {
-                StatusCode::CREATED | StatusCode::NO_CONTENT => Ok((RpCopy::default(), ())),
+                StatusCode::CREATED | StatusCode::NO_CONTENT => Ok(Metadata::default()),
                 _ => Err(parse_error(resp)),
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
 
     async fn rename(

--- a/core/services/webdav/src/backend.rs
+++ b/core/services/webdav/src/backend.rs
@@ -382,13 +382,20 @@ impl Service for WebdavBackend {
         let from = from.to_string();
         let to = to.to_string();
 
-        Ok(oio::OneShotCopier::new(async move {
-            let resp = core.webdav_copy(&ctx, &from, &to).await?;
-            let status = resp.status();
+        Ok(oio::OneShotCopier::new_with(move || {
+            let core = core.clone();
+            let ctx = ctx.clone();
+            let from = from.clone();
+            let to = to.clone();
 
-            match status {
-                StatusCode::CREATED | StatusCode::NO_CONTENT => Ok(Metadata::default()),
-                _ => Err(parse_error(resp)),
+            async move {
+                let resp = core.webdav_copy(&ctx, &from, &to).await?;
+                let status = resp.status();
+
+                match status {
+                    StatusCode::CREATED | StatusCode::NO_CONTENT => Ok(Metadata::default()),
+                    _ => Err(parse_error(resp)),
+                }
             }
         }))
     }

--- a/core/services/webdav/src/writer.rs
+++ b/core/services/webdav/src/writer.rs
@@ -59,6 +59,13 @@ impl WebdavWriter {
 
 impl oio::OneShotWrite for WebdavWriter {
     async fn write_once(&self, bs: Buffer) -> Result<Metadata> {
+        // Ensure parent path exists unless disabled for servers that don't support PROPFIND.
+        if !self.core.disable_create_dir {
+            self.core
+                .webdav_mkcol(&self.ctx, get_parent(&self.path))
+                .await?;
+        }
+
         let resp = self
             .core
             .webdav_put(&self.ctx, &self.path, Some(bs.len() as u64), &self.op, bs)

--- a/core/services/webhdfs/src/backend.rs
+++ b/core/services/webhdfs/src/backend.rs
@@ -356,29 +356,21 @@ impl Service for WebhdfsBackend {
             _ => Err(parse_error(resp)),
         }
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<WebhdfsReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(WebhdfsReader::new(self.clone(), ctx.clone(), path, args)),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<WebhdfsReader> = {
+            Ok(oio::StreamReader::new(WebhdfsReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, WebhdfsWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
+        let output: WebhdfsWriters = {
             let w = WebhdfsWriter::new(
                 self.core.clone(),
                 ctx.clone(),
@@ -396,30 +388,25 @@ impl Service for WebhdfsBackend {
                 ))
             };
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<WebhdfsDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(WebhdfsDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<WebhdfsDeleter> = {
+            Ok(oio::OneShotDeleter::new(WebhdfsDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<WebhdfsLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<WebhdfsLister> = {
             if args.recursive() {
                 return Err(Error::new(
                     ErrorKind::Unsupported,
@@ -429,20 +416,20 @@ impl Service for WebhdfsBackend {
 
             let path = path.trim_end_matches('/');
             let l = WebhdfsLister::new(self.core.clone(), ctx.clone(), path);
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _ctx: &OperationContext,
         _from: &str,
         _to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/yandex-disk/src/backend.rs
+++ b/core/services/yandex-disk/src/backend.rs
@@ -176,7 +176,7 @@ impl Service for YandexDiskBackend {
     type Writer = YandexDiskWriters;
     type Lister = oio::PageLister<YandexDiskLister>;
     type Deleter = oio::OneShotDeleter<YandexDiskDeleter>;
-    type Copier = ();
+    type Copier = oio::OneShotCopier;
 
     fn info(&self) -> ServiceInfo {
         self.core.info.clone()
@@ -216,48 +216,43 @@ impl Service for YandexDiskBackend {
         }
     }
 
-    async fn copy(
+    fn copy(
         &self,
         ctx: &OperationContext,
         from: &str,
         to: &str,
         _args: OpCopy,
         _opts: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
-        let (rp, output): (_, ()) = {
-            self.core.ensure_dir_exists(ctx, to).await?;
+    ) -> Result<Self::Copier> {
+        let core = self.core.clone();
+        let ctx = ctx.clone();
+        let from = from.to_string();
+        let to = to.to_string();
 
-            let resp = self.core.copy(ctx, from, to).await?;
+        Ok(oio::OneShotCopier::new(async move {
+            core.ensure_dir_exists(&ctx, &to).await?;
+
+            let resp = core.copy(&ctx, &from, &to).await?;
 
             let status = resp.status();
 
             match status {
-                StatusCode::OK | StatusCode::CREATED => Ok((RpCopy::default(), ())),
+                StatusCode::OK | StatusCode::CREATED => Ok(Metadata::default()),
                 _ => Err(parse_error(resp)),
             }
-        }?;
-
-        Ok((rp, output))
+        }))
     }
-    async fn read(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        let (rp, output): (_, oio::StreamReader<YandexDiskReader>) = {
-            Ok((
-                RpRead::default(),
-                oio::StreamReader::new(YandexDiskReader::new(
-                    self.clone(),
-                    ctx.clone(),
-                    path,
-                    args,
-                )),
-            ))
+    fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        let output: oio::StreamReader<YandexDiskReader> = {
+            Ok(oio::StreamReader::new(YandexDiskReader::new(
+                self.clone(),
+                ctx.clone(),
+                path,
+                args,
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
     async fn stat(&self, ctx: &OperationContext, path: &str, _args: OpStat) -> Result<RpStat> {
@@ -278,46 +273,36 @@ impl Service for YandexDiskBackend {
         }
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        _args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
-        let (rp, output): (_, YandexDiskWriters) = {
+    fn write(&self, ctx: &OperationContext, path: &str, _args: OpWrite) -> Result<Self::Writer> {
+        let output: YandexDiskWriters = {
             let writer = YandexDiskWriter::new(self.core.clone(), ctx.clone(), path.to_string());
 
             let w = oio::OneShotWriter::new(writer);
 
-            Ok((RpWrite::default(), w))
+            Ok(w)
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn delete(&self, ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
-        let (rp, output): (_, oio::OneShotDeleter<YandexDiskDeleter>) = {
-            Ok((
-                RpDelete::default(),
-                oio::OneShotDeleter::new(YandexDiskDeleter::new(self.core.clone(), ctx.clone())),
-            ))
+    fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
+        let output: oio::OneShotDeleter<YandexDiskDeleter> = {
+            Ok(oio::OneShotDeleter::new(YandexDiskDeleter::new(
+                self.core.clone(),
+                ctx.clone(),
+            )))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
-    async fn list(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let (rp, output): (_, oio::PageLister<YandexDiskLister>) = {
+    fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let output: oio::PageLister<YandexDiskLister> = {
             let l = YandexDiskLister::new(self.core.clone(), ctx.clone(), path, args.limit());
-            Ok((RpList::default(), oio::PageLister::new(l)))
+            Ok(oio::PageLister::new(l))
         }?;
 
-        Ok((rp, output))
+        Ok(output)
     }
 
     async fn presign(

--- a/integrations/object_store/src/service/lister.rs
+++ b/integrations/object_store/src/service/lister.rs
@@ -31,7 +31,7 @@ pub struct ObjectStoreLister {
 }
 
 impl ObjectStoreLister {
-    pub(crate) async fn new(
+    pub(crate) fn new(
         store: Arc<dyn ObjectStore + 'static>,
         path: &str,
         args: OpList,

--- a/integrations/object_store/src/service/mod.rs
+++ b/integrations/object_store/src/service/mod.rs
@@ -148,54 +148,37 @@ impl Service for ObjectStoreService {
         Ok(RpStat::new(metadata))
     }
 
-    async fn read(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpRead,
-    ) -> Result<(RpRead, Self::Reader)> {
-        Ok((
-            RpRead::default(),
-            oio::StreamReader::new(ObjectStoreReader::new(self.store.clone(), path, args)),
-        ))
+    fn read(&self, _ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
+        Ok(oio::StreamReader::new(ObjectStoreReader::new(
+            self.store.clone(),
+            path,
+            args,
+        )))
     }
 
-    async fn write(
-        &self,
-        ctx: &OperationContext,
-        path: &str,
-        args: OpWrite,
-    ) -> Result<(RpWrite, Self::Writer)> {
+    fn write(&self, ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let writer = ObjectStoreWriter::new(self.store.clone(), path, args);
-        Ok((
-            RpWrite::default(),
-            MultipartWriter::new(ctx.executor().clone(), writer, 10),
-        ))
+        Ok(MultipartWriter::new(ctx.executor().clone(), writer, 10))
     }
 
-    async fn delete(&self, _ctx: &OperationContext) -> Result<(RpDelete, Self::Deleter)> {
+    fn delete(&self, _ctx: &OperationContext) -> Result<Self::Deleter> {
         let deleter = BatchDeleter::new(ObjectStoreDeleter::new(self.store.clone()), Some(1000));
-        Ok((RpDelete::default(), deleter))
+        Ok(deleter)
     }
 
-    async fn list(
-        &self,
-        _ctx: &OperationContext,
-        path: &str,
-        args: OpList,
-    ) -> Result<(RpList, Self::Lister)> {
-        let lister = ObjectStoreLister::new(self.store.clone(), path, args).await?;
-        Ok((RpList::default(), lister))
+    fn list(&self, _ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        let lister = ObjectStoreLister::new(self.store.clone(), path, args)?;
+        Ok(lister)
     }
 
-    async fn copy(
+    fn copy(
         &self,
         _: &OperationContext,
         _: &str,
         _: &str,
         _: OpCopy,
         _: OpCopier,
-    ) -> Result<(RpCopy, Self::Copier)> {
+    ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
@@ -275,9 +258,8 @@ mod tests {
         let content = b"Hello, world!";
 
         // Test write
-        let (_, mut writer) = backend
+        let mut writer = backend
             .write(&ctx, path, OpWrite::default())
-            .await
             .expect("write should succeed");
 
         writer
@@ -298,9 +280,8 @@ mod tests {
         );
 
         // Test read
-        let (_, reader) = backend
+        let reader = backend
             .read(&ctx, path, OpRead::default())
-            .await
             .expect("read should succeed");
 
         let (_, mut stream) = reader
@@ -325,9 +306,8 @@ mod tests {
         let content_len = content.len();
 
         // Test multipart upload with multiple chunks
-        let (_, mut writer) = backend
+        let mut writer = backend
             .write(&ctx, path, OpWrite::default())
-            .await
             .expect("write should succeed");
 
         // Write content in chunks to simulate multipart upload
@@ -353,9 +333,8 @@ mod tests {
         );
 
         // Read back and verify content
-        let (_, reader) = backend
+        let reader = backend
             .read(&ctx, path, OpRead::default())
-            .await
             .expect("read should succeed");
 
         let (_, mut stream) = reader
@@ -382,9 +361,8 @@ mod tests {
         ];
 
         for (path, content) in &files {
-            let (_, mut writer) = backend
+            let mut writer = backend
                 .write(&ctx, path, OpWrite::default())
-                .await
                 .expect("write should succeed");
             writer
                 .write(Buffer::from(&content[..]))
@@ -394,9 +372,8 @@ mod tests {
         }
 
         // List directory
-        let (_, mut lister) = backend
+        let mut lister = backend
             .list(&ctx, "dir1/", OpList::default())
-            .await
             .expect("list should succeed");
 
         let mut entries = Vec::new();
@@ -421,9 +398,8 @@ mod tests {
         let content = b"To be deleted";
 
         // Write file
-        let (_, mut writer) = backend
+        let mut writer = backend
             .write(&ctx, path, OpWrite::default())
-            .await
             .expect("write should succeed");
         writer
             .write(Buffer::from(&content[..]))
@@ -438,7 +414,7 @@ mod tests {
             .expect("file should exist");
 
         // Delete file
-        let (_, mut deleter) = backend.delete(&ctx).await.expect("delete should succeed");
+        let mut deleter = backend.delete(&ctx).expect("delete should succeed");
         deleter
             .delete(path, OpDelete::default())
             .await
@@ -465,19 +441,16 @@ mod tests {
         assert!(result.is_err());
 
         // Test read on non-existent file
-        let (_, reader) = backend
+        let reader = backend
             .read(&ctx, "non_existent.txt", OpRead::default())
-            .await
             .expect("read should create reader");
         let result = reader.read(BytesRange::from(0..1)).await;
         assert!(result.is_err());
 
         // Test list on non-existent directory
-        let result = backend
-            .list(&ctx, "non_existent_dir/", OpList::default())
-            .await;
+        let result = backend.list(&ctx, "non_existent_dir/", OpList::default());
         // This should succeed but return empty results
-        if let Ok((_, mut lister)) = result {
+        if let Ok(mut lister) = result {
             let entry = lister.next().await.expect("next should succeed");
             assert!(entry.is_none());
         }

--- a/integrations/object_store/src/store.rs
+++ b/integrations/object_store/src/store.rs
@@ -1064,49 +1064,49 @@ mod tests {
                 self.srv.stat(ctx, path, args).await
             }
 
-            async fn read(
+            fn read(
                 &self,
                 ctx: &opendal::raw::OperationContext,
                 path: &str,
                 args: opendal::raw::OpRead,
-            ) -> opendal::Result<(opendal::raw::RpRead, Self::Reader)> {
-                self.srv.read(ctx, path, args).await
+            ) -> opendal::Result<Self::Reader> {
+                self.srv.read(ctx, path, args)
             }
 
-            async fn write(
+            fn write(
                 &self,
                 ctx: &opendal::raw::OperationContext,
                 path: &str,
                 args: opendal::raw::OpWrite,
-            ) -> opendal::Result<(opendal::raw::RpWrite, Self::Writer)> {
-                self.srv.write(ctx, path, args).await
+            ) -> opendal::Result<Self::Writer> {
+                self.srv.write(ctx, path, args)
             }
 
-            async fn delete(
+            fn delete(
                 &self,
                 ctx: &opendal::raw::OperationContext,
-            ) -> opendal::Result<(opendal::raw::RpDelete, Self::Deleter)> {
-                self.srv.delete(ctx).await
+            ) -> opendal::Result<Self::Deleter> {
+                self.srv.delete(ctx)
             }
 
-            async fn list(
+            fn list(
                 &self,
                 ctx: &opendal::raw::OperationContext,
                 path: &str,
                 args: opendal::raw::OpList,
-            ) -> opendal::Result<(opendal::raw::RpList, Self::Lister)> {
-                self.srv.list(ctx, path, args).await
+            ) -> opendal::Result<Self::Lister> {
+                self.srv.list(ctx, path, args)
             }
 
-            async fn copy(
+            fn copy(
                 &self,
                 ctx: &opendal::raw::OperationContext,
                 from: &str,
                 to: &str,
                 args: opendal::raw::OpCopy,
                 opts: opendal::raw::OpCopier,
-            ) -> opendal::Result<(opendal::raw::RpCopy, Self::Copier)> {
-                self.srv.copy(ctx, from, to, args, opts).await
+            ) -> opendal::Result<Self::Copier> {
+                self.srv.copy(ctx, from, to, args, opts)
             }
 
             async fn rename(


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7745.

# Rationale for this change

RFC-7744 proposes simplifying stateful operation factories after RFC-7740 split the runtime service composition path. The previous factory contract returned both response metadata and a future for the body, so layers had to wrap factory futures even when the actual I/O happened later. Keeping factories synchronous and body-only makes the boundary clear: factories construct operation bodies, and all asynchronous I/O happens inside those bodies.

# What changes are included in this PR?

This PR updates `Service` and `ServiceDyn` so `read`, `write`, `delete`, `list`, and `copy` return only their OIO bodies synchronously. It migrates core operators, layers, services, and the object_store integration to the new contract.

Backends that previously performed async setup in factories now move that work into lazy readers, writers, listers, deleters, or `OneShotCopier`. `oio::Read::open` and `oio::Read::read` still return `RpRead` with the body or read result, so response metadata continues to be produced at the actual I/O boundary.

Validation:

- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `OPENDAL_TEST=memory cargo test behavior --features tests`
- `cargo check --all-targets` in `integrations/object_store`
- `cargo clippy --all-targets -- -D warnings` in `integrations/object_store`
- `git diff --check`

# Are there any user-facing changes?

There are no public `Operator` API changes.

This is a breaking change for raw service and layer implementors that use `opendal_core::raw::Service` or `ServiceDyn`: stateful operation factories must now return body types synchronously instead of `(Rp*, body)` futures.

# AI Usage Statement

AI assistance was used to implement and revise this PR.
