### PR TITLE
ci: add cargo updates for other directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,6 +86,18 @@ updates:
           # Please upgrade to new APIs when updating "rand"
           - "rand"
           - "getrandom"
+  
+  # Cargo dependencies - bindings, example, tests
+  - package-ecosystem: "cargo"
+    directories: # use `directories` to apply glob pattern. `directory` doesn't support glob pattern.
+      - "**/*"
+    open-pull-requests-limit: 5
+    exclude-paths:
+      - "core/**"
+    cooldown:
+      semver-patch-days: 90
+      include:
+        - "*"
 
   - package-ecosystem: "cargo"
     directory: "/integrations/dav-server"


### PR DESCRIPTION
# Which issue does this PR close?

Nice fix on #7750.

Follow up #7750 #7742.

# Rationale for this change

- add cargo updates to other repo again.

# What changes are included in this PR?

- fix `directories` supports only array.

# Are there any user-facing changes?

None

# AI Usage Statement

Nope.