### PR TITLE
Wire AGENTS.md -> SECURITY.md -> threat model for agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,3 +136,12 @@ When adding or changing a public optional layer:
 - Use `opendal_core::raw::oio::{ReadStream, Write, List, Delete}` for operation bodies.
 - Use `Operator` and `blocking::Operator` as the public API entry points.
 - Prefer existing helpers in `opendal-core` before adding service-local utilities.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md` and the threat
+model it links (`SECURITY-THREAT-MODEL.md`) for the project's in-scope /
+out-of-scope declarations, adversary model, and known non-findings before
+reporting issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+# Security Policy
+
+## Reporting a Vulnerability
+
+Apache OpenDAL follows the [Apache Software Foundation security process](https://www.apache.org/security/).
+Please report suspected vulnerabilities privately to `security@apache.org`;
+do not open public GitHub issues or pull requests for security reports.
+
+## Threat Model
+
+What the project treats as in scope and out of scope, the security
+properties it provides and disclaims, the adversary model, and how
+findings are triaged are documented in
+[SECURITY-THREAT-MODEL.md](./SECURITY-THREAT-MODEL.md).


### PR DESCRIPTION
**This is a proposal for the OpenDAL PMC to review — please adjust or reject as you see fit.**

The security threat model already lives in `SECURITY-THREAT-MODEL.md`. This small follow-up wires the conventional discoverability chain so an automated security-scan agent can mechanically reach it:

- Adds `SECURITY.md` — ASF reporting pointer + a "Threat Model" link to `SECURITY-THREAT-MODEL.md`.
- Adds a `## Security` section to `AGENTS.md` pointing at `SECURITY.md`.

No model content changes. Context: the ASF Security team is preparing the project for an automated agentic security scan we're piloting; such scans refuse to run unless the model is reachable via the `AGENTS.md -> SECURITY.md` chain. Wording/placement tweaks welcome.

Generated-by: Claude Opus 4.8 (1M context)
