### PR TITLE
ci: fix dependabot cargo directory overlap

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,14 +86,26 @@ updates:
           # Please upgrade to new APIs when updating "rand"
           - "rand"
           - "getrandom"
-  
+
   # Cargo dependencies - bindings, example, tests
   - package-ecosystem: "cargo"
-    directories: # use `directories` to apply glob pattern. `directory` doesn't support glob pattern.
-      - "**/*"
+    directories:
+      - "/bindings/c"
+      - "/bindings/cpp"
+      - "/bindings/dart/rust"
+      - "/bindings/dotnet"
+      - "/bindings/haskell"
+      - "/bindings/lua"
+      - "/bindings/ocaml"
+      - "/bindings/php"
+      - "/bindings/python"
+      - "/bindings/ruby"
+      - "/dev"
+      - "/integrations/parquet"
+      - "/integrations/unftp-sbe"
     open-pull-requests-limit: 5
-    exclude-paths:
-      - "core/**"
+    schedule:
+      interval: "quarterly"
     cooldown:
       semver-patch-days: 90
       include:


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

Dependabot rejects the current `.github/dependabot.yml` because the broad Cargo `directories` entry overlaps with existing Cargo update entries such as `/core`, `/bindings/java`, `/bindings/nodejs`, `/integrations/dav-server`, and `/integrations/object_store`.

# What changes are included in this PR?

This PR replaces the broad Cargo glob with explicit non-overlapping Cargo directories for the remaining bindings, dev tooling, and integrations, and adds the required quarterly schedule to that update block.

# Are there any user-facing changes?

No.

# AI Usage Statement

AI tools were used to prepare this change.
