### PR TITLE
refactor!: Remove native and full capability APIs

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -2150,14 +2150,9 @@ char *opendal_operator_info_get_root(const struct opendal_operator_info *self);
 char *opendal_operator_info_get_name(const struct opendal_operator_info *self);
 
 /**
- * \brief Return the operator's full capability
+ * \brief Return the operator's capability
  */
-struct opendal_capability opendal_operator_info_get_full_capability(const struct opendal_operator_info *self);
-
-/**
- * \brief Return the operator's native capability
- */
-struct opendal_capability opendal_operator_info_get_native_capability(const struct opendal_operator_info *self);
+struct opendal_capability opendal_operator_info_get_capability(const struct opendal_operator_info *self);
 
 /**
  * \brief Presign a read operation.

--- a/bindings/c/src/operator_info.rs
+++ b/bindings/c/src/operator_info.rs
@@ -254,21 +254,10 @@ impl opendal_operator_info {
             .into_raw()
     }
 
-    /// \brief Return the operator's full capability
+    /// \brief Return the operator's capability
     #[no_mangle]
-    pub unsafe extern "C" fn opendal_operator_info_get_full_capability(
-        &self,
-    ) -> opendal_capability {
+    pub unsafe extern "C" fn opendal_operator_info_get_capability(&self) -> opendal_capability {
         let cap = self.deref().capability();
-        cap.into()
-    }
-
-    /// \brief Return the operator's native capability
-    #[no_mangle]
-    pub unsafe extern "C" fn opendal_operator_info_get_native_capability(
-        &self,
-    ) -> opendal_capability {
-        let cap = self.deref().native_capability();
         cap.into()
     }
 }

--- a/bindings/c/tests/example_test.cpp
+++ b/bindings/c/tests/example_test.cpp
@@ -56,7 +56,7 @@ void simple_test()
     // Test basic write/read if supported
     opendal_operator_info* info = opendal_operator_info_new(config->operator_instance);
     if (info) {
-        opendal_capability cap = opendal_operator_info_get_full_capability(info);
+        opendal_capability cap = opendal_operator_info_get_capability(info);
 
         if (cap.write && cap.read) {
             printf("Testing write/read operations...\n");

--- a/bindings/c/tests/opinfo.cpp
+++ b/bindings/c/tests/opinfo.cpp
@@ -60,26 +60,16 @@ protected:
 // We test the capability set by **memory** service.
 TEST_F(OpendalOperatorInfoTest, CapabilityTest)
 {
-    opendal_capability full_cap = opendal_operator_info_get_full_capability(this->info);
-    opendal_capability native_cap = opendal_operator_info_get_native_capability(this->info);
+    opendal_capability cap = opendal_operator_info_get_capability(this->info);
 
-    EXPECT_TRUE(full_cap.read);
-    EXPECT_TRUE(full_cap.stat);
-    EXPECT_TRUE(full_cap.write);
-    EXPECT_TRUE(full_cap.write_can_empty);
-    EXPECT_TRUE(full_cap.create_dir);
-    EXPECT_TRUE(full_cap.delete_);
-    EXPECT_TRUE(full_cap.list);
-    EXPECT_TRUE(full_cap.list_with_recursive);
-
-    EXPECT_TRUE(native_cap.read);
-    EXPECT_TRUE(native_cap.stat);
-    EXPECT_TRUE(native_cap.write);
-    EXPECT_TRUE(native_cap.write_can_empty);
-    EXPECT_FALSE(native_cap.create_dir);
-    EXPECT_TRUE(native_cap.delete_);
-    EXPECT_TRUE(native_cap.list);
-    EXPECT_TRUE(native_cap.list_with_recursive);
+    EXPECT_TRUE(cap.read);
+    EXPECT_TRUE(cap.stat);
+    EXPECT_TRUE(cap.write);
+    EXPECT_TRUE(cap.write_can_empty);
+    EXPECT_TRUE(cap.create_dir);
+    EXPECT_TRUE(cap.delete_);
+    EXPECT_TRUE(cap.list);
+    EXPECT_TRUE(cap.list_with_recursive);
 }
 
 TEST_F(OpendalOperatorInfoTest, InfoTest)

--- a/bindings/c/tests/test_framework.cpp
+++ b/bindings/c/tests/test_framework.cpp
@@ -164,7 +164,7 @@ bool opendal_check_capability(const opendal_operator* op,
     if (!info)
         return false;
 
-    opendal_capability cap = opendal_operator_info_get_full_capability(info);
+    opendal_capability cap = opendal_operator_info_get_capability(info);
 
     bool result = true;
     if (required.stat && !cap.stat)

--- a/bindings/c/tests/test_runner.cpp
+++ b/bindings/c/tests/test_runner.cpp
@@ -169,7 +169,7 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    opendal_capability cap = opendal_operator_info_get_full_capability(info);
+    opendal_capability cap = opendal_operator_info_get_capability(info);
 
     // Check operator availability - only perform list-based check if list is supported
     if (cap.list) {

--- a/bindings/c/tests/test_suites_basic.cpp
+++ b/bindings/c/tests/test_suites_basic.cpp
@@ -26,7 +26,7 @@ void test_check(opendal_test_context* ctx)
     opendal_operator_info* info = opendal_operator_info_new(ctx->config->operator_instance);
     OPENDAL_ASSERT_NOT_NULL(info, "Should be able to get operator info");
 
-    opendal_capability cap = opendal_operator_info_get_full_capability(info);
+    opendal_capability cap = opendal_operator_info_get_capability(info);
 
     if (cap.list) {
         // Only perform the standard check if list operations are supported

--- a/bindings/c/tests/test_suites_presign.cpp
+++ b/bindings/c/tests/test_suites_presign.cpp
@@ -661,7 +661,7 @@ void test_presign_delete(opendal_test_context* ctx)
 {
     opendal_operator_info* info = opendal_operator_info_new(ctx->config->operator_instance);
     OPENDAL_ASSERT_NOT_NULL(info, "Operator info should not be null");
-    opendal_capability cap = opendal_operator_info_get_full_capability(info);
+    opendal_capability cap = opendal_operator_info_get_capability(info);
     opendal_operator_info_free(info);
     if (!cap.presign_delete) {
         return;

--- a/bindings/dotnet/OpenDAL.Tests/Behavior/BehaviorOperatorFixture.cs
+++ b/bindings/dotnet/OpenDAL.Tests/Behavior/BehaviorOperatorFixture.cs
@@ -57,7 +57,7 @@ public sealed class BehaviorOperatorFixture : IDisposable
             op = op.WithLayer(new CapabilityOverrideLayer(capabilityOverrides));
         }
 
-        capability = op.Info.FullCapability;
+        capability = op.Info.Capability;
     }
 
     public bool IsEnabled => op is not null;

--- a/bindings/dotnet/OpenDAL.Tests/OperatorInfoTest.cs
+++ b/bindings/dotnet/OpenDAL.Tests/OperatorInfoTest.cs
@@ -35,8 +35,8 @@ public class OperatorInfoTest
         var info = op.Info;
 
         Assert.Equal("memory", info.Scheme);
-        Assert.True(info.FullCapability.Read);
-        Assert.True(info.FullCapability.Write);
+        Assert.True(info.Capability.Read);
+        Assert.True(info.Capability.Write);
     }
 
     [Fact]
@@ -56,8 +56,8 @@ public class OperatorInfoTest
             var info = op.Info;
 
             Assert.Equal("fs", info.Scheme);
-            Assert.True(info.FullCapability.Read);
-            Assert.True(info.FullCapability.Write);
+            Assert.True(info.Capability.Read);
+            Assert.True(info.Capability.Write);
         }
         finally
         {

--- a/bindings/dotnet/OpenDAL/Interop/Marshalling/OperatorInfoMarshaller.cs
+++ b/bindings/dotnet/OpenDAL/Interop/Marshalling/OperatorInfoMarshaller.cs
@@ -55,8 +55,7 @@ internal static class OperatorInfoMarshaller
             Utilities.ReadUtf8(payload.Scheme),
             Utilities.ReadUtf8(payload.Root),
             Utilities.ReadUtf8(payload.Name),
-            new Capability(payload.FullCapability),
-            new Capability(payload.NativeCapability)
+            new Capability(payload.Capability)
         );
     }
 }

--- a/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALOperatorInfo.cs
+++ b/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALOperatorInfo.cs
@@ -33,7 +33,5 @@ internal struct OpenDALOperatorInfo
 
     public IntPtr Name;
 
-    public OpenDALCapability FullCapability;
-
-    public OpenDALCapability NativeCapability;
+    public OpenDALCapability Capability;
 }

--- a/bindings/dotnet/OpenDAL/OperatorInfo.cs
+++ b/bindings/dotnet/OpenDAL/OperatorInfo.cs
@@ -40,21 +40,15 @@ public sealed class OperatorInfo
     public string Name { get; }
 
     /// <summary>
-    /// Gets the full capability of this operator.
+    /// Gets the capability of this operator.
     /// </summary>
-    public Capability FullCapability { get; }
+    public Capability Capability { get; }
 
-    /// <summary>
-    /// Gets the native capability of this operator.
-    /// </summary>
-    public Capability NativeCapability { get; }
-
-    internal OperatorInfo(string scheme, string root, string name, Capability fullCapability, Capability nativeCapability)
+    internal OperatorInfo(string scheme, string root, string name, Capability capability)
     {
         Scheme = scheme;
         Root = root;
         Name = name;
-        FullCapability = fullCapability;
-        NativeCapability = nativeCapability;
+        Capability = capability;
     }
 }

--- a/bindings/dotnet/README.md
+++ b/bindings/dotnet/README.md
@@ -235,10 +235,10 @@ catch (OpenDALException ex) when (ex.Code == ErrorCode.NotFound)
 }
 ```
 
-Some features depend on backend capability. Check `op.Info.FullCapability` before using optional options/features:
+Some features depend on backend capability. Check `op.Info.Capability` before using optional options/features:
 
 ```csharp
-var cap = op.Info.FullCapability;
+var cap = op.Info.Capability;
 if (cap.PresignRead)
 {
 	var req = await op.PresignReadAsync("a.txt", TimeSpan.FromMinutes(5));

--- a/bindings/dotnet/src/operator_info.rs
+++ b/bindings/dotnet/src/operator_info.rs
@@ -25,8 +25,7 @@ pub struct OpendalOperatorInfo {
     pub scheme: *mut c_char,
     pub root: *mut c_char,
     pub name: *mut c_char,
-    pub full_capability: Capability,
-    pub native_capability: Capability,
+    pub capability: Capability,
 }
 
 pub fn into_operator_info(info: opendal::OperatorInfo) -> OpendalOperatorInfo {
@@ -34,7 +33,6 @@ pub fn into_operator_info(info: opendal::OperatorInfo) -> OpendalOperatorInfo {
         scheme: into_string_ptr(info.scheme().to_string()),
         root: into_string_ptr(info.root()),
         name: into_string_ptr(info.name()),
-        full_capability: Capability::new(info.capability()),
-        native_capability: Capability::new(info.native_capability()),
+        capability: Capability::new(info.capability()),
     }
 }

--- a/bindings/go/operator_info.go
+++ b/bindings/go/operator_info.go
@@ -38,11 +38,10 @@ func (op *Operator) Info() *OperatorInfo {
 	defer ffiOperatorInfoFree.symbol(op.ctx)(inner)
 
 	return &OperatorInfo{
-		scheme:    ffiOperatorInfoGetScheme.symbol(op.ctx)(inner),
-		root:      ffiOperatorInfoGetRoot.symbol(op.ctx)(inner),
-		name:      ffiOperatorInfoGetName.symbol(op.ctx)(inner),
-		fullCap:   &Capability{inner: ffiOperatorInfoGetFullCapability.symbol(op.ctx)(inner)},
-		nativeCap: &Capability{inner: ffiOperatorInfoGetNativeCapability.symbol(op.ctx)(inner)},
+		scheme:     ffiOperatorInfoGetScheme.symbol(op.ctx)(inner),
+		root:       ffiOperatorInfoGetRoot.symbol(op.ctx)(inner),
+		name:       ffiOperatorInfoGetName.symbol(op.ctx)(inner),
+		capability: &Capability{inner: ffiOperatorInfoGetCapability.symbol(op.ctx)(inner)},
 	}
 }
 
@@ -52,19 +51,14 @@ func (op *Operator) Info() *OperatorInfo {
 // and its capabilities, allowing users to query details about the
 // Operator they are working with.
 type OperatorInfo struct {
-	scheme    string
-	root      string
-	name      string
-	fullCap   *Capability
-	nativeCap *Capability
+	scheme     string
+	root       string
+	name       string
+	capability *Capability
 }
 
-func (i *OperatorInfo) GetFullCapability() *Capability {
-	return i.fullCap
-}
-
-func (i *OperatorInfo) GetNativeCapability() *Capability {
-	return i.nativeCap
+func (i *OperatorInfo) GetCapability() *Capability {
+	return i.capability
 }
 
 func (i *OperatorInfo) GetScheme() string {
@@ -359,23 +353,8 @@ var ffiOperatorInfoFree = newFFI(ffiOpts{
 	}
 })
 
-var ffiOperatorInfoGetFullCapability = newFFI(ffiOpts{
-	sym:    "opendal_operator_info_get_full_capability",
-	rType:  &typeCapability,
-	aTypes: []*ffi.Type{&ffi.TypePointer},
-}, func(ctx context.Context, ffiCall ffiCall) func(info *opendalOperatorInfo) *opendalCapability {
-	return func(info *opendalOperatorInfo) *opendalCapability {
-		var cap opendalCapability
-		ffiCall(
-			unsafe.Pointer(&cap),
-			unsafe.Pointer(&info),
-		)
-		return &cap
-	}
-})
-
-var ffiOperatorInfoGetNativeCapability = newFFI(ffiOpts{
-	sym:    "opendal_operator_info_get_native_capability",
+var ffiOperatorInfoGetCapability = newFFI(ffiOpts{
+	sym:    "opendal_operator_info_get_capability",
 	rType:  &typeCapability,
 	aTypes: []*ffi.Type{&ffi.TypePointer},
 }, func(ctx context.Context, ffiCall ffiCall) func(info *opendalOperatorInfo) *opendalCapability {

--- a/bindings/go/string_ownership_test.go
+++ b/bindings/go/string_ownership_test.go
@@ -59,8 +59,7 @@ func TestOperatorInfoCopiesAndFreesOwnedStrings(t *testing.T) {
 	rootPtr := mustBytePtrFromString(t, "/tmp/")
 	namePtr := mustBytePtrFromString(t, "namespace")
 	infoInner := &opendalOperatorInfo{}
-	fullCap := &opendalCapability{stat: 1}
-	nativeCap := &opendalCapability{list: 1}
+	capability := &opendalCapability{stat: 1}
 	infoFreed := 0
 
 	ctx := context.Background()
@@ -89,17 +88,11 @@ func TestOperatorInfoCopiesAndFreesOwnedStrings(t *testing.T) {
 		assertOperatorInfoPointer(t, infoInner, aValues...)
 		*(**byte)(rValue) = namePtr
 	}))
-	ctx = context.WithValue(ctx, ffiOperatorInfoGetFullCapability.opts.sym, func(info *opendalOperatorInfo) *opendalCapability {
+	ctx = context.WithValue(ctx, ffiOperatorInfoGetCapability.opts.sym, func(info *opendalOperatorInfo) *opendalCapability {
 		if info != infoInner {
 			t.Fatalf("Info() requested full capability for unexpected operator info: %p", info)
 		}
-		return fullCap
-	})
-	ctx = context.WithValue(ctx, ffiOperatorInfoGetNativeCapability.opts.sym, func(info *opendalOperatorInfo) *opendalCapability {
-		if info != infoInner {
-			t.Fatalf("Info() requested native capability for unexpected operator info: %p", info)
-		}
-		return nativeCap
+		return capability
 	})
 
 	op := &Operator{
@@ -117,11 +110,8 @@ func TestOperatorInfoCopiesAndFreesOwnedStrings(t *testing.T) {
 	if info.GetName() != "namespace" {
 		t.Fatalf("Info().GetName() = %q, want namespace", info.GetName())
 	}
-	if !info.GetFullCapability().Stat() {
-		t.Fatal("Info().GetFullCapability().Stat() = false, want true")
-	}
-	if !info.GetNativeCapability().List() {
-		t.Fatal("Info().GetNativeCapability().List() = false, want true")
+	if !info.GetCapability().Stat() {
+		t.Fatal("Info().GetCapability().Stat() = false, want true")
 	}
 	if infoFreed != 1 {
 		t.Fatalf("Info() freed operator info %d times, want 1", infoFreed)

--- a/bindings/go/tests/behavior_tests/copy_test.go
+++ b/bindings/go/tests/behavior_tests/copy_test.go
@@ -283,7 +283,7 @@ func copyMultiChunkSize(cap *opendal.Capability) (uint, uint) {
 }
 
 func testCopyWithChunk(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	chunk, sourceSize := copyMultiChunkSize(op.Info().GetFullCapability())
+	chunk, sourceSize := copyMultiChunkSize(op.Info().GetCapability())
 	if sourceSize == 0 {
 		return
 	}
@@ -301,7 +301,7 @@ func testCopyWithChunk(assert *require.Assertions, op *opendal.Operator, fixture
 }
 
 func testCopyWithChunkAndConcurrent(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	chunk, sourceSize := copyMultiChunkSize(op.Info().GetFullCapability())
+	chunk, sourceSize := copyMultiChunkSize(op.Info().GetCapability())
 	if sourceSize == 0 {
 		return
 	}

--- a/bindings/go/tests/behavior_tests/delete_test.go
+++ b/bindings/go/tests/behavior_tests/delete_test.go
@@ -57,7 +57,7 @@ func testDeleteFile(assert *require.Assertions, op *opendal.Operator, fixture *f
 }
 
 func testDeleteEmptyDir(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !op.Info().GetFullCapability().CreateDir() {
+	if !op.Info().GetCapability().CreateDir() {
 		return
 	}
 
@@ -86,7 +86,7 @@ func testDeleteNotExisting(assert *require.Assertions, op *opendal.Operator, fix
 }
 
 func testDeleteWithRecursive(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !op.Info().GetFullCapability().CreateDir() {
+	if !op.Info().GetCapability().CreateDir() {
 		return
 	}
 

--- a/bindings/go/tests/behavior_tests/opendal_test.go
+++ b/bindings/go/tests/behavior_tests/opendal_test.go
@@ -63,7 +63,7 @@ type behaviorTest = func(assert *require.Assertions, op *opendal.Operator, fixtu
 func TestBehavior(t *testing.T) {
 	assert := require.New(t)
 
-	cap := op.Info().GetFullCapability()
+	cap := op.Info().GetCapability()
 
 	var tests []behaviorTest
 
@@ -256,7 +256,7 @@ func (f *fixture) NewFile() (string, []byte, uint) {
 }
 
 func (f *fixture) NewFileWithPath(path string) (string, []byte, uint) {
-	maxSize := contentMaxSize(f.op.Info().GetFullCapability())
+	maxSize := contentMaxSize(f.op.Info().GetCapability())
 	return f.NewFileWithRange(path, 1, maxSize)
 }
 
@@ -276,7 +276,7 @@ func contentMaxSize(cap *opendal.Capability) uint {
 }
 
 func (f *fixture) Cleanup(assert *require.Assertions) {
-	if !f.op.Info().GetFullCapability().Delete() {
+	if !f.op.Info().GetCapability().Delete() {
 		return
 	}
 	f.lock.Lock()

--- a/bindings/go/tests/behavior_tests/read_test.go
+++ b/bindings/go/tests/behavior_tests/read_test.go
@@ -281,7 +281,7 @@ func testReadNotExist(assert *require.Assertions, op *opendal.Operator, fixture 
 }
 
 func testReadWithDirPath(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !op.Info().GetFullCapability().CreateDir() {
+	if !op.Info().GetCapability().CreateDir() {
 		return
 	}
 

--- a/bindings/go/tests/behavior_tests/rename_test.go
+++ b/bindings/go/tests/behavior_tests/rename_test.go
@@ -70,7 +70,7 @@ func testRenameNonExistingSource(assert *require.Assertions, op *opendal.Operato
 }
 
 func testRenameSourceDir(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !op.Info().GetFullCapability().CreateDir() {
+	if !op.Info().GetCapability().CreateDir() {
 		return
 	}
 
@@ -85,7 +85,7 @@ func testRenameSourceDir(assert *require.Assertions, op *opendal.Operator, fixtu
 }
 
 func testRenameTargetDir(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !op.Info().GetFullCapability().CreateDir() {
+	if !op.Info().GetCapability().CreateDir() {
 		return
 	}
 

--- a/bindings/go/tests/behavior_tests/stat_test.go
+++ b/bindings/go/tests/behavior_tests/stat_test.go
@@ -78,7 +78,7 @@ func testStatFile(assert *require.Assertions, op *opendal.Operator, fixture *fix
 	assert.True(meta.IsFile())
 	assert.Equal(meta.ContentLength(), uint64(size))
 
-	if op.Info().GetFullCapability().CreateDir() {
+	if op.Info().GetCapability().CreateDir() {
 		_, err := op.Stat(fmt.Sprintf("%s/", path))
 		assert.NotNil(err)
 		assert.Equal(opendal.CodeNotFound, assertErrorCode(err))
@@ -86,7 +86,7 @@ func testStatFile(assert *require.Assertions, op *opendal.Operator, fixture *fix
 }
 
 func testStatDir(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !op.Info().GetFullCapability().CreateDir() {
+	if !op.Info().GetCapability().CreateDir() {
 		return
 	}
 
@@ -106,7 +106,7 @@ func testStatDir(assert *require.Assertions, op *opendal.Operator, fixture *fixt
 }
 
 func testStatNestedParentDir(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !op.Info().GetFullCapability().CreateDir() {
+	if !op.Info().GetCapability().CreateDir() {
 		return
 	}
 
@@ -149,7 +149,7 @@ func testStatNotExist(assert *require.Assertions, op *opendal.Operator, fixture 
 	assert.NotNil(err)
 	assert.Equal(opendal.CodeNotFound, assertErrorCode(err))
 
-	if op.Info().GetFullCapability().CreateDir() {
+	if op.Info().GetCapability().CreateDir() {
 		_, err := op.Stat(fmt.Sprintf("%s/", path))
 		assert.NotNil(err)
 		assert.Equal(opendal.CodeNotFound, assertErrorCode(err))
@@ -169,7 +169,7 @@ func testStatRoot(assert *require.Assertions, op *opendal.Operator, fixture *fix
 
 func testStatFileMetadata(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
 	path, content, size := fixture.NewFile()
-	cap := op.Info().GetFullCapability()
+	cap := op.Info().GetCapability()
 
 	writeOpts := make([]opendal.WithWriteFn, 0, 5)
 	writeWithCacheControl := isCapEnabled(cap.WriteWithCacheControl, "write_with_cache_control")
@@ -262,7 +262,7 @@ func testStatFileMetadata(assert *require.Assertions, op *opendal.Operator, fixt
 }
 
 func testStatWithIfMatch(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	cap := op.Info().GetFullCapability()
+	cap := op.Info().GetCapability()
 	if !isCapEnabled(cap.StatWithIfMatch, "stat_with_if_match") {
 		return
 	}
@@ -293,7 +293,7 @@ func testStatWithIfMatch(assert *require.Assertions, op *opendal.Operator, fixtu
 }
 
 func testStatWithIfNoneMatch(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	cap := op.Info().GetFullCapability()
+	cap := op.Info().GetCapability()
 	if !isCapEnabled(cap.StatWithIfNoneMatch, "stat_with_if_none_match") {
 		return
 	}
@@ -319,7 +319,7 @@ func testStatWithIfNoneMatch(assert *require.Assertions, op *opendal.Operator, f
 }
 
 func testStatWithIfModifiedSince(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	cap := op.Info().GetFullCapability()
+	cap := op.Info().GetCapability()
 	if !isCapEnabled(cap.StatWithIfModifiedSince, "stat_with_if_modified_since") {
 		return
 	}
@@ -346,7 +346,7 @@ func testStatWithIfModifiedSince(assert *require.Assertions, op *opendal.Operato
 }
 
 func testStatWithIfUnmodifiedSince(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	cap := op.Info().GetFullCapability()
+	cap := op.Info().GetCapability()
 	if !isCapEnabled(cap.StatWithIfUnmodifiedSince, "stat_with_if_unmodified_since") {
 		return
 	}
@@ -373,7 +373,7 @@ func testStatWithIfUnmodifiedSince(assert *require.Assertions, op *opendal.Opera
 }
 
 func testStatDirMetadata(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !op.Info().GetFullCapability().CreateDir() {
+	if !op.Info().GetCapability().CreateDir() {
 		return
 	}
 

--- a/bindings/go/tests/behavior_tests/write_test.go
+++ b/bindings/go/tests/behavior_tests/write_test.go
@@ -60,7 +60,7 @@ func testWriteOnly(assert *require.Assertions, op *opendal.Operator, fixture *fi
 }
 
 func testWriteWithEmptyContent(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !op.Info().GetFullCapability().WriteCanEmpty() {
+	if !op.Info().GetCapability().WriteCanEmpty() {
 		return
 	}
 
@@ -91,7 +91,7 @@ func testWriteWithSpecialChars(assert *require.Assertions, op *opendal.Operator,
 }
 
 func testWriteOverwrite(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !op.Info().GetFullCapability().WriteCanMulti() {
+	if !op.Info().GetCapability().WriteCanMulti() {
 		return
 	}
 
@@ -112,7 +112,7 @@ func testWriteOverwrite(assert *require.Assertions, op *opendal.Operator, fixtur
 }
 
 func testWriteWithCacheControl(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !isCapEnabled(op.Info().GetFullCapability().WriteWithCacheControl, "write_with_cache_control") {
+	if !isCapEnabled(op.Info().GetCapability().WriteWithCacheControl, "write_with_cache_control") {
 		return
 	}
 
@@ -129,7 +129,7 @@ func testWriteWithCacheControl(assert *require.Assertions, op *opendal.Operator,
 }
 
 func testWriteWithContentType(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !isCapEnabled(op.Info().GetFullCapability().WriteWithContentType, "write_with_content_type") {
+	if !isCapEnabled(op.Info().GetCapability().WriteWithContentType, "write_with_content_type") {
 		return
 	}
 
@@ -146,7 +146,7 @@ func testWriteWithContentType(assert *require.Assertions, op *opendal.Operator, 
 }
 
 func testWriteWithContentDisposition(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !isCapEnabled(op.Info().GetFullCapability().WriteWithContentDisposition, "write_with_content_disposition") {
+	if !isCapEnabled(op.Info().GetCapability().WriteWithContentDisposition, "write_with_content_disposition") {
 		return
 	}
 
@@ -163,7 +163,7 @@ func testWriteWithContentDisposition(assert *require.Assertions, op *opendal.Ope
 }
 
 func testWriteWithContentEncoding(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !isCapEnabled(op.Info().GetFullCapability().WriteWithContentEncoding, "write_with_content_encoding") {
+	if !isCapEnabled(op.Info().GetCapability().WriteWithContentEncoding, "write_with_content_encoding") {
 		return
 	}
 
@@ -180,7 +180,7 @@ func testWriteWithContentEncoding(assert *require.Assertions, op *opendal.Operat
 }
 
 func testWriteWithUserMetadata(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !isCapEnabled(op.Info().GetFullCapability().WriteWithUserMetadata, "write_with_user_metadata") {
+	if !isCapEnabled(op.Info().GetCapability().WriteWithUserMetadata, "write_with_user_metadata") {
 		return
 	}
 
@@ -201,7 +201,7 @@ func testWriteWithUserMetadata(assert *require.Assertions, op *opendal.Operator,
 }
 
 func testWriteWithIfMatch(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !isCapEnabled(op.Info().GetFullCapability().WriteWithIfMatch, "write_with_if_match") {
+	if !isCapEnabled(op.Info().GetCapability().WriteWithIfMatch, "write_with_if_match") {
 		return
 	}
 
@@ -219,7 +219,7 @@ func testWriteWithIfMatch(assert *require.Assertions, op *opendal.Operator, fixt
 }
 
 func testWriteWithIfNoneMatch(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !isCapEnabled(op.Info().GetFullCapability().WriteWithIfNoneMatch, "write_with_if_none_match") {
+	if !isCapEnabled(op.Info().GetCapability().WriteWithIfNoneMatch, "write_with_if_none_match") {
 		return
 	}
 
@@ -240,7 +240,7 @@ func testWriteWithIfNoneMatch(assert *require.Assertions, op *opendal.Operator, 
 }
 
 func testWriteWithIfNotExists(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !isCapEnabled(op.Info().GetFullCapability().WriteWithIfNotExists, "write_with_if_not_exists") {
+	if !isCapEnabled(op.Info().GetCapability().WriteWithIfNotExists, "write_with_if_not_exists") {
 		return
 	}
 
@@ -256,7 +256,7 @@ func testWriteWithIfNotExists(assert *require.Assertions, op *opendal.Operator, 
 }
 
 func testWriterWrite(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !op.Info().GetFullCapability().WriteCanMulti() {
+	if !op.Info().GetCapability().WriteCanMulti() {
 		return
 	}
 
@@ -285,7 +285,7 @@ func testWriterWrite(assert *require.Assertions, op *opendal.Operator, fixture *
 }
 
 func testWriteWithChunkAndConcurrent(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !isCapEnabled(op.Info().GetFullCapability().WriteCanMulti, "write_can_multi") {
+	if !isCapEnabled(op.Info().GetCapability().WriteCanMulti, "write_can_multi") {
 		return
 	}
 
@@ -299,7 +299,7 @@ func testWriteWithChunkAndConcurrent(assert *require.Assertions, op *opendal.Ope
 }
 
 func testWriterWithAppend(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
-	if !isCapEnabled(op.Info().GetFullCapability().WriteCanAppend, "write_can_append") {
+	if !isCapEnabled(op.Info().GetCapability().WriteCanAppend, "write_can_append") {
 		return
 	}
 

--- a/bindings/java/src/lib.rs
+++ b/bindings/java/src/lib.rs
@@ -73,21 +73,18 @@ fn make_operator_info<'a>(env: &mut JNIEnv<'a>, info: OperatorInfo) -> Result<JO
     let scheme = env.new_string(info.scheme().to_string())?;
     let root = env.new_string(info.root().to_string())?;
     let name = env.new_string(info.name().to_string())?;
-    let full_capability_obj = make_capability(env, info.capability())?;
-    let native_capability_obj = make_capability(env, info.native_capability())?;
+    let capability_obj = make_capability(env, info.capability())?;
 
-    let result = env
-        .new_object(
-            "org/apache/opendal/OperatorInfo",
-            "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/apache/opendal/Capability;Lorg/apache/opendal/Capability;)V",
-            &[
-                JValue::Object(&scheme),
-                JValue::Object(&root),
-                JValue::Object(&name),
-                JValue::Object(&full_capability_obj),
-                JValue::Object(&native_capability_obj),
-            ],
-        )?;
+    let result = env.new_object(
+        "org/apache/opendal/OperatorInfo",
+        "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/apache/opendal/Capability;)V",
+        &[
+            JValue::Object(&scheme),
+            JValue::Object(&root),
+            JValue::Object(&name),
+            JValue::Object(&capability_obj),
+        ],
+    )?;
     Ok(result)
 }
 

--- a/bindings/java/src/main/java/org/apache/opendal/OperatorInfo.java
+++ b/bindings/java/src/main/java/org/apache/opendal/OperatorInfo.java
@@ -27,19 +27,16 @@ public class OperatorInfo {
     public final String scheme;
     public final String root;
     public final String name;
-    public final Capability fullCapability;
-    public final Capability nativeCapability;
+    public final Capability capability;
 
     public OperatorInfo(
             @NonNull String scheme,
             @NonNull String root,
             @NonNull String name,
-            @NonNull Capability fullCapability,
-            @NonNull Capability nativeCapability) {
+            @NonNull Capability capability) {
         this.scheme = scheme;
         this.root = root;
         this.name = name;
-        this.fullCapability = fullCapability;
-        this.nativeCapability = nativeCapability;
+        this.capability = capability;
     }
 }

--- a/bindings/java/src/main/java/org/apache/opendal/OperatorInfo.java
+++ b/bindings/java/src/main/java/org/apache/opendal/OperatorInfo.java
@@ -30,10 +30,7 @@ public class OperatorInfo {
     public final Capability capability;
 
     public OperatorInfo(
-            @NonNull String scheme,
-            @NonNull String root,
-            @NonNull String name,
-            @NonNull Capability capability) {
+            @NonNull String scheme, @NonNull String root, @NonNull String name, @NonNull Capability capability) {
         this.scheme = scheme;
         this.root = root;
         this.name = name;

--- a/bindings/java/src/test/java/org/apache/opendal/test/OperatorInfoTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/OperatorInfoTest.java
@@ -43,15 +43,13 @@ public class OperatorInfoTest {
             assertThat(info).isNotNull();
             assertThat(info.scheme).isEqualTo("fs");
 
-            assertThat(info.fullCapability).isNotNull();
-            assertThat(info.fullCapability.read).isTrue();
-            assertThat(info.fullCapability.write).isTrue();
-            assertThat(info.fullCapability.delete).isTrue();
-            assertThat(info.fullCapability.writeCanAppend).isTrue();
-            assertThat(info.fullCapability.writeMultiMaxSize).isEqualTo(-1);
-            assertThat(info.fullCapability.writeMultiMinSize).isEqualTo(-1);
-
-            assertThat(info.nativeCapability).isNotNull();
+            assertThat(info.capability).isNotNull();
+            assertThat(info.capability.read).isTrue();
+            assertThat(info.capability.write).isTrue();
+            assertThat(info.capability.delete).isTrue();
+            assertThat(info.capability.writeCanAppend).isTrue();
+            assertThat(info.capability.writeMultiMaxSize).isEqualTo(-1);
+            assertThat(info.capability.writeMultiMinSize).isEqualTo(-1);
         }
     }
 
@@ -64,15 +62,13 @@ public class OperatorInfoTest {
             assertThat(info).isNotNull();
             assertThat(info.scheme).isEqualTo("memory");
 
-            assertThat(info.fullCapability).isNotNull();
-            assertThat(info.fullCapability.read).isTrue();
-            assertThat(info.fullCapability.write).isTrue();
-            assertThat(info.fullCapability.delete).isTrue();
-            assertThat(info.fullCapability.writeCanAppend).isFalse();
-            assertThat(info.fullCapability.writeMultiMaxSize).isEqualTo(-1);
-            assertThat(info.fullCapability.writeMultiMinSize).isEqualTo(-1);
-
-            assertThat(info.nativeCapability).isNotNull();
+            assertThat(info.capability).isNotNull();
+            assertThat(info.capability.read).isTrue();
+            assertThat(info.capability.write).isTrue();
+            assertThat(info.capability.delete).isTrue();
+            assertThat(info.capability.writeCanAppend).isFalse();
+            assertThat(info.capability.writeMultiMaxSize).isEqualTo(-1);
+            assertThat(info.capability.writeMultiMinSize).isEqualTo(-1);
         }
     }
 }

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncCopyTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncCopyTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.TestInstance;
 class AsyncCopyTest extends BehaviorTestBase {
     @BeforeAll
     public void precondition() {
-        final Capability capability = asyncOp().info.fullCapability;
+        final Capability capability = asyncOp().info.capability;
         assumeTrue(capability.read && capability.write && capability.copy && capability.createDir);
     }
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncCreateDirTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncCreateDirTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.TestInstance;
 class AsyncCreateDirTest extends BehaviorTestBase {
     @BeforeAll
     public void precondition() {
-        final Capability capability = asyncOp().info.fullCapability;
+        final Capability capability = asyncOp().info.capability;
         assumeTrue(capability.createDir);
     }
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncListTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncListTest.java
@@ -44,7 +44,7 @@ class AsyncListTest extends BehaviorTestBase {
 
     @BeforeAll
     public void precondition() {
-        final Capability capability = asyncOp().info.fullCapability;
+        final Capability capability = asyncOp().info.capability;
         assumeTrue(capability.read && capability.write && capability.list && capability.createDir);
     }
 
@@ -254,7 +254,7 @@ class AsyncListTest extends BehaviorTestBase {
 
     @Test
     void testListWithLimitCollectsAllPages() {
-        assumeTrue(asyncOp().info.fullCapability.listWithLimit);
+        assumeTrue(asyncOp().info.capability.listWithLimit);
 
         String dir = String.format("%s/", UUID.randomUUID());
         asyncOp().createDir(dir).join();
@@ -272,7 +272,7 @@ class AsyncListTest extends BehaviorTestBase {
 
     @Test
     void testListWithStartAfter() {
-        assumeTrue(asyncOp().info.fullCapability.listWithStartAfter);
+        assumeTrue(asyncOp().info.capability.listWithStartAfter);
 
         String dir = String.format("%s/", UUID.randomUUID());
         asyncOp().createDir(dir).join();
@@ -295,7 +295,7 @@ class AsyncListTest extends BehaviorTestBase {
 
     @Test
     void testListWithVersions() {
-        assumeTrue(asyncOp().info.fullCapability.listWithVersions);
+        assumeTrue(asyncOp().info.capability.listWithVersions);
 
         String dir = String.format("%s/", UUID.randomUUID());
         String path = dir + "versioned-file";
@@ -313,7 +313,7 @@ class AsyncListTest extends BehaviorTestBase {
 
     @Test
     void testListWithDeleted() {
-        assumeTrue(asyncOp().info.fullCapability.listWithDeleted);
+        assumeTrue(asyncOp().info.capability.listWithDeleted);
 
         String dir = String.format("%s/", UUID.randomUUID());
         String path = dir + "file";

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncPresignTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncPresignTest.java
@@ -47,7 +47,7 @@ public class AsyncPresignTest extends BehaviorTestBase {
 
     @BeforeAll
     public void precondition() {
-        final Capability capability = asyncOp().info.fullCapability;
+        final Capability capability = asyncOp().info.capability;
         assumeTrue(capability.list && capability.write && capability.presign);
     }
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncReadOnlyTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncReadOnlyTest.java
@@ -46,7 +46,7 @@ public class AsyncReadOnlyTest extends BehaviorTestBase {
 
     @BeforeAll
     public void precondition() {
-        final Capability capability = asyncOp().info.fullCapability;
+        final Capability capability = asyncOp().info.capability;
         assumeTrue(capability.read && !capability.write);
     }
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncRenameTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncRenameTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.TestInstance;
 class AsyncRenameTest extends BehaviorTestBase {
     @BeforeAll
     public void precondition() {
-        final Capability capability = asyncOp().info.fullCapability;
+        final Capability capability = asyncOp().info.capability;
         assumeTrue(capability.read && capability.write && capability.rename && capability.createDir);
     }
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncStatOptionsTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncStatOptionsTest.java
@@ -39,13 +39,13 @@ public class AsyncStatOptionsTest extends BehaviorTestBase {
 
     @BeforeAll
     public void precondition() {
-        Capability capability = asyncOp().info.fullCapability;
+        Capability capability = asyncOp().info.capability;
         assumeTrue(capability.read && capability.write && capability.stat);
     }
 
     @Test
     void testStatWithIfMatch() {
-        assumeTrue(asyncOp().info.fullCapability.statWithIfMatch);
+        assumeTrue(asyncOp().info.capability.statWithIfMatch);
 
         String path = UUID.randomUUID().toString();
         byte[] content = generateBytes();
@@ -66,7 +66,7 @@ public class AsyncStatOptionsTest extends BehaviorTestBase {
 
     @Test
     void testStatWithIfNoneMatch() {
-        assumeTrue(asyncOp().info.fullCapability.statWithIfNoneMatch);
+        assumeTrue(asyncOp().info.capability.statWithIfNoneMatch);
 
         String path = UUID.randomUUID().toString();
         byte[] content = generateBytes();
@@ -88,7 +88,7 @@ public class AsyncStatOptionsTest extends BehaviorTestBase {
 
     @Test
     void testStatWithIfModifiedSince() {
-        assumeTrue(asyncOp().info.fullCapability.statWithIfModifiedSince);
+        assumeTrue(asyncOp().info.capability.statWithIfModifiedSince);
 
         String path = UUID.randomUUID().toString();
         byte[] content = generateBytes();
@@ -116,7 +116,7 @@ public class AsyncStatOptionsTest extends BehaviorTestBase {
 
     @Test
     void testStatWithIfUnmodifiedSince() {
-        assumeTrue(asyncOp().info.fullCapability.statWithIfUnmodifiedSince);
+        assumeTrue(asyncOp().info.capability.statWithIfUnmodifiedSince);
 
         String path = UUID.randomUUID().toString();
         byte[] content = generateBytes();
@@ -147,7 +147,7 @@ public class AsyncStatOptionsTest extends BehaviorTestBase {
 
     @Test
     void testStatWithVersion() {
-        assumeTrue(asyncOp().info.fullCapability.statWithVersion);
+        assumeTrue(asyncOp().info.capability.statWithVersion);
 
         String path = UUID.randomUUID().toString();
         byte[] content = generateBytes();
@@ -173,7 +173,7 @@ public class AsyncStatOptionsTest extends BehaviorTestBase {
 
     @Test
     void testStatWithNotExistingVersion() {
-        assumeTrue(asyncOp().info.fullCapability.statWithVersion);
+        assumeTrue(asyncOp().info.capability.statWithVersion);
 
         String path = UUID.randomUUID().toString();
         byte[] content = generateBytes();

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncWriteOptionsTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncWriteOptionsTest.java
@@ -32,7 +32,7 @@ public class AsyncWriteOptionsTest extends BehaviorTestBase {
 
     @Test
     void testIfNotExists() {
-        assumeTrue(asyncOp().info.fullCapability.writeWithIfNotExists);
+        assumeTrue(asyncOp().info.capability.writeWithIfNotExists);
         final String path = UUID.randomUUID().toString();
         final byte[] content = generateBytes();
         WriteOptions options = WriteOptions.builder().ifNotExists(true).build();
@@ -44,7 +44,7 @@ public class AsyncWriteOptionsTest extends BehaviorTestBase {
 
     @Test
     void testWriteWithChunk() {
-        assumeTrue(asyncOp().info.fullCapability.writeCanMulti);
+        assumeTrue(asyncOp().info.capability.writeCanMulti);
 
         final String path = UUID.randomUUID().toString();
         final byte[] content = generateBytes(5 * 1024 * 1024);
@@ -59,7 +59,7 @@ public class AsyncWriteOptionsTest extends BehaviorTestBase {
 
     @Test
     void testWriteWithConcurrentChunk() {
-        assumeTrue(asyncOp().info.fullCapability.writeCanMulti);
+        assumeTrue(asyncOp().info.capability.writeCanMulti);
 
         final String path = UUID.randomUUID().toString();
         final byte[] content = generateBytes(5 * 1024 * 1024);
@@ -75,7 +75,7 @@ public class AsyncWriteOptionsTest extends BehaviorTestBase {
 
     @Test
     void testWriteWithCacheControl() {
-        assumeTrue(asyncOp().info.fullCapability.writeWithCacheControl);
+        assumeTrue(asyncOp().info.capability.writeWithCacheControl);
         final String path = UUID.randomUUID().toString();
         final byte[] content = generateBytes();
         final String cacheControl = "max-age=3600";
@@ -90,7 +90,7 @@ public class AsyncWriteOptionsTest extends BehaviorTestBase {
 
     @Test
     void testWriteWithIfNoneMatch() {
-        assumeTrue(asyncOp().info.fullCapability.writeWithIfNoneMatch);
+        assumeTrue(asyncOp().info.capability.writeWithIfNoneMatch);
         final String path = UUID.randomUUID().toString();
         final byte[] content = generateBytes();
 
@@ -105,7 +105,7 @@ public class AsyncWriteOptionsTest extends BehaviorTestBase {
 
     @Test
     void testWriteWithIfMatch() {
-        assumeTrue(asyncOp().info.fullCapability.writeWithIfMatch);
+        assumeTrue(asyncOp().info.capability.writeWithIfMatch);
 
         final String pathA = UUID.randomUUID().toString();
         final String pathB = UUID.randomUUID().toString();
@@ -130,7 +130,7 @@ public class AsyncWriteOptionsTest extends BehaviorTestBase {
 
     @Test
     void testWriteWithAppend() {
-        assumeTrue(asyncOp().info.fullCapability.writeCanAppend);
+        assumeTrue(asyncOp().info.capability.writeCanAppend);
 
         final String path = UUID.randomUUID().toString();
         final byte[] contentOne = "Test".getBytes();

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncWriteTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/AsyncWriteTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.TestInstance;
 public class AsyncWriteTest extends BehaviorTestBase {
     @BeforeAll
     public void precondition() {
-        final Capability capability = asyncOp().info.fullCapability;
+        final Capability capability = asyncOp().info.capability;
         assumeTrue(capability.read && capability.write);
     }
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingCopyTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingCopyTest.java
@@ -36,7 +36,7 @@ class BlockingCopyTest extends BehaviorTestBase {
 
     @BeforeAll
     public void precondition() {
-        final Capability capability = op().info.fullCapability;
+        final Capability capability = op().info.capability;
         assumeTrue(capability.read && capability.write && capability.copy && capability.createDir);
     }
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingCreateDirTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingCreateDirTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.TestInstance;
 class BlockingCreateDirTest extends BehaviorTestBase {
     @BeforeAll
     public void precondition() {
-        final Capability capability = op().info.fullCapability;
+        final Capability capability = op().info.capability;
         assumeTrue(capability.createDir);
     }
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingListTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingListTest.java
@@ -42,7 +42,7 @@ public class BlockingListTest extends BehaviorTestBase {
 
     @BeforeAll
     public void precondition() {
-        final Capability capability = op().info.fullCapability;
+        final Capability capability = op().info.capability;
         assumeTrue(capability.read && capability.write && capability.copy && capability.list && capability.createDir);
     }
 
@@ -134,7 +134,7 @@ public class BlockingListTest extends BehaviorTestBase {
 
     @Test
     void testListWithLimitCollectsAllPages() {
-        assumeTrue(op().info.fullCapability.listWithLimit);
+        assumeTrue(op().info.capability.listWithLimit);
 
         String dir = String.format("%s/", UUID.randomUUID());
         op().createDir(dir);
@@ -152,7 +152,7 @@ public class BlockingListTest extends BehaviorTestBase {
 
     @Test
     void testListWithStartAfter() {
-        assumeTrue(op().info.fullCapability.listWithStartAfter);
+        assumeTrue(op().info.capability.listWithStartAfter);
 
         String dir = String.format("%s/", UUID.randomUUID());
         op().createDir(dir);
@@ -175,7 +175,7 @@ public class BlockingListTest extends BehaviorTestBase {
 
     @Test
     void testListWithVersions() {
-        assumeTrue(op().info.fullCapability.listWithVersions);
+        assumeTrue(op().info.capability.listWithVersions);
 
         String dir = String.format("%s/", UUID.randomUUID());
         String path = dir + "versioned-file";
@@ -193,7 +193,7 @@ public class BlockingListTest extends BehaviorTestBase {
 
     @Test
     void testListWithDeleted() {
-        assumeTrue(op().info.fullCapability.listWithDeleted);
+        assumeTrue(op().info.capability.listWithDeleted);
 
         String dir = String.format("%s/", UUID.randomUUID());
         String path = dir + "file";

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingReadOnlyTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingReadOnlyTest.java
@@ -46,7 +46,7 @@ public class BlockingReadOnlyTest extends BehaviorTestBase {
 
     @BeforeAll
     public void precondition() {
-        final Capability capability = op().info.fullCapability;
+        final Capability capability = op().info.capability;
         assumeTrue(capability.read && !capability.write);
     }
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingRenameTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingRenameTest.java
@@ -36,7 +36,7 @@ class BlockingRenameTest extends BehaviorTestBase {
 
     @BeforeAll
     public void precondition() {
-        final Capability capability = op().info.fullCapability;
+        final Capability capability = op().info.capability;
         assumeTrue(capability.read && capability.write && capability.rename && capability.createDir);
     }
 

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingStatOptionsTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingStatOptionsTest.java
@@ -39,13 +39,13 @@ public class BlockingStatOptionsTest extends BehaviorTestBase {
 
     @BeforeAll
     public void precondition() {
-        Capability capability = op().info.fullCapability;
+        Capability capability = op().info.capability;
         assumeTrue(capability.read && capability.write && capability.stat);
     }
 
     @Test
     void testStatWithIfMatch() {
-        assumeTrue(op().info.fullCapability.statWithIfMatch);
+        assumeTrue(op().info.capability.statWithIfMatch);
 
         String path = UUID.randomUUID().toString();
         byte[] content = generateBytes();
@@ -66,7 +66,7 @@ public class BlockingStatOptionsTest extends BehaviorTestBase {
 
     @Test
     void testStatWithIfNoneMatch() {
-        assumeTrue(op().info.fullCapability.statWithIfNoneMatch);
+        assumeTrue(op().info.capability.statWithIfNoneMatch);
 
         String path = UUID.randomUUID().toString();
         byte[] content = generateBytes();
@@ -88,7 +88,7 @@ public class BlockingStatOptionsTest extends BehaviorTestBase {
 
     @Test
     void testStatWithIfModifiedSince() {
-        assumeTrue(op().info.fullCapability.statWithIfModifiedSince);
+        assumeTrue(op().info.capability.statWithIfModifiedSince);
 
         String path = UUID.randomUUID().toString();
         byte[] content = generateBytes();
@@ -117,7 +117,7 @@ public class BlockingStatOptionsTest extends BehaviorTestBase {
 
     @Test
     void testStatWithIfUnmodifiedSince() {
-        assumeTrue(op().info.fullCapability.statWithIfUnmodifiedSince);
+        assumeTrue(op().info.capability.statWithIfUnmodifiedSince);
 
         String path = UUID.randomUUID().toString();
         byte[] content = generateBytes();
@@ -148,7 +148,7 @@ public class BlockingStatOptionsTest extends BehaviorTestBase {
 
     @Test
     void testStatWithVersion() {
-        assumeTrue(op().info.fullCapability.statWithVersion);
+        assumeTrue(op().info.capability.statWithVersion);
 
         String path = UUID.randomUUID().toString();
         byte[] content = generateBytes();
@@ -174,7 +174,7 @@ public class BlockingStatOptionsTest extends BehaviorTestBase {
 
     @Test
     void testStatWithNotExistingVersion() {
-        assumeTrue(op().info.fullCapability.statWithVersion);
+        assumeTrue(op().info.capability.statWithVersion);
 
         String path = UUID.randomUUID().toString();
         byte[] content = generateBytes();

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingWriteOptionTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingWriteOptionTest.java
@@ -29,7 +29,7 @@ public class BlockingWriteOptionTest extends BehaviorTestBase {
 
     @Test
     void testWriteWithCacheControl() {
-        assumeTrue(op().info.fullCapability.writeWithCacheControl);
+        assumeTrue(op().info.capability.writeWithCacheControl);
 
         final String path = UUID.randomUUID().toString();
         final byte[] content = generateBytes();
@@ -44,7 +44,7 @@ public class BlockingWriteOptionTest extends BehaviorTestBase {
 
     @Test
     void testWriteWithContentType() {
-        assumeTrue(op().info.fullCapability.writeWithContentType);
+        assumeTrue(op().info.capability.writeWithContentType);
 
         final String path = UUID.randomUUID().toString();
         final byte[] content = generateBytes();
@@ -59,7 +59,7 @@ public class BlockingWriteOptionTest extends BehaviorTestBase {
 
     @Test
     void testWriteWithContentDisposition() {
-        assumeTrue(op().info.fullCapability.writeWithContentDisposition);
+        assumeTrue(op().info.capability.writeWithContentDisposition);
 
         final String path = UUID.randomUUID().toString();
         final byte[] content = generateBytes();
@@ -75,7 +75,7 @@ public class BlockingWriteOptionTest extends BehaviorTestBase {
 
     @Test
     void testWriteWithAppend() {
-        assumeTrue(op().info.fullCapability.writeCanAppend);
+        assumeTrue(op().info.capability.writeCanAppend);
 
         final String path = UUID.randomUUID().toString();
         final byte[] contentOne = "Test".getBytes();
@@ -92,7 +92,7 @@ public class BlockingWriteOptionTest extends BehaviorTestBase {
 
     @Test
     void testWriteWithChunk() {
-        assumeTrue(op().info.fullCapability.writeCanMulti);
+        assumeTrue(op().info.capability.writeCanMulti);
 
         final String path = UUID.randomUUID().toString();
         final byte[] content = generateBytes(5 * 1024 * 1024);
@@ -107,7 +107,7 @@ public class BlockingWriteOptionTest extends BehaviorTestBase {
 
     @Test
     void testWriteWithConcurrentChunk() {
-        assumeTrue(op().info.fullCapability.writeCanMulti);
+        assumeTrue(op().info.capability.writeCanMulti);
 
         final String path = UUID.randomUUID().toString();
         final byte[] content = generateBytes(5 * 1024 * 1024);

--- a/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingWriteTest.java
+++ b/bindings/java/src/test/java/org/apache/opendal/test/behavior/BlockingWriteTest.java
@@ -36,7 +36,7 @@ class BlockingWriteTest extends BehaviorTestBase {
 
     @BeforeAll
     public void precondition() {
-        final Capability capability = op().info.fullCapability;
+        final Capability capability = op().info.capability;
         assumeTrue(capability.read && capability.write);
     }
 

--- a/bindings/zig/src/opendal.zig
+++ b/bindings/zig/src/opendal.zig
@@ -145,12 +145,8 @@ pub const OperatorInfo = struct {
         return std.mem.span(ptr);
     }
 
-    pub fn fullCapability(self: *const OperatorInfo) c.opendal_capability {
-        return c.opendal_operator_info_get_full_capability(self.inner);
-    }
-
-    pub fn nativeCapability(self: *const OperatorInfo) c.opendal_capability {
-        return c.opendal_operator_info_get_native_capability(self.inner);
+    pub fn capability(self: *const OperatorInfo) c.opendal_capability {
+        return c.opendal_operator_info_get_capability(self.inner);
     }
 };
 

--- a/core/core/src/layers/capability_override.rs
+++ b/core/core/src/layers/capability_override.rs
@@ -298,7 +298,7 @@ mod tests {
     use crate::services;
 
     #[test]
-    fn capability_override_updates_effective_capability_only() -> Result<()> {
+    fn capability_override_updates_capability() -> Result<()> {
         let op = Operator::new(services::Memory::default())?.layer(CapabilityOverrideLayer::new(
             |mut cap| {
                 cap.read = false;
@@ -309,12 +309,6 @@ mod tests {
 
         assert!(!op.info().capability().read);
         assert_eq!(op.info().capability().delete_max_size, Some(7));
-
-        assert!(op.info().native_capability().read);
-        assert_ne!(
-            op.info().native_capability().delete_max_size,
-            op.info().capability().delete_max_size
-        );
 
         Ok(())
     }

--- a/core/core/src/types/capability.rs
+++ b/core/core/src/types/capability.rs
@@ -31,16 +31,11 @@ use serde::Serialize;
 /// - Advanced operation variants (conditional operations, metadata handling)
 /// - Operational constraints (size limits, batch limitations)
 ///
-/// # Capability Types
+/// # Capability Type
 ///
-/// Every operator maintains two capability sets:
-///
-/// 1. [`OperatorInfo::native_capability`][crate::OperatorInfo::native_capability]:
-///    Represents operations natively supported by the storage backend.
-///
-/// 2. [`OperatorInfo::capability`][crate::OperatorInfo::capability]:
-///    Represents all available operations, including those implemented through
-///    alternative mechanisms.
+/// [`OperatorInfo::capability`][crate::OperatorInfo::capability] represents all
+/// operations available on the current operator, including those implemented
+/// through layers.
 ///
 /// # Implementation Details
 ///
@@ -49,9 +44,7 @@ use serde::Serialize;
 ///
 /// - Blocking operations are provided through the BlockingLayer
 ///
-/// Developers should:
-/// - Use `capability` to determine available operations
-/// - Use `native_capability` to identify optimized operations
+/// Developers should use `capability` to determine available operations.
 ///
 /// # Field Naming Conventions
 ///

--- a/core/core/src/types/operator/info.rs
+++ b/core/core/src/types/operator/info.rs
@@ -23,20 +23,11 @@ use crate::*;
 pub struct OperatorInfo {
     info: ServiceInfo,
     capability: Capability,
-    native_capability: Capability,
 }
 
 impl OperatorInfo {
-    pub(super) fn new(
-        info: ServiceInfo,
-        capability: Capability,
-        native_capability: Capability,
-    ) -> Self {
-        Self {
-            info,
-            capability,
-            native_capability,
-        }
+    pub(super) fn new(info: ServiceInfo, capability: Capability) -> Self {
+        Self { info, capability }
     }
 
     /// Scheme of operator.
@@ -62,10 +53,5 @@ impl OperatorInfo {
     /// Get effective capability of operator.
     pub fn capability(&self) -> Capability {
         self.capability
-    }
-
-    /// Get native capability of the base service.
-    pub fn native_capability(&self) -> Capability {
-        self.native_capability
     }
 }

--- a/core/core/src/types/operator/operator.rs
+++ b/core/core/src/types/operator/operator.rs
@@ -244,8 +244,7 @@ impl Operator {
 
     /// Get information of this operator.
     ///
-    /// The effective capability is read from the composed `srv`; native
-    /// capability is read from `base_srv`.
+    /// The effective capability is read from the composed `srv`.
     ///
     /// # Examples
     ///
@@ -260,11 +259,7 @@ impl Operator {
     /// # }
     /// ```
     pub fn info(&self) -> OperatorInfo {
-        OperatorInfo::new(
-            self.srv.info(),
-            self.srv.capability(),
-            self.base_srv.capability(),
-        )
+        OperatorInfo::new(self.srv.info(), self.srv.capability())
     }
 
     /// Get the executor used by the current `ctx`.


### PR DESCRIPTION
# Which issue does this PR close?

Refs #7700.

# Rationale for this change

OpenDAL now exposes `Capability` as the public availability contract through `OperatorInfo::capability()`. Keeping public `native` and `full` capability APIs leaks implementation details and makes the availability check harder to teach consistently.

# What changes are included in this PR?

This PR removes the Rust `OperatorInfo::native_capability()` public API and stops storing native capability in `OperatorInfo`. It also renames the binding-facing capability APIs to expose only `capability` across C, Go, Java, .NET, and Zig, and updates the related tests and docs.

# Are there any user-facing changes?

Yes. Public capability APIs that used `native` or `full` naming have been removed or renamed to `capability`. This is a breaking API change.

# AI Usage Statement

N/A.
