### PR TITLE
refactor(core): make reqsign-core an optional dependency

### DIFF
--- a/core/core/Cargo.toml
+++ b/core/core/Cargo.toml
@@ -51,6 +51,14 @@ internal-tokio-rt = ["tokio/rt-multi-thread"]
 # Enable tokio executors support.
 executors-tokio = ["tokio/rt"]
 
+# Enable reqsign integration.
+#
+# This wires OpenDAL's `HttpTransporter` into reqsign as an `HttpSend` backend,
+# so signing services (s3, gcs, azblob, ...) can load credentials over HTTP.
+# Services that need request signing enable it automatically; it is off by
+# default so local-only services (memory, fs, ...) don't pull in reqsign-core.
+reqsign = ["dep:reqsign-core"]
+
 # Deprecated: memory service is always enabled.
 services-memory = []
 
@@ -71,7 +79,7 @@ md-5 = "0.11.0"
 mea = { workspace = true }
 percent-encoding = "2"
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
-reqsign-core = { version = "3.0.1", default-features = false }
+reqsign-core = { version = "3.0.1", default-features = false, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "io-util"] }

--- a/core/core/src/types/http_transport/mod.rs
+++ b/core/core/src/types/http_transport/mod.rs
@@ -21,6 +21,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
+#[cfg(feature = "reqsign")]
 use bytes::Bytes;
 use http::Request;
 use http::Response;
@@ -124,6 +125,7 @@ impl HttpTransport for HttpTransporter {
     }
 }
 
+#[cfg(feature = "reqsign")]
 impl reqsign_core::HttpSend for HttpTransporter {
     async fn http_send(&self, req: Request<Bytes>) -> reqsign_core::Result<Response<Bytes>> {
         let req = req.map(Buffer::from);

--- a/core/services/azblob/Cargo.toml
+++ b/core/services/azblob/Cargo.toml
@@ -35,7 +35,9 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+  "reqsign",
+] }
 opendal-service-azure-common = { path = "../azure-common", version = "0.57.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.0.1", default-features = false }

--- a/core/services/azdls/Cargo.toml
+++ b/core/services/azdls/Cargo.toml
@@ -36,7 +36,9 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+  "reqsign",
+] }
 opendal-service-azure-common = { path = "../azure-common", version = "0.57.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.0.1", default-features = false }

--- a/core/services/azfile/Cargo.toml
+++ b/core/services/azfile/Cargo.toml
@@ -34,7 +34,9 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+  "reqsign",
+] }
 opendal-service-azure-common = { path = "../azure-common", version = "0.57.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.0.1", default-features = false }

--- a/core/services/cos/Cargo.toml
+++ b/core/services/cos/Cargo.toml
@@ -34,7 +34,9 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+  "reqsign",
+] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-core = { version = "3.0.1", default-features = false }
 reqsign-file-read-tokio = { version = "3.0.1", default-features = false }

--- a/core/services/gcs/Cargo.toml
+++ b/core/services/gcs/Cargo.toml
@@ -35,7 +35,9 @@ async-trait = "0.1"
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+  "reqsign",
+] }
 percent-encoding = "2.3"
 quick-xml = { workspace = true, features = ["serialize"] }
 reqsign-core = { version = "3.0.1", default-features = false }

--- a/core/services/obs/Cargo.toml
+++ b/core/services/obs/Cargo.toml
@@ -34,7 +34,9 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+  "reqsign",
+] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-core = "3.0.1"
 reqsign-file-read-tokio = "3.0.1"

--- a/core/services/oss/Cargo.toml
+++ b/core/services/oss/Cargo.toml
@@ -34,7 +34,9 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+  "reqsign",
+] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-aliyun-oss = { version = "3.1.0", default-features = false }
 reqsign-core = { version = "3.0.1", default-features = false }

--- a/core/services/s3/Cargo.toml
+++ b/core/services/s3/Cargo.toml
@@ -37,7 +37,9 @@ crc-fast = "1.9.0"
 http = { workspace = true }
 log = { workspace = true }
 md-5 = "0.11.0"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+  "reqsign",
+] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-aws-v4 = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.1", default-features = false }

--- a/core/services/tos/Cargo.toml
+++ b/core/services/tos/Cargo.toml
@@ -33,7 +33,9 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+  "reqsign",
+] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-core = { version = "3.0.1", default-features = false }
 reqsign-file-read-tokio = { version = "3.0.1", default-features = false }


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

`opendal-core` unconditionally depended on `reqsign-core`, so even local-only setups (e.g. `memory`, `fs`) pulled it into the dependency tree. `reqsign-core` is only needed by the `HttpSend` bridge that lets signing services load credentials over HTTP, so it should not be a hard dependency of the core.

# What changes are included in this PR?

- Mark `reqsign-core` as `optional` in `opendal-core` and add an internal `reqsign` feature (`reqsign = ["dep:reqsign-core"]`), off by default.
- Gate `impl reqsign_core::HttpSend for HttpTransporter` (and its `bytes::Bytes` import) behind `#[cfg(feature = "reqsign")]`. The impl must stay in `opendal-core` because of the orphan rule.
- Enable the `reqsign` feature on the `opendal-core` dependency of the signing services: s3, gcs, azblob, azdls, cos, oss, obs, tos, azfile.

# Are there any user-facing changes?

No breaking changes for `opendal` facade or service users: enabling any signing service automatically turns on the `reqsign` feature, so their behavior is unchanged, and local-only builds no longer compile `reqsign-core`.

Note for users depending on the `opendal-core` crate directly: if you relied on `reqsign-core` being pulled in transitively, or used the `reqsign_core::HttpSend for HttpTransporter` impl, enable `features = ["reqsign"]` on your `opendal-core` dependency.

# AI Usage Statement

This PR was prepared with assistance from Claude Code (Claude Opus).
