### PR TITLE
ci: fix release workflow tag publishing

### DIFF
--- a/.github/workflows/release_dotnet.yml
+++ b/.github/workflows/release_dotnet.yml
@@ -18,6 +18,10 @@
 name: Release Dotnet Binding
 
 on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
   pull_request:
     branches:
       - main
@@ -126,18 +130,41 @@ jobs:
         id: version
         shell: bash
         run: |
-          case "${{ inputs.release_type }}" in
-            rc)
-              SUFFIX="rc"
-              ;;
-            *)
-              SUFFIX="preview.${GITHUB_RUN_NUMBER}"
-              ;;
-          esac
-          echo "VERSION_SUFFIX=${SUFFIX}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+
+          suffix=""
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.([0-9]+)$ ]]; then
+            suffix="rc.${BASH_REMATCH[1]}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            suffix=""
+          else
+            case "${{ inputs.release_type }}" in
+              rc)
+                suffix="rc"
+                ;;
+              *)
+                suffix="preview.${GITHUB_RUN_NUMBER}"
+                ;;
+            esac
+          fi
+
+          echo "version_suffix=${suffix}" >> "$GITHUB_OUTPUT"
 
       - name: Pack OpenDAL
-        run: dotnet pack OpenDAL/OpenDAL.csproj -c Release -o artifacts/package --version-suffix "${{ steps.version.outputs.VERSION_SUFFIX }}"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pack_args=(
+            OpenDAL/OpenDAL.csproj
+            -c Release
+            -o artifacts/package
+          )
+          if [[ -n "${{ steps.version.outputs.version_suffix }}" ]]; then
+            pack_args+=(--version-suffix "${{ steps.version.outputs.version_suffix }}")
+          fi
+
+          dotnet pack "${pack_args[@]}"
 
       - name: Upload NuGet package
         uses: actions/upload-artifact@v7
@@ -148,7 +175,7 @@ jobs:
 
   publish:
     name: Publish
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.release_type != 'none' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.release_type != 'none') || (startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')) }}
     runs-on: ubuntu-latest
     needs:
       - package

--- a/.github/workflows/release_ruby.yml
+++ b/.github/workflows/release_ruby.yml
@@ -162,8 +162,9 @@ jobs:
           retention-days: 30
 
   publish:
-    # allow tag releases
-    if: startsWith(github.ref, 'refs/tags/v')
+    # RC tags only build artifacts for release verification. RubyGems does not
+    # provide a staging registry, so publish only from the final release tag.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
 
     needs: [build, build-native]
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

The release preparation for the next OpenDAL release found two workflow issues:

- Ruby RC tags currently reach the publish job, which can publish prerelease gems to RubyGems even though RubyGems is not used as a staging registry.
- The .NET release workflow is only manually dispatched, so release tags do not build RC/final NuGet artifacts consistently with the rest of the release process.

# What changes are included in this PR?

- Restrict the Ruby publish job to final release tags only, while keeping RC tag builds available as artifacts for verification.
- Add .NET tag triggers for final and RC release tags.
- Make .NET RC tag builds pack NuGet artifacts with an `rc.N` suffix, while final release tags pack the stable version and publish to NuGet.

# Are there any user-facing changes?

No public API changes. This only affects release automation.

# AI Usage Statement

Used OpenAI Codex (GPT-5) to prepare this PR.

Validation:

- `git diff --check -- .github/workflows/release_ruby.yml .github/workflows/release_dotnet.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/release_ruby.yml .github/workflows/release_dotnet.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release_ruby.yml .github/workflows/release_dotnet.yml`
