### PR TITLE
feat(core): expose operator base service and context

### DIFF
--- a/core/core/src/types/operator/operator.rs
+++ b/core/core/src/types/operator/operator.rs
@@ -213,6 +213,16 @@ impl Operator {
         (srv, ctx)
     }
 
+    /// Get the base `srv` that layers are applied to.
+    pub fn base_service(&self) -> &Servicer {
+        &self.base_srv
+    }
+
+    /// Get the base `ctx` that layers are applied to.
+    pub fn base_context(&self) -> &OperationContext {
+        &self.base_ctx
+    }
+
     /// Get the composed `srv` used by the current operator.
     pub fn service(&self) -> &Servicer {
         &self.srv


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7783.

# Rationale for this change

Expose the operator's base service and context so users can rebuild operators with custom layer ordering

# What changes are included in this PR?

This PR adds two public `Operator` getters (`Operator::base_service()`, `Operator::base_context()`) to expose the base service and context that layers are applied to.

# Are there any user-facing changes?

Yes. `Operator` now exposes two new public getter APIs.

# AI Usage Statement

None