### PR TITLE
feat(services/s3): support sha256 checksum algorithm

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -7450,6 +7450,7 @@ dependencies = [
  "reqsign-file-read-tokio",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "tokio",
  "url",
 ]

--- a/core/services/s3/Cargo.toml
+++ b/core/services/s3/Cargo.toml
@@ -45,6 +45,7 @@ reqsign-aws-v4 = { version = "3.0.0", default-features = false }
 reqsign-core = { version = "3.0.1", default-features = false }
 reqsign-file-read-tokio = { version = "3.0.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
+sha2 = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -568,6 +568,7 @@ impl S3Builder {
     ///
     /// Available options:
     /// - "crc32c"
+    /// - "sha256"
     /// - "md5"
     pub fn checksum_algorithm(mut self, checksum_algorithm: &str) -> Self {
         self.config.checksum_algorithm = Some(checksum_algorithm.to_string());
@@ -800,6 +801,7 @@ impl Builder for S3Builder {
 
         let checksum_algorithm = match config.checksum_algorithm.as_deref() {
             Some("crc32c") => Some(ChecksumAlgorithm::Crc32c),
+            Some("sha256") => Some(ChecksumAlgorithm::Sha256),
             Some("md5") => Some(ChecksumAlgorithm::Md5),
             None => None,
             v => {

--- a/core/services/s3/src/config.rs
+++ b/core/services/s3/src/config.rs
@@ -271,6 +271,7 @@ pub struct S3Config {
     ///
     /// Available options:
     /// - "crc32c"
+    /// - "sha256"
     /// - "md5"
     ///
     /// <!-- @group Behavior -->

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -43,6 +43,8 @@ use reqsign_aws_v4::Credential;
 use reqsign_core::{Context, Signer};
 use serde::Deserialize;
 use serde::Serialize;
+use sha2::Digest as Sha2Digest;
+use sha2::Sha256;
 
 use opendal_core::raw::*;
 use opendal_core::*;
@@ -123,6 +125,13 @@ fn format_crc32c_iter(body: Buffer) -> String {
 
     let crc = digest.finalize() as u32;
     BASE64_STANDARD.encode(crc.to_be_bytes())
+}
+
+fn format_sha256_iter(body: Buffer) -> String {
+    let mut hasher = Sha256::new();
+    body.for_each(|b| hasher.update(&b));
+
+    BASE64_STANDARD.encode(hasher.finalize())
 }
 
 impl Debug for S3Core {
@@ -296,6 +305,7 @@ impl S3Core {
         match self.checksum_algorithm {
             None => None,
             Some(ChecksumAlgorithm::Crc32c) => Some(format_crc32c_iter(body.clone())),
+            Some(ChecksumAlgorithm::Sha256) => Some(format_sha256_iter(body.clone())),
             Some(ChecksumAlgorithm::Md5) => Some(format_content_md5_iter(body.clone())),
         }
     }
@@ -1406,6 +1416,8 @@ pub struct CompleteMultipartUploadRequestPart {
     pub etag: String,
     #[serde(rename = "ChecksumCRC32C", skip_serializing_if = "Option::is_none")]
     pub checksum_crc32c: Option<String>,
+    #[serde(rename = "ChecksumSHA256", skip_serializing_if = "Option::is_none")]
+    pub checksum_sha256: Option<String>,
 }
 
 /// Output of `CompleteMultipartUpload` operation
@@ -1557,6 +1569,7 @@ pub struct ListObjectVersionsOutputDeleteMarker {
 
 pub enum ChecksumAlgorithm {
     Crc32c,
+    Sha256,
     /// Mapping to the `Content-MD5` header from S3.
     Md5,
 }
@@ -1564,6 +1577,7 @@ impl ChecksumAlgorithm {
     pub fn to_header_name(&self) -> HeaderName {
         match self {
             Self::Crc32c => HeaderName::from_static("x-amz-checksum-crc32c"),
+            Self::Sha256 => HeaderName::from_static("x-amz-checksum-sha256"),
             Self::Md5 => HeaderName::from_static("content-md5"),
         }
     }
@@ -1575,6 +1589,7 @@ impl Display for ChecksumAlgorithm {
             "{}",
             match self {
                 Self::Crc32c => "CRC32C",
+                Self::Sha256 => "SHA256",
                 Self::Md5 => "MD5",
             }
         )
@@ -1587,6 +1602,20 @@ mod tests {
     use bytes::Bytes;
 
     use super::*;
+
+    #[test]
+    fn test_format_sha256_iter() {
+        // Base64-encoded SHA256 of "hello".
+        assert_eq!(
+            format_sha256_iter(Buffer::from("hello")),
+            "LPJNul+wow4m6DsqxbninhsWHlwfp0JecwQzYpOLmCQ="
+        );
+        // Base64-encoded SHA256 of an empty input.
+        assert_eq!(
+            format_sha256_iter(Buffer::new()),
+            "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
+        );
+    }
 
     /// This example is from https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html#API_CreateMultipartUpload_Examples
     #[test]

--- a/core/services/s3/src/writer.rs
+++ b/core/services/s3/src/writer.rs
@@ -170,6 +170,13 @@ impl oio::MultipartWrite for S3Writer {
                         part_number: p.part_number,
                         etag: p.etag.clone(),
                         checksum_crc32c: p.checksum.clone(),
+                        ..Default::default()
+                    },
+                    ChecksumAlgorithm::Sha256 => CompleteMultipartUploadRequestPart {
+                        part_number: p.part_number,
+                        etag: p.etag.clone(),
+                        checksum_sha256: p.checksum.clone(),
+                        ..Default::default()
                     },
                     ChecksumAlgorithm::Md5 => CompleteMultipartUploadRequestPart {
                         part_number: p.part_number,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

S3 supports several checksum algorithms for verifying upload integrity (e.g. for buckets with Object Lock). OpenDAL's S3 service already supports `crc32c` and `md5`, but not `sha256`, which is one of the most commonly used and is accepted by S3 for both single and multipart uploads.

# What changes are included in this PR?

- Add a `Sha256` variant to the internal `ChecksumAlgorithm` enum, mapping to the `x-amz-checksum-sha256` header.
- Compute the base64-encoded SHA256 digest of the body via a new `format_sha256_iter` helper (using the `sha2` crate) in `calculate_checksum`.
- Accept `"sha256"` for the `checksum_algorithm` config / builder option.
- Send the per-part `ChecksumSHA256` element when completing multipart uploads.
- Add a unit test guarding the SHA256 digest output and update docs.

# Are there any user-facing changes?

Yes. `"sha256"` is now a valid value for the S3 `checksum_algorithm` option. Builder and config docs are updated. No breaking changes.

# AI Usage Statement

This PR was prepared with the assistance of Claude Code (Claude Opus 4.8). All changes were reviewed by the author.