### PR TITLE
chore(release): finalize Ruby binding version

### DIFF
--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.1.7-rc.2"
+version = "0.1.7"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -143,7 +143,7 @@ opendal-layer-logging@0.57.0	X
 opendal-layer-retry@0.57.0	X													
 opendal-layer-throttle@0.57.0	X													
 opendal-layer-timeout@0.57.0	X													
-opendal-ruby@0.1.6	X													
+opendal-ruby@0.1.7	X
 opendal-service-azblob@0.57.0	X													
 opendal-service-azdls@0.57.0	X													
 opendal-service-azfile@0.57.0	X													

--- a/dev/src/release/package.rs
+++ b/dev/src/release/package.rs
@@ -77,7 +77,7 @@ pub fn all_packages() -> Vec<Package> {
     let java = make_package("bindings/java", "0.49.0", vec![core.clone()]);
     let nodejs = make_package("bindings/nodejs", "0.49.4", vec![core.clone()]);
     let python = make_package("bindings/python", "0.47.2", vec![core.clone()]);
-    let ruby = make_package("bindings/ruby", "0.1.6", vec![core.clone()]);
+    let ruby = make_package("bindings/ruby", "0.1.7", vec![core.clone()]);
 
     vec![
         core,
@@ -533,24 +533,38 @@ mod tests {
         std::env::temp_dir().join(format!("odev-package-{name}-{nanos}"))
     }
 
+    fn release_package(name: &str) -> Package {
+        all_packages()
+            .into_iter()
+            .find(|package| package.name() == name)
+            .unwrap()
+    }
+
+    fn cargo_manifest_version(package: &Package) -> Version {
+        let manifest_path = package.path.join("Cargo.toml");
+        let manifest = std::fs::read_to_string(manifest_path).unwrap();
+        let manifest = DocumentMut::from_str(&manifest).unwrap();
+
+        manifest["package"]["version"]
+            .as_str()
+            .map(Version::parse)
+            .transpose()
+            .unwrap()
+            .unwrap()
+    }
+
     #[test]
     fn parquet_release_version_matches_manifest() {
-        let parquet = all_packages()
-            .into_iter()
-            .find(|package| package.name() == "integrations/parquet")
-            .unwrap();
+        let parquet = release_package("integrations/parquet");
 
-        assert_eq!(parquet.version, Version::parse("0.8.1").unwrap());
+        assert_eq!(parquet.version, cargo_manifest_version(&parquet));
     }
 
     #[test]
     fn ruby_release_version_matches_manifest() {
-        let ruby = all_packages()
-            .into_iter()
-            .find(|package| package.name() == "bindings/ruby")
-            .unwrap();
+        let ruby = release_package("bindings/ruby");
 
-        assert_eq!(ruby.version, Version::parse("0.1.6").unwrap());
+        assert_eq!(ruby.version, cargo_manifest_version(&ruby));
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

The Ruby binding is ready for its final 0.1.7 release. Its manifest still used the RC version, while the release package map still pointed at the previous Ruby package version. The release package tests also duplicated concrete version numbers, which made ordinary version bumps require test edits.

# What changes are included in this PR?

- Finalize the Ruby binding version as 0.1.7.
- Sync the Ruby entry in the odev release package map and dependency list.
- Make release package tests compare package versions with the corresponding Cargo manifests instead of hard-coded expected versions.

# Are there any user-facing changes?

No runtime API changes. The Ruby package release version is finalized as 0.1.7.

# AI Usage Statement

This PR was prepared with OpenAI Codex.
