### PR TITLE
fix(services/fs): cache fs reader

### DIFF
--- a/core/services/fs/Cargo.toml
+++ b/core/services/fs/Cargo.toml
@@ -37,7 +37,7 @@ opendal-core = { path = "../../core", version = "0.57.0", default-features = fal
   "internal-tokio-rt",
 ] }
 serde = { workspace = true, features = ["derive"] }
-tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["fs", "rt-multi-thread", "sync"] }
 
 [target.'cfg(unix)'.dependencies]
 xattr = "1"

--- a/core/services/fs/src/backend.rs
+++ b/core/services/fs/src/backend.rs
@@ -219,6 +219,8 @@ impl oio::PositionRead for FsReader {
 pub struct FsLazyReader {
     core: Arc<FsCore>,
     path: String,
+    // Open the file once and reuse the same handle across every read operation
+    reader: tokio::sync::OnceCell<oio::PositionReader<FsReader>>,
 }
 
 impl FsLazyReader {
@@ -226,15 +228,20 @@ impl FsLazyReader {
         Self {
             core,
             path: path.to_string(),
+            reader: tokio::sync::OnceCell::new(),
         }
     }
 
-    async fn reader(&self) -> Result<oio::PositionReader<FsReader>> {
-        let file = self.core.fs_open(&self.path).await?;
-        Ok(oio::PositionReader::new(FsReader::new(
-            self.core.clone(),
-            file,
-        )))
+    async fn reader(&self) -> Result<&oio::PositionReader<FsReader>> {
+        self.reader
+            .get_or_try_init(|| async {
+                let file = self.core.fs_open(&self.path).await?;
+                Ok(oio::PositionReader::new(FsReader::new(
+                    self.core.clone(),
+                    file,
+                )))
+            })
+            .await
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

In the current implementation, each filesystem read call (for example, stream read, chunk read, etc) involves a new syscall file open, even if it was already done before.

# What changes are included in this PR?

This PR caches file handle on the first creation, and reused on later read operations.
No new unit test added because it's functionality-wise a no-op change.

# Are there any user-facing changes?

No.

# AI Usage Statement

Opus-4.8 found the issue and made the change, composer-2.5 did the code review.