### PR TITLE
ci: fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,22 +87,13 @@ updates:
           - "rand"
           - "getrandom"
 
-  # Cargo dependencies - bindings, example, tests
-  - package-ecosystem: "cargo"
-    directories: "**/*"
-    open-pull-requests-limit: 5
-    cooldown:
-      semver-patch-days: 120
-      include:
-        - "*"
-
   - package-ecosystem: "cargo"
     directory: "/integrations/dav-server"
     open-pull-requests-limit: 1
     schedule:
       interval: "quarterly"
     cooldown:
-      semver-patch-days: 120
+      semver-patch-days: 90
       include:
         - "*"
 
@@ -112,7 +103,7 @@ updates:
     schedule:
       interval: "quarterly"
     cooldown:
-      semver-patch-days: 120
+      semver-patch-days: 90
       include:
         - "*"
 
@@ -123,7 +114,7 @@ updates:
     schedule:
       interval: "quarterly"
     cooldown:
-      semver-patch-days: 120
+      semver-patch-days: 90
       include:
         - "*"
 
@@ -142,7 +133,7 @@ updates:
         patterns:
           - "*"
     cooldown:
-      semver-patch-days: 120
+      semver-patch-days: 90
       include:
         - "*"
 
@@ -153,7 +144,7 @@ updates:
     schedule:
       interval: "quarterly"
     cooldown:
-      semver-patch-days: 120
+      semver-patch-days: 90
       include:
         - "*"
 
@@ -179,7 +170,7 @@ updates:
         patterns:
           - "*"
     cooldown:
-      semver-patch-days: 120
+      semver-patch-days: 90
       include:
         - "*"
 
@@ -190,7 +181,7 @@ updates:
     schedule:
       interval: "quarterly"
     cooldown:
-      semver-patch-days: 120
+      semver-patch-days: 90
       include:
         - "*"
 
@@ -201,7 +192,7 @@ updates:
     schedule:
       interval: "quarterly"
     cooldown:
-      semver-patch-days: 120
+      semver-patch-days: 90
       include:
         - "*"
 
@@ -212,7 +203,7 @@ updates:
     schedule:
       interval: "quarterly"
     cooldown:
-      semver-patch-days: 120
+      semver-patch-days: 90
       include:
         - "*"
 
@@ -223,7 +214,7 @@ updates:
     schedule:
       interval: "quarterly"
     cooldown:
-      semver-patch-days: 120
+      semver-patch-days: 90
       include:
         - "*"
 


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

Dependabot rejects the current `.github/dependabot.yml` after #7742 because one `directories` value is a string instead of an array, and several `cooldown.semver-patch-days` values exceed GitHub's allowed maximum of 90 days.

# What changes are included in this PR?

This PR removes the broad overlapping Cargo Dependabot entry and restores all Dependabot cooldown patch delays to 90 days.

# Are there any user-facing changes?

No.

# AI Usage Statement

AI tools were used to prepare this change.
