### PR TITLE
fix(fuzz): resolve fuzz_reader timeout on OSS-Fuzz

### DIFF
--- a/core/fuzz/fuzz_reader.rs
+++ b/core/fuzz/fuzz_reader.rs
@@ -31,7 +31,7 @@ use opendal::tests::ReadChecker;
 use opendal::tests::TEST_RUNTIME;
 use opendal::tests::init_test_service;
 
-const MAX_DATA_SIZE: usize = 16 * 1024 * 1024;
+const MAX_DATA_SIZE: usize = 4 * 1024 * 1024;
 
 #[derive(Clone)]
 struct FuzzInput {
@@ -59,7 +59,7 @@ impl Arbitrary<'_> for FuzzInput {
     fn arbitrary(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
         let total_size = u.int_in_range(1..=MAX_DATA_SIZE)?;
 
-        let count = u.int_in_range(1..=1024)?;
+        let count = u.int_in_range(1..=256)?;
         let mut actions = vec![];
 
         for _ in 0..count {

--- a/core/fuzz/fuzz_writer.rs
+++ b/core/fuzz/fuzz_writer.rs
@@ -29,7 +29,7 @@ use opendal::tests::WriteAction;
 use opendal::tests::WriteChecker;
 use opendal::tests::init_test_service;
 
-const MAX_DATA_SIZE: usize = 16 * 1024 * 1024;
+const MAX_DATA_SIZE: usize = 4 * 1024 * 1024;
 
 #[derive(Debug, Clone)]
 struct FuzzInput {
@@ -52,7 +52,7 @@ impl Arbitrary<'_> for FuzzInput {
             None
         };
 
-        let count = u.int_in_range(1..=1024)?;
+        let count = u.int_in_range(1..=256)?;
 
         for _ in 0..count {
             let size = u.int_in_range(1..=MAX_DATA_SIZE)?;

--- a/core/testkit/src/read.rs
+++ b/core/testkit/src/read.rs
@@ -91,12 +91,13 @@ impl ReadChecker {
 
         let expected = &self.raw_data[offset..offset + output.len()];
 
-        // Check the read result
-        assert_eq!(
-            sha256_digest(output),
-            sha256_digest(expected),
-            "check read failed: output bs is different with expected bs",
-        );
+        if output != expected {
+            assert_eq!(
+                sha256_digest(output),
+                sha256_digest(expected),
+                "check read failed: output bs is different with expected bs",
+            );
+        }
     }
 
     /// Check will check the correctness of the read process via given actions.

--- a/core/testkit/src/write.rs
+++ b/core/testkit/src/write.rs
@@ -70,10 +70,12 @@ impl WriteChecker {
 
     /// Check the correctness of the write process.
     pub fn check(&self, actual: &[u8]) {
-        assert_eq!(
-            sha256_digest(actual),
-            sha256_digest(&self.data),
-            "check failed: result is not expected"
-        )
+        if actual != self.data.as_ref() {
+            assert_eq!(
+                sha256_digest(actual),
+                sha256_digest(&self.data),
+                "check failed: result is not expected"
+            );
+        }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7808.

# Rationale for this change

`fuzz_reader_memory` reliably times out (>60s) on OSS-Fuzz. The root cause is excessive SHA256 computation in the verification path:

- `ReadChecker::check_read` computes SHA256 twice per action (output + expected) even when data matches
- With old limits (16MB data, 1024 actions), worst-case SHA256 work is ~32GB
- Under ASAN (which OSS-Fuzz uses), this takes ~48-62s, right at the 60s timeout boundary

Benchmark on the worst-case input:

| Scenario | Time (local release) | Estimated ASAN ~3x |
|----------|---------------------|---------------------|
| Old params (16MB × 1024 × 2) | 16.13s | ~48s |
| Reduced limits only (4MB × 256 × 2) | 1.02s | ~3.1s |
| Full fix (memcmp-first) | 0.03s | ~0.09s |

# What changes are included in this PR?

Two complementary fixes:

1. **Reduce fuzz limits** (`fuzz_reader.rs`, `fuzz_writer.rs`):
   - `MAX_DATA_SIZE`: 16MB → 4MB
   - Max actions: 1024 → 256

2. **Eliminate hot-path SHA256** (`testkit/src/read.rs`, `testkit/src/write.rs`):
   - Use direct memory comparison (`==` / memcmp) first
   - Only compute SHA256 on mismatch for the assertion error message
   - Normal path (data correct) has zero SHA256 overhead

# Are there any user-facing changes?

No.