### PR TITLE
feat(dev): support dotnet version updates

### DIFF
--- a/dev/src/release/package.rs
+++ b/dev/src/release/package.rs
@@ -78,6 +78,7 @@ pub fn all_packages() -> Vec<Package> {
     let nodejs = make_package("bindings/nodejs", "0.49.4", vec![core.clone()]);
     let python = make_package("bindings/python", "0.47.2", vec![core.clone()]);
     let ruby = make_package("bindings/ruby", "0.1.7", vec![core.clone()]);
+    let dotnet = make_package("bindings/dotnet", "0.1.0", vec![core.clone()]);
 
     vec![
         core,
@@ -91,6 +92,7 @@ pub fn all_packages() -> Vec<Package> {
         nodejs,
         python,
         ruby,
+        dotnet,
     ]
 }
 
@@ -120,6 +122,7 @@ pub fn update_package_version(package: &Package) -> bool {
         }
         "bindings/java" => update_maven_version(&package.path, &package.version),
         "bindings/nodejs" => update_nodejs_version(&package.path, &package.version),
+        "bindings/dotnet" => update_dotnet_version(&package.path, &package.version),
 
         name => panic!("unknown package: {name}"),
     }
@@ -521,6 +524,33 @@ fn update_nodejs_version(path: &Path, version: &Version) -> bool {
     updated
 }
 
+fn update_dotnet_version(path: &Path, version: &Version) -> bool {
+    let path = path.join("OpenDAL").join("OpenDAL.csproj");
+    let manifest = std::fs::read_to_string(&path).unwrap();
+    let matcher = regex::Regex::new(r"<VersionPrefix>(\d+\.\d+\.\d+)</VersionPrefix>").unwrap();
+    let old_version = matcher
+        .captures(&manifest)
+        .and_then(|captures| captures.get(1))
+        .map(|matched| Version::parse(matched.as_str()).unwrap())
+        .unwrap_or_else(|| panic!("missing VersionPrefix for package: {}", path.display()));
+
+    if old_version == *version {
+        return false;
+    }
+
+    let new_version_string = format!("<VersionPrefix>{version}</VersionPrefix>");
+    let new_manifest = matcher.replace(&manifest, new_version_string.as_str());
+    std::fs::write(&path, new_manifest.as_bytes()).unwrap();
+    println!(
+        "updating version for package: {} from {} to {}",
+        path.display(),
+        old_version,
+        version
+    );
+
+    true
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -553,6 +583,17 @@ mod tests {
             .unwrap()
     }
 
+    fn dotnet_project_version(package: &Package) -> Version {
+        let manifest_path = package.path.join("OpenDAL").join("OpenDAL.csproj");
+        let manifest = std::fs::read_to_string(manifest_path).unwrap();
+        let matcher = regex::Regex::new(r"<VersionPrefix>(\d+\.\d+\.\d+)</VersionPrefix>").unwrap();
+        matcher
+            .captures(&manifest)
+            .and_then(|captures| captures.get(1))
+            .map(|matched| Version::parse(matched.as_str()).unwrap())
+            .unwrap()
+    }
+
     #[test]
     fn parquet_release_version_matches_manifest() {
         let parquet = release_package("integrations/parquet");
@@ -565,6 +606,13 @@ mod tests {
         let ruby = release_package("bindings/ruby");
 
         assert_eq!(ruby.version, cargo_manifest_version(&ruby));
+    }
+
+    #[test]
+    fn dotnet_release_version_matches_project() {
+        let dotnet = release_package("bindings/dotnet");
+
+        assert_eq!(dotnet.version, dotnet_project_version(&dotnet));
     }
 
     #[test]
@@ -663,6 +711,40 @@ opendal = { version = "0.55.0", path = "../core" }
             manifest["target"]["cfg(windows)"]["dependencies"]["opendal"]["version"].as_str(),
             Some("0.55.0")
         );
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn update_dotnet_version_updates_version_prefix() {
+        let dir = temp_test_dir("dotnet-version");
+        let project_dir = dir.join("OpenDAL");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let project_path = project_dir.join("OpenDAL.csproj");
+        std::fs::write(
+            &project_path,
+            r#"<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <VersionPrefix>0.1.0</VersionPrefix>
+        <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
+        <FileVersion>$(VersionPrefix)</FileVersion>
+    </PropertyGroup>
+</Project>"#,
+        )
+        .unwrap();
+
+        let updated = update_dotnet_version(&dir, &Version::parse("0.2.0").unwrap());
+        assert!(updated);
+
+        let manifest = std::fs::read_to_string(&project_path).unwrap();
+        assert!(manifest.contains("<VersionPrefix>0.2.0</VersionPrefix>"));
+        assert!(manifest.contains("<AssemblyVersion>$(VersionPrefix)</AssemblyVersion>"));
+        assert!(manifest.contains("<FileVersion>$(VersionPrefix)</FileVersion>"));
+        assert!(!update_dotnet_version(
+            &dir,
+            &Version::parse("0.2.0").unwrap()
+        ));
 
         std::fs::remove_dir_all(dir).unwrap();
     }


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

`odev update-version` already manages release package versions for Rust, Java, Node.js, Python, and Ruby packages, but the .NET binding was not listed in the release package map. This meant the NuGet `VersionPrefix` in `bindings/dotnet/OpenDAL/OpenDAL.csproj` had to be kept in sync manually.

# What changes are included in this PR?

- Add `bindings/dotnet` to the odev release package list with its current package version.
- Add .NET version update support by rewriting `OpenDAL.csproj` `VersionPrefix`.
- Add tests that check the release package version matches the project file and that the updater only changes `VersionPrefix` while preserving the existing `AssemblyVersion` and `FileVersion` indirection.

# Are there any user-facing changes?

No runtime API changes. Release tooling can now keep the .NET binding version in sync through `odev update-version`.

# AI Usage Statement

This PR was prepared with OpenAI Codex.
