### PR TITLE
docs(website): link landing service and binding entries to docs

### DIFF
--- a/website/src/components/landing/data.js
+++ b/website/src/components/landing/data.js
@@ -330,24 +330,27 @@ export const serviceGroups = [
   },
 ];
 
+// Each binding links to its docs landing page. Rust is the core crate and lives
+// at /docs/core; every other binding lives under /docs/bindings/<dir>, where the
+// dir matches the doc slug (e.g. Node.js -> nodejs, C++ -> cpp, .NET -> dotnet).
 export const bindings = [
-  { name: "Rust", icon: "/img/bindings/rust.svg" },
-  { name: "Python", icon: "/img/bindings/python.svg" },
-  { name: "Java", icon: "/img/bindings/java.svg" },
-  { name: "Go", icon: "/img/bindings/go.svg" },
-  { name: "Node.js", icon: "/img/bindings/nodejs.svg" },
-  { name: "C", icon: "/img/bindings/c.svg" },
-  { name: "C++", icon: "/img/bindings/cpp.svg" },
-  { name: ".NET", icon: "/img/bindings/dotnet.svg" },
-  { name: "Ruby", icon: "/img/bindings/ruby.svg" },
-  { name: "PHP", icon: "/img/bindings/php.svg" },
-  { name: "Swift", icon: "/img/bindings/swift.svg" },
-  { name: "Haskell", icon: "/img/bindings/haskell.svg" },
-  { name: "OCaml", icon: "/img/bindings/ocaml.svg" },
-  { name: "Lua", icon: "/img/bindings/lua.svg" },
-  { name: "Dart", icon: "/img/bindings/dart.svg" },
-  { name: "D", icon: "/img/bindings/d.svg" },
-  { name: "Zig", icon: "/img/bindings/zig.svg" },
+  { name: "Rust", icon: "/img/bindings/rust.svg", doc: "/docs/core" },
+  { name: "Python", icon: "/img/bindings/python.svg", doc: "/docs/bindings/python" },
+  { name: "Java", icon: "/img/bindings/java.svg", doc: "/docs/bindings/java" },
+  { name: "Go", icon: "/img/bindings/go.svg", doc: "/docs/bindings/go" },
+  { name: "Node.js", icon: "/img/bindings/nodejs.svg", doc: "/docs/bindings/nodejs" },
+  { name: "C", icon: "/img/bindings/c.svg", doc: "/docs/bindings/c" },
+  { name: "C++", icon: "/img/bindings/cpp.svg", doc: "/docs/bindings/cpp" },
+  { name: ".NET", icon: "/img/bindings/dotnet.svg", doc: "/docs/bindings/dotnet" },
+  { name: "Ruby", icon: "/img/bindings/ruby.svg", doc: "/docs/bindings/ruby" },
+  { name: "PHP", icon: "/img/bindings/php.svg", doc: "/docs/bindings/php" },
+  { name: "Swift", icon: "/img/bindings/swift.svg", doc: "/docs/bindings/swift" },
+  { name: "Haskell", icon: "/img/bindings/haskell.svg", doc: "/docs/bindings/haskell" },
+  { name: "OCaml", icon: "/img/bindings/ocaml.svg", doc: "/docs/bindings/ocaml" },
+  { name: "Lua", icon: "/img/bindings/lua.svg", doc: "/docs/bindings/lua" },
+  { name: "Dart", icon: "/img/bindings/dart.svg", doc: "/docs/bindings/dart" },
+  { name: "D", icon: "/img/bindings/d.svg", doc: "/docs/bindings/d" },
+  { name: "Zig", icon: "/img/bindings/zig.svg", doc: "/docs/bindings/zig" },
 ];
 
 export const layers = [

--- a/website/src/components/landing/sections.jsx
+++ b/website/src/components/landing/sections.jsx
@@ -250,7 +250,13 @@ export function Services() {
               <h3 className={styles.serviceGroupTitle}>{group.category}</h3>
               <div className={styles.serviceChips}>
                 {group.services.map((s) => (
-                  <span className={styles.serviceChip} key={s.name}>
+                  // Service docs live at /services/<scheme>, registered by
+                  // plugins/services-docs-plugin.js; s.name is the scheme.
+                  <Link
+                    className={styles.serviceChip}
+                    to={`/services/${s.name}`}
+                    key={s.name}
+                  >
                     <img
                       src={withBaseUrl(s.icon)}
                       alt=""
@@ -259,7 +265,7 @@ export function Services() {
                       loading="lazy"
                     />
                     {s.name}
-                  </span>
+                  </Link>
                 ))}
               </div>
             </div>
@@ -293,7 +299,7 @@ export function Bindings() {
         </div>
         <div className={`${styles.bindingGrid} ${styles.reveal}`}>
           {bindings.map((b) => (
-            <div className={styles.bindingCard} key={b.name}>
+            <Link className={styles.bindingCard} to={b.doc} key={b.name}>
               <img
                 src={withBaseUrl(b.icon)}
                 alt=""
@@ -302,7 +308,7 @@ export function Bindings() {
                 loading="lazy"
               />
               <span className={styles.bindingName}>{b.name}</span>
-            </div>
+            </Link>
           ))}
         </div>
       </div>

--- a/website/src/components/landing/styles.module.css
+++ b/website/src/components/landing/styles.module.css
@@ -539,6 +539,15 @@
   font-family: var(--odl-font-mono);
   font-size: var(--odl-text-xs);
   color: var(--odl-fg);
+  text-decoration: none;
+  transition: border-color var(--odl-dur) var(--odl-ease),
+    background-color var(--odl-dur) var(--odl-ease);
+}
+.serviceChip:hover {
+  border-color: var(--odl-accent);
+  background: var(--odl-surface-2);
+  color: var(--odl-fg);
+  text-decoration: none;
 }
 .serviceChip img {
   width: 15px;
@@ -572,10 +581,12 @@
   justify-content: center;
   gap: var(--odl-space-3);
   padding: var(--odl-space-5) var(--odl-space-3);
+  text-decoration: none;
   transition: background-color var(--odl-dur) var(--odl-ease);
 }
 .bindingCard:hover {
   background: var(--odl-surface-2);
+  text-decoration: none;
 }
 .bindingCard img {
   width: 30px;
@@ -586,6 +597,10 @@
   font-family: var(--odl-font-mono);
   font-size: var(--odl-text-xs);
   color: var(--odl-fg-muted);
+  transition: color var(--odl-dur) var(--odl-ease);
+}
+.bindingCard:hover .bindingName {
+  color: var(--odl-fg);
 }
 
 /* ===== Layers (tile grid left, live code preview right) ================= */


### PR DESCRIPTION
# Which issue does this PR close?

N/A — small website docs/UX improvement, no tracking issue.

# Rationale for this change

On the landing page, the Services and Bindings sections listed entries as static, non-interactive elements (service names as `<span>` chips, language bindings as `<div>` cards). Visitors had no way to jump from a service or language they recognized to its documentation. This adds the obvious navigation.

# What changes are included in this PR?

- Service chips now link to their reference page at `/services/<scheme>` (routes registered by `plugins/services-docs-plugin.js`; every listed service name matches a real scheme in `data/services.json`).
- Binding cards now link to their docs landing page: `/docs/core` for Rust and `/docs/bindings/<slug>` for the other bindings (slugs taken from each binding overview's frontmatter).
- Minor CSS so chips/cards read as links (no underline, hover feedback) while keeping the existing visual style.

# Are there any user-facing changes?

Yes. On the landing page, each service and language entry is now a clickable link to the corresponding documentation page. `pnpm build` passes with `onBrokenLinks: "throw"`, so every new link resolves to a real page.

# AI Usage Statement

This PR was prepared with Claude Code (model: Claude Opus 4.8).
