### PR TITLE
refactor(foyer): implement Code manually to drop bincode dependency

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -1131,15 +1131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3448,14 +3439,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3db80d5dece93adb7ad709c84578794724a9cba342a7e566c3551c7ec626789"
 dependencies = [
  "anyhow",
- "bincode",
  "bytes",
  "cfg-if 1.0.4",
  "foyer-tokio",
  "mixtrics",
  "parking_lot 0.12.5",
  "pin-project",
- "serde",
  "twox-hash",
 ]
 
@@ -3520,7 +3509,6 @@ dependencies = [
  "parking_lot 0.12.5",
  "pin-project",
  "rand 0.9.4",
- "serde",
  "tracing",
  "twox-hash",
  "zstd",
@@ -6595,10 +6583,8 @@ dependencies = [
 name = "opendal-layer-foyer"
 version = "0.57.0"
 dependencies = [
- "bincode",
  "foyer",
  "opendal-core",
- "serde",
  "size",
  "tempfile",
  "tokio",

--- a/core/layers/foyer/Cargo.toml
+++ b/core/layers/foyer/Cargo.toml
@@ -31,10 +31,8 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-bincode = "1"
-foyer = { version = "0.22.3", features = ["serde"] }
+foyer = { version = "0.22.3" }
 opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
-serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 opendal-core = { path = "../../core", version = "0.57.0", features = [

--- a/core/layers/foyer/src/lib.rs
+++ b/core/layers/foyer/src/lib.rs
@@ -34,18 +34,71 @@ use opendal_core::*;
 pub use deleter::Deleter;
 pub use writer::Writer;
 
-/// [`FoyerKey`] is a key for the foyer cache. It's encoded via bincode, which is
-/// backed by foyer's "serde" feature.
+/// [`FoyerKey`] is a key for the foyer cache. It implements foyer's [`Code`] trait
+/// directly, so the layer does not depend on foyer's `serde` feature (and its bincode
+/// dependency).
 ///
 /// It's possible to specify a version in the [`OpRead`] args:
 ///
 /// - If a version is given, the object is cached under that versioned key.
 /// - If version is not supplied, the object is cached exactly as returned by the backend,
 ///   We do NOT interpret `None` as "latest" and we do not promote it to any other version.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FoyerKey {
     pub path: String,
     pub version: Option<String>,
+}
+
+impl Code for FoyerKey {
+    fn encode(&self, writer: &mut impl std::io::Write) -> FoyerResult<()> {
+        write_bytes(writer, self.path.as_bytes())?;
+        match &self.version {
+            None => writer.write_all(&[0u8])?,
+            Some(version) => {
+                writer.write_all(&[1u8])?;
+                write_bytes(writer, version.as_bytes())?;
+            }
+        }
+        Ok(())
+    }
+
+    fn decode(reader: &mut impl std::io::Read) -> FoyerResult<Self> {
+        let path = read_string(reader)?;
+        let mut tag = [0u8; 1];
+        reader.read_exact(&mut tag)?;
+        let version = match tag[0] {
+            0 => None,
+            1 => Some(read_string(reader)?),
+            other => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("invalid FoyerKey version tag: {other}"),
+                )
+                .into());
+            }
+        };
+        Ok(FoyerKey { path, version })
+    }
+
+    fn estimated_size(&self) -> usize {
+        8 + self.path.len() + 1 + self.version.as_ref().map_or(0, |v| 8 + v.len())
+    }
+}
+
+fn write_bytes(writer: &mut impl std::io::Write, bytes: &[u8]) -> FoyerResult<()> {
+    writer.write_all(&(bytes.len() as u64).to_le_bytes())?;
+    writer.write_all(bytes)?;
+    Ok(())
+}
+
+fn read_string(reader: &mut impl std::io::Read) -> FoyerResult<String> {
+    let mut len = [0u8; 8];
+    reader.read_exact(&mut len)?;
+    let len = u64::from_le_bytes(len) as usize;
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf)?;
+    String::from_utf8(buf)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e).into())
 }
 
 /// [`FoyerValue`] is a wrapper around `Buffer` that implements the `Code` trait.

--- a/core/services/foyer/Cargo.toml
+++ b/core/services/foyer/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-foyer = { version = "0.22.3", features = ["serde"] }
+foyer = { version = "0.22.3" }
 log = { workspace = true }
 opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/foyer/src/lib.rs
+++ b/core/services/foyer/src/lib.rs
@@ -48,11 +48,39 @@ pub const FOYER_SCHEME: &str = "foyer";
 
 /// [`FoyerKey`] is a key for the foyer cache.
 ///
-/// It uses bincode (via serde) for efficient serialization.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+/// It implements foyer's [`Code`] trait directly, so the service does not depend on
+/// foyer's `serde` feature (and its bincode dependency).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FoyerKey {
     /// The path of the key.
     pub path: String,
+}
+
+impl Code for FoyerKey {
+    fn encode(&self, writer: &mut impl std::io::Write) -> FoyerResult<()> {
+        let path = self.path.as_bytes();
+        writer.write_all(&(path.len() as u64).to_le_bytes())?;
+        writer.write_all(path)?;
+        Ok(())
+    }
+
+    fn decode(reader: &mut impl std::io::Read) -> FoyerResult<Self>
+    where
+        Self: Sized,
+    {
+        let mut len_bytes = [0u8; 8];
+        reader.read_exact(&mut len_bytes)?;
+        let len = u64::from_le_bytes(len_bytes) as usize;
+        let mut buf = vec![0u8; len];
+        reader.read_exact(&mut buf)?;
+        let path = String::from_utf8(buf)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        Ok(FoyerKey { path })
+    }
+
+    fn estimated_size(&self) -> usize {
+        8 + self.path.len()
+    }
 }
 
 /// [`FoyerValue`] is a wrapper around `Buffer` that implements the `Code` trait.


### PR DESCRIPTION
# Which issue does this PR close?

N/A. Small dependency cleanup with no tracking issue.

# Rationale for this change

`opendal-layer-foyer` and `opendal-service-foyer` enabled foyer's `serde` feature only to obtain a blanket `Code` implementation for their cache key types. That feature pulls bincode (via `foyer-common`) into the dependency tree, even though OpenDAL never calls bincode directly. Implementing `Code` by hand removes an unnecessary transitive dependency.

# What changes are included in this PR?

- Implement foyer's `Code` trait directly for `FoyerKey` in both crates, matching the existing hand-written `Code` impl for `FoyerValue`.
- Drop the `serde` feature from the foyer dependency, and remove the now-unused `bincode` and `serde` direct dependencies from `opendal-layer-foyer`.

After this change, bincode is no longer present in the dependency tree even with `--all-features`.

# Are there any user-facing changes?

The on-disk encoding of foyer cache keys changes from bincode to a hand-written format. Foyer disk-cache data written by older versions cannot be decoded after upgrading and will be dropped by foyer's recovery handling. Foyer's hybrid cache is a volatile cache, so this only affects cache hit rate right after an upgrade, not correctness.

# AI Usage Statement

This PR was prepared with assistance from Claude Code (model: Claude Opus 4.x).
