### PR TITLE
[2/N] feat(metrics): annotate metrics with operation name

### DIFF
--- a/core/services/aliyun-drive/src/core.rs
+++ b/core/services/aliyun-drive/src/core.rs
@@ -210,6 +210,7 @@ impl AliyunDriveCore {
         .map_err(new_json_serialize_error)?;
         let req = req
             .extension(Operation::Read)
+            .extension(ServiceOperation("GetFileByPath"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
         self.send(ctx, req, token.as_deref()).await
@@ -278,6 +279,7 @@ impl AliyunDriveCore {
         .map_err(new_json_serialize_error)?;
         let req = Request::post(format!("{}/adrive/v1.0/openFile/create", self.endpoint))
             .extension(Operation::Write)
+            .extension(ServiceOperation("CreateFile"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
         self.send(ctx, req, token.as_deref()).await
@@ -308,6 +310,7 @@ impl AliyunDriveCore {
             self.endpoint
         ))
         .extension(Operation::Read)
+        .extension(ServiceOperation("GetDownloadUrl"))
         .body(Buffer::from(body))
         .map_err(new_request_build_error)?;
 
@@ -328,6 +331,7 @@ impl AliyunDriveCore {
         let download_url = self.get_download_url(ctx, file_id).await?;
         let req = Request::get(download_url)
             .extension(Operation::Read)
+            .extension(ServiceOperation("DownloadFile"))
             .header(header::RANGE, range.to_header())
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
@@ -350,6 +354,7 @@ impl AliyunDriveCore {
         .map_err(new_json_serialize_error)?;
         let req = Request::post(format!("{}/adrive/v1.0/openFile/move", self.endpoint))
             .extension(Operation::Write)
+            .extension(ServiceOperation("MoveFile"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
         self.send(ctx, req, token.as_deref()).await?;
@@ -372,6 +377,7 @@ impl AliyunDriveCore {
         .map_err(new_json_serialize_error)?;
         let req = Request::post(format!("{}/adrive/v1.0/openFile/update", self.endpoint))
             .extension(Operation::Write)
+            .extension(ServiceOperation("UpdateFile"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
         self.send(ctx, req, token.as_deref()).await?;
@@ -395,6 +401,7 @@ impl AliyunDriveCore {
         .map_err(new_json_serialize_error)?;
         let req = Request::post(format!("{}/adrive/v1.0/openFile/copy", self.endpoint))
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyFile"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
         self.send(ctx, req, token.as_deref()).await
@@ -409,6 +416,7 @@ impl AliyunDriveCore {
         .map_err(new_json_serialize_error)?;
         let req = Request::post(format!("{}/adrive/v1.0/openFile/delete", self.endpoint))
             .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteFile"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
         self.send(ctx, req, token.as_deref()).await?;
@@ -432,6 +440,7 @@ impl AliyunDriveCore {
         .map_err(new_json_serialize_error)?;
         let req = Request::post(format!("{}/adrive/v1.0/openFile/list", self.endpoint))
             .extension(Operation::List)
+            .extension(ServiceOperation("ListFiles"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
         self.send(ctx, req, token.as_deref()).await
@@ -452,6 +461,7 @@ impl AliyunDriveCore {
         .map_err(new_json_serialize_error)?;
         let req = Request::post(format!("{}/adrive/v1.0/openFile/complete", self.endpoint))
             .extension(Operation::Write)
+            .extension(ServiceOperation("CompleteUpload"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
         self.send(ctx, req, token.as_deref()).await
@@ -481,6 +491,7 @@ impl AliyunDriveCore {
             self.endpoint
         ))
         .extension(Operation::Write)
+        .extension(ServiceOperation("GetUploadUrl"))
         .body(Buffer::from(body))
         .map_err(new_request_build_error)?;
 
@@ -513,6 +524,7 @@ impl AliyunDriveCore {
             .await?;
         let req = Request::put(upload_url)
             .extension(Operation::Write)
+            .extension(ServiceOperation("UploadPart"))
             .body(body)
             .map_err(new_request_build_error)?;
         self.send(ctx, req, None).await

--- a/core/services/alluxio/src/core.rs
+++ b/core/services/alluxio/src/core.rs
@@ -68,7 +68,9 @@ impl AlluxioCore {
 
         req = req.header("Content-Type", "application/json");
 
-        let req = req.extension(Operation::CreateDir);
+        let req = req
+            .extension(Operation::CreateDir)
+            .extension(ServiceOperation("CreateDirectory"));
 
         let req = req
             .body(Buffer::from(body))
@@ -100,7 +102,9 @@ impl AlluxioCore {
 
         req = req.header("Content-Type", "application/json");
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("CreateFile"));
 
         let req = req
             .body(Buffer::from(body))
@@ -129,7 +133,9 @@ impl AlluxioCore {
             percent_encode_path(&path)
         ));
 
-        let req = req.extension(Operation::Read);
+        let req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("OpenFile"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
         let resp = ctx.http_client().send(req).await?;
@@ -156,7 +162,9 @@ impl AlluxioCore {
             percent_encode_path(&path)
         ));
 
-        let req = req.extension(Operation::Delete);
+        let req = req
+            .extension(Operation::Delete)
+            .extension(ServiceOperation("Delete"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
         let resp = ctx.http_client().send(req).await?;
@@ -186,7 +194,9 @@ impl AlluxioCore {
             percent_encode_path(&dst)
         ));
 
-        let req = req.extension(Operation::Rename);
+        let req = req
+            .extension(Operation::Rename)
+            .extension(ServiceOperation("Rename"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -209,7 +219,9 @@ impl AlluxioCore {
             percent_encode_path(&path)
         ));
 
-        let req = req.extension(Operation::Stat);
+        let req = req
+            .extension(Operation::Stat)
+            .extension(ServiceOperation("GetStatus"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -241,7 +253,9 @@ impl AlluxioCore {
             percent_encode_path(&path)
         ));
 
-        let req = req.extension(Operation::List);
+        let req = req
+            .extension(Operation::List)
+            .extension(ServiceOperation("ListStatus"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -279,7 +293,9 @@ impl AlluxioCore {
             self.endpoint, stream_id,
         ));
 
-        let req = req.extension(Operation::Read);
+        let req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("ReadStream"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -297,7 +313,9 @@ impl AlluxioCore {
             self.endpoint, stream_id
         ));
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("WriteStream"));
 
         let req = req.body(body).map_err(new_request_build_error)?;
 
@@ -322,7 +340,9 @@ impl AlluxioCore {
             self.endpoint, stream_id
         ));
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("CloseStream"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 

--- a/core/services/b2/src/core.rs
+++ b/core/services/b2/src/core.rs
@@ -157,7 +157,9 @@ impl B2Core {
             req = req.header(header::RANGE, range.to_header());
         }
 
-        let req = req.extension(Operation::Read);
+        let req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("DownloadFileByName"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -179,7 +181,9 @@ impl B2Core {
 
         req = req.header(header::AUTHORIZATION, auth_info.authorization_token);
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("GetUploadUrl"));
 
         // Set body
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
@@ -287,7 +291,9 @@ impl B2Core {
             }
         }
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("UploadFile"));
 
         // Set body
         let req = req.body(body).map_err(new_request_build_error)?;
@@ -332,7 +338,9 @@ impl B2Core {
             start_large_file_request.file_info = Some(file_info);
         }
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("StartLargeFile"));
 
         let body =
             serde_json::to_vec(&start_large_file_request).map_err(new_json_serialize_error)?;
@@ -361,7 +369,9 @@ impl B2Core {
 
         req = req.header(header::AUTHORIZATION, auth_info.authorization_token);
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("GetUploadPartUrl"));
 
         // Set body
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
@@ -400,7 +410,9 @@ impl B2Core {
 
         req = req.header(X_BZ_CONTENT_SHA1, "do_not_verify");
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("UploadPart"));
 
         // Set body
         let req = req.body(body).map_err(new_request_build_error)?;
@@ -422,7 +434,9 @@ impl B2Core {
 
         req = req.header(header::AUTHORIZATION, auth_info.authorization_token);
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("FinishLargeFile"));
 
         let body = serde_json::to_vec(&FinishLargeFileRequest {
             file_id: file_id.to_owned(),
@@ -452,7 +466,9 @@ impl B2Core {
 
         req = req.header(header::AUTHORIZATION, auth_info.authorization_token);
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("CancelLargeFile"));
 
         let body = serde_json::to_vec(&CancelLargeFileRequest {
             file_id: file_id.to_owned(),
@@ -545,7 +561,9 @@ impl B2Core {
 
         req = req.header(header::AUTHORIZATION, auth_info.authorization_token);
 
-        req = req.extension(operation);
+        req = req
+            .extension(operation)
+            .extension(ServiceOperation("ListFileNames"));
 
         // Set body
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
@@ -569,7 +587,9 @@ impl B2Core {
 
         req = req.header(header::AUTHORIZATION, auth_info.authorization_token);
 
-        let req = req.extension(Operation::Copy);
+        let req = req
+            .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyFile"));
 
         let body = CopyFileRequest {
             source_file_id,
@@ -598,7 +618,9 @@ impl B2Core {
 
         req = req.header(header::AUTHORIZATION, auth_info.authorization_token);
 
-        let req = req.extension(Operation::Delete);
+        let req = req
+            .extension(Operation::Delete)
+            .extension(ServiceOperation("HideFile"));
 
         let body = HideFileRequest {
             bucket_id: self.bucket_id.clone(),

--- a/core/services/cloudflare-kv/src/core.rs
+++ b/core/services/cloudflare-kv/src/core.rs
@@ -68,6 +68,7 @@ impl CloudflareKvCore {
 
         let req = req
             .extension(Operation::Stat)
+            .extension(ServiceOperation("GetMetadata"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -82,6 +83,7 @@ impl CloudflareKvCore {
 
         let req = req
             .extension(Operation::Read)
+            .extension(ServiceOperation("GetValue"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -99,7 +101,9 @@ impl CloudflareKvCore {
 
         let req = Request::put(url);
         let req = self.sign(req);
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("WriteValue"));
 
         let mut multipart = Multipart::new()
             .part(FormDataPart::new("value").content(value))
@@ -132,6 +136,7 @@ impl CloudflareKvCore {
         let req_body = &json!(paths);
         let req = req
             .extension(Operation::Delete)
+            .extension(ServiceOperation("BulkDelete"))
             .header(header::CONTENT_TYPE, "application/json")
             .body(Buffer::from(req_body.to_string()))
             .map_err(new_request_build_error)?;
@@ -161,6 +166,7 @@ impl CloudflareKvCore {
         let req = self.sign(req);
         let req = req
             .extension(Operation::List)
+            .extension(ServiceOperation("ListKeys"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 

--- a/core/services/d1/src/core.rs
+++ b/core/services/d1/src/core.rs
@@ -49,7 +49,13 @@ impl Debug for D1Core {
 }
 
 impl D1Core {
-    fn create_d1_query_request(&self, sql: &str, params: Vec<Value>) -> Result<Request<Buffer>> {
+    fn create_d1_query_request(
+        &self,
+        sql: &str,
+        params: Vec<Value>,
+        op: Operation,
+        service_operation: &'static str,
+    ) -> Result<Request<Buffer>> {
         let p = format!(
             "/accounts/{}/d1/database/{}/query",
             self.account_id, self.database_id
@@ -72,7 +78,9 @@ impl D1Core {
         });
 
         let body = serde_json::to_vec(&json).map_err(new_json_serialize_error)?;
-        req.body(Buffer::from(body))
+        req.extension(op)
+            .extension(ServiceOperation(service_operation))
+            .body(Buffer::from(body))
             .map_err(new_request_build_error)
     }
 
@@ -81,7 +89,8 @@ impl D1Core {
             "SELECT {} FROM {} WHERE {} = ? LIMIT 1",
             self.value_field, self.table, self.key_field
         );
-        let req = self.create_d1_query_request(&query, vec![path.into()])?;
+        let req =
+            self.create_d1_query_request(&query, vec![path.into()], Operation::Read, "Get")?;
 
         let resp = ctx.http_client().send(req).await?;
         let status = resp.status();
@@ -108,7 +117,7 @@ impl D1Core {
         );
 
         let params = vec![path.into(), value.to_vec().into()];
-        let req = self.create_d1_query_request(&query, params)?;
+        let req = self.create_d1_query_request(&query, params, Operation::Write, "Set")?;
 
         let resp = ctx.http_client().send(req).await?;
         let status = resp.status();
@@ -120,7 +129,8 @@ impl D1Core {
 
     pub async fn delete(&self, ctx: &OperationContext, path: &str) -> Result<()> {
         let query = format!("DELETE FROM {} WHERE {} = ?", self.table, self.key_field);
-        let req = self.create_d1_query_request(&query, vec![path.into()])?;
+        let req =
+            self.create_d1_query_request(&query, vec![path.into()], Operation::Delete, "Delete")?;
 
         let resp = ctx.http_client().send(req).await?;
         let status = resp.status();

--- a/core/services/dbfs/src/core.rs
+++ b/core/services/dbfs/src/core.rs
@@ -67,7 +67,11 @@ impl DbfsCore {
         });
         let body = Buffer::from(Bytes::from(req_body.to_string()));
 
-        let req = req.body(body).map_err(new_request_build_error)?;
+        let req = req
+            .extension(Operation::CreateDir)
+            .extension(ServiceOperation("Mkdirs"))
+            .body(body)
+            .map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
     }
@@ -95,7 +99,11 @@ impl DbfsCore {
 
         let body = Buffer::from(Bytes::from(request_body.to_string()));
 
-        let req = req.body(body).map_err(new_request_build_error)?;
+        let req = req
+            .extension(Operation::Delete)
+            .extension(ServiceOperation("Delete"))
+            .body(body)
+            .map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
     }
@@ -122,7 +130,11 @@ impl DbfsCore {
 
         let body = Buffer::from(Bytes::from(req_body.to_string()));
 
-        let req = req.body(body).map_err(new_request_build_error)?;
+        let req = req
+            .extension(Operation::Rename)
+            .extension(ServiceOperation("Move"))
+            .body(body)
+            .map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
     }
@@ -142,7 +154,11 @@ impl DbfsCore {
         let auth_header_content = format!("Bearer {}", self.token);
         req = req.header(header::AUTHORIZATION, auth_header_content);
 
-        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
+        let req = req
+            .extension(Operation::List)
+            .extension(ServiceOperation("List"))
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
     }
@@ -164,7 +180,10 @@ impl DbfsCore {
 
         let body = Buffer::from(Bytes::from(req_body.to_string()));
 
-        req.body(body).map_err(new_request_build_error)
+        req.extension(Operation::Write)
+            .extension(ServiceOperation("Put"))
+            .body(body)
+            .map_err(new_request_build_error)
     }
 
     pub async fn dbfs_get_status(
@@ -187,7 +206,11 @@ impl DbfsCore {
         let auth_header_content = format!("Bearer {}", self.token);
         req = req.header(header::AUTHORIZATION, auth_header_content);
 
-        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
+        let req = req
+            .extension(Operation::Stat)
+            .extension(ServiceOperation("GetStatus"))
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
     }

--- a/core/services/dropbox/src/core.rs
+++ b/core/services/dropbox/src/core.rs
@@ -127,7 +127,9 @@ impl DropboxCore {
             req = req.header(header::RANGE, range.to_header());
         }
 
-        let req = req.extension(Operation::Read);
+        let req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("DownloadFile"));
 
         let mut request = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -157,7 +159,9 @@ impl DropboxCore {
             args.content_type().unwrap_or("application/octet-stream"),
         );
 
-        let request_builder = request_builder.extension(Operation::Write);
+        let request_builder = request_builder
+            .extension(Operation::Write)
+            .extension(ServiceOperation("UploadFile"));
 
         let mut request = request_builder
             .header(
@@ -187,6 +191,7 @@ impl DropboxCore {
             .header(CONTENT_TYPE, "application/json")
             .header(CONTENT_LENGTH, bs.len())
             .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteFile"))
             .body(Buffer::from(bs))
             .map_err(new_request_build_error)?;
 
@@ -210,6 +215,7 @@ impl DropboxCore {
             .header(CONTENT_TYPE, "application/json")
             .header(CONTENT_LENGTH, bs.len())
             .extension(Operation::CreateDir)
+            .extension(ServiceOperation("CreateFolder"))
             .body(Buffer::from(bs))
             .map_err(new_request_build_error)?;
 
@@ -251,6 +257,7 @@ impl DropboxCore {
             .header(CONTENT_TYPE, "application/json")
             .header(CONTENT_LENGTH, bs.len())
             .extension(Operation::List)
+            .extension(ServiceOperation("ListFolder"))
             .body(Buffer::from(bs))
             .map_err(new_request_build_error)?;
 
@@ -275,6 +282,7 @@ impl DropboxCore {
             .header(CONTENT_TYPE, "application/json")
             .header(CONTENT_LENGTH, bs.len())
             .extension(Operation::List)
+            .extension(ServiceOperation("ListFolderContinue"))
             .body(Buffer::from(bs))
             .map_err(new_request_build_error)?;
 
@@ -301,6 +309,7 @@ impl DropboxCore {
             .header(CONTENT_TYPE, "application/json")
             .header(CONTENT_LENGTH, bs.len())
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyFile"))
             .body(Buffer::from(bs))
             .map_err(new_request_build_error)?;
 
@@ -327,6 +336,7 @@ impl DropboxCore {
             .header(CONTENT_TYPE, "application/json")
             .header(CONTENT_LENGTH, bs.len())
             .extension(Operation::Rename)
+            .extension(ServiceOperation("MoveFile"))
             .body(Buffer::from(bs))
             .map_err(new_request_build_error)?;
 
@@ -351,6 +361,7 @@ impl DropboxCore {
             .header(CONTENT_TYPE, "application/json")
             .header(CONTENT_LENGTH, bs.len())
             .extension(Operation::Stat)
+            .extension(ServiceOperation("GetMetadata"))
             .body(Buffer::from(bs))
             .map_err(new_request_build_error)?;
 

--- a/core/services/gdrive/src/core.rs
+++ b/core/services/gdrive/src/core.rs
@@ -246,6 +246,7 @@ impl GdriveCore {
             "https://www.googleapis.com/drive/v3/files/{file_id}?fields=id,name,mimeType,size,modifiedTime"
         ))
         .extension(Operation::Stat)
+        .extension(ServiceOperation("GetFile"))
         .body(Buffer::new())
         .map_err(new_request_build_error)?;
         self.sign(ctx, &mut req).await?;
@@ -286,6 +287,7 @@ impl GdriveCore {
 
         let mut req = Request::get(&url)
             .extension(Operation::Read)
+            .extension(ServiceOperation("DownloadFile"))
             .header(header::RANGE, range.to_header())
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
@@ -316,6 +318,7 @@ impl GdriveCore {
 
         let mut req = Request::get(url.finish())
             .extension(Operation::List)
+            .extension(ServiceOperation("ListFiles"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
         self.sign(ctx, &mut req).await?;
@@ -363,6 +366,7 @@ impl GdriveCore {
 
         let mut req = Request::get(url.finish())
             .extension(Operation::List)
+            .extension(ServiceOperation("ListFiles"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
         self.sign(ctx, &mut req).await?;
@@ -408,6 +412,7 @@ impl GdriveCore {
         let url = format!("https://www.googleapis.com/drive/v3/files/{source_file_id}");
         let mut req = Request::patch(url)
             .extension(Operation::Rename)
+            .extension(ServiceOperation("MoveFile"))
             .body(Buffer::from(Bytes::from(metadata.to_string())))
             .map_err(new_request_build_error)?;
 
@@ -430,6 +435,7 @@ impl GdriveCore {
 
         let mut req = Request::patch(&url)
             .extension(Operation::Delete)
+            .extension(ServiceOperation("TrashFile"))
             .body(Buffer::from(Bytes::from(body)))
             .map_err(new_request_build_error)?;
 
@@ -460,7 +466,8 @@ impl GdriveCore {
 
         let req = Request::post(url)
             .header("X-Upload-Content-Length", size)
-            .extension(Operation::Write);
+            .extension(Operation::Write)
+            .extension(ServiceOperation("UploadFile"));
 
         let multipart = Multipart::new()
             .part(
@@ -507,6 +514,7 @@ impl GdriveCore {
             .header(header::CONTENT_LENGTH, size)
             .header("X-Upload-Content-Length", size)
             .extension(Operation::Write)
+            .extension(ServiceOperation("UploadFile"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -557,6 +565,7 @@ impl GdriveCore {
 
         let mut req = Request::post(&url)
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyFile"))
             .body(body)
             .map_err(new_request_build_error)?;
         self.sign(ctx, &mut req).await?;
@@ -815,6 +824,7 @@ impl crate::path_index::GdrivePathQueryer for GdrivePathQuery {
 
         let mut req = Request::get(&url)
             .extension(Operation::Stat)
+            .extension(ServiceOperation("ListFiles"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -857,6 +867,7 @@ impl crate::path_index::GdrivePathQueryer for GdrivePathQuery {
 
         let mut req = Request::post(url)
             .extension(Operation::CreateDir)
+            .extension(ServiceOperation("CreateFolder"))
             .header(header::CONTENT_TYPE, "application/json")
             .body(Buffer::from(Bytes::from(content)))
             .map_err(new_request_build_error)?;

--- a/core/services/ghac/src/core.rs
+++ b/core/services/ghac/src/core.rs
@@ -119,6 +119,7 @@ impl GhacCore {
 
                 let req = req
                     .extension(Operation::Read)
+                    .extension(ServiceOperation("GetCacheEntry"))
                     .body(Buffer::new())
                     .map_err(new_request_build_error)?;
                 let resp = ctx.http_client().send(req).await?;
@@ -153,6 +154,7 @@ impl GhacCore {
                     .header(CONTENT_TYPE, CONTENT_TYPE_PROTOBUF)
                     .header(CONTENT_LENGTH, body.len())
                     .extension(Operation::Read)
+                    .extension(ServiceOperation("GetCacheEntryDownloadURL"))
                     .body(body)
                     .map_err(new_request_build_error)?;
                 let resp = ctx.http_client().send(req).await?;
@@ -193,6 +195,7 @@ impl GhacCore {
         let req = Request::get(location)
             .header(header::RANGE, "bytes=0-0")
             .extension(Operation::Stat)
+            .extension(ServiceOperation("DownloadCache"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -214,6 +217,7 @@ impl GhacCore {
         }
         let req = req
             .extension(Operation::Read)
+            .extension(ServiceOperation("DownloadCache"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -241,6 +245,7 @@ impl GhacCore {
 
                 let req = req
                     .extension(Operation::Write)
+                    .extension(ServiceOperation("ReserveCache"))
                     .body(Buffer::from(Bytes::from(bs)))
                     .map_err(new_request_build_error)?;
                 let resp = ctx.http_client().send(req).await?;
@@ -278,6 +283,7 @@ impl GhacCore {
                     .header(CONTENT_TYPE, CONTENT_TYPE_PROTOBUF)
                     .header(CONTENT_LENGTH, body.len())
                     .extension(Operation::Write)
+                    .extension(ServiceOperation("CreateCacheEntry"))
                     .body(body)
                     .map_err(new_request_build_error)?;
                 let resp = ctx.http_client().send(req).await?;
@@ -322,6 +328,7 @@ impl GhacCore {
         );
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("UploadCache"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -348,6 +355,7 @@ impl GhacCore {
                     .header(CONTENT_TYPE, CONTENT_TYPE_JSON)
                     .header(CONTENT_LENGTH, bs.len())
                     .extension(Operation::Write)
+                    .extension(ServiceOperation("CommitCache"))
                     .body(Buffer::from(bs))
                     .map_err(new_request_build_error)?;
                 let resp = ctx.http_client().send(req).await?;
@@ -377,6 +385,7 @@ impl GhacCore {
                     .header(CONTENT_TYPE, CONTENT_TYPE_PROTOBUF)
                     .header(CONTENT_LENGTH, body.len())
                     .extension(Operation::Write)
+                    .extension(ServiceOperation("FinalizeCacheEntryUpload"))
                     .body(body)
                     .map_err(new_request_build_error)?;
                 let resp = ctx.http_client().send(req).await?;

--- a/core/services/github/src/core.rs
+++ b/core/services/github/src/core.rs
@@ -121,7 +121,9 @@ impl GithubCore {
 
         let req = Request::get(url);
 
-        let req = req.extension(Operation::Stat);
+        let req = req
+            .extension(Operation::Stat)
+            .extension(ServiceOperation("GetRepositoryContent"));
 
         let req = self.sign(req)?;
 
@@ -150,7 +152,9 @@ impl GithubCore {
 
         let req = Request::get(url);
 
-        let req = req.extension(Operation::Read);
+        let req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("GetRepositoryContent"));
 
         let req = self.sign(req)?;
 
@@ -182,7 +186,9 @@ impl GithubCore {
 
         let req = Request::put(url);
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("CreateOrUpdateFileContents"));
 
         let req = self.sign(req)?;
 
@@ -230,7 +236,9 @@ impl GithubCore {
 
         let req = Request::delete(url);
 
-        let req = req.extension(Operation::Delete);
+        let req = req
+            .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteFile"));
 
         let req = self.sign(req)?;
 
@@ -267,7 +275,9 @@ impl GithubCore {
 
         let req = Request::get(url);
 
-        let req = req.extension(Operation::List);
+        let req = req
+            .extension(Operation::List)
+            .extension(ServiceOperation("GetRepositoryContent"));
 
         let req = self.sign(req)?;
 
@@ -301,7 +311,9 @@ impl GithubCore {
 
         let req = Request::get(url);
 
-        let req = req.extension(Operation::List);
+        let req = req
+            .extension(Operation::List)
+            .extension(ServiceOperation("GetTree"));
 
         let req = self.sign(req)?;
 

--- a/core/services/hf/src/core.rs
+++ b/core/services/hf/src/core.rs
@@ -374,8 +374,13 @@ impl HfCore {
         method: http::Method,
         url: &str,
         op: Operation,
+        service_operation: &'static str,
     ) -> Result<http::request::Builder> {
-        let mut req = Request::builder().method(method).uri(url).extension(op);
+        let mut req = Request::builder()
+            .method(method)
+            .uri(url)
+            .extension(op)
+            .extension(ServiceOperation(service_operation));
         match &self.token {
             Some(token) => {
                 if let Ok(auth) = format_authorization_by_bearer(token) {
@@ -447,7 +452,7 @@ impl HfCore {
         let form_body = format!("paths={}&expand=True", percent_encode_path(&uri.path));
 
         let req = self
-            .request(http::Method::POST, &url, Operation::Stat)?
+            .request(http::Method::POST, &url, Operation::Stat, "PathInfo")?
             .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
             .body(Buffer::from(Bytes::from(form_body)))
             .map_err(new_request_build_error)?;
@@ -476,7 +481,7 @@ impl HfCore {
         let uri = self.uri(path);
         let url = uri.resolve_url(&self.endpoint, self.repo.revision());
 
-        let mut req = self.request(http::Method::GET, &url, Operation::Read)?;
+        let mut req = self.request(http::Method::GET, &url, Operation::Read, "Resolve")?;
 
         if mode == HfDownloadMode::Xet {
             req = req.header(header::ACCEPT, "application/vnd.xet-fileinfo+json");
@@ -529,7 +534,7 @@ impl HfCore {
         let json_body = serde_json::to_vec(&payload).map_err(new_json_serialize_error)?;
 
         let req = self
-            .request(http::Method::POST, &url, Operation::Write)?
+            .request(http::Method::POST, &url, Operation::Write, "CommitGit")?
             .header(header::CONTENT_TYPE, "application/json")
             .header(header::CONTENT_LENGTH, json_body.len())
             .body(Buffer::from(json_body))
@@ -564,7 +569,7 @@ impl HfCore {
         }
 
         let req = self
-            .request(http::Method::POST, &url, Operation::Write)?
+            .request(http::Method::POST, &url, Operation::Write, "CommitBucket")?
             .header(header::CONTENT_TYPE, "application/x-ndjson")
             .header(header::CONTENT_LENGTH, body.len())
             .body(Buffer::from(Bytes::from(body)))

--- a/core/services/hf/src/lister.rs
+++ b/core/services/hf/src/lister.rs
@@ -89,7 +89,7 @@ impl HfLister {
 
         let req = self
             .core
-            .request(http::Method::GET, &url, Operation::List)?
+            .request(http::Method::GET, &url, Operation::List, "FileTree")?
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
         let (parts, files) = self

--- a/core/services/http/src/core.rs
+++ b/core/services/http/src/core.rs
@@ -78,7 +78,9 @@ impl HttpCore {
             req = req.header(header::RANGE, range.to_header());
         }
 
-        let req = req.extension(Operation::Read);
+        let req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("Get"));
 
         req.body(Buffer::new()).map_err(new_request_build_error)
     }
@@ -113,7 +115,9 @@ impl HttpCore {
             req = req.header(header::AUTHORIZATION, auth.clone())
         }
 
-        let req = req.extension(Operation::Stat);
+        let req = req
+            .extension(Operation::Stat)
+            .extension(ServiceOperation("Head"));
 
         req.body(Buffer::new()).map_err(new_request_build_error)
     }

--- a/core/services/ipfs/src/core.rs
+++ b/core/services/ipfs/src/core.rs
@@ -58,7 +58,11 @@ impl IpfsCore {
             req = req.header(http::header::RANGE, range.to_header());
         }
 
-        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
+        let req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("Get"))
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
 
         ctx.http_client().fetch(req).await
     }
@@ -68,7 +72,9 @@ impl IpfsCore {
 
         let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
 
-        let req = Request::head(&url);
+        let req = Request::head(&url)
+            .extension(Operation::Stat)
+            .extension(ServiceOperation("Head"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -88,7 +94,11 @@ impl IpfsCore {
         // ref: https://github.com/ipfs/specs/blob/main/http-gateways/PATH_GATEWAY.md
         req = req.header(http::header::ACCEPT, "application/vnd.ipld.raw");
 
-        let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
+        let req = req
+            .extension(Operation::List)
+            .extension(ServiceOperation("List"))
+            .body(Buffer::new())
+            .map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
     }

--- a/core/services/ipmfs/src/core.rs
+++ b/core/services/ipmfs/src/core.rs
@@ -50,7 +50,9 @@ impl IpmfsCore {
             percent_encode_path(&p)
         );
 
-        let req = Request::post(url);
+        let req = Request::post(url)
+            .extension(Operation::Stat)
+            .extension(ServiceOperation("Stat"));
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
@@ -75,7 +77,9 @@ impl IpmfsCore {
             write!(url, "&count={count}").expect("write into string must succeed")
         }
 
-        let req = Request::post(url);
+        let req = Request::post(url)
+            .extension(Operation::Read)
+            .extension(ServiceOperation("Read"));
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
         ctx.http_client().fetch(req).await
@@ -90,7 +94,9 @@ impl IpmfsCore {
             percent_encode_path(&p)
         );
 
-        let req = Request::post(url);
+        let req = Request::post(url)
+            .extension(Operation::Delete)
+            .extension(ServiceOperation("Rm"));
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
@@ -109,7 +115,9 @@ impl IpmfsCore {
             percent_encode_path(&p)
         );
 
-        let req = Request::post(url);
+        let req = Request::post(url)
+            .extension(Operation::List)
+            .extension(ServiceOperation("Ls"));
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
@@ -128,7 +136,9 @@ impl IpmfsCore {
             percent_encode_path(&p)
         );
 
-        let req = Request::post(url);
+        let req = Request::post(url)
+            .extension(Operation::CreateDir)
+            .extension(ServiceOperation("Mkdir"));
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
@@ -151,7 +161,9 @@ impl IpmfsCore {
 
         let multipart = Multipart::new().part(FormDataPart::new("data").content(body));
 
-        let req: http::request::Builder = Request::post(url);
+        let req: http::request::Builder = Request::post(url)
+            .extension(Operation::Write)
+            .extension(ServiceOperation("Write"));
         let req = multipart.apply(req)?;
 
         ctx.http_client().send(req).await

--- a/core/services/koofr/src/core.rs
+++ b/core/services/koofr/src/core.rs
@@ -208,6 +208,7 @@ impl KoofrCore {
                 let req = req
                     .header(header::CONTENT_TYPE, "application/json")
                     .extension(Operation::CreateDir)
+                    .extension(ServiceOperation("CreateFolder"))
                     .body(Buffer::from(Bytes::from(bs)))
                     .map_err(new_request_build_error)?;
 
@@ -243,6 +244,7 @@ impl KoofrCore {
 
         let req = req
             .extension(Operation::Stat)
+            .extension(ServiceOperation("FilesInfo"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -272,6 +274,7 @@ impl KoofrCore {
 
         let req = req
             .extension(Operation::Read)
+            .extension(ServiceOperation("FilesGet"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -314,7 +317,9 @@ impl KoofrCore {
 
         let req = self.sign(ctx, req).await?;
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("FilesPut"));
 
         let req = multipart.apply(req)?;
 
@@ -339,6 +344,7 @@ impl KoofrCore {
 
         let req = req
             .extension(Operation::Delete)
+            .extension(ServiceOperation("FilesRemove"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -377,6 +383,7 @@ impl KoofrCore {
         let req = req
             .header(header::CONTENT_TYPE, "application/json")
             .extension(Operation::Copy)
+            .extension(ServiceOperation("FilesCopy"))
             .body(Buffer::from(Bytes::from(bs)))
             .map_err(new_request_build_error)?;
 
@@ -415,6 +422,7 @@ impl KoofrCore {
         let req = req
             .header(header::CONTENT_TYPE, "application/json")
             .extension(Operation::Rename)
+            .extension(ServiceOperation("FilesMove"))
             .body(Buffer::from(Bytes::from(bs)))
             .map_err(new_request_build_error)?;
 
@@ -439,6 +447,7 @@ impl KoofrCore {
 
         let req = req
             .extension(Operation::List)
+            .extension(ServiceOperation("FilesList"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 

--- a/core/services/lakefs/src/core.rs
+++ b/core/services/lakefs/src/core.rs
@@ -72,7 +72,9 @@ impl LakefsCore {
         let auth_header_content = format_authorization_by_basic(&self.username, &self.password)?;
         req = req.header(header::AUTHORIZATION, auth_header_content);
         // Inject operation to the request.
-        let req = req.extension(Operation::Read);
+        let req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("StatObject"));
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
@@ -106,7 +108,9 @@ impl LakefsCore {
             req = req.header(header::RANGE, range.to_header());
         }
         // Inject operation to the request.
-        let req = req.extension(Operation::Read);
+        let req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("GetObject"));
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
         ctx.http_client().fetch(req).await
@@ -148,7 +152,9 @@ impl LakefsCore {
         let auth_header_content = format_authorization_by_basic(&self.username, &self.password)?;
         req = req.header(header::AUTHORIZATION, auth_header_content);
         // Inject operation to the request.
-        let req = req.extension(Operation::Read);
+        let req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("ListObjects"));
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
@@ -178,7 +184,9 @@ impl LakefsCore {
         let auth_header_content = format_authorization_by_basic(&self.username, &self.password)?;
         req = req.header(header::AUTHORIZATION, auth_header_content);
         // Inject operation to the request.
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("UploadObject"));
         let req = req.body(body).map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
@@ -207,7 +215,9 @@ impl LakefsCore {
         let auth_header_content = format_authorization_by_basic(&self.username, &self.password)?;
         req = req.header(header::AUTHORIZATION, auth_header_content);
         // Inject operation to the request.
-        let req = req.extension(Operation::Delete);
+        let req = req
+            .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteObject"));
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
         ctx.http_client().send(req).await
@@ -245,6 +255,7 @@ impl LakefsCore {
         let req = req
             // Inject operation to the request.
             .extension(Operation::Delete)
+            .extension(ServiceOperation("CopyObject"))
             .body(serde_json::to_vec(&map).unwrap().into())
             .map_err(new_request_build_error)?;
         ctx.http_client().send(req).await

--- a/core/services/onedrive/src/core.rs
+++ b/core/services/onedrive/src/core.rs
@@ -99,6 +99,7 @@ impl OneDriveCore {
 
         let mut request = request
             .extension(Operation::Stat)
+            .extension(ServiceOperation("GetItem"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -190,6 +191,7 @@ impl OneDriveCore {
 
         let mut request = request
             .extension(Operation::Stat)
+            .extension(ServiceOperation("GetItem"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -255,6 +257,7 @@ impl OneDriveCore {
 
         let mut request = Request::get(url)
             .extension(Operation::List)
+            .extension(ServiceOperation("ListVersions"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -274,6 +277,7 @@ impl OneDriveCore {
     ) -> Result<Response<Buffer>> {
         let mut request = Request::get(url)
             .extension(Operation::List)
+            .extension(ServiceOperation("ListChildren"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -308,6 +312,7 @@ impl OneDriveCore {
 
         let mut request = request
             .extension(Operation::Read)
+            .extension(ServiceOperation("DownloadContent"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -360,6 +365,7 @@ impl OneDriveCore {
 
         let mut request = request
             .extension(Operation::Write)
+            .extension(ServiceOperation("UploadContent"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -393,6 +399,7 @@ impl OneDriveCore {
 
         let request = request
             .extension(Operation::Write)
+            .extension(ServiceOperation("UploadFragment"))
             .body(body)
             .map_err(new_request_build_error)?;
         // OneDrive documentation requires not sending the `Authorization` header
@@ -428,6 +435,7 @@ impl OneDriveCore {
         let body = Buffer::from(Bytes::from(body_bytes));
         let mut request = request
             .extension(Operation::Write)
+            .extension(ServiceOperation("CreateUploadSession"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -464,6 +472,7 @@ impl OneDriveCore {
         let mut request = Request::post(url)
             .header(header::CONTENT_TYPE, "application/json")
             .extension(Operation::CreateDir)
+            .extension(ServiceOperation("CreateFolder"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -484,6 +493,7 @@ impl OneDriveCore {
 
         let mut request = Request::delete(&url)
             .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteItem"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -549,6 +559,7 @@ impl OneDriveCore {
         let mut request = Request::post(&url)
             .header(header::CONTENT_TYPE, "application/json")
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyItem"))
             .body(buffer)
             .map_err(new_request_build_error)?;
 
@@ -577,6 +588,7 @@ impl OneDriveCore {
             let mut request = Request::get(monitor_url.to_string())
                 .header(header::CONTENT_TYPE, "application/json")
                 .extension(Operation::Copy)
+                .extension(ServiceOperation("MonitorCopy"))
                 .body(Buffer::new())
                 .map_err(new_request_build_error)?;
 
@@ -635,6 +647,7 @@ impl OneDriveCore {
         let mut request = Request::patch(&url)
             .header(header::CONTENT_TYPE, "application/json")
             .extension(Operation::Rename)
+            .extension(ServiceOperation("MoveItem"))
             .body(buffer)
             .map_err(new_request_build_error)?;
 

--- a/core/services/pcloud/src/core.rs
+++ b/core/services/pcloud/src/core.rs
@@ -82,6 +82,7 @@ impl PcloudCore {
         // set body
         let req = req
             .extension(Operation::Read)
+            .extension(ServiceOperation("GetFileLink"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -126,6 +127,7 @@ impl PcloudCore {
         let req = req
             .header(header::RANGE, range.to_header())
             .extension(Operation::Read)
+            .extension(ServiceOperation("DownloadFile"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -184,6 +186,7 @@ impl PcloudCore {
         // set body
         let req = req
             .extension(Operation::CreateDir)
+            .extension(ServiceOperation("CreateFolderIfNotExists"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -213,6 +216,7 @@ impl PcloudCore {
         // set body
         let req = req
             .extension(Operation::Rename)
+            .extension(ServiceOperation("RenameFile"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -241,6 +245,7 @@ impl PcloudCore {
         // set body
         let req = req
             .extension(Operation::Rename)
+            .extension(ServiceOperation("RenameFolder"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -267,6 +272,7 @@ impl PcloudCore {
         // set body
         let req = req
             .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteFolder"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -293,6 +299,7 @@ impl PcloudCore {
         // set body
         let req = req
             .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteFile"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -322,6 +329,7 @@ impl PcloudCore {
         // set body
         let req = req
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyFile"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -351,6 +359,7 @@ impl PcloudCore {
         // set body
         let req = req
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyFolder"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -375,6 +384,7 @@ impl PcloudCore {
         // set body
         let req = req
             .extension(Operation::Stat)
+            .extension(ServiceOperation("Stat"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -405,6 +415,7 @@ impl PcloudCore {
         // set body
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("UploadFile"))
             .body(bs)
             .map_err(new_request_build_error)?;
 
@@ -435,6 +446,7 @@ impl PcloudCore {
         // set body
         let req = req
             .extension(Operation::List)
+            .extension(ServiceOperation("ListFolder"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 

--- a/core/services/seafile/src/core.rs
+++ b/core/services/seafile/src/core.rs
@@ -172,6 +172,7 @@ impl SeafileCore {
         let req = req
             .header(header::AUTHORIZATION, format!("Token {}", auth_info.token))
             .extension(Operation::Write)
+            .extension(ServiceOperation("GetUploadLink"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -197,7 +198,9 @@ impl SeafileCore {
     ) -> Result<Response<Buffer>> {
         let upload_url = self.get_upload_url(ctx).await?;
 
-        let req = Request::post(upload_url).extension(Operation::Write);
+        let req = Request::post(upload_url)
+            .extension(Operation::Write)
+            .extension(ServiceOperation("UploadFile"));
 
         let (filename, relative_path) = if path.ends_with('/') {
             ("", build_abs_path(&self.root, path))
@@ -246,6 +249,7 @@ impl SeafileCore {
             .header(header::AUTHORIZATION, format!("Token {}", auth_info.token))
             .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
             .extension(Operation::CreateDir)
+            .extension(ServiceOperation("Mkdir"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -272,6 +276,7 @@ impl SeafileCore {
         let req = req
             .header(header::AUTHORIZATION, format!("Token {}", auth_info.token))
             .extension(Operation::Read)
+            .extension(ServiceOperation("GetDownloadLink"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -304,6 +309,7 @@ impl SeafileCore {
         let req = req
             .header(header::RANGE, range.to_header())
             .extension(Operation::Read)
+            .extension(ServiceOperation("DownloadFile"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -325,6 +331,7 @@ impl SeafileCore {
         let req = req
             .header(header::AUTHORIZATION, format!("Token {}", auth_info.token))
             .extension(Operation::Stat)
+            .extension(ServiceOperation("GetFileDetail"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -357,6 +364,7 @@ impl SeafileCore {
         let req = req
             .header(header::AUTHORIZATION, format!("Token {}", auth_info.token))
             .extension(Operation::Stat)
+            .extension(ServiceOperation("GetDirDetail"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -398,6 +406,7 @@ impl SeafileCore {
         let req = req
             .header(header::AUTHORIZATION, format!("Token {}", auth_info.token))
             .extension(Operation::Delete)
+            .extension(ServiceOperation("Delete"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -428,6 +437,7 @@ impl SeafileCore {
         let req = req
             .header(header::AUTHORIZATION, format!("Token {}", auth_info.token))
             .extension(Operation::List)
+            .extension(ServiceOperation("ListDir"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 

--- a/core/services/swift/src/core.rs
+++ b/core/services/swift/src/core.rs
@@ -147,6 +147,7 @@ impl SwiftCore {
 
         let req = req
             .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteObject"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -185,6 +186,7 @@ impl SwiftCore {
 
         let req = req
             .extension(Operation::Delete)
+            .extension(ServiceOperation("BulkDelete"))
             .body(Buffer::from(bytes::Bytes::from(body_str)))
             .map_err(new_request_build_error)?;
 
@@ -221,6 +223,7 @@ impl SwiftCore {
 
         let req = req
             .extension(Operation::List)
+            .extension(ServiceOperation("ListObjects"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -270,6 +273,7 @@ impl SwiftCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("CreateObject"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -317,6 +321,7 @@ impl SwiftCore {
 
         let req = req
             .extension(Operation::Read)
+            .extension(ServiceOperation("GetObject"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -362,6 +367,7 @@ impl SwiftCore {
 
         let req = req
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyObject"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -402,6 +408,7 @@ impl SwiftCore {
 
         let req = req
             .extension(Operation::Stat)
+            .extension(ServiceOperation("ShowObjectMetadata"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -447,6 +454,7 @@ impl SwiftCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("UploadSegment"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -490,6 +498,7 @@ impl SwiftCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("UploadManifest"))
             .body(Buffer::from(bytes::Bytes::from(body)))
             .map_err(new_request_build_error)?;
 
@@ -525,6 +534,7 @@ impl SwiftCore {
 
         let req = req
             .extension(Operation::List)
+            .extension(ServiceOperation("ListObjects"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -551,6 +561,7 @@ impl SwiftCore {
 
                 let req = req
                     .extension(Operation::Delete)
+                    .extension(ServiceOperation("DeleteObject"))
                     .body(Buffer::new())
                     .map_err(new_request_build_error)?;
 

--- a/core/services/tos/src/core.rs
+++ b/core/services/tos/src/core.rs
@@ -517,6 +517,7 @@ impl TosCore {
 
         let req = req
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyObject"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -548,6 +549,7 @@ impl TosCore {
 
         let req = req
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CreateMultipartUpload"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -573,6 +575,7 @@ impl TosCore {
 
         let req = Request::put(&url)
             .extension(Operation::Copy)
+            .extension(ServiceOperation("UploadPartCopy"))
             .header(constants::X_TOS_COPY_SOURCE, source)
             .header(constants::X_TOS_COPY_SOURCE_RANGE, input.range.to_header());
 
@@ -612,6 +615,7 @@ impl TosCore {
 
         let req = req
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CompleteMultipartUpload"))
             .body(Buffer::from(content))
             .map_err(new_request_build_error)?;
 
@@ -636,6 +640,7 @@ impl TosCore {
 
         let req = Request::delete(&url)
             .extension(Operation::Copy)
+            .extension(ServiceOperation("AbortMultipartUpload"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -681,6 +686,7 @@ impl TosCore {
 
         let req = Request::get(url.finish())
             .extension(Operation::List)
+            .extension(ServiceOperation("ListObjectsV2"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -723,6 +729,7 @@ impl TosCore {
 
         let req = Request::get(url.finish())
             .extension(Operation::List)
+            .extension(ServiceOperation("ListObjectVersions"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -775,7 +782,9 @@ impl TosCore {
             }
         }
 
-        req = req.extension(Operation::Write);
+        req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("CreateMultipartUpload"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -804,6 +813,7 @@ impl TosCore {
         let req = Request::put(&url)
             .header(CONTENT_LENGTH, size)
             .extension(Operation::Write)
+            .extension(ServiceOperation("UploadPart"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -844,6 +854,7 @@ impl TosCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("CompleteMultipartUpload"))
             .body(Buffer::from(content))
             .map_err(new_request_build_error)?;
 
@@ -868,6 +879,7 @@ impl TosCore {
 
         let req = Request::delete(&url)
             .extension(Operation::Write)
+            .extension(ServiceOperation("AbortMultipartUpload"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 

--- a/core/services/upyun/src/core.rs
+++ b/core/services/upyun/src/core.rs
@@ -123,6 +123,7 @@ impl UpyunCore {
         let mut req = req
             .header(header::RANGE, range.to_header())
             .extension(Operation::Read)
+            .extension(ServiceOperation("DownloadFile"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -144,6 +145,7 @@ impl UpyunCore {
 
         let mut req = req
             .extension(Operation::Stat)
+            .extension(ServiceOperation("GetFileInfo"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -185,7 +187,9 @@ impl UpyunCore {
             req = req.header(X_UPYUN_CACHE_CONTROL, cache_control)
         }
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("UploadFile"));
 
         // Set body
         let mut req = req.body(body).map_err(new_request_build_error)?;
@@ -206,7 +210,9 @@ impl UpyunCore {
 
         let req = Request::delete(url);
 
-        let req = req.extension(Operation::Delete);
+        let req = req
+            .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteFile"));
 
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -238,7 +244,9 @@ impl UpyunCore {
 
         req = req.header(X_UPYUN_METADATA_DIRECTIVE, "copy");
 
-        let req = req.extension(Operation::Copy);
+        let req = req
+            .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyFile"));
 
         // Set body
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
@@ -271,7 +279,9 @@ impl UpyunCore {
 
         req = req.header(X_UPYUN_METADATA_DIRECTIVE, "copy");
 
-        let req = req.extension(Operation::Rename);
+        let req = req
+            .extension(Operation::Rename)
+            .extension(ServiceOperation("MoveFile"));
 
         // Set body
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
@@ -297,7 +307,9 @@ impl UpyunCore {
 
         req = req.header(X_UPYUN_FOLDER, "true");
 
-        let req = req.extension(Operation::CreateDir);
+        let req = req
+            .extension(Operation::CreateDir)
+            .extension(ServiceOperation("CreateFolder"));
 
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -338,7 +350,9 @@ impl UpyunCore {
             req = req.header(X_UPYUN_CACHE_CONTROL, cache_control)
         }
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("InitiateMultipartUpload"));
 
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -373,7 +387,9 @@ impl UpyunCore {
 
         req = req.header(X_UPYUN_PART_ID, part_number);
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("UploadPart"));
 
         // Set body
         let mut req = req.body(body).map_err(new_request_build_error)?;
@@ -403,7 +419,9 @@ impl UpyunCore {
 
         req = req.header(X_UPYUN_MULTI_UUID, upload_id);
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("CompleteMultipartUpload"));
 
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -442,7 +460,9 @@ impl UpyunCore {
             req = req.header(X_UPYUN_LIST_LIMIT, limit);
         }
 
-        let req = req.extension(Operation::List);
+        let req = req
+            .extension(Operation::List)
+            .extension(ServiceOperation("ListObjects"));
 
         // Set body
         let mut req = req.body(Buffer::new()).map_err(new_request_build_error)?;

--- a/core/services/vercel-artifacts/src/core.rs
+++ b/core/services/vercel-artifacts/src/core.rs
@@ -63,7 +63,9 @@ impl VercelArtifactsCore {
         let auth_header_content = format!("Bearer {}", self.access_token);
         req = req.header(header::AUTHORIZATION, auth_header_content);
 
-        req = req.extension(Operation::Read);
+        req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("DownloadArtifact"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 
@@ -91,7 +93,9 @@ impl VercelArtifactsCore {
         req = req.header(header::AUTHORIZATION, auth_header_content);
         req = req.header(header::CONTENT_LENGTH, size);
 
-        req = req.extension(Operation::Write);
+        req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("UploadArtifact"));
 
         let req = req.body(body).map_err(new_request_build_error)?;
 
@@ -116,7 +120,9 @@ impl VercelArtifactsCore {
         req = req.header(header::AUTHORIZATION, auth_header_content);
         req = req.header(header::CONTENT_LENGTH, 0);
 
-        req = req.extension(Operation::Stat);
+        req = req
+            .extension(Operation::Stat)
+            .extension(ServiceOperation("ArtifactExists"));
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
 

--- a/core/services/vercel-blob/src/core.rs
+++ b/core/services/vercel-blob/src/core.rs
@@ -115,6 +115,7 @@ impl VercelBlobCore {
         // Set body
         let req = req
             .extension(Operation::Read)
+            .extension(ServiceOperation("DownloadBlob"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -151,6 +152,7 @@ impl VercelBlobCore {
         // Set body
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("PutBlob"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -178,6 +180,7 @@ impl VercelBlobCore {
         // Set body
         let req = req
             .extension(Operation::Stat)
+            .extension(ServiceOperation("HeadBlob"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -215,6 +218,7 @@ impl VercelBlobCore {
         // Set body
         let req = req
             .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyBlob"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -245,6 +249,7 @@ impl VercelBlobCore {
         // Set body
         let req = req
             .extension(Operation::List)
+            .extension(ServiceOperation("ListBlobs"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -286,6 +291,7 @@ impl VercelBlobCore {
         // Set body
         let req = req
             .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteBlob"))
             .header(header::CONTENT_TYPE, "application/json")
             .body(Buffer::from(Bytes::from(req_body.to_string())))
             .map_err(new_request_build_error)?;
@@ -327,6 +333,7 @@ impl VercelBlobCore {
         // Set body
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("CreateMultipartUpload"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -362,6 +369,7 @@ impl VercelBlobCore {
         // Set body
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("UploadPart"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -395,6 +403,7 @@ impl VercelBlobCore {
         let req = req
             .header(header::CONTENT_TYPE, "application/json")
             .extension(Operation::Write)
+            .extension(ServiceOperation("CompleteMultipartUpload"))
             .body(Buffer::from(Bytes::from(parts_json.to_string())))
             .map_err(new_request_build_error)?;
 

--- a/core/services/webdav/src/core.rs
+++ b/core/services/webdav/src/core.rs
@@ -135,6 +135,7 @@ impl WebdavCore {
 
         let req = req
             .extension(Operation::Stat)
+            .extension(ServiceOperation("Propfind"))
             .body(Buffer::from(Bytes::from(PROPFIND_REQUEST)))
             .map_err(new_request_build_error)?;
 
@@ -188,6 +189,7 @@ impl WebdavCore {
 
         let req = req
             .extension(Operation::Read)
+            .extension(ServiceOperation("Get"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -225,6 +227,7 @@ impl WebdavCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("Put"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -264,6 +267,7 @@ impl WebdavCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("Proppatch"))
             .body(Buffer::from(Bytes::from(proppatch_body)))
             .map_err(new_request_build_error)?;
 
@@ -286,6 +290,7 @@ impl WebdavCore {
 
         let req = req
             .extension(Operation::Delete)
+            .extension(ServiceOperation("Delete"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -320,6 +325,7 @@ impl WebdavCore {
 
         let req = req
             .extension(Operation::Copy)
+            .extension(ServiceOperation("Copy"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -354,6 +360,7 @@ impl WebdavCore {
 
         let req = req
             .extension(Operation::Rename)
+            .extension(ServiceOperation("Move"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -385,6 +392,7 @@ impl WebdavCore {
 
         let req = req
             .extension(Operation::List)
+            .extension(ServiceOperation("Propfind"))
             .body(Buffer::from(Bytes::from(PROPFIND_REQUEST)))
             .map_err(new_request_build_error)?;
 
@@ -448,6 +456,7 @@ impl WebdavCore {
 
         let req = req
             .extension(Operation::CreateDir)
+            .extension(ServiceOperation("Mkcol"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 

--- a/core/services/webhdfs/src/core.rs
+++ b/core/services/webhdfs/src/core.rs
@@ -76,6 +76,7 @@ impl WebhdfsCore {
 
         let req = req
             .extension(Operation::CreateDir)
+            .extension(ServiceOperation("Mkdirs"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -109,6 +110,7 @@ impl WebhdfsCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("Create"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -136,6 +138,7 @@ impl WebhdfsCore {
         };
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("Create"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -187,6 +190,7 @@ impl WebhdfsCore {
 
         let req = Request::post(url)
             .extension(Operation::Write)
+            .extension(ServiceOperation("Append"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -227,6 +231,7 @@ impl WebhdfsCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("Append"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -265,6 +270,7 @@ impl WebhdfsCore {
 
         let req = req
             .extension(Operation::Write)
+            .extension(ServiceOperation("Concat"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -347,6 +353,7 @@ impl WebhdfsCore {
 
         let req = Request::get(&url)
             .extension(Operation::Read)
+            .extension(ServiceOperation("Open"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -383,6 +390,7 @@ impl WebhdfsCore {
 
         let req = Request::get(&url)
             .extension(Operation::Stat)
+            .extension(ServiceOperation("GetFileStatus"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -409,6 +417,7 @@ impl WebhdfsCore {
 
         let req = Request::delete(&url)
             .extension(Operation::Delete)
+            .extension(ServiceOperation("Delete"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 

--- a/core/services/yandex-disk/src/core.rs
+++ b/core/services/yandex-disk/src/core.rs
@@ -78,7 +78,9 @@ impl YandexDiskCore {
 
         let req = Request::get(url);
 
-        let req = req.extension(Operation::Write);
+        let req = req
+            .extension(Operation::Write)
+            .extension(ServiceOperation("GetUploadUrl"));
 
         let req = self.sign(req);
 
@@ -111,6 +113,7 @@ impl YandexDiskCore {
         let upload_url = self.get_upload_url(ctx, path).await?;
         let req = Request::put(upload_url)
             .extension(Operation::Write)
+            .extension(ServiceOperation("Upload"))
             .body(body)
             .map_err(new_request_build_error)?;
 
@@ -127,7 +130,9 @@ impl YandexDiskCore {
 
         let req = Request::get(url);
 
-        let req = req.extension(Operation::Read);
+        let req = req
+            .extension(Operation::Read)
+            .extension(ServiceOperation("GetDownloadUrl"));
 
         let req = self.sign(req);
 
@@ -161,6 +166,7 @@ impl YandexDiskCore {
         let req = Request::get(download_url)
             .header(header::RANGE, range.to_header())
             .extension(Operation::Read)
+            .extension(ServiceOperation("Download"))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 
@@ -194,7 +200,9 @@ impl YandexDiskCore {
 
         let req = Request::put(url);
 
-        let req = req.extension(Operation::CreateDir);
+        let req = req
+            .extension(Operation::CreateDir)
+            .extension(ServiceOperation("CreateResource"));
 
         let req = self.sign(req);
 
@@ -221,7 +229,9 @@ impl YandexDiskCore {
 
         let req = Request::post(url);
 
-        let req = req.extension(Operation::Copy);
+        let req = req
+            .extension(Operation::Copy)
+            .extension(ServiceOperation("CopyResource"));
 
         let req = self.sign(req);
 
@@ -248,7 +258,9 @@ impl YandexDiskCore {
 
         let req = Request::post(url);
 
-        let req = req.extension(Operation::Rename);
+        let req = req
+            .extension(Operation::Rename)
+            .extension(ServiceOperation("MoveResource"));
 
         let req = self.sign(req);
 
@@ -268,7 +280,9 @@ impl YandexDiskCore {
 
         let req = Request::delete(url);
 
-        let req = req.extension(Operation::Delete);
+        let req = req
+            .extension(Operation::Delete)
+            .extension(ServiceOperation("DeleteResource"));
 
         let req = self.sign(req);
 
@@ -302,7 +316,9 @@ impl YandexDiskCore {
 
         let req = Request::get(url);
 
-        let req = req.extension(Operation::Stat);
+        let req = req
+            .extension(Operation::Stat)
+            .extension(ServiceOperation("GetMetainformation"));
 
         let req = self.sign(req);
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

This PR followup https://github.com/apache/opendal/pull/7530 to annotate all left storage backend operations.
The naming convention is to follow function name in CamelCase.
For example, if the function is named as `s3_get_object` then we use `GetObject` as operation name.

# What changes are included in this PR?

This PR adds operation name annotation to all left-over storage backends.

# Are there any user-facing changes?

No

# AI Usage Statement

I used opus-4.8 for all code changes, and composer-2.5 and opus-4.6 for code review