### PR TITLE
feat(services/swift): support list with start_after

### DIFF
--- a/core/services/swift/src/backend.rs
+++ b/core/services/swift/src/backend.rs
@@ -205,6 +205,7 @@ impl Builder for SwiftBuilder {
 
                     list: true,
                     list_with_recursive: true,
+                    list_with_start_after: true,
 
                     presign: has_temp_url_key,
                     presign_stat: has_temp_url_key,
@@ -325,6 +326,7 @@ impl Service for SwiftBackend {
                 path.to_string(),
                 args.recursive(),
                 args.limit(),
+                args.start_after().map(String::from),
             );
 
             Ok(oio::PageLister::new(l))

--- a/core/services/swift/src/lister.rs
+++ b/core/services/swift/src/lister.rs
@@ -30,6 +30,7 @@ pub struct SwiftLister {
     path: String,
     delimiter: &'static str,
     limit: Option<usize>,
+    abs_start_after: Option<String>,
 }
 
 impl SwiftLister {
@@ -39,29 +40,36 @@ impl SwiftLister {
         path: String,
         recursive: bool,
         limit: Option<usize>,
+        start_after: Option<String>,
     ) -> Self {
         let delimiter = if recursive { "" } else { "/" };
+        // Swift listing names are absolute (root-prefixed) and the lister pages
+        // by `marker`, so the start-after must be made absolute as well.
+        let abs_start_after =
+            start_after.map(|start_after| build_abs_path(&core.root, &start_after));
         Self {
             core,
             ctx,
             path,
             delimiter,
             limit,
+            abs_start_after,
         }
     }
 }
 
 impl oio::PageList for SwiftLister {
     async fn next_page(&self, ctx: &mut oio::PageContext) -> Result<()> {
+        // `start_after` applies to the first page only; subsequent pages
+        // continue from the previous page's last entry carried in `ctx.token`.
+        let marker = if ctx.token.is_empty() {
+            self.abs_start_after.as_deref().unwrap_or("")
+        } else {
+            ctx.token.as_str()
+        };
         let response = self
             .core
-            .swift_list(
-                &self.ctx,
-                &self.path,
-                self.delimiter,
-                self.limit,
-                &ctx.token,
-            )
+            .swift_list(&self.ctx, &self.path, self.delimiter, self.limit, marker)
             .await?;
 
         let status_code = response.status();


### PR DESCRIPTION
## Which issue does this PR close?

Closes #7809

## Rationale for this change

OpenStack Swift's container listing supports a `marker` query parameter — an exclusive start-after (see [Swift pagination docs](https://docs.openstack.org/swift/latest/api/pagination.html)). The Swift service already pages through it via `ctx.token`, but never seeds it from the user's `start_after`, and `Capability::list_with_start_after` was `false`. As a result a supplied `start_after` was silently ignored and the full keyspace was returned, which breaks range-split / sharded enumeration of large flat buckets (works on S3/GCS, not Swift).

## What changes are included in this PR?

- `SwiftLister` takes an optional `start_after`, made absolute via `build_abs_path` (mirroring the S3 lister), and seeds the **first** page's `marker` from it; later pages keep using the continuation marker in `ctx.token`.
- `SwiftBackend::list` passes `args.start_after()` through.
- The native `Capability` now advertises `list_with_start_after: true`.

No core/`swift_list` changes were needed — it already accepts a `marker`.

## Are there any user-facing changes?

Yes: `list_with(...).start_after(...)` is now honored by the Swift service, and `Capability::list_with_start_after` reports `true`. The capability-gated behavior tests (`test_list_with_start_after`, `test_list_root_with_start_after`) now run for Swift in CI.