### PR TITLE
Set shared capability of Mini Moka and OPFS

### DIFF
--- a/core/core/src/services/memory/backend.rs
+++ b/core/core/src/services/memory/backend.rs
@@ -79,7 +79,6 @@ impl MemoryBackend {
             stat: true,
             list: true,
             list_with_recursive: true,
-            shared: false,
             ..Default::default()
         };
 

--- a/core/services/cacache/src/backend.rs
+++ b/core/services/cacache/src/backend.rs
@@ -62,7 +62,6 @@ impl Builder for CacacheBuilder {
             stat: true,
             rename: false,
             list: false,
-            shared: false,
             ..Default::default()
         };
 

--- a/core/services/cloudflare-kv/src/backend.rs
+++ b/core/services/cloudflare-kv/src/backend.rs
@@ -171,8 +171,6 @@ impl Builder for CloudflareKvBuilder {
                     delete: true,
                     delete_max_size: Some(10000),
 
-                    shared: false,
-
                     ..Default::default()
                 },
             }),

--- a/core/services/dashmap/src/backend.rs
+++ b/core/services/dashmap/src/backend.rs
@@ -98,7 +98,6 @@ impl DashmapBackend {
             delete: true,
             stat: true,
             list: true,
-            shared: false,
             ..Default::default()
         };
 

--- a/core/services/mini_moka/src/backend.rs
+++ b/core/services/mini_moka/src/backend.rs
@@ -135,6 +135,7 @@ impl MiniMokaBackend {
             write_can_empty: true,
             delete: true,
             list: true,
+            shared: false,
 
             ..Default::default()
         };

--- a/core/services/mini_moka/src/backend.rs
+++ b/core/services/mini_moka/src/backend.rs
@@ -135,7 +135,6 @@ impl MiniMokaBackend {
             write_can_empty: true,
             delete: true,
             list: true,
-            shared: false,
 
             ..Default::default()
         };

--- a/core/services/moka/src/backend.rs
+++ b/core/services/moka/src/backend.rs
@@ -202,7 +202,6 @@ impl MokaBackend {
             delete: true,
             stat: true,
             list: true,
-            shared: false,
             ..Default::default()
         };
 

--- a/core/services/opfs/src/core.rs
+++ b/core/services/opfs/src/core.rs
@@ -44,6 +44,8 @@ impl OpfsCore {
 
             delete: true,
 
+            shared: true,
+
             ..Default::default()
         };
 

--- a/core/services/persy/src/backend.rs
+++ b/core/services/persy/src/backend.rs
@@ -136,7 +136,6 @@ impl PersyBackend {
             write: true,
             write_can_empty: true,
             delete: true,
-            shared: false,
             ..Default::default()
         };
 

--- a/core/services/redb/src/backend.rs
+++ b/core/services/redb/src/backend.rs
@@ -148,7 +148,6 @@ impl RedbBackend {
             write: true,
             write_can_empty: true,
             delete: true,
-            shared: false,
             ..Default::default()
         };
 

--- a/core/services/rocksdb/src/backend.rs
+++ b/core/services/rocksdb/src/backend.rs
@@ -98,7 +98,6 @@ impl RocksdbBackend {
             delete: true,
             list: true,
             list_with_recursive: true,
-            shared: false,
             ..Default::default()
         };
 

--- a/core/services/sled/src/backend.rs
+++ b/core/services/sled/src/backend.rs
@@ -122,7 +122,6 @@ impl SledBackend {
             delete: true,
             list: true,
             list_with_recursive: true,
-            shared: false,
             ..Default::default()
         };
 

--- a/core/services/sqlite/src/backend.rs
+++ b/core/services/sqlite/src/backend.rs
@@ -188,7 +188,6 @@ impl SqliteBackend {
             stat: true,
             write_can_empty: true,
             list: false,
-            shared: false,
             ..Default::default()
         };
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7855.

# Rationale for this change

The shared capability flag is set for all other services, but is missing for OPFS and Mini Moka.
The choice to mark one shared and the other not is based on [Xuanwo's definition in this comment](https://github.com/apache/opendal/pull/5324#issuecomment-2480461643).

# What changes are included in this PR?

1. [Set mini moka backend shared capability to false](https://github.com/apache/opendal/commit/c3c277afbe3bf0694512ca6d133454be51b3dfbc)
2. [Set opfs backend shared capability to true](https://github.com/apache/opendal/commit/b5503c5caf3ae1636a3873ed98c48710df01a1d2)

# Are there any user-facing changes?

`opfs` shared capability becomes true instead of defaulting to false.

# AI Usage Statement

No AI used