### PR TITLE
fix(layers/tracing): propagate spans to executor tasks

### DIFF
--- a/core/layers/tracing/src/lib.rs
+++ b/core/layers/tracing/src/lib.rs
@@ -149,7 +149,11 @@ impl Layer for TracingLayer {
         let transport = HttpTransporter::new(TracingHttpTransport {
             inner: inner.http_transport().clone(),
         });
-        inner.with_http_transport(transport)
+        let executor = Executor::with(TracingExecutor {
+            inner: inner.executor().clone().into_inner(),
+        });
+
+        inner.with_http_transport(transport).with_executor(executor)
     }
 }
 
@@ -173,6 +177,21 @@ impl HttpTransport for TracingHttpTransport {
         // Keep response body polling inside the same HTTP fetch span.
         let body = body.map_inner(|s| Box::new(TracingStream { inner: s, span }));
         Ok(http::Response::from_parts(parts, body))
+    }
+}
+
+struct TracingExecutor {
+    inner: Arc<dyn Execute>,
+}
+
+impl Execute for TracingExecutor {
+    fn execute(&self, f: BoxedStaticFuture<()>) {
+        self.inner
+            .execute(Box::pin(f.instrument(Span::current())) as BoxedStaticFuture<()>)
+    }
+
+    fn timeout(&self) -> Option<BoxedStaticFuture<()>> {
+        self.inner.timeout()
     }
 }
 


### PR DESCRIPTION


# Which issue does this PR close?

Related to #7377.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Wrap the composed executor so futures spawned by the tracing layer inherit the caller's current tracing span.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

Bugfix only, instrumentation will start working for spawned tasks.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement
None
<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
