### PR TITLE
refactor(core): delegate presign_stat/presign_read to their _with variants

### DIFF
--- a/core/core/src/types/operator/operator.rs
+++ b/core/core/src/types/operator/operator.rs
@@ -1939,12 +1939,7 @@ impl Operator {
     /// # }
     /// ```
     pub async fn presign_stat(&self, path: &str, expire: Duration) -> Result<PresignedRequest> {
-        let path = normalize_path(path);
-
-        let op = OpPresign::new(OpStat::new(), expire);
-
-        let rp = self.srv.presign(&self.ctx, &path, op).await?;
-        Ok(rp.into_presigned_request())
+        self.presign_stat_with(path, expire).await
     }
 
     /// Presign an operation for stat(head).
@@ -2071,12 +2066,7 @@ impl Operator {
     /// curl "https://s3.amazonaws.com/examplebucket/test.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=access_key_id/20130721/us-east-1/s3/aws4_request&X-Amz-Date=20130721T201207Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=<signature-value>" -O /tmp/test.txt
     /// ```
     pub async fn presign_read(&self, path: &str, expire: Duration) -> Result<PresignedRequest> {
-        let path = normalize_path(path);
-
-        let op = OpPresign::new(OpRead::new(), expire);
-
-        let rp = self.srv.presign(&self.ctx, &path, op).await?;
-        Ok(rp.into_presigned_request())
+        self.presign_read_with(path, expire).await
     }
 
     /// Presign an operation for read with extra options.


### PR DESCRIPTION
# Which issue does this PR close?

No associated issue; this is a small internal refactor.

# Rationale for this change

`presign_stat` and `presign_read` inlined their own `OpPresign` construction, while `presign_write` and `presign_delete` already delegate to their `*_with` variants. Aligning all four removes the duplicated presign plumbing and keeps a single code path per operation.

# What changes are included in this PR?

`presign_stat` and `presign_read` now delegate to `presign_stat_with` / `presign_read_with`.

The change is behavior-preserving:

- `presign_stat_with` defaults to `OpStat::from(StatOptions::default())`, which maps field-by-field to `OpStat::new()`.
- `presign_read_with` defaults to `ReadOptions::default()`, whose conversion yields `BytesRange::default()` and an `OpRead` equal to `OpRead::new()` (the `OpReader` is discarded for presign), matching the previous inline path.

# Are there any user-facing changes?

No.

# AI Usage Statement

This PR was prepared with Claude Code (Opus 4.8). All changes were reviewed and verified by the author.
