### PR TITLE
feat(binding/go): add reader with options

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -523,6 +523,76 @@ typedef struct opendal_result_operator_reader {
 } opendal_result_operator_reader;
 
 /**
+ * \brief The options for creating a reader via `opendal_operator_reader_with`.
+ *
+ * Use `opendal_reader_options_new()` to construct and
+ * `opendal_reader_options_free()` to free.
+ */
+typedef struct opendal_reader_options {
+  /**
+   * The version of the object to read; NULL means unset.
+   */
+  const char *version;
+  /**
+   * If-Match header value; NULL means unset.
+   */
+  const char *if_match;
+  /**
+   * If-None-Match header value; NULL means unset.
+   */
+  const char *if_none_match;
+  /**
+   * Whether `if_modified_since` has been set.
+   */
+  bool has_if_modified_since;
+  /**
+   * If-Modified-Since condition, in Unix milliseconds.
+   */
+  int64_t if_modified_since;
+  /**
+   * Whether `if_unmodified_since` has been set.
+   */
+  bool has_if_unmodified_since;
+  /**
+   * If-Unmodified-Since condition, in Unix milliseconds.
+   */
+  int64_t if_unmodified_since;
+  /**
+   * Whether `content_length_hint` has been set.
+   */
+  bool has_content_length_hint;
+  /**
+   * Known content length of the object, used as an execution hint to avoid
+   * extra metadata requests while planning reads.
+   */
+  uint64_t content_length_hint;
+  /**
+   * Concurrent read operations. `0` falls back to sequential reads.
+   */
+  uintptr_t concurrent;
+  /**
+   * Whether `chunk` has been set.
+   */
+  bool has_chunk;
+  /**
+   * Chunk size for each read request.
+   */
+  uintptr_t chunk;
+  /**
+   * Whether `gap` has been set.
+   */
+  bool has_gap;
+  /**
+   * Gap size for merging nearby range reads.
+   */
+  uintptr_t gap;
+  /**
+   * Number of prefetched byte ranges buffered during concurrent reads.
+   */
+  uintptr_t prefetch;
+} opendal_reader_options;
+
+/**
  * \brief The result type returned by opendal's writer operation.
  * \note The opendal_writer actually owns a pointer to
  * an opendal::blocking::Writer, which is inside the Rust core code.
@@ -1560,6 +1630,37 @@ struct opendal_result_operator_reader opendal_operator_reader(const struct opend
                                                               const char *path);
 
 /**
+ * \brief Blocking create a reader for the specified path with options.
+ *
+ * This function prepares a reader, applying the conditional, version and
+ * concurrency options carried by `opts`. A NULL `opts` is treated as the
+ * default options, behaving like `opendal_operator_reader`.
+ *
+ * @param op The opendal_operator created previously
+ * @param path The designated path where the reader will be used
+ * @param opts The reader options, or NULL to use the defaults
+ * @see opendal_operator
+ * @see opendal_reader_options
+ * @see opendal_result_operator_reader
+ * @return Returns opendal_result_operator_reader, containing a reader and an opendal_error.
+ * If the operation succeeds, the `reader` field holds a valid reader and the `error` field
+ * is null. Otherwise, the `reader` will be null and the `error` will be set correspondingly.
+ *
+ * # Safety
+ *
+ * It is **safe** under the cases below
+ * * The memory pointed to by `path` must contain a valid nul terminator at the end of
+ *   the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics, i.e. exits with information
+ */
+struct opendal_result_operator_reader opendal_operator_reader_with(const struct opendal_operator *op,
+                                                                   const char *path,
+                                                                   const struct opendal_reader_options *opts);
+
+/**
  * \brief Blocking create a writer for the specified path.
  *
  * This function prepares a writer that can be used to write data to the specified path
@@ -2563,6 +2664,75 @@ void opendal_read_options_set_override_cache_control(struct opendal_read_options
  */
 void opendal_read_options_set_override_content_disposition(struct opendal_read_options *opts,
                                                            const char *override_content_disposition);
+
+/**
+ * \brief Construct a heap-allocated opendal_reader_options with default values.
+ */
+struct opendal_reader_options *opendal_reader_options_new(void);
+
+/**
+ * \brief Free the heap memory used by opendal_reader_options.
+ */
+void opendal_reader_options_free(struct opendal_reader_options *opts);
+
+/**
+ * \brief Set the version of the object to read.
+ */
+void opendal_reader_options_set_version(struct opendal_reader_options *opts, const char *version);
+
+/**
+ * \brief Set If-Match.
+ */
+void opendal_reader_options_set_if_match(struct opendal_reader_options *opts, const char *if_match);
+
+/**
+ * \brief Set If-None-Match.
+ */
+void opendal_reader_options_set_if_none_match(struct opendal_reader_options *opts,
+                                              const char *if_none_match);
+
+/**
+ * \brief Set If-Modified-Since, in Unix milliseconds.
+ */
+void opendal_reader_options_set_if_modified_since(struct opendal_reader_options *opts,
+                                                  int64_t if_modified_since);
+
+/**
+ * \brief Set If-Unmodified-Since, in Unix milliseconds.
+ */
+void opendal_reader_options_set_if_unmodified_since(struct opendal_reader_options *opts,
+                                                    int64_t if_unmodified_since);
+
+/**
+ * \brief Set the known content length of the object.
+ *
+ * This is an execution hint that allows OpenDAL to avoid extra metadata
+ * requests while planning reads. It must not be used as an object identity
+ * or consistency condition.
+ */
+void opendal_reader_options_set_content_length_hint(struct opendal_reader_options *opts,
+                                                    uint64_t content_length_hint);
+
+/**
+ * \brief Set concurrent read operations.
+ */
+void opendal_reader_options_set_concurrent(struct opendal_reader_options *opts,
+                                           uintptr_t concurrent);
+
+/**
+ * \brief Set chunk size.
+ */
+void opendal_reader_options_set_chunk(struct opendal_reader_options *opts, uintptr_t chunk);
+
+/**
+ * \brief Set gap size.
+ */
+void opendal_reader_options_set_gap(struct opendal_reader_options *opts, uintptr_t gap);
+
+/**
+ * \brief Set the number of prefetched byte ranges buffered during concurrent reads.
+ */
+void opendal_reader_options_set_prefetch(struct opendal_reader_options *opts, uintptr_t prefetch);
 
 /**
  * \brief Construct a heap-allocated opendal_copy_options with default values.

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -77,6 +77,7 @@ pub use types::opendal_delete_options;
 pub use types::opendal_list_options;
 pub use types::opendal_operator_options;
 pub use types::opendal_read_options;
+pub use types::opendal_reader_options;
 pub use types::opendal_stat_options;
 pub use types::opendal_write_options;
 pub use types::opendal_write_user_metadata_pair;

--- a/bindings/c/src/operator.rs
+++ b/bindings/c/src/operator.rs
@@ -487,6 +487,68 @@ pub unsafe extern "C" fn opendal_operator_reader(
     }
 }
 
+/// \brief Blocking create a reader for the specified path with options.
+///
+/// This function prepares a reader, applying the conditional, version and
+/// concurrency options carried by `opts`. A NULL `opts` is treated as the
+/// default options, behaving like `opendal_operator_reader`.
+///
+/// @param op The opendal_operator created previously
+/// @param path The designated path where the reader will be used
+/// @param opts The reader options, or NULL to use the defaults
+/// @see opendal_operator
+/// @see opendal_reader_options
+/// @see opendal_result_operator_reader
+/// @return Returns opendal_result_operator_reader, containing a reader and an opendal_error.
+/// If the operation succeeds, the `reader` field holds a valid reader and the `error` field
+/// is null. Otherwise, the `reader` will be null and the `error` will be set correspondingly.
+///
+/// # Safety
+///
+/// It is **safe** under the cases below
+/// * The memory pointed to by `path` must contain a valid nul terminator at the end of
+///   the string.
+///
+/// # Panic
+///
+/// * If the `path` points to NULL, this function panics, i.e. exits with information
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_reader_with(
+    op: &opendal_operator,
+    path: *const c_char,
+    opts: *const opendal_reader_options,
+) -> opendal_result_operator_reader {
+    assert!(!path.is_null());
+    let path = std::ffi::CStr::from_ptr(path)
+        .to_str()
+        .expect("malformed path");
+    let opts = if opts.is_null() {
+        core::options::ReaderOptions::default()
+    } else {
+        (&*opts).into()
+    };
+    let reader = match op.deref().reader_options(path, opts) {
+        Ok(reader) => reader,
+        Err(err) => {
+            return opendal_result_operator_reader {
+                reader: std::ptr::null_mut(),
+                error: opendal_error::new(err),
+            };
+        }
+    };
+
+    match reader.into_std_read(..) {
+        Ok(reader) => opendal_result_operator_reader {
+            reader: Box::into_raw(Box::new(opendal_reader::new(reader))),
+            error: std::ptr::null_mut(),
+        },
+        Err(e) => opendal_result_operator_reader {
+            reader: std::ptr::null_mut(),
+            error: opendal_error::new(e),
+        },
+    }
+}
+
 /// \brief Blocking create a writer for the specified path.
 ///
 /// This function prepares a writer that can be used to write data to the specified path

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -1057,6 +1057,227 @@ impl From<&opendal_read_options> for options::ReadOptions {
     }
 }
 
+/// \brief The options for creating a reader via `opendal_operator_reader_with`.
+///
+/// Use `opendal_reader_options_new()` to construct and
+/// `opendal_reader_options_free()` to free.
+#[repr(C)]
+pub struct opendal_reader_options {
+    /// The version of the object to read; NULL means unset.
+    pub version: *const c_char,
+    /// If-Match header value; NULL means unset.
+    pub if_match: *const c_char,
+    /// If-None-Match header value; NULL means unset.
+    pub if_none_match: *const c_char,
+    /// Whether `if_modified_since` has been set.
+    pub has_if_modified_since: bool,
+    /// If-Modified-Since condition, in Unix milliseconds.
+    pub if_modified_since: i64,
+    /// Whether `if_unmodified_since` has been set.
+    pub has_if_unmodified_since: bool,
+    /// If-Unmodified-Since condition, in Unix milliseconds.
+    pub if_unmodified_since: i64,
+    /// Whether `content_length_hint` has been set.
+    pub has_content_length_hint: bool,
+    /// Known content length of the object, used as an execution hint to avoid
+    /// extra metadata requests while planning reads.
+    pub content_length_hint: u64,
+    /// Concurrent read operations. `0` falls back to sequential reads.
+    pub concurrent: usize,
+    /// Whether `chunk` has been set.
+    pub has_chunk: bool,
+    /// Chunk size for each read request.
+    pub chunk: usize,
+    /// Whether `gap` has been set.
+    pub has_gap: bool,
+    /// Gap size for merging nearby range reads.
+    pub gap: usize,
+    /// Number of prefetched byte ranges buffered during concurrent reads.
+    pub prefetch: usize,
+}
+
+impl Default for opendal_reader_options {
+    fn default() -> Self {
+        Self {
+            version: std::ptr::null(),
+            if_match: std::ptr::null(),
+            if_none_match: std::ptr::null(),
+            has_if_modified_since: false,
+            if_modified_since: 0,
+            has_if_unmodified_since: false,
+            if_unmodified_since: 0,
+            has_content_length_hint: false,
+            content_length_hint: 0,
+            concurrent: 0,
+            has_chunk: false,
+            chunk: 0,
+            has_gap: false,
+            gap: 0,
+            prefetch: 0,
+        }
+    }
+}
+
+impl opendal_reader_options {
+    /// \brief Construct a heap-allocated opendal_reader_options with default values.
+    #[no_mangle]
+    pub extern "C" fn opendal_reader_options_new() -> *mut Self {
+        Box::into_raw(Box::new(Self::default()))
+    }
+
+    /// \brief Free the heap memory used by opendal_reader_options.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_reader_options_free(opts: *mut opendal_reader_options) {
+        if !opts.is_null() {
+            drop(Box::from_raw(opts));
+        }
+    }
+
+    /// \brief Set the version of the object to read.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_reader_options_set_version(
+        opts: *mut opendal_reader_options,
+        version: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).version = version;
+        }
+    }
+
+    /// \brief Set If-Match.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_reader_options_set_if_match(
+        opts: *mut opendal_reader_options,
+        if_match: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).if_match = if_match;
+        }
+    }
+
+    /// \brief Set If-None-Match.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_reader_options_set_if_none_match(
+        opts: *mut opendal_reader_options,
+        if_none_match: *const c_char,
+    ) {
+        if !opts.is_null() {
+            (*opts).if_none_match = if_none_match;
+        }
+    }
+
+    /// \brief Set If-Modified-Since, in Unix milliseconds.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_reader_options_set_if_modified_since(
+        opts: *mut opendal_reader_options,
+        if_modified_since: i64,
+    ) {
+        if !opts.is_null() {
+            (*opts).has_if_modified_since = true;
+            (*opts).if_modified_since = if_modified_since;
+        }
+    }
+
+    /// \brief Set If-Unmodified-Since, in Unix milliseconds.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_reader_options_set_if_unmodified_since(
+        opts: *mut opendal_reader_options,
+        if_unmodified_since: i64,
+    ) {
+        if !opts.is_null() {
+            (*opts).has_if_unmodified_since = true;
+            (*opts).if_unmodified_since = if_unmodified_since;
+        }
+    }
+
+    /// \brief Set the known content length of the object.
+    ///
+    /// This is an execution hint that allows OpenDAL to avoid extra metadata
+    /// requests while planning reads. It must not be used as an object identity
+    /// or consistency condition.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_reader_options_set_content_length_hint(
+        opts: *mut opendal_reader_options,
+        content_length_hint: u64,
+    ) {
+        if !opts.is_null() {
+            (*opts).has_content_length_hint = true;
+            (*opts).content_length_hint = content_length_hint;
+        }
+    }
+
+    /// \brief Set concurrent read operations.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_reader_options_set_concurrent(
+        opts: *mut opendal_reader_options,
+        concurrent: usize,
+    ) {
+        if !opts.is_null() {
+            (*opts).concurrent = concurrent;
+        }
+    }
+
+    /// \brief Set chunk size.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_reader_options_set_chunk(
+        opts: *mut opendal_reader_options,
+        chunk: usize,
+    ) {
+        if !opts.is_null() {
+            (*opts).has_chunk = true;
+            (*opts).chunk = chunk;
+        }
+    }
+
+    /// \brief Set gap size.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_reader_options_set_gap(
+        opts: *mut opendal_reader_options,
+        gap: usize,
+    ) {
+        if !opts.is_null() {
+            (*opts).has_gap = true;
+            (*opts).gap = gap;
+        }
+    }
+
+    /// \brief Set the number of prefetched byte ranges buffered during concurrent reads.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_reader_options_set_prefetch(
+        opts: *mut opendal_reader_options,
+        prefetch: usize,
+    ) {
+        if !opts.is_null() {
+            (*opts).prefetch = prefetch;
+        }
+    }
+}
+
+impl From<&opendal_reader_options> for options::ReaderOptions {
+    fn from(value: &opendal_reader_options) -> Self {
+        Self {
+            version: unsafe { optional_cstr(value.version) },
+            if_match: unsafe { optional_cstr(value.if_match) },
+            if_none_match: unsafe { optional_cstr(value.if_none_match) },
+            if_modified_since: value
+                .has_if_modified_since
+                .then(|| Timestamp::from_millisecond(value.if_modified_since).ok())
+                .flatten(),
+            if_unmodified_since: value
+                .has_if_unmodified_since
+                .then(|| Timestamp::from_millisecond(value.if_unmodified_since).ok())
+                .flatten(),
+            content_length_hint: value
+                .has_content_length_hint
+                .then_some(value.content_length_hint),
+            concurrent: value.concurrent,
+            chunk: value.has_chunk.then_some(value.chunk),
+            gap: value.has_gap.then_some(value.gap),
+            prefetch: value.prefetch,
+        }
+    }
+}
+
 /// \brief The options for copy operations.
 ///
 /// Use `opendal_copy_options_new()` to construct and

--- a/bindings/c/tests/test_suites_reader_writer.cpp
+++ b/bindings/c/tests/test_suites_reader_writer.cpp
@@ -324,10 +324,73 @@ void test_reader_partial_read(opendal_test_context* ctx)
     opendal_operator_delete(ctx->config->operator_instance, path);
 }
 
+// Test: Reader with options
+void test_reader_with_options(opendal_test_context* ctx)
+{
+    const char* path = "test_reader_with_options.txt";
+    const char* content = "Hello, OpenDAL Reader With Options!";
+    size_t content_len = strlen(content);
+
+    // Write test data first
+    opendal_bytes data = {
+        .data = (uint8_t*)content, .len = content_len, .capacity = content_len
+    };
+
+    opendal_error* error = opendal_operator_write(ctx->config->operator_instance, path, &data);
+    OPENDAL_ASSERT_NO_ERROR(error, "Write operation should succeed");
+
+    // Build reader options exercising the concurrency knobs.
+    opendal_reader_options* options = opendal_reader_options_new();
+    OPENDAL_ASSERT_NOT_NULL(options, "Reader options should not be null");
+    opendal_reader_options_set_concurrent(options, 2);
+    opendal_reader_options_set_chunk(options, 1024 * 1024);
+    opendal_reader_options_set_gap(options, 4096);
+    opendal_reader_options_set_prefetch(options, 2);
+
+    opendal_result_operator_reader reader_result
+        = opendal_operator_reader_with(ctx->config->operator_instance, path, options);
+    opendal_reader_options_free(options);
+    OPENDAL_ASSERT_NO_ERROR(reader_result.error,
+        "Reader-with-options creation should succeed");
+    OPENDAL_ASSERT_NOT_NULL(reader_result.reader, "Reader should not be null");
+
+    // A single read() may return a short count under chunked/concurrent reads,
+    // so accumulate until the whole object has been read.
+    uint8_t buffer[100];
+    size_t total_read = 0;
+    while (total_read < content_len) {
+        opendal_result_reader_read read_result = opendal_reader_read(
+            reader_result.reader, buffer + total_read, sizeof(buffer) - total_read);
+        OPENDAL_ASSERT_NO_ERROR(read_result.error, "Read operation should succeed");
+        if (read_result.size == 0) {
+            break; // EOF
+        }
+        total_read += read_result.size;
+    }
+    OPENDAL_ASSERT_EQ(content_len, total_read,
+        "Total read size should match content length");
+    OPENDAL_ASSERT(memcmp(content, buffer, content_len) == 0,
+        "Read content should match written content");
+
+    // A NULL options pointer must behave like opendal_operator_reader.
+    opendal_result_operator_reader default_result
+        = opendal_operator_reader_with(ctx->config->operator_instance, path, NULL);
+    OPENDAL_ASSERT_NO_ERROR(default_result.error,
+        "Reader-with-NULL-options creation should succeed");
+    OPENDAL_ASSERT_NOT_NULL(default_result.reader, "Reader should not be null");
+
+    // Cleanup
+    opendal_reader_free(reader_result.reader);
+    opendal_reader_free(default_result.reader);
+    opendal_operator_delete(ctx->config->operator_instance, path);
+}
+
 // Define the reader/writer test suite
 opendal_test_case reader_writer_tests[] = {
     { "reader_basic", test_reader_basic, make_capability_read_write() },
     { "reader_seek", test_reader_seek, make_capability_read_write() },
+    { "reader_with_options", test_reader_with_options,
+        make_capability_read_write() },
     { "writer_basic", test_writer_basic, make_capability_read_write() },
     { "writer_large_data", test_writer_large_data, make_capability_write_stat() },
     { "reader_partial_read", test_reader_partial_read,

--- a/bindings/go/reader.go
+++ b/bindings/go/reader.go
@@ -305,13 +305,172 @@ func newOpendalReadOptions(ctx context.Context, o *readOptions) (*opendalReadOpt
 	return cOpts, keepAlive, nil
 }
 
+// WithReaderFn is a functional option for creating a Reader.
+type WithReaderFn func(*readerOptions)
+
+// ReaderWithVersion sets the version of the object to read.
+func ReaderWithVersion(version string) WithReaderFn {
+	return func(o *readerOptions) {
+		o.version = version
+	}
+}
+
+// ReaderWithIfMatch sets the If-Match condition for the reader.
+func ReaderWithIfMatch(ifMatch string) WithReaderFn {
+	return func(o *readerOptions) {
+		o.ifMatch = ifMatch
+	}
+}
+
+// ReaderWithIfNoneMatch sets the If-None-Match condition for the reader.
+func ReaderWithIfNoneMatch(ifNoneMatch string) WithReaderFn {
+	return func(o *readerOptions) {
+		o.ifNoneMatch = ifNoneMatch
+	}
+}
+
+// ReaderWithIfModifiedSince sets the If-Modified-Since condition for the reader.
+func ReaderWithIfModifiedSince(t time.Time) WithReaderFn {
+	return func(o *readerOptions) {
+		millis := t.UnixMilli()
+		o.ifModifiedSince = &millis
+	}
+}
+
+// ReaderWithIfUnmodifiedSince sets the If-Unmodified-Since condition for the reader.
+func ReaderWithIfUnmodifiedSince(t time.Time) WithReaderFn {
+	return func(o *readerOptions) {
+		millis := t.UnixMilli()
+		o.ifUnmodifiedSince = &millis
+	}
+}
+
+// ReaderWithContentLengthHint sets the known content length of the object.
+//
+// This is an execution hint that allows OpenDAL to avoid extra metadata
+// requests while planning reads. It must not be used as an object identity
+// or consistency condition.
+func ReaderWithContentLengthHint(length uint64) WithReaderFn {
+	return func(o *readerOptions) {
+		o.contentLengthHint = &length
+	}
+}
+
+// ReaderWithConcurrent sets the number of concurrent read tasks.
+func ReaderWithConcurrent(concurrent uint) WithReaderFn {
+	return func(o *readerOptions) {
+		o.concurrent = concurrent
+	}
+}
+
+// ReaderWithChunk sets the chunk size for each read request.
+func ReaderWithChunk(chunk uint) WithReaderFn {
+	return func(o *readerOptions) {
+		o.chunk = chunk
+	}
+}
+
+// ReaderWithGap sets the gap size for merging nearby range reads.
+func ReaderWithGap(gap uint) WithReaderFn {
+	return func(o *readerOptions) {
+		o.gap = gap
+	}
+}
+
+// ReaderWithPrefetch sets the number of prefetched byte ranges buffered during concurrent reads.
+func ReaderWithPrefetch(prefetch uint) WithReaderFn {
+	return func(o *readerOptions) {
+		o.prefetch = prefetch
+	}
+}
+
+type readerOptions struct {
+	version           string
+	ifMatch           string
+	ifNoneMatch       string
+	ifModifiedSince   *int64
+	ifUnmodifiedSince *int64
+	contentLengthHint *uint64
+	concurrent        uint
+	chunk             uint
+	gap               uint
+	prefetch          uint
+}
+
+func parseReaderOptions(opts ...WithReaderFn) *readerOptions {
+	o := &readerOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+func newOpendalReaderOptions(ctx context.Context, o *readerOptions) (*opendalReaderOptions, readOptionsKeepAlive, error) {
+	cOpts := ffiReaderOptionsNew.symbol(ctx)()
+	keepAlive := readOptionsKeepAlive{}
+
+	// fail frees the C-allocated options before returning
+	fail := func(err error) (*opendalReaderOptions, readOptionsKeepAlive, error) {
+		ffiReaderOptionsFree.symbol(ctx)(cOpts)
+		return nil, readOptionsKeepAlive{}, err
+	}
+
+	setString := func(value string, set func(*opendalReaderOptions, string) ([]byte, error)) error {
+		if value == "" {
+			return nil
+		}
+		data, err := set(cOpts, value)
+		if err != nil {
+			return err
+		}
+		keepAlive.strings = append(keepAlive.strings, data)
+		return nil
+	}
+
+	if err := setString(o.version, ffiReaderOptionsSetVersion.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if err := setString(o.ifMatch, ffiReaderOptionsSetIfMatch.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if err := setString(o.ifNoneMatch, ffiReaderOptionsSetIfNoneMatch.symbol(ctx)); err != nil {
+		return fail(err)
+	}
+	if o.ifModifiedSince != nil {
+		ffiReaderOptionsSetIfModifiedSince.symbol(ctx)(cOpts, *o.ifModifiedSince)
+	}
+	if o.ifUnmodifiedSince != nil {
+		ffiReaderOptionsSetIfUnmodifiedSince.symbol(ctx)(cOpts, *o.ifUnmodifiedSince)
+	}
+	if o.contentLengthHint != nil {
+		ffiReaderOptionsSetContentLengthHint.symbol(ctx)(cOpts, *o.contentLengthHint)
+	}
+	if o.concurrent != 0 {
+		ffiReaderOptionsSetConcurrent.symbol(ctx)(cOpts, o.concurrent)
+	}
+	if o.chunk != 0 {
+		ffiReaderOptionsSetChunk.symbol(ctx)(cOpts, o.chunk)
+	}
+	if o.gap != 0 {
+		ffiReaderOptionsSetGap.symbol(ctx)(cOpts, o.gap)
+	}
+	if o.prefetch != 0 {
+		ffiReaderOptionsSetPrefetch.symbol(ctx)(cOpts, o.prefetch)
+	}
+
+	return cOpts, keepAlive, nil
+}
+
 // Reader creates a new Reader for reading the contents of a file at the specified path.
 //
-// This function is a wrapper around the C-binding function `opendal_operator_reader`.
+// Reader is a wrapper around the C-binding function `opendal_operator_reader`.
+// When options are provided, it uses `opendal_operator_reader_with`.
 //
 // # Parameters
 //
 //   - path: The path of the file to read.
+//   - opts: Optional reader options such as conditional headers, version or
+//     concurrency tuning.
 //
 // # Returns
 //
@@ -320,7 +479,6 @@ func newOpendalReadOptions(ctx context.Context, o *readOptions) (*opendalReadOpt
 //
 // # Notes
 //
-//   - This implementation does not support the `reader_with` functionality.
 //   - The returned reader allows for more controlled and efficient reading of large files.
 //
 // # Example
@@ -345,16 +503,27 @@ func newOpendalReadOptions(ctx context.Context, o *readOptions) (*opendalReadOpt
 //	}
 //
 // Note: This example assumes proper error handling and import statements.
-func (op *Operator) Reader(path string) (*Reader, error) {
-	inner, err := ffiOperatorReader.symbol(op.ctx)(op.inner, path)
+func (op *Operator) Reader(path string, opts ...WithReaderFn) (*Reader, error) {
+	if len(opts) == 0 {
+		inner, err := ffiOperatorReader.symbol(op.ctx)(op.inner, path)
+		if err != nil {
+			return nil, err
+		}
+		return &Reader{inner: inner, ctx: op.ctx}, nil
+	}
+
+	o := parseReaderOptions(opts...)
+	cOpts, keepAlive, err := newOpendalReaderOptions(op.ctx, o)
 	if err != nil {
 		return nil, err
 	}
-	reader := &Reader{
-		inner: inner,
-		ctx:   op.ctx,
+	defer ffiReaderOptionsFree.symbol(op.ctx)(cOpts)
+	inner, err := ffiOperatorReaderWith.symbol(op.ctx)(op.inner, path, cOpts)
+	runtime.KeepAlive(keepAlive)
+	if err != nil {
+		return nil, err
 	}
-	return reader, nil
+	return &Reader{inner: inner, ctx: op.ctx}, nil
 }
 
 type Reader struct {
@@ -666,6 +835,143 @@ var ffiOperatorReader = newFFI(ffiOpts{
 			return nil, parseError(ctx, result.error)
 		}
 		return result.reader, nil
+	}
+})
+
+var ffiOperatorReaderWith = newFFI(ffiOpts{
+	sym:    "opendal_operator_reader_with",
+	rType:  &typeResultOperatorReader,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(op *opendalOperator, path string, opts *opendalReaderOptions) (*opendalReader, error) {
+	return func(op *opendalOperator, path string, opts *opendalReaderOptions) (*opendalReader, error) {
+		bytePath, err := BytePtrFromString(path)
+		if err != nil {
+			return nil, err
+		}
+		var result resultOperatorReader
+		ffiCall(
+			unsafe.Pointer(&result),
+			unsafe.Pointer(&op),
+			unsafe.Pointer(&bytePath),
+			unsafe.Pointer(&opts),
+		)
+		if result.error != nil {
+			return nil, parseError(ctx, result.error)
+		}
+		return result.reader, nil
+	}
+})
+
+var ffiReaderOptionsNew = newFFI(ffiOpts{
+	sym:   "opendal_reader_options_new",
+	rType: &ffi.TypePointer,
+}, func(_ context.Context, ffiCall ffiCall) func() *opendalReaderOptions {
+	return func() *opendalReaderOptions {
+		var opts *opendalReaderOptions
+		ffiCall(unsafe.Pointer(&opts))
+		return opts
+	}
+})
+
+var ffiReaderOptionsFree = newFFI(ffiOpts{
+	sym:    "opendal_reader_options_free",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReaderOptions) {
+	return func(opts *opendalReaderOptions) {
+		ffiCall(nil, unsafe.Pointer(&opts))
+	}
+})
+
+func newReaderOptionsSetStringFFI(sym string) *FFI[func(*opendalReaderOptions, string) ([]byte, error)] {
+	return newFFI(ffiOpts{
+		sym:    contextKey(sym),
+		rType:  &ffi.TypeVoid,
+		aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
+	}, func(_ context.Context, ffiCall ffiCall) func(*opendalReaderOptions, string) ([]byte, error) {
+		return func(opts *opendalReaderOptions, value string) ([]byte, error) {
+			data, err := byteSliceFromString(value)
+			if err != nil {
+				return nil, err
+			}
+			byteValue := &data[0]
+			ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&byteValue))
+			return data, nil
+		}
+	})
+}
+
+var ffiReaderOptionsSetVersion = newReaderOptionsSetStringFFI("opendal_reader_options_set_version")
+var ffiReaderOptionsSetIfMatch = newReaderOptionsSetStringFFI("opendal_reader_options_set_if_match")
+var ffiReaderOptionsSetIfNoneMatch = newReaderOptionsSetStringFFI("opendal_reader_options_set_if_none_match")
+
+var ffiReaderOptionsSetIfModifiedSince = newFFI(ffiOpts{
+	sym:    "opendal_reader_options_set_if_modified_since",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypeSint64},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReaderOptions, millis int64) {
+	return func(opts *opendalReaderOptions, millis int64) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&millis))
+	}
+})
+
+var ffiReaderOptionsSetIfUnmodifiedSince = newFFI(ffiOpts{
+	sym:    "opendal_reader_options_set_if_unmodified_since",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypeSint64},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReaderOptions, millis int64) {
+	return func(opts *opendalReaderOptions, millis int64) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&millis))
+	}
+})
+
+var ffiReaderOptionsSetContentLengthHint = newFFI(ffiOpts{
+	sym:    "opendal_reader_options_set_content_length_hint",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypeUint64},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReaderOptions, length uint64) {
+	return func(opts *opendalReaderOptions, length uint64) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&length))
+	}
+})
+
+var ffiReaderOptionsSetConcurrent = newFFI(ffiOpts{
+	sym:    "opendal_reader_options_set_concurrent",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReaderOptions, concurrent uint) {
+	return func(opts *opendalReaderOptions, concurrent uint) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&concurrent))
+	}
+})
+
+var ffiReaderOptionsSetChunk = newFFI(ffiOpts{
+	sym:    "opendal_reader_options_set_chunk",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReaderOptions, chunk uint) {
+	return func(opts *opendalReaderOptions, chunk uint) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&chunk))
+	}
+})
+
+var ffiReaderOptionsSetGap = newFFI(ffiOpts{
+	sym:    "opendal_reader_options_set_gap",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReaderOptions, gap uint) {
+	return func(opts *opendalReaderOptions, gap uint) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&gap))
+	}
+})
+
+var ffiReaderOptionsSetPrefetch = newFFI(ffiOpts{
+	sym:    "opendal_reader_options_set_prefetch",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(opts *opendalReaderOptions, prefetch uint) {
+	return func(opts *opendalReaderOptions, prefetch uint) {
+		ffiCall(nil, unsafe.Pointer(&opts), unsafe.Pointer(&prefetch))
 	}
 })
 

--- a/bindings/go/string_ownership_test.go
+++ b/bindings/go/string_ownership_test.go
@@ -1062,6 +1062,131 @@ func TestReadOptionsSetterArgTypes(t *testing.T) {
 	}
 }
 
+func TestReaderWithOptions(t *testing.T) {
+	modified := time.Unix(1700000000, 0)
+	unmodified := time.Unix(1700000123, 0)
+
+	o := &readerOptions{}
+	ReaderWithVersion("v1")(o)
+	ReaderWithIfMatch("etag-a")(o)
+	ReaderWithIfNoneMatch("etag-b")(o)
+	ReaderWithIfModifiedSince(modified)(o)
+	ReaderWithIfUnmodifiedSince(unmodified)(o)
+	ReaderWithContentLengthHint(4096)(o)
+	ReaderWithConcurrent(4)(o)
+	ReaderWithChunk(1024)(o)
+	ReaderWithGap(512)(o)
+	ReaderWithPrefetch(8)(o)
+
+	if o.version != "v1" {
+		t.Fatalf("version = %q, want v1", o.version)
+	}
+	if o.ifMatch != "etag-a" {
+		t.Fatalf("ifMatch = %q, want etag-a", o.ifMatch)
+	}
+	if o.ifNoneMatch != "etag-b" {
+		t.Fatalf("ifNoneMatch = %q, want etag-b", o.ifNoneMatch)
+	}
+	if o.ifModifiedSince == nil || *o.ifModifiedSince != modified.UnixMilli() {
+		t.Fatalf("ifModifiedSince = %v, want %d", o.ifModifiedSince, modified.UnixMilli())
+	}
+	if o.ifUnmodifiedSince == nil || *o.ifUnmodifiedSince != unmodified.UnixMilli() {
+		t.Fatalf("ifUnmodifiedSince = %v, want %d", o.ifUnmodifiedSince, unmodified.UnixMilli())
+	}
+	if o.contentLengthHint == nil || *o.contentLengthHint != 4096 {
+		t.Fatalf("contentLengthHint = %v, want 4096", o.contentLengthHint)
+	}
+	if o.concurrent != 4 {
+		t.Fatalf("concurrent = %d, want 4", o.concurrent)
+	}
+	if o.chunk != 1024 {
+		t.Fatalf("chunk = %d, want 1024", o.chunk)
+	}
+	if o.gap != 512 {
+		t.Fatalf("gap = %d, want 512", o.gap)
+	}
+	if o.prefetch != 8 {
+		t.Fatalf("prefetch = %d, want 8", o.prefetch)
+	}
+}
+
+func TestFfiOperatorReaderWithReturnType(t *testing.T) {
+	if ffiOperatorReaderWith.opts.rType != &typeResultOperatorReader {
+		t.Fatalf("ffiOperatorReaderWith rType = %v, want typeResultOperatorReader", ffiOperatorReaderWith.opts.rType)
+	}
+}
+
+func TestFfiOperatorReaderWithArgTypes(t *testing.T) {
+	aTypes := ffiOperatorReaderWith.opts.aTypes
+	if len(aTypes) != 3 {
+		t.Fatalf("ffiOperatorReaderWith aTypes len = %d, want 3", len(aTypes))
+	}
+	for i, at := range aTypes {
+		if at != &ffi.TypePointer {
+			t.Fatalf("ffiOperatorReaderWith aTypes[%d] = %v, want TypePointer", i, at)
+		}
+	}
+}
+
+func TestReaderOptionsSetterArgTypes(t *testing.T) {
+	stringSetters := []*FFI[func(*opendalReaderOptions, string) ([]byte, error)]{
+		ffiReaderOptionsSetVersion,
+		ffiReaderOptionsSetIfMatch,
+		ffiReaderOptionsSetIfNoneMatch,
+	}
+	for _, setter := range stringSetters {
+		aTypes := setter.opts.aTypes
+		if len(aTypes) != 2 {
+			t.Fatalf("%s aTypes len = %d, want 2", setter.opts.sym, len(aTypes))
+		}
+		for i, at := range aTypes {
+			if at != &ffi.TypePointer {
+				t.Fatalf("%s aTypes[%d] = %v, want TypePointer", setter.opts.sym, i, at)
+			}
+		}
+	}
+
+	int64Setters := []*FFI[func(*opendalReaderOptions, int64)]{
+		ffiReaderOptionsSetIfModifiedSince,
+		ffiReaderOptionsSetIfUnmodifiedSince,
+	}
+	for _, setter := range int64Setters {
+		aTypes := setter.opts.aTypes
+		if len(aTypes) != 2 {
+			t.Fatalf("%s aTypes len = %d, want 2", setter.opts.sym, len(aTypes))
+		}
+		if aTypes[0] != &ffi.TypePointer || aTypes[1] != &ffi.TypeSint64 {
+			t.Fatalf("%s aTypes = %v, want TypePointer, TypeSint64", setter.opts.sym, aTypes)
+		}
+	}
+
+	uintSetters := []*FFI[func(*opendalReaderOptions, uint)]{
+		ffiReaderOptionsSetConcurrent,
+		ffiReaderOptionsSetChunk,
+		ffiReaderOptionsSetGap,
+		ffiReaderOptionsSetPrefetch,
+	}
+	for _, setter := range uintSetters {
+		aTypes := setter.opts.aTypes
+		if len(aTypes) != 2 {
+			t.Fatalf("%s aTypes len = %d, want 2", setter.opts.sym, len(aTypes))
+		}
+		for i, at := range aTypes {
+			if at != &ffi.TypePointer {
+				t.Fatalf("%s aTypes[%d] = %v, want TypePointer", setter.opts.sym, i, at)
+			}
+		}
+	}
+
+	hintATypes := ffiReaderOptionsSetContentLengthHint.opts.aTypes
+	if len(hintATypes) != 2 {
+		t.Fatalf("ffiReaderOptionsSetContentLengthHint aTypes len = %d, want 2", len(hintATypes))
+	}
+	if hintATypes[0] != &ffi.TypePointer || hintATypes[1] != &ffi.TypeUint64 {
+		t.Fatalf("ffiReaderOptionsSetContentLengthHint aTypes = %v, want TypePointer, TypeUint64", hintATypes)
+	}
+}
+
 func TestFfiOperatorPresignWithSignatures(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/bindings/go/tests/behavior_tests/read_test.go
+++ b/bindings/go/tests/behavior_tests/read_test.go
@@ -43,6 +43,7 @@ func testsRead(cap *opendal.Capability) []behaviorTest {
 		testReadWithRangeFrom,
 		testReadWithContentLengthHint,
 		testReadWithConcurrentChunkGap,
+		testReaderWithConcurrentChunkGap,
 	}
 	if cap.WriteCanMulti() {
 		tests = append(tests, testIOCopy)
@@ -50,6 +51,7 @@ func testsRead(cap *opendal.Capability) []behaviorTest {
 	}
 	if cap.ReadWithIfMatch() {
 		tests = append(tests, testReadWithIfMatch)
+		tests = append(tests, testReaderWithIfMatch)
 	}
 	if cap.ReadWithIfNoneMatch() {
 		tests = append(tests, testReadWithIfNoneMatch)
@@ -62,6 +64,7 @@ func testsRead(cap *opendal.Capability) []behaviorTest {
 	}
 	if cap.ReadWithVersion() {
 		tests = append(tests, testReadWithVersion)
+		tests = append(tests, testReaderWithVersion)
 	}
 	return tests
 }
@@ -367,4 +370,80 @@ func testReaderSeek(assert *require.Assertions, op *opendal.Operator, fixture *f
 	assert.Nil(err, "read must succeed")
 	assert.Equal(length, int64(n), "read size")
 	assert.Equal(content[int64(size)-length:size], bs[:n], "read content")
+}
+
+func testReaderWithConcurrentChunkGap(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, size := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	r, err := op.Reader(path,
+		opendal.ReaderWithConcurrent(2),
+		opendal.ReaderWithChunk(1024*1024),
+		opendal.ReaderWithGap(4096),
+		opendal.ReaderWithPrefetch(2),
+	)
+	assert.Nil(err)
+	defer r.Close()
+
+	bs := make([]byte, size)
+	n, err := io.ReadFull(r, bs)
+	assert.Nil(err)
+	assert.Equal(size, uint(n), "read size")
+	assert.Equal(content, bs[:n], "read content")
+}
+
+func testReaderWithIfMatch(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, size := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	meta, err := op.Stat(path)
+	assert.Nil(err)
+	etag, ok := meta.ETag()
+	if !ok {
+		return
+	}
+
+	// Some backends defer the request to the first read: reader creation then
+	// succeeds and the condition failure surfaces from Read(). The C reader maps
+	// read-time errors to CodeUnexpected, so only the eager (creation) path
+	// carries the precise CodeConditionNotMatch.
+	r, err := op.Reader(path, opendal.ReaderWithIfMatch("\"invalid_etag\""))
+	if err != nil {
+		assert.Equal(opendal.CodeConditionNotMatch, assertErrorCode(err))
+	} else {
+		_, readErr := r.Read(make([]byte, size))
+		assert.NotNil(readErr, "reader with non-matching etag must fail on read")
+		assert.Nil(r.Close(), "close reader must succeed")
+	}
+
+	r, err = op.Reader(path, opendal.ReaderWithIfMatch(etag))
+	assert.Nil(err, "reader with matching etag must succeed")
+	defer r.Close()
+	bs := make([]byte, size)
+	n, err := io.ReadFull(r, bs)
+	assert.Nil(err)
+	assert.Equal(content, bs[:n], "read content")
+}
+
+func testReaderWithVersion(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	path, content, size := fixture.NewFile()
+
+	assert.Nil(op.Write(path, content), "write must succeed")
+
+	meta, err := op.Stat(path)
+	assert.Nil(err)
+	version, ok := meta.Version()
+	if !ok {
+		return
+	}
+
+	r, err := op.Reader(path, opendal.ReaderWithVersion(version))
+	assert.Nil(err)
+	defer r.Close()
+	bs := make([]byte, size)
+	n, err := io.ReadFull(r, bs)
+	assert.Nil(err)
+	assert.Equal(content, bs[:n], "read version content")
 }

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -367,6 +367,8 @@ type opendalDeleteOptions struct{}
 
 type opendalReadOptions struct{}
 
+type opendalReaderOptions struct{}
+
 type opendalCopyOptions struct{}
 
 type opendalWriteOptions struct{}


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

`Operator.Reader` accepted no options, unlike `Operator.Writer`. This brings it to
parity with the Rust core's `Operator::reader_options`.

# What changes are included in this PR?

- **C FFI:** add `opendal_operator_reader_with` and the `opendal_reader_options` struct
  (mirrors core `ReaderOptions`: version, conditional headers, content-length hint, and
  concurrent/chunk/gap/prefetch), with setters and a `From` impl; regenerate `opendal.h`.
- **Go:** add the `WithReaderFn` option family and `Reader(path string, opts ...WithReaderFn)`;
  the `len(opts) == 0` fast path is unchanged.
- Unit, C++, and behavior tests.

# Are there any user-facing changes?

Yes. `Operator.Reader` gains an optional variadic `opts ...WithReaderFn` and ten `ReaderWith*`
constructors. Existing `op.Reader(path)` calls are unaffected.

# AI Usage Statement

Implemented and reviewed with Claude Code (Claude Opus 4.8) and Codex.
