### PR TITLE
refactor(core): remove whitespace trimming from path normalization and rename

### DIFF
--- a/core/core/src/raw/path.rs
+++ b/core/core/src/raw/path.rs
@@ -67,13 +67,6 @@ pub fn build_absolute_path(root: &str, path: &str) -> String {
     }
 }
 
-/// Deprecated: use [`build_absolute_path`] instead.
-#[deprecated(note = "use build_absolute_path instead")]
-#[inline]
-pub fn build_abs_path(root: &str, path: &str) -> String {
-    build_absolute_path(root, path)
-}
-
 /// Build an absolute path by joining root and path, preserving the leading `/`.
 ///
 /// # Conformance
@@ -119,13 +112,6 @@ pub fn build_rooted_absolute_path(root: &str, path: &str) -> String {
         debug_assert!(!path.starts_with('/'), "path must not start with /");
         p + path
     }
-}
-
-/// Deprecated: use [`build_rooted_absolute_path`] instead.
-#[deprecated(note = "use build_rooted_absolute_path instead")]
-#[inline]
-pub fn build_rooted_abs_path(root: &str, path: &str) -> String {
-    build_rooted_absolute_path(root, path)
 }
 
 /// Build a relative path from a rooted absolute path by stripping the root prefix.
@@ -183,13 +169,6 @@ pub fn build_relative_path(root: &str, path: &str) -> String {
         );
         path[root.len() - 1..].to_string()
     }
-}
-
-/// Deprecated: use [`build_relative_path`] instead.
-#[deprecated(note = "use build_relative_path instead")]
-#[inline]
-pub fn build_rel_path(root: &str, path: &str) -> String {
-    build_relative_path(root, path)
 }
 
 /// Normalize a user-provided path for services.

--- a/core/core/src/raw/path.rs
+++ b/core/core/src/raw/path.rs
@@ -18,19 +18,48 @@
 use crate::*;
 use std::hash::{BuildHasher, Hasher};
 
-/// build_abs_path will build an absolute path with root.
+// a representation of root path.
+// Don't get confused with file system root. Because services can define services' root.
+// For example, when users create an `Operator` with a root like `/root/dir/`, the root path is `/root/dir/`.
+const ROOT_PATH: &str = "/";
+const PATH_SEPARATOR: &str = "/";
+const PATH_SEPARATOR_CHAR: char = '/';
+
+/// Build an absolute path by joining root and path, stripping the leading `/` from root.
 ///
-/// # Rules
+/// # Conformance
 ///
-/// - Input root MUST be the format like `/abc/def/`
-/// - Output will be the format like `path/to/root/path`.
-pub fn build_abs_path(root: &str, path: &str) -> String {
+/// - Users MUST provide a root that follows a format like `/`, `/root/dir/`.
+/// - Output will follow a format like `path/to/root/path`.
+///
+/// # Examples
+///
+/// ```
+/// # use opendal_core::raw::build_absolute_path;
+/// #
+/// assert_eq!(
+///     build_absolute_path("/root/", "dir/"),
+///     "root/dir/",
+///     "input dir with root /root/"
+/// );
+/// assert_eq!(
+///     build_absolute_path("/root/", "file.txt"),
+///     "root/file.txt",
+///     "input file with root /root/"
+/// );
+/// assert_eq!(
+///     build_absolute_path("/", "dir/"),
+///     "dir/",
+///     "input dir with root /"
+/// );
+/// ```
+pub fn build_absolute_path(root: &str, path: &str) -> String {
     debug_assert!(root.starts_with('/'), "root must start with /");
     debug_assert!(root.ends_with('/'), "root must end with /");
 
     let p = root[1..].to_string();
 
-    if path == "/" {
+    if path == ROOT_PATH {
         p
     } else {
         debug_assert!(!path.starts_with('/'), "path must not start with /");
@@ -38,19 +67,53 @@ pub fn build_abs_path(root: &str, path: &str) -> String {
     }
 }
 
-/// build_rooted_abs_path will build an absolute path with root.
+/// Deprecated: use [`build_absolute_path`] instead.
+#[deprecated(note = "use build_absolute_path instead")]
+#[inline]
+pub fn build_abs_path(root: &str, path: &str) -> String {
+    build_absolute_path(root, path)
+}
+
+/// Build an absolute path by joining root and path, preserving the leading `/`.
 ///
-/// # Rules
+/// # Conformance
 ///
-/// - Input root MUST be the format like `/abc/def/`
-/// - Output will be the format like `/path/to/root/path`.
-pub fn build_rooted_abs_path(root: &str, path: &str) -> String {
+/// - Users MUST provide a root that follows a format like `/`, `/abc/def/`.
+/// - Output will follow a format like `/path/to/root/path`.
+///
+/// # Examples
+///
+/// ```
+/// # use opendal_core::raw::build_rooted_absolute_path;
+/// #
+/// assert_eq!(
+///     build_rooted_absolute_path("/root/", "dir/"),
+///     "/root/dir/",
+///     "input dir with root /root/"
+/// );
+/// assert_eq!(
+///     build_rooted_absolute_path("/", "dir/"),
+///     "/dir/",
+///     "input dir with root /"
+/// );
+/// assert_eq!(
+///     build_rooted_absolute_path("/root/", "file.txt"),
+///     "/root/file.txt",
+///     "input file with root /root/"
+/// );
+/// assert_eq!(
+///     build_rooted_absolute_path("/", ""),
+///     "/",
+///     "input root path with root /"
+/// );
+/// ```
+pub fn build_rooted_absolute_path(root: &str, path: &str) -> String {
     debug_assert!(root.starts_with('/'), "root must start with /");
     debug_assert!(root.ends_with('/'), "root must end with /");
 
     let p = root.to_string();
 
-    if path == "/" {
+    if path == ROOT_PATH {
         p
     } else {
         debug_assert!(!path.starts_with('/'), "path must not start with /");
@@ -58,17 +121,56 @@ pub fn build_rooted_abs_path(root: &str, path: &str) -> String {
     }
 }
 
-/// build_rel_path will build a relative path towards root.
-///
-/// # Rules
-///
-/// - Input root MUST be the format like `/abc/def/`
-/// - Input path MUST start with root like `/abc/def/path/to/file`
-/// - Output will be the format like `path/to/file`.
-pub fn build_rel_path(root: &str, path: &str) -> String {
-    debug_assert!(root != path, "get rel path with root is invalid");
+/// Deprecated: use [`build_rooted_absolute_path`] instead.
+#[deprecated(note = "use build_rooted_absolute_path instead")]
+#[inline]
+pub fn build_rooted_abs_path(root: &str, path: &str) -> String {
+    build_rooted_absolute_path(root, path)
+}
 
-    if path.starts_with('/') {
+/// Build a relative path from a rooted absolute path by stripping the root prefix.
+///
+/// # Conformance
+///
+/// - Users MUST provide a root that follows a format like `/`, `/root/dir/`.
+/// - Output will follow a format like `path/to/file` stripping the root prefix.
+///   The output will not have a leading `/`.
+///
+/// # Examples
+///
+/// ```
+/// # use opendal_core::raw::build_relative_path;
+/// #
+/// assert_eq!(
+///     build_relative_path("/root/", "/root/file.txt"),
+///     "file.txt",
+///     "input absolute file with root /root/"
+/// );
+/// assert_eq!(
+///     build_relative_path("/root/", "/root/dir/file.txt"),
+///     "dir/file.txt",
+///     "input file path with root /root/"
+/// );
+/// assert_eq!(
+///     build_relative_path("/", "/dir"),
+///     "dir",
+///     "input absolute file with root /"
+/// );
+/// assert_eq!(
+///     build_relative_path("/", "dir"),
+///     "dir",
+///     "input file with root /"
+/// );
+/// assert_eq!(
+///     build_relative_path("/root/", "/root/file.txt"),
+///     "file.txt",
+///     "input file path with root /root/"
+/// );
+/// ```
+pub fn build_relative_path(root: &str, path: &str) -> String {
+    debug_assert!(root != path, "build relative path with root is invalid");
+
+    if path.starts_with(ROOT_PATH) {
         debug_assert!(
             path.starts_with(root),
             "path {path} doesn't start with root {root}"
@@ -83,81 +185,158 @@ pub fn build_rel_path(root: &str, path: &str) -> String {
     }
 }
 
-/// Make sure all operation are constructed by normalized path:
+/// Deprecated: use [`build_relative_path`] instead.
+#[deprecated(note = "use build_relative_path instead")]
+#[inline]
+pub fn build_rel_path(root: &str, path: &str) -> String {
+    build_relative_path(root, path)
+}
+
+/// Normalize a user-provided path for services.
 ///
-/// - Path endswith `/` means it's a dir path.
-/// - Otherwise, it's a file path.
+/// OpenDAL core's `Operator` normalizes paths before services process normalized paths in `Service` trait.
+/// e.g., when users call `op.read("///root/dir/")`, OpenDAL normalizes the path to `root/dir/`
+/// before calling `Service::read` in services.
+///
+/// # Path conventions for OpenDAL users
+///
+/// - Paths ending with `/` represent directories.
+/// - Otherwise, paths represent files.
 ///
 /// # Normalize Rules
 ///
-/// - All whitespace will be trimmed: ` abc/def ` => `abc/def`
-/// - All leading / will be trimmed: `///abc` => `abc`
-/// - Internal // will be replaced by /: `abc///def` => `abc/def`
-/// - Empty path will be `/`: `` => `/`
+/// - Strip leading `/`: `/root` => `root`
+/// - Collapse double slashes `//` in a path: `root///dir` => `root/dir`
+/// - Remove `.` segments:
+///    - `./root/./dir` => `root/dir`
+///    - `./` => `/`
+/// - Preserve trailing `/`: `dir/` => `dir/`
+/// - Empty path becomes `/`: `` => `/`
+/// - Preserve content within path components (including whitespace):
+///      - `root/file   ` => `root/file   `
+///      - `  root/dir` => `  root/dir`
+///      - ` root/dir ` => ` root/dir `
+///
+///   This aligns with POSIX, URI, and object-store conventions where
+///   whitespace is significant content — `file` and `file ` are
+///   distinct objects.
+///
+/// # Examples
+///
+/// ```
+/// # use opendal_core::raw::normalize_path;
+/// #
+/// assert_eq!(normalize_path("file"), "file", "normalize file path");
+/// assert_eq!(normalize_path("dir/"), "dir/", "normalize dir path");
+/// assert_eq!(
+///     normalize_path("/root/dir/"),
+///     "root/dir/",
+///     "absolute dir path with root /root/"
+/// );
+/// assert_eq!(normalize_path("///root//dir"), "root/dir");
+/// assert_eq!(
+///     normalize_path("./root/./dir"),
+///     "root/dir",
+///     "removes dot segment"
+/// );
+/// assert_eq!(normalize_path(""), "/", "empty path");
+/// ```
 pub fn normalize_path(path: &str) -> String {
-    // - all whitespace has been trimmed.
-    // - all leading `/` has been trimmed.
-    let path = path.trim().trim_start_matches('/');
+    let path = path.trim_start_matches(PATH_SEPARATOR);
 
-    // Fast line for empty path.
     if path.is_empty() {
-        return "/".to_string();
+        return ROOT_PATH.to_string();
     }
 
-    let has_trailing = path.ends_with('/');
+    let has_trailing = path.ends_with(PATH_SEPARATOR);
 
     let mut p = path
-        .split('/')
-        .filter(|v| !v.is_empty())
+        .split(PATH_SEPARATOR_CHAR)
+        .filter(|v| !v.is_empty() && *v != ".")
         .collect::<Vec<&str>>()
-        .join("/");
+        .join(PATH_SEPARATOR);
 
-    // Append trailing back if input path is endswith `/`.
+    if p.is_empty() {
+        return ROOT_PATH.to_string();
+    }
+
     if has_trailing {
-        p.push('/');
+        p.push_str(PATH_SEPARATOR);
     }
 
     p
 }
 
-/// Make sure root is normalized to style like `/abc/def/`.
+/// Normalize a root path to the style `/root/dir/`.
 ///
 /// # Normalize Rules
 ///
-/// - All whitespace will be trimmed: ` abc/def ` => `abc/def`
-/// - All leading / will be trimmed: `///abc` => `abc`
-/// - Internal // will be replaced by /: `abc///def` => `abc/def`
-/// - Empty path will be `/`: `` => `/`
-/// - Add leading `/` if not starts with: `abc/` => `/abc/`
-/// - Add trailing `/` if not ends with: `/abc` => `/abc/`
+/// - Strip excessive leading `/` but keep one: `///root` => `/root/`
+/// - Ensure leading `/` presence: `root/` => `/root/`
+/// - Collapse internal `//`: `root///dir` => `/root/dir/`
+/// - Remove `.` segments: `./workspace/./root/` => `/workspace/root/`
+/// - Ensure trailing `/` presence: `/root` => `/root/`
+/// - Empty path becomes `/`: `` => `/`
+/// - Preserves content within path components including whitespace: `workspace/file ` => `workspace/file `
 ///
-/// Finally, we will get path like `/path/to/root/`.
+/// # Examples
+///
+/// ```
+/// # use opendal_core::raw::normalize_root;
+/// #
+/// assert_eq!(normalize_root("root/"), "/root/", "dir path");
+/// assert_eq!(
+///     normalize_root("///root//dir"),
+///     "/root/dir/",
+///     "abs dir path with extra /"
+/// );
+/// assert_eq!(normalize_root("."), "/", "only dot");
+/// assert_eq!(
+///     normalize_root("./workspace/./report/"),
+///     "/workspace/report/",
+///     "dot within path"
+/// );
+/// assert_eq!(
+///     normalize_root("/root/dir v1"),
+///     "/root/dir v1/",
+///     "respects whitespace in path component"
+/// );
+/// ```
 pub fn normalize_root(v: &str) -> String {
     let mut v = v
-        .split('/')
-        .filter(|v| !v.is_empty())
+        .split(PATH_SEPARATOR)
+        .filter(|v| !v.is_empty() && *v != ".")
         .collect::<Vec<&str>>()
-        .join("/");
-    if !v.starts_with('/') {
-        v.insert(0, '/');
+        .join(PATH_SEPARATOR);
+    if !v.starts_with(PATH_SEPARATOR) {
+        v.insert_str(0, PATH_SEPARATOR);
     }
-    if !v.ends_with('/') {
-        v.push('/')
+    if !v.ends_with(PATH_SEPARATOR) {
+        v.push_str(PATH_SEPARATOR);
     }
     v
 }
 
 /// Get basename from path.
+///
+/// # Examples
+///
+/// ```
+/// # use opendal_core::raw::get_basename;
+/// assert_eq!(get_basename("root/dir/file.txt"), "file.txt", "file absolute path");
+/// assert_eq!(get_basename("root/dir/"), "dir/");
+/// assert_eq!(get_basename("/"), "/", "dir root");
+/// ```
 pub fn get_basename(path: &str) -> &str {
     // Handle root case
-    if path == "/" {
-        return "/";
+    if path == ROOT_PATH {
+        return ROOT_PATH;
     }
 
     // Handle file case
-    if !path.ends_with('/') {
+    if !path.ends_with(PATH_SEPARATOR) {
         return path
-            .split('/')
+            .split(PATH_SEPARATOR_CHAR)
             .next_back()
             .expect("file path without name is invalid");
     }
@@ -165,7 +344,7 @@ pub fn get_basename(path: &str) -> &str {
     // The idx of second `/` if path in reserve order.
     // - `abc/` => `None`
     // - `abc/def/` => `Some(3)`
-    let idx = path[..path.len() - 1].rfind('/').map(|v| v + 1);
+    let idx = path[..path.len() - 1].rfind(PATH_SEPARATOR).map(|v| v + 1);
 
     match idx {
         Some(v) => {
@@ -177,37 +356,49 @@ pub fn get_basename(path: &str) -> &str {
 }
 
 /// Get parent from path.
+///
+/// # Examples
+///
+/// ```
+/// # use opendal_core::raw::get_parent;
+/// assert_eq!(get_parent("root/dir/file.txt"), "root/dir/", "get parent of a file's path");
+/// assert_eq!(get_parent("root/dir/"), "root/", "get parent of a dir's path");
+/// assert_eq!(get_parent("/root/dir/file.txt"), "/root/dir/", "get parent of a file's path");
+/// assert_eq!(get_parent("/root/dir/"), "/root/", "get parent of a dir's path");
+/// assert_eq!(get_parent("dir"), "/");
+/// assert_eq!(get_parent("/"), "/", "dir root");
+/// ```
 pub fn get_parent(path: &str) -> &str {
-    if path == "/" {
-        return "/";
+    if path == ROOT_PATH {
+        return ROOT_PATH;
     }
 
-    if !path.ends_with('/') {
+    if !path.ends_with(PATH_SEPARATOR) {
         // The idx of first `/` if path in reserve order.
         // - `abc` => `None`
         // - `abc/def` => `Some(3)`
-        let idx = path.rfind('/');
+        let idx = path.rfind(PATH_SEPARATOR);
 
         return match idx {
             Some(v) => {
                 let (parent, _) = path.split_at(v + 1);
                 parent
             }
-            None => "/",
+            None => PATH_SEPARATOR,
         };
     }
 
     // The idx of second `/` if path in reserve order.
     // - `abc/` => `None`
     // - `abc/def/` => `Some(3)`
-    let idx = path[..path.len() - 1].rfind('/').map(|v| v + 1);
+    let idx = path[..path.len() - 1].rfind(PATH_SEPARATOR).map(|v| v + 1);
 
     match idx {
         Some(v) => {
             let (parent, _) = path.split_at(v);
             parent
         }
-        None => "/",
+        None => PATH_SEPARATOR,
     }
 }
 
@@ -221,6 +412,16 @@ const CHARS_LENGTH: u64 = CHARS.len() as u64;
 ///
 /// `build_tmp_path_of` appends a dot following a random generated postfix.
 /// Don't use it with a path to a folder.
+///
+/// # Examples
+///
+/// ```
+/// # use opendal_core::raw::build_tmp_path_of;
+/// #
+/// let name = "a file path in a directory";
+/// let tmp = build_tmp_path_of("report.txt");
+/// assert!(tmp.starts_with("report.txt."), "use file name as prefix");
+/// ```
 #[inline]
 pub fn build_tmp_path_of(path: &str) -> String {
     let name = get_basename(path);
@@ -254,14 +455,28 @@ pub fn build_tmp_path_of(path: &str) -> String {
     buf
 }
 
-/// Validate given path is match with given EntryMode.
+/// Validate if a path matches EntryMode by OpenDAL path convention.
+///
+/// # Examples
+///
+/// ```
+/// # use opendal_core::raw::validate_path;
+/// # use opendal_core::EntryMode;
+/// #
+/// assert!(validate_path("file.txt", EntryMode::FILE), "is a file");
+/// assert!(!validate_path("dir/", EntryMode::FILE), "dir is not a file with FILE mode");
+/// assert!(validate_path("dir/", EntryMode::DIR), "is a directory");
+/// assert!(!validate_path("dir/", EntryMode::FILE), "dir is not a file");
+/// assert!(!validate_path("file.txt", EntryMode::Unknown), "is not a valid mode");
+/// assert!(!validate_path("dir/", EntryMode::Unknown), "is not a valid mode");
+/// ```
 #[inline]
 pub fn validate_path(path: &str, mode: EntryMode) -> bool {
     debug_assert!(!path.is_empty(), "input path should not be empty");
 
     match mode {
-        EntryMode::FILE => !path.ends_with('/'),
-        EntryMode::DIR => path.ends_with('/'),
+        EntryMode::FILE => !path.ends_with(ROOT_PATH),
+        EntryMode::DIR => path.ends_with(ROOT_PATH),
         EntryMode::Unknown => false,
     }
 }
@@ -270,182 +485,236 @@ pub fn validate_path(path: &str, mode: EntryMode) -> bool {
 mod tests {
     use super::*;
 
+    struct Case {
+        name: &'static str,
+        input: &'static str,
+        expect: &'static str,
+    }
+
+    struct RootCase {
+        name: &'static str,
+        root: &'static str,
+        expect: &'static str,
+    }
+
     #[test]
     fn test_normalize_path() {
         let cases = vec![
-            ("file path", "abc", "abc"),
-            ("dir path", "abc/", "abc/"),
-            ("empty path", "", "/"),
-            ("root path", "/", "/"),
-            ("root path with extra /", "///", "/"),
-            ("abs file path", "/abc/def", "abc/def"),
-            ("abs dir path", "/abc/def/", "abc/def/"),
-            ("abs file path with extra /", "///abc/def", "abc/def"),
-            ("abs dir path with extra /", "///abc/def/", "abc/def/"),
-            ("file path contains ///", "abc///def", "abc/def"),
-            ("dir path contains ///", "abc///def///", "abc/def/"),
-            ("file with whitespace", "abc/def   ", "abc/def"),
+            Case {
+                name: "root path",
+                input: "/",
+                expect: "/",
+            },
+            Case {
+                name: "root path with extra /",
+                input: "///",
+                expect: "/",
+            },
+            Case {
+                name: "absolute file path",
+                input: "/abc/def",
+                expect: "abc/def",
+            },
+            Case {
+                name: "absolute file path with extra /",
+                input: "///abc/def",
+                expect: "abc/def",
+            },
+            Case {
+                name: "absolute dir path with extra /",
+                input: "///abc/def/",
+                expect: "abc/def/",
+            },
+            Case {
+                name: "file path contains ///",
+                input: "abc///def",
+                expect: "abc/def",
+            },
+            Case {
+                name: "dir path contains ///",
+                input: "abc///def///",
+                expect: "abc/def/",
+            },
+            Case {
+                name: "file with trailing whitespace",
+                input: "abc/def   ",
+                expect: "abc/def   ",
+            },
+            Case {
+                name: "file with leading whitespace",
+                input: "  abc/def",
+                expect: "  abc/def",
+            },
+            Case {
+                name: "whitespace preserved",
+                input: " a/b ",
+                expect: " a/b ",
+            },
+            Case {
+                name: "whitespace only preserved as file name",
+                input: "   ",
+                expect: "   ",
+            },
+            Case {
+                name: "dot dir becomes root",
+                input: "./",
+                expect: "/",
+            },
+            Case {
+                name: "only dot",
+                input: ".",
+                expect: "/",
+            },
+            Case {
+                name: "dot in middle",
+                input: "a/./b/./c",
+                expect: "a/b/c",
+            },
+            Case {
+                name: "dot with trailing slash",
+                input: "a/./b/",
+                expect: "a/b/",
+            },
         ];
 
-        for (name, input, expect) in cases {
-            assert_eq!(normalize_path(input), expect, "{name}")
+        for case in cases {
+            assert_eq!(normalize_path(case.input), case.expect, "{}", case.name);
         }
     }
 
     #[test]
     fn test_normalize_root() {
         let cases = vec![
-            ("dir path", "abc/", "/abc/"),
-            ("empty path", "", "/"),
-            ("root path", "/", "/"),
-            ("root path with extra /", "///", "/"),
-            ("abs dir path", "/abc/def/", "/abc/def/"),
-            ("abs file path with extra /", "///abc/def", "/abc/def/"),
-            ("abs dir path with extra /", "///abc/def/", "/abc/def/"),
-            ("dir path contains ///", "abc///def///", "/abc/def/"),
+            RootCase {
+                name: "empty path",
+                root: "",
+                expect: "/",
+            },
+            RootCase {
+                name: "root path",
+                root: "/",
+                expect: "/",
+            },
+            RootCase {
+                name: "root path with extra /",
+                root: "///",
+                expect: "/",
+            },
+            RootCase {
+                name: "abs dir path",
+                root: "/abc/def/",
+                expect: "/abc/def/",
+            },
+            RootCase {
+                name: "abs file path with extra /",
+                root: "///abc/def",
+                expect: "/abc/def/",
+            },
+            RootCase {
+                name: "abs dir path with extra /",
+                root: "///abc/def/",
+                expect: "/abc/def/",
+            },
+            RootCase {
+                name: "dir path contains ///",
+                root: "abc///def///",
+                expect: "/abc/def/",
+            },
+            RootCase {
+                name: "dot segment removed",
+                root: "./data/./root/",
+                expect: "/data/root/",
+            },
+            RootCase {
+                name: "dot with path",
+                root: "./abc",
+                expect: "/abc/",
+            },
         ];
 
-        for (name, input, expect) in cases {
-            assert_eq!(normalize_root(input), expect, "{name}")
+        for case in cases {
+            assert_eq!(normalize_root(case.root), case.expect, "{}", case.name);
         }
     }
 
     #[test]
     fn test_get_basename() {
         let cases = vec![
-            ("file abs path", "foo/bar/baz.txt", "baz.txt"),
-            ("file rel path", "bar/baz.txt", "baz.txt"),
-            ("file walk", "foo/bar/baz", "baz"),
-            ("dir rel path", "bar/baz/", "baz/"),
-            ("dir root", "/", "/"),
-            ("dir walk", "foo/bar/baz/", "baz/"),
+            Case {
+                name: "file relative path",
+                input: "bar/baz.txt",
+                expect: "baz.txt",
+            },
+            Case {
+                name: "file walk",
+                input: "foo/bar/baz",
+                expect: "baz",
+            },
+            Case {
+                name: "dir relative path",
+                input: "bar/baz/",
+                expect: "baz/",
+            },
+            Case {
+                name: "dir walk",
+                input: "foo/bar/baz/",
+                expect: "baz/",
+            },
         ];
 
-        for (name, input, expect) in cases {
-            let actual = get_basename(input);
-            assert_eq!(actual, expect, "{name}")
+        for case in cases {
+            let actual = get_basename(case.input);
+            assert_eq!(actual, case.expect, "{}", case.name);
         }
     }
 
     #[test]
     fn test_get_parent() {
-        let cases = vec![
-            ("file abs path", "foo/bar/baz.txt", "foo/bar/"),
-            ("file rel path", "bar/baz.txt", "bar/"),
-            ("file walk", "foo/bar/baz", "foo/bar/"),
-            ("dir rel path", "bar/baz/", "bar/"),
-            ("dir root", "/", "/"),
-            ("dir abs path", "/foo/bar/", "/foo/"),
-            ("dir walk", "foo/bar/baz/", "foo/bar/"),
-        ];
-
-        for (name, input, expect) in cases {
-            let actual = get_parent(input);
-            assert_eq!(actual, expect, "{name}")
-        }
+        assert_eq!(get_parent("foo/bar/baz/"), "foo/bar/", "dir walk")
     }
 
     #[test]
-    fn test_build_abs_path() {
-        let cases = vec![
-            ("input abs file", "/abc/", "/", "abc/"),
-            ("input dir", "/abc/", "def/", "abc/def/"),
-            ("input file", "/abc/", "def", "abc/def"),
-            ("input abs file with root /", "/", "/", ""),
-            ("input empty with root /", "/", "", ""),
-            ("input dir with root /", "/", "def/", "def/"),
-            ("input file with root /", "/", "def", "def"),
-        ];
-
-        for (name, root, input, expect) in cases {
-            let actual = build_abs_path(root, input);
-            assert_eq!(actual, expect, "{name}")
-        }
+    fn test_build_absolute_path() {
+        assert_eq!(
+            build_absolute_path("/", "/"),
+            "",
+            "input root path with root /"
+        );
+        assert_eq!(
+            build_absolute_path("/", ""),
+            "",
+            "input empty file path with root /"
+        );
+        assert_eq!(
+            build_absolute_path("/", "def"),
+            "def",
+            "input file with root /"
+        );
     }
 
     #[test]
-    fn test_build_rooted_abs_path() {
-        let cases = vec![
-            ("input abs file", "/abc/", "/", "/abc/"),
-            ("input dir", "/abc/", "def/", "/abc/def/"),
-            ("input file", "/abc/", "def", "/abc/def"),
-            ("input abs file with root /", "/", "/", "/"),
-            ("input dir with root /", "/", "def/", "/def/"),
-            ("input file with root /", "/", "def", "/def"),
-        ];
+    fn test_build_rooted_absolute_path() {
+        assert_eq!(
+            build_rooted_absolute_path("/", ""),
+            "/",
+            "input empty with root /"
+        );
 
-        for (name, root, input, expect) in cases {
-            let actual = build_rooted_abs_path(root, input);
-            assert_eq!(actual, expect, "{name}")
-        }
-    }
-
-    #[test]
-    fn test_build_rel_path() {
-        let cases = vec![
-            ("input abs file", "/abc/", "/abc/def", "def"),
-            ("input dir", "/abc/", "/abc/def/", "def/"),
-            ("input file", "/abc/", "abc/def", "def"),
-            ("input dir with root /", "/", "def/", "def/"),
-            ("input file with root /", "/", "def", "def"),
-        ];
-
-        for (name, root, input, expect) in cases {
-            let actual = build_rel_path(root, input);
-            assert_eq!(actual, expect, "{name}")
-        }
-    }
-
-    #[test]
-    fn test_validate_path() {
-        let cases = vec![
-            ("input file with mode file", "abc", EntryMode::FILE, true),
-            ("input file with mode dir", "abc", EntryMode::DIR, false),
-            ("input dir with mode file", "abc/", EntryMode::FILE, false),
-            ("input dir with mode dir", "abc/", EntryMode::DIR, true),
-            ("root with mode dir", "/", EntryMode::DIR, true),
-            (
-                "input file with mode unknown",
-                "abc",
-                EntryMode::Unknown,
-                false,
-            ),
-            (
-                "input dir with mode unknown",
-                "abc/",
-                EntryMode::Unknown,
-                false,
-            ),
-        ];
-
-        for (name, path, mode, expect) in cases {
-            let actual = validate_path(path, mode);
-            assert_eq!(actual, expect, "{name}")
-        }
+        assert_eq!(
+            build_rooted_absolute_path("/", "def/"),
+            "/def/",
+            "input dir with root /"
+        );
     }
 
     #[test]
     fn test_build_tmp_path_of() {
-        let cases = vec![
-            ("a file path", "example.txt", "example.txt."),
-            (
-                "a file path in a directory",
-                "folder/example.txt",
-                "example.txt.",
-            ),
-        ];
+        let actual = build_tmp_path_of("folder/example.txt");
 
-        for (name, path, expect_starts_with) in cases {
-            let actual = build_tmp_path_of(path);
-            assert!(
-                actual.starts_with(expect_starts_with),
-                "{name}: got `{actual}`, but expect `{expect_starts_with}`"
-            );
-            assert_eq!(
-                actual.len(),
-                expect_starts_with.len() + 8, // See RANDOM_TMP_PATH_POSTFIX_SIZE
-                "{name}: got `{actual}`, but expect `{expect_starts_with}`"
-            )
-        }
+        assert_eq!(
+            actual.len(),
+            "example.txt.".len() + 8, // See RANDOM_TMP_PATH_POSTFIX_SIZE
+            "a file path in a directory: got `{actual}`, but expect `example.txt.`"
+        )
     }
 }

--- a/core/core/src/services/memory/backend.rs
+++ b/core/core/src/services/memory/backend.rs
@@ -126,9 +126,9 @@ impl Service for MemoryBackend {
     }
 
     async fn stat(&self, _: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             match self.core.get(&p)? {
@@ -150,7 +150,7 @@ impl Service for MemoryBackend {
     }
 
     fn write(&self, _ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         Ok(MemoryWriter::new(self.core.clone(), p, args))
     }
 
@@ -162,7 +162,7 @@ impl Service for MemoryBackend {
     }
 
     fn list(&self, _ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let keys = self.core.scan(&p)?;
         let lister = MemoryLister::new(&self.root, keys);
         let lister = oio::HierarchyLister::new(lister, path, args.recursive());
@@ -224,7 +224,7 @@ impl oio::StreamRead for MemoryReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
 
         let value = match backend.core.get(&p)? {
             Some(value) => value,

--- a/core/core/src/services/memory/deleter.rs
+++ b/core/core/src/services/memory/deleter.rs
@@ -35,7 +35,7 @@ impl MemoryDeleter {
 
 impl oio::OneShotDelete for MemoryDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p)?;
         Ok(())
     }

--- a/core/core/src/services/memory/lister.rs
+++ b/core/core/src/services/memory/lister.rs
@@ -44,7 +44,7 @@ impl oio::List for MemoryLister {
                 } else {
                     EntryMode::FILE
                 };
-                let mut path = build_rel_path(&self.root, &key);
+                let mut path = build_relative_path(&self.root, &key);
                 if path.is_empty() {
                     path = "/".to_string();
                 }

--- a/core/services/aliyun-drive/src/core.rs
+++ b/core/services/aliyun-drive/src/core.rs
@@ -184,9 +184,9 @@ impl AliyunDriveCore {
 
     pub fn build_path(&self, path: &str, rooted: bool) -> String {
         let file_path = if rooted {
-            build_rooted_abs_path(&self.root, path)
+            build_rooted_absolute_path(&self.root, path)
         } else {
-            build_abs_path(&self.root, path)
+            build_absolute_path(&self.root, path)
         };
         let file_path = file_path.strip_suffix('/').unwrap_or(&file_path);
         if file_path.is_empty() {

--- a/core/services/alluxio/src/core.rs
+++ b/core/services/alluxio/src/core.rs
@@ -49,7 +49,7 @@ impl Debug for AlluxioCore {
 
 impl AlluxioCore {
     pub async fn create_dir(&self, ctx: &OperationContext, path: &str) -> Result<()> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let r = CreateDirRequest {
             recursive: Some(true),
@@ -85,7 +85,7 @@ impl AlluxioCore {
     }
 
     pub async fn create_file(&self, ctx: &OperationContext, path: &str) -> Result<u64> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let r = CreateFileRequest {
             recursive: Some(true),
@@ -124,7 +124,7 @@ impl AlluxioCore {
     }
 
     pub(super) async fn open_file(&self, ctx: &OperationContext, path: &str) -> Result<u64> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let req = Request::post(format!(
             "{}/api/v1/paths/{}/open-file",
@@ -153,7 +153,7 @@ impl AlluxioCore {
     }
 
     pub(super) async fn delete(&self, ctx: &OperationContext, path: &str) -> Result<()> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let req = Request::post(format!(
             "{}/api/v1/paths/{}/delete",
@@ -183,8 +183,8 @@ impl AlluxioCore {
     }
 
     pub(super) async fn rename(&self, ctx: &OperationContext, path: &str, dst: &str) -> Result<()> {
-        let path = build_rooted_abs_path(&self.root, path);
-        let dst = build_rooted_abs_path(&self.root, dst);
+        let path = build_rooted_absolute_path(&self.root, path);
+        let dst = build_rooted_absolute_path(&self.root, dst);
 
         let req = Request::post(format!(
             "{}/api/v1/paths/{}/rename?dst={}",
@@ -210,7 +210,7 @@ impl AlluxioCore {
     }
 
     pub(super) async fn get_status(&self, ctx: &OperationContext, path: &str) -> Result<FileInfo> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let req = Request::post(format!(
             "{}/api/v1/paths/{}/get-status",
@@ -244,7 +244,7 @@ impl AlluxioCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Vec<FileInfo>> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let req = Request::post(format!(
             "{}/api/v1/paths/{}/list-status",

--- a/core/services/alluxio/src/lister.rs
+++ b/core/services/alluxio/src/lister.rs
@@ -57,7 +57,7 @@ impl oio::PageList for AlluxioLister {
                         path
                     };
                     ctx.entries.push_back(Entry::new(
-                        &build_rel_path(&self.core.root, &path),
+                        &build_relative_path(&self.core.root, &path),
                         file_info.try_into()?,
                     ));
                 }

--- a/core/services/azblob/src/core.rs
+++ b/core/services/azblob/src/core.rs
@@ -208,7 +208,7 @@ impl AzblobCore {
             "{}/{}/{}",
             self.endpoint,
             self.container,
-            percent_encode_path(&build_abs_path(&self.root, path))
+            percent_encode_path(&build_absolute_path(&self.root, path))
         )
     }
 
@@ -768,7 +768,7 @@ impl AzblobCore {
         delimiter: &str,
         limit: Option<usize>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let mut url = QueryPairsWriter::new(&format!("{}/{}", self.endpoint, self.container))
             .push("restype", "container")
             .push("comp", "list");

--- a/core/services/azblob/src/lister.rs
+++ b/core/services/azblob/src/lister.rs
@@ -89,7 +89,7 @@ impl oio::PageList for AzblobLister {
 
         for prefix in prefixes {
             let de = oio::Entry::new(
-                &build_rel_path(&self.core.root, &prefix.name),
+                &build_relative_path(&self.core.root, &prefix.name),
                 Metadata::new(EntryMode::DIR),
             );
 
@@ -97,7 +97,7 @@ impl oio::PageList for AzblobLister {
         }
 
         for object in output.blobs.blob {
-            let mut path = build_rel_path(&self.core.root, &object.name);
+            let mut path = build_relative_path(&self.core.root, &object.name);
             if path.is_empty() {
                 path = "/".to_string();
             }

--- a/core/services/azdls/src/core.rs
+++ b/core/services/azdls/src/core.rs
@@ -120,7 +120,7 @@ impl AzdlsCore {
         range: BytesRange,
         args: &OpRead,
     ) -> Result<Response<HttpBody>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}/{}",
@@ -168,7 +168,7 @@ impl AzdlsCore {
         resource: &str,
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 
@@ -233,8 +233,8 @@ impl AzdlsCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let source = build_abs_path(&self.root, from);
-        let target = build_abs_path(&self.root, to);
+        let source = build_absolute_path(&self.root, from);
+        let target = build_absolute_path(&self.root, to);
 
         let url = format!(
             "{}/{}/{}",
@@ -269,7 +269,7 @@ impl AzdlsCore {
         close: bool,
         body: Buffer,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!(
             "{}/{}/{}?action=append&position={}",
@@ -310,7 +310,7 @@ impl AzdlsCore {
         position: u64,
         close: bool,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!(
             "{}/{}/{}?action=flush&position={}",
@@ -340,7 +340,7 @@ impl AzdlsCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 
@@ -422,7 +422,7 @@ impl AzdlsCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 
@@ -448,7 +448,7 @@ impl AzdlsCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 
@@ -509,7 +509,7 @@ impl AzdlsCore {
         continuation: &str,
         limit: Option<usize>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 

--- a/core/services/azdls/src/lister.rs
+++ b/core/services/azdls/src/lister.rs
@@ -106,7 +106,7 @@ impl oio::PageList for AzdlsLister {
                 })?)
                 .with_last_modified(Timestamp::parse_rfc2822(&object.last_modified)?);
 
-            let mut path = build_rel_path(&self.core.root, &object.name);
+            let mut path = build_relative_path(&self.core.root, &object.name);
             if mode.is_dir() {
                 path += "/"
             };

--- a/core/services/azfile/src/core.rs
+++ b/core/services/azfile/src/core.rs
@@ -103,7 +103,7 @@ impl AzfileCore {
         path: &str,
         range: BytesRange,
     ) -> Result<Response<HttpBody>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}/{}",
@@ -134,7 +134,7 @@ impl AzfileCore {
         size: usize,
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_start_matches('/')
             .to_string();
         let url = format!(
@@ -187,7 +187,7 @@ impl AzfileCore {
         position: u64,
         body: Buffer,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_start_matches('/')
             .to_string();
 
@@ -223,7 +223,7 @@ impl AzfileCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let url = format!(
             "{}/{}/{}",
             self.endpoint,
@@ -247,7 +247,7 @@ impl AzfileCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}/{}?restype=directory",
@@ -273,11 +273,11 @@ impl AzfileCore {
         path: &str,
         new_path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_start_matches('/')
             .to_string();
 
-        let new_p = build_abs_path(&self.root, new_path)
+        let new_p = build_absolute_path(&self.root, new_path)
             .trim_start_matches('/')
             .to_string();
 
@@ -331,7 +331,7 @@ impl AzfileCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_start_matches('/')
             .to_string();
 
@@ -360,7 +360,7 @@ impl AzfileCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_start_matches('/')
             .to_string();
 
@@ -387,7 +387,7 @@ impl AzfileCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_start_matches('/')
             .to_string();
 
@@ -416,7 +416,7 @@ impl AzfileCore {
         limit: &Option<usize>,
         continuation: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_start_matches('/')
             .to_string();
 

--- a/core/services/b2/src/backend.rs
+++ b/core/services/b2/src/backend.rs
@@ -368,7 +368,7 @@ impl Service for B2Backend {
                     .core
                     .get_download_authorization(ctx, path, args.expire())
                     .await?;
-                let path = build_abs_path(&self.core.root, path);
+                let path = build_absolute_path(&self.core.root, path);
 
                 let auth_info = self.core.get_auth_info(ctx).await?;
 
@@ -395,7 +395,7 @@ impl Service for B2Backend {
                     .core
                     .get_download_authorization(ctx, path, args.expire())
                     .await?;
-                let path = build_abs_path(&self.core.root, path);
+                let path = build_absolute_path(&self.core.root, path);
 
                 let auth_info = self.core.get_auth_info(ctx).await?;
 
@@ -423,7 +423,7 @@ impl Service for B2Backend {
                 let mut req = Request::post(&resp.upload_url);
 
                 req = req.header(http::header::AUTHORIZATION, resp.authorization_token);
-                req = req.header("X-Bz-File-Name", build_abs_path(&self.core.root, path));
+                req = req.header("X-Bz-File-Name", build_absolute_path(&self.core.root, path));
                 req = req.header(http::header::CONTENT_TYPE, "b2/x-auto");
                 req = req.header(constants::X_BZ_CONTENT_SHA1, "do_not_verify");
 

--- a/core/services/b2/src/core.rs
+++ b/core/services/b2/src/core.rs
@@ -136,7 +136,7 @@ impl B2Core {
         range: BytesRange,
         _args: &OpRead,
     ) -> Result<Response<HttpBody>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let auth_info = self.get_auth_info(ctx).await?;
 
@@ -206,7 +206,7 @@ impl B2Core {
         path: &str,
         expire: Duration,
     ) -> Result<GetDownloadAuthorizationResponse> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let auth_info = self.get_auth_info(ctx).await?;
 
@@ -255,7 +255,7 @@ impl B2Core {
     ) -> Result<Response<Buffer>> {
         let resp = self.get_upload_url(ctx).await?;
 
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut req = Request::post(resp.upload_url);
 
@@ -306,7 +306,7 @@ impl B2Core {
         path: &str,
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let auth_info = self.get_auth_info(ctx).await?;
 
@@ -538,7 +538,7 @@ impl B2Core {
         url = url.push("bucketId", &self.bucket_id);
 
         if let Some(prefix) = prefix {
-            let prefix = build_abs_path(&self.root, prefix);
+            let prefix = build_absolute_path(&self.root, prefix);
             if !prefix.is_empty() {
                 url = url.push("prefix", &percent_encode_path(&prefix));
             }
@@ -576,7 +576,7 @@ impl B2Core {
         source_file_id: String,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let to = build_abs_path(&self.root, to);
+        let to = build_absolute_path(&self.root, to);
 
         let auth_info = self.get_auth_info(ctx).await?;
 
@@ -607,7 +607,7 @@ impl B2Core {
     }
 
     pub async fn hide_file(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let auth_info = self.get_auth_info(ctx).await?;
 

--- a/core/services/b2/src/lister.rs
+++ b/core/services/b2/src/lister.rs
@@ -72,7 +72,7 @@ impl oio::PageList for B2Lister {
                 if ctx.token.is_empty() {
                     self.start_after
                         .as_ref()
-                        .map(|v| build_abs_path(&self.core.root, v))
+                        .map(|v| build_absolute_path(&self.core.root, v))
                 } else {
                     Some(ctx.token.clone())
                 },
@@ -96,7 +96,7 @@ impl oio::PageList for B2Lister {
 
         for file in output.files {
             if let Some(start_after) = self.start_after.clone() {
-                if build_abs_path(&self.core.root, &start_after) == file.file_name {
+                if build_absolute_path(&self.core.root, &start_after) == file.file_name {
                     continue;
                 }
             }
@@ -104,7 +104,7 @@ impl oio::PageList for B2Lister {
             let metadata = parse_file_info(&file);
 
             ctx.entries.push_back(oio::Entry::new(
-                &build_rel_path(&self.core.root, &file_name),
+                &build_relative_path(&self.core.root, &file_name),
                 metadata,
             ))
         }

--- a/core/services/cloudflare-kv/src/backend.rs
+++ b/core/services/cloudflare-kv/src/backend.rs
@@ -206,9 +206,9 @@ impl Service for CloudflareKvBackend {
         path: &str,
         _args: OpCreateDir,
     ) -> Result<RpCreateDir> {
-        let path = build_abs_path(&self.core.info.root(), path);
+        let path = build_absolute_path(&self.core.info.root(), path);
 
-        if path == build_abs_path(&self.core.info.root(), "") {
+        if path == build_absolute_path(&self.core.info.root(), "") {
             return Ok(RpCreateDir::default());
         }
 
@@ -247,7 +247,7 @@ impl Service for CloudflareKvBackend {
     }
 
     async fn stat(&self, ctx: &OperationContext, path: &str, args: OpStat) -> Result<RpStat> {
-        let path = build_abs_path(&self.core.info.root(), path);
+        let path = build_absolute_path(&self.core.info.root(), path);
         let new_path = path.trim_end_matches('/');
 
         let resp = self.core.metadata(ctx, new_path).await?;
@@ -382,7 +382,7 @@ impl Service for CloudflareKvBackend {
 
     fn write(&self, ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: oio::OneShotWriter<CloudflareWriter> = {
-            let path = build_abs_path(&self.core.info.root(), path);
+            let path = build_absolute_path(&self.core.info.root(), path);
             let writer = CloudflareWriter::new(self.core.clone(), ctx.clone(), path);
 
             let w = oio::OneShotWriter::new(writer);
@@ -406,7 +406,7 @@ impl Service for CloudflareKvBackend {
 
     fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         let output: oio::PageLister<CloudflareKvLister> = {
-            let path = build_abs_path(&self.core.info.root(), path);
+            let path = build_absolute_path(&self.core.info.root(), path);
 
             let limit = match args.limit() {
                 Some(limit) => {

--- a/core/services/cloudflare-kv/src/deleter.rs
+++ b/core/services/cloudflare-kv/src/deleter.rs
@@ -40,7 +40,7 @@ impl CloudflareKvDeleter {
 
 impl oio::BatchDelete for CloudflareKvDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let path = build_abs_path(&self.core.info.root(), &path);
+        let path = build_absolute_path(&self.core.info.root(), &path);
         let resp = self
             .core
             .delete(&self.ctx, &[path.trim_end_matches('/').to_string()])
@@ -67,7 +67,7 @@ impl oio::BatchDelete for CloudflareKvDeleter {
         let keys = batch
             .iter()
             .map(|path| {
-                let path = build_abs_path(&self.core.info.root(), &path.0);
+                let path = build_absolute_path(&self.core.info.root(), &path.0);
                 path.trim_end_matches('/').to_string()
             })
             .collect::<Vec<String>>();

--- a/core/services/cloudflare-kv/src/reader.rs
+++ b/core/services/cloudflare-kv/src/reader.rs
@@ -52,7 +52,7 @@ impl oio::StreamRead for CloudflareKvReader {
         let backend = &self.backend;
         let path = self.path.as_str();
         let args = self.args.clone();
-        let path = build_abs_path(&backend.core.info.root(), path);
+        let path = build_absolute_path(&backend.core.info.root(), path);
         let resp = backend.core.get(&self.ctx, &path).await?;
 
         let status = resp.status();

--- a/core/services/cos/src/core.rs
+++ b/core/services/cos/src/core.rs
@@ -132,7 +132,7 @@ impl CosCore {
         range: BytesRange,
         args: &OpRead,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
@@ -186,7 +186,7 @@ impl CosCore {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
@@ -246,7 +246,7 @@ impl CosCore {
     }
 
     pub fn cos_head_object_request(&self, path: &str, args: &OpStat) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
@@ -287,7 +287,7 @@ impl CosCore {
         path: &str,
         args: &OpDelete,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
@@ -323,7 +323,7 @@ impl CosCore {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let url = format!(
             "{}/{}?append&position={}",
             self.endpoint,
@@ -362,8 +362,8 @@ impl CosCore {
         to: &str,
         args: &OpCopy,
     ) -> Result<Response<Buffer>> {
-        let source = build_abs_path(&self.root, from);
-        let target = build_abs_path(&self.root, to);
+        let source = build_absolute_path(&self.root, from);
+        let target = build_absolute_path(&self.root, to);
 
         let source = format!("/{}/{}", self.bucket, percent_encode_path(&source));
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&target));
@@ -396,7 +396,7 @@ impl CosCore {
         delimiter: &str,
         limit: Option<usize>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = QueryPairsWriter::new(&self.endpoint);
 
@@ -430,7 +430,7 @@ impl CosCore {
         path: &str,
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}?uploads", self.endpoint, percent_encode_path(&p));
 
@@ -474,7 +474,7 @@ impl CosCore {
         size: u64,
         body: Buffer,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}?partNumber={}&uploadId={}",
@@ -505,7 +505,7 @@ impl CosCore {
         upload_id: &str,
         parts: Vec<CompleteMultipartUploadRequestPart>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}?uploadId={}",
@@ -543,7 +543,7 @@ impl CosCore {
         path: &str,
         upload_id: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}?uploadId={}",
@@ -570,7 +570,7 @@ impl CosCore {
         key_marker: &str,
         version_id_marker: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, prefix);
+        let p = build_absolute_path(&self.root, prefix);
 
         let mut url = QueryPairsWriter::new(&self.endpoint);
         url = url.push("versions", "");

--- a/core/services/cos/src/lister.rs
+++ b/core/services/cos/src/lister.rs
@@ -92,7 +92,7 @@ impl oio::PageList for CosLister {
 
         for prefix in output.common_prefixes {
             let de = oio::Entry::new(
-                &build_rel_path(&self.core.root, &prefix.prefix),
+                &build_relative_path(&self.core.root, &prefix.prefix),
                 Metadata::new(EntryMode::DIR),
             );
 
@@ -100,7 +100,7 @@ impl oio::PageList for CosLister {
         }
 
         for object in output.contents {
-            let mut path = build_rel_path(&self.core.root, &object.key);
+            let mut path = build_relative_path(&self.core.root, &object.key);
             if path.is_empty() {
                 path = "/".to_string();
             }
@@ -138,7 +138,7 @@ impl CosObjectVersionsLister {
         let delimiter = if args.recursive() { "" } else { "/" };
         let abs_start_after = args
             .start_after()
-            .map(|start_after| build_abs_path(&core.root, start_after));
+            .map(|start_after| build_absolute_path(&core.root, start_after));
 
         Self {
             core,
@@ -200,7 +200,7 @@ impl oio::PageList for CosObjectVersionsLister {
 
         for prefix in output.common_prefixes {
             let de = oio::Entry::new(
-                &build_rel_path(&self.core.root, &prefix.prefix),
+                &build_relative_path(&self.core.root, &prefix.prefix),
                 Metadata::new(EntryMode::DIR),
             );
             ctx.entries.push_back(de);
@@ -215,7 +215,7 @@ impl oio::PageList for CosObjectVersionsLister {
                 continue;
             }
 
-            let mut path = build_rel_path(&self.core.root, &version_object.key);
+            let mut path = build_relative_path(&self.core.root, &version_object.key);
             if path.is_empty() {
                 path = "/".to_owned();
             }
@@ -236,7 +236,7 @@ impl oio::PageList for CosObjectVersionsLister {
 
         if self.args.deleted() {
             for delete_marker in output.delete_marker {
-                let mut path = build_rel_path(&self.core.root, &delete_marker.key);
+                let mut path = build_relative_path(&self.core.root, &delete_marker.key);
                 if path.is_empty() {
                     path = "/".to_owned();
                 }

--- a/core/services/d1/src/backend.rs
+++ b/core/services/d1/src/backend.rs
@@ -244,9 +244,9 @@ impl Service for D1Backend {
     }
 
     async fn stat(&self, ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(ctx, &p).await?;
@@ -273,7 +273,7 @@ impl Service for D1Backend {
 
     fn write(&self, ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: D1Writer = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(D1Writer::new(self.core.clone(), ctx.clone(), p))
         }?;
 

--- a/core/services/d1/src/deleter.rs
+++ b/core/services/d1/src/deleter.rs
@@ -36,7 +36,7 @@ impl D1Deleter {
 
 impl oio::OneShotDelete for D1Deleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&self.ctx, &p).await?;
         Ok(())
     }

--- a/core/services/d1/src/reader.rs
+++ b/core/services/d1/src/reader.rs
@@ -40,7 +40,7 @@ impl oio::StreamRead for D1Reader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
         let bs = match backend.core.get(&self.ctx, &p).await? {
             Some(bs) => bs,
             None => {

--- a/core/services/dashmap/src/backend.rs
+++ b/core/services/dashmap/src/backend.rs
@@ -139,7 +139,7 @@ impl Service for DashmapBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         match self.core.get(&p)? {
             Some(value) => {
@@ -171,7 +171,7 @@ impl Service for DashmapBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let output: DashmapWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(DashmapWriter::new(self.core.clone(), p, args))
         }?;
 

--- a/core/services/dashmap/src/deleter.rs
+++ b/core/services/dashmap/src/deleter.rs
@@ -35,7 +35,7 @@ impl DashmapDeleter {
 
 impl oio::OneShotDelete for DashmapDeleter {
     async fn delete_once(&self, path: String, _op: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p)
     }
 }

--- a/core/services/dashmap/src/lister.rs
+++ b/core/services/dashmap/src/lister.rs
@@ -36,7 +36,7 @@ impl DashmapLister {
             .iter()
             .map(|item| (item.key().clone(), item.value().metadata.clone()))
             .collect();
-        let path = build_abs_path(&root, &path);
+        let path = build_absolute_path(&root, &path);
 
         Self {
             root,
@@ -50,7 +50,7 @@ impl oio::List for DashmapLister {
     async fn next(&mut self) -> Result<Option<oio::Entry>> {
         for (key, metadata) in self.iter.by_ref() {
             if key.starts_with(&self.path) {
-                let path = build_rel_path(&self.root, &key);
+                let path = build_relative_path(&self.root, &key);
                 let entry = oio::Entry::new(&path, metadata);
                 return Ok(Some(entry));
             }

--- a/core/services/dashmap/src/reader.rs
+++ b/core/services/dashmap/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for DashmapReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
 
         match backend.core.get(&p)? {
             Some(value) => {

--- a/core/services/dbfs/src/core.rs
+++ b/core/services/dbfs/src/core.rs
@@ -57,7 +57,7 @@ impl DbfsCore {
         let auth_header_content = format!("Bearer {}", self.token);
         req = req.header(header::AUTHORIZATION, auth_header_content);
 
-        let p = build_rooted_abs_path(&self.root, path)
+        let p = build_rooted_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 
@@ -86,7 +86,7 @@ impl DbfsCore {
         let auth_header_content = format!("Bearer {}", self.token);
         req = req.header(header::AUTHORIZATION, auth_header_content);
 
-        let p = build_rooted_abs_path(&self.root, path)
+        let p = build_rooted_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 
@@ -113,8 +113,8 @@ impl DbfsCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let source = build_rooted_abs_path(&self.root, from);
-        let target = build_rooted_abs_path(&self.root, to);
+        let source = build_rooted_absolute_path(&self.root, from);
+        let target = build_rooted_absolute_path(&self.root, to);
 
         let url = format!("{}/api/2.0/dbfs/move", self.endpoint);
         let mut req = Request::post(&url);
@@ -139,7 +139,7 @@ impl DbfsCore {
     }
 
     pub async fn dbfs_list(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let p = build_rooted_abs_path(&self.root, path)
+        let p = build_rooted_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 
@@ -190,7 +190,7 @@ impl DbfsCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_rooted_abs_path(&self.root, path)
+        let p = build_rooted_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 

--- a/core/services/dropbox/src/core.rs
+++ b/core/services/dropbox/src/core.rs
@@ -50,7 +50,7 @@ impl Debug for DropboxCore {
 
 impl DropboxCore {
     fn build_path(&self, path: &str) -> String {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
         // For dropbox, even the path is a directory,
         // we still need to remove the trailing slash.
         path.trim_end_matches('/').to_string()
@@ -113,7 +113,7 @@ impl DropboxCore {
     ) -> Result<Response<HttpBody>> {
         let url: String = "https://content.dropboxapi.com/2/files/download".to_string();
         let download_args = DropboxDownloadArgs {
-            path: build_rooted_abs_path(&self.root, path),
+            path: build_rooted_absolute_path(&self.root, path),
         };
         let request_payload =
             serde_json::to_string(&download_args).map_err(new_json_serialize_error)?;
@@ -146,7 +146,7 @@ impl DropboxCore {
     ) -> Result<Response<Buffer>> {
         let url = "https://content.dropboxapi.com/2/files/upload".to_string();
         let dropbox_update_args = DropboxUploadArgs {
-            path: build_rooted_abs_path(&self.root, path),
+            path: build_rooted_absolute_path(&self.root, path),
             ..Default::default()
         };
         let mut request_builder = Request::post(&url);

--- a/core/services/etcd/src/backend.rs
+++ b/core/services/etcd/src/backend.rs
@@ -224,7 +224,7 @@ impl Service for EtcdBackend {
         path: &str,
         _args: OpCreateDir,
     ) -> Result<RpCreateDir> {
-        let abs_path = build_abs_path(&self.info.root(), path);
+        let abs_path = build_absolute_path(&self.info.root(), path);
 
         // In etcd, we simulate directory creation by storing an empty value
         // with the directory path (ensuring it ends with '/')
@@ -241,7 +241,7 @@ impl Service for EtcdBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let abs_path = build_abs_path(&self.info.root(), path);
+        let abs_path = build_absolute_path(&self.info.root(), path);
 
         // First check if it's a direct key
         match self.core.get(&abs_path).await? {
@@ -284,7 +284,7 @@ impl Service for EtcdBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _op: OpWrite) -> Result<Self::Writer> {
         let output: EtcdWriter = {
-            let abs_path = build_abs_path(&self.info.root(), path);
+            let abs_path = build_absolute_path(&self.info.root(), path);
             let writer = EtcdWriter::new(self.core.clone(), abs_path);
             Ok(writer)
         }?;

--- a/core/services/etcd/src/deleter.rs
+++ b/core/services/etcd/src/deleter.rs
@@ -35,7 +35,7 @@ impl EtcdDeleter {
 
 impl oio::OneShotDelete for EtcdDeleter {
     async fn delete_once(&self, path: String, _args: OpDelete) -> Result<()> {
-        let abs_path = build_abs_path(&self.root, &path);
+        let abs_path = build_absolute_path(&self.root, &path);
         self.core.delete(&abs_path).await
     }
 }

--- a/core/services/etcd/src/lister.rs
+++ b/core/services/etcd/src/lister.rs
@@ -20,7 +20,7 @@ use std::vec::IntoIter;
 
 use super::core::EtcdCore;
 use opendal_core::raw::oio::Entry;
-use opendal_core::raw::{build_abs_path, build_rel_path, oio};
+use opendal_core::raw::{build_absolute_path, build_relative_path, oio};
 use opendal_core::*;
 
 pub struct EtcdLister {
@@ -31,7 +31,7 @@ pub struct EtcdLister {
 
 impl EtcdLister {
     pub async fn new(core: Arc<EtcdCore>, root: String, path: String) -> Result<Self> {
-        let abs_path = build_abs_path(&root, &path);
+        let abs_path = build_absolute_path(&root, &path);
 
         // Get all keys with the specified prefix
         let mut client = core.conn().await?;
@@ -67,7 +67,7 @@ impl oio::List for EtcdLister {
     async fn next(&mut self) -> Result<Option<Entry>> {
         for key in self.iter.by_ref() {
             if key.starts_with(&self.path) {
-                let path = build_rel_path(&self.root, &key);
+                let path = build_relative_path(&self.root, &key);
 
                 let entry = Entry::new(&path, Metadata::new(EntryMode::from_path(&key)));
                 return Ok(Some(entry));

--- a/core/services/etcd/src/reader.rs
+++ b/core/services/etcd/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for EtcdReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let abs_path = build_abs_path(&backend.info.root(), path);
+        let abs_path = build_absolute_path(&backend.info.root(), path);
 
         match backend.core.get(&abs_path).await? {
             Some(buffer) => {

--- a/core/services/foundationdb/src/backend.rs
+++ b/core/services/foundationdb/src/backend.rs
@@ -148,9 +148,9 @@ impl Service for FoundationdbBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p).await?;
@@ -179,7 +179,7 @@ impl Service for FoundationdbBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: FoundationdbWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(FoundationdbWriter::new(self.core.clone(), p))
         }?;
 

--- a/core/services/foundationdb/src/deleter.rs
+++ b/core/services/foundationdb/src/deleter.rs
@@ -35,7 +35,7 @@ impl FoundationdbDeleter {
 
 impl oio::OneShotDelete for FoundationdbDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p).await?;
         Ok(())
     }

--- a/core/services/foundationdb/src/reader.rs
+++ b/core/services/foundationdb/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for FoundationdbReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
         let bs = match backend.core.get(&p).await? {
             Some(bs) => bs,
             None => {

--- a/core/services/foyer/src/backend.rs
+++ b/core/services/foyer/src/backend.rs
@@ -267,9 +267,9 @@ impl Service for FoyerBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             match self.core.get(&p).await? {
@@ -294,7 +294,7 @@ impl Service for FoyerBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: FoyerWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(FoyerWriter::new(self.core.clone(), p))
         }?;
 

--- a/core/services/foyer/src/deleter.rs
+++ b/core/services/foyer/src/deleter.rs
@@ -35,7 +35,7 @@ impl FoyerDeleter {
 
 impl oio::OneShotDelete for FoyerDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.remove(&p).await?;
         Ok(())
     }

--- a/core/services/foyer/src/reader.rs
+++ b/core/services/foyer/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for FoyerReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
 
         let buffer = match backend.core.get(&p).await? {
             Some(bs) => bs,

--- a/core/services/gcs/src/core.rs
+++ b/core/services/gcs/src/core.rs
@@ -159,7 +159,7 @@ impl GcsCore {
         range: BytesRange,
         args: &OpRead,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/storage/v1/b/{}/o/{}?alt=media",
@@ -196,7 +196,7 @@ impl GcsCore {
         range: BytesRange,
         args: &OpRead,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}/{}", self.endpoint, self.bucket, p);
 
@@ -249,7 +249,7 @@ impl GcsCore {
         op: &OpWrite,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let request_metadata = InsertRequestMetadata {
             storage_class: self.default_storage_class.as_deref(),
@@ -336,7 +336,7 @@ impl GcsCore {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}/{}", self.endpoint, self.bucket, p);
 
@@ -378,7 +378,7 @@ impl GcsCore {
     }
 
     pub fn gcs_head_object_request(&self, path: &str, args: &OpStat) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/storage/v1/b/{}/o/{}",
@@ -412,7 +412,7 @@ impl GcsCore {
         path: &str,
         args: &OpStat,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}/{}", self.endpoint, self.bucket, p);
 
@@ -460,7 +460,7 @@ impl GcsCore {
     }
 
     pub fn gcs_delete_object_request(&self, path: &str) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/storage/v1/b/{}/o/{}",
@@ -511,8 +511,8 @@ impl GcsCore {
         max_bytes_rewritten_per_call: Option<usize>,
         rewrite_token: Option<&str>,
     ) -> Result<Response<Buffer>> {
-        let source = build_abs_path(&self.root, from);
-        let dest = build_abs_path(&self.root, to);
+        let source = build_absolute_path(&self.root, from);
+        let dest = build_absolute_path(&self.root, to);
 
         let url = format!(
             "{}/storage/v1/b/{}/o/{}/rewriteTo/b/{}/o/{}",
@@ -558,7 +558,7 @@ impl GcsCore {
         limit: Option<usize>,
         start_after: Option<String>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/storage/v1/b/{}/o", self.endpoint, self.bucket,);
 
@@ -572,7 +572,7 @@ impl GcsCore {
             url = url.push("maxResults", &limit.to_string());
         }
         if let Some(start_after) = start_after {
-            let start_after = build_abs_path(&self.root, &start_after);
+            let start_after = build_absolute_path(&self.root, &start_after);
             url = url.push("startOffset", &gcs_percent_encode_path(&start_after));
         }
 
@@ -603,7 +603,7 @@ impl GcsCore {
         path: &str,
         op: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}/{}?uploads", self.endpoint, self.bucket, p);
 
@@ -659,7 +659,7 @@ impl GcsCore {
         size: u64,
         body: Buffer,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}/{}?partNumber={}&uploadId={}",
@@ -691,7 +691,7 @@ impl GcsCore {
         upload_id: &str,
         parts: Vec<CompleteMultipartUploadRequestPart>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}/{}?uploadId={}",
@@ -728,7 +728,7 @@ impl GcsCore {
         path: &str,
         upload_id: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}/{}?uploadId={}",

--- a/core/services/gcs/src/lister.rs
+++ b/core/services/gcs/src/lister.rs
@@ -96,7 +96,7 @@ impl oio::PageList for GcsLister {
 
         for prefix in output.prefixes {
             let de = oio::Entry::new(
-                &build_rel_path(&self.core.root, &prefix),
+                &build_relative_path(&self.core.root, &prefix),
                 Metadata::new(EntryMode::DIR),
             );
 
@@ -105,7 +105,7 @@ impl oio::PageList for GcsLister {
 
         for object in output.items {
             // exclude the inclusive start_after itself
-            let mut path = build_rel_path(&self.core.root, &object.name);
+            let mut path = build_relative_path(&self.core.root, &object.name);
             if path.is_empty() {
                 path = "/".to_string();
             }

--- a/core/services/gdrive/src/backend.rs
+++ b/core/services/gdrive/src/backend.rs
@@ -230,7 +230,7 @@ impl Service for GdriveBackend {
         path: &str,
         _args: OpCreateDir,
     ) -> Result<RpCreateDir> {
-        let path = build_abs_path(&self.core.root, path);
+        let path = build_absolute_path(&self.core.root, path);
         let dir_id = self.core.ensure_dir(ctx, &path).await?;
         let metadata = Metadata::new(EntryMode::DIR);
 
@@ -241,7 +241,7 @@ impl Service for GdriveBackend {
     }
 
     async fn stat(&self, ctx: &OperationContext, path: &str, _args: OpStat) -> Result<RpStat> {
-        let path = build_abs_path(&self.core.root, path);
+        let path = build_absolute_path(&self.core.root, path);
 
         match self.core.recent_entry_for_path(&path).await {
             GdriveRecentPathState::Present(metadata) => {
@@ -325,7 +325,7 @@ impl Service for GdriveBackend {
 
     fn write(&self, ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: oio::OneShotWriter<GdriveWriter> = {
-            let path = build_abs_path(&self.core.root, path);
+            let path = build_absolute_path(&self.core.root, path);
 
             Ok(oio::OneShotWriter::new(GdriveWriter::new(
                 self.core.clone(),
@@ -351,7 +351,7 @@ impl Service for GdriveBackend {
 
     fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         let output: GdriveListers = {
-            let path = build_abs_path(&self.core.root, path);
+            let path = build_absolute_path(&self.core.root, path);
 
             if args.recursive() {
                 // Use optimized batch-query recursive lister
@@ -381,8 +381,8 @@ impl Service for GdriveBackend {
         let to = to.to_string();
 
         Ok(oio::OneShotCopier::new(async move {
-            let source = build_abs_path(&core.root, &from);
-            let target = build_abs_path(&core.root, &to);
+            let source = build_absolute_path(&core.root, &from);
+            let target = build_absolute_path(&core.root, &to);
             let resp = core.gdrive_copy(&ctx, &from, &to).await?;
 
             match resp.status() {
@@ -391,7 +391,7 @@ impl Service for GdriveBackend {
                     let meta: GdriveFile = serde_json::from_reader(body.reader())
                         .map_err(new_json_deserialize_error)?;
 
-                    let to_path = build_abs_path(&core.root, &to);
+                    let to_path = build_absolute_path(&core.root, &to);
                     let mut metadata = if meta.mime_type == "application/vnd.google-apps.folder" {
                         Metadata::new(EntryMode::DIR)
                     } else {
@@ -424,7 +424,7 @@ impl Service for GdriveBackend {
                             let meta: GdriveFile = serde_json::from_reader(body.reader())
                                 .map_err(new_json_deserialize_error)?;
 
-                            let to_path = build_abs_path(&core.root, &to);
+                            let to_path = build_absolute_path(&core.root, &to);
                             let mut metadata =
                                 if meta.mime_type == "application/vnd.google-apps.folder" {
                                     Metadata::new(EntryMode::DIR)
@@ -464,8 +464,8 @@ impl Service for GdriveBackend {
         to: &str,
         _args: OpRename,
     ) -> Result<RpRename> {
-        let source = build_abs_path(&self.core.root, from);
-        let target = build_abs_path(&self.core.root, to);
+        let source = build_absolute_path(&self.core.root, from);
+        let target = build_absolute_path(&self.core.root, to);
 
         // rename will overwrite `to`, delete it if exist
         self.core.trash_path_if_exists(ctx, &target).await?;
@@ -484,14 +484,14 @@ impl Service for GdriveBackend {
                     serde_json::from_reader(body.reader()).map_err(new_json_deserialize_error)?;
 
                 let source_path = if meta.mime_type == "application/vnd.google-apps.folder" {
-                    normalize_dir_path(&build_abs_path(&self.core.root, from))
+                    normalize_dir_path(&build_absolute_path(&self.core.root, from))
                 } else {
-                    build_abs_path(&self.core.root, from)
+                    build_absolute_path(&self.core.root, from)
                 };
                 let target_path = if meta.mime_type == "application/vnd.google-apps.folder" {
-                    normalize_dir_path(&build_abs_path(&self.core.root, to))
+                    normalize_dir_path(&build_absolute_path(&self.core.root, to))
                 } else {
-                    build_abs_path(&self.core.root, to)
+                    build_absolute_path(&self.core.root, to)
                 };
                 let mut metadata = if meta.mime_type == "application/vnd.google-apps.folder" {
                     Metadata::new(EntryMode::DIR)
@@ -536,14 +536,14 @@ impl Service for GdriveBackend {
                     serde_json::from_reader(body.reader()).map_err(new_json_deserialize_error)?;
 
                 let source_path = if meta.mime_type == "application/vnd.google-apps.folder" {
-                    normalize_dir_path(&build_abs_path(&self.core.root, from))
+                    normalize_dir_path(&build_absolute_path(&self.core.root, from))
                 } else {
-                    build_abs_path(&self.core.root, from)
+                    build_absolute_path(&self.core.root, from)
                 };
                 let target_path = if meta.mime_type == "application/vnd.google-apps.folder" {
-                    normalize_dir_path(&build_abs_path(&self.core.root, to))
+                    normalize_dir_path(&build_absolute_path(&self.core.root, to))
                 } else {
-                    build_abs_path(&self.core.root, to)
+                    build_absolute_path(&self.core.root, to)
                 };
                 let mut metadata = if meta.mime_type == "application/vnd.google-apps.folder" {
                     Metadata::new(EntryMode::DIR)

--- a/core/services/gdrive/src/core.rs
+++ b/core/services/gdrive/src/core.rs
@@ -259,7 +259,7 @@ impl GdriveCore {
         path: &str,
         range: BytesRange,
     ) -> Result<Response<HttpBody>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
         match self.recent_entry_for_path(&path).await {
             GdriveRecentPathState::Deleted => {
                 return Err(Error::new(
@@ -533,7 +533,7 @@ impl GdriveCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let from = build_abs_path(&self.root, from);
+        let from = build_absolute_path(&self.root, from);
 
         let from_file_id = match self.resolve_path(ctx, &from).await? {
             Some(id) => id,
@@ -549,7 +549,7 @@ impl GdriveCore {
         };
 
         let to_name = get_basename(to);
-        let to_path = build_abs_path(&self.root, to);
+        let to_path = build_absolute_path(&self.root, to);
         let to_parent_id = self.ensure_dir(ctx, get_parent(&to_path)).await?;
 
         self.trash_path_if_exists(ctx, &to_path).await?;

--- a/core/services/gdrive/src/deleter.rs
+++ b/core/services/gdrive/src/deleter.rs
@@ -37,7 +37,7 @@ impl GdriveDeleter {
 
 impl oio::OneShotDelete for GdriveDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let path = build_abs_path(&self.core.root, &path);
+        let path = build_absolute_path(&self.core.root, &path);
         let mut file_id = match self.core.resolve_path(&self.ctx, &path).await? {
             Some(id) => id,
             None => match self

--- a/core/services/gdrive/src/lister.rs
+++ b/core/services/gdrive/src/lister.rs
@@ -71,12 +71,12 @@ impl GdriveLister {
     ) -> Result<()> {
         match self.core.recent_entry_for_path(&abs_path).await {
             GdriveRecentPathState::Present(recent_metadata) => {
-                let path = build_rel_path(&self.core.root, &abs_path);
+                let path = build_relative_path(&self.core.root, &abs_path);
                 self.push_entry(ctx, path, *recent_metadata).await
             }
             GdriveRecentPathState::Deleted => Ok(()),
             GdriveRecentPathState::Missing => {
-                let path = build_rel_path(&self.core.root, &abs_path);
+                let path = build_relative_path(&self.core.root, &abs_path);
                 self.push_entry(ctx, path, metadata).await
             }
         }
@@ -90,7 +90,7 @@ impl GdriveLister {
         *recent_entries_loaded = true;
 
         for (abs_path, metadata) in self.core.recent_entries_for_list(&self.path, false).await {
-            let path = build_rel_path(&self.core.root, &abs_path);
+            let path = build_relative_path(&self.core.root, &abs_path);
             self.push_entry(ctx, path, metadata).await?;
         }
 
@@ -226,7 +226,7 @@ impl oio::PageList for GdriveLister {
 
         // Include the current directory itself when handling the first page of the listing.
         if ctx.token.is_empty() && !ctx.done {
-            let path = build_rel_path(&self.core.root, &self.path);
+            let path = build_relative_path(&self.core.root, &self.path);
             self.push_entry(ctx, path, Metadata::new(EntryMode::DIR))
                 .await?;
             self.inject_recent_entries(ctx).await?;
@@ -364,12 +364,12 @@ impl GdriveFlatLister {
     ) -> Result<()> {
         match recent_state {
             GdriveRecentPathState::Present(recent_metadata) => {
-                let rel_path = build_rel_path(&self.core.root, &abs_path);
+                let rel_path = build_relative_path(&self.core.root, &abs_path);
                 self.push_entry(rel_path, *recent_metadata);
             }
             GdriveRecentPathState::Deleted => {}
             GdriveRecentPathState::Missing => {
-                let rel_path = build_rel_path(&self.core.root, &abs_path);
+                let rel_path = build_relative_path(&self.core.root, &abs_path);
                 self.push_entry(rel_path, metadata);
             }
         }
@@ -385,7 +385,7 @@ impl GdriveFlatLister {
 
         let scope_path = self.prefix.as_deref().unwrap_or(&self.root_path);
         for (abs_path, metadata) in self.core.recent_entries_for_list(scope_path, true).await {
-            let rel_path = build_rel_path(&self.core.root, &abs_path);
+            let rel_path = build_relative_path(&self.core.root, &abs_path);
             self.push_entry(rel_path, metadata);
         }
 
@@ -540,7 +540,7 @@ impl GdriveFlatLister {
             }
 
             // Add the root directory entry first.
-            let mut rel_path = build_rel_path(&self.core.root, &self.root_path);
+            let mut rel_path = build_relative_path(&self.core.root, &self.root_path);
             if !rel_path.is_empty() && !rel_path.ends_with('/') {
                 rel_path.push('/');
             }

--- a/core/services/gdrive/src/reader.rs
+++ b/core/services/gdrive/src/reader.rs
@@ -48,7 +48,7 @@ impl oio::StreamRead for GdriveReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let abs_path = build_abs_path(&backend.core.root, path);
+        let abs_path = build_absolute_path(&backend.core.root, path);
         let resp = match backend.core.gdrive_get(&self.ctx, path, range).await {
             Ok(resp) => resp,
             Err(err) if err.kind() == ErrorKind::NotFound => {

--- a/core/services/ghac/src/core.rs
+++ b/core/services/ghac/src/core.rs
@@ -99,7 +99,7 @@ impl Debug for GhacCore {
 
 impl GhacCore {
     async fn ghac_get_download_url(&self, ctx: &OperationContext, path: &str) -> Result<String> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         match self.service_version {
             GhacVersion::V1 => {
@@ -224,7 +224,7 @@ impl GhacCore {
     }
 
     pub async fn ghac_get_upload_url(&self, ctx: &OperationContext, path: &str) -> Result<String> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         match self.service_version {
             GhacVersion::V1 => {
@@ -341,7 +341,7 @@ impl GhacCore {
         url: &str,
         size: u64,
     ) -> Result<()> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         match self.service_version {
             GhacVersion::V1 => {

--- a/core/services/github/src/core.rs
+++ b/core/services/github/src/core.rs
@@ -109,7 +109,7 @@ impl GithubCore {
     }
 
     pub async fn stat(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://api.github.com/repos/{}/{}/contents/{}",
@@ -140,7 +140,7 @@ impl GithubCore {
         path: &str,
         range: BytesRange,
     ) -> Result<Response<HttpBody>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://api.github.com/repos/{}/{}/contents/{}",
@@ -174,7 +174,7 @@ impl GithubCore {
     ) -> Result<Response<Buffer>> {
         let sha = self.get_file_sha(ctx, path).await?;
 
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://api.github.com/repos/{}/{}/contents/{}",
@@ -224,7 +224,7 @@ impl GithubCore {
             return Ok(());
         };
 
-        let path = build_abs_path(&self.root, p);
+        let path = build_absolute_path(&self.root, p);
 
         let url = format!(
             "https://api.github.com/repos/{}/{}/contents/{}",
@@ -263,7 +263,7 @@ impl GithubCore {
     }
 
     pub async fn list(&self, ctx: &OperationContext, path: &str) -> Result<ListResponse> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://api.github.com/repos/{}/{}/contents/{}",

--- a/core/services/github/src/lister.rs
+++ b/core/services/github/src/lister.rs
@@ -53,7 +53,7 @@ impl oio::PageList for GithubLister {
 
         if !self.recursive || !has_dir {
             for entry in resp.entries {
-                let path = build_rel_path(&self.core.root, &entry.path);
+                let path = build_relative_path(&self.core.root, &entry.path);
                 let entry = if entry.type_field == "dir" {
                     let path = format!("{path}/");
                     Entry::new(&path, Metadata::new(EntryMode::DIR))

--- a/core/services/goosefs/src/core.rs
+++ b/core/services/goosefs/src/core.rs
@@ -200,7 +200,7 @@ impl GoosefsCore {
 
     /// Build the full GooseFS path from a relative OpenDAL path.
     fn full_path(&self, path: &str) -> String {
-        build_rooted_abs_path(&self.root, path)
+        build_rooted_absolute_path(&self.root, path)
     }
 
     // ── Metadata Operations ──────────────────────────────────
@@ -489,7 +489,7 @@ impl GoosefsCore {
         } else {
             path
         };
-        let rel = build_rel_path(&self.root, &rel_path);
+        let rel = build_relative_path(&self.root, &rel_path);
         Ok((rel, self.file_info_to_metadata(info)))
     }
 }
@@ -500,7 +500,7 @@ impl GoosefsCore {
 ///
 /// Input paths here are always produced by [`GoosefsCore::full_path`],
 /// so they are already normalized, absolute (leading `/`) and do not
-/// contain trailing slashes (OpenDAL's `build_rooted_abs_path` strips
+/// contain trailing slashes (OpenDAL's `build_rooted_absolute_path` strips
 /// them for non-directory paths). We deliberately do not depend on
 /// `opendal_core::raw::get_parent` because that function's contract is
 /// defined for OpenDAL *relative* paths and treats trailing slashes

--- a/core/services/gridfs/src/backend.rs
+++ b/core/services/gridfs/src/backend.rs
@@ -218,9 +218,9 @@ impl Service for GridfsBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p).await?;
@@ -246,7 +246,7 @@ impl Service for GridfsBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: GridfsWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(GridfsWriter::new(self.core.clone(), p))
         }?;
 

--- a/core/services/gridfs/src/deleter.rs
+++ b/core/services/gridfs/src/deleter.rs
@@ -35,7 +35,7 @@ impl GridfsDeleter {
 
 impl oio::OneShotDelete for GridfsDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p).await?;
         Ok(())
     }

--- a/core/services/gridfs/src/reader.rs
+++ b/core/services/gridfs/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for GridfsReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
         let bs = match backend.core.get(&p).await? {
             Some(bs) => bs,
             None => {

--- a/core/services/hdfs-native/src/core.rs
+++ b/core/services/hdfs-native/src/core.rs
@@ -43,7 +43,7 @@ impl Debug for HdfsNativeCore {
 
 impl HdfsNativeCore {
     pub async fn hdfs_create_dir(&self, path: &str) -> Result<()> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         self.client
             .mkdirs(&p, 0o777, true)
@@ -54,7 +54,7 @@ impl HdfsNativeCore {
     }
 
     pub async fn hdfs_stat(&self, path: &str) -> Result<Metadata> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         let status: hdfs_native::client::FileStatus = self
             .client
@@ -79,7 +79,7 @@ impl HdfsNativeCore {
     }
 
     pub async fn hdfs_open(&self, path: &str) -> Result<hdfs_native::file::FileReader> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         self.client.read(&p).await.map_err(parse_hdfs_error)
     }
@@ -89,7 +89,7 @@ impl HdfsNativeCore {
         path: &str,
         args: &OpWrite,
     ) -> Result<(hdfs_native::file::FileWriter, u64)> {
-        let target_path = build_rooted_abs_path(&self.root, path);
+        let target_path = build_rooted_absolute_path(&self.root, path);
         let mut initial_size = 0;
 
         let target_exists = match self.client.get_file_info(&target_path).await {
@@ -128,7 +128,7 @@ impl HdfsNativeCore {
     }
 
     pub async fn hdfs_delete(&self, path: &str) -> Result<()> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         self.client
             .delete(&p, true)
@@ -139,7 +139,7 @@ impl HdfsNativeCore {
     }
 
     pub async fn hdfs_list(&self, path: &str) -> Result<Option<(String, Option<String>)>> {
-        let p: String = build_rooted_abs_path(&self.root, path);
+        let p: String = build_rooted_absolute_path(&self.root, path);
 
         let isdir = match self.client.get_file_info(&p).await {
             Ok(status) => status.isdir,
@@ -165,8 +165,8 @@ impl HdfsNativeCore {
     }
 
     pub async fn hdfs_rename(&self, from: &str, to: &str) -> Result<()> {
-        let from_path = build_rooted_abs_path(&self.root, from);
-        let to_path = build_rooted_abs_path(&self.root, to);
+        let from_path = build_rooted_absolute_path(&self.root, from);
+        let to_path = build_rooted_absolute_path(&self.root, to);
 
         match self.client.get_file_info(&to_path).await {
             Ok(status) => {

--- a/core/services/hdfs-native/src/lister.rs
+++ b/core/services/hdfs-native/src/lister.rs
@@ -59,7 +59,7 @@ impl oio::List for HdfsNativeLister {
 
         match self.iter.next().await {
             Some(Ok(status)) => {
-                let path = build_rel_path(&self.root, &status.path);
+                let path = build_relative_path(&self.root, &status.path);
 
                 let entry = if status.isdir {
                     oio::Entry::new(&format!("{path}/"), Metadata::new(EntryMode::DIR))

--- a/core/services/hdfs/src/core.rs
+++ b/core/services/hdfs/src/core.rs
@@ -43,13 +43,13 @@ impl Debug for HdfsCore {
 
 impl HdfsCore {
     pub fn hdfs_create_dir(&self, path: &str) -> Result<()> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
         self.client.create_dir(&p).map_err(new_std_io_error)?;
         Ok(())
     }
 
     pub fn hdfs_stat(&self, path: &str) -> Result<Metadata> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
         let meta = self.client.metadata(&p).map_err(new_std_io_error)?;
 
         let mode = if meta.is_dir() {
@@ -67,7 +67,7 @@ impl HdfsCore {
     }
 
     pub async fn hdfs_open(&self, path: &str) -> Result<hdrs::File> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         let client = self.client.clone();
         let f = tokio::task::spawn_blocking(move || client.open_file().read(true).open(&p))
@@ -83,7 +83,7 @@ impl HdfsCore {
         path: &str,
         op: &OpWrite,
     ) -> Result<(String, Option<String>, hdrs::AsyncFile, bool, u64)> {
-        let target_path = build_rooted_abs_path(&self.root, path);
+        let target_path = build_rooted_absolute_path(&self.root, path);
         let mut initial_size = 0;
         let target_exists = match self.client.metadata(&target_path) {
             Ok(meta) => {
@@ -101,7 +101,7 @@ impl HdfsCore {
         let should_append = op.append() && target_exists;
         let tmp_path = self.atomic_write_dir.as_ref().and_then(|atomic_write_dir| {
             // If the target file exists, we should append to the end of it directly.
-            (!should_append).then_some(build_rooted_abs_path(
+            (!should_append).then_some(build_rooted_absolute_path(
                 atomic_write_dir,
                 &build_tmp_path_of(path),
             ))
@@ -132,7 +132,7 @@ impl HdfsCore {
     }
 
     pub fn hdfs_list(&self, path: &str) -> Result<Option<hdrs::Readdir>> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         match self.client.read_dir(&p) {
             Ok(f) => Ok(Some(f)),
@@ -147,10 +147,10 @@ impl HdfsCore {
     }
 
     pub fn hdfs_rename(&self, from: &str, to: &str) -> Result<()> {
-        let from_path = build_rooted_abs_path(&self.root, from);
+        let from_path = build_rooted_absolute_path(&self.root, from);
         self.client.metadata(&from_path).map_err(new_std_io_error)?;
 
-        let to_path = build_rooted_abs_path(&self.root, to);
+        let to_path = build_rooted_absolute_path(&self.root, to);
         let result = self.client.metadata(&to_path);
         match result {
             Err(err) => {

--- a/core/services/hdfs/src/deleter.rs
+++ b/core/services/hdfs/src/deleter.rs
@@ -34,7 +34,7 @@ impl HdfsDeleter {
 
 impl oio::OneShotDelete for HdfsDeleter {
     async fn delete_once(&self, path: String, args: OpDelete) -> Result<()> {
-        let p = build_rooted_abs_path(&self.core.root, &path);
+        let p = build_rooted_absolute_path(&self.core.root, &path);
 
         let meta = self.core.client.metadata(&p);
 

--- a/core/services/hdfs/src/lister.rs
+++ b/core/services/hdfs/src/lister.rs
@@ -51,7 +51,7 @@ impl oio::List for HdfsLister {
             None => return Ok(None),
         };
 
-        let path = build_rel_path(&self.root, de.path());
+        let path = build_relative_path(&self.root, de.path());
 
         let entry = if de.is_file() {
             let meta = Metadata::new(EntryMode::FILE)

--- a/core/services/hf/src/core.rs
+++ b/core/services/hf/src/core.rs
@@ -404,7 +404,7 @@ impl HfCore {
     /// Convert an operator-relative path to a repo-absolute path
     /// (no leading `/`) for use in commit/delete/batch payloads.
     pub(super) fn repo_path(&self, path: &str) -> String {
-        build_abs_path(&self.root, path)
+        build_absolute_path(&self.root, path)
             .trim_start_matches('/')
             .to_string()
     }
@@ -905,7 +905,7 @@ mod uri {
         pub fn uri(&self, root: &str, path: &str) -> HfUri {
             HfUri {
                 repo: self.clone(),
-                path: build_abs_path(root, path)
+                path: build_absolute_path(root, path)
                     .trim_start_matches('/')
                     .trim_end_matches('/')
                     .to_string(),

--- a/core/services/hf/src/lister.rs
+++ b/core/services/hf/src/lister.rs
@@ -141,7 +141,7 @@ impl oio::PageList for HfLister {
             } else {
                 info.path.clone()
             };
-            let rel_path = build_rel_path(&self.core.root, &path);
+            let rel_path = build_relative_path(&self.core.root, &path);
 
             // Filter by prefix when doing prefix-based listing.
             if let Some(prefix) = &self.prefix {

--- a/core/services/http/src/core.rs
+++ b/core/services/http/src/core.rs
@@ -56,7 +56,7 @@ impl HttpCore {
         range: BytesRange,
         args: &OpRead,
     ) -> Result<Request<Buffer>> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
 
@@ -97,7 +97,7 @@ impl HttpCore {
     }
 
     pub fn http_head_request(&self, path: &str, args: &OpStat) -> Result<Request<Buffer>> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
 

--- a/core/services/ipfs/src/core.rs
+++ b/core/services/ipfs/src/core.rs
@@ -47,7 +47,7 @@ impl IpfsCore {
         path: &str,
         range: BytesRange,
     ) -> Result<Response<HttpBody>> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
 
@@ -67,7 +67,7 @@ impl IpfsCore {
     }
 
     pub async fn ipfs_head(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
 
@@ -81,7 +81,7 @@ impl IpfsCore {
     }
 
     pub async fn ipfs_list(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         let url = format!("{}{}", self.endpoint, percent_encode_path(&p));
 

--- a/core/services/ipmfs/src/core.rs
+++ b/core/services/ipmfs/src/core.rs
@@ -42,7 +42,7 @@ impl Debug for IpmfsCore {
 
 impl IpmfsCore {
     pub async fn ipmfs_stat(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/api/v0/files/stat?arg={}",
@@ -64,7 +64,7 @@ impl IpmfsCore {
         path: &str,
         range: BytesRange,
     ) -> Result<Response<HttpBody>> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         let mut url = format!(
             "{}/api/v0/files/read?arg={}",
@@ -86,7 +86,7 @@ impl IpmfsCore {
     }
 
     pub async fn ipmfs_rm(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/api/v0/files/rm?arg={}",
@@ -107,7 +107,7 @@ impl IpmfsCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/api/v0/files/ls?arg={}&long=true",
@@ -128,7 +128,7 @@ impl IpmfsCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/api/v0/files/mkdir?arg={}&parents=true",
@@ -151,7 +151,7 @@ impl IpmfsCore {
         path: &str,
         body: Buffer,
     ) -> Result<Response<Buffer>> {
-        let p = build_rooted_abs_path(&self.root, path);
+        let p = build_rooted_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/api/v0/files/write?arg={}&parents=true&create=true&truncate=true",

--- a/core/services/ipmfs/src/lister.rs
+++ b/core/services/ipmfs/src/lister.rs
@@ -64,8 +64,8 @@ impl oio::PageList for IpmfsLister {
 
         // Add current directory entry when processing the first page
         if ctx.token.is_empty() && !ctx.done {
-            let path = build_abs_path(&self.root, self.path.as_str());
-            let path = build_rel_path(&self.root, &path);
+            let path = build_absolute_path(&self.root, self.path.as_str());
+            let path = build_relative_path(&self.root, &path);
 
             ctx.entries
                 .push_back(oio::Entry::new(&path, Metadata::new(EntryMode::DIR)));
@@ -85,7 +85,7 @@ impl oio::PageList for IpmfsLister {
                 EntryMode::Unknown => unreachable!(),
             };
 
-            let path = build_rel_path(&self.root, &path);
+            let path = build_relative_path(&self.root, &path);
 
             ctx.entries.push_back(oio::Entry::new(
                 &path,

--- a/core/services/koofr/src/backend.rs
+++ b/core/services/koofr/src/backend.rs
@@ -207,13 +207,13 @@ impl Service for KoofrBackend {
     ) -> Result<RpCreateDir> {
         self.core.ensure_dir_exists(ctx, path).await?;
         self.core
-            .create_dir(ctx, &build_abs_path(&self.core.root, path))
+            .create_dir(ctx, &build_absolute_path(&self.core.root, path))
             .await?;
         Ok(RpCreateDir::default())
     }
 
     async fn stat(&self, ctx: &OperationContext, path: &str, _args: OpStat) -> Result<RpStat> {
-        let path = build_rooted_abs_path(&self.core.root, path);
+        let path = build_rooted_absolute_path(&self.core.root, path);
         let resp = self.core.info(ctx, &path).await?;
 
         let status = resp.status();

--- a/core/services/koofr/src/core.rs
+++ b/core/services/koofr/src/core.rs
@@ -159,7 +159,7 @@ impl KoofrCore {
     pub async fn ensure_dir_exists(&self, ctx: &OperationContext, path: &str) -> Result<()> {
         let mut dirs = VecDeque::default();
 
-        let mut p = build_abs_path(&self.root, path);
+        let mut p = build_absolute_path(&self.root, path);
 
         while p != "/" {
             let parent = get_parent(&p).to_string();
@@ -256,7 +256,7 @@ impl KoofrCore {
         path: &str,
         range: BytesRange,
     ) -> Result<Response<HttpBody>> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let mount_id = self.get_mount_id(ctx).await?;
 
@@ -286,7 +286,7 @@ impl KoofrCore {
         path: &str,
         bs: Buffer,
     ) -> Result<Response<Buffer>> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let filename = get_basename(&path);
         let parent = get_parent(&path);
@@ -326,7 +326,7 @@ impl KoofrCore {
     }
 
     pub async fn remove(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let mount_id = self.get_mount_id(ctx).await?;
 
@@ -356,8 +356,8 @@ impl KoofrCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let from = build_rooted_abs_path(&self.root, from);
-        let to = build_rooted_abs_path(&self.root, to);
+        let from = build_rooted_absolute_path(&self.root, from);
+        let to = build_rooted_absolute_path(&self.root, to);
 
         let mount_id = self.get_mount_id(ctx).await?;
 
@@ -395,8 +395,8 @@ impl KoofrCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let from = build_rooted_abs_path(&self.root, from);
-        let to = build_rooted_abs_path(&self.root, to);
+        let from = build_rooted_absolute_path(&self.root, from);
+        let to = build_rooted_absolute_path(&self.root, to);
 
         let mount_id = self.get_mount_id(ctx).await?;
 
@@ -429,7 +429,7 @@ impl KoofrCore {
     }
 
     pub async fn list(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let mount_id = self.get_mount_id(ctx).await?;
 

--- a/core/services/koofr/src/lister.rs
+++ b/core/services/koofr/src/lister.rs
@@ -68,7 +68,7 @@ impl oio::PageList for KoofrLister {
             serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
 
         for file in response.files {
-            let path = build_abs_path(&normalize_root(&self.path), &file.name);
+            let path = build_absolute_path(&normalize_root(&self.path), &file.name);
 
             let entry = if file.ty == "dir" {
                 let path = format!("{path}/");

--- a/core/services/lakefs/src/core.rs
+++ b/core/services/lakefs/src/core.rs
@@ -55,7 +55,7 @@ impl LakefsCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 
@@ -87,7 +87,7 @@ impl LakefsCore {
         range: BytesRange,
         _args: &OpRead,
     ) -> Result<Response<HttpBody>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 
@@ -124,7 +124,7 @@ impl LakefsCore {
         amount: &Option<usize>,
         after: Option<String>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!(
             "{}/api/v1/repositories/{}/refs/{}/objects/ls?",
@@ -167,7 +167,7 @@ impl LakefsCore {
         _args: &OpWrite,
         body: Buffer,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 
@@ -198,7 +198,7 @@ impl LakefsCore {
         path: &str,
         _args: &OpDelete,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 
@@ -229,10 +229,10 @@ impl LakefsCore {
         path: &str,
         dest: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
-        let d = build_abs_path(&self.root, dest)
+        let d = build_absolute_path(&self.root, dest)
             .trim_end_matches('/')
             .to_string();
 

--- a/core/services/lakefs/src/lister.rs
+++ b/core/services/lakefs/src/lister.rs
@@ -112,7 +112,7 @@ impl oio::PageList for LakefsLister {
             };
 
             ctx.entries.push_back(oio::Entry::new(
-                &build_rel_path(&self.core.root, &path),
+                &build_relative_path(&self.core.root, &path),
                 meta,
             ));
         }

--- a/core/services/memcached/src/backend.rs
+++ b/core/services/memcached/src/backend.rs
@@ -243,9 +243,9 @@ impl Service for MemcachedBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p).await?;
@@ -271,7 +271,7 @@ impl Service for MemcachedBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: MemcachedWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(MemcachedWriter::new(self.core.clone(), p))
         }?;
 

--- a/core/services/memcached/src/deleter.rs
+++ b/core/services/memcached/src/deleter.rs
@@ -35,7 +35,7 @@ impl MemcachedDeleter {
 
 impl oio::OneShotDelete for MemcachedDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p).await?;
         Ok(())
     }

--- a/core/services/memcached/src/reader.rs
+++ b/core/services/memcached/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for MemcachedReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
         let bs = match backend.core.get(&p).await? {
             Some(bs) => bs,
             None => return Err(Error::new(ErrorKind::NotFound, "kv not found in memcached")),

--- a/core/services/mini_moka/src/backend.rs
+++ b/core/services/mini_moka/src/backend.rs
@@ -175,7 +175,7 @@ impl Service for MiniMokaBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         // Check if path exists directly in cache
         match self.core.get(&p) {
@@ -221,7 +221,7 @@ impl Service for MiniMokaBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, op: OpWrite) -> Result<Self::Writer> {
         let output: MiniMokaWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             let writer = MiniMokaWriter::new(self.core.clone(), p, op);
             Ok(writer)
         }?;
@@ -243,7 +243,7 @@ impl Service for MiniMokaBackend {
 
     fn list(&self, _ctx: &OperationContext, path: &str, op: OpList) -> Result<Self::Lister> {
         let output: oio::HierarchyLister<MiniMokaLister> = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
 
             let mini_moka_lister = MiniMokaLister::new(self.core.clone(), self.root.clone(), p);
             let lister = oio::HierarchyLister::new(mini_moka_lister, path, op.recursive());

--- a/core/services/mini_moka/src/deleter.rs
+++ b/core/services/mini_moka/src/deleter.rs
@@ -35,7 +35,7 @@ impl MiniMokaDeleter {
 
 impl oio::OneShotDelete for MiniMokaDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.cache.invalidate(&p);
         Ok(())
     }

--- a/core/services/mini_moka/src/lister.rs
+++ b/core/services/mini_moka/src/lister.rs
@@ -47,7 +47,7 @@ impl oio::List for MiniMokaLister {
     async fn next(&mut self) -> Result<Option<oio::Entry>> {
         match self.entries.next() {
             Some((key, metadata)) => {
-                let rel_path = build_rel_path(&self.root, &key);
+                let rel_path = build_relative_path(&self.root, &key);
 
                 Ok(Some(oio::Entry::new(&rel_path, metadata)))
             }

--- a/core/services/mini_moka/src/reader.rs
+++ b/core/services/mini_moka/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for MiniMokaReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
 
         match backend.core.get(&p) {
             Some(value) => {

--- a/core/services/moka/src/backend.rs
+++ b/core/services/moka/src/backend.rs
@@ -249,9 +249,9 @@ impl Service for MokaBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             // Check the exact path first
@@ -301,7 +301,7 @@ impl Service for MokaBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, args: OpWrite) -> Result<Self::Writer> {
         let output: MokaWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(MokaWriter::new(self.core.clone(), p, args))
         }?;
 

--- a/core/services/moka/src/deleter.rs
+++ b/core/services/moka/src/deleter.rs
@@ -35,7 +35,7 @@ impl MokaDeleter {
 
 impl oio::OneShotDelete for MokaDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p).await?;
         Ok(())
     }

--- a/core/services/moka/src/lister.rs
+++ b/core/services/moka/src/lister.rs
@@ -47,7 +47,7 @@ impl oio::List for MokaLister {
     async fn next(&mut self) -> Result<Option<oio::Entry>> {
         match self.entries.next() {
             Some((key, metadata)) => {
-                let mut path = build_rel_path(&self.root, &key);
+                let mut path = build_relative_path(&self.root, &key);
                 if path.is_empty() {
                     path = "/".to_string();
                 }

--- a/core/services/moka/src/reader.rs
+++ b/core/services/moka/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for MokaReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
 
         match backend.core.get(&p).await? {
             Some(value) => {

--- a/core/services/mongodb/src/backend.rs
+++ b/core/services/mongodb/src/backend.rs
@@ -236,9 +236,9 @@ impl Service for MongodbBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p).await?;
@@ -264,7 +264,7 @@ impl Service for MongodbBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: MongodbWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(MongodbWriter::new(self.core.clone(), p))
         }?;
 

--- a/core/services/mongodb/src/deleter.rs
+++ b/core/services/mongodb/src/deleter.rs
@@ -35,7 +35,7 @@ impl MongodbDeleter {
 
 impl oio::OneShotDelete for MongodbDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p).await?;
         Ok(())
     }

--- a/core/services/mongodb/src/reader.rs
+++ b/core/services/mongodb/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for MongodbReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
         let bs = match backend.core.get(&p).await? {
             Some(bs) => bs,
             None => {

--- a/core/services/mysql/src/backend.rs
+++ b/core/services/mysql/src/backend.rs
@@ -217,9 +217,9 @@ impl Service for MysqlBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p).await?;
@@ -245,7 +245,7 @@ impl Service for MysqlBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: MysqlWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(MysqlWriter::new(self.core.clone(), p))
         }?;
 

--- a/core/services/mysql/src/deleter.rs
+++ b/core/services/mysql/src/deleter.rs
@@ -35,7 +35,7 @@ impl MysqlDeleter {
 
 impl oio::OneShotDelete for MysqlDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p).await?;
         Ok(())
     }

--- a/core/services/mysql/src/lister.rs
+++ b/core/services/mysql/src/lister.rs
@@ -20,7 +20,7 @@ use std::vec::IntoIter;
 
 use opendal_core::Result;
 use opendal_core::raw::oio::{Entry, List};
-use opendal_core::raw::{build_abs_path, build_rel_path};
+use opendal_core::raw::{build_absolute_path, build_relative_path};
 use opendal_core::{EntryMode, Metadata};
 
 use super::core::MysqlCore;
@@ -32,7 +32,10 @@ pub struct MysqlLister {
 
 impl MysqlLister {
     pub async fn new(core: Arc<MysqlCore>, root: String, path: String) -> Result<Self> {
-        let entries = core.list(&build_abs_path(&root, &path)).await?.into_iter();
+        let entries = core
+            .list(&build_absolute_path(&root, &path))
+            .await?
+            .into_iter();
         Ok(Self { root, entries })
     }
 }
@@ -43,7 +46,7 @@ impl List for MysqlLister {
             return Ok(None);
         };
 
-        let mut path = build_rel_path(&self.root, &key);
+        let mut path = build_relative_path(&self.root, &key);
         if path.is_empty() {
             path = "/".to_string();
         }

--- a/core/services/mysql/src/reader.rs
+++ b/core/services/mysql/src/reader.rs
@@ -39,7 +39,7 @@ impl oio::StreamRead for MysqlReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
         let bs = match backend.core.get(&p).await? {
             Some(bs) => bs,
             None => return Err(Error::new(ErrorKind::NotFound, "kv not found in mysql")),

--- a/core/services/obs/src/core.rs
+++ b/core/services/obs/src/core.rs
@@ -126,7 +126,7 @@ impl ObsCore {
         range: BytesRange,
         args: &OpRead,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
@@ -160,7 +160,7 @@ impl ObsCore {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
@@ -207,7 +207,7 @@ impl ObsCore {
     }
 
     pub fn obs_head_object_request(&self, path: &str, args: &OpStat) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
@@ -238,7 +238,7 @@ impl ObsCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
@@ -263,7 +263,7 @@ impl ObsCore {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let url = format!(
             "{}/{}?append&position={}",
             self.endpoint,
@@ -302,8 +302,8 @@ impl ObsCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let source = build_abs_path(&self.root, from);
-        let target = build_abs_path(&self.root, to);
+        let source = build_absolute_path(&self.root, from);
+        let target = build_absolute_path(&self.root, to);
 
         let source = format!("/{}/{}", self.bucket, percent_encode_path(&source));
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&target));
@@ -328,7 +328,7 @@ impl ObsCore {
         delimiter: &str,
         limit: Option<usize>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let mut url = QueryPairsWriter::new(&self.endpoint);
 
         if !path.is_empty() {
@@ -360,7 +360,7 @@ impl ObsCore {
         path: &str,
         content_type: Option<&str>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}?uploads", self.endpoint, percent_encode_path(&p));
         let mut req = Request::post(&url);
@@ -388,7 +388,7 @@ impl ObsCore {
         size: Option<u64>,
         body: Buffer,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}?partNumber={}&uploadId={}",
@@ -423,7 +423,7 @@ impl ObsCore {
         upload_id: &str,
         parts: Vec<CompleteMultipartUploadRequestPart>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let url = format!(
             "{}/{}?uploadId={}",
             self.endpoint,
@@ -459,7 +459,7 @@ impl ObsCore {
         path: &str,
         upload_id: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}?uploadId={}",

--- a/core/services/obs/src/lister.rs
+++ b/core/services/obs/src/lister.rs
@@ -91,7 +91,7 @@ impl oio::PageList for ObsLister {
 
         for prefix in common_prefixes {
             let de = oio::Entry::new(
-                &build_rel_path(&self.core.root, &prefix.prefix),
+                &build_relative_path(&self.core.root, &prefix.prefix),
                 Metadata::new(EntryMode::DIR),
             );
 
@@ -99,7 +99,7 @@ impl oio::PageList for ObsLister {
         }
 
         for object in output.contents {
-            let mut path = build_rel_path(&self.core.root, &object.key);
+            let mut path = build_relative_path(&self.core.root, &object.key);
             if path.is_empty() {
                 path = "/".to_string();
             }

--- a/core/services/onedrive/src/core.rs
+++ b/core/services/onedrive/src/core.rs
@@ -65,7 +65,7 @@ impl OneDriveCore {
         } else {
             // OneDrive returns 400 when try to access a folder with a ending slash
             let absolute_path = if build_absolute_path {
-                let rooted_path = build_rooted_abs_path(&self.root, path);
+                let rooted_path = build_rooted_absolute_path(&self.root, path);
                 rooted_path
                     .strip_suffix('/')
                     .unwrap_or(rooted_path.as_str())

--- a/core/services/onedrive/src/lister.rs
+++ b/core/services/onedrive/src/lister.rs
@@ -118,7 +118,7 @@ impl oio::PageList for OneDriveLister {
                 .unwrap_or("");
 
             let path = format!("{parent_path}/{name}");
-            let mut normalized_path = build_rel_path(self.core.root.as_str(), path.as_str());
+            let mut normalized_path = build_relative_path(self.core.root.as_str(), path.as_str());
             let entry_mode = match drive_item.item_type {
                 ItemType::Folder { .. } => EntryMode::DIR,
                 ItemType::File { .. } => EntryMode::FILE,

--- a/core/services/opfs/src/backend.rs
+++ b/core/services/opfs/src/backend.rs
@@ -83,7 +83,7 @@ impl Service for OpfsBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _args: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.core.root, path);
+        let p = build_absolute_path(&self.core.root, path);
 
         if p.ends_with('/') {
             get_directory_handle(&p, false).await?;
@@ -130,7 +130,7 @@ impl Service for OpfsBackend {
         _: OpCreateDir,
     ) -> Result<RpCreateDir> {
         debug_assert!(path != "/", "root path should be handled upstream");
-        let p = build_abs_path(&self.core.root, path);
+        let p = build_absolute_path(&self.core.root, path);
         get_directory_handle(&p, true).await?;
 
         Ok(RpCreateDir::default())

--- a/core/services/opfs/src/deleter.rs
+++ b/core/services/opfs/src/deleter.rs
@@ -38,7 +38,7 @@ impl OpfsDeleter {
 
 impl oio::OneShotDelete for OpfsDeleter {
     async fn delete_once(&self, path: String, args: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.core.root, &path);
+        let p = build_absolute_path(&self.core.root, &path);
         let (dir, name) = get_parent_dir_and_name(&p, false).await?;
 
         let opt = FileSystemRemoveOptions::new();

--- a/core/services/opfs/src/lister.rs
+++ b/core/services/opfs/src/lister.rs
@@ -50,7 +50,7 @@ impl OpfsLister {
             return Ok(());
         }
 
-        let p = build_abs_path(&self.core.root, &self.path);
+        let p = build_absolute_path(&self.core.root, &self.path);
         let dir = get_directory_handle(&p, false).await?;
         self.iter = Some(SendWrapper::new(dir.entries()));
 

--- a/core/services/opfs/src/reader.rs
+++ b/core/services/opfs/src/reader.rs
@@ -101,7 +101,7 @@ impl oio::StreamRead for OpfsReader {
         let backend = &self.backend;
         let path = self.path.as_str();
 
-        let p = build_abs_path(&backend.core.root, path);
+        let p = build_absolute_path(&backend.core.root, path);
         let handle = get_file_handle(&p, false).await?;
         let rp = RpRead::default();
         let stream = OpfsReadStream::new(handle, range);

--- a/core/services/opfs/src/writer.rs
+++ b/core/services/opfs/src/writer.rs
@@ -54,7 +54,7 @@ impl OpfsWriter {
             return Ok(());
         }
 
-        let p = build_abs_path(&self.core.root, &self.path);
+        let p = build_absolute_path(&self.core.root, &self.path);
         let handle = get_file_handle(&p, true).await?;
         let stream: FileSystemWritableFileStream = JsFuture::from(handle.create_writable())
             .await

--- a/core/services/oss/src/core.rs
+++ b/core/services/oss/src/core.rs
@@ -260,7 +260,7 @@ impl OssCore {
         body: Buffer,
         is_presign: bool,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let endpoint = self.get_endpoint(is_presign);
         let url = format!("{}/{}", endpoint, percent_encode_path(&p));
 
@@ -287,7 +287,7 @@ impl OssCore {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let endpoint = self.get_endpoint(false);
         let url = format!(
             "{}/{}?append&position={}",
@@ -318,7 +318,7 @@ impl OssCore {
         range: BytesRange,
         args: &OpRead,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let endpoint = self.get_endpoint(is_presign);
         let mut url = format!("{}/{}", endpoint, percent_encode_path(&p));
 
@@ -377,7 +377,7 @@ impl OssCore {
     }
 
     fn oss_delete_object_request(&self, path: &str, args: &OpDelete) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let endpoint = self.get_endpoint(false);
         let mut url = format!("{}/{}", endpoint, percent_encode_path(&p));
 
@@ -412,7 +412,7 @@ impl OssCore {
         is_presign: bool,
         args: &OpStat,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let endpoint = self.get_endpoint(is_presign);
         let mut url = format!("{}/{}", endpoint, percent_encode_path(&p));
 
@@ -455,7 +455,7 @@ impl OssCore {
         limit: Option<usize>,
         start_after: Option<String>,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let endpoint = self.get_endpoint(false);
         let mut url = QueryPairsWriter::new(endpoint);
@@ -480,7 +480,7 @@ impl OssCore {
 
         // start-after
         if let Some(start_after) = start_after {
-            let start_after = build_abs_path(&self.root, &start_after);
+            let start_after = build_absolute_path(&self.root, &start_after);
             url = url.push("start-after", &percent_encode_path(&start_after));
         }
 
@@ -521,8 +521,8 @@ impl OssCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let source = build_abs_path(&self.root, from);
-        let target = build_abs_path(&self.root, to);
+        let source = build_absolute_path(&self.root, from);
+        let target = build_absolute_path(&self.root, to);
 
         let url = format!(
             "{}/{}",
@@ -569,7 +569,7 @@ impl OssCore {
         key_marker: &str,
         version_id_marker: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, prefix);
+        let p = build_absolute_path(&self.root, prefix);
 
         let mut url = QueryPairsWriter::new(&self.endpoint);
         url = url.push("versions", "");
@@ -624,7 +624,7 @@ impl OssCore {
             object: paths
                 .into_iter()
                 .map(|(path, op)| DeleteObjectsRequestObject {
-                    key: build_abs_path(&self.root, &path),
+                    key: build_absolute_path(&self.root, &path),
                     version_id: op.version().map(|v| v.to_owned()),
                 })
                 .collect(),
@@ -668,7 +668,7 @@ impl OssCore {
         content_encoding: Option<&str>,
         is_presign: bool,
     ) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
         let endpoint = self.get_endpoint(is_presign);
         let url = format!("{}/{}?uploads", endpoint, percent_encode_path(&path));
         let mut req = Request::post(&url);
@@ -707,7 +707,7 @@ impl OssCore {
         size: u64,
         body: Buffer,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let endpoint = self.get_endpoint(is_presign);
 
         let url = format!(
@@ -738,7 +738,7 @@ impl OssCore {
         is_presign: bool,
         parts: Vec<MultipartUploadPart>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let endpoint = self.get_endpoint(is_presign);
         let url = format!(
             "{}/{}?uploadId={}",
@@ -777,7 +777,7 @@ impl OssCore {
         path: &str,
         upload_id: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}?uploadId={}",

--- a/core/services/oss/src/deleter.rs
+++ b/core/services/oss/src/deleter.rs
@@ -87,7 +87,7 @@ impl oio::BatchDelete for OssDeleter {
         };
 
         for i in result.deleted {
-            let path = build_rel_path(&self.core.root, &i.key);
+            let path = build_relative_path(&self.core.root, &i.key);
             let mut op = OpDelete::default();
             if let Some(version) = &i.version_id {
                 op = op.with_version(version);

--- a/core/services/oss/src/lister.rs
+++ b/core/services/oss/src/lister.rs
@@ -93,14 +93,14 @@ impl oio::PageList for OssLister {
 
         for prefix in output.common_prefixes {
             let de = oio::Entry::new(
-                &build_rel_path(&self.core.root, &prefix.prefix),
+                &build_relative_path(&self.core.root, &prefix.prefix),
                 Metadata::new(EntryMode::DIR),
             );
             ctx.entries.push_back(de);
         }
 
         for object in output.contents {
-            let mut path = build_rel_path(&self.core.root, &object.key);
+            let mut path = build_relative_path(&self.core.root, &object.key);
             if path.is_empty() {
                 path = "/".to_string();
             }
@@ -140,7 +140,7 @@ impl OssObjectVersionsLister {
         let delimiter = if args.recursive() { "" } else { "/" };
         let abs_start_after = args
             .start_after()
-            .map(|start_after| build_abs_path(&core.root, start_after));
+            .map(|start_after| build_absolute_path(&core.root, start_after));
 
         Self {
             core,
@@ -202,7 +202,7 @@ impl oio::PageList for OssObjectVersionsLister {
 
         for prefix in output.common_prefixes {
             let de = oio::Entry::new(
-                &build_rel_path(&self.core.root, &prefix.prefix),
+                &build_relative_path(&self.core.root, &prefix.prefix),
                 Metadata::new(EntryMode::DIR),
             );
             ctx.entries.push_back(de);
@@ -217,7 +217,7 @@ impl oio::PageList for OssObjectVersionsLister {
                 continue;
             }
 
-            let mut path = build_rel_path(&self.core.root, &version_object.key);
+            let mut path = build_relative_path(&self.core.root, &version_object.key);
             if path.is_empty() {
                 path = "/".to_owned();
             }
@@ -238,7 +238,7 @@ impl oio::PageList for OssObjectVersionsLister {
 
         if self.args.deleted() {
             for delete_marker in output.delete_marker {
-                let mut path = build_rel_path(&self.core.root, &delete_marker.key);
+                let mut path = build_relative_path(&self.core.root, &delete_marker.key);
                 if path.is_empty() {
                     path = "/".to_owned();
                 }

--- a/core/services/pcloud/src/core.rs
+++ b/core/services/pcloud/src/core.rs
@@ -64,7 +64,7 @@ impl PcloudCore {
 
 impl PcloudCore {
     pub async fn get_file_link(&self, ctx: &OperationContext, path: &str) -> Result<String> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/getfilelink?path=/{}&username={}&password={}",
@@ -132,7 +132,7 @@ impl PcloudCore {
     }
 
     pub async fn ensure_dir_exists(&self, ctx: &OperationContext, path: &str) -> Result<()> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let paths = path.split('/').collect::<Vec<&str>>();
 
@@ -196,8 +196,8 @@ impl PcloudCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_abs_path(&self.root, to);
+        let from = build_absolute_path(&self.root, from);
+        let to = build_absolute_path(&self.root, to);
 
         let url = format!(
             "{}/renamefile?path=/{}&topath=/{}&username={}&password={}",
@@ -226,8 +226,8 @@ impl PcloudCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_abs_path(&self.root, to);
+        let from = build_absolute_path(&self.root, from);
+        let to = build_absolute_path(&self.root, to);
         let url = format!(
             "{}/renamefolder?path=/{}&topath=/{}&username={}&password={}",
             self.endpoint,
@@ -254,7 +254,7 @@ impl PcloudCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/deletefolder?path=/{}&username={}&password={}",
@@ -281,7 +281,7 @@ impl PcloudCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/deletefile?path=/{}&username={}&password={}",
@@ -309,8 +309,8 @@ impl PcloudCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_abs_path(&self.root, to);
+        let from = build_absolute_path(&self.root, from);
+        let to = build_absolute_path(&self.root, to);
 
         let url = format!(
             "{}/copyfile?path=/{}&topath=/{}&username={}&password={}",
@@ -339,8 +339,8 @@ impl PcloudCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_abs_path(&self.root, to);
+        let from = build_absolute_path(&self.root, from);
+        let to = build_absolute_path(&self.root, to);
 
         let url = format!(
             "{}/copyfolder?path=/{}&topath=/{}&username={}&password={}",
@@ -364,7 +364,7 @@ impl PcloudCore {
     }
 
     pub async fn stat(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let path = path.trim_end_matches('/');
 
@@ -394,7 +394,7 @@ impl PcloudCore {
         path: &str,
         bs: Buffer,
     ) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let (name, path) = (get_basename(&path), get_parent(&path).trim_end_matches('/'));
 
@@ -424,7 +424,7 @@ impl PcloudCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let path = normalize_root(&path);
 

--- a/core/services/pcloud/src/lister.rs
+++ b/core/services/pcloud/src/lister.rs
@@ -75,7 +75,7 @@ impl oio::PageList for PcloudLister {
                             };
 
                             let md = parse_list_metadata(content)?;
-                            let path = build_rel_path(&self.core.root, &path);
+                            let path = build_relative_path(&self.core.root, &path);
 
                             ctx.entries.push_back(oio::Entry::new(&path, md))
                         }

--- a/core/services/persy/src/backend.rs
+++ b/core/services/persy/src/backend.rs
@@ -177,9 +177,9 @@ impl Service for PersyBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p)?;
@@ -205,7 +205,7 @@ impl Service for PersyBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: PersyWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(PersyWriter::new(self.core.clone(), p))
         }?;
 

--- a/core/services/persy/src/deleter.rs
+++ b/core/services/persy/src/deleter.rs
@@ -35,7 +35,7 @@ impl PersyDeleter {
 
 impl oio::OneShotDelete for PersyDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p)?;
         Ok(())
     }

--- a/core/services/persy/src/reader.rs
+++ b/core/services/persy/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for PersyReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
         let bs = match backend.core.get(&p)? {
             Some(bs) => bs,
             None => {

--- a/core/services/postgresql/src/backend.rs
+++ b/core/services/postgresql/src/backend.rs
@@ -209,9 +209,9 @@ impl Service for PostgresqlBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p).await?;
@@ -240,7 +240,7 @@ impl Service for PostgresqlBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: PostgresqlWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(PostgresqlWriter::new(self.core.clone(), p))
         }?;
 

--- a/core/services/postgresql/src/deleter.rs
+++ b/core/services/postgresql/src/deleter.rs
@@ -35,7 +35,7 @@ impl PostgresqlDeleter {
 
 impl oio::OneShotDelete for PostgresqlDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p).await?;
         Ok(())
     }

--- a/core/services/postgresql/src/reader.rs
+++ b/core/services/postgresql/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for PostgresqlReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
         let bs = match backend.core.get(&p).await? {
             Some(bs) => bs,
             None => {

--- a/core/services/redb/src/backend.rs
+++ b/core/services/redb/src/backend.rs
@@ -195,9 +195,9 @@ impl Service for RedbBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p)?;
@@ -223,7 +223,7 @@ impl Service for RedbBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: RedbWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(RedbWriter::new(self.core.clone(), p))
         }?;
 

--- a/core/services/redb/src/deleter.rs
+++ b/core/services/redb/src/deleter.rs
@@ -35,7 +35,7 @@ impl RedbDeleter {
 
 impl oio::OneShotDelete for RedbDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p)?;
         Ok(())
     }

--- a/core/services/redb/src/reader.rs
+++ b/core/services/redb/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for RedbReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
         let bs = match backend.core.get(&p)? {
             Some(bs) => bs,
             None => {

--- a/core/services/redis/src/backend.rs
+++ b/core/services/redis/src/backend.rs
@@ -335,9 +335,9 @@ impl Service for RedisBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p).await?;
@@ -363,7 +363,7 @@ impl Service for RedisBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: RedisWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(RedisWriter::new(self.core.clone(), p))
         }?;
 

--- a/core/services/redis/src/deleter.rs
+++ b/core/services/redis/src/deleter.rs
@@ -35,7 +35,7 @@ impl RedisDeleter {
 
 impl oio::OneShotDelete for RedisDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p).await?;
         Ok(())
     }

--- a/core/services/redis/src/reader.rs
+++ b/core/services/redis/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for RedisReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
 
         let (buffer, metadata) = if range.is_full() {
             // Full read - use GET

--- a/core/services/rocksdb/src/backend.rs
+++ b/core/services/rocksdb/src/backend.rs
@@ -145,9 +145,9 @@ impl Service for RocksdbBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p)?;
@@ -173,7 +173,7 @@ impl Service for RocksdbBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: RocksdbWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             let writer = RocksdbWriter::new(self.core.clone(), p);
             Ok(writer)
         }?;
@@ -192,7 +192,7 @@ impl Service for RocksdbBackend {
 
     fn list(&self, _ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         let output: oio::HierarchyLister<RocksdbLister> = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             let lister = RocksdbLister::new(self.core.clone(), self.root.clone(), p)?;
             Ok(oio::HierarchyLister::new(lister, path, args.recursive()))
         }?;

--- a/core/services/rocksdb/src/deleter.rs
+++ b/core/services/rocksdb/src/deleter.rs
@@ -35,7 +35,7 @@ impl RocksdbDeleter {
 
 impl oio::OneShotDelete for RocksdbDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p)?;
         Ok(())
     }

--- a/core/services/rocksdb/src/lister.rs
+++ b/core/services/rocksdb/src/lister.rs
@@ -42,7 +42,7 @@ impl RocksdbLister {
 impl oio::List for RocksdbLister {
     async fn next(&mut self) -> Result<Option<oio::Entry>> {
         if let Some((key, value_len)) = self.iter.next() {
-            let path = build_rel_path(&self.root, &key);
+            let path = build_relative_path(&self.root, &key);
 
             // Determine if it's a file or directory based on trailing slash
             let mode = if key.ends_with('/') {

--- a/core/services/rocksdb/src/reader.rs
+++ b/core/services/rocksdb/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for RocksdbReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
         let bs = match backend.core.get(&p)? {
             Some(bs) => bs,
             None => {

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -389,7 +389,7 @@ impl S3Core {
 
 impl S3Core {
     pub fn s3_head_object_request(&self, path: &str, args: OpStat) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
@@ -464,7 +464,7 @@ impl S3Core {
         range: BytesRange,
         args: &OpRead,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         // Construct headers to add to the request
         let mut url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
@@ -560,7 +560,7 @@ impl S3Core {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
@@ -599,7 +599,7 @@ impl S3Core {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
         let mut req = Request::put(&url);
 
@@ -652,7 +652,7 @@ impl S3Core {
         path: &str,
         args: &OpDelete,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!("{}/{}", self.endpoint, percent_encode_path(&p));
 
@@ -692,8 +692,8 @@ impl S3Core {
         to: &str,
         args: &OpCopy,
     ) -> Result<Response<Buffer>> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_abs_path(&self.root, to);
+        let from = build_absolute_path(&self.root, from);
+        let to = build_absolute_path(&self.root, to);
 
         let source = format!("{}/{}", self.bucket, percent_encode_path(&from));
         let source = if let Some(version) = args.source_version() {
@@ -779,7 +779,7 @@ impl S3Core {
         delimiter: &str,
         limit: Option<usize>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = QueryPairsWriter::new(&self.endpoint);
 
@@ -820,7 +820,7 @@ impl S3Core {
         limit: Option<usize>,
         start_after: Option<String>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = QueryPairsWriter::new(&self.endpoint);
         url = url.push("list-type", "2");
@@ -869,7 +869,7 @@ impl S3Core {
         path: &str,
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}?uploads", self.endpoint, percent_encode_path(&p));
 
@@ -941,7 +941,7 @@ impl S3Core {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!("{}/{}?uploads", self.endpoint, percent_encode_path(&p));
 
@@ -976,8 +976,8 @@ impl S3Core {
         &self,
         input: S3UploadPartCopyRequest<'_>,
     ) -> Result<Request<Buffer>> {
-        let from = build_abs_path(&self.root, input.from);
-        let to = build_abs_path(&self.root, input.to);
+        let from = build_absolute_path(&self.root, input.from);
+        let to = build_absolute_path(&self.root, input.to);
 
         let source = format!("{}/{}", self.bucket, percent_encode_path(&from));
         let source = if let Some(version) = input.source_version {
@@ -1063,7 +1063,7 @@ impl S3Core {
         body: Buffer,
         checksum: Option<String>,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}?partNumber={}&uploadId={}",
@@ -1107,7 +1107,7 @@ impl S3Core {
         parts: Vec<CompleteMultipartUploadRequestPart>,
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}?uploadId={}",
@@ -1159,7 +1159,7 @@ impl S3Core {
         parts: Vec<CompleteMultipartUploadRequestPart>,
         args: &OpCopy,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}?uploadId={}",
@@ -1206,7 +1206,7 @@ impl S3Core {
         path: &str,
         upload_id: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}?uploadId={}",
@@ -1237,7 +1237,7 @@ impl S3Core {
         path: &str,
         upload_id: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}?uploadId={}",
@@ -1274,7 +1274,7 @@ impl S3Core {
             object: paths
                 .iter()
                 .map(|(path, op)| DeleteObjectsRequestObject {
-                    key: build_abs_path(&self.root, path),
+                    key: build_absolute_path(&self.root, path),
                     version_id: op.version().map(|v| v.to_owned()),
                 })
                 .collect(),
@@ -1312,7 +1312,7 @@ impl S3Core {
         key_marker: &str,
         version_id_marker: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, prefix);
+        let p = build_absolute_path(&self.root, prefix);
 
         let mut url = format!("{}?versions", self.endpoint);
         if !p.is_empty() {

--- a/core/services/s3/src/deleter.rs
+++ b/core/services/s3/src/deleter.rs
@@ -81,7 +81,7 @@ impl oio::BatchDelete for S3Deleter {
             failed: Vec::with_capacity(errors.len()),
         };
         for (path, op) in batch {
-            let abs_path = build_abs_path(&self.core.root, &path);
+            let abs_path = build_absolute_path(&self.core.root, &path);
             // Assume errors are rare, so lookup and erase is acceptable.
             if let Some(idx) = errors
                 .iter()

--- a/core/services/s3/src/lister.rs
+++ b/core/services/s3/src/lister.rs
@@ -56,7 +56,7 @@ impl S3ListerV1 {
         let delimiter = if args.recursive() { "" } else { "/" };
         let first_marker = args
             .start_after()
-            .map(|start_after| build_abs_path(&core.root, start_after))
+            .map(|start_after| build_absolute_path(&core.root, start_after))
             .unwrap_or_default();
 
         Self {
@@ -129,7 +129,7 @@ impl oio::PageList for S3ListerV1 {
 
         for prefix in output.common_prefixes {
             let de = oio::Entry::new(
-                &build_rel_path(&self.core.root, &prefix.prefix),
+                &build_relative_path(&self.core.root, &prefix.prefix),
                 Metadata::new(EntryMode::DIR),
             );
 
@@ -137,7 +137,7 @@ impl oio::PageList for S3ListerV1 {
         }
 
         for object in output.contents {
-            let mut path = build_rel_path(&self.core.root, &object.key);
+            let mut path = build_relative_path(&self.core.root, &object.key);
             if path.is_empty() {
                 path = "/".to_string();
             }
@@ -178,7 +178,7 @@ impl S3ListerV2 {
         let delimiter = if args.recursive() { "" } else { "/" };
         let abs_start_after = args
             .start_after()
-            .map(|start_after| build_abs_path(&core.root, start_after));
+            .map(|start_after| build_absolute_path(&core.root, start_after));
 
         Self {
             core,
@@ -241,7 +241,7 @@ impl oio::PageList for S3ListerV2 {
 
         for prefix in output.common_prefixes {
             let de = oio::Entry::new(
-                &build_rel_path(&self.core.root, &prefix.prefix),
+                &build_relative_path(&self.core.root, &prefix.prefix),
                 Metadata::new(EntryMode::DIR),
             );
 
@@ -249,7 +249,7 @@ impl oio::PageList for S3ListerV2 {
         }
 
         for object in output.contents {
-            let mut path = build_rel_path(&self.core.root, &object.key);
+            let mut path = build_relative_path(&self.core.root, &object.key);
             if path.is_empty() {
                 path = "/".to_string();
             }
@@ -290,7 +290,7 @@ impl S3ObjectVersionsLister {
         let delimiter = if args.recursive() { "" } else { "/" };
         let abs_start_after = args
             .start_after()
-            .map(|start_after| build_abs_path(&core.root, start_after));
+            .map(|start_after| build_absolute_path(&core.root, start_after));
 
         Self {
             core,
@@ -352,7 +352,7 @@ impl oio::PageList for S3ObjectVersionsLister {
 
         for prefix in output.common_prefixes {
             let de = oio::Entry::new(
-                &build_rel_path(&self.core.root, &prefix.prefix),
+                &build_relative_path(&self.core.root, &prefix.prefix),
                 Metadata::new(EntryMode::DIR),
             );
             ctx.entries.push_back(de);
@@ -367,7 +367,7 @@ impl oio::PageList for S3ObjectVersionsLister {
                 continue;
             }
 
-            let mut path = build_rel_path(&self.core.root, &version_object.key);
+            let mut path = build_relative_path(&self.core.root, &version_object.key);
             if path.is_empty() {
                 path = "/".to_owned();
             }
@@ -388,7 +388,7 @@ impl oio::PageList for S3ObjectVersionsLister {
 
         if self.args.deleted() {
             for delete_marker in output.delete_marker {
-                let mut path = build_rel_path(&self.core.root, &delete_marker.key);
+                let mut path = build_relative_path(&self.core.root, &delete_marker.key);
                 if path.is_empty() {
                     path = "/".to_owned();
                 }

--- a/core/services/seafile/src/core.rs
+++ b/core/services/seafile/src/core.rs
@@ -202,10 +202,10 @@ impl SeafileCore {
             .extension(ServiceOperation("UploadFile"));
 
         let (filename, relative_path) = if path.ends_with('/') {
-            ("", build_abs_path(&self.root, path))
+            ("", build_absolute_path(&self.root, path))
         } else {
             let (filename, relative_path) = (get_basename(path), get_parent(path));
-            (filename, build_abs_path(&self.root, relative_path))
+            (filename, build_absolute_path(&self.root, relative_path))
         };
 
         let file_part = FormDataPart::new("file")
@@ -233,7 +233,7 @@ impl SeafileCore {
             return Ok(());
         }
 
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
         let path = percent_encode_path(path.trim_end_matches('/'));
 
         let auth_info = self.get_auth_info(ctx).await?;
@@ -262,7 +262,7 @@ impl SeafileCore {
 
     /// get download
     async fn get_download_url(&self, ctx: &OperationContext, path: &str) -> Result<String> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
         let path = percent_encode_path(&path);
 
         let auth_info = self.get_auth_info(ctx).await?;
@@ -317,7 +317,7 @@ impl SeafileCore {
 
     /// file detail
     pub async fn file_detail(&self, ctx: &OperationContext, path: &str) -> Result<FileDetail> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
         let path = percent_encode_path(&path);
 
         let auth_info = self.get_auth_info(ctx).await?;
@@ -350,7 +350,7 @@ impl SeafileCore {
 
     /// dir detail
     pub async fn dir_detail(&self, ctx: &OperationContext, path: &str) -> Result<DirDetail> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
         let path = percent_encode_path(&path);
 
         let auth_info = self.get_auth_info(ctx).await?;
@@ -383,7 +383,7 @@ impl SeafileCore {
 
     /// delete file or dir
     pub async fn delete(&self, ctx: &OperationContext, path: &str) -> Result<()> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
         let path = percent_encode_path(&path);
 
         let auth_info = self.get_auth_info(ctx).await?;
@@ -420,7 +420,7 @@ impl SeafileCore {
     }
 
     pub async fn list(&self, ctx: &OperationContext, path: &str) -> Result<ListResponse> {
-        let rooted_abs_path = build_rooted_abs_path(&self.root, path);
+        let rooted_abs_path = build_rooted_absolute_path(&self.root, path);
 
         let auth_info = self.get_auth_info(ctx).await?;
 

--- a/core/services/seafile/src/lister.rs
+++ b/core/services/seafile/src/lister.rs
@@ -52,7 +52,7 @@ impl oio::PageList for SeafileLister {
 
                 for info in infos {
                     if !info.name.is_empty() {
-                        let rel_path = build_rel_path(
+                        let rel_path = build_relative_path(
                             &self.core.root,
                             &format!("{}{}", list_response.rooted_abs_path, info.name),
                         );

--- a/core/services/sled/src/backend.rs
+++ b/core/services/sled/src/backend.rs
@@ -169,9 +169,9 @@ impl Service for SledBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p)?;
@@ -197,7 +197,7 @@ impl Service for SledBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: SledWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             let writer = SledWriter::new(self.core.clone(), p);
             Ok(writer)
         }?;
@@ -216,7 +216,7 @@ impl Service for SledBackend {
 
     fn list(&self, _ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
         let output: oio::HierarchyLister<SledLister> = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             let lister = SledLister::new(self.core.clone(), self.root.clone(), p)?;
             Ok(oio::HierarchyLister::new(lister, path, args.recursive()))
         }?;

--- a/core/services/sled/src/deleter.rs
+++ b/core/services/sled/src/deleter.rs
@@ -35,7 +35,7 @@ impl SledDeleter {
 
 impl oio::OneShotDelete for SledDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p)?;
         Ok(())
     }

--- a/core/services/sled/src/lister.rs
+++ b/core/services/sled/src/lister.rs
@@ -42,7 +42,7 @@ impl SledLister {
 impl oio::List for SledLister {
     async fn next(&mut self) -> Result<Option<oio::Entry>> {
         if let Some((key, value_len)) = self.iter.next() {
-            let path = build_rel_path(&self.root, &key);
+            let path = build_relative_path(&self.root, &key);
 
             // Determine if it's a file or directory based on trailing slash
             let mode = if key.ends_with('/') {

--- a/core/services/sled/src/reader.rs
+++ b/core/services/sled/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for SledReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
         let bs = match backend.core.get(&p)? {
             Some(bs) => bs,
             None => {

--- a/core/services/sqlite/src/backend.rs
+++ b/core/services/sqlite/src/backend.rs
@@ -223,9 +223,9 @@ impl Service for SqliteBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p).await?;
@@ -273,7 +273,7 @@ impl Service for SqliteBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: SqliteWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(SqliteWriter::new(self.core.clone(), &p))
         }?;
 
@@ -297,7 +297,7 @@ impl Service for SqliteBackend {
         path: &str,
         _: OpCreateDir,
     ) -> Result<RpCreateDir> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         // Ensure path ends with '/' for directory marker
         let dir_path = if p.ends_with('/') {

--- a/core/services/sqlite/src/deleter.rs
+++ b/core/services/sqlite/src/deleter.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use opendal_core::raw::{OpDelete, build_abs_path, oio};
+use opendal_core::raw::{OpDelete, build_absolute_path, oio};
 
 use super::core::SqliteCore;
 
@@ -32,7 +32,7 @@ impl SqliteDeleter {
 
 impl oio::OneShotDelete for SqliteDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> opendal_core::Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p).await?;
         Ok(())
     }

--- a/core/services/sqlite/src/reader.rs
+++ b/core/services/sqlite/src/reader.rs
@@ -39,7 +39,7 @@ impl oio::StreamRead for SqliteReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
 
         let (buffer, content_length) = if range.is_full() {
             // Full read - use GET

--- a/core/services/surrealdb/src/backend.rs
+++ b/core/services/surrealdb/src/backend.rs
@@ -263,9 +263,9 @@ impl Service for SurrealdbBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p).await?;
@@ -291,7 +291,7 @@ impl Service for SurrealdbBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: SurrealdbWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(SurrealdbWriter::new(self.core.clone(), p))
         }?;
 

--- a/core/services/surrealdb/src/deleter.rs
+++ b/core/services/surrealdb/src/deleter.rs
@@ -35,7 +35,7 @@ impl SurrealdbDeleter {
 
 impl oio::OneShotDelete for SurrealdbDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p).await?;
         Ok(())
     }

--- a/core/services/surrealdb/src/reader.rs
+++ b/core/services/surrealdb/src/reader.rs
@@ -38,7 +38,7 @@ impl oio::StreamRead for SurrealdbReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
         let bs = match backend.core.get(&p).await? {
             Some(bs) => bs,
             None => {

--- a/core/services/swift/src/core.rs
+++ b/core/services/swift/src/core.rs
@@ -130,7 +130,7 @@ impl SwiftCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}/{}",
@@ -176,7 +176,7 @@ impl SwiftCore {
         let body_str: String = paths
             .iter()
             .map(|(path, _)| {
-                let abs = build_abs_path(&self.root, path);
+                let abs = build_absolute_path(&self.root, path);
                 format!("{}/{}", &self.container, percent_encode_path(&abs))
             })
             .collect::<Vec<_>>()
@@ -201,7 +201,7 @@ impl SwiftCore {
         limit: Option<usize>,
         marker: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         // The delimiter is used to disable recursive listing.
         // Swift returns a 200 status code when there is no such pseudo directory in prefix.
@@ -238,7 +238,7 @@ impl SwiftCore {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let url = format!(
             "{}/{}/{}",
             &self.endpoint,
@@ -287,7 +287,7 @@ impl SwiftCore {
         range: BytesRange,
         args: &OpRead,
     ) -> Result<Response<HttpBody>> {
-        let p = build_abs_path(&self.root, path)
+        let p = build_absolute_path(&self.root, path)
             .trim_end_matches('/')
             .to_string();
 
@@ -339,10 +339,10 @@ impl SwiftCore {
         let src_p = format!(
             "/{}/{}",
             self.container,
-            build_abs_path(&self.root, src_p).trim_end_matches('/')
+            build_absolute_path(&self.root, src_p).trim_end_matches('/')
         );
 
-        let dst_p = build_abs_path(&self.root, dst_p)
+        let dst_p = build_absolute_path(&self.root, dst_p)
             .trim_end_matches('/')
             .to_string();
 
@@ -380,7 +380,7 @@ impl SwiftCore {
         path: &str,
         args: &OpStat,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "{}/{}/{}",
@@ -419,7 +419,7 @@ impl SwiftCore {
     ///
     /// Segments are stored as: `.segments/{object_path}/{upload_id}/{part_number:08}`
     pub fn slo_segment_path(&self, path: &str, upload_id: &str, part_number: usize) -> String {
-        let abs = build_abs_path(&self.root, path);
+        let abs = build_absolute_path(&self.root, path);
         format!(
             ".segments/{}{}/{:08}",
             abs.trim_end_matches('/'),
@@ -474,7 +474,7 @@ impl SwiftCore {
         manifest: &[SloManifestEntry],
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let abs = build_abs_path(&self.root, path);
+        let abs = build_absolute_path(&self.root, path);
         let url = format!(
             "{}/{}/{}?multipart-manifest=put",
             &self.endpoint,
@@ -520,7 +520,7 @@ impl SwiftCore {
         // List segments under the upload_id prefix and delete them individually.
         // We can't use multipart-manifest=delete because we haven't created
         // the manifest yet (abort happens before complete).
-        let abs = build_abs_path(&self.root, path);
+        let abs = build_absolute_path(&self.root, path);
         let prefix = format!(".segments/{}{}/", abs.trim_end_matches('/'), upload_id);
 
         // List all segments with this prefix.
@@ -587,7 +587,7 @@ impl SwiftCore {
             ));
         }
 
-        let abs = build_abs_path(&self.root, path);
+        let abs = build_absolute_path(&self.root, path);
 
         // Extract the path portion from the endpoint URL for signing.
         // The endpoint is like "https://host:port/v1/AUTH_account".

--- a/core/services/swift/src/deleter.rs
+++ b/core/services/swift/src/deleter.rs
@@ -72,7 +72,7 @@ impl oio::BatchDelete for SwiftDeleter {
             // Check if this path appears in the errors list.
             // The error paths from Swift include the container prefix, so we need
             // to reconstruct the full path for comparison.
-            let abs = build_abs_path(&self.core.root, &path);
+            let abs = build_absolute_path(&self.core.root, &path);
             let full_path = format!("{}/{}", &self.core.container, abs);
 
             if let Some(error_entry) = result.errors.iter().find(|e| {

--- a/core/services/swift/src/lister.rs
+++ b/core/services/swift/src/lister.rs
@@ -89,7 +89,7 @@ impl oio::PageList for SwiftLister {
         for status in decoded_response {
             let entry: oio::Entry = match status {
                 ListOpResponse::Subdir { subdir } => {
-                    let mut path = build_rel_path(self.core.root.as_str(), subdir.as_str());
+                    let mut path = build_relative_path(self.core.root.as_str(), subdir.as_str());
                     if path.is_empty() {
                         path = "/".to_string();
                     }
@@ -103,7 +103,7 @@ impl oio::PageList for SwiftLister {
                     content_type,
                     mut last_modified,
                 } => {
-                    let mut path = build_rel_path(self.core.root.as_str(), name.as_str());
+                    let mut path = build_relative_path(self.core.root.as_str(), name.as_str());
                     if path.is_empty() {
                         path = "/".to_string();
                     }

--- a/core/services/tikv/src/backend.rs
+++ b/core/services/tikv/src/backend.rs
@@ -171,9 +171,9 @@ impl Service for TikvBackend {
     }
 
     async fn stat(&self, _ctx: &OperationContext, path: &str, _: OpStat) -> Result<RpStat> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
-        if p == build_abs_path(&self.root, "") {
+        if p == build_absolute_path(&self.root, "") {
             Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
         } else {
             let bs = self.core.get(&p).await?;
@@ -199,7 +199,7 @@ impl Service for TikvBackend {
 
     fn write(&self, _ctx: &OperationContext, path: &str, _: OpWrite) -> Result<Self::Writer> {
         let output: TikvWriter = {
-            let p = build_abs_path(&self.root, path);
+            let p = build_absolute_path(&self.root, path);
             Ok(TikvWriter::new(self.core.clone(), p))
         }?;
 

--- a/core/services/tikv/src/deleter.rs
+++ b/core/services/tikv/src/deleter.rs
@@ -35,7 +35,7 @@ impl TikvDeleter {
 
 impl oio::OneShotDelete for TikvDeleter {
     async fn delete_once(&self, path: String, _: OpDelete) -> Result<()> {
-        let p = build_abs_path(&self.root, &path);
+        let p = build_absolute_path(&self.root, &path);
         self.core.delete(&p).await?;
         Ok(())
     }

--- a/core/services/tikv/src/reader.rs
+++ b/core/services/tikv/src/reader.rs
@@ -39,7 +39,7 @@ impl oio::StreamRead for TikvReader {
     async fn open(&self, range: BytesRange) -> Result<(RpRead, Box<dyn oio::ReadStreamDyn>)> {
         let backend = &self.backend;
         let path = self.path.as_str();
-        let p = build_abs_path(&backend.root, path);
+        let p = build_absolute_path(&backend.root, path);
         let bs = match backend.core.get(&p).await? {
             Some(bs) => bs,
             None => return Err(Error::new(ErrorKind::NotFound, "kv not found in tikv")),

--- a/core/services/tos/src/core.rs
+++ b/core/services/tos/src/core.rs
@@ -210,7 +210,7 @@ impl TosCore {
         range: BytesRange,
         args: &OpRead,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!(
             "https://{}.{}/{}",
@@ -307,7 +307,7 @@ impl TosCore {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://{}.{}/{}",
@@ -330,7 +330,7 @@ impl TosCore {
     }
 
     pub fn tos_head_object_request(&self, path: &str, args: OpStat) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!(
             "https://{}.{}/{}",
@@ -419,7 +419,7 @@ impl TosCore {
         path: &str,
         args: &OpDelete,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!(
             "https://{}.{}/{}",
@@ -466,7 +466,7 @@ impl TosCore {
             objects: paths
                 .iter()
                 .map(|(path, op)| DeleteObjectsRequestObject {
-                    key: build_abs_path(&self.root, path),
+                    key: build_absolute_path(&self.root, path),
                     version_id: op.version().map(|v| v.to_owned()),
                 })
                 .collect(),
@@ -496,8 +496,8 @@ impl TosCore {
         to: &str,
         args: &OpCopy,
     ) -> Result<Response<Buffer>> {
-        let source = build_abs_path(&self.root, from);
-        let target = build_abs_path(&self.root, to);
+        let source = build_absolute_path(&self.root, from);
+        let target = build_absolute_path(&self.root, to);
 
         let url = format!(
             "https://{}.{}/{}",
@@ -529,7 +529,7 @@ impl TosCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://{}.{}/{}?uploads",
@@ -560,8 +560,8 @@ impl TosCore {
         &self,
         input: TosUploadPartCopyRequest<'_>,
     ) -> Result<Request<Buffer>> {
-        let source = build_abs_path(&self.root, input.from);
-        let target = build_abs_path(&self.root, input.to);
+        let source = build_absolute_path(&self.root, input.from);
+        let target = build_absolute_path(&self.root, input.to);
 
         let url = format!(
             "https://{}.{}/{}?partNumber={}&uploadId={}",
@@ -592,7 +592,7 @@ impl TosCore {
         parts: Vec<CompleteMultipartUploadRequestPart>,
         args: &OpCopy,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://{}.{}/{}?uploadId={}",
@@ -628,7 +628,7 @@ impl TosCore {
         path: &str,
         upload_id: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://{}.{}/{}?uploadId={}",
@@ -656,7 +656,7 @@ impl TosCore {
         limit: Option<usize>,
         start_after: Option<String>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url =
             QueryPairsWriter::new(&format!("https://{}.{}", self.bucket, self.endpoint_domain));
@@ -673,7 +673,7 @@ impl TosCore {
         }
         if let Some(start_after) = start_after {
             if path.is_empty() || path == "/" || start_after.starts_with(path) {
-                let start_after = build_abs_path(&self.root, &start_after);
+                let start_after = build_absolute_path(&self.root, &start_after);
                 url = url.push("start-after", &percent_encode_query(&start_after));
             }
         }
@@ -702,7 +702,7 @@ impl TosCore {
         key_marker: &str,
         version_id_marker: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, prefix);
+        let p = build_absolute_path(&self.root, prefix);
 
         let mut url =
             QueryPairsWriter::new(&format!("https://{}.{}", self.bucket, self.endpoint_domain));
@@ -742,7 +742,7 @@ impl TosCore {
         path: &str,
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://{}.{}/{}?uploads",
@@ -799,7 +799,7 @@ impl TosCore {
         size: u64,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://{}.{}/{}?partNumber={}&uploadId={}",
@@ -828,7 +828,7 @@ impl TosCore {
         parts: Vec<CompleteMultipartUploadRequestPart>,
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://{}.{}/{}?uploadId={}",
@@ -867,7 +867,7 @@ impl TosCore {
         path: &str,
         upload_id: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://{}.{}/{}?uploadId={}",

--- a/core/services/tos/src/deleter.rs
+++ b/core/services/tos/src/deleter.rs
@@ -74,7 +74,7 @@ impl oio::BatchDelete for TosDeleter {
             failed: Vec::with_capacity(errors.len()),
         };
         for (path, op) in batch {
-            let abs_path = build_abs_path(&self.core.root, &path);
+            let abs_path = build_absolute_path(&self.core.root, &path);
             if let Some(idx) = errors
                 .iter()
                 .position(|e| e.key == abs_path && e.version_id.as_deref() == op.version())

--- a/core/services/tos/src/lister.rs
+++ b/core/services/tos/src/lister.rs
@@ -89,7 +89,7 @@ impl oio::PageList for TosLister {
 
         for prefix in output.common_prefixes {
             let de = oio::Entry::new(
-                &build_rel_path(&self.core.root, &prefix.prefix),
+                &build_relative_path(&self.core.root, &prefix.prefix),
                 Metadata::new(EntryMode::DIR),
             );
 
@@ -97,7 +97,7 @@ impl oio::PageList for TosLister {
         }
 
         for object in output.contents {
-            let mut path = build_rel_path(&self.core.root, &object.key);
+            let mut path = build_relative_path(&self.core.root, &object.key);
             if path.is_empty() {
                 path = "/".to_string();
             }
@@ -135,7 +135,7 @@ impl TosObjectVersionsLister {
         let delimiter = if args.recursive() { "" } else { "/" };
         let abs_start_after = args
             .start_after()
-            .map(|start_after| build_abs_path(&core.root, start_after));
+            .map(|start_after| build_absolute_path(&core.root, start_after));
 
         Self {
             core,
@@ -192,7 +192,7 @@ impl oio::PageList for TosObjectVersionsLister {
 
         for prefix in output.common_prefixes {
             let de = oio::Entry::new(
-                &build_rel_path(&self.core.root, &prefix.prefix),
+                &build_relative_path(&self.core.root, &prefix.prefix),
                 Metadata::new(EntryMode::DIR),
             );
 
@@ -204,7 +204,7 @@ impl oio::PageList for TosObjectVersionsLister {
                 continue;
             }
 
-            let mut path = build_rel_path(&self.core.root, &version_object.key);
+            let mut path = build_relative_path(&self.core.root, &version_object.key);
             if path.is_empty() {
                 path = "/".to_string();
             }
@@ -226,7 +226,7 @@ impl oio::PageList for TosObjectVersionsLister {
 
         if self.args.deleted() {
             for delete_marker in output.delete_markers {
-                let mut path = build_rel_path(&self.core.root, &delete_marker.key);
+                let mut path = build_relative_path(&self.core.root, &delete_marker.key);
                 if path.is_empty() {
                     path = "/".to_string();
                 }

--- a/core/services/upyun/src/core.rs
+++ b/core/services/upyun/src/core.rs
@@ -110,7 +110,7 @@ impl UpyunCore {
         path: &str,
         range: BytesRange,
     ) -> Result<Response<HttpBody>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://v0.api.upyun.com/{}/{}",
@@ -133,7 +133,7 @@ impl UpyunCore {
     }
 
     pub async fn info(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://v0.api.upyun.com/{}/{}",
@@ -161,7 +161,7 @@ impl UpyunCore {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://v0.api.upyun.com/{}/{}",
@@ -200,7 +200,7 @@ impl UpyunCore {
     }
 
     pub async fn delete(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://v0.api.upyun.com/{}/{}",
@@ -227,8 +227,8 @@ impl UpyunCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let from = format!("/{}/{}", self.bucket, build_abs_path(&self.root, from));
-        let to = build_abs_path(&self.root, to);
+        let from = format!("/{}/{}", self.bucket, build_absolute_path(&self.root, from));
+        let to = build_absolute_path(&self.root, to);
 
         let url = format!(
             "https://v0.api.upyun.com/{}/{}",
@@ -262,8 +262,8 @@ impl UpyunCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let from = format!("/{}/{}", self.bucket, build_abs_path(&self.root, from));
-        let to = build_abs_path(&self.root, to);
+        let from = format!("/{}/{}", self.bucket, build_absolute_path(&self.root, from));
+        let to = build_absolute_path(&self.root, to);
 
         let url = format!(
             "https://v0.api.upyun.com/{}/{}",
@@ -292,7 +292,7 @@ impl UpyunCore {
     }
 
     pub async fn create_dir(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
         let path = path[..path.len() - 1].to_string();
 
         let url = format!(
@@ -324,7 +324,7 @@ impl UpyunCore {
         path: &str,
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://v0.api.upyun.com/{}/{}",
@@ -369,7 +369,7 @@ impl UpyunCore {
         size: u64,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://v0.api.upyun.com/{}/{}",
@@ -405,7 +405,7 @@ impl UpyunCore {
         path: &str,
         upload_id: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://v0.api.upyun.com/{}/{}",
@@ -437,7 +437,7 @@ impl UpyunCore {
         iter: &str,
         limit: Option<usize>,
     ) -> Result<Response<Buffer>> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://v0.api.upyun.com/{}/{}",

--- a/core/services/upyun/src/lister.rs
+++ b/core/services/upyun/src/lister.rs
@@ -84,7 +84,7 @@ impl oio::PageList for UpyunLister {
         ctx.token = response.iter;
 
         for file in response.files {
-            let path = build_abs_path(&normalize_root(&self.path), &file.name);
+            let path = build_absolute_path(&normalize_root(&self.path), &file.name);
 
             let entry = if file.type_field == "folder" {
                 let path = format!("{path}/");

--- a/core/services/vercel-blob/src/core.rs
+++ b/core/services/vercel-blob/src/core.rs
@@ -93,7 +93,7 @@ impl VercelBlobCore {
         range: BytesRange,
         _: &OpRead,
     ) -> Result<Response<HttpBody>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         // Vercel blob use an unguessable random id url to download the file
         // So we use list to get the url of the file and then use it to download the file
         let resp = self.list(ctx, &p, Some(1)).await?;
@@ -129,7 +129,7 @@ impl VercelBlobCore {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://blob.vercel-storage.com/{}",
@@ -159,7 +159,7 @@ impl VercelBlobCore {
     }
 
     pub async fn head(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let resp = self.list(ctx, &p, Some(1)).await?;
 
@@ -192,7 +192,7 @@ impl VercelBlobCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let from = build_abs_path(&self.root, from);
+        let from = build_absolute_path(&self.root, from);
 
         let resp = self.list(ctx, &from, Some(1)).await?;
 
@@ -202,7 +202,7 @@ impl VercelBlobCore {
             return Err(Error::new(ErrorKind::NotFound, "Blob not found"));
         }
 
-        let to = build_abs_path(&self.root, to);
+        let to = build_absolute_path(&self.root, to);
 
         let to_url = format!(
             "https://blob.vercel-storage.com/{}?fromUrl={}",
@@ -269,7 +269,7 @@ impl VercelBlobCore {
     }
 
     pub async fn vercel_delete_blob(&self, ctx: &OperationContext, path: &str) -> Result<()> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let resp = self.list(ctx, &p, Some(1)).await?;
 
@@ -311,7 +311,7 @@ impl VercelBlobCore {
         path: &str,
         args: &OpWrite,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://blob.vercel-storage.com/mpu/{}",
@@ -348,7 +348,7 @@ impl VercelBlobCore {
         size: u64,
         body: Buffer,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://blob.vercel-storage.com/mpu/{}",
@@ -382,7 +382,7 @@ impl VercelBlobCore {
         upload_id: &str,
         parts: Vec<Part>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let url = format!(
             "https://blob.vercel-storage.com/mpu/{}",

--- a/core/services/vercel-blob/src/lister.rs
+++ b/core/services/vercel-blob/src/lister.rs
@@ -50,7 +50,7 @@ impl VercelBlobLister {
 
 impl oio::PageList for VercelBlobLister {
     async fn next_page(&self, ctx: &mut oio::PageContext) -> Result<()> {
-        let p = build_abs_path(&self.core.root, &self.path);
+        let p = build_absolute_path(&self.core.root, &self.path);
 
         let resp = self.core.list(&self.ctx, &p, self.limit).await?;
 
@@ -61,7 +61,7 @@ impl oio::PageList for VercelBlobLister {
         }
 
         for blob in resp.blobs {
-            let path = build_rel_path(&self.core.root, &blob.pathname);
+            let path = build_relative_path(&self.core.root, &blob.pathname);
 
             if path == self.path {
                 continue;

--- a/core/services/webdav/src/core.rs
+++ b/core/services/webdav/src/core.rs
@@ -110,7 +110,7 @@ impl Debug for WebdavCore {
 
 impl WebdavCore {
     pub async fn webdav_stat(&self, ctx: &OperationContext, path: &str) -> Result<Metadata> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
         self.webdav_stat_rooted_abs_path(ctx, &path).await
     }
 
@@ -173,7 +173,7 @@ impl WebdavCore {
         range: BytesRange,
         _: &OpRead,
     ) -> Result<Response<HttpBody>> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
         let url: String = format!("{}{}", self.endpoint, percent_encode_path(&path));
 
         let mut req = Request::get(&url);
@@ -203,7 +203,7 @@ impl WebdavCore {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Response<Buffer>> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
         let url = format!("{}{}", self.endpoint, percent_encode_path(&path));
 
         let mut req = Request::put(&url);
@@ -247,7 +247,7 @@ impl WebdavCore {
         path: &str,
         user_metadata: &HashMap<String, String>,
     ) -> Result<Response<Buffer>> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
         let url = format!("{}{}", self.endpoint, percent_encode_path(&path));
 
         let mut req = Request::builder().method("PROPPATCH").uri(&url);
@@ -278,7 +278,7 @@ impl WebdavCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
         let url = format!("{}{}", self.endpoint, percent_encode_path(&path));
 
         let mut req = Request::delete(&url);
@@ -307,10 +307,10 @@ impl WebdavCore {
         // Make sure target's dir is exist.
         self.webdav_mkcol(ctx, get_parent(to)).await?;
 
-        let source = build_rooted_abs_path(&self.root, from);
+        let source = build_rooted_absolute_path(&self.root, from);
         let source_uri = format!("{}{}", self.endpoint, percent_encode_path(&source));
 
-        let target = build_rooted_abs_path(&self.root, to);
+        let target = build_rooted_absolute_path(&self.root, to);
         let target_uri = format!("{}{}", self.endpoint, percent_encode_path(&target));
 
         let mut req = Request::builder().method("COPY").uri(&source_uri);
@@ -342,10 +342,10 @@ impl WebdavCore {
         // Make sure target's dir is exist.
         self.webdav_mkcol(ctx, get_parent(to)).await?;
 
-        let source = build_rooted_abs_path(&self.root, from);
+        let source = build_rooted_absolute_path(&self.root, from);
         let source_uri = format!("{}{}", self.endpoint, percent_encode_path(&source));
 
-        let target = build_rooted_abs_path(&self.root, to);
+        let target = build_rooted_absolute_path(&self.root, to);
         let target_uri = format!("{}{}", self.endpoint, percent_encode_path(&target));
 
         let mut req = Request::builder().method("MOVE").uri(&source_uri);
@@ -372,7 +372,7 @@ impl WebdavCore {
         path: &str,
         args: &OpList,
     ) -> Result<Response<Buffer>> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
         let url = format!("{}{}", self.endpoint, percent_encode_path(&path));
 
         let mut req = Request::builder().method("PROPFIND").uri(&url);
@@ -404,7 +404,7 @@ impl WebdavCore {
     ///
     /// We only expose this method to the backend since there are dependencies on input path.
     pub async fn webdav_mkcol(&self, ctx: &OperationContext, path: &str) -> Result<()> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
         let mut path = path.as_str();
 
         let mut dirs = VecDeque::default();

--- a/core/services/webdav/src/lister.rs
+++ b/core/services/webdav/src/lister.rs
@@ -87,7 +87,7 @@ impl oio::PageList for WebdavLister {
 
             let decoded_path = percent_decode_path(&path);
             let normalized_path = if self.core.root != decoded_path {
-                build_rel_path(&self.core.root, &decoded_path)
+                build_relative_path(&self.core.root, &decoded_path)
             } else {
                 "/".to_owned()
             };

--- a/core/services/webhdfs/src/core.rs
+++ b/core/services/webhdfs/src/core.rs
@@ -57,7 +57,7 @@ impl WebhdfsCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!(
             "{}/webhdfs/v1/{}?op=MKDIRS&overwrite=true&noredirect=true",
@@ -91,7 +91,7 @@ impl WebhdfsCore {
         args: &OpWrite,
         body: Buffer,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!(
             "{}/webhdfs/v1/{}?op=CREATE&overwrite=true&noredirect=true",
@@ -150,8 +150,8 @@ impl WebhdfsCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let from = build_abs_path(&self.root, from);
-        let to = build_rooted_abs_path(&self.root, to);
+        let from = build_absolute_path(&self.root, from);
+        let to = build_rooted_absolute_path(&self.root, to);
 
         let mut url = format!(
             "{}/webhdfs/v1/{}?op=RENAME&destination={}",
@@ -174,7 +174,7 @@ impl WebhdfsCore {
     }
 
     async fn webhdfs_init_append(&self, ctx: &OperationContext, path: &str) -> Result<String> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let mut url = format!(
             "{}/webhdfs/v1/{}?op=APPEND&noredirect=true",
             self.endpoint,
@@ -244,11 +244,11 @@ impl WebhdfsCore {
         path: &str,
         sources: Vec<String>,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let sources = sources
             .iter()
-            .map(|p| build_rooted_abs_path(&self.root, p))
+            .map(|p| build_rooted_absolute_path(&self.root, p))
             .collect::<Vec<String>>()
             .join(",");
 
@@ -281,7 +281,7 @@ impl WebhdfsCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let mut url = format!(
             "{}/webhdfs/v1/{}?op=LISTSTATUS",
             self.endpoint,
@@ -306,7 +306,7 @@ impl WebhdfsCore {
         path: &str,
         start_after: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
 
         let mut url = format!(
             "{}/webhdfs/v1/{}?op=LISTSTATUS_BATCH",
@@ -330,7 +330,7 @@ impl WebhdfsCore {
     }
 
     fn webhdfs_open_request(&self, path: &str, range: &BytesRange) -> Result<Request<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let mut url = format!(
             "{}/webhdfs/v1/{}?op=OPEN",
             self.endpoint,
@@ -374,7 +374,7 @@ impl WebhdfsCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let mut url = format!(
             "{}/webhdfs/v1/{}?op=GETFILESTATUS",
             self.endpoint,
@@ -401,7 +401,7 @@ impl WebhdfsCore {
         ctx: &OperationContext,
         path: &str,
     ) -> Result<Response<Buffer>> {
-        let p = build_abs_path(&self.root, path);
+        let p = build_absolute_path(&self.root, path);
         let mut url = format!(
             "{}/webhdfs/v1/{}?op=DELETE&recursive=false",
             self.endpoint,

--- a/core/services/yandex-disk/src/core.rs
+++ b/core/services/yandex-disk/src/core.rs
@@ -68,7 +68,7 @@ impl YandexDiskCore {
 impl YandexDiskCore {
     /// Get upload url.
     async fn get_upload_url(&self, ctx: &OperationContext, path: &str) -> Result<String> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let url = format!(
             "https://cloud-api.yandex.net/v1/disk/resources/upload?path={}&overwrite=true",
@@ -120,7 +120,7 @@ impl YandexDiskCore {
     }
 
     async fn get_download_url(&self, ctx: &OperationContext, path: &str) -> Result<String> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let url = format!(
             "https://cloud-api.yandex.net/v1/disk/resources/download?path={}&overwrite=true",
@@ -173,7 +173,7 @@ impl YandexDiskCore {
     }
 
     pub async fn ensure_dir_exists(&self, ctx: &OperationContext, path: &str) -> Result<()> {
-        let path = build_abs_path(&self.root, path);
+        let path = build_absolute_path(&self.root, path);
 
         let paths = path.split('/').collect::<Vec<&str>>();
 
@@ -217,8 +217,8 @@ impl YandexDiskCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let from = build_rooted_abs_path(&self.root, from);
-        let to = build_rooted_abs_path(&self.root, to);
+        let from = build_rooted_absolute_path(&self.root, from);
+        let to = build_rooted_absolute_path(&self.root, to);
 
         let url = format!(
             "https://cloud-api.yandex.net/v1/disk/resources/copy?from={}&path={}&overwrite=true",
@@ -246,8 +246,8 @@ impl YandexDiskCore {
         from: &str,
         to: &str,
     ) -> Result<Response<Buffer>> {
-        let from = build_rooted_abs_path(&self.root, from);
-        let to = build_rooted_abs_path(&self.root, to);
+        let from = build_rooted_absolute_path(&self.root, from);
+        let to = build_rooted_absolute_path(&self.root, to);
 
         let url = format!(
             "https://cloud-api.yandex.net/v1/disk/resources/move?from={}&path={}&overwrite=true",
@@ -270,7 +270,7 @@ impl YandexDiskCore {
     }
 
     pub async fn delete(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let url = format!(
             "https://cloud-api.yandex.net/v1/disk/resources?path={}&permanently=true",
@@ -298,7 +298,7 @@ impl YandexDiskCore {
         limit: Option<usize>,
         offset: Option<String>,
     ) -> Result<Response<Buffer>> {
-        let path = build_rooted_abs_path(&self.root, path);
+        let path = build_rooted_absolute_path(&self.root, path);
 
         let mut url = format!(
             "https://cloud-api.yandex.net/v1/disk/resources?path={}",

--- a/core/services/yandex-disk/src/lister.rs
+++ b/core/services/yandex-disk/src/lister.rs
@@ -84,7 +84,7 @@ impl oio::PageList for YandexDiskLister {
                         let path = mf.path.strip_prefix("disk:");
 
                         if let Some(path) = path {
-                            let mut path = build_rel_path(&self.core.root, path);
+                            let mut path = build_relative_path(&self.core.root, path);
 
                             let md = parse_info(mf)?;
 


### PR DESCRIPTION
# Which issue does this PR close?

Implements RFC 7799's path normalization part.

Also closes #6577

# Rationale for this change

- Improve readability and documentation
- More defined path normalization conventions, rules, and who should use what.

# What changes are included in this PR?

- Remove `.trim()` from `normalize_path` to preserve whitespace in path components, aligning with POSIX, URI, and object-store conventions where whitespace is significant content.
- Add `.` segment filtering to both `normalize_path` and `normalize_root` so that `./a/./b` normalizes to `a/b`.
- Introduce `build_absolute_path`, `build_rooted_absolute_path`, and `build_relative_path` as the canonical names; deprecate the old `build_abs_path`, `build_rooted_abs_path`, `build_rel_path` aliases.
- Use doctests when possible
- Update services to use the new function names.

# Are there any user-facing changes?

No

# AI Usage Statement

GPT-5.5 with codex implements some code.