### PR TITLE
fix(object_store): export send future helper

### DIFF
--- a/integrations/object_store/src/lib.rs
+++ b/integrations/object_store/src/lib.rs
@@ -60,11 +60,24 @@
 //!     assert_eq!(content, bytes);
 //! }
 //! ```
+//!
+//! Use the re-exported future helper when an integration needs the same OpenDAL
+//! future wrapper used by this crate:
+//!
+//! ```no_run
+//! use object_store_opendal::IntoSendFuture;
+//! use opendal::Operator;
+//!
+//! async fn rename(op: Operator) -> opendal::Result<()> {
+//!     op.rename("from", "to").into_send().await
+//! }
+//! ```
 
 mod store;
 pub use store::OpendalStore;
 
 mod utils;
+pub use utils::IntoSendFuture;
 
 #[cfg(feature = "services-s3")]
 mod amazon_s3;


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

`IntoSendFuture` is implemented by `object_store_opendal`, but it currently lives behind the private `utils` module. External integrations that need to wrap OpenDAL futures cannot import the trait from the crate root, so `.into_send()` is not available at call sites.

# What changes are included in this PR?

- Re-export `IntoSendFuture` from `object_store_opendal`.
- Add a small crate-level example showing the public import path.

# Are there any user-facing changes?

Yes. `object_store_opendal::IntoSendFuture` is now available for external integrations.

# AI Usage Statement

None.

# Validation

- `cargo check` in `integrations/object_store`
- `cargo fmt --check` in `integrations/object_store`
- Temporary external crate check importing `object_store_opendal::IntoSendFuture` and calling `.into_send()`