### PR TITLE
chore(release): prepare v0.58.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,198 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- Release notes generated with: gh release create v_draft --generate-notes --draft -->
 
+## [v0.58.0] - 2026-07-07
+
+### Breaking Changes
+* core: `Operator::new(builder)` now returns a finished `Operator`; remove the old `.finish()` call. The typed runtime composition pipeline has been replaced by `Service` / `ServiceDyn` / `Servicer` plus `OperationContext`.
+* core: raw `Service` / `ServiceDyn` factories for `read`, `write`, `delete`, `list`, and `copy` now return OIO bodies synchronously. Move asynchronous work into the returned body implementation.
+* core: `OperatorInfo::native_capability()` and native/full capability APIs have been removed. Use `OperatorInfo::capability()` as the composed operator availability contract.
+* core: runtime composition APIs have been consolidated around `OperationContext`, `Operator::with_context`, `Operator::from_parts`, and `Operator::into_parts`; `inner`, `into_inner`, `executor_ref`, `http_transport`, `executor`, and `from_service` have been removed.
+* core: `raw::AtomicContentLength`, `raw::PathCacher`, `raw::PathQuery`, and the `internal-path-cache` feature have been removed.
+* core: `BytesRange` is now public and suffix reads are expressed with `BytesRange::suffix(size)`.
+* bindings/c, bindings/go, bindings/java, and bindings/dotnet: operator info now exposes a single composed `capability`; previous `full` and `native` capability APIs were removed or renamed.
+
+### Added
+* feat(binding/go): Add ListOptions with recursive support by @FrankYang0529 in https://github.com/apache/opendal/pull/7605
+* feat(website): introduce a design system and rebuild the homepage by @Xuanwo in https://github.com/apache/opendal/pull/7638
+* feat(binding/go): expose all metata fields to golang by @dentiny in https://github.com/apache/opendal/pull/7646
+* feat(website): add Paimon Rust to logo wall by @QuakeWang in https://github.com/apache/opendal/pull/7643
+* feat(lister.go): Add opendal_list_options_set_limit and opendal_list_options_set_start_after by @FrankYang0529 in https://github.com/apache/opendal/pull/7649
+* feat(binding/go): expose all write options by @dentiny in https://github.com/apache/opendal/pull/7647
+* feat(services/oss): support content_encoding in write operations by @ITpandaffm in https://github.com/apache/opendal/pull/7658
+* feat(binding/go): expose all read options by @dentiny in https://github.com/apache/opendal/pull/7665
+* feat(services/azdls): support conditional read headers by @YuangGao in https://github.com/apache/opendal/pull/7667
+* feat(delete.go): add options version and recursive by @FrankYang0529 in https://github.com/apache/opendal/pull/7676
+* feat(binding/go): expose all stats options by @dentiny in https://github.com/apache/opendal/pull/7670
+* feat(binding/go): upgrade FFI package to latest version by @dentiny in https://github.com/apache/opendal/pull/7681
+* feat(core): Add copy source version support by @Xuanwo in https://github.com/apache/opendal/pull/7679
+* feat(lister.go): Add opendal_list_options_set_versions and opendal_list_options_set_deleted by @FrankYang0529 in https://github.com/apache/opendal/pull/7645
+* feat(website): add GooseFS to logo wall and services by @XuQianJin-Stars in https://github.com/apache/opendal/pull/7709
+* feat(copy.go): add copy options by @FrankYang0529 in https://github.com/apache/opendal/pull/7707
+* feat(binding/go): add missing read options by @dentiny in https://github.com/apache/opendal/pull/7728
+* feat(website): Add per-service configuration reference pages by @Xuanwo in https://github.com/apache/opendal/pull/7730
+* feat(core)!: Add suffix read support by @Xuanwo in https://github.com/apache/opendal/pull/7734
+* feat(metrics): add operation label to a few backends [1/N] by @dentiny in https://github.com/apache/opendal/pull/7530
+* [2/N] feat(metrics): annotate metrics with operation name by @dentiny in https://github.com/apache/opendal/pull/7748
+* feat(core): expose operator base service and context by @ngg in https://github.com/apache/opendal/pull/7788
+* feat(services/swift): support list with start_after by @edmc-ss in https://github.com/apache/opendal/pull/7810
+* feat(binding/go): add presign with options by @dentiny in https://github.com/apache/opendal/pull/7814
+* feat(fs): copy with metadata by @dentiny in https://github.com/apache/opendal/pull/7535
+* feat(services/webdav): support conditional read headers by @YuangGao in https://github.com/apache/opendal/pull/7637
+* feat(services/obs): support if_modified_since and if_unmodified_since… by @YuangGao in https://github.com/apache/opendal/pull/7708
+* feat(binding/go): add reader with options by @ryankert01 in https://github.com/apache/opendal/pull/7817
+* feat(services/http): support if_modified_since and if_unmodified_since by @YuangGao in https://github.com/apache/opendal/pull/7636
+* feat(services/hf): honor HF_HUB_DISABLE_XET to force http download mode by @AlJohri in https://github.com/apache/opendal/pull/7819
+* feat(core): add conditional rename option by @hfutatzhanghb in https://github.com/apache/opendal/pull/7815
+* feat(binding/go): add write with metadata by @ryankert01 in https://github.com/apache/opendal/pull/7827
+* feat(http-transport-reqwest): allow tls options by @erickguan in https://github.com/apache/opendal/pull/7798
+* feat(dev): support dotnet version updates by @Xuanwo in https://github.com/apache/opendal/pull/7862
+### Changed
+* refactor: switch S3 crc32c checksum to crc-fast by @PsiACE in https://github.com/apache/opendal/pull/7662
+* refactor(core): Rename oio::Read to ReadStream by @Xuanwo in https://github.com/apache/opendal/pull/7675
+* refactor(core): Move read range to raw reader by @Xuanwo in https://github.com/apache/opendal/pull/7678
+* refactor!: Refactor runtime service composition by @Xuanwo in https://github.com/apache/opendal/pull/7743
+* refactor!: simplify stateful operation factories by @Xuanwo in https://github.com/apache/opendal/pull/7746
+* refactor!: Remove native and full capability APIs by @Xuanwo in https://github.com/apache/opendal/pull/7747
+* refactor: introduce HTTP transporter API by @Xuanwo in https://github.com/apache/opendal/pull/7759
+* refactor(foyer): implement Code manually to drop bincode dependency by @Xuanwo in https://github.com/apache/opendal/pull/7772
+* refactor(core)!: remove unused AtomicContentLength util by @Xuanwo in https://github.com/apache/opendal/pull/7773
+* refactor(core): delegate presign_stat/presign_read to their _with variants by @Xuanwo in https://github.com/apache/opendal/pull/7775
+* refactor(core)!: remove unused PathCacher and internal-path-cache feature by @Xuanwo in https://github.com/apache/opendal/pull/7778
+* refactor(core)!: rework Operator runtime composition API by @Xuanwo in https://github.com/apache/opendal/pull/7779
+* refactor(core): make reqsign-core an optional dependency by @Xuanwo in https://github.com/apache/opendal/pull/7784
+* refactor(core): lazy open positioned read handles by @Xuanwo in https://github.com/apache/opendal/pull/7796
+* refactor: normalize service module layout by @Xuanwo in https://github.com/apache/opendal/pull/7797
+* refactor(bindings/python): use declarative pymodule syntax by @chitralverma in https://github.com/apache/opendal/pull/7812
+* refactor(bindings/python): generate type stubs with pyo3 introspection by @chitralverma in https://github.com/apache/opendal/pull/7824
+### Fixed
+* fix(services/hf): avoid logging full HTML error pages by @kszucs in https://github.com/apache/opendal/pull/7634
+* fix(website): mobile drawer menu by @suyanhanx in https://github.com/apache/opendal/pull/7644
+* fix(services/azdls): Handle not modified as condition mismatch by @Xuanwo in https://github.com/apache/opendal/pull/7674
+* fix(ci): release dotnet workflow by @Fatorin in https://github.com/apache/opendal/pull/7673
+* fix(services): bound batch-delete result allocation against malformed server responses by @tonghuaroot in https://github.com/apache/opendal/pull/7683
+* fix(services/fs): confine object keys to the configured root by rejecting parent-dir traversal by @tonghuaroot in https://github.com/apache/opendal/pull/7684
+* fix(layers): Align reader observability by @Xuanwo in https://github.com/apache/opendal/pull/7687
+* fix(services/webdav): remove unnecessary mut by @Xuanwo in https://github.com/apache/opendal/pull/7717
+* fix(services/fs): preserve backslash in filenames on Unix during list by @tonghuaroot in https://github.com/apache/opendal/pull/7721
+* fix(services): confine compfs/monoiofs object keys to root by rejecting parent-dir traversal by @tonghuaroot in https://github.com/apache/opendal/pull/7702
+* fix(fuzz): fall back to fs operator so fuzz targets produce real coverage by @tonghuaroot in https://github.com/apache/opendal/pull/7723
+* fix(services/fs): cache fs reader by @dentiny in https://github.com/apache/opendal/pull/7782
+* fix(services/onedrive): build correct children URL when listing root by @tonghuaroot in https://github.com/apache/opendal/pull/7720
+* fix(services/memcached): TCP address resolution by @flip1995 in https://github.com/apache/opendal/pull/7701
+* fix(webdav): support multiple propstat entries by @ZeonXr in https://github.com/apache/opendal/pull/7823
+* Fix C binding empty byte buffers by @fallintoplace in https://github.com/apache/opendal/pull/7807
+* fix(layers/foyer): preserve read args while filling full-object cache by @tonghuaroot in https://github.com/apache/opendal/pull/7718
+* fix(fuzz): resolve fuzz_reader timeout on OSS-Fuzz by @tonghuaroot in https://github.com/apache/opendal/pull/7831
+* fix(object_store): export send future helper by @hfutatzhanghb in https://github.com/apache/opendal/pull/7851
+* fix(services/sqlite): stat getting the entire object by @erickguan in https://github.com/apache/opendal/pull/7853
+* fix(services): improve stat implementation by @erickguan in https://github.com/apache/opendal/pull/7857
+### Docs
+* docs: update OpenDAL release skill by @Xuanwo in https://github.com/apache/opendal/pull/7655
+* docs(website): use project logos in used-by wall by @Xuanwo in https://github.com/apache/opendal/pull/7657
+* docs: update PMC member nomination process by @Xuanwo in https://github.com/apache/opendal/pull/7668
+* RFC-7660: Move Read Range To Reader by @Xuanwo in https://github.com/apache/opendal/pull/7660
+* RFC-7182:  file restoration API by @NikitaMatskevich in https://github.com/apache/opendal/pull/7182
+* docs: Sync AGENTS.md with current layout by @Xuanwo in https://github.com/apache/opendal/pull/7677
+* RFC: Capability API by @Xuanwo in https://github.com/apache/opendal/pull/7700
+* Add Ruby binding links by @erickguan in https://github.com/apache/opendal/pull/7713
+* docs: add Noorle to users list by @scollins99 in https://github.com/apache/opendal/pull/7727
+* docs: remove non-core docs pages by @Xuanwo in https://github.com/apache/opendal/pull/7733
+* feat(website): Add a concepts page with an interactive mental model by @Xuanwo in https://github.com/apache/opendal/pull/7735
+* RFC-7740: Operator Composition by @Xuanwo in https://github.com/apache/opendal/pull/7740
+* RFC-7744: Simplify Stateful Operation Factory by @Xuanwo in https://github.com/apache/opendal/pull/7744
+* docs: Add project security threat model by @potiuk in https://github.com/apache/opendal/pull/7641
+* RFC: Add HTTP transporter design by @Xuanwo in https://github.com/apache/opendal/pull/7749
+* docs: fix threat model style by @erickguan in https://github.com/apache/opendal/pull/7781
+* Wire AGENTS.md -> SECURITY.md -> threat model for agent discoverability by @potiuk in https://github.com/apache/opendal/pull/7785
+* docs: rework per-language guides around a task-centric structure by @Xuanwo in https://github.com/apache/opendal/pull/7787
+* docs: clarify operator context composition by @Xuanwo in https://github.com/apache/opendal/pull/7791
+* docs: source every Getting Started snippet from a runnable, CI-checked example by @Xuanwo in https://github.com/apache/opendal/pull/7790
+* docs(website): link landing service and binding entries to docs by @Xuanwo in https://github.com/apache/opendal/pull/7795
+* rfc: path normalization and secure hardening by @erickguan in https://github.com/apache/opendal/pull/7799
+* docs(services/s3): fix inverted comment on disable_list_objects_v2 by @yangyang233333 in https://github.com/apache/opendal/pull/7820
+* RFC: rename if not exists by @hfutatzhanghb in https://github.com/apache/opendal/pull/7818
+* docs(website): add more language snippets by @erickguan in https://github.com/apache/opendal/pull/7805
+### CI
+* chore(bindings/ruby): use service tests scheme for ruby binding tests by @erickguan in https://github.com/apache/opendal/pull/7635
+* fix(ci): keep website root deployment on main only by @suyanhanx in https://github.com/apache/opendal/pull/7654
+* ci: Use asfml for discussion thread links by @Xuanwo in https://github.com/apache/opendal/pull/7669
+* ci: reduce cache conflict and usage by @erickguan in https://github.com/apache/opendal/pull/7642
+* feat(ci): add golang package into dependabot by @dentiny in https://github.com/apache/opendal/pull/7682
+* ci: update rustdoc toolchain by @Xuanwo in https://github.com/apache/opendal/pull/7699
+* ci: fix release Ruby binding workflow by @erickguan in https://github.com/apache/opendal/pull/7672
+* ci: start azurite via npm by @Xuanwo in https://github.com/apache/opendal/pull/7715
+* ci: fix hadoop connector cache size by @erickguan in https://github.com/apache/opendal/pull/7729
+* ci: binding dependabot configs  by @erickguan in https://github.com/apache/opendal/pull/7742
+* ci: fix dependabot config by @Xuanwo in https://github.com/apache/opendal/pull/7750
+* ci: add cargo updates for other directories by @erickguan in https://github.com/apache/opendal/pull/7761
+* ci: fix dependabot cargo directory overlap by @Xuanwo in https://github.com/apache/opendal/pull/7763
+* ci: fix ruby native build by @erickguan in https://github.com/apache/opendal/pull/7704
+* ci: collapse dependabot group and fix by @erickguan in https://github.com/apache/opendal/pull/7771
+* ci: build only generic macOS target by @erickguan in https://github.com/apache/opendal/pull/7800
+* ci: cache docusaurus build cache by @erickguan in https://github.com/apache/opendal/pull/7806
+* ci: tighten ruby release process by @erickguan in https://github.com/apache/opendal/pull/7859
+* ci: fix release workflow tag publishing by @Xuanwo in https://github.com/apache/opendal/pull/7863
+### Chore
+* chore(services/compfs): bump compio version by @George-Miao in https://github.com/apache/opendal/pull/7666
+* chore(deps): update reqwest requirement from 0.12.24 to 0.13.1 in /integrations/dav-server by @dependabot[bot] in https://github.com/apache/opendal/pull/7171
+* chore(deps): bump the logs-errors-checksums group in /core with 2 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7697
+* chore(deps): bump tokio from 1.52.2 to 1.52.3 in /core in the async-runtime group by @dependabot[bot] in https://github.com/apache/opendal/pull/7696
+* chore(deps): bump the others group in /bindings/go/tests/behavior_tests with 4 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7689
+* chore(deps): bump golang.org/x/sys from 0.24.0 to 0.45.0 in /bindings/go in the others group by @dependabot[bot] in https://github.com/apache/opendal/pull/7688
+* chore(deps): update object_store requirement from 0.12.3 to 0.13.0 in /integrations/object_store by @dependabot[bot] in https://github.com/apache/opendal/pull/7118
+* chore(deps): bump the http-serialization-utils group in /core with 6 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7693
+* chore(deps): bump the pyo3 group in /bindings/python with 3 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7690
+* chore(deps): bump the others group in /core with 22 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7698
+* chore(deps): bump the others group across 1 directory with 5 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7652
+* chore(deps): bump the third-party-actions group with 4 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7695
+* chore(deps): bump the github-actions group with 3 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7691
+* chore(deps-dev): update activesupport requirement from ~> 8.0.5 to ~> 8.1.3 in /bindings/ruby by @dependabot[bot] in https://github.com/apache/opendal/pull/7753
+* chore(deps): bump golang.org/x/sys from 0.45.0 to 0.46.0 in /bindings/go by @dependabot[bot] in https://github.com/apache/opendal/pull/7751
+* chore(deps): update datafusion requirement from 53.0.0 to 54.0.0 in /integrations/object_store by @dependabot[bot] in https://github.com/apache/opendal/pull/7754
+* chore(deps): bump the http-serialization-utils group across 1 directory with 3 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7755
+* chore: upgrade pyo3 to 0.29 by @Xuanwo in https://github.com/apache/opendal/pull/7789
+* chore: Update copyright year in NOTICE file by @tisonkun in https://github.com/apache/opendal/pull/7792
+* chore(bindings/java): migrate to jni 0.22 by @Xuanwo in https://github.com/apache/opendal/pull/7777
+* chore(deps): bump the others group across 1 directory with 6 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7776
+* chore(deps-dev): update minitest-reporters requirement from ~> 1.7.1 to ~> 1.8.0 in /bindings/ruby by @dependabot[bot] in https://github.com/apache/opendal/pull/7774
+* chore(deps): update rb-sys-env requirement from 0.1.2 to 0.2.3 in /bindings/ruby by @dependabot[bot] in https://github.com/apache/opendal/pull/7770
+* chore(deps): update mlua requirement from 0.9 to 0.11 in /bindings/lua by @dependabot[bot] in https://github.com/apache/opendal/pull/7766
+* chore(deps): update ext-php-rs requirement from 0.13.1 to 0.15.15 in /bindings/php by @dependabot[bot] in https://github.com/apache/opendal/pull/7767
+* chore(deps): bump the third-party-actions group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7757
+* chore(bindings/python): replace pyright with ty for type checking by @chitralverma in https://github.com/apache/opendal/pull/7813
+* chore(deps): bump syn from 2.0.100 to 2.0.117 in /dev by @dependabot[bot] in https://github.com/apache/opendal/pull/7846
+* chore(deps): bump minijinja from 2.5.0 to 2.21.0 in /dev by @dependabot[bot] in https://github.com/apache/opendal/pull/7845
+* chore(deps): bump semver from 1.0.25 to 1.0.27 in /dev by @dependabot[bot] in https://github.com/apache/opendal/pull/7842
+* chore(deps): bump flate2 from 1.1.0 to 1.1.9 in /dev by @dependabot[bot] in https://github.com/apache/opendal/pull/7843
+* chore(deps): bump the others group in /core with 6 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7847
+* chore(deps): bump clap from 4.5.23 to 4.5.60 in /dev by @dependabot[bot] in https://github.com/apache/opendal/pull/7844
+* chore(deps): bump the logs-errors-checksums group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7841
+* chore(deps): bump the http-serialization-utils group across 1 directory with 3 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7835
+* chore(deps): bump crate-ci/typos from 1.47.2 to 1.48.0 in the third-party-actions group by @dependabot[bot] in https://github.com/apache/opendal/pull/7837
+* chore(deps): bump the github-actions group across 1 directory with 2 updates by @dependabot[bot] in https://github.com/apache/opendal/pull/7833
+* chore: MSRV 1.91 by @tisonkun in https://github.com/apache/opendal/pull/7849
+* chore(release): finalize Ruby binding version by @Xuanwo in https://github.com/apache/opendal/pull/7861
+
+## New Contributors
+* @FrankYang0529 made their first contribution in https://github.com/apache/opendal/pull/7605
+* @ITpandaffm made their first contribution in https://github.com/apache/opendal/pull/7658
+* @NikitaMatskevich made their first contribution in https://github.com/apache/opendal/pull/7182
+* @tonghuaroot made their first contribution in https://github.com/apache/opendal/pull/7683
+* @georgeorange-crypto made their first contribution in https://github.com/apache/opendal/pull/7639
+* @scollins99 made their first contribution in https://github.com/apache/opendal/pull/7727
+* @potiuk made their first contribution in https://github.com/apache/opendal/pull/7641
+* @edmc-ss made their first contribution in https://github.com/apache/opendal/pull/7810
+* @flip1995 made their first contribution in https://github.com/apache/opendal/pull/7701
+* @yangyang233333 made their first contribution in https://github.com/apache/opendal/pull/7820
+* @hfutatzhanghb made their first contribution in https://github.com/apache/opendal/pull/7818
+* @ZeonXr made their first contribution in https://github.com/apache/opendal/pull/7823
+* @ryankert01 made their first contribution in https://github.com/apache/opendal/pull/7817
+* @fallintoplace made their first contribution in https://github.com/apache/opendal/pull/7807
+* @AlJohri made their first contribution in https://github.com/apache/opendal/pull/7819
+
+**Full Changelog**: https://github.com/apache/opendal/compare/v0.57.0...v0.58.0
+
 ## [v0.57.0] - 2026-05-28
 
 ### Breaking Changes

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -4,19 +4,18 @@ anstyle@1.0.14	X							X
 anstyle-parse@1.0.0	X							X				
 anstyle-query@1.1.5	X							X				
 anstyle-wincon@3.0.11	X							X				
-anyhow@1.0.102	X							X				
+anyhow@1.0.103	X							X				
 atomic-waker@1.1.2	X							X				
-aws-lc-rs@1.17.0	X					X						
-aws-lc-sys@0.41.0	X		X			X		X	X			
+aws-lc-rs@1.17.1	X					X						
+aws-lc-sys@0.42.0	X		X			X		X	X			
 backon@1.6.0	X											
 base64@0.22.1	X							X				
-bitflags@2.11.1	X							X				
-block-buffer@0.10.4	X							X				
-block-buffer@0.12.0	X							X				
-bumpalo@3.20.2	X							X				
-bytes@1.11.1								X				
-cbindgen@0.29.2										X		
-cc@1.2.62	X							X				
+bitflags@2.13.0	X							X				
+block-buffer@0.12.1	X							X				
+bumpalo@3.20.3	X							X				
+bytes@1.12.0								X				
+cbindgen@0.29.4										X		
+cc@1.2.66	X							X				
 cfg-if@1.0.4	X							X				
 clap@4.6.1	X							X				
 clap_builder@4.6.0	X							X				
@@ -25,16 +24,12 @@ cmake@0.1.58	X							X
 colorchoice@1.0.5	X							X				
 combine@4.6.7								X				
 const-oid@0.10.2	X							X				
-const-oid@0.9.6	X							X				
 core-foundation@0.10.1	X							X				
 core-foundation-sys@0.8.7	X							X				
-cpufeatures@0.2.17	X							X				
-crypto-common@0.1.7	X							X				
 crypto-common@0.2.2	X							X				
-ctor@1.0.6	X							X				
-digest@0.10.7	X							X				
+ctor@1.0.8	X							X				
 digest@0.11.3	X							X				
-displaydoc@0.2.5	X							X				
+displaydoc@0.2.6	X							X				
 dunce@1.0.5	X			X					X			
 equivalent@1.0.2	X							X				
 errno@0.3.14	X							X				
@@ -45,26 +40,21 @@ fs_extra@1.3.0								X
 futures@0.3.32	X							X				
 futures-channel@0.3.32	X							X				
 futures-core@0.3.32	X							X				
-futures-executor@0.3.32	X							X				
 futures-io@0.3.32	X							X				
 futures-macro@0.3.32	X							X				
 futures-sink@0.3.32	X							X				
 futures-task@0.3.32	X							X				
 futures-util@0.3.32	X							X				
-generic-array@0.14.7								X				
-getrandom@0.3.4	X							X				
-getrandom@0.4.2	X							X				
+getrandom@0.4.3	X							X				
 gloo-timers@0.3.0	X							X				
 hashbrown@0.17.1	X							X				
 heck@0.5.0	X							X				
-hex@0.4.3	X							X				
-hmac@0.12.1	X							X				
-http@1.4.0	X							X				
+http@1.4.2	X							X				
 http-body@1.0.1								X				
 http-body-util@0.1.3								X				
 httparse@1.10.1	X							X				
-hybrid-array@0.4.12	X							X				
-hyper@1.9.0								X				
+hybrid-array@0.4.13	X							X				
+hyper@1.10.1								X				
 hyper-rustls@0.27.9	X					X		X				
 hyper-util@0.1.20								X				
 icu_collections@2.2.0											X	
@@ -80,52 +70,52 @@ indexmap@2.14.0	X							X
 ipnet@2.12.0	X							X				
 is_terminal_polyfill@1.70.2	X							X				
 itoa@1.0.18	X							X				
-jiff@0.2.24								X				X
-jiff-tzdb@0.1.6								X				X
+jiff@0.2.31								X				X
+jiff-tzdb@0.1.7								X				X
 jiff-tzdb-platform@0.1.3								X				X
 jni@0.22.4	X							X				
 jni-macros@0.22.4	X							X				
 jni-sys@0.4.1	X							X				
 jni-sys-macros@0.4.1	X							X				
-jobserver@0.1.34	X							X				
-js-sys@0.3.98	X							X				
+jobserver@0.1.35	X							X				
+js-sys@0.3.103	X							X				
 libc@0.2.186	X							X				
-link-section@0.17.2	X							X				
-linktime-proc-macro@0.1.0	X							X				
+link-section@0.19.0	X							X				
+linktime-proc-macro@0.2.0	X							X				
 linux-raw-sys@0.12.1	X	X						X				
 litemap@0.8.2											X	
-log@0.4.29	X							X				
+log@0.4.33	X							X				
 md-5@0.11.0	X							X				
-mea@0.6.3	X											
-memchr@2.8.0								X				X
-mio@1.2.0								X				
+mea@0.6.4	X											
+memchr@2.8.2								X				X
+mio@1.2.1								X				
 once_cell@1.21.4	X							X				
 once_cell_polyfill@1.70.2	X							X				
-opendal@0.57.0	X											
+opendal@0.58.0	X											
 opendal-c@0.0.0	X											
-opendal-core@0.57.0	X											
-opendal-layer-concurrent-limit@0.57.0	X											
-opendal-layer-logging@0.57.0	X											
-opendal-layer-retry@0.57.0	X											
-opendal-layer-timeout@0.57.0	X											
+opendal-core@0.58.0	X											
+opendal-http-transport-reqwest@0.58.0	X											
+opendal-layer-concurrent-limit@0.58.0	X											
+opendal-layer-logging@0.58.0	X											
+opendal-layer-retry@0.58.0	X											
+opendal-layer-timeout@0.58.0	X											
 openssl-probe@0.2.1	X							X				
 percent-encoding@2.3.2	X							X				
 pin-project-lite@0.2.17	X							X				
+pkg-config@0.3.33	X							X				
 portable-atomic@1.13.1	X							X				
 portable-atomic-util@0.2.7	X							X				
 potential_utf@0.1.5											X	
 proc-macro2@1.0.106	X							X				
-quick-xml@0.39.4								X				
-quote@1.0.45	X							X				
-r-efi@5.3.0	X						X	X				
+quick-xml@0.41.0								X				
+quote@1.0.46	X							X				
 r-efi@6.0.0	X						X	X				
-reqsign-core@3.0.0	X											
-reqwest@0.13.3	X							X				
+reqwest@0.13.4	X							X				
 rustc_version@0.4.1	X							X				
 rustix@1.1.4	X	X						X				
-rustls@0.23.40	X					X		X				
-rustls-native-certs@0.8.3	X					X		X				
-rustls-pki-types@1.14.1	X							X				
+rustls@0.23.41	X					X		X				
+rustls-native-certs@0.8.4	X					X		X				
+rustls-pki-types@1.15.0	X							X				
 rustls-platform-verifier@0.7.0	X							X				
 rustls-platform-verifier-android@0.1.1	X							X				
 rustls-webpki@0.103.13						X						
@@ -140,18 +130,16 @@ serde_core@1.0.228	X							X
 serde_derive@1.0.228	X							X				
 serde_json@1.0.150	X							X				
 serde_spanned@1.1.1	X							X				
-sha1@0.10.6	X							X				
-sha2@0.10.9	X							X				
-shlex@1.3.0	X							X				
+shlex@2.0.1	X							X				
 simd_cesu8@1.1.1	X							X				
 simdutf8@0.1.5	X							X				
 slab@0.4.12								X				
-smallvec@1.15.1	X							X				
-socket2@0.6.3	X							X				
+smallvec@1.15.2	X							X				
+socket2@0.6.4	X							X				
 stable_deref_trait@1.2.1	X							X				
 strsim@0.11.1								X				
 subtle@2.6.1			X									
-syn@2.0.117	X							X				
+syn@2.0.118	X							X				
 sync_wrapper@1.0.2	X											
 synstructure@0.13.2								X				
 tempfile@3.27.0	X							X				
@@ -172,41 +160,36 @@ tower-service@0.3.3								X
 tracing@0.1.44								X				
 tracing-core@0.1.36								X				
 try-lock@0.2.5								X				
-typenum@1.20.0	X							X				
+typenum@1.20.1	X							X				
 unicode-ident@1.0.24	X							X			X	
 untrusted@0.9.0						X						
 url@2.5.8	X							X				
 utf8_iter@1.0.4	X							X				
 utf8parse@0.2.2	X							X				
-uuid@1.23.1	X							X				
-version_check@0.9.5	X							X				
+uuid@1.23.4	X							X				
 walkdir@2.5.0								X				X
 want@0.3.1								X				
 wasi@0.11.1+wasi-snapshot-preview1	X	X						X				
-wasip2@1.0.3+wasi-0.2.9	X	X						X				
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X						X				
-wasm-bindgen@0.2.121	X							X				
-wasm-bindgen-futures@0.4.71	X							X				
-wasm-bindgen-macro@0.2.121	X							X				
-wasm-bindgen-macro-support@0.2.121	X							X				
-wasm-bindgen-shared@0.2.121	X							X				
+wasm-bindgen@0.2.126	X							X				
+wasm-bindgen-futures@0.4.76	X							X				
+wasm-bindgen-macro@0.2.126	X							X				
+wasm-bindgen-macro-support@0.2.126	X							X				
+wasm-bindgen-shared@0.2.126	X							X				
 wasm-streams@0.5.0	X							X				
-web-sys@0.3.98	X							X				
+web-sys@0.3.103	X							X				
 web-time@1.1.0	X							X				
-webpki-root-certs@1.0.7					X							
+webpki-root-certs@1.0.8					X							
 winapi-util@0.1.11								X				X
 windows-link@0.2.1	X							X				
 windows-sys@0.61.2	X							X				
 winnow@0.7.15								X				
 winnow@1.0.3								X				
-wit-bindgen@0.51.0	X	X						X				
-wit-bindgen@0.57.1	X	X						X				
 writeable@0.6.3											X	
-yoke@0.8.2											X	
+yoke@0.8.3											X	
 yoke-derive@0.8.2											X	
 zerofrom@0.1.8											X	
 zerofrom-derive@0.1.7											X	
-zeroize@1.8.2	X							X				
+zeroize@1.9.0	X							X				
 zerotrie@0.2.4											X	
 zerovec@0.11.6											X	
 zerovec-derive@0.11.3											X	

--- a/bindings/cpp/DEPENDENCIES.rust.tsv
+++ b/bindings/cpp/DEPENDENCIES.rust.tsv
@@ -1,35 +1,30 @@
 crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib
-anyhow@1.0.102	X							X				
+anyhow@1.0.103	X							X				
 atomic-waker@1.1.2	X							X				
-aws-lc-rs@1.17.0	X					X						
-aws-lc-sys@0.41.0	X		X			X		X	X			
+aws-lc-rs@1.17.1	X					X						
+aws-lc-sys@0.42.0	X		X			X		X	X			
 backon@1.6.0	X											
 base64@0.22.1	X							X				
-bitflags@2.11.1	X							X				
-block-buffer@0.10.4	X							X				
-block-buffer@0.12.0	X							X				
-bumpalo@3.20.2	X							X				
-bytes@1.11.1								X				
-cc@1.2.62	X							X				
+bitflags@2.13.0	X							X				
+block-buffer@0.12.1	X							X				
+bumpalo@3.20.3	X							X				
+bytes@1.12.0								X				
+cc@1.2.66	X							X				
 cfg-if@1.0.4	X							X				
 cmake@0.1.58	X							X				
 codespan-reporting@0.13.1	X											
 combine@4.6.7								X				
 const-oid@0.10.2	X							X				
-const-oid@0.9.6	X							X				
 core-foundation@0.10.1	X							X				
 core-foundation-sys@0.8.7	X							X				
-cpufeatures@0.2.17	X							X				
-crypto-common@0.1.7	X							X				
 crypto-common@0.2.2	X							X				
-ctor@1.0.6	X							X				
-cxx@1.0.194	X							X				
-cxx-build@1.0.194	X							X				
-cxxbridge-flags@1.0.194	X							X				
-cxxbridge-macro@1.0.194	X							X				
-digest@0.10.7	X							X				
+ctor@1.0.8	X							X				
+cxx@1.0.196	X							X				
+cxx-build@1.0.196	X							X				
+cxxbridge-flags@1.0.196	X							X				
+cxxbridge-macro@1.0.196	X							X				
 digest@0.11.3	X							X				
-displaydoc@0.2.5	X							X				
+displaydoc@0.2.6	X							X				
 dunce@1.0.5	X			X					X			
 equivalent@1.0.2	X							X				
 fastrand@2.4.1	X							X				
@@ -46,77 +41,73 @@ futures-macro@0.3.32	X							X
 futures-sink@0.3.32	X							X				
 futures-task@0.3.32	X							X				
 futures-util@0.3.32	X							X				
-generic-array@0.14.7								X				
-getrandom@0.3.4	X							X				
-getrandom@0.4.2	X							X				
+getrandom@0.4.3	X							X				
 gloo-timers@0.3.0	X							X				
 hashbrown@0.17.1	X							X				
-hex@0.4.3	X							X				
-hmac@0.12.1	X							X				
-http@1.4.0	X							X				
+http@1.4.2	X							X				
 http-body@1.0.1								X				
 http-body-util@0.1.3								X				
 httparse@1.10.1	X							X				
-hybrid-array@0.4.12	X							X				
-hyper@1.9.0								X				
+hybrid-array@0.4.13	X							X				
+hyper@1.10.1								X				
 hyper-rustls@0.27.9	X					X		X				
 hyper-util@0.1.20								X				
-icu_collections@2.1.1										X		
-icu_locale_core@2.1.1										X		
-icu_normalizer@2.1.1										X		
-icu_normalizer_data@2.1.1										X		
-icu_properties@2.1.2										X		
-icu_properties_data@2.1.2										X		
-icu_provider@2.1.1										X		
+icu_collections@2.2.0										X		
+icu_locale_core@2.2.0										X		
+icu_normalizer@2.2.0										X		
+icu_normalizer_data@2.2.0										X		
+icu_properties@2.2.0										X		
+icu_properties_data@2.2.0										X		
+icu_provider@2.2.0										X		
 idna@1.1.0	X							X				
-idna_adapter@1.2.1	X							X				
+idna_adapter@1.2.2	X							X				
 indexmap@2.14.0	X							X				
 ipnet@2.12.0	X							X				
 itoa@1.0.18	X							X				
-jiff@0.2.24								X			X	
-jiff-tzdb@0.1.6								X			X	
+jiff@0.2.31								X			X	
+jiff-tzdb@0.1.7								X			X	
 jiff-tzdb-platform@0.1.3								X			X	
 jni@0.22.4	X							X				
 jni-macros@0.22.4	X							X				
 jni-sys@0.4.1	X							X				
 jni-sys-macros@0.4.1	X							X				
-jobserver@0.1.34	X							X				
-js-sys@0.3.98	X							X				
+jobserver@0.1.35	X							X				
+js-sys@0.3.103	X							X				
 libc@0.2.186	X							X				
 link-cplusplus@1.0.12	X							X				
-link-section@0.17.2	X							X				
-linktime-proc-macro@0.1.0	X							X				
+link-section@0.19.0	X							X				
+linktime-proc-macro@0.2.0	X							X				
 litemap@0.8.2										X		
-log@0.4.29	X							X				
+log@0.4.33	X							X				
 md-5@0.11.0	X							X				
-mea@0.6.3	X											
-memchr@2.8.0								X			X	
-mio@1.2.0								X				
+mea@0.6.4	X											
+memchr@2.8.2								X			X	
+mio@1.2.1								X				
 once_cell@1.21.4	X							X				
-opendal@0.57.0	X											
-opendal-core@0.57.0	X											
+opendal@0.58.0	X											
+opendal-core@0.58.0	X											
 opendal-cpp@0.0.0	X											
-opendal-layer-concurrent-limit@0.57.0	X											
-opendal-layer-logging@0.57.0	X											
-opendal-layer-retry@0.57.0	X											
-opendal-layer-timeout@0.57.0	X											
+opendal-http-transport-reqwest@0.58.0	X											
+opendal-layer-concurrent-limit@0.58.0	X											
+opendal-layer-logging@0.58.0	X											
+opendal-layer-retry@0.58.0	X											
+opendal-layer-timeout@0.58.0	X											
 openssl-probe@0.2.1	X							X				
 percent-encoding@2.3.2	X							X				
 pin-project-lite@0.2.17	X							X				
+pkg-config@0.3.33	X							X				
 portable-atomic@1.13.1	X							X				
 portable-atomic-util@0.2.7	X							X				
 potential_utf@0.1.5										X		
 proc-macro2@1.0.106	X							X				
-quick-xml@0.39.4								X				
-quote@1.0.45	X							X				
-r-efi@5.3.0	X						X	X				
+quick-xml@0.41.0								X				
+quote@1.0.46	X							X				
 r-efi@6.0.0	X						X	X				
-reqsign-core@3.0.0	X											
-reqwest@0.13.3	X							X				
+reqwest@0.13.4	X							X				
 rustc_version@0.4.1	X							X				
-rustls@0.23.40	X					X		X				
-rustls-native-certs@0.8.3	X					X		X				
-rustls-pki-types@1.14.1	X							X				
+rustls@0.23.41	X					X		X				
+rustls-native-certs@0.8.4	X					X		X				
+rustls-pki-types@1.15.0	X							X				
 rustls-platform-verifier@0.7.0	X							X				
 rustls-platform-verifier-android@0.1.1	X							X				
 rustls-webpki@0.103.13						X						
@@ -131,17 +122,15 @@ serde@1.0.228	X							X
 serde_core@1.0.228	X							X				
 serde_derive@1.0.228	X							X				
 serde_json@1.0.150	X							X				
-sha1@0.10.6	X							X				
-sha2@0.10.9	X							X				
-shlex@1.3.0	X							X				
+shlex@2.0.1	X							X				
 simd_cesu8@1.1.1	X							X				
 simdutf8@0.1.5	X							X				
 slab@0.4.12								X				
-smallvec@1.15.1	X							X				
-socket2@0.6.3	X							X				
+smallvec@1.15.2	X							X				
+socket2@0.6.4	X							X				
 stable_deref_trait@1.2.1	X							X				
 subtle@2.6.1			X									
-syn@2.0.117	X							X				
+syn@2.0.118	X							X				
 sync_wrapper@1.0.2	X											
 synstructure@0.13.2								X				
 termcolor@1.4.1								X			X	
@@ -159,39 +148,34 @@ tower-service@0.3.3								X
 tracing@0.1.44								X				
 tracing-core@0.1.36								X				
 try-lock@0.2.5								X				
-typenum@1.20.0	X							X				
+typenum@1.20.1	X							X				
 unicode-ident@1.0.24	X							X		X		
 unicode-width@0.2.2	X							X				
 untrusted@0.9.0						X						
 url@2.5.8	X							X				
 utf8_iter@1.0.4	X							X				
-uuid@1.23.1	X							X				
-version_check@0.9.5	X							X				
+uuid@1.23.4	X							X				
 walkdir@2.5.0								X			X	
 want@0.3.1								X				
 wasi@0.11.1+wasi-snapshot-preview1	X	X						X				
-wasip2@1.0.1+wasi-0.2.4	X	X						X				
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X						X				
-wasm-bindgen@0.2.121	X							X				
-wasm-bindgen-futures@0.4.71	X							X				
-wasm-bindgen-macro@0.2.121	X							X				
-wasm-bindgen-macro-support@0.2.121	X							X				
-wasm-bindgen-shared@0.2.121	X							X				
+wasm-bindgen@0.2.126	X							X				
+wasm-bindgen-futures@0.4.76	X							X				
+wasm-bindgen-macro@0.2.126	X							X				
+wasm-bindgen-macro-support@0.2.126	X							X				
+wasm-bindgen-shared@0.2.126	X							X				
 wasm-streams@0.5.0	X							X				
-web-sys@0.3.98	X							X				
+web-sys@0.3.103	X							X				
 web-time@1.1.0	X							X				
-webpki-root-certs@1.0.7					X							
+webpki-root-certs@1.0.8					X							
 winapi-util@0.1.11								X			X	
 windows-link@0.2.1	X							X				
 windows-sys@0.61.2	X							X				
-wit-bindgen@0.46.0	X	X						X				
-wit-bindgen@0.51.0	X	X						X				
 writeable@0.6.3										X		
-yoke@0.8.2										X		
+yoke@0.8.3										X		
 yoke-derive@0.8.2										X		
 zerofrom@0.1.8										X		
 zerofrom-derive@0.1.7										X		
-zeroize@1.8.2	X							X				
+zeroize@1.9.0	X							X				
 zerotrie@0.2.4										X		
 zerovec@0.11.6										X		
 zerovec-derive@0.11.3										X		

--- a/bindings/dotnet/DEPENDENCIES.rust.tsv
+++ b/bindings/dotnet/DEPENDENCIES.rust.tsv
@@ -10,79 +10,79 @@ anstyle@1.0.14		X									X
 anstyle-parse@1.0.0		X									X					
 anstyle-query@1.1.5		X									X					
 anstyle-wincon@3.0.11		X									X					
-anyhow@1.0.102		X									X					
+anyhow@1.0.103		X									X					
 approx@0.5.1		X														
-arc-swap@1.9.1		X									X					
+arc-swap@1.9.2		X									X					
 arcstr@1.2.0		X									X					X
 arrayref@0.3.9				X												
-arrayvec@0.7.6		X									X					
+arrayvec@0.7.8		X									X					
 async-lock@3.4.2		X									X					
 async-recursion@0.3.2		X									X					
 async-stream@0.3.6											X					
 async-stream-impl@0.3.6											X					
-async-task@4.7.1		X									X					
 async-trait@0.1.89		X									X					
 atoi@2.0.0											X					
 atomic-waker@1.1.2		X									X					
 auto-const-array@0.2.2		X									X					
-autocfg@1.5.0		X									X					
+autocfg@1.5.1		X									X					
 awaitable@0.4.0											X					
 awaitable-error@0.1.0											X					
-aws-lc-rs@1.17.0		X							X							
-aws-lc-sys@0.41.0		X			X				X		X	X				
+aws-lc-rs@1.17.1		X							X							
+aws-lc-sys@0.42.0		X			X				X		X	X				
 axum@0.6.20											X					
-axum@0.7.9											X					
 axum@0.8.9											X					
 axum-core@0.3.4											X					
-axum-core@0.4.5											X					
 axum-core@0.5.6											X					
 backon@1.6.0		X														
 base64@0.21.7		X									X					
 base64@0.22.1		X									X					
 base64ct@1.8.3		X									X					
 bitflags@1.3.2		X									X					
-bitflags@2.11.1		X									X					
-bitvec@1.0.1											X					
+bitflags@2.13.0		X									X					
+bitvec@1.1.1											X					
 blake3@1.8.5		X	X				X									
 block-buffer@0.10.4		X									X					
-block-buffer@0.12.0		X									X					
+block-buffer@0.12.1		X									X					
 block-padding@0.3.3		X									X					
 bson@2.15.0											X					
-bstr@1.12.1		X									X					
-bumpalo@3.20.2		X									X					
+bstr@1.12.3		X									X					
+bumpalo@3.20.3		X									X					
 bytecount@0.6.9		X									X					
 bytemuck@1.25.0		X									X					X
 byteorder@1.5.0											X				X	
-bytes@1.11.1											X					
+bytes@1.12.0											X					
 cacache@13.1.0		X														
-camino@1.2.2		X									X					
+camino@1.2.4		X									X					
 cargo-platform@0.1.9		X									X					
 cargo_metadata@0.14.2											X					
 cbc@0.1.2		X									X					
-cc@1.2.62		X									X					
+cc@1.2.66		X									X					
 cfg-if@0.1.10		X									X					
 cfg-if@1.0.4		X									X					
 cfg_aliases@0.2.1											X					
-chacha20@0.10.0		X									X					
-chrono@0.4.44		X									X					
+chacha20@0.10.1		X									X					
+chrono@0.4.45		X									X					
 cipher@0.4.4		X									X					
 clap@4.6.1		X									X					
 clap_builder@4.6.0		X									X					
 clap_derive@4.6.1		X									X					
 clap_lex@1.1.0		X									X					
 cmake@0.1.58		X									X					
-cmov@0.5.3		X									X					
+cmov@0.5.4		X									X					
 colorchoice@1.0.5		X									X					
 colored@3.1.1													X			
 combine@4.6.7											X					
-compio@0.18.0											X					
-compio-buf@0.8.1											X					
-compio-dispatcher@0.10.0											X					
-compio-driver@0.11.4											X					
-compio-fs@0.11.0											X					
-compio-io@0.9.1											X					
-compio-log@0.1.0											X					
-compio-runtime@0.11.0											X					
+compio@0.19.1											X					
+compio-buf@0.8.3											X					
+compio-dispatcher@0.11.0											X					
+compio-driver@0.12.3											X					
+compio-executor@0.1.2											X					
+compio-fs@0.12.0											X					
+compio-io@0.10.1											X					
+compio-log@0.2.0											X					
+compio-net@0.12.1											X					
+compio-runtime@0.12.2											X					
+compio-send-wrapper@0.7.2		X									X					
 concurrent-queue@2.5.0		X									X					
 concurrent_arena@0.1.11											X					
 const-oid@0.10.2		X									X					
@@ -102,26 +102,26 @@ cpufeatures@0.2.17		X									X
 cpufeatures@0.3.0		X									X					
 crc@3.4.0		X									X					
 crc-catalog@2.5.0		X									X					
+crc-fast@1.10.0		X									X					
 crc16@0.4.0											X					
-crc32c@0.6.8		X									X					
 crc32fast@1.5.0		X									X					
 critical-section@1.2.0		X									X					
-crossbeam-channel@0.5.15		X									X					
-crossbeam-epoch@0.9.18		X									X					
-crossbeam-queue@0.3.12		X									X					
-crossbeam-utils@0.8.21		X									X					
+crossbeam-channel@0.5.16		X									X					
+crossbeam-epoch@0.9.19		X									X					
+crossbeam-queue@0.3.13		X									X					
+crossbeam-utils@0.8.22		X									X					
 crunchy@0.2.4											X					
 crypto-common@0.1.7		X									X					
 crypto-common@0.2.2		X									X					
 csv@1.4.0											X				X	
 csv-core@0.1.13											X				X	
 ctor@0.6.3		X									X					
-ctor@1.0.6		X									X					
+ctor@1.0.8		X									X					
 ctor-proc-macro@0.0.7		X									X					
 ctutils@0.4.2		X									X					
-darling@0.21.3											X					
-darling_core@0.21.3											X					
-darling_macro@0.21.3											X					
+darling@0.23.0											X					
+darling_core@0.23.0											X					
+darling_macro@0.23.0											X					
 dashmap@5.5.3											X					
 dashmap@6.2.1											X					
 data-encoding@2.11.0											X					
@@ -137,18 +137,17 @@ digest@0.10.7		X									X
 digest@0.11.3		X									X					
 dirs@6.0.0		X									X					
 dirs-sys@0.5.0		X									X					
-displaydoc@0.2.5		X									X					
+displaydoc@0.2.6		X									X					
 dlv-list@0.5.2		X									X					
 dotenvy@0.15.7											X					
 dtor@0.1.1		X									X					
 dtor-proc-macro@0.0.6		X									X					
 dunce@1.0.5		X					X					X				
 either@1.16.0		X									X					
-enum-as-inner@0.6.1		X									X					
 equivalent@1.0.2		X									X					
 errno@0.3.14		X									X					
 error-chain@0.12.4		X									X					
-etcd-client@0.18.0		X									X					
+etcd-client@0.19.0		X									X					
 etcetera@0.8.0		X									X					
 event-listener@5.4.1		X									X					
 event-listener-strategy@0.5.4		X									X					
@@ -178,20 +177,20 @@ futures-task@0.3.32		X									X
 futures-util@0.3.32		X									X					
 fxhash@0.2.1		X									X					
 gearhash@0.1.3		X									X					
-generator@0.8.8		X									X					
+generator@0.8.9		X									X					
 generic-array@0.14.7											X					
 getrandom@0.1.16		X									X					
 getrandom@0.2.17		X									X					
 getrandom@0.3.4		X									X					
-getrandom@0.4.2		X									X					
+getrandom@0.4.3		X									X					
 ghac@0.3.0		X														
 git-version@0.3.9				X												
 git-version-macro@0.3.9				X												
 glob@0.3.3		X									X					
 gloo-timers@0.3.0		X									X					
-goosefs-sdk@0.1.2		X														
+goosefs-sdk@0.1.5		X														
 h2@0.3.27											X					
-h2@0.4.14											X					
+h2@0.4.15											X					
 hashbrown@0.12.3		X									X					
 hashbrown@0.14.5		X									X					
 hashbrown@0.15.5		X									X					
@@ -202,91 +201,90 @@ heck@0.5.0		X									X
 hermit-abi@0.5.2		X									X					
 hex@0.4.3		X									X					
 hf-xet@1.5.2		X														
-hickory-proto@0.25.2		X									X					
-hickory-resolver@0.25.2		X									X					
+hickory-net@0.26.1		X									X					
+hickory-proto@0.26.1		X									X					
+hickory-resolver@0.26.1		X									X					
 hkdf@0.12.4		X									X					
 hmac@0.12.1		X									X					
 hmac@0.13.0		X									X					
-home@0.5.11		X									X					
-hostname@0.3.1											X					
+home@0.5.12		X									X					
+hostname@0.4.2											X					
 http@0.2.12		X									X					
-http@1.4.0		X									X					
+http@1.4.2		X									X					
 http-body@0.4.6											X					
 http-body@1.0.1											X					
 http-body-util@0.1.3											X					
 httparse@1.10.1		X									X					
 httpdate@1.0.3		X									X					
-humantime@2.3.0		X									X					
-hybrid-array@0.4.12		X									X					
+humantime@2.4.0		X									X					
+hybrid-array@0.4.13		X									X					
 hyper@0.14.32											X					
-hyper@1.9.0											X					
+hyper@1.10.1											X					
 hyper-rustls@0.27.9		X							X		X					
 hyper-timeout@0.4.1		X									X					
 hyper-timeout@0.5.2		X									X					
 hyper-util@0.1.20											X					
 iana-time-zone@0.1.65		X									X					
 iana-time-zone-haiku@0.1.2		X									X					
-icu_collections@2.1.1														X		
-icu_locale_core@2.1.1														X		
-icu_normalizer@2.1.1														X		
-icu_normalizer_data@2.1.1														X		
-icu_properties@2.1.2														X		
-icu_properties_data@2.1.2														X		
-icu_provider@2.1.1														X		
+icu_collections@2.2.0														X		
+icu_locale_core@2.2.0														X		
+icu_normalizer@2.2.0														X		
+icu_normalizer_data@2.2.0														X		
+icu_properties@2.2.0														X		
+icu_properties_data@2.2.0														X		
+icu_provider@2.2.0														X		
 ident_case@1.0.1		X									X					
 idna@1.1.0		X									X					
-idna_adapter@1.2.1		X									X					
+idna_adapter@1.2.2		X									X					
 indexmap@1.9.3		X									X					
 indexmap@2.14.0		X									X					
 inout@0.1.4		X									X					
 instant@0.1.13					X											
 io-uring@0.6.4		X									X					
-io-uring@0.7.12		X									X					
-io_uring_buf_ring@0.2.3											X					
+io-uring@0.7.13		X									X					
 ipconfig@0.3.4		X									X					
 ipnet@2.12.0		X									X					
 is_terminal_polyfill@1.70.2		X									X					
 itertools@0.12.1		X									X					
 itertools@0.14.0		X									X					
 itoa@1.0.18		X									X					
-jiff@0.2.24											X				X	
-jiff-tzdb@0.1.6											X				X	
+jiff@0.2.31											X				X	
+jiff-tzdb@0.1.7											X				X	
 jiff-tzdb-platform@0.1.3											X				X	
 jni@0.22.4		X									X					
 jni-macros@0.22.4		X									X					
 jni-sys@0.4.1		X									X					
 jni-sys-macros@0.4.1		X									X					
-jobserver@0.1.34		X									X					
-js-sys@0.3.98		X									X					
-jsonwebtoken@10.3.0											X					
+jobserver@0.1.35		X									X					
+js-sys@0.3.103		X									X					
 konst@0.4.3																X
 konst_proc_macros@0.4.1																X
 lazy_static@1.5.0		X									X					
 libc@0.2.186		X									X					
 libm@0.2.16											X					
-libredox@0.1.16											X					
+libredox@0.1.18											X					
 libsqlite3-sys@0.30.1											X					
-link-section@0.17.2		X									X					
+link-section@0.19.0		X									X					
 linked-hash-map@0.5.6		X									X					
-linktime-proc-macro@0.1.0		X									X					
+linktime-proc-macro@0.2.0		X									X					
 linux-raw-sys@0.12.1		X	X								X					
 litemap@0.8.2														X		
+local-event@0.1.2											X					
 lock_api@0.4.14		X									X					
-log@0.4.29		X									X					
+log@0.4.33		X									X					
 loom@0.7.2											X					
 lz4_flex@0.13.1											X					
 macro_magic@0.5.1											X					
 macro_magic_core@0.5.1											X					
 macro_magic_core_macros@0.5.1											X					
 macro_magic_macros@0.5.1											X					
-match_cfg@0.1.0		X									X					
 matchers@0.2.0											X					
 matchit@0.7.3					X						X					
 matchit@0.8.4					X						X					
 md-5@0.10.6		X									X					
 md-5@0.11.0		X									X					
-mea@0.6.3		X														
-memchr@2.8.0											X				X	
+mea@0.6.4		X														
+memchr@2.8.2											X				X	
 memmap2@0.5.10		X									X					
 memoffset@0.7.1											X					
 miette@5.10.0		X														
@@ -295,19 +293,21 @@ mime@0.3.17		X									X
 mini-moka@0.10.3		X									X					
 miniz_oxide@0.8.9		X									X					X
 mio@0.8.11											X					
-mio@1.2.0											X					
+mio@1.2.1											X					
+mod_use@0.2.3											X					
 moka@0.12.15		X									X					
-mongodb@3.6.0		X														
-mongodb-internal-macros@3.6.0		X														
+mongodb@3.7.0		X														
+mongodb-internal-macros@3.7.0		X														
 monoio@0.2.4		X									X					
 monoio-macros@0.1.0		X									X					
 more-asserts@0.3.1		X					X				X				X	
 multimap@0.10.1		X									X					
 nanorand@0.7.0																X
+ndk-context@0.1.1		X									X					
 nix@0.26.4											X					
 ntapi@0.4.3		X									X					
 nu-ansi-term@0.50.3											X					
-num-bigint@0.4.6		X									X					
+num-bigint@0.4.8		X									X					
 num-bigint-dig@0.8.6		X									X					
 num-conv@0.2.2		X									X					
 num-derive@0.4.2		X									X					
@@ -321,63 +321,64 @@ objc2-system-configuration@0.3.2		X									X					X
 once_cell@1.21.4		X									X					
 once_cell_polyfill@1.70.2		X									X					
 oneshot@0.1.13		X									X					
-opendal@0.57.0		X														
-opendal-core@0.57.0		X														
+opendal@0.58.0		X														
+opendal-core@0.58.0		X														
 opendal-dotnet@0.0.0		X														
-opendal-layer-concurrent-limit@0.57.0		X														
-opendal-layer-logging@0.57.0		X														
-opendal-layer-retry@0.57.0		X														
-opendal-layer-timeout@0.57.0		X														
-opendal-service-aliyun-drive@0.57.0		X														
-opendal-service-alluxio@0.57.0		X														
-opendal-service-azblob@0.57.0		X														
-opendal-service-azdls@0.57.0		X														
-opendal-service-azfile@0.57.0		X														
-opendal-service-azure-common@0.57.0		X														
-opendal-service-b2@0.57.0		X														
-opendal-service-cacache@0.57.0		X														
-opendal-service-compfs@0.57.0		X														
-opendal-service-cos@0.57.0		X														
-opendal-service-dashmap@0.57.0		X														
-opendal-service-dropbox@0.57.0		X														
-opendal-service-etcd@0.57.0		X														
-opendal-service-fs@0.57.0		X														
-opendal-service-gcs@0.57.0		X														
-opendal-service-gdrive@0.57.0		X														
-opendal-service-ghac@0.57.0		X														
-opendal-service-goosefs@0.57.0		X														
-opendal-service-gridfs@0.57.0		X														
-opendal-service-hf@0.57.0		X														
-opendal-service-http@0.57.0		X														
-opendal-service-ipfs@0.57.0		X														
-opendal-service-ipmfs@0.57.0		X														
-opendal-service-koofr@0.57.0		X														
-opendal-service-memcached@0.57.0		X														
-opendal-service-mini-moka@0.57.0		X														
-opendal-service-moka@0.57.0		X														
-opendal-service-mongodb@0.57.0		X														
-opendal-service-monoiofs@0.57.0		X														
-opendal-service-mysql@0.57.0		X														
-opendal-service-obs@0.57.0		X														
-opendal-service-onedrive@0.57.0		X														
-opendal-service-oss@0.57.0		X														
-opendal-service-persy@0.57.0		X														
-opendal-service-postgresql@0.57.0		X														
-opendal-service-redb@0.57.0		X														
-opendal-service-redis@0.57.0		X														
-opendal-service-s3@0.57.0		X														
-opendal-service-seafile@0.57.0		X														
-opendal-service-sftp@0.57.0		X														
-opendal-service-sled@0.57.0		X														
-opendal-service-sqlite@0.57.0		X														
-opendal-service-swift@0.57.0		X														
-opendal-service-tikv@0.57.0		X														
-opendal-service-tos@0.57.0		X														
-opendal-service-upyun@0.57.0		X														
-opendal-service-vercel-artifacts@0.57.0		X														
-opendal-service-webdav@0.57.0		X														
-opendal-service-webhdfs@0.57.0		X														
-opendal-service-yandex-disk@0.57.0		X														
+opendal-http-transport-reqwest@0.58.0		X														
+opendal-layer-concurrent-limit@0.58.0		X														
+opendal-layer-logging@0.58.0		X														
+opendal-layer-retry@0.58.0		X														
+opendal-layer-timeout@0.58.0		X														
+opendal-service-aliyun-drive@0.58.0		X														
+opendal-service-alluxio@0.58.0		X														
+opendal-service-azblob@0.58.0		X														
+opendal-service-azdls@0.58.0		X														
+opendal-service-azfile@0.58.0		X														
+opendal-service-azure-common@0.58.0		X														
+opendal-service-b2@0.58.0		X														
+opendal-service-cacache@0.58.0		X														
+opendal-service-compfs@0.58.0		X														
+opendal-service-cos@0.58.0		X														
+opendal-service-dashmap@0.58.0		X														
+opendal-service-dropbox@0.58.0		X														
+opendal-service-etcd@0.58.0		X														
+opendal-service-fs@0.58.0		X														
+opendal-service-gcs@0.58.0		X														
+opendal-service-gdrive@0.58.0		X														
+opendal-service-ghac@0.58.0		X														
+opendal-service-goosefs@0.58.0		X														
+opendal-service-gridfs@0.58.0		X														
+opendal-service-hf@0.58.0		X														
+opendal-service-http@0.58.0		X														
+opendal-service-ipfs@0.58.0		X														
+opendal-service-ipmfs@0.58.0		X														
+opendal-service-koofr@0.58.0		X														
+opendal-service-memcached@0.58.0		X														
+opendal-service-mini-moka@0.58.0		X														
+opendal-service-moka@0.58.0		X														
+opendal-service-mongodb@0.58.0		X														
+opendal-service-monoiofs@0.58.0		X														
+opendal-service-mysql@0.58.0		X														
+opendal-service-obs@0.58.0		X														
+opendal-service-onedrive@0.58.0		X														
+opendal-service-oss@0.58.0		X														
+opendal-service-persy@0.58.0		X														
+opendal-service-postgresql@0.58.0		X														
+opendal-service-redb@0.58.0		X														
+opendal-service-redis@0.58.0		X														
+opendal-service-s3@0.58.0		X														
+opendal-service-seafile@0.58.0		X														
+opendal-service-sftp@0.58.0		X														
+opendal-service-sled@0.58.0		X														
+opendal-service-sqlite@0.58.0		X														
+opendal-service-swift@0.58.0		X														
+opendal-service-tikv@0.58.0		X														
+opendal-service-tos@0.58.0		X														
+opendal-service-upyun@0.58.0		X														
+opendal-service-vercel-artifacts@0.58.0		X														
+opendal-service-webdav@0.58.0		X														
+opendal-service-webhdfs@0.58.0		X														
+opendal-service-yandex-disk@0.58.0		X														
 openssh@0.11.6		X									X					
 openssh-sftp-client@0.15.7											X					
 openssh-sftp-client-lowlevel@0.7.2											X					
@@ -387,20 +388,18 @@ openssh-sftp-protocol-error@0.1.1											X
 openssl-probe@0.2.1		X									X					
 option-ext@0.2.0													X			
 ordered-multimap@0.7.3											X					
-os_pipe@1.2.3											X					
 os_str_bytes@6.6.1		X									X					
 parking@2.2.1		X									X					
 parking_lot@0.11.2		X									X					
 parking_lot@0.12.5		X									X					
 parking_lot_core@0.8.6		X									X					
 parking_lot_core@0.9.12		X									X					
-paste@1.0.15		X									X					
+pastey@0.2.3		X									X					
 pbkdf2@0.12.2		X									X					
 pem@3.0.6											X					
 pem-rfc7468@0.7.0		X									X					
 percent-encoding@2.3.2		X									X					
-persy@1.7.1													X			
-petgraph@0.7.1		X									X					
+persy@1.8.1													X			
 petgraph@0.8.3		X									X					
 pin-project@1.1.13		X									X					
 pin-project-internal@1.1.13		X									X					
@@ -417,28 +416,26 @@ portable-atomic-util@0.2.7		X									X
 potential_utf@0.1.5														X		
 powerfmt@0.2.0		X									X					
 ppv-lite86@0.2.21		X									X					
+prefix-trie@0.8.4		X									X					
 prettyplease@0.2.37		X									X					
 proc-macro2@1.0.106		X									X					
 prometheus@0.13.4		X														
 prost@0.12.6		X														
-prost@0.13.5		X														
-prost@0.14.3		X														
-prost-build@0.13.5		X														
-prost-build@0.14.3		X														
+prost@0.14.4		X														
+prost-build@0.14.4		X														
 prost-derive@0.12.6		X														
-prost-derive@0.13.5		X														
-prost-derive@0.14.3		X														
-prost-types@0.13.5		X														
-prost-types@0.14.3		X														
+prost-derive@0.14.4		X														
+prost-types@0.14.4		X														
 pulldown-cmark@0.13.4											X					
 pulldown-cmark@0.9.6											X					
 pulldown-cmark-to-cmark@22.0.0		X														
-quick-xml@0.39.4											X					
-quote@1.0.45		X									X					
+quick-xml@0.40.1											X					
+quick-xml@0.41.0											X					
+quote@1.0.46		X									X					
 r-efi@5.3.0		X								X	X					
 r-efi@6.0.0		X								X	X					
 radium@0.7.0											X					
-rand@0.10.1		X									X					
+rand@0.10.2		X									X					
 rand@0.7.3		X									X					
 rand@0.8.6		X									X					
 rand@0.9.4		X									X					
@@ -450,26 +447,27 @@ rand_core@0.5.1		X									X
 rand_core@0.6.4		X									X					
 rand_core@0.9.5		X									X					
 rand_hc@0.2.0		X									X					
-redb@2.6.3		X									X					
 redb@3.1.3		X									X					
-redis@1.2.1					X											
+redb@4.1.0		X									X					
+redis@1.3.0					X											
 redox_syscall@0.2.16											X					
 redox_syscall@0.5.18											X					
 redox_users@0.5.2											X					
-reflink-copy@0.1.29		X									X					
-regex@1.12.3		X									X					
+reflink-copy@0.1.30		X									X					
+regex@1.12.4		X									X					
 regex-automata@0.4.14		X									X					
-regex-syntax@0.8.10		X									X					
-reqsign-aliyun-oss@3.0.0		X														
-reqsign-aws-v4@3.0.0		X														
-reqsign-azure-storage@3.0.0		X														
-reqsign-core@3.0.0		X														
-reqsign-file-read-tokio@3.0.0		X														
-reqsign-google@3.0.0		X														
-reqsign-huaweicloud-obs@3.0.0		X														
-reqsign-tencent-cos@3.0.0		X														
-reqsign-volcengine-tos@3.0.0		X														
-reqwest@0.13.3		X									X					
+regex-syntax@0.8.11		X									X					
+reqsign-aliyun-oss@3.1.0		X														
+reqsign-aws-v4@3.0.1		X														
+reqsign-azure-storage@3.0.1		X														
+reqsign-core@3.0.1		X														
+reqsign-file-read-tokio@3.0.1		X														
+reqsign-google@3.0.1		X														
+reqsign-huaweicloud-obs@3.0.1		X														
+reqsign-tencent-cos@3.0.1		X														
+reqsign-volcengine-tos@3.0.1		X														
+reqwest@0.12.28		X									X					
+reqwest@0.13.4		X									X					
 reqwest-middleware@0.5.2		X									X					
 resolv-conf@0.7.6		X									X					
 ring@0.17.14		X							X							
@@ -479,11 +477,10 @@ rustc_version@0.4.1		X									X
 rustc_version_runtime@0.3.0											X					
 rustix@1.1.4		X	X								X					
 rustls@0.21.12		X							X		X					
-rustls@0.23.40		X							X		X					
-rustls-native-certs@0.8.3		X							X		X					
+rustls@0.23.41		X							X		X					
+rustls-native-certs@0.8.4		X							X		X					
 rustls-pemfile@1.0.4		X							X		X					
-rustls-pemfile@2.2.0		X							X		X					
-rustls-pki-types@1.14.1		X									X					
+rustls-pki-types@1.15.0		X									X					
 rustls-platform-verifier@0.7.0		X									X					
 rustls-platform-verifier-android@0.1.1		X									X					
 rustls-webpki@0.101.7									X							
@@ -508,8 +505,8 @@ serde_derive@1.0.228		X									X
 serde_json@1.0.150		X									X					
 serde_repr@0.1.20		X									X					
 serde_urlencoded@0.7.1		X									X					
-serde_with@3.17.0		X									X					
-serde_with_macros@3.17.0		X									X					
+serde_with@3.21.0		X									X					
+serde_with_macros@3.21.0		X									X					
 sha-1@0.10.1		X									X					
 sha1@0.10.6		X									X					
 sha1@0.11.0		X									X					
@@ -520,19 +517,20 @@ sha2-asm@0.6.4											X
 sharded-slab@0.1.7											X					
 shell-escape@0.1.5		X									X					
 shellexpand@3.1.2		X									X					
-shlex@1.3.0		X									X					
+shlex@2.0.1		X									X					
 signal-hook-registry@1.4.8		X									X					
 signature@2.2.0		X									X					
 simd-adler32@0.3.9											X					
 simd_cesu8@1.1.1		X									X					
 simdutf8@0.1.5		X									X					
-simple_asn1@0.6.4									X							
 skeptic@0.13.7		X									X					
 slab@0.4.12											X					
 sled@0.34.7		X									X					
-smallvec@1.15.1		X									X					
+slotmap@1.1.1																X
+smallvec@1.15.2		X									X					
 socket2@0.5.10		X									X					
-socket2@0.6.3		X									X					
+socket2@0.6.4		X									X					
+spin@0.10.0											X					
 spin@0.9.8											X					
 spki@0.7.3		X									X					
 sqlx@0.8.6		X									X					
@@ -553,7 +551,7 @@ strsim@0.11.1											X
 subtle@2.6.1					X											
 symlink@0.1.0		X									X					
 syn@1.0.109		X									X					
-syn@2.0.117		X									X					
+syn@2.0.118		X									X					
 sync_wrapper@0.1.2		X														
 sync_wrapper@1.0.2		X														
 synchrony@0.1.8											X					
@@ -565,7 +563,7 @@ tagptr@0.2.0		X									X
 take_mut@0.2.2											X					
 tap@1.0.1											X					
 tempfile@3.27.0		X									X					
-thin-cell@0.1.2											X					
+thin-cell@0.2.1											X					
 thin-vec@0.2.18		X									X					
 thiserror@1.0.69		X									X					
 thiserror@2.0.18		X									X					
@@ -574,9 +572,9 @@ thiserror-impl@2.0.18		X									X
 thread_local@1.1.9		X									X					
 threadpool@1.8.1		X									X					
 tikv-client@0.4.0		X														
-time@0.3.47		X									X					
-time-core@0.1.8		X									X					
-time-macros@0.2.27		X									X					
+time@0.3.53		X									X					
+time-core@0.1.9		X									X					
+time-macros@0.2.31		X									X					
 tiny-keccak@2.0.2							X									
 tinystr@0.8.3														X		
 tinyvec@1.11.0		X									X					X
@@ -585,18 +583,16 @@ tokio@1.52.3											X
 tokio-io-timeout@1.2.1		X									X					
 tokio-io-utility@0.7.6											X					
 tokio-macros@2.7.0											X					
-tokio-retry@0.3.1											X					
+tokio-retry@0.3.2											X					
 tokio-rustls@0.24.1		X									X					
 tokio-rustls@0.26.4		X									X					
 tokio-stream@0.1.18											X					
 tokio-util@0.7.18											X					
 tonic@0.10.2											X					
-tonic@0.12.3											X					
-tonic@0.14.5											X					
-tonic-build@0.12.3											X					
-tonic-build@0.14.5											X					
-tonic-prost@0.14.5											X					
-tonic-prost-build@0.14.5											X					
+tonic@0.14.6											X					
+tonic-build@0.14.6											X					
+tonic-prost@0.14.6											X					
+tonic-prost-build@0.14.6											X					
 tower@0.4.13											X					
 tower@0.5.3											X					
 tower-http@0.6.11											X					
@@ -609,29 +605,28 @@ tracing-core@0.1.36											X
 tracing-log@0.2.0											X					
 tracing-serde@0.2.0											X					
 tracing-subscriber@0.3.23											X					
-triomphe@0.1.15		X									X					
+triomphe@0.1.16		X									X					
 try-lock@0.2.5											X					
 twox-hash@2.1.2											X					
 typed-builder@0.22.0		X									X					
 typed-builder-macro@0.22.0		X									X					
-typenum@1.20.0		X									X					
+typenum@1.20.1		X									X					
 typewit@1.15.2																X
 unicase@2.9.0		X									X					
 unicode-bidi@0.3.18		X									X					
 unicode-ident@1.0.24		X									X			X		
 unicode-normalization@0.1.25		X									X					
 unicode-properties@0.1.4		X									X					
-unicode-segmentation@1.13.2		X									X					
+unicode-segmentation@1.13.3		X									X					
 unicode-width@0.1.14		X									X					
 unicode-xid@0.2.6		X									X					
 unsigned-varint@0.8.0											X					
-untrusted@0.7.1									X							
 untrusted@0.9.0									X							
 url@2.5.8		X									X					
 urlencoding@2.1.3											X					
 utf8_iter@1.0.4		X									X					
 utf8parse@0.2.2		X									X					
-uuid@1.23.1		X									X					
+uuid@1.23.4		X									X					
 vcpkg@0.2.15		X									X					
 vec-strings@0.4.8											X					
 version_check@0.9.5		X									X					
@@ -640,21 +635,20 @@ want@0.3.1											X
 wasi@0.11.1+wasi-snapshot-preview1		X	X								X					
 wasi@0.14.7+wasi-0.2.4		X	X								X					
 wasi@0.9.0+wasi-snapshot-preview1		X	X								X					
-wasip2@1.0.1+wasi-0.2.4		X	X								X					
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X					
+wasip2@1.0.4+wasi-0.2.12		X	X								X					
 wasite@0.1.0		X				X					X					
 wasite@1.0.2		X				X					X					
-wasm-bindgen@0.2.121		X									X					
-wasm-bindgen-futures@0.4.71		X									X					
-wasm-bindgen-macro@0.2.121		X									X					
-wasm-bindgen-macro-support@0.2.121		X									X					
-wasm-bindgen-shared@0.2.121		X									X					
+wasm-bindgen@0.2.126		X									X					
+wasm-bindgen-futures@0.4.76		X									X					
+wasm-bindgen-macro@0.2.126		X									X					
+wasm-bindgen-macro-support@0.2.126		X									X					
+wasm-bindgen-shared@0.2.126		X									X					
 wasm-streams@0.5.0		X									X					
-web-sys@0.3.98		X									X					
+web-sys@0.3.103		X									X					
 web-time@1.1.0		X									X					
-webpki-root-certs@1.0.7								X								
+webpki-root-certs@1.0.8								X								
 webpki-roots@0.26.11								X								
-webpki-roots@1.0.7								X								
+webpki-roots@1.0.8								X								
 whoami@1.6.1		X				X					X					
 whoami@2.1.2		X				X					X					
 widestring@1.2.1		X									X					
@@ -675,7 +669,6 @@ windows-result@0.4.1		X									X
 windows-strings@0.5.1		X									X					
 windows-sys@0.48.0		X									X					
 windows-sys@0.52.0		X									X					
-windows-sys@0.59.0		X									X					
 windows-sys@0.61.2		X									X					
 windows-targets@0.48.5		X									X					
 windows-targets@0.52.6		X									X					
@@ -695,8 +688,7 @@ windows_x86_64_gnullvm@0.48.5		X									X
 windows_x86_64_gnullvm@0.52.6		X									X					
 windows_x86_64_msvc@0.48.5		X									X					
 windows_x86_64_msvc@0.52.6		X									X					
-wit-bindgen@0.46.0		X	X								X					
-wit-bindgen@0.51.0		X	X								X					
+wit-bindgen@0.57.1		X	X								X					
 writeable@0.6.3														X		
 wyz@0.5.1											X					
 xattr@1.6.1		X									X					
@@ -704,13 +696,13 @@ xet-client@1.5.2		X
 xet-core-structures@1.5.2		X														
 xet-data@1.5.2		X														
 xet-runtime@1.5.2		X														
-xxhash-rust@0.8.15						X										
-yoke@0.8.2														X		
+xxhash-rust@0.8.16						X										
+yoke@0.8.3														X		
 yoke-derive@0.8.2														X		
-zerocopy@0.8.48		X		X							X					
+zerocopy@0.8.53		X		X							X					
 zerofrom@0.1.8														X		
 zerofrom-derive@0.1.7														X		
-zeroize@1.8.2		X									X					
+zeroize@1.9.0		X									X					
 zerotrie@0.2.4														X		
 zerovec@0.11.6														X		
 zerovec-derive@0.11.3														X		

--- a/bindings/haskell/DEPENDENCIES.rust.tsv
+++ b/bindings/haskell/DEPENDENCIES.rust.tsv
@@ -1,25 +1,26 @@
 crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
 aes@0.8.4	X									X			
-anyhow@1.0.102	X									X			
+anyhow@1.0.103	X									X			
 async-trait@0.1.89	X									X			
 atomic-waker@1.1.2	X									X			
-autocfg@1.5.0	X									X			
-aws-lc-rs@1.17.0	X							X					
-aws-lc-sys@0.41.0	X			X				X		X	X		
+autocfg@1.5.1	X									X			
+aws-lc-rs@1.17.1	X							X					
+aws-lc-sys@0.42.0	X			X				X		X	X		
 backon@1.6.0	X												
 base64@0.22.1	X									X			
 base64ct@1.8.3	X									X			
-bitflags@2.11.1	X									X			
+bitflags@2.13.0	X									X			
 block-buffer@0.10.4	X									X			
-block-buffer@0.12.0	X									X			
+block-buffer@0.12.1	X									X			
 block-padding@0.3.3	X									X			
-bumpalo@3.20.2	X									X			
-bytes@1.11.1										X			
+bumpalo@3.20.3	X									X			
+bytes@1.12.0										X			
 cbc@0.1.2	X									X			
-cc@1.2.62	X									X			
+cc@1.2.66	X									X			
 cfg-if@1.0.4	X									X			
 cipher@0.4.4	X									X			
 cmake@0.1.58	X									X			
+cmov@0.5.4	X									X			
 combine@4.6.7										X			
 const-oid@0.10.2	X									X			
 const-oid@0.9.6	X									X			
@@ -29,16 +30,16 @@ core-foundation@0.10.1	X									X
 core-foundation-sys@0.8.7	X									X			
 cpufeatures@0.2.17	X									X			
 cpufeatures@0.3.0	X									X			
-crc32c@0.6.8	X									X			
+crc-fast@1.10.0	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
 crypto-common@0.2.2	X									X			
-ctor@1.0.6	X									X			
+ctor@1.0.8	X									X			
+ctutils@0.4.2	X									X			
 der@0.7.10	X									X			
-deranged@0.5.8	X									X			
 digest@0.10.7	X									X			
 digest@0.11.3	X									X			
-displaydoc@0.2.5	X									X			
+displaydoc@0.2.6	X									X			
 dlv-list@0.5.2	X									X			
 dunce@1.0.5	X					X					X		
 either@1.16.0	X									X			
@@ -58,86 +59,84 @@ futures-task@0.3.32	X									X
 futures-util@0.3.32	X									X			
 generic-array@0.14.7										X			
 getrandom@0.2.17	X									X			
-getrandom@0.3.4	X									X			
-getrandom@0.4.2	X									X			
+getrandom@0.4.3	X									X			
 ghac@0.3.0	X												
 gloo-timers@0.3.0	X									X			
 hashbrown@0.14.5	X									X			
 hex@0.4.3	X									X			
 hmac@0.12.1	X									X			
-http@1.4.0	X									X			
+hmac@0.13.0	X									X			
+http@1.4.2	X									X			
 http-body@1.0.1										X			
 http-body-util@0.1.3										X			
 httparse@1.10.1	X									X			
-hybrid-array@0.4.12	X									X			
-hyper@1.9.0										X			
+hybrid-array@0.4.13	X									X			
+hyper@1.10.1										X			
 hyper-rustls@0.27.9	X							X		X			
 hyper-util@0.1.20										X			
-icu_collections@2.1.1												X	
-icu_locale_core@2.1.1												X	
-icu_normalizer@2.1.1												X	
-icu_normalizer_data@2.1.1												X	
-icu_properties@2.1.2												X	
-icu_properties_data@2.1.2												X	
-icu_provider@2.1.1												X	
+icu_collections@2.2.0												X	
+icu_locale_core@2.2.0												X	
+icu_normalizer@2.2.0												X	
+icu_normalizer_data@2.2.0												X	
+icu_properties@2.2.0												X	
+icu_properties_data@2.2.0												X	
+icu_provider@2.2.0												X	
 idna@1.1.0	X									X			
-idna_adapter@1.2.1	X									X			
+idna_adapter@1.2.2	X									X			
 inout@0.1.4	X									X			
 ipnet@2.12.0	X									X			
 itertools@0.14.0	X									X			
 itoa@1.0.18	X									X			
-jiff@0.2.24										X			X
-jiff-tzdb@0.1.6										X			X
+jiff@0.2.31										X			X
+jiff-tzdb@0.1.7										X			X
 jiff-tzdb-platform@0.1.3										X			X
 jni@0.22.4	X									X			
 jni-macros@0.22.4	X									X			
 jni-sys@0.4.1	X									X			
 jni-sys-macros@0.4.1	X									X			
-jobserver@0.1.34	X									X			
-js-sys@0.3.98	X									X			
-jsonwebtoken@10.3.0										X			
+jobserver@0.1.35	X									X			
+js-sys@0.3.103	X									X			
 lazy_static@1.5.0	X									X			
 libc@0.2.186	X									X			
 libm@0.2.16										X			
-link-section@0.17.2	X									X			
-linktime-proc-macro@0.1.0	X									X			
+link-section@0.19.0	X									X			
+linktime-proc-macro@0.2.0	X									X			
 linux-raw-sys@0.12.1	X	X								X			
 litemap@0.8.2												X	
 lock_api@0.4.14	X									X			
-log@0.4.29	X									X			
+log@0.4.33	X									X			
 md-5@0.11.0	X									X			
-mea@0.6.3	X												
-memchr@2.8.0										X			X
-mio@1.2.0										X			
-num-bigint@0.4.6	X									X			
+mea@0.6.4	X												
+memchr@2.8.2										X			X
+mio@1.2.1										X			
 num-bigint-dig@0.8.6	X									X			
-num-conv@0.2.2	X									X			
 num-integer@0.1.46	X									X			
 num-iter@0.1.45	X									X			
 num-traits@0.2.19	X									X			
 once_cell@1.21.4	X									X			
-opendal@0.57.0	X												
-opendal-core@0.57.0	X												
+opendal@0.58.0	X												
+opendal-core@0.58.0	X												
 opendal-hs@0.0.0	X												
-opendal-layer-concurrent-limit@0.57.0	X												
-opendal-layer-logging@0.57.0	X												
-opendal-layer-retry@0.57.0	X												
-opendal-layer-timeout@0.57.0	X												
-opendal-service-azblob@0.57.0	X												
-opendal-service-azdls@0.57.0	X												
-opendal-service-azfile@0.57.0	X												
-opendal-service-azure-common@0.57.0	X												
-opendal-service-cos@0.57.0	X												
-opendal-service-fs@0.57.0	X												
-opendal-service-gcs@0.57.0	X												
-opendal-service-ghac@0.57.0	X												
-opendal-service-http@0.57.0	X												
-opendal-service-ipmfs@0.57.0	X												
-opendal-service-obs@0.57.0	X												
-opendal-service-oss@0.57.0	X												
-opendal-service-s3@0.57.0	X												
-opendal-service-webdav@0.57.0	X												
-opendal-service-webhdfs@0.57.0	X												
+opendal-http-transport-reqwest@0.58.0	X												
+opendal-layer-concurrent-limit@0.58.0	X												
+opendal-layer-logging@0.58.0	X												
+opendal-layer-retry@0.58.0	X												
+opendal-layer-timeout@0.58.0	X												
+opendal-service-azblob@0.58.0	X												
+opendal-service-azdls@0.58.0	X												
+opendal-service-azfile@0.58.0	X												
+opendal-service-azure-common@0.58.0	X												
+opendal-service-cos@0.58.0	X												
+opendal-service-fs@0.58.0	X												
+opendal-service-gcs@0.58.0	X												
+opendal-service-ghac@0.58.0	X												
+opendal-service-http@0.58.0	X												
+opendal-service-ipmfs@0.58.0	X												
+opendal-service-obs@0.58.0	X												
+opendal-service-oss@0.58.0	X												
+opendal-service-s3@0.58.0	X												
+opendal-service-webdav@0.58.0	X												
+opendal-service-webhdfs@0.58.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-multimap@0.7.3										X			
 parking_lot@0.12.5	X									X			
@@ -150,38 +149,38 @@ pin-project-lite@0.2.17	X									X
 pkcs1@0.7.5	X									X			
 pkcs5@0.7.1	X									X			
 pkcs8@0.10.2	X									X			
+pkg-config@0.3.33	X									X			
 portable-atomic@1.13.1	X									X			
 portable-atomic-util@0.2.7	X									X			
 potential_utf@0.1.5												X	
-powerfmt@0.2.0	X									X			
 ppv-lite86@0.2.21	X									X			
 proc-macro2@1.0.106	X									X			
-prost@0.14.3	X												
-prost-derive@0.14.3	X												
-quick-xml@0.39.4										X			
-quote@1.0.45	X									X			
-r-efi@5.3.0	X								X	X			
+prost@0.14.4	X												
+prost-derive@0.14.4	X												
+quick-xml@0.40.1										X			
+quick-xml@0.41.0										X			
+quote@1.0.46	X									X			
 r-efi@6.0.0	X								X	X			
 rand@0.8.6	X									X			
 rand_chacha@0.3.1	X									X			
 rand_core@0.6.4	X									X			
 redox_syscall@0.5.18										X			
-reqsign-aliyun-oss@3.0.0	X												
-reqsign-aws-v4@3.0.0	X												
-reqsign-azure-storage@3.0.0	X												
-reqsign-core@3.0.0	X												
-reqsign-file-read-tokio@3.0.0	X												
-reqsign-google@3.0.0	X												
-reqsign-huaweicloud-obs@3.0.0	X												
-reqsign-tencent-cos@3.0.0	X												
-reqwest@0.13.3	X									X			
+reqsign-aliyun-oss@3.1.0	X												
+reqsign-aws-v4@3.0.1	X												
+reqsign-azure-storage@3.0.1	X												
+reqsign-core@3.0.1	X												
+reqsign-file-read-tokio@3.0.1	X												
+reqsign-google@3.0.1	X												
+reqsign-huaweicloud-obs@3.0.1	X												
+reqsign-tencent-cos@3.0.1	X												
+reqwest@0.13.4	X									X			
 rsa@0.9.10	X									X			
 rust-ini@0.21.3										X			
 rustc_version@0.4.1	X									X			
 rustix@1.1.4	X	X								X			
-rustls@0.23.40	X							X		X			
-rustls-native-certs@0.8.3	X							X		X			
-rustls-pki-types@1.14.1	X									X			
+rustls@0.23.41	X							X		X			
+rustls-native-certs@0.8.4	X							X		X			
+rustls-pki-types@1.15.0	X									X			
 rustls-platform-verifier@0.7.0	X									X			
 rustls-platform-verifier-android@0.1.1	X									X			
 rustls-webpki@0.103.13								X					
@@ -200,30 +199,27 @@ serde_core@1.0.228	X									X
 serde_derive@1.0.228	X									X			
 serde_json@1.0.150	X									X			
 serde_urlencoded@0.7.1	X									X			
-sha1@0.10.6	X									X			
+sha1@0.11.0	X									X			
 sha2@0.10.9	X									X			
 sha2@0.11.0	X									X			
-shlex@1.3.0	X									X			
+shlex@2.0.1	X									X			
 signal-hook-registry@1.4.8	X									X			
 signature@2.2.0	X									X			
 simd_cesu8@1.1.1	X									X			
 simdutf8@0.1.5	X									X			
-simple_asn1@0.6.4								X					
 slab@0.4.12										X			
-smallvec@1.15.1	X									X			
-socket2@0.6.3	X									X			
+smallvec@1.15.2	X									X			
+socket2@0.6.4	X									X			
+spin@0.10.0										X			
 spin@0.9.8										X			
 spki@0.7.3	X									X			
 stable_deref_trait@1.2.1	X									X			
 subtle@2.6.1				X									
-syn@2.0.117	X									X			
+syn@2.0.118	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
 thiserror@2.0.18	X									X			
 thiserror-impl@2.0.18	X									X			
-time@0.3.47	X									X			
-time-core@0.1.8	X									X			
-time-macros@0.2.27	X									X			
 tiny-keccak@2.0.2						X							
 tinystr@0.8.3												X	
 tokio@1.52.3										X			
@@ -237,41 +233,36 @@ tower-service@0.3.3										X
 tracing@0.1.44										X			
 tracing-core@0.1.36										X			
 try-lock@0.2.5										X			
-typenum@1.20.0	X									X			
+typenum@1.20.1	X									X			
 unicode-ident@1.0.24	X									X		X	
-untrusted@0.7.1								X					
 untrusted@0.9.0								X					
 url@2.5.8	X									X			
 utf8_iter@1.0.4	X									X			
-uuid@1.23.1	X									X			
+uuid@1.23.4	X									X			
 version_check@0.9.5	X									X			
 walkdir@2.5.0										X			X
 want@0.3.1										X			
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
-wasip2@1.0.1+wasi-0.2.4	X	X								X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
-wasm-bindgen@0.2.121	X									X			
-wasm-bindgen-futures@0.4.71	X									X			
-wasm-bindgen-macro@0.2.121	X									X			
-wasm-bindgen-macro-support@0.2.121	X									X			
-wasm-bindgen-shared@0.2.121	X									X			
+wasm-bindgen@0.2.126	X									X			
+wasm-bindgen-futures@0.4.76	X									X			
+wasm-bindgen-macro@0.2.126	X									X			
+wasm-bindgen-macro-support@0.2.126	X									X			
+wasm-bindgen-shared@0.2.126	X									X			
 wasm-streams@0.5.0	X									X			
-web-sys@0.3.98	X									X			
+web-sys@0.3.103	X									X			
 web-time@1.1.0	X									X			
-webpki-root-certs@1.0.7							X						
+webpki-root-certs@1.0.8							X						
 winapi-util@0.1.11										X			X
 windows-link@0.2.1	X									X			
 windows-sys@0.61.2	X									X			
-wit-bindgen@0.46.0	X	X								X			
-wit-bindgen@0.51.0	X	X								X			
 writeable@0.6.3												X	
 xattr@1.6.1	X									X			
-yoke@0.8.2												X	
+yoke@0.8.3												X	
 yoke-derive@0.8.2												X	
-zerocopy@0.8.48	X		X							X			
+zerocopy@0.8.53	X		X							X			
 zerofrom@0.1.8												X	
 zerofrom-derive@0.1.7												X	
-zeroize@1.8.2	X									X			
+zeroize@1.9.0	X									X			
 zerotrie@0.2.4												X	
 zerovec@0.11.6												X	
 zerovec-derive@0.11.3												X	

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -10,12 +10,12 @@ anstyle@1.0.14		X									X
 anstyle-parse@1.0.0		X									X					
 anstyle-query@1.1.5		X									X					
 anstyle-wincon@3.0.11		X									X					
-anyhow@1.0.102		X									X					
+anyhow@1.0.103		X									X					
 approx@0.5.1		X														
-arc-swap@1.9.1		X									X					
+arc-swap@1.9.2		X									X					
 arcstr@1.2.0		X									X					X
 arrayref@0.3.9				X												
-arrayvec@0.7.6		X									X					
+arrayvec@0.7.8		X									X					
 async-lock@3.4.2		X									X					
 async-recursion@0.3.2		X									X					
 async-stream@0.3.6											X					
@@ -23,53 +23,50 @@ async-stream-impl@0.3.6											X
 async-trait@0.1.89		X									X					
 atoi@2.0.0											X					
 atomic-waker@1.1.2		X									X					
-autocfg@1.5.0		X									X					
+autocfg@1.5.1		X									X					
 awaitable@0.4.0											X					
 awaitable-error@0.1.0											X					
-aws-lc-rs@1.17.0		X							X							
-aws-lc-sys@0.41.0		X			X				X		X	X				
+aws-lc-rs@1.17.1		X							X							
+aws-lc-sys@0.42.0		X			X				X		X	X				
 axum@0.6.20											X					
-axum@0.7.9											X					
 axum@0.8.9											X					
 axum-core@0.3.4											X					
-axum-core@0.4.5											X					
 axum-core@0.5.6											X					
 backon@1.6.0		X														
 base64@0.21.7		X									X					
 base64@0.22.1		X									X					
 base64ct@1.8.3		X									X					
 bitflags@1.3.2		X									X					
-bitflags@2.11.1		X									X					
-bitvec@1.0.1											X					
+bitflags@2.13.0		X									X					
+bitvec@1.1.1											X					
 blake3@1.8.5		X	X				X									
 block-buffer@0.10.4		X									X					
-block-buffer@0.12.0		X									X					
+block-buffer@0.12.1		X									X					
 block-padding@0.3.3		X									X					
 bson@2.15.0											X					
-bstr@1.12.1		X									X					
-bumpalo@3.20.2		X									X					
+bstr@1.12.3		X									X					
+bumpalo@3.20.3		X									X					
 bytecount@0.6.9		X									X					
 bytemuck@1.25.0		X									X					X
 byteorder@1.5.0											X				X	
-bytes@1.11.1											X					
+bytes@1.12.0											X					
 cacache@13.1.0		X														
-camino@1.2.2		X									X					
+camino@1.2.4		X									X					
 cargo-platform@0.1.9		X									X					
 cargo_metadata@0.14.2											X					
 cbc@0.1.2		X									X					
-cc@1.2.62		X									X					
-cesu8@1.1.0		X									X					
+cc@1.2.66		X									X					
 cfg-if@0.1.10		X									X					
 cfg-if@1.0.4		X									X					
-chacha20@0.10.0		X									X					
-chrono@0.4.44		X									X					
+chacha20@0.10.1		X									X					
+chrono@0.4.45		X									X					
 cipher@0.4.4		X									X					
 clap@4.6.1		X									X					
 clap_builder@4.6.0		X									X					
 clap_derive@4.6.1		X									X					
 clap_lex@1.1.0		X									X					
 cmake@0.1.58		X									X					
-cmov@0.5.3		X									X					
+cmov@0.5.4		X									X					
 colorchoice@1.0.5		X									X					
 colored@3.1.1													X			
 combine@4.6.7											X					
@@ -91,26 +88,26 @@ cpufeatures@0.2.17		X									X
 cpufeatures@0.3.0		X									X					
 crc@3.4.0		X									X					
 crc-catalog@2.5.0		X									X					
+crc-fast@1.10.0		X									X					
 crc16@0.4.0											X					
-crc32c@0.6.8		X									X					
 crc32fast@1.5.0		X									X					
 critical-section@1.2.0		X									X					
-crossbeam-channel@0.5.15		X									X					
-crossbeam-epoch@0.9.18		X									X					
-crossbeam-queue@0.3.12		X									X					
-crossbeam-utils@0.8.21		X									X					
+crossbeam-channel@0.5.16		X									X					
+crossbeam-epoch@0.9.19		X									X					
+crossbeam-queue@0.3.13		X									X					
+crossbeam-utils@0.8.22		X									X					
 crunchy@0.2.4											X					
 crypto-common@0.1.7		X									X					
 crypto-common@0.2.2		X									X					
 csv@1.4.0											X				X	
 csv-core@0.1.13											X				X	
 ctor@0.6.3		X									X					
-ctor@1.0.6		X									X					
+ctor@1.0.8		X									X					
 ctor-proc-macro@0.0.7		X									X					
 ctutils@0.4.2		X									X					
-darling@0.21.3											X					
-darling_core@0.21.3											X					
-darling_macro@0.21.3											X					
+darling@0.23.0											X					
+darling_core@0.23.0											X					
+darling_macro@0.23.0											X					
 dashmap@5.5.3											X					
 dashmap@6.2.1											X					
 data-encoding@2.11.0											X					
@@ -126,18 +123,17 @@ digest@0.10.7		X									X
 digest@0.11.3		X									X					
 dirs@6.0.0		X									X					
 dirs-sys@0.5.0		X									X					
-displaydoc@0.2.5		X									X					
+displaydoc@0.2.6		X									X					
 dlv-list@0.5.2		X									X					
 dotenvy@0.15.7											X					
 dtor@0.1.1		X									X					
 dtor-proc-macro@0.0.6		X									X					
 dunce@1.0.5		X					X					X				
 either@1.16.0		X									X					
-enum-as-inner@0.6.1		X									X					
 equivalent@1.0.2		X									X					
 errno@0.3.14		X									X					
 error-chain@0.12.4		X									X					
-etcd-client@0.18.0		X									X					
+etcd-client@0.19.0		X									X					
 etcetera@0.8.0		X									X					
 event-listener@5.4.1		X									X					
 event-listener-strategy@0.5.4		X									X					
@@ -170,15 +166,15 @@ generic-array@0.14.7											X
 getrandom@0.1.16		X									X					
 getrandom@0.2.17		X									X					
 getrandom@0.3.4		X									X					
-getrandom@0.4.2		X									X					
+getrandom@0.4.3		X									X					
 ghac@0.3.0		X														
 git-version@0.3.9				X												
 git-version-macro@0.3.9				X												
 glob@0.3.3		X									X					
 gloo-timers@0.3.0		X									X					
-goosefs-sdk@0.1.2		X														
+goosefs-sdk@0.1.5		X														
 h2@0.3.27											X					
-h2@0.4.14											X					
+h2@0.4.15											X					
 hashbrown@0.12.3		X									X					
 hashbrown@0.14.5		X									X					
 hashbrown@0.15.5		X									X					
@@ -188,40 +184,41 @@ heapify@0.2.0		X									X
 heck@0.5.0		X									X					
 hex@0.4.3		X									X					
 hf-xet@1.5.2		X														
-hickory-proto@0.25.2		X									X					
-hickory-resolver@0.25.2		X									X					
+hickory-net@0.26.1		X									X					
+hickory-proto@0.26.1		X									X					
+hickory-resolver@0.26.1		X									X					
 hkdf@0.12.4		X									X					
 hmac@0.12.1		X									X					
 hmac@0.13.0		X									X					
-home@0.5.11		X									X					
-hostname@0.3.1											X					
+home@0.5.12		X									X					
+hostname@0.4.2											X					
 http@0.2.12		X									X					
-http@1.4.0		X									X					
+http@1.4.2		X									X					
 http-body@0.4.6											X					
 http-body@1.0.1											X					
 http-body-util@0.1.3											X					
 httparse@1.10.1		X									X					
 httpdate@1.0.3		X									X					
-humantime@2.3.0		X									X					
-hybrid-array@0.4.12		X									X					
+humantime@2.4.0		X									X					
+hybrid-array@0.4.13		X									X					
 hyper@0.14.32											X					
-hyper@1.9.0											X					
+hyper@1.10.1											X					
 hyper-rustls@0.27.9		X							X		X					
 hyper-timeout@0.4.1		X									X					
 hyper-timeout@0.5.2		X									X					
 hyper-util@0.1.20											X					
 iana-time-zone@0.1.65		X									X					
 iana-time-zone-haiku@0.1.2		X									X					
-icu_collections@2.1.1														X		
-icu_locale_core@2.1.1														X		
-icu_normalizer@2.1.1														X		
-icu_normalizer_data@2.1.1														X		
-icu_properties@2.1.2														X		
-icu_properties_data@2.1.2														X		
-icu_provider@2.1.1														X		
+icu_collections@2.2.0														X		
+icu_locale_core@2.2.0														X		
+icu_normalizer@2.2.0														X		
+icu_normalizer_data@2.2.0														X		
+icu_properties@2.2.0														X		
+icu_properties_data@2.2.0														X		
+icu_provider@2.2.0														X		
 ident_case@1.0.1		X									X					
 idna@1.1.0		X									X					
-idna_adapter@1.2.1		X									X					
+idna_adapter@1.2.2		X									X					
 indexmap@1.9.3		X									X					
 indexmap@2.14.0		X									X					
 inout@0.1.4		X									X					
@@ -232,60 +229,57 @@ is_terminal_polyfill@1.70.2		X									X
 itertools@0.12.1		X									X					
 itertools@0.14.0		X									X					
 itoa@1.0.18		X									X					
-jiff@0.2.24											X				X	
-jiff-tzdb@0.1.6											X				X	
+jiff@0.2.31											X				X	
+jiff-tzdb@0.1.7											X				X	
 jiff-tzdb-platform@0.1.3											X				X	
-jni@0.21.1		X									X					
 jni@0.22.4		X									X					
 jni-macros@0.22.4		X									X					
-jni-sys@0.3.1		X									X					
 jni-sys@0.4.1		X									X					
 jni-sys-macros@0.4.1		X									X					
-jobserver@0.1.34		X									X					
-js-sys@0.3.98		X									X					
-jsonwebtoken@10.3.0											X					
+jobserver@0.1.35		X									X					
+js-sys@0.3.103		X									X					
 konst@0.4.3																X
 konst_proc_macros@0.4.1																X
 lazy_static@1.5.0		X									X					
 libc@0.2.186		X									X					
 libm@0.2.16											X					
-libredox@0.1.16											X					
+libredox@0.1.18											X					
 libsqlite3-sys@0.30.1											X					
-link-section@0.17.2		X									X					
+link-section@0.19.0		X									X					
 linked-hash-map@0.5.6		X									X					
-linktime-proc-macro@0.1.0		X									X					
+linktime-proc-macro@0.2.0		X									X					
 linux-raw-sys@0.12.1		X	X								X					
 litemap@0.8.2														X		
 lock_api@0.4.14		X									X					
-log@0.4.29		X									X					
+log@0.4.33		X									X					
 lz4_flex@0.13.1											X					
 macro_magic@0.5.1											X					
 macro_magic_core@0.5.1											X					
 macro_magic_core_macros@0.5.1											X					
 macro_magic_macros@0.5.1											X					
-match_cfg@0.1.0		X									X					
 matchers@0.2.0											X					
 matchit@0.7.3					X						X					
 matchit@0.8.4					X						X					
 md-5@0.10.6		X									X					
 md-5@0.11.0		X									X					
-mea@0.6.3		X														
-memchr@2.8.0											X				X	
+mea@0.6.4		X														
+memchr@2.8.2											X				X	
 memmap2@0.5.10		X									X					
 miette@5.10.0		X														
 miette-derive@5.10.0		X														
 mime@0.3.17		X									X					
 mini-moka@0.10.3		X									X					
 miniz_oxide@0.8.9		X									X					X
-mio@1.2.0											X					
+mio@1.2.1											X					
 moka@0.12.15		X									X					
-mongodb@3.6.0		X														
-mongodb-internal-macros@3.6.0		X														
+mongodb@3.7.0		X														
+mongodb-internal-macros@3.7.0		X														
 more-asserts@0.3.1		X					X				X				X	
 multimap@0.10.1		X									X					
+ndk-context@0.1.1		X									X					
 ntapi@0.4.3		X									X					
 nu-ansi-term@0.50.3											X					
-num-bigint@0.4.6		X									X					
+num-bigint@0.4.8		X									X					
 num-bigint-dig@0.8.6		X									X					
 num-conv@0.2.2		X									X					
 num-derive@0.4.2		X									X					
@@ -298,61 +292,62 @@ objc2-system-configuration@0.3.2		X									X					X
 once_cell@1.21.4		X									X					
 once_cell_polyfill@1.70.2		X									X					
 oneshot@0.1.13		X									X					
-opendal@0.57.0		X														
-opendal-core@0.57.0		X														
+opendal@0.58.0		X														
+opendal-core@0.58.0		X														
+opendal-http-transport-reqwest@0.58.0		X														
 opendal-java@0.0.0		X														
-opendal-layer-concurrent-limit@0.57.0		X														
-opendal-layer-logging@0.57.0		X														
-opendal-layer-retry@0.57.0		X														
-opendal-layer-timeout@0.57.0		X														
-opendal-service-aliyun-drive@0.57.0		X														
-opendal-service-alluxio@0.57.0		X														
-opendal-service-azblob@0.57.0		X														
-opendal-service-azdls@0.57.0		X														
-opendal-service-azfile@0.57.0		X														
-opendal-service-azure-common@0.57.0		X														
-opendal-service-b2@0.57.0		X														
-opendal-service-cacache@0.57.0		X														
-opendal-service-cos@0.57.0		X														
-opendal-service-dashmap@0.57.0		X														
-opendal-service-dropbox@0.57.0		X														
-opendal-service-etcd@0.57.0		X														
-opendal-service-fs@0.57.0		X														
-opendal-service-gcs@0.57.0		X														
-opendal-service-gdrive@0.57.0		X														
-opendal-service-ghac@0.57.0		X														
-opendal-service-goosefs@0.57.0		X														
-opendal-service-gridfs@0.57.0		X														
-opendal-service-hf@0.57.0		X														
-opendal-service-http@0.57.0		X														
-opendal-service-ipfs@0.57.0		X														
-opendal-service-ipmfs@0.57.0		X														
-opendal-service-koofr@0.57.0		X														
-opendal-service-memcached@0.57.0		X														
-opendal-service-mini-moka@0.57.0		X														
-opendal-service-moka@0.57.0		X														
-opendal-service-mongodb@0.57.0		X														
-opendal-service-mysql@0.57.0		X														
-opendal-service-obs@0.57.0		X														
-opendal-service-onedrive@0.57.0		X														
-opendal-service-oss@0.57.0		X														
-opendal-service-persy@0.57.0		X														
-opendal-service-postgresql@0.57.0		X														
-opendal-service-redb@0.57.0		X														
-opendal-service-redis@0.57.0		X														
-opendal-service-s3@0.57.0		X														
-opendal-service-seafile@0.57.0		X														
-opendal-service-sftp@0.57.0		X														
-opendal-service-sled@0.57.0		X														
-opendal-service-sqlite@0.57.0		X														
-opendal-service-swift@0.57.0		X														
-opendal-service-tikv@0.57.0		X														
-opendal-service-tos@0.57.0		X														
-opendal-service-upyun@0.57.0		X														
-opendal-service-vercel-artifacts@0.57.0		X														
-opendal-service-webdav@0.57.0		X														
-opendal-service-webhdfs@0.57.0		X														
-opendal-service-yandex-disk@0.57.0		X														
+opendal-layer-concurrent-limit@0.58.0		X														
+opendal-layer-logging@0.58.0		X														
+opendal-layer-retry@0.58.0		X														
+opendal-layer-timeout@0.58.0		X														
+opendal-service-aliyun-drive@0.58.0		X														
+opendal-service-alluxio@0.58.0		X														
+opendal-service-azblob@0.58.0		X														
+opendal-service-azdls@0.58.0		X														
+opendal-service-azfile@0.58.0		X														
+opendal-service-azure-common@0.58.0		X														
+opendal-service-b2@0.58.0		X														
+opendal-service-cacache@0.58.0		X														
+opendal-service-cos@0.58.0		X														
+opendal-service-dashmap@0.58.0		X														
+opendal-service-dropbox@0.58.0		X														
+opendal-service-etcd@0.58.0		X														
+opendal-service-fs@0.58.0		X														
+opendal-service-gcs@0.58.0		X														
+opendal-service-gdrive@0.58.0		X														
+opendal-service-ghac@0.58.0		X														
+opendal-service-goosefs@0.58.0		X														
+opendal-service-gridfs@0.58.0		X														
+opendal-service-hf@0.58.0		X														
+opendal-service-http@0.58.0		X														
+opendal-service-ipfs@0.58.0		X														
+opendal-service-ipmfs@0.58.0		X														
+opendal-service-koofr@0.58.0		X														
+opendal-service-memcached@0.58.0		X														
+opendal-service-mini-moka@0.58.0		X														
+opendal-service-moka@0.58.0		X														
+opendal-service-mongodb@0.58.0		X														
+opendal-service-mysql@0.58.0		X														
+opendal-service-obs@0.58.0		X														
+opendal-service-onedrive@0.58.0		X														
+opendal-service-oss@0.58.0		X														
+opendal-service-persy@0.58.0		X														
+opendal-service-postgresql@0.58.0		X														
+opendal-service-redb@0.58.0		X														
+opendal-service-redis@0.58.0		X														
+opendal-service-s3@0.58.0		X														
+opendal-service-seafile@0.58.0		X														
+opendal-service-sftp@0.58.0		X														
+opendal-service-sled@0.58.0		X														
+opendal-service-sqlite@0.58.0		X														
+opendal-service-swift@0.58.0		X														
+opendal-service-tikv@0.58.0		X														
+opendal-service-tos@0.58.0		X														
+opendal-service-upyun@0.58.0		X														
+opendal-service-vercel-artifacts@0.58.0		X														
+opendal-service-webdav@0.58.0		X														
+opendal-service-webhdfs@0.58.0		X														
+opendal-service-yandex-disk@0.58.0		X														
 openssh@0.11.6		X									X					
 openssh-sftp-client@0.15.7											X					
 openssh-sftp-client-lowlevel@0.7.2											X					
@@ -372,8 +367,7 @@ pbkdf2@0.12.2		X									X
 pem@3.0.6											X					
 pem-rfc7468@0.7.0		X									X					
 percent-encoding@2.3.2		X									X					
-persy@1.7.1													X			
-petgraph@0.7.1		X									X					
+persy@1.8.1													X			
 petgraph@0.8.3		X									X					
 pin-project@1.1.13		X									X					
 pin-project-internal@1.1.13		X									X					
@@ -388,28 +382,26 @@ portable-atomic-util@0.2.7		X									X
 potential_utf@0.1.5														X		
 powerfmt@0.2.0		X									X					
 ppv-lite86@0.2.21		X									X					
+prefix-trie@0.8.4		X									X					
 prettyplease@0.2.37		X									X					
 proc-macro2@1.0.106		X									X					
 prometheus@0.13.4		X														
 prost@0.12.6		X														
-prost@0.13.5		X														
-prost@0.14.3		X														
-prost-build@0.13.5		X														
-prost-build@0.14.3		X														
+prost@0.14.4		X														
+prost-build@0.14.4		X														
 prost-derive@0.12.6		X														
-prost-derive@0.13.5		X														
-prost-derive@0.14.3		X														
-prost-types@0.13.5		X														
-prost-types@0.14.3		X														
+prost-derive@0.14.4		X														
+prost-types@0.14.4		X														
 pulldown-cmark@0.13.4											X					
 pulldown-cmark@0.9.6											X					
 pulldown-cmark-to-cmark@22.0.0		X														
-quick-xml@0.39.4											X					
-quote@1.0.45		X									X					
+quick-xml@0.40.1											X					
+quick-xml@0.41.0											X					
+quote@1.0.46		X									X					
 r-efi@5.3.0		X								X	X					
 r-efi@6.0.0		X								X	X					
 radium@0.7.0											X					
-rand@0.10.1		X									X					
+rand@0.10.2		X									X					
 rand@0.7.3		X									X					
 rand@0.8.6		X									X					
 rand@0.9.4		X									X					
@@ -421,26 +413,27 @@ rand_core@0.5.1		X									X
 rand_core@0.6.4		X									X					
 rand_core@0.9.5		X									X					
 rand_hc@0.2.0		X									X					
-redb@2.6.3		X									X					
 redb@3.1.3		X									X					
-redis@1.2.1					X											
+redb@4.1.0		X									X					
+redis@1.3.0					X											
 redox_syscall@0.2.16											X					
 redox_syscall@0.5.18											X					
 redox_users@0.5.2											X					
-reflink-copy@0.1.29		X									X					
-regex@1.12.3		X									X					
+reflink-copy@0.1.30		X									X					
+regex@1.12.4		X									X					
 regex-automata@0.4.14		X									X					
-regex-syntax@0.8.10		X									X					
-reqsign-aliyun-oss@3.0.0		X														
-reqsign-aws-v4@3.0.0		X														
-reqsign-azure-storage@3.0.0		X														
-reqsign-core@3.0.0		X														
-reqsign-file-read-tokio@3.0.0		X														
-reqsign-google@3.0.0		X														
-reqsign-huaweicloud-obs@3.0.0		X														
-reqsign-tencent-cos@3.0.0		X														
-reqsign-volcengine-tos@3.0.0		X														
-reqwest@0.13.3		X									X					
+regex-syntax@0.8.11		X									X					
+reqsign-aliyun-oss@3.1.0		X														
+reqsign-aws-v4@3.0.1		X														
+reqsign-azure-storage@3.0.1		X														
+reqsign-core@3.0.1		X														
+reqsign-file-read-tokio@3.0.1		X														
+reqsign-google@3.0.1		X														
+reqsign-huaweicloud-obs@3.0.1		X														
+reqsign-tencent-cos@3.0.1		X														
+reqsign-volcengine-tos@3.0.1		X														
+reqwest@0.12.28		X									X					
+reqwest@0.13.4		X									X					
 reqwest-middleware@0.5.2		X									X					
 resolv-conf@0.7.6		X									X					
 ring@0.17.14		X							X							
@@ -450,11 +443,10 @@ rustc_version@0.4.1		X									X
 rustc_version_runtime@0.3.0											X					
 rustix@1.1.4		X	X								X					
 rustls@0.21.12		X							X		X					
-rustls@0.23.40		X							X		X					
-rustls-native-certs@0.8.3		X							X		X					
+rustls@0.23.41		X							X		X					
+rustls-native-certs@0.8.4		X							X		X					
 rustls-pemfile@1.0.4		X							X		X					
-rustls-pemfile@2.2.0		X							X		X					
-rustls-pki-types@1.14.1		X									X					
+rustls-pki-types@1.15.0		X									X					
 rustls-platform-verifier@0.7.0		X									X					
 rustls-platform-verifier-android@0.1.1		X									X					
 rustls-webpki@0.101.7									X							
@@ -478,8 +470,8 @@ serde_derive@1.0.228		X									X
 serde_json@1.0.150		X									X					
 serde_repr@0.1.20		X									X					
 serde_urlencoded@0.7.1		X									X					
-serde_with@3.17.0		X									X					
-serde_with_macros@3.17.0		X									X					
+serde_with@3.21.0		X									X					
+serde_with_macros@3.21.0		X									X					
 sha-1@0.10.1		X									X					
 sha1@0.10.6		X									X					
 sha1@0.11.0		X									X					
@@ -490,19 +482,19 @@ sha2-asm@0.6.4											X
 sharded-slab@0.1.7											X					
 shell-escape@0.1.5		X									X					
 shellexpand@3.1.2		X									X					
-shlex@1.3.0		X									X					
+shlex@2.0.1		X									X					
 signal-hook-registry@1.4.8		X									X					
 signature@2.2.0		X									X					
 simd-adler32@0.3.9											X					
 simd_cesu8@1.1.1		X									X					
 simdutf8@0.1.5		X									X					
-simple_asn1@0.6.4									X							
 skeptic@0.13.7		X									X					
 slab@0.4.12											X					
 sled@0.34.7		X									X					
-smallvec@1.15.1		X									X					
+smallvec@1.15.2		X									X					
 socket2@0.5.10		X									X					
-socket2@0.6.3		X									X					
+socket2@0.6.4		X									X					
+spin@0.10.0											X					
 spin@0.9.8											X					
 spki@0.7.3		X									X					
 sqlx@0.8.6		X									X					
@@ -523,7 +515,7 @@ strsim@0.11.1											X
 subtle@2.6.1					X											
 symlink@0.1.0		X									X					
 syn@1.0.109		X									X					
-syn@2.0.117		X									X					
+syn@2.0.118		X									X					
 sync_wrapper@0.1.2		X														
 sync_wrapper@1.0.2		X														
 synstructure@0.13.2											X					
@@ -541,9 +533,9 @@ thiserror-impl@1.0.69		X									X
 thiserror-impl@2.0.18		X									X					
 thread_local@1.1.9		X									X					
 tikv-client@0.4.0		X														
-time@0.3.47		X									X					
-time-core@0.1.8		X									X					
-time-macros@0.2.27		X									X					
+time@0.3.53		X									X					
+time-core@0.1.9		X									X					
+time-macros@0.2.31		X									X					
 tiny-keccak@2.0.2							X									
 tinystr@0.8.3														X		
 tinyvec@1.11.0		X									X					X
@@ -552,18 +544,16 @@ tokio@1.52.3											X
 tokio-io-timeout@1.2.1		X									X					
 tokio-io-utility@0.7.6											X					
 tokio-macros@2.7.0											X					
-tokio-retry@0.3.1											X					
+tokio-retry@0.3.2											X					
 tokio-rustls@0.24.1		X									X					
 tokio-rustls@0.26.4		X									X					
 tokio-stream@0.1.18											X					
 tokio-util@0.7.18											X					
 tonic@0.10.2											X					
-tonic@0.12.3											X					
-tonic@0.14.5											X					
-tonic-build@0.12.3											X					
-tonic-build@0.14.5											X					
-tonic-prost@0.14.5											X					
-tonic-prost-build@0.14.5											X					
+tonic@0.14.6											X					
+tonic-build@0.14.6											X					
+tonic-prost@0.14.6											X					
+tonic-prost-build@0.14.6											X					
 tower@0.4.13											X					
 tower@0.5.3											X					
 tower-http@0.6.11											X					
@@ -576,29 +566,28 @@ tracing-core@0.1.36											X
 tracing-log@0.2.0											X					
 tracing-serde@0.2.0											X					
 tracing-subscriber@0.3.23											X					
-triomphe@0.1.15		X									X					
+triomphe@0.1.16		X									X					
 try-lock@0.2.5											X					
 twox-hash@2.1.2											X					
 typed-builder@0.22.0		X									X					
 typed-builder-macro@0.22.0		X									X					
-typenum@1.20.0		X									X					
+typenum@1.20.1		X									X					
 typewit@1.15.2																X
 unicase@2.9.0		X									X					
 unicode-bidi@0.3.18		X									X					
 unicode-ident@1.0.24		X									X			X		
 unicode-normalization@0.1.25		X									X					
 unicode-properties@0.1.4		X									X					
-unicode-segmentation@1.13.2		X									X					
+unicode-segmentation@1.13.3		X									X					
 unicode-width@0.1.14		X									X					
 unicode-xid@0.2.6		X									X					
 unsigned-varint@0.8.0											X					
-untrusted@0.7.1									X							
 untrusted@0.9.0									X							
 url@2.5.8		X									X					
 urlencoding@2.1.3											X					
 utf8_iter@1.0.4		X									X					
 utf8parse@0.2.2		X									X					
-uuid@1.23.1		X									X					
+uuid@1.23.4		X									X					
 vcpkg@0.2.15		X									X					
 vec-strings@0.4.8											X					
 version_check@0.9.5		X									X					
@@ -607,21 +596,20 @@ want@0.3.1											X
 wasi@0.11.1+wasi-snapshot-preview1		X	X								X					
 wasi@0.14.7+wasi-0.2.4		X	X								X					
 wasi@0.9.0+wasi-snapshot-preview1		X	X								X					
-wasip2@1.0.1+wasi-0.2.4		X	X								X					
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X					
+wasip2@1.0.4+wasi-0.2.12		X	X								X					
 wasite@0.1.0		X				X					X					
 wasite@1.0.2		X				X					X					
-wasm-bindgen@0.2.121		X									X					
-wasm-bindgen-futures@0.4.71		X									X					
-wasm-bindgen-macro@0.2.121		X									X					
-wasm-bindgen-macro-support@0.2.121		X									X					
-wasm-bindgen-shared@0.2.121		X									X					
+wasm-bindgen@0.2.126		X									X					
+wasm-bindgen-futures@0.4.76		X									X					
+wasm-bindgen-macro@0.2.126		X									X					
+wasm-bindgen-macro-support@0.2.126		X									X					
+wasm-bindgen-shared@0.2.126		X									X					
 wasm-streams@0.5.0		X									X					
-web-sys@0.3.98		X									X					
+web-sys@0.3.103		X									X					
 web-time@1.1.0		X									X					
-webpki-root-certs@1.0.7								X								
+webpki-root-certs@1.0.8								X								
 webpki-roots@0.26.11								X								
-webpki-roots@1.0.7								X								
+webpki-roots@1.0.8								X								
 whoami@1.6.1		X				X					X					
 whoami@2.1.2		X				X					X					
 widestring@1.2.1		X									X					
@@ -640,39 +628,28 @@ windows-numerics@0.3.1		X									X
 windows-registry@0.6.1		X									X					
 windows-result@0.4.1		X									X					
 windows-strings@0.5.1		X									X					
-windows-sys@0.45.0		X									X					
 windows-sys@0.48.0		X									X					
 windows-sys@0.52.0		X									X					
-windows-sys@0.59.0		X									X					
 windows-sys@0.61.2		X									X					
-windows-targets@0.42.2		X									X					
 windows-targets@0.48.5		X									X					
 windows-targets@0.52.6		X									X					
 windows-threading@0.2.1		X									X					
-windows_aarch64_gnullvm@0.42.2		X									X					
 windows_aarch64_gnullvm@0.48.5		X									X					
 windows_aarch64_gnullvm@0.52.6		X									X					
-windows_aarch64_msvc@0.42.2		X									X					
 windows_aarch64_msvc@0.48.5		X									X					
 windows_aarch64_msvc@0.52.6		X									X					
-windows_i686_gnu@0.42.2		X									X					
 windows_i686_gnu@0.48.5		X									X					
 windows_i686_gnu@0.52.6		X									X					
 windows_i686_gnullvm@0.52.6		X									X					
-windows_i686_msvc@0.42.2		X									X					
 windows_i686_msvc@0.48.5		X									X					
 windows_i686_msvc@0.52.6		X									X					
-windows_x86_64_gnu@0.42.2		X									X					
 windows_x86_64_gnu@0.48.5		X									X					
 windows_x86_64_gnu@0.52.6		X									X					
-windows_x86_64_gnullvm@0.42.2		X									X					
 windows_x86_64_gnullvm@0.48.5		X									X					
 windows_x86_64_gnullvm@0.52.6		X									X					
-windows_x86_64_msvc@0.42.2		X									X					
 windows_x86_64_msvc@0.48.5		X									X					
 windows_x86_64_msvc@0.52.6		X									X					
-wit-bindgen@0.46.0		X	X								X					
-wit-bindgen@0.51.0		X	X								X					
+wit-bindgen@0.57.1		X	X								X					
 writeable@0.6.3														X		
 wyz@0.5.1											X					
 xattr@1.6.1		X									X					
@@ -680,13 +657,13 @@ xet-client@1.5.2		X
 xet-core-structures@1.5.2		X														
 xet-data@1.5.2		X														
 xet-runtime@1.5.2		X														
-xxhash-rust@0.8.15						X										
-yoke@0.8.2														X		
+xxhash-rust@0.8.16						X										
+yoke@0.8.3														X		
 yoke-derive@0.8.2														X		
-zerocopy@0.8.48		X		X							X					
+zerocopy@0.8.53		X		X							X					
 zerofrom@0.1.8														X		
 zerofrom-derive@0.1.7														X		
-zeroize@1.8.2		X									X					
+zeroize@1.9.0		X									X					
 zerotrie@0.2.4														X		
 zerovec@0.11.6														X		
 zerovec-derive@0.11.3														X		

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal</artifactId>
-    <version>0.49.0</version> <!-- update version number -->
+    <version>0.50.0</version> <!-- update version number -->
 
     <name>Apache OpenDAL™</name>
     <description>

--- a/bindings/java/upgrade.md
+++ b/bindings/java/upgrade.md
@@ -1,3 +1,16 @@
+# Upgrade to v0.50
+
+## Breaking change
+
+### `OperatorInfo` exposes a single capability
+
+`OperatorInfo.fullCapability` and `OperatorInfo.nativeCapability` have been replaced by `OperatorInfo.capability`.
+
+```diff
+-Capability caps = operator.info().fullCapability;
++Capability caps = operator.info().capability;
+```
+
 # Upgrade to v0.49
 
 ## Breaking changes

--- a/bindings/lua/DEPENDENCIES.rust.tsv
+++ b/bindings/lua/DEPENDENCIES.rust.tsv
@@ -1,27 +1,28 @@
 crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
 aes@0.8.4	X									X			
 aho-corasick@1.1.4										X			X
-anyhow@1.0.102	X									X			
+anyhow@1.0.103	X									X			
 async-trait@0.1.89	X									X			
 atomic-waker@1.1.2	X									X			
-autocfg@1.5.0	X									X			
-aws-lc-rs@1.17.0	X							X					
-aws-lc-sys@0.41.0	X			X				X		X	X		
+autocfg@1.5.1	X									X			
+aws-lc-rs@1.17.1	X							X					
+aws-lc-sys@0.42.0	X			X				X		X	X		
 backon@1.6.0	X												
 base64@0.22.1	X									X			
 base64ct@1.8.3	X									X			
-bitflags@2.11.1	X									X			
+bitflags@2.13.0	X									X			
 block-buffer@0.10.4	X									X			
-block-buffer@0.12.0	X									X			
+block-buffer@0.12.1	X									X			
 block-padding@0.3.3	X									X			
-bstr@1.12.1	X									X			
-bumpalo@3.20.2	X									X			
-bytes@1.11.1										X			
+bstr@1.12.3	X									X			
+bumpalo@3.20.3	X									X			
+bytes@1.12.0										X			
 cbc@0.1.2	X									X			
-cc@1.2.62	X									X			
+cc@1.2.66	X									X			
 cfg-if@1.0.4	X									X			
 cipher@0.4.4	X									X			
 cmake@0.1.58	X									X			
+cmov@0.5.4	X									X			
 combine@4.6.7										X			
 const-oid@0.10.2	X									X			
 const-oid@0.9.6	X									X			
@@ -31,16 +32,16 @@ core-foundation@0.10.1	X									X
 core-foundation-sys@0.8.7	X									X			
 cpufeatures@0.2.17	X									X			
 cpufeatures@0.3.0	X									X			
-crc32c@0.6.8	X									X			
+crc-fast@1.10.0	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
 crypto-common@0.2.2	X									X			
-ctor@1.0.6	X									X			
+ctor@1.0.8	X									X			
+ctutils@0.4.2	X									X			
 der@0.7.10	X									X			
-deranged@0.5.8	X									X			
 digest@0.10.7	X									X			
 digest@0.11.3	X									X			
-displaydoc@0.2.5	X									X			
+displaydoc@0.2.6	X									X			
 dlv-list@0.5.2	X									X			
 dunce@1.0.5	X					X					X		
 either@1.16.0	X									X			
@@ -60,90 +61,87 @@ futures-task@0.3.32	X									X
 futures-util@0.3.32	X									X			
 generic-array@0.14.7										X			
 getrandom@0.2.17	X									X			
-getrandom@0.3.4	X									X			
-getrandom@0.4.2	X									X			
+getrandom@0.4.3	X									X			
 ghac@0.3.0	X												
 gloo-timers@0.3.0	X									X			
 hashbrown@0.14.5	X									X			
 hex@0.4.3	X									X			
 hmac@0.12.1	X									X			
-http@1.4.0	X									X			
+hmac@0.13.0	X									X			
+http@1.4.2	X									X			
 http-body@1.0.1										X			
 http-body-util@0.1.3										X			
 httparse@1.10.1	X									X			
-hybrid-array@0.4.12	X									X			
-hyper@1.9.0										X			
+hybrid-array@0.4.13	X									X			
+hyper@1.10.1										X			
 hyper-rustls@0.27.9	X							X		X			
 hyper-util@0.1.20										X			
-icu_collections@2.1.1												X	
-icu_locale_core@2.1.1												X	
-icu_normalizer@2.1.1												X	
-icu_normalizer_data@2.1.1												X	
-icu_properties@2.1.2												X	
-icu_properties_data@2.1.2												X	
-icu_provider@2.1.1												X	
+icu_collections@2.2.0												X	
+icu_locale_core@2.2.0												X	
+icu_normalizer@2.2.0												X	
+icu_normalizer_data@2.2.0												X	
+icu_properties@2.2.0												X	
+icu_properties_data@2.2.0												X	
+icu_provider@2.2.0												X	
 idna@1.1.0	X									X			
-idna_adapter@1.2.1	X									X			
+idna_adapter@1.2.2	X									X			
 inout@0.1.4	X									X			
 ipnet@2.12.0	X									X			
-itertools@0.12.1	X									X			
 itertools@0.14.0	X									X			
 itoa@1.0.18	X									X			
-jiff@0.2.24										X			X
-jiff-tzdb@0.1.6										X			X
+jiff@0.2.31										X			X
+jiff-tzdb@0.1.7										X			X
 jiff-tzdb-platform@0.1.3										X			X
 jni@0.22.4	X									X			
 jni-macros@0.22.4	X									X			
 jni-sys@0.4.1	X									X			
 jni-sys-macros@0.4.1	X									X			
-jobserver@0.1.34	X									X			
-js-sys@0.3.98	X									X			
-jsonwebtoken@10.3.0										X			
+jobserver@0.1.35	X									X			
+js-sys@0.3.103	X									X			
 lazy_static@1.5.0	X									X			
 libc@0.2.186	X									X			
 libm@0.2.16										X			
-link-section@0.17.2	X									X			
-linktime-proc-macro@0.1.0	X									X			
+link-section@0.19.0	X									X			
+linktime-proc-macro@0.2.0	X									X			
 linux-raw-sys@0.12.1	X	X								X			
 litemap@0.8.2												X	
 lock_api@0.4.14	X									X			
-log@0.4.29	X									X			
+log@0.4.33	X									X			
 md-5@0.11.0	X									X			
-mea@0.6.3	X												
-memchr@2.8.0										X			X
-mio@1.2.0										X			
-mlua@0.9.9										X			
-mlua-sys@0.6.8										X			
-mlua_derive@0.9.3										X			
-num-bigint@0.4.6	X									X			
+mea@0.6.4	X												
+memchr@2.8.2										X			X
+mio@1.2.1										X			
+mlua@0.11.6										X			
+mlua-sys@0.10.0										X			
+mlua_derive@0.11.0										X			
 num-bigint-dig@0.8.6	X									X			
-num-conv@0.2.2	X									X			
 num-integer@0.1.46	X									X			
 num-iter@0.1.45	X									X			
 num-traits@0.2.19	X									X			
 once_cell@1.21.4	X									X			
-opendal@0.57.0	X												
-opendal-core@0.57.0	X												
-opendal-layer-concurrent-limit@0.57.0	X												
-opendal-layer-logging@0.57.0	X												
-opendal-layer-retry@0.57.0	X												
-opendal-layer-timeout@0.57.0	X												
+opendal@0.58.0	X												
+opendal-core@0.58.0	X												
+opendal-http-transport-reqwest@0.58.0	X												
+opendal-layer-concurrent-limit@0.58.0	X												
+opendal-layer-logging@0.58.0	X												
+opendal-layer-retry@0.58.0	X												
+opendal-layer-timeout@0.58.0	X												
 opendal-lua@0.0.0	X												
-opendal-service-azblob@0.57.0	X												
-opendal-service-azdls@0.57.0	X												
-opendal-service-azfile@0.57.0	X												
-opendal-service-azure-common@0.57.0	X												
-opendal-service-cos@0.57.0	X												
-opendal-service-fs@0.57.0	X												
-opendal-service-gcs@0.57.0	X												
-opendal-service-ghac@0.57.0	X												
-opendal-service-http@0.57.0	X												
-opendal-service-ipmfs@0.57.0	X												
-opendal-service-obs@0.57.0	X												
-opendal-service-oss@0.57.0	X												
-opendal-service-s3@0.57.0	X												
-opendal-service-webdav@0.57.0	X												
-opendal-service-webhdfs@0.57.0	X												
+opendal-service-azblob@0.58.0	X												
+opendal-service-azdls@0.58.0	X												
+opendal-service-azfile@0.58.0	X												
+opendal-service-azure-common@0.58.0	X												
+opendal-service-cos@0.58.0	X												
+opendal-service-fs@0.58.0	X												
+opendal-service-gcs@0.58.0	X												
+opendal-service-ghac@0.58.0	X												
+opendal-service-http@0.58.0	X												
+opendal-service-ipmfs@0.58.0	X												
+opendal-service-obs@0.58.0	X												
+opendal-service-oss@0.58.0	X												
+opendal-service-s3@0.58.0	X												
+opendal-service-webdav@0.58.0	X												
+opendal-service-webhdfs@0.58.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-multimap@0.7.3										X			
 parking_lot@0.12.5	X									X			
@@ -160,41 +158,40 @@ pkg-config@0.3.33	X									X
 portable-atomic@1.13.1	X									X			
 portable-atomic-util@0.2.7	X									X			
 potential_utf@0.1.5												X	
-powerfmt@0.2.0	X									X			
 ppv-lite86@0.2.21	X									X			
-proc-macro-error@1.0.4	X									X			
-proc-macro-error-attr@1.0.4	X									X			
+proc-macro-error-attr2@2.0.0	X									X			
+proc-macro-error2@2.0.1	X									X			
 proc-macro2@1.0.106	X									X			
-prost@0.14.3	X												
-prost-derive@0.14.3	X												
-quick-xml@0.39.4										X			
-quote@1.0.45	X									X			
-r-efi@5.3.0	X								X	X			
+prost@0.14.4	X												
+prost-derive@0.14.4	X												
+quick-xml@0.40.1										X			
+quick-xml@0.41.0										X			
+quote@1.0.46	X									X			
 r-efi@6.0.0	X								X	X			
 rand@0.8.6	X									X			
 rand_chacha@0.3.1	X									X			
 rand_core@0.6.4	X									X			
 redox_syscall@0.5.18										X			
-regex@1.12.3	X									X			
+regex@1.12.4	X									X			
 regex-automata@0.4.14	X									X			
-regex-syntax@0.8.10	X									X			
-reqsign-aliyun-oss@3.0.0	X												
-reqsign-aws-v4@3.0.0	X												
-reqsign-azure-storage@3.0.0	X												
-reqsign-core@3.0.0	X												
-reqsign-file-read-tokio@3.0.0	X												
-reqsign-google@3.0.0	X												
-reqsign-huaweicloud-obs@3.0.0	X												
-reqsign-tencent-cos@3.0.0	X												
-reqwest@0.13.3	X									X			
+regex-syntax@0.8.11	X									X			
+reqsign-aliyun-oss@3.1.0	X												
+reqsign-aws-v4@3.0.1	X												
+reqsign-azure-storage@3.0.1	X												
+reqsign-core@3.0.1	X												
+reqsign-file-read-tokio@3.0.1	X												
+reqsign-google@3.0.1	X												
+reqsign-huaweicloud-obs@3.0.1	X												
+reqsign-tencent-cos@3.0.1	X												
+reqwest@0.13.4	X									X			
 rsa@0.9.10	X									X			
 rust-ini@0.21.3										X			
-rustc-hash@2.1.2	X									X			
+rustc-hash@2.1.3	X									X			
 rustc_version@0.4.1	X									X			
 rustix@1.1.4	X	X								X			
-rustls@0.23.40	X							X		X			
-rustls-native-certs@0.8.3	X							X		X			
-rustls-pki-types@1.14.1	X									X			
+rustls@0.23.41	X							X		X			
+rustls-native-certs@0.8.4	X							X		X			
+rustls-pki-types@1.15.0	X									X			
 rustls-platform-verifier@0.7.0	X									X			
 rustls-platform-verifier-android@0.1.1	X									X			
 rustls-webpki@0.103.13								X					
@@ -213,31 +210,27 @@ serde_core@1.0.228	X									X
 serde_derive@1.0.228	X									X			
 serde_json@1.0.150	X									X			
 serde_urlencoded@0.7.1	X									X			
-sha1@0.10.6	X									X			
+sha1@0.11.0	X									X			
 sha2@0.10.9	X									X			
 sha2@0.11.0	X									X			
-shlex@1.3.0	X									X			
+shlex@2.0.1	X									X			
 signal-hook-registry@1.4.8	X									X			
 signature@2.2.0	X									X			
 simd_cesu8@1.1.1	X									X			
 simdutf8@0.1.5	X									X			
-simple_asn1@0.6.4								X					
 slab@0.4.12										X			
-smallvec@1.15.1	X									X			
-socket2@0.6.3	X									X			
+smallvec@1.15.2	X									X			
+socket2@0.6.4	X									X			
+spin@0.10.0										X			
 spin@0.9.8										X			
 spki@0.7.3	X									X			
 stable_deref_trait@1.2.1	X									X			
 subtle@2.6.1				X									
-syn@1.0.109	X									X			
-syn@2.0.117	X									X			
+syn@2.0.118	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
 thiserror@2.0.18	X									X			
 thiserror-impl@2.0.18	X									X			
-time@0.3.47	X									X			
-time-core@0.1.8	X									X			
-time-macros@0.2.27	X									X			
 tiny-keccak@2.0.2						X							
 tinystr@0.8.3												X	
 tokio@1.52.3										X			
@@ -251,41 +244,36 @@ tower-service@0.3.3										X
 tracing@0.1.44										X			
 tracing-core@0.1.36										X			
 try-lock@0.2.5										X			
-typenum@1.20.0	X									X			
+typenum@1.20.1	X									X			
 unicode-ident@1.0.24	X									X		X	
-untrusted@0.7.1								X					
 untrusted@0.9.0								X					
 url@2.5.8	X									X			
 utf8_iter@1.0.4	X									X			
-uuid@1.23.1	X									X			
+uuid@1.23.4	X									X			
 version_check@0.9.5	X									X			
 walkdir@2.5.0										X			X
 want@0.3.1										X			
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
-wasip2@1.0.1+wasi-0.2.4	X	X								X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
-wasm-bindgen@0.2.121	X									X			
-wasm-bindgen-futures@0.4.71	X									X			
-wasm-bindgen-macro@0.2.121	X									X			
-wasm-bindgen-macro-support@0.2.121	X									X			
-wasm-bindgen-shared@0.2.121	X									X			
+wasm-bindgen@0.2.126	X									X			
+wasm-bindgen-futures@0.4.76	X									X			
+wasm-bindgen-macro@0.2.126	X									X			
+wasm-bindgen-macro-support@0.2.126	X									X			
+wasm-bindgen-shared@0.2.126	X									X			
 wasm-streams@0.5.0	X									X			
-web-sys@0.3.98	X									X			
+web-sys@0.3.103	X									X			
 web-time@1.1.0	X									X			
-webpki-root-certs@1.0.7							X						
+webpki-root-certs@1.0.8							X						
 winapi-util@0.1.11										X			X
 windows-link@0.2.1	X									X			
 windows-sys@0.61.2	X									X			
-wit-bindgen@0.46.0	X	X								X			
-wit-bindgen@0.51.0	X	X								X			
 writeable@0.6.3												X	
 xattr@1.6.1	X									X			
-yoke@0.8.2												X	
+yoke@0.8.3												X	
 yoke-derive@0.8.2												X	
-zerocopy@0.8.48	X		X							X			
+zerocopy@0.8.53	X		X							X			
 zerofrom@0.1.8												X	
 zerofrom-derive@0.1.7												X	
-zeroize@1.8.2	X									X			
+zeroize@1.9.0	X									X			
 zerotrie@0.2.4												X	
 zerovec@0.11.6												X	
 zerovec-derive@0.11.3												X	

--- a/bindings/nodejs/DEPENDENCIES.rust.tsv
+++ b/bindings/nodejs/DEPENDENCIES.rust.tsv
@@ -1,53 +1,50 @@
 crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib
 aes@0.8.4	X									X				
 allocator-api2@0.2.21	X									X				
-anyhow@1.0.102	X									X				
+anyhow@1.0.103	X									X				
 async-trait@0.1.89	X									X				
 atomic-waker@1.1.2	X									X				
-autocfg@1.5.0	X									X				
-aws-lc-rs@1.17.0	X							X						
-aws-lc-sys@0.41.0	X			X				X		X	X			
+autocfg@1.5.1	X									X				
+aws-lc-rs@1.17.1	X							X						
+aws-lc-sys@0.42.0	X			X				X		X	X			
 backon@1.6.0	X													
 base64@0.22.1	X									X				
 base64ct@1.8.3	X									X				
-bitflags@2.11.1	X									X				
+bitflags@2.13.0	X									X				
 block-buffer@0.10.4	X									X				
-block-buffer@0.12.0	X									X				
+block-buffer@0.12.1	X									X				
 block-padding@0.3.3	X									X				
-bumpalo@3.20.2	X									X				
-bytes@1.11.1										X				
+bumpalo@3.20.3	X									X				
+bytes@1.12.0										X				
 cbc@0.1.2	X									X				
-cc@1.2.62	X									X				
+cc@1.2.66	X									X				
 cfg-if@1.0.4	X									X				
 cipher@0.4.4	X									X				
 cmake@0.1.58	X									X				
+cmov@0.5.4	X									X				
 combine@4.6.7										X				
 const-oid@0.10.2	X									X				
 const-oid@0.9.6	X									X				
 const-random@0.1.18	X									X				
 const-random-macro@0.1.16	X									X				
-convert_case@0.8.0										X				
+convert_case@0.11.0										X				
 core-foundation@0.10.1	X									X				
 core-foundation-sys@0.8.7	X									X				
 cpufeatures@0.2.17	X									X				
 cpufeatures@0.3.0	X									X				
-crc32c@0.6.8	X									X				
-crossbeam-utils@0.8.21	X									X				
+crc-fast@1.10.0	X									X				
+crossbeam-utils@0.8.22	X									X				
 crunchy@0.2.4										X				
 crypto-common@0.1.7	X									X				
 crypto-common@0.2.2	X									X				
-ctor@0.6.3	X									X				
-ctor@1.0.6	X									X				
-ctor-proc-macro@0.0.7	X									X				
+ctor@1.0.8	X									X				
+ctutils@0.4.2	X									X				
 dashmap@6.2.1										X				
 der@0.7.10	X									X				
-deranged@0.5.8	X									X				
 digest@0.10.7	X									X				
 digest@0.11.3	X									X				
-displaydoc@0.2.5	X									X				
+displaydoc@0.2.6	X									X				
 dlv-list@0.5.2	X									X				
-dtor@0.1.1	X									X				
-dtor-proc-macro@0.0.6	X									X				
 dunce@1.0.5	X					X					X			
 either@1.16.0	X									X				
 equivalent@1.0.2	X									X				
@@ -70,7 +67,7 @@ futures-util@0.3.32	X									X
 generic-array@0.14.7										X				
 getrandom@0.2.17	X									X				
 getrandom@0.3.4	X									X				
-getrandom@0.4.2	X									X				
+getrandom@0.4.3	X									X				
 ghac@0.3.0	X													
 gloo-timers@0.3.0	X									X				
 governor@0.10.4										X				
@@ -78,87 +75,86 @@ hashbrown@0.14.5	X									X
 hashbrown@0.16.1	X									X				
 hex@0.4.3	X									X				
 hmac@0.12.1	X									X				
-http@1.4.0	X									X				
+hmac@0.13.0	X									X				
+http@1.4.2	X									X				
 http-body@1.0.1										X				
 http-body-util@0.1.3										X				
 httparse@1.10.1	X									X				
-hybrid-array@0.4.12	X									X				
-hyper@1.9.0										X				
+hybrid-array@0.4.13	X									X				
+hyper@1.10.1										X				
 hyper-rustls@0.27.9	X							X		X				
 hyper-util@0.1.20										X				
-icu_collections@2.1.1												X		
-icu_locale_core@2.1.1												X		
-icu_normalizer@2.1.1												X		
-icu_normalizer_data@2.1.1												X		
-icu_properties@2.1.2												X		
-icu_properties_data@2.1.2												X		
-icu_provider@2.1.1												X		
+icu_collections@2.2.0												X		
+icu_locale_core@2.2.0												X		
+icu_normalizer@2.2.0												X		
+icu_normalizer_data@2.2.0												X		
+icu_properties@2.2.0												X		
+icu_properties_data@2.2.0												X		
+icu_provider@2.2.0												X		
 idna@1.1.0	X									X				
-idna_adapter@1.2.1	X									X				
+idna_adapter@1.2.2	X									X				
 inout@0.1.4	X									X				
 ipnet@2.12.0	X									X				
 itertools@0.14.0	X									X				
 itoa@1.0.18	X									X				
-jiff@0.2.24										X			X	
-jiff-tzdb@0.1.6										X			X	
+jiff@0.2.31										X			X	
+jiff-tzdb@0.1.7										X			X	
 jiff-tzdb-platform@0.1.3										X			X	
 jni@0.22.4	X									X				
 jni-macros@0.22.4	X									X				
 jni-sys@0.4.1	X									X				
 jni-sys-macros@0.4.1	X									X				
-jobserver@0.1.34	X									X				
-js-sys@0.3.98	X									X				
-jsonwebtoken@10.3.0										X				
+jobserver@0.1.35	X									X				
+js-sys@0.3.103	X									X				
 lazy_static@1.5.0	X									X				
 libc@0.2.186	X									X				
-libloading@0.8.9								X						
+libloading@0.9.0								X						
 libm@0.2.16										X				
-link-section@0.17.2	X									X				
-linktime-proc-macro@0.1.0	X									X				
+link-section@0.19.0	X									X				
+linktime-proc-macro@0.2.0	X									X				
 linux-raw-sys@0.12.1	X	X								X				
 litemap@0.8.2												X		
 lock_api@0.4.14	X									X				
-log@0.4.29	X									X				
+log@0.4.33	X									X				
 md-5@0.11.0	X									X				
-mea@0.6.3	X													
-memchr@2.8.0										X			X	
-mio@1.2.0										X				
-napi@3.4.0										X				
-napi-build@2.2.4										X				
-napi-derive@3.3.0										X				
-napi-derive-backend@3.0.0										X				
-napi-sys@3.0.1										X				
+mea@0.6.4	X													
+memchr@2.8.2										X			X	
+mio@1.2.1										X				
+napi@3.10.3										X				
+napi-build@2.3.2										X				
+napi-derive@3.5.9										X				
+napi-derive-backend@5.1.1										X				
+napi-sys@3.2.2										X				
 nohash-hasher@0.2.0	X									X				
 nonzero_ext@0.3.0	X													
-num-bigint@0.4.6	X									X				
 num-bigint-dig@0.8.6	X									X				
-num-conv@0.2.2	X									X				
 num-integer@0.1.46	X									X				
 num-iter@0.1.45	X									X				
 num-traits@0.2.19	X									X				
 once_cell@1.21.4	X									X				
-opendal@0.57.0	X													
-opendal-core@0.57.0	X													
-opendal-layer-concurrent-limit@0.57.0	X													
-opendal-layer-logging@0.57.0	X													
-opendal-layer-retry@0.57.0	X													
-opendal-layer-throttle@0.57.0	X													
-opendal-layer-timeout@0.57.0	X													
+opendal@0.58.0	X													
+opendal-core@0.58.0	X													
+opendal-http-transport-reqwest@0.58.0	X													
+opendal-layer-concurrent-limit@0.58.0	X													
+opendal-layer-logging@0.58.0	X													
+opendal-layer-retry@0.58.0	X													
+opendal-layer-throttle@0.58.0	X													
+opendal-layer-timeout@0.58.0	X													
 opendal-nodejs@0.0.0	X													
-opendal-service-azblob@0.57.0	X													
-opendal-service-azdls@0.57.0	X													
-opendal-service-azure-common@0.57.0	X													
-opendal-service-cos@0.57.0	X													
-opendal-service-fs@0.57.0	X													
-opendal-service-gcs@0.57.0	X													
-opendal-service-ghac@0.57.0	X													
-opendal-service-http@0.57.0	X													
-opendal-service-ipmfs@0.57.0	X													
-opendal-service-obs@0.57.0	X													
-opendal-service-oss@0.57.0	X													
-opendal-service-s3@0.57.0	X													
-opendal-service-webdav@0.57.0	X													
-opendal-service-webhdfs@0.57.0	X													
+opendal-service-azblob@0.58.0	X													
+opendal-service-azdls@0.58.0	X													
+opendal-service-azure-common@0.58.0	X													
+opendal-service-cos@0.58.0	X													
+opendal-service-fs@0.58.0	X													
+opendal-service-gcs@0.58.0	X													
+opendal-service-ghac@0.58.0	X													
+opendal-service-http@0.58.0	X													
+opendal-service-ipmfs@0.58.0	X													
+opendal-service-obs@0.58.0	X													
+opendal-service-oss@0.58.0	X													
+opendal-service-s3@0.58.0	X													
+opendal-service-webdav@0.58.0	X													
+opendal-service-webhdfs@0.58.0	X													
 openssl-probe@0.2.1	X									X				
 ordered-multimap@0.7.3										X				
 parking_lot@0.12.5	X									X				
@@ -171,17 +167,18 @@ pin-project-lite@0.2.17	X									X
 pkcs1@0.7.5	X									X				
 pkcs5@0.7.1	X									X				
 pkcs8@0.10.2	X									X				
+pkg-config@0.3.33	X									X				
 portable-atomic@1.13.1	X									X				
 portable-atomic-util@0.2.7	X									X				
 potential_utf@0.1.5												X		
-powerfmt@0.2.0	X									X				
 ppv-lite86@0.2.21	X									X				
 proc-macro2@1.0.106	X									X				
-prost@0.14.3	X													
-prost-derive@0.14.3	X													
+prost@0.14.4	X													
+prost-derive@0.14.4	X													
 quanta@0.12.6										X				
-quick-xml@0.39.4										X				
-quote@1.0.45	X									X				
+quick-xml@0.40.1										X				
+quick-xml@0.41.0										X				
+quote@1.0.46	X									X				
 r-efi@5.3.0	X								X	X				
 r-efi@6.0.0	X								X	X				
 rand@0.8.6	X									X				
@@ -192,23 +189,23 @@ rand_core@0.6.4	X									X
 rand_core@0.9.5	X									X				
 raw-cpuid@11.6.0										X				
 redox_syscall@0.5.18										X				
-reqsign-aliyun-oss@3.0.0	X													
-reqsign-aws-v4@3.0.0	X													
-reqsign-azure-storage@3.0.0	X													
-reqsign-core@3.0.0	X													
-reqsign-file-read-tokio@3.0.0	X													
-reqsign-google@3.0.0	X													
-reqsign-huaweicloud-obs@3.0.0	X													
-reqsign-tencent-cos@3.0.0	X													
-reqwest@0.13.3	X									X				
+reqsign-aliyun-oss@3.1.0	X													
+reqsign-aws-v4@3.0.1	X													
+reqsign-azure-storage@3.0.1	X													
+reqsign-core@3.0.1	X													
+reqsign-file-read-tokio@3.0.1	X													
+reqsign-google@3.0.1	X													
+reqsign-huaweicloud-obs@3.0.1	X													
+reqsign-tencent-cos@3.0.1	X													
+reqwest@0.13.4	X									X				
 rsa@0.9.10	X									X				
 rust-ini@0.21.3										X				
-rustc-hash@2.1.2	X									X				
+rustc-hash@2.1.3	X									X				
 rustc_version@0.4.1	X									X				
 rustix@1.1.4	X	X								X				
-rustls@0.23.40	X							X		X				
-rustls-native-certs@0.8.3	X							X		X				
-rustls-pki-types@1.14.1	X									X				
+rustls@0.23.41	X							X		X				
+rustls-native-certs@0.8.4	X							X		X				
+rustls-pki-types@1.15.0	X									X				
 rustls-platform-verifier@0.7.0	X									X				
 rustls-platform-verifier-android@0.1.1	X									X				
 rustls-webpki@0.103.13								X						
@@ -227,30 +224,27 @@ serde_core@1.0.228	X									X
 serde_derive@1.0.228	X									X				
 serde_json@1.0.150	X									X				
 serde_urlencoded@0.7.1	X									X				
-sha1@0.10.6	X									X				
+sha1@0.11.0	X									X				
 sha2@0.10.9	X									X				
 sha2@0.11.0	X									X				
-shlex@1.3.0	X									X				
+shlex@2.0.1	X									X				
 signature@2.2.0	X									X				
 simd_cesu8@1.1.1	X									X				
 simdutf8@0.1.5	X									X				
-simple_asn1@0.6.4								X						
 slab@0.4.12										X				
-smallvec@1.15.1	X									X				
-socket2@0.6.3	X									X				
+smallvec@1.15.2	X									X				
+socket2@0.6.4	X									X				
+spin@0.10.0										X				
 spin@0.9.8										X				
 spinning_top@0.3.0	X									X				
 spki@0.7.3	X									X				
 stable_deref_trait@1.2.1	X									X				
 subtle@2.6.1				X										
-syn@2.0.117	X									X				
+syn@2.0.118	X									X				
 sync_wrapper@1.0.2	X													
 synstructure@0.13.2										X				
 thiserror@2.0.18	X									X				
 thiserror-impl@2.0.18	X									X				
-time@0.3.47	X									X				
-time-core@0.1.8	X									X				
-time-macros@0.2.27	X									X				
 tiny-keccak@2.0.2						X								
 tinystr@0.8.3												X		
 tokio@1.52.3										X				
@@ -264,45 +258,42 @@ tower-service@0.3.3										X
 tracing@0.1.44										X				
 tracing-core@0.1.36										X				
 try-lock@0.2.5										X				
-typenum@1.20.0	X									X				
+typenum@1.20.1	X									X				
 unicode-ident@1.0.24	X									X		X		
-unicode-segmentation@1.13.2	X									X				
-untrusted@0.7.1								X						
+unicode-segmentation@1.13.3	X									X				
 untrusted@0.9.0								X						
 url@2.5.8	X									X				
 utf8_iter@1.0.4	X									X				
-uuid@1.23.1	X									X				
+uuid@1.23.4	X									X				
 version_check@0.9.5	X									X				
 walkdir@2.5.0										X			X	
 want@0.3.1										X				
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X				
-wasip2@1.0.1+wasi-0.2.4	X	X								X				
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X				
-wasm-bindgen@0.2.121	X									X				
-wasm-bindgen-futures@0.4.71	X									X				
-wasm-bindgen-macro@0.2.121	X									X				
-wasm-bindgen-macro-support@0.2.121	X									X				
-wasm-bindgen-shared@0.2.121	X									X				
+wasip2@1.0.4+wasi-0.2.12	X	X								X				
+wasm-bindgen@0.2.126	X									X				
+wasm-bindgen-futures@0.4.76	X									X				
+wasm-bindgen-macro@0.2.126	X									X				
+wasm-bindgen-macro-support@0.2.126	X									X				
+wasm-bindgen-shared@0.2.126	X									X				
 wasm-streams@0.5.0	X									X				
-web-sys@0.3.98	X									X				
+web-sys@0.3.103	X									X				
 web-time@1.1.0	X									X				
-webpki-root-certs@1.0.7							X							
+webpki-root-certs@1.0.8							X							
 winapi@0.3.9	X									X				
 winapi-i686-pc-windows-gnu@0.4.0	X									X				
 winapi-util@0.1.11										X			X	
 winapi-x86_64-pc-windows-gnu@0.4.0	X									X				
 windows-link@0.2.1	X									X				
 windows-sys@0.61.2	X									X				
-wit-bindgen@0.46.0	X	X								X				
-wit-bindgen@0.51.0	X	X								X				
+wit-bindgen@0.57.1	X	X								X				
 writeable@0.6.3												X		
 xattr@1.6.1	X									X				
-yoke@0.8.2												X		
+yoke@0.8.3												X		
 yoke-derive@0.8.2												X		
-zerocopy@0.8.48	X		X							X				
+zerocopy@0.8.53	X		X							X				
 zerofrom@0.1.8												X		
 zerofrom-derive@0.1.7												X		
-zeroize@1.8.2	X									X				
+zeroize@1.9.0	X									X				
 zerotrie@0.2.4												X		
 zerovec@0.11.6												X		
 zerovec-derive@0.11.3												X		

--- a/bindings/nodejs/generated.js
+++ b/bindings/nodejs/generated.js
@@ -99,8 +99,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-android-arm64')
         const bindingPackageVersion = require('@opendal/lib-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -115,8 +115,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-android-arm-eabi')
         const bindingPackageVersion = require('@opendal/lib-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -135,8 +135,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-x64-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-ia32-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-arm64-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@opendal/lib-darwin-universal')
       const bindingPackageVersion = require('@opendal/lib-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-darwin-x64')
         const bindingPackageVersion = require('@opendal/lib-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-darwin-arm64')
         const bindingPackageVersion = require('@opendal/lib-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-freebsd-x64')
         const bindingPackageVersion = require('@opendal/lib-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-freebsd-arm64')
         const bindingPackageVersion = require('@opendal/lib-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-x64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-x64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm-musleabihf')
           const bindingPackageVersion = require('@opendal/lib-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@opendal/lib-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-riscv64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-riscv64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -410,8 +410,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-linux-ppc64-gnu')
         const bindingPackageVersion = require('@opendal/lib-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -426,8 +426,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-linux-s390x-gnu')
         const bindingPackageVersion = require('@opendal/lib-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -446,8 +446,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-arm64')
         const bindingPackageVersion = require('@opendal/lib-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -462,8 +462,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-x64')
         const bindingPackageVersion = require('@opendal/lib-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -478,8 +478,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-arm')
         const bindingPackageVersion = require('@opendal/lib-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.49.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-arm64",
-  "version": "0.49.4",
+  "version": "0.49.5",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-x64",
-  "version": "0.49.4",
+  "version": "0.49.5",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-gnu",
-  "version": "0.49.4",
+  "version": "0.49.5",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-musl",
-  "version": "0.49.4",
+  "version": "0.49.5",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.49.4",
+  "version": "0.49.5",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/linux-x64-musl/package.json
+++ b/bindings/nodejs/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-musl",
-  "version": "0.49.4",
+  "version": "0.49.5",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-arm64-msvc",
-  "version": "0.49.4",
+  "version": "0.49.5",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.49.4",
+  "version": "0.49.5",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "Apache OpenDAL <dev@opendal.apache.org>",
-  "version": "0.49.4",
+  "version": "0.49.5",
   "license": "Apache-2.0",
   "main": "index.cjs",
   "module": "index.mjs",

--- a/bindings/ocaml/DEPENDENCIES.rust.tsv
+++ b/bindings/ocaml/DEPENDENCIES.rust.tsv
@@ -1,25 +1,26 @@
 crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
 aes@0.8.4	X									X			
-anyhow@1.0.102	X									X			
+anyhow@1.0.103	X									X			
 async-trait@0.1.89	X									X			
 atomic-waker@1.1.2	X									X			
-autocfg@1.5.0	X									X			
-aws-lc-rs@1.17.0	X							X					
-aws-lc-sys@0.41.0	X			X				X		X	X		
+autocfg@1.5.1	X									X			
+aws-lc-rs@1.17.1	X							X					
+aws-lc-sys@0.42.0	X			X				X		X	X		
 backon@1.6.0	X												
 base64@0.22.1	X									X			
 base64ct@1.8.3	X									X			
-bitflags@2.11.1	X									X			
+bitflags@2.13.0	X									X			
 block-buffer@0.10.4	X									X			
-block-buffer@0.12.0	X									X			
+block-buffer@0.12.1	X									X			
 block-padding@0.3.3	X									X			
-bumpalo@3.20.2	X									X			
-bytes@1.11.1										X			
+bumpalo@3.20.3	X									X			
+bytes@1.12.0										X			
 cbc@0.1.2	X									X			
-cc@1.2.62	X									X			
+cc@1.2.66	X									X			
 cfg-if@1.0.4	X									X			
 cipher@0.4.4	X									X			
 cmake@0.1.58	X									X			
+cmov@0.5.4	X									X			
 combine@4.6.7										X			
 const-oid@0.10.2	X									X			
 const-oid@0.9.6	X									X			
@@ -29,17 +30,17 @@ core-foundation@0.10.1	X									X
 core-foundation-sys@0.8.7	X									X			
 cpufeatures@0.2.17	X									X			
 cpufeatures@0.3.0	X									X			
-crc32c@0.6.8	X									X			
+crc-fast@1.10.0	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
 crypto-common@0.2.2	X									X			
-ctor@1.0.6	X									X			
+ctor@1.0.8	X									X			
+ctutils@0.4.2	X									X			
 cty@0.2.2	X									X			
 der@0.7.10	X									X			
-deranged@0.5.8	X									X			
 digest@0.10.7	X									X			
 digest@0.11.3	X									X			
-displaydoc@0.2.5	X									X			
+displaydoc@0.2.6	X									X			
 dlv-list@0.5.2	X									X			
 dunce@1.0.5	X					X					X		
 either@1.16.0	X									X			
@@ -59,60 +60,57 @@ futures-task@0.3.32	X									X
 futures-util@0.3.32	X									X			
 generic-array@0.14.7										X			
 getrandom@0.2.17	X									X			
-getrandom@0.3.4	X									X			
-getrandom@0.4.2	X									X			
+getrandom@0.4.3	X									X			
 ghac@0.3.0	X												
 gloo-timers@0.3.0	X									X			
 hashbrown@0.14.5	X									X			
 hex@0.4.3	X									X			
 hmac@0.12.1	X									X			
-http@1.4.0	X									X			
+hmac@0.13.0	X									X			
+http@1.4.2	X									X			
 http-body@1.0.1										X			
 http-body-util@0.1.3										X			
 httparse@1.10.1	X									X			
-hybrid-array@0.4.12	X									X			
-hyper@1.9.0										X			
+hybrid-array@0.4.13	X									X			
+hyper@1.10.1										X			
 hyper-rustls@0.27.9	X							X		X			
 hyper-util@0.1.20										X			
-icu_collections@2.1.1												X	
-icu_locale_core@2.1.1												X	
-icu_normalizer@2.1.1												X	
-icu_normalizer_data@2.1.1												X	
-icu_properties@2.1.2												X	
-icu_properties_data@2.1.2												X	
-icu_provider@2.1.1												X	
+icu_collections@2.2.0												X	
+icu_locale_core@2.2.0												X	
+icu_normalizer@2.2.0												X	
+icu_normalizer_data@2.2.0												X	
+icu_properties@2.2.0												X	
+icu_properties_data@2.2.0												X	
+icu_provider@2.2.0												X	
 idna@1.1.0	X									X			
-idna_adapter@1.2.1	X									X			
+idna_adapter@1.2.2	X									X			
 inout@0.1.4	X									X			
 ipnet@2.12.0	X									X			
 itertools@0.14.0	X									X			
 itoa@1.0.18	X									X			
-jiff@0.2.24										X			X
-jiff-tzdb@0.1.6										X			X
+jiff@0.2.31										X			X
+jiff-tzdb@0.1.7										X			X
 jiff-tzdb-platform@0.1.3										X			X
 jni@0.22.4	X									X			
 jni-macros@0.22.4	X									X			
 jni-sys@0.4.1	X									X			
 jni-sys-macros@0.4.1	X									X			
-jobserver@0.1.34	X									X			
-js-sys@0.3.98	X									X			
-jsonwebtoken@10.3.0										X			
+jobserver@0.1.35	X									X			
+js-sys@0.3.103	X									X			
 lazy_static@1.5.0	X									X			
 libc@0.2.186	X									X			
 libm@0.2.16										X			
-link-section@0.17.2	X									X			
-linktime-proc-macro@0.1.0	X									X			
+link-section@0.19.0	X									X			
+linktime-proc-macro@0.2.0	X									X			
 linux-raw-sys@0.12.1	X	X								X			
 litemap@0.8.2												X	
 lock_api@0.4.14	X									X			
-log@0.4.29	X									X			
+log@0.4.33	X									X			
 md-5@0.11.0	X									X			
-mea@0.6.3	X												
-memchr@2.8.0										X			X
-mio@1.2.0										X			
-num-bigint@0.4.6	X									X			
+mea@0.6.4	X												
+memchr@2.8.2										X			X
+mio@1.2.1										X			
 num-bigint-dig@0.8.6	X									X			
-num-conv@0.2.2	X									X			
 num-integer@0.1.46	X									X			
 num-iter@0.1.45	X									X			
 num-traits@0.2.19	X									X			
@@ -122,28 +120,29 @@ ocaml-build@1.0.0								X
 ocaml-derive@1.0.0								X					
 ocaml-sys@0.26.0								X					
 once_cell@1.21.4	X									X			
-opendal@0.57.0	X												
-opendal-core@0.57.0	X												
-opendal-layer-concurrent-limit@0.57.0	X												
-opendal-layer-logging@0.57.0	X												
-opendal-layer-retry@0.57.0	X												
-opendal-layer-timeout@0.57.0	X												
+opendal@0.58.0	X												
+opendal-core@0.58.0	X												
+opendal-http-transport-reqwest@0.58.0	X												
+opendal-layer-concurrent-limit@0.58.0	X												
+opendal-layer-logging@0.58.0	X												
+opendal-layer-retry@0.58.0	X												
+opendal-layer-timeout@0.58.0	X												
 opendal-ocaml@0.0.0	X												
-opendal-service-azblob@0.57.0	X												
-opendal-service-azdls@0.57.0	X												
-opendal-service-azfile@0.57.0	X												
-opendal-service-azure-common@0.57.0	X												
-opendal-service-cos@0.57.0	X												
-opendal-service-fs@0.57.0	X												
-opendal-service-gcs@0.57.0	X												
-opendal-service-ghac@0.57.0	X												
-opendal-service-http@0.57.0	X												
-opendal-service-ipmfs@0.57.0	X												
-opendal-service-obs@0.57.0	X												
-opendal-service-oss@0.57.0	X												
-opendal-service-s3@0.57.0	X												
-opendal-service-webdav@0.57.0	X												
-opendal-service-webhdfs@0.57.0	X												
+opendal-service-azblob@0.58.0	X												
+opendal-service-azdls@0.58.0	X												
+opendal-service-azfile@0.58.0	X												
+opendal-service-azure-common@0.58.0	X												
+opendal-service-cos@0.58.0	X												
+opendal-service-fs@0.58.0	X												
+opendal-service-gcs@0.58.0	X												
+opendal-service-ghac@0.58.0	X												
+opendal-service-http@0.58.0	X												
+opendal-service-ipmfs@0.58.0	X												
+opendal-service-obs@0.58.0	X												
+opendal-service-oss@0.58.0	X												
+opendal-service-s3@0.58.0	X												
+opendal-service-webdav@0.58.0	X												
+opendal-service-webhdfs@0.58.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-multimap@0.7.3										X			
 parking_lot@0.12.5	X									X			
@@ -156,38 +155,38 @@ pin-project-lite@0.2.17	X									X
 pkcs1@0.7.5	X									X			
 pkcs5@0.7.1	X									X			
 pkcs8@0.10.2	X									X			
+pkg-config@0.3.33	X									X			
 portable-atomic@1.13.1	X									X			
 portable-atomic-util@0.2.7	X									X			
 potential_utf@0.1.5												X	
-powerfmt@0.2.0	X									X			
 ppv-lite86@0.2.21	X									X			
 proc-macro2@1.0.106	X									X			
-prost@0.14.3	X												
-prost-derive@0.14.3	X												
-quick-xml@0.39.4										X			
-quote@1.0.45	X									X			
-r-efi@5.3.0	X								X	X			
+prost@0.14.4	X												
+prost-derive@0.14.4	X												
+quick-xml@0.40.1										X			
+quick-xml@0.41.0										X			
+quote@1.0.46	X									X			
 r-efi@6.0.0	X								X	X			
 rand@0.8.6	X									X			
 rand_chacha@0.3.1	X									X			
 rand_core@0.6.4	X									X			
 redox_syscall@0.5.18										X			
-reqsign-aliyun-oss@3.0.0	X												
-reqsign-aws-v4@3.0.0	X												
-reqsign-azure-storage@3.0.0	X												
-reqsign-core@3.0.0	X												
-reqsign-file-read-tokio@3.0.0	X												
-reqsign-google@3.0.0	X												
-reqsign-huaweicloud-obs@3.0.0	X												
-reqsign-tencent-cos@3.0.0	X												
-reqwest@0.13.3	X									X			
+reqsign-aliyun-oss@3.1.0	X												
+reqsign-aws-v4@3.0.1	X												
+reqsign-azure-storage@3.0.1	X												
+reqsign-core@3.0.1	X												
+reqsign-file-read-tokio@3.0.1	X												
+reqsign-google@3.0.1	X												
+reqsign-huaweicloud-obs@3.0.1	X												
+reqsign-tencent-cos@3.0.1	X												
+reqwest@0.13.4	X									X			
 rsa@0.9.10	X									X			
 rust-ini@0.21.3										X			
 rustc_version@0.4.1	X									X			
 rustix@1.1.4	X	X								X			
-rustls@0.23.40	X							X		X			
-rustls-native-certs@0.8.3	X							X		X			
-rustls-pki-types@1.14.1	X									X			
+rustls@0.23.41	X							X		X			
+rustls-native-certs@0.8.4	X							X		X			
+rustls-pki-types@1.15.0	X									X			
 rustls-platform-verifier@0.7.0	X									X			
 rustls-platform-verifier-android@0.1.1	X									X			
 rustls-webpki@0.103.13								X					
@@ -206,30 +205,27 @@ serde_core@1.0.228	X									X
 serde_derive@1.0.228	X									X			
 serde_json@1.0.150	X									X			
 serde_urlencoded@0.7.1	X									X			
-sha1@0.10.6	X									X			
+sha1@0.11.0	X									X			
 sha2@0.10.9	X									X			
 sha2@0.11.0	X									X			
-shlex@1.3.0	X									X			
+shlex@2.0.1	X									X			
 signal-hook-registry@1.4.8	X									X			
 signature@2.2.0	X									X			
 simd_cesu8@1.1.1	X									X			
 simdutf8@0.1.5	X									X			
-simple_asn1@0.6.4								X					
 slab@0.4.12										X			
-smallvec@1.15.1	X									X			
-socket2@0.6.3	X									X			
+smallvec@1.15.2	X									X			
+socket2@0.6.4	X									X			
+spin@0.10.0										X			
 spin@0.9.8										X			
 spki@0.7.3	X									X			
 stable_deref_trait@1.2.1	X									X			
 subtle@2.6.1				X									
-syn@2.0.117	X									X			
+syn@2.0.118	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
 thiserror@2.0.18	X									X			
 thiserror-impl@2.0.18	X									X			
-time@0.3.47	X									X			
-time-core@0.1.8	X									X			
-time-macros@0.2.27	X									X			
 tiny-keccak@2.0.2						X							
 tinystr@0.8.3												X	
 tokio@1.52.3										X			
@@ -243,41 +239,36 @@ tower-service@0.3.3										X
 tracing@0.1.44										X			
 tracing-core@0.1.36										X			
 try-lock@0.2.5										X			
-typenum@1.20.0	X									X			
+typenum@1.20.1	X									X			
 unicode-ident@1.0.24	X									X		X	
-untrusted@0.7.1								X					
 untrusted@0.9.0								X					
 url@2.5.8	X									X			
 utf8_iter@1.0.4	X									X			
-uuid@1.23.1	X									X			
+uuid@1.23.4	X									X			
 version_check@0.9.5	X									X			
 walkdir@2.5.0										X			X
 want@0.3.1										X			
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
-wasip2@1.0.1+wasi-0.2.4	X	X								X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
-wasm-bindgen@0.2.121	X									X			
-wasm-bindgen-futures@0.4.71	X									X			
-wasm-bindgen-macro@0.2.121	X									X			
-wasm-bindgen-macro-support@0.2.121	X									X			
-wasm-bindgen-shared@0.2.121	X									X			
+wasm-bindgen@0.2.126	X									X			
+wasm-bindgen-futures@0.4.76	X									X			
+wasm-bindgen-macro@0.2.126	X									X			
+wasm-bindgen-macro-support@0.2.126	X									X			
+wasm-bindgen-shared@0.2.126	X									X			
 wasm-streams@0.5.0	X									X			
-web-sys@0.3.98	X									X			
+web-sys@0.3.103	X									X			
 web-time@1.1.0	X									X			
-webpki-root-certs@1.0.7							X						
+webpki-root-certs@1.0.8							X						
 winapi-util@0.1.11										X			X
 windows-link@0.2.1	X									X			
 windows-sys@0.61.2	X									X			
-wit-bindgen@0.46.0	X	X								X			
-wit-bindgen@0.51.0	X	X								X			
 writeable@0.6.3												X	
 xattr@1.6.1	X									X			
-yoke@0.8.2												X	
+yoke@0.8.3												X	
 yoke-derive@0.8.2												X	
-zerocopy@0.8.48	X		X							X			
+zerocopy@0.8.53	X		X							X			
 zerofrom@0.1.8												X	
 zerofrom-derive@0.1.7												X	
-zeroize@1.8.2	X									X			
+zeroize@1.9.0	X									X			
 zerotrie@0.2.4												X	
 zerovec@0.11.6												X	
 zerovec-derive@0.11.3												X	

--- a/bindings/php/DEPENDENCIES.rust.tsv
+++ b/bindings/php/DEPENDENCIES.rust.tsv
@@ -1,349 +1,344 @@
-crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib
-adler2@2.0.1	X	X									X				
-aes@0.8.4		X									X				
-anyhow@1.0.102		X									X				
-async-trait@0.1.89		X									X				
-atomic-waker@1.1.2		X									X				
-autocfg@1.5.0		X									X				
-aws-lc-rs@1.17.0		X							X						
-aws-lc-sys@0.41.0		X			X				X		X	X			
-backon@1.6.0		X													
-base64@0.22.1		X									X				
-base64ct@1.8.3		X									X				
-bindgen@0.68.1					X										
-bitflags@2.11.1		X									X				
-block-buffer@0.10.4		X									X				
-block-buffer@0.12.0		X									X				
-block-padding@0.3.3		X									X				
-bumpalo@3.20.2		X									X				
-bytecount@0.6.9		X									X				
-byteorder@1.5.0											X			X	
-bytes@1.11.1											X				
-bzip2@0.4.4		X									X				
-bzip2-sys@0.1.13+1.0.8		X									X				
-camino@1.2.2		X									X				
-cargo-platform@0.1.9		X									X				
-cargo_metadata@0.14.2											X				
-cbc@0.1.2		X									X				
-cc@1.2.62		X									X				
-cexpr@0.6.0		X									X				
-cfg-if@1.0.4		X									X				
-cipher@0.4.4		X									X				
-clang-sys@1.8.1		X													
-cmake@0.1.58		X									X				
-combine@4.6.7											X				
-const-oid@0.10.2		X									X				
-const-oid@0.9.6		X									X				
-const-random@0.1.18		X									X				
-const-random-macro@0.1.16		X									X				
-constant_time_eq@0.1.5							X								
-core-foundation@0.10.1		X									X				
-core-foundation-sys@0.8.7		X									X				
-cpufeatures@0.2.17		X									X				
-cpufeatures@0.3.0		X									X				
-crc32c@0.6.8		X									X				
-crc32fast@1.5.0		X									X				
-crossbeam-utils@0.8.21		X									X				
-crunchy@0.2.4											X				
-crypto-common@0.1.7		X									X				
-crypto-common@0.2.2		X									X				
-ctor@1.0.6		X									X				
-darling@0.14.4											X				
-darling_core@0.14.4											X				
-darling_macro@0.14.4											X				
-der@0.7.10		X									X				
-deranged@0.5.8		X									X				
-digest@0.10.7		X									X				
-digest@0.11.3		X									X				
-displaydoc@0.2.5		X									X				
-dlv-list@0.5.2		X									X				
-dunce@1.0.5		X					X					X			
-either@1.16.0		X									X				
-errno@0.3.14		X									X				
-error-chain@0.12.4		X									X				
-ext-php-rs@0.13.1		X									X				
-ext-php-rs-derive@0.10.2		X									X				
-fastrand@2.4.1		X									X				
-find-msvc-tools@0.1.9		X									X				
-flate2@1.1.9		X									X				
-fnv@1.0.7		X									X				
-foreign-types@0.3.2		X									X				
-foreign-types-shared@0.1.1		X									X				
-form_urlencoded@1.2.2		X									X				
-fs_extra@1.3.0											X				
-futures@0.3.32		X									X				
-futures-channel@0.3.32		X									X				
-futures-core@0.3.32		X									X				
-futures-executor@0.3.32		X									X				
-futures-io@0.3.32		X									X				
-futures-macro@0.3.32		X									X				
-futures-sink@0.3.32		X									X				
-futures-task@0.3.32		X									X				
-futures-util@0.3.32		X									X				
-generic-array@0.14.7											X				
-getrandom@0.2.17		X									X				
-getrandom@0.3.4		X									X				
-getrandom@0.4.2		X									X				
-ghac@0.3.0		X													
-glob@0.3.3		X									X				
-gloo-timers@0.3.0		X									X				
-hashbrown@0.14.5		X									X				
-hex@0.4.3		X									X				
-hmac@0.12.1		X									X				
-home@0.5.11		X									X				
-http@1.4.0		X									X				
-http-body@1.0.1											X				
-http-body-util@0.1.3											X				
-httparse@1.10.1		X									X				
-hybrid-array@0.4.12		X									X				
-hyper@1.9.0											X				
-hyper-rustls@0.27.9		X							X		X				
-hyper-util@0.1.20											X				
-icu_collections@2.1.1													X		
-icu_locale_core@2.1.1													X		
-icu_normalizer@2.1.1													X		
-icu_normalizer_data@2.1.1													X		
-icu_properties@2.1.2													X		
-icu_properties_data@2.1.2													X		
-icu_provider@2.1.1													X		
-ident_case@1.0.1		X									X				
-idna@1.1.0		X									X				
-idna_adapter@1.2.1		X									X				
-inout@0.1.4		X									X				
-ipnet@2.12.0		X									X				
-itertools@0.14.0		X									X				
-itoa@1.0.18		X									X				
-jiff@0.2.24											X			X	
-jiff-tzdb@0.1.6											X			X	
-jiff-tzdb-platform@0.1.3											X			X	
-jni@0.22.4		X									X				
-jni-macros@0.22.4		X									X				
-jni-sys@0.4.1		X									X				
-jni-sys-macros@0.4.1		X									X				
-jobserver@0.1.34		X									X				
-js-sys@0.3.98		X									X				
-jsonwebtoken@10.3.0											X				
-lazy_static@1.5.0		X									X				
-lazycell@1.3.0		X									X				
-libc@0.2.186		X									X				
-libloading@0.8.9									X						
-libm@0.2.16											X				
-link-section@0.17.2		X									X				
-linktime-proc-macro@0.1.0		X									X				
-linux-raw-sys@0.12.1		X	X								X				
-linux-raw-sys@0.4.15		X	X								X				
-litemap@0.8.2													X		
-lock_api@0.4.14		X									X				
-log@0.4.29		X									X				
-md-5@0.11.0		X									X				
-mea@0.6.3		X													
-memchr@2.8.0											X			X	
-minimal-lexical@0.2.1		X									X				
-miniz_oxide@0.8.9		X									X				X
-mio@1.2.0											X				
-native-tls@0.2.18		X									X				
-nom@7.1.3											X				
-num-bigint@0.4.6		X									X				
-num-bigint-dig@0.8.6		X									X				
-num-conv@0.2.2		X									X				
-num-integer@0.1.46		X									X				
-num-iter@0.1.45		X									X				
-num-traits@0.2.19		X									X				
-once_cell@1.21.4		X									X				
-opendal@0.57.0		X													
-opendal-core@0.57.0		X													
-opendal-layer-concurrent-limit@0.57.0		X													
-opendal-layer-logging@0.57.0		X													
-opendal-layer-retry@0.57.0		X													
-opendal-layer-timeout@0.57.0		X													
-opendal-php@0.0.0		X													
-opendal-service-azblob@0.57.0		X													
-opendal-service-azdls@0.57.0		X													
-opendal-service-azfile@0.57.0		X													
-opendal-service-azure-common@0.57.0		X													
-opendal-service-cos@0.57.0		X													
-opendal-service-fs@0.57.0		X													
-opendal-service-gcs@0.57.0		X													
-opendal-service-ghac@0.57.0		X													
-opendal-service-http@0.57.0		X													
-opendal-service-ipmfs@0.57.0		X													
-opendal-service-obs@0.57.0		X													
-opendal-service-oss@0.57.0		X													
-opendal-service-s3@0.57.0		X													
-opendal-service-webdav@0.57.0		X													
-opendal-service-webhdfs@0.57.0		X													
-openssl@0.10.80		X													
-openssl-macros@0.1.1		X									X				
-openssl-probe@0.2.1		X									X				
-openssl-sys@0.9.116											X				
-ordered-multimap@0.7.3											X				
-parking_lot@0.12.5		X									X				
-parking_lot_core@0.9.12		X									X				
-password-hash@0.4.2		X									X				
-pbkdf2@0.11.0		X									X				
-pbkdf2@0.12.2		X									X				
-peeking_take_while@0.1.2		X									X				
-pem@3.0.6											X				
-pem-rfc7468@0.7.0		X									X				
-percent-encoding@2.3.2		X									X				
-pin-project-lite@0.2.17		X									X				
-pkcs1@0.7.5		X									X				
-pkcs5@0.7.1		X									X				
-pkcs8@0.10.2		X									X				
-pkg-config@0.3.33		X									X				
-portable-atomic@1.13.1		X									X				
-portable-atomic-util@0.2.7		X									X				
-potential_utf@0.1.5													X		
-powerfmt@0.2.0		X									X				
-ppv-lite86@0.2.21		X									X				
-prettyplease@0.2.37		X									X				
-proc-macro2@1.0.106		X									X				
-prost@0.14.3		X													
-prost-derive@0.14.3		X													
-pulldown-cmark@0.9.6											X				
-quick-xml@0.39.4											X				
-quote@1.0.45		X									X				
-r-efi@5.3.0		X								X	X				
-r-efi@6.0.0		X								X	X				
-rand@0.8.6		X									X				
-rand_chacha@0.3.1		X									X				
-rand_core@0.6.4		X									X				
-redox_syscall@0.5.18											X				
-regex@1.12.3		X									X				
-regex-automata@0.4.14		X									X				
-regex-syntax@0.8.10		X									X				
-reqsign-aliyun-oss@3.0.0		X													
-reqsign-aws-v4@3.0.0		X													
-reqsign-azure-storage@3.0.0		X													
-reqsign-core@3.0.0		X													
-reqsign-file-read-tokio@3.0.0		X													
-reqsign-google@3.0.0		X													
-reqsign-huaweicloud-obs@3.0.0		X													
-reqsign-tencent-cos@3.0.0		X													
-reqwest@0.13.3		X									X				
-rsa@0.9.10		X									X				
-rust-ini@0.21.3											X				
-rustc-hash@1.1.0		X									X				
-rustc_version@0.4.1		X									X				
-rustix@0.38.44		X	X								X				
-rustix@1.1.4		X	X								X				
-rustls@0.23.40		X							X		X				
-rustls-native-certs@0.8.3		X							X		X				
-rustls-pki-types@1.14.1		X									X				
-rustls-platform-verifier@0.7.0		X									X				
-rustls-platform-verifier-android@0.1.1		X									X				
-rustls-webpki@0.103.13									X						
-rustversion@1.0.22		X									X				
-ryu@1.0.23		X				X									
-salsa20@0.10.2		X									X				
-same-file@1.0.6											X			X	
-schannel@0.1.29											X				
-scopeguard@1.2.0		X									X				
-scrypt@0.11.0		X									X				
-security-framework@3.7.0		X									X				
-security-framework-sys@2.17.0		X									X				
-semver@1.0.28		X									X				
-serde@1.0.228		X									X				
-serde_core@1.0.228		X									X				
-serde_derive@1.0.228		X									X				
-serde_json@1.0.150		X									X				
-serde_urlencoded@0.7.1		X									X				
-sha1@0.10.6		X									X				
-sha2@0.10.9		X									X				
-sha2@0.11.0		X									X				
-shlex@1.3.0		X									X				
-signal-hook-registry@1.4.8		X									X				
-signature@2.2.0		X									X				
-simd-adler32@0.3.9											X				
-simd_cesu8@1.1.1		X									X				
-simdutf8@0.1.5		X									X				
-simple_asn1@0.6.4									X						
-skeptic@0.13.7		X									X				
-slab@0.4.12											X				
-smallvec@1.15.1		X									X				
-socket2@0.6.3		X									X				
-spin@0.9.8											X				
-spki@0.7.3		X									X				
-stable_deref_trait@1.2.1		X									X				
-strsim@0.10.0											X				
-subtle@2.6.1					X										
-syn@1.0.109		X									X				
-syn@2.0.117		X									X				
-sync_wrapper@1.0.2		X													
-synstructure@0.13.2											X				
-tempfile@3.27.0		X									X				
-thiserror@2.0.18		X									X				
-thiserror-impl@2.0.18		X									X				
-time@0.3.47		X									X				
-time-core@0.1.8		X									X				
-time-macros@0.2.27		X									X				
-tiny-keccak@2.0.2							X								
-tinystr@0.8.3													X		
-tokio@1.52.3											X				
-tokio-macros@2.7.0											X				
-tokio-rustls@0.26.4		X									X				
-tokio-util@0.7.18											X				
-tower@0.5.3											X				
-tower-http@0.6.11											X				
-tower-layer@0.3.3											X				
-tower-service@0.3.3											X				
-tracing@0.1.44											X				
-tracing-core@0.1.36											X				
-try-lock@0.2.5											X				
-typenum@1.20.0		X									X				
-unicase@2.9.0		X									X				
-unicode-ident@1.0.24		X									X		X		
-untrusted@0.7.1									X						
-untrusted@0.9.0									X						
-ureq@2.12.1		X									X				
-url@2.5.8		X									X				
-utf8_iter@1.0.4		X									X				
-uuid@1.23.1		X									X				
-vcpkg@0.2.15		X									X				
-version_check@0.9.5		X									X				
-walkdir@2.5.0											X			X	
-want@0.3.1											X				
-wasi@0.11.1+wasi-snapshot-preview1		X	X								X				
-wasip2@1.0.1+wasi-0.2.4		X	X								X				
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06		X	X								X				
-wasm-bindgen@0.2.121		X									X				
-wasm-bindgen-futures@0.4.71		X									X				
-wasm-bindgen-macro@0.2.121		X									X				
-wasm-bindgen-macro-support@0.2.121		X									X				
-wasm-bindgen-shared@0.2.121		X									X				
-wasm-streams@0.5.0		X									X				
-web-sys@0.3.98		X									X				
-web-time@1.1.0		X									X				
-webpki-root-certs@1.0.7								X							
-which@4.4.2											X				
-winapi-util@0.1.11											X			X	
-windows-link@0.2.1		X									X				
-windows-sys@0.59.0		X									X				
-windows-sys@0.61.2		X									X				
-windows-targets@0.52.6		X									X				
-windows_aarch64_gnullvm@0.52.6		X									X				
-windows_aarch64_msvc@0.52.6		X									X				
-windows_i686_gnu@0.52.6		X									X				
-windows_i686_gnullvm@0.52.6		X									X				
-windows_i686_msvc@0.52.6		X									X				
-windows_x86_64_gnu@0.52.6		X									X				
-windows_x86_64_gnullvm@0.52.6		X									X				
-windows_x86_64_msvc@0.52.6		X									X				
-wit-bindgen@0.46.0		X	X								X				
-wit-bindgen@0.51.0		X	X								X				
-writeable@0.6.3													X		
-xattr@1.6.1		X									X				
-yoke@0.8.2													X		
-yoke-derive@0.8.2													X		
-zerocopy@0.8.48		X		X							X				
-zerofrom@0.1.8													X		
-zerofrom-derive@0.1.7													X		
-zeroize@1.8.2		X									X				
-zerotrie@0.2.4													X		
-zerovec@0.11.6													X		
-zerovec-derive@0.11.3													X		
-zip@0.6.6											X				
-zmij@1.0.21											X				
-zstd@0.11.2+zstd.1.5.2											X				
-zstd-safe@5.0.2+zstd.1.5.2		X									X				
-zstd-sys@2.0.16+zstd.1.5.7		X									X				
+crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
+adler2@2.0.1	X	X									X					
+aes@0.8.4		X									X					
+aes@0.9.1		X									X					
+anyhow@1.0.103		X									X					
+async-trait@0.1.89		X									X					
+atomic-waker@1.1.2		X									X					
+autocfg@1.5.1		X									X					
+aws-lc-rs@1.17.1		X							X							
+aws-lc-sys@0.42.0		X			X				X		X	X				
+backon@1.6.0		X														
+base64@0.22.1		X									X					
+base64ct@1.8.3		X									X					
+bitflags@2.13.0		X									X					
+block-buffer@0.10.4		X									X					
+block-buffer@0.12.1		X									X					
+block-padding@0.3.3		X									X					
+bumpalo@3.20.3		X									X					
+bytecount@0.6.9		X									X					
+bytes@1.12.0											X					
+bzip2@0.6.1		X									X					
+camino@1.2.4		X									X					
+cargo-platform@0.1.9		X									X					
+cargo_metadata@0.14.2											X					
+cbc@0.1.2		X									X					
+cc@1.2.66		X									X					
+cexpr@0.6.0		X									X					
+cfg-if@1.0.4		X									X					
+cipher@0.4.4		X									X					
+cipher@0.5.2		X									X					
+clang-sys@1.8.1		X														
+cmake@0.1.58		X									X					
+cmov@0.5.4		X									X					
+combine@4.6.7											X					
+const-oid@0.10.2		X									X					
+const-oid@0.9.6		X									X					
+const-random@0.1.18		X									X					
+const-random-macro@0.1.16		X									X					
+constant_time_eq@0.4.2		X					X					X				
+convert_case@0.11.0											X					
+core-foundation@0.10.1		X									X					
+core-foundation-sys@0.8.7		X									X					
+cpubits@0.1.1		X									X					
+cpufeatures@0.2.17		X									X					
+cpufeatures@0.3.0		X									X					
+crc-fast@1.10.0		X									X					
+crc32fast@1.5.0		X									X					
+crunchy@0.2.4											X					
+crypto-common@0.1.7		X									X					
+crypto-common@0.2.2		X									X					
+ctor@1.0.8		X									X					
+ctutils@0.4.2		X									X					
+darling@0.23.0											X					
+darling_core@0.23.0											X					
+darling_macro@0.23.0											X					
+deflate64@0.1.12											X					
+der@0.7.10		X									X					
+der@0.8.0		X									X					
+deranged@0.5.8		X									X					
+digest@0.10.7		X									X					
+digest@0.11.3		X									X					
+displaydoc@0.2.6		X									X					
+dlv-list@0.5.2		X									X					
+dunce@1.0.5		X					X					X				
+either@1.16.0		X									X					
+equivalent@1.0.2		X									X					
+errno@0.3.14		X									X					
+error-chain@0.12.4		X									X					
+ext-php-rs@0.15.15		X									X					
+ext-php-rs-bindgen@0.72.1-extphprs.2					X											
+ext-php-rs-build@0.1.1		X									X					
+ext-php-rs-derive@0.11.14		X									X					
+fastrand@2.4.1		X									X					
+find-msvc-tools@0.1.9		X									X					
+flate2@1.1.9		X									X					
+foreign-types@0.3.2		X									X					
+foreign-types-shared@0.1.1		X									X					
+form_urlencoded@1.2.2		X									X					
+fs_extra@1.3.0											X					
+futures@0.3.32		X									X					
+futures-channel@0.3.32		X									X					
+futures-core@0.3.32		X									X					
+futures-executor@0.3.32		X									X					
+futures-io@0.3.32		X									X					
+futures-macro@0.3.32		X									X					
+futures-sink@0.3.32		X									X					
+futures-task@0.3.32		X									X					
+futures-util@0.3.32		X									X					
+generic-array@0.14.7											X					
+getrandom@0.2.17		X									X					
+getrandom@0.4.3		X									X					
+ghac@0.3.0		X														
+glob@0.3.3		X									X					
+gloo-timers@0.3.0		X									X					
+hashbrown@0.14.5		X									X					
+hashbrown@0.17.1		X									X					
+hex@0.4.3		X									X					
+hmac@0.12.1		X									X					
+hmac@0.13.0		X									X					
+http@1.4.2		X									X					
+http-body@1.0.1											X					
+http-body-util@0.1.3											X					
+httparse@1.10.1		X									X					
+hybrid-array@0.4.13		X									X					
+hyper@1.10.1											X					
+hyper-rustls@0.27.9		X							X		X					
+hyper-util@0.1.20											X					
+icu_collections@2.2.0													X			
+icu_locale_core@2.2.0													X			
+icu_normalizer@2.2.0													X			
+icu_normalizer_data@2.2.0													X			
+icu_properties@2.2.0													X			
+icu_properties_data@2.2.0													X			
+icu_provider@2.2.0													X			
+ident_case@1.0.1		X									X					
+idna@1.1.0		X									X					
+idna_adapter@1.2.2		X									X					
+indexmap@2.14.0		X									X					
+inout@0.1.4		X									X					
+inout@0.2.2		X									X					
+inventory@0.3.24		X									X					
+ipnet@2.12.0		X									X					
+itertools@0.14.0		X									X					
+itoa@1.0.18		X									X					
+jiff@0.2.31											X			X		
+jiff-tzdb@0.1.7											X			X		
+jiff-tzdb-platform@0.1.3											X			X		
+jni@0.22.4		X									X					
+jni-macros@0.22.4		X									X					
+jni-sys@0.4.1		X									X					
+jni-sys-macros@0.4.1		X									X					
+jobserver@0.1.35		X									X					
+js-sys@0.3.103		X									X					
+lazy_static@1.5.0		X									X					
+libbz2-rs-sys@0.2.5																X
+libc@0.2.186		X									X					
+libm@0.2.16											X					
+link-section@0.19.0		X									X					
+linktime-proc-macro@0.2.0		X									X					
+linux-raw-sys@0.12.1		X	X								X					
+litemap@0.8.2													X			
+lock_api@0.4.14		X									X					
+log@0.4.33		X									X					
+lzma-rust2@0.16.5		X														
+md-5@0.11.0		X									X					
+mea@0.6.4		X														
+memchr@2.8.2											X			X		
+minimal-lexical@0.2.1		X									X					
+miniz_oxide@0.8.9		X									X				X	
+mio@1.2.1											X					
+native-tls@0.2.18		X									X					
+nom@7.1.3											X					
+num-bigint-dig@0.8.6		X									X					
+num-conv@0.2.2		X									X					
+num-integer@0.1.46		X									X					
+num-iter@0.1.45		X									X					
+num-traits@0.2.19		X									X					
+once_cell@1.21.4		X									X					
+opendal@0.58.0		X														
+opendal-core@0.58.0		X														
+opendal-http-transport-reqwest@0.58.0		X														
+opendal-layer-concurrent-limit@0.58.0		X														
+opendal-layer-logging@0.58.0		X														
+opendal-layer-retry@0.58.0		X														
+opendal-layer-timeout@0.58.0		X														
+opendal-php@0.0.0		X														
+opendal-service-azblob@0.58.0		X														
+opendal-service-azdls@0.58.0		X														
+opendal-service-azfile@0.58.0		X														
+opendal-service-azure-common@0.58.0		X														
+opendal-service-cos@0.58.0		X														
+opendal-service-fs@0.58.0		X														
+opendal-service-gcs@0.58.0		X														
+opendal-service-ghac@0.58.0		X														
+opendal-service-http@0.58.0		X														
+opendal-service-ipmfs@0.58.0		X														
+opendal-service-obs@0.58.0		X														
+opendal-service-oss@0.58.0		X														
+opendal-service-s3@0.58.0		X														
+opendal-service-webdav@0.58.0		X														
+opendal-service-webhdfs@0.58.0		X														
+openssl@0.10.81		X														
+openssl-macros@0.1.1		X									X					
+openssl-probe@0.2.1		X									X					
+openssl-sys@0.9.117											X					
+ordered-multimap@0.7.3											X					
+parking_lot@0.12.5		X									X					
+parking_lot_core@0.9.12		X									X					
+pbkdf2@0.12.2		X									X					
+pbkdf2@0.13.0		X									X					
+pem@3.0.6											X					
+pem-rfc7468@0.7.0		X									X					
+pem-rfc7468@1.0.0		X									X					
+percent-encoding@2.3.2		X									X					
+pin-project-lite@0.2.17		X									X					
+pkcs1@0.7.5		X									X					
+pkcs5@0.7.1		X									X					
+pkcs8@0.10.2		X									X					
+pkg-config@0.3.33		X									X					
+portable-atomic@1.13.1		X									X					
+portable-atomic-util@0.2.7		X									X					
+potential_utf@0.1.5													X			
+powerfmt@0.2.0		X									X					
+ppmd-rust@1.4.0							X					X				
+ppv-lite86@0.2.21		X									X					
+prettyplease@0.2.37		X									X					
+proc-macro2@1.0.106		X									X					
+prost@0.14.4		X														
+prost-derive@0.14.4		X														
+pulldown-cmark@0.9.6											X					
+quick-xml@0.40.1											X					
+quick-xml@0.41.0											X					
+quote@1.0.46		X									X					
+r-efi@6.0.0		X								X	X					
+rand@0.8.6		X									X					
+rand_chacha@0.3.1		X									X					
+rand_core@0.6.4		X									X					
+redox_syscall@0.5.18											X					
+regex@1.12.4		X									X					
+regex-automata@0.4.14		X									X					
+regex-syntax@0.8.11		X									X					
+reqsign-aliyun-oss@3.1.0		X														
+reqsign-aws-v4@3.0.1		X														
+reqsign-azure-storage@3.0.1		X														
+reqsign-core@3.0.1		X														
+reqsign-file-read-tokio@3.0.1		X														
+reqsign-google@3.0.1		X														
+reqsign-huaweicloud-obs@3.0.1		X														
+reqsign-tencent-cos@3.0.1		X														
+reqwest@0.13.4		X									X					
+rsa@0.9.10		X									X					
+rust-ini@0.21.3											X					
+rustc-hash@2.1.3		X									X					
+rustc_version@0.4.1		X									X					
+rustix@1.1.4		X	X								X					
+rustls@0.23.41		X							X		X					
+rustls-native-certs@0.8.4		X							X		X					
+rustls-pki-types@1.15.0		X									X					
+rustls-platform-verifier@0.7.0		X									X					
+rustls-platform-verifier-android@0.1.1		X									X					
+rustls-webpki@0.103.13									X							
+rustversion@1.0.22		X									X					
+ryu@1.0.23		X				X										
+salsa20@0.10.2		X									X					
+same-file@1.0.6											X			X		
+schannel@0.1.29											X					
+scopeguard@1.2.0		X									X					
+scrypt@0.11.0		X									X					
+security-framework@3.7.0		X									X					
+security-framework-sys@2.17.0		X									X					
+semver@1.0.28		X									X					
+serde@1.0.228		X									X					
+serde_core@1.0.228		X									X					
+serde_derive@1.0.228		X									X					
+serde_json@1.0.150		X									X					
+serde_urlencoded@0.7.1		X									X					
+sha1@0.11.0		X									X					
+sha2@0.10.9		X									X					
+sha2@0.11.0		X									X					
+shlex@1.3.0		X									X					
+shlex@2.0.1		X									X					
+signal-hook-registry@1.4.8		X									X					
+signature@2.2.0		X									X					
+simd-adler32@0.3.9											X					
+simd_cesu8@1.1.1		X									X					
+simdutf8@0.1.5		X									X					
+skeptic@0.13.7		X									X					
+slab@0.4.12											X					
+smallvec@1.15.2		X									X					
+socket2@0.6.4		X									X					
+spin@0.10.0											X					
+spin@0.9.8											X					
+spki@0.7.3		X									X					
+stable_deref_trait@1.2.1		X									X					
+strsim@0.11.1											X					
+subtle@2.6.1					X											
+syn@2.0.118		X									X					
+sync_wrapper@1.0.2		X														
+synstructure@0.13.2											X					
+tempfile@3.27.0		X									X					
+thiserror@2.0.18		X									X					
+thiserror-impl@2.0.18		X									X					
+time@0.3.53		X									X					
+time-core@0.1.9		X									X					
+tiny-keccak@2.0.2							X									
+tinystr@0.8.3													X			
+tokio@1.52.3											X					
+tokio-macros@2.7.0											X					
+tokio-rustls@0.26.4		X									X					
+tokio-util@0.7.18											X					
+tower@0.5.3											X					
+tower-http@0.6.11											X					
+tower-layer@0.3.3											X					
+tower-service@0.3.3											X					
+tracing@0.1.44											X					
+tracing-core@0.1.36											X					
+try-lock@0.2.5											X					
+typed-path@0.12.3		X									X					
+typenum@1.20.1		X									X					
+unicase@2.9.0		X									X					
+unicode-ident@1.0.24		X									X		X			
+unicode-segmentation@1.13.3		X									X					
+untrusted@0.9.0									X							
+ureq@3.3.0		X									X					
+ureq-proto@0.6.0		X									X					
+url@2.5.8		X									X					
+utf8-zero@0.8.1		X									X					
+utf8_iter@1.0.4		X									X					
+uuid@1.23.4		X									X					
+vcpkg@0.2.15		X									X					
+version_check@0.9.5		X									X					
+walkdir@2.5.0											X			X		
+want@0.3.1											X					
+wasi@0.11.1+wasi-snapshot-preview1		X	X								X					
+wasm-bindgen@0.2.126		X									X					
+wasm-bindgen-futures@0.4.76		X									X					
+wasm-bindgen-macro@0.2.126		X									X					
+wasm-bindgen-macro-support@0.2.126		X									X					
+wasm-bindgen-shared@0.2.126		X									X					
+wasm-streams@0.5.0		X									X					
+web-sys@0.3.103		X									X					
+web-time@1.1.0		X									X					
+webpki-root-certs@1.0.8								X								
+winapi-util@0.1.11											X			X		
+windows-link@0.2.1		X									X					
+windows-sys@0.61.2		X									X					
+writeable@0.6.3													X			
+xattr@1.6.1		X									X					
+yoke@0.8.3													X			
+yoke-derive@0.8.2													X			
+zerocopy@0.8.53		X		X							X					
+zerofrom@0.1.8													X			
+zerofrom-derive@0.1.7													X			
+zeroize@1.9.0		X									X					
+zerotrie@0.2.4													X			
+zerovec@0.11.6													X			
+zerovec-derive@0.11.3													X			
+zip@8.6.0											X					
+zlib-rs@0.6.5															X	
+zmij@1.0.21											X					
+zopfli@0.8.3		X														
+zstd@0.13.3											X					
+zstd-safe@7.2.4		X									X					
+zstd-sys@2.0.16+zstd.1.5.7		X									X					

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.47.2"
+version = "0.47.3"
 
 [features]
 default = [

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -1,341 +1,274 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unicode-DFS-2016	Unlicense
-aes@0.8.4	X									X				
-android_system_properties@0.1.5	X									X				
-anyhow@1.0.102	X									X				
-async-trait@0.1.89	X									X				
-atomic-waker@1.1.2	X									X				
-autocfg@1.5.0	X									X				
-aws-lc-rs@1.17.0	X							X						
-aws-lc-sys@0.41.0	X			X				X		X	X			
-backon@1.6.0	X													
-base64@0.22.1	X									X				
-base64ct@1.8.3	X									X				
-bitflags@2.11.1	X									X				
-block-buffer@0.10.4	X									X				
-block-buffer@0.12.0	X									X				
-block-padding@0.3.3	X									X				
-bumpalo@3.20.2	X									X				
-bytes@1.11.1										X				
-cbc@0.1.2	X									X				
-cc@1.2.62	X									X				
-cfg-if@1.0.4	X									X				
-chrono@0.4.44	X									X				
-cipher@0.4.4	X									X				
-cmake@0.1.58	X									X				
-combine@4.6.7										X				
-const-oid@0.10.2	X									X				
-const-oid@0.9.6	X									X				
-const-random@0.1.18	X									X				
-const-random-macro@0.1.16	X									X				
-core-foundation@0.10.1	X									X				
-core-foundation-sys@0.8.7	X									X				
-cpufeatures@0.2.17	X									X				
-cpufeatures@0.3.0	X									X				
-crc32c@0.6.8	X									X				
-crunchy@0.2.4										X				
-crypto-common@0.1.7	X									X				
-crypto-common@0.2.2	X									X				
-ctor@1.0.6	X									X				
-der@0.7.10	X									X				
-deranged@0.5.8	X									X				
-digest@0.10.7	X									X				
-digest@0.11.3	X									X				
-displaydoc@0.2.5	X									X				
-dlv-list@0.5.2	X									X				
-dunce@1.0.5	X					X					X			
-either@1.16.0	X									X				
-equivalent@1.0.2	X									X				
-errno@0.3.14	X									X				
-fastrand@2.4.1	X									X				
-find-msvc-tools@0.1.9	X									X				
-form_urlencoded@1.2.2	X									X				
-fs_extra@1.3.0										X				
-futures@0.3.32	X									X				
-futures-channel@0.3.32	X									X				
-futures-core@0.3.32	X									X				
-futures-executor@0.3.32	X									X				
-futures-io@0.3.32	X									X				
-futures-macro@0.3.32	X									X				
-futures-sink@0.3.32	X									X				
-futures-task@0.3.32	X									X				
-futures-util@0.3.32	X									X				
-generic-array@0.14.7										X				
-getopts@0.2.24	X									X				
-getrandom@0.2.17	X									X				
-getrandom@0.3.4	X									X				
-getrandom@0.4.2	X									X				
-ghac@0.3.0	X													
-gloo-timers@0.3.0	X									X				
-hashbrown@0.14.5	X									X				
-hashbrown@0.17.1	X									X				
-heck@0.5.0	X									X				
-hex@0.4.3	X									X				
-hmac@0.12.1	X									X				
-http@1.4.0	X									X				
-http-body@1.0.1										X				
-http-body-util@0.1.3										X				
-httparse@1.10.1	X									X				
-hybrid-array@0.4.12	X									X				
-hyper@1.9.0										X				
-hyper-rustls@0.27.9	X							X		X				
-hyper-util@0.1.20										X				
-iana-time-zone@0.1.65	X									X				
-iana-time-zone-haiku@0.1.2	X									X				
-icu_collections@2.1.1												X		
-icu_locale_core@2.1.1												X		
-icu_normalizer@2.1.1												X		
-icu_normalizer_data@2.1.1												X		
-icu_properties@2.1.2												X		
-icu_properties_data@2.1.2												X		
-icu_provider@2.1.1												X		
-idna@1.1.0	X									X				
-idna_adapter@1.2.1	X									X				
-indexmap@2.14.0	X									X				
-indoc@2.0.7	X									X				
-inout@0.1.4	X									X				
-inventory@0.3.24	X									X				
-ipnet@2.12.0	X									X				
-is-macro@0.3.7	X													
-itertools@0.11.0	X									X				
-itertools@0.14.0	X									X				
-itoa@1.0.18	X									X				
-jiff@0.2.24										X				X
-jiff-tzdb@0.1.6										X				X
-jiff-tzdb-platform@0.1.3										X				X
-jni@0.22.4	X									X				
-jni-macros@0.22.4	X									X				
-jni-sys@0.4.1	X									X				
-jni-sys-macros@0.4.1	X									X				
-jobserver@0.1.34	X									X				
-js-sys@0.3.98	X									X				
-jsonwebtoken@10.3.0										X				
-lalrpop-util@0.20.2	X									X				
-lazy_static@1.5.0	X									X				
-libc@0.2.186	X									X				
-libm@0.2.16										X				
-link-section@0.17.2	X									X				
-linktime-proc-macro@0.1.0	X									X				
-linux-raw-sys@0.12.1	X	X								X				
-litemap@0.8.2												X		
-log@0.4.29	X									X				
-maplit@1.0.2	X									X				
-matrixmultiply@0.3.10	X									X				
-md-5@0.11.0	X									X				
-mea@0.6.3	X													
-memchr@2.8.0										X				X
-memoffset@0.9.1										X				
-mime@0.3.17	X									X				
-mime_guess@2.0.5										X				
-mio@1.2.0										X				
-ndarray@0.17.2	X									X				
-num-bigint@0.4.6	X									X				
-num-bigint-dig@0.8.6	X									X				
-num-complex@0.4.6	X									X				
-num-conv@0.2.2	X									X				
-num-integer@0.1.46	X									X				
-num-iter@0.1.45	X									X				
-num-traits@0.2.19	X									X				
-numpy@0.27.1			X											
-once_cell@1.21.4	X									X				
-opendal@0.57.0	X													
-opendal-core@0.57.0	X													
-opendal-layer-concurrent-limit@0.57.0	X													
-opendal-layer-logging@0.57.0	X													
-opendal-layer-mime-guess@0.57.0	X													
-opendal-layer-retry@0.57.0	X													
-opendal-layer-timeout@0.57.0	X													
-opendal-python@0.47.2	X													
-opendal-service-azblob@0.57.0	X													
-opendal-service-azdls@0.57.0	X													
-opendal-service-azure-common@0.57.0	X													
-opendal-service-cos@0.57.0	X													
-opendal-service-fs@0.57.0	X													
-opendal-service-gcs@0.57.0	X													
-opendal-service-ghac@0.57.0	X													
-opendal-service-http@0.57.0	X													
-opendal-service-ipmfs@0.57.0	X													
-opendal-service-obs@0.57.0	X													
-opendal-service-oss@0.57.0	X													
-opendal-service-s3@0.57.0	X													
-opendal-service-webdav@0.57.0	X													
-opendal-service-webhdfs@0.57.0	X													
-openssl-probe@0.2.1	X									X				
-ordered-float@5.3.0										X				
-ordered-multimap@0.7.3										X				
-pbkdf2@0.12.2	X									X				
-pem@3.0.6										X				
-pem-rfc7468@0.7.0	X									X				
-percent-encoding@2.3.2	X									X				
-phf@0.11.3										X				
-phf_codegen@0.11.3										X				
-phf_generator@0.11.3										X				
-phf_shared@0.11.3										X				
-pin-project-lite@0.2.17	X									X				
-pkcs1@0.7.5	X									X				
-pkcs5@0.7.1	X									X				
-pkcs8@0.10.2	X									X				
-portable-atomic@1.13.1	X									X				
-portable-atomic-util@0.2.7	X									X				
-potential_utf@0.1.5												X		
-powerfmt@0.2.0	X									X				
-ppv-lite86@0.2.21	X									X				
-proc-macro2@1.0.106	X									X				
-prost@0.14.3	X													
-prost-derive@0.14.3	X													
-pyo3@0.27.2	X									X				
-pyo3-async-runtimes@0.27.0	X													
-pyo3-build-config@0.27.2	X									X				
-pyo3-ffi@0.27.2	X									X				
-pyo3-macros@0.27.2	X									X				
-pyo3-macros-backend@0.27.2	X									X				
-pyo3-stub-gen@0.17.2	X									X				
-pyo3-stub-gen-derive@0.17.2	X									X				
-python3-dll-a@0.2.15										X				
-quick-xml@0.39.4										X				
-quote@1.0.45	X									X				
-r-efi@5.3.0	X								X	X				
-r-efi@6.0.0	X								X	X				
-rand@0.8.6	X									X				
-rand_chacha@0.3.1	X									X				
-rand_core@0.6.4	X									X				
-rawpointer@0.2.1	X									X				
-reqsign-aliyun-oss@3.0.0	X													
-reqsign-aws-v4@3.0.0	X													
-reqsign-azure-storage@3.0.0	X													
-reqsign-core@3.0.0	X													
-reqsign-file-read-tokio@3.0.0	X													
-reqsign-google@3.0.0	X													
-reqsign-huaweicloud-obs@3.0.0	X													
-reqsign-tencent-cos@3.0.0	X													
-reqwest@0.13.3	X									X				
-rsa@0.9.10	X									X				
-rust-ini@0.21.3										X				
-rustc-hash@1.1.0	X									X				
-rustc-hash@2.1.2	X									X				
-rustc_version@0.4.1	X									X				
-rustix@1.1.4	X	X								X				
-rustls@0.23.40	X							X		X				
-rustls-native-certs@0.8.3	X							X		X				
-rustls-pki-types@1.14.1	X									X				
-rustls-platform-verifier@0.7.0	X									X				
-rustls-platform-verifier-android@0.1.1	X									X				
-rustls-webpki@0.103.13								X						
-rustpython-ast@0.4.0										X				
-rustpython-parser@0.4.0										X				
-rustpython-parser-core@0.4.0										X				
-rustpython-parser-vendored@0.4.0										X				
-rustversion@1.0.22	X									X				
-ryu@1.0.23	X				X									
-salsa20@0.10.2	X									X				
-same-file@1.0.6										X				X
-schannel@0.1.29										X				
-scrypt@0.11.0	X									X				
-security-framework@3.7.0	X									X				
-security-framework-sys@2.17.0	X									X				
-semver@1.0.28	X									X				
-serde@1.0.228	X									X				
-serde_core@1.0.228	X									X				
-serde_derive@1.0.228	X									X				
-serde_json@1.0.150	X									X				
-serde_spanned@1.1.1	X									X				
-serde_urlencoded@0.7.1	X									X				
-sha1@0.10.6	X									X				
-sha2@0.10.9	X									X				
-sha2@0.11.0	X									X				
-shlex@1.3.0	X									X				
-signature@2.2.0	X									X				
-simd_cesu8@1.1.1	X									X				
-simdutf8@0.1.5	X									X				
-simple_asn1@0.6.4								X						
-siphasher@1.0.3	X									X				
-slab@0.4.12										X				
-smallvec@1.15.1	X									X				
-socket2@0.6.3	X									X				
-spin@0.9.8										X				
-spki@0.7.3	X									X				
-stable_deref_trait@1.2.1	X									X				
-static_assertions@1.1.0	X									X				
-subtle@2.6.1				X										
-syn@2.0.117	X									X				
-sync_wrapper@1.0.2	X													
-synstructure@0.13.2										X				
-target-lexicon@0.13.5		X												
-thiserror@2.0.18	X									X				
-thiserror-impl@2.0.18	X									X				
-time@0.3.47	X									X				
-time-core@0.1.8	X									X				
-time-macros@0.2.27	X									X				
-tiny-keccak@2.0.2						X								
-tinystr@0.8.3												X		
-tokio@1.52.3										X				
-tokio-macros@2.7.0										X				
-tokio-rustls@0.26.4	X									X				
-tokio-util@0.7.18										X				
-toml@0.9.12+spec-1.1.0	X									X				
-toml_datetime@0.7.5+spec-1.1.0	X									X				
-toml_parser@1.1.2+spec-1.1.0	X									X				
-toml_writer@1.1.1+spec-1.1.0	X									X				
-tower@0.5.3										X				
-tower-http@0.6.11										X				
-tower-layer@0.3.3										X				
-tower-service@0.3.3										X				
-tracing@0.1.44										X				
-tracing-core@0.1.36										X				
-try-lock@0.2.5										X				
-typenum@1.20.0	X									X				
-unic-char-property@0.9.0	X									X				
-unic-char-range@0.9.0	X									X				
-unic-common@0.9.0	X									X				
-unic-emoji-char@0.9.0	X									X				
-unic-ucd-ident@0.9.0	X									X				
-unic-ucd-version@0.9.0	X									X				
-unicase@2.9.0	X									X				
-unicode-ident@1.0.24	X									X		X		
-unicode-width@0.2.2	X									X				
-unicode_names2@1.3.0	X									X			X	
-unicode_names2_generator@1.3.0	X									X				
-unindent@0.2.4	X									X				
-untrusted@0.7.1								X						
-untrusted@0.9.0								X						
-url@2.5.8	X									X				
-utf8_iter@1.0.4	X									X				
-uuid@1.23.1	X									X				
-version_check@0.9.5	X									X				
-walkdir@2.5.0										X				X
-want@0.3.1										X				
-wasi@0.11.1+wasi-snapshot-preview1	X	X								X				
-wasip2@1.0.1+wasi-0.2.4	X	X								X				
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X				
-wasm-bindgen@0.2.121	X									X				
-wasm-bindgen-futures@0.4.71	X									X				
-wasm-bindgen-macro@0.2.121	X									X				
-wasm-bindgen-macro-support@0.2.121	X									X				
-wasm-bindgen-shared@0.2.121	X									X				
-wasm-streams@0.5.0	X									X				
-web-sys@0.3.98	X									X				
-web-time@1.1.0	X									X				
-webpki-root-certs@1.0.7							X							
-winapi-util@0.1.11										X				X
-windows-core@0.62.2	X									X				
-windows-implement@0.60.2	X									X				
-windows-interface@0.59.3	X									X				
-windows-link@0.2.1	X									X				
-windows-result@0.4.1	X									X				
-windows-strings@0.5.1	X									X				
-windows-sys@0.61.2	X									X				
-winnow@0.7.15										X				
-winnow@1.0.3										X				
-wit-bindgen@0.46.0	X	X								X				
-wit-bindgen@0.51.0	X	X								X				
-writeable@0.6.3												X		
-xattr@1.6.1	X									X				
-yoke@0.8.2												X		
-yoke-derive@0.8.2												X		
-zerocopy@0.8.48	X		X							X				
-zerofrom@0.1.8												X		
-zerofrom-derive@0.1.7												X		
-zeroize@1.8.2	X									X				
-zerotrie@0.2.4												X		
-zerovec@0.11.6												X		
-zerovec-derive@0.11.3												X		
-zmij@1.0.21										X				
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
+aes@0.8.4	X									X			
+anyhow@1.0.103	X									X			
+async-trait@0.1.89	X									X			
+atomic-waker@1.1.2	X									X			
+autocfg@1.5.1	X									X			
+aws-lc-rs@1.17.1	X							X					
+aws-lc-sys@0.42.0	X			X				X		X	X		
+backon@1.6.0	X												
+base64@0.22.1	X									X			
+base64ct@1.8.3	X									X			
+bitflags@2.13.0	X									X			
+block-buffer@0.10.4	X									X			
+block-buffer@0.12.1	X									X			
+block-padding@0.3.3	X									X			
+bumpalo@3.20.3	X									X			
+bytes@1.12.0										X			
+cbc@0.1.2	X									X			
+cc@1.2.66	X									X			
+cfg-if@1.0.4	X									X			
+cipher@0.4.4	X									X			
+cmake@0.1.58	X									X			
+cmov@0.5.4	X									X			
+combine@4.6.7										X			
+const-oid@0.10.2	X									X			
+const-oid@0.9.6	X									X			
+const-random@0.1.18	X									X			
+const-random-macro@0.1.16	X									X			
+core-foundation@0.10.1	X									X			
+core-foundation-sys@0.8.7	X									X			
+cpufeatures@0.2.17	X									X			
+cpufeatures@0.3.0	X									X			
+crc-fast@1.10.0	X									X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7	X									X			
+crypto-common@0.2.2	X									X			
+ctor@1.0.8	X									X			
+ctutils@0.4.2	X									X			
+der@0.7.10	X									X			
+digest@0.10.7	X									X			
+digest@0.11.3	X									X			
+displaydoc@0.2.6	X									X			
+dlv-list@0.5.2	X									X			
+dunce@1.0.5	X					X					X		
+either@1.16.0	X									X			
+errno@0.3.14	X									X			
+fastrand@2.4.1	X									X			
+find-msvc-tools@0.1.9	X									X			
+form_urlencoded@1.2.2	X									X			
+fs_extra@1.3.0										X			
+futures@0.3.32	X									X			
+futures-channel@0.3.32	X									X			
+futures-core@0.3.32	X									X			
+futures-executor@0.3.32	X									X			
+futures-io@0.3.32	X									X			
+futures-macro@0.3.32	X									X			
+futures-sink@0.3.32	X									X			
+futures-task@0.3.32	X									X			
+futures-util@0.3.32	X									X			
+generic-array@0.14.7										X			
+getrandom@0.2.17	X									X			
+getrandom@0.4.3	X									X			
+ghac@0.3.0	X												
+gloo-timers@0.3.0	X									X			
+hashbrown@0.14.5	X									X			
+heck@0.5.0	X									X			
+hex@0.4.3	X									X			
+hmac@0.12.1	X									X			
+hmac@0.13.0	X									X			
+http@1.4.2	X									X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1	X									X			
+hybrid-array@0.4.13	X									X			
+hyper@1.10.1										X			
+hyper-rustls@0.27.9	X							X		X			
+hyper-util@0.1.20										X			
+icu_collections@2.2.0												X	
+icu_locale_core@2.2.0												X	
+icu_normalizer@2.2.0												X	
+icu_normalizer_data@2.2.0												X	
+icu_properties@2.2.0												X	
+icu_properties_data@2.2.0												X	
+icu_provider@2.2.0												X	
+idna@1.1.0	X									X			
+idna_adapter@1.2.2	X									X			
+inout@0.1.4	X									X			
+ipnet@2.12.0	X									X			
+itertools@0.14.0	X									X			
+itoa@1.0.18	X									X			
+jiff@0.2.31										X			X
+jiff-tzdb@0.1.7										X			X
+jiff-tzdb-platform@0.1.3										X			X
+jni@0.22.4	X									X			
+jni-macros@0.22.4	X									X			
+jni-sys@0.4.1	X									X			
+jni-sys-macros@0.4.1	X									X			
+jobserver@0.1.35	X									X			
+js-sys@0.3.103	X									X			
+lazy_static@1.5.0	X									X			
+libc@0.2.186	X									X			
+libm@0.2.16										X			
+link-section@0.19.0	X									X			
+linktime-proc-macro@0.2.0	X									X			
+linux-raw-sys@0.12.1	X	X								X			
+litemap@0.8.2												X	
+log@0.4.33	X									X			
+md-5@0.11.0	X									X			
+mea@0.6.4	X												
+memchr@2.8.2										X			X
+mime@0.3.17	X									X			
+mime_guess@2.0.5										X			
+mio@1.2.1										X			
+num-bigint-dig@0.8.6	X									X			
+num-integer@0.1.46	X									X			
+num-iter@0.1.45	X									X			
+num-traits@0.2.19	X									X			
+once_cell@1.21.4	X									X			
+opendal@0.58.0	X												
+opendal-core@0.58.0	X												
+opendal-http-transport-reqwest@0.58.0	X												
+opendal-layer-concurrent-limit@0.58.0	X												
+opendal-layer-logging@0.58.0	X												
+opendal-layer-mime-guess@0.58.0	X												
+opendal-layer-retry@0.58.0	X												
+opendal-layer-timeout@0.58.0	X												
+opendal-python@0.47.3	X												
+opendal-service-azblob@0.58.0	X												
+opendal-service-azdls@0.58.0	X												
+opendal-service-azure-common@0.58.0	X												
+opendal-service-cos@0.58.0	X												
+opendal-service-fs@0.58.0	X												
+opendal-service-gcs@0.58.0	X												
+opendal-service-ghac@0.58.0	X												
+opendal-service-http@0.58.0	X												
+opendal-service-ipmfs@0.58.0	X												
+opendal-service-obs@0.58.0	X												
+opendal-service-oss@0.58.0	X												
+opendal-service-s3@0.58.0	X												
+opendal-service-webdav@0.58.0	X												
+opendal-service-webhdfs@0.58.0	X												
+openssl-probe@0.2.1	X									X			
+ordered-multimap@0.7.3										X			
+pbkdf2@0.12.2	X									X			
+pem@3.0.6										X			
+pem-rfc7468@0.7.0	X									X			
+percent-encoding@2.3.2	X									X			
+pin-project-lite@0.2.17	X									X			
+pkcs1@0.7.5	X									X			
+pkcs5@0.7.1	X									X			
+pkcs8@0.10.2	X									X			
+pkg-config@0.3.33	X									X			
+portable-atomic@1.13.1	X									X			
+portable-atomic-util@0.2.7	X									X			
+potential_utf@0.1.5												X	
+ppv-lite86@0.2.21	X									X			
+proc-macro2@1.0.106	X									X			
+prost@0.14.4	X												
+prost-derive@0.14.4	X												
+pyo3@0.29.0	X									X			
+pyo3-async-runtimes@0.29.0	X												
+pyo3-build-config@0.29.0	X									X			
+pyo3-ffi@0.29.0	X									X			
+pyo3-macros@0.29.0	X									X			
+pyo3-macros-backend@0.29.0	X									X			
+quick-xml@0.40.1										X			
+quick-xml@0.41.0										X			
+quote@1.0.46	X									X			
+r-efi@6.0.0	X								X	X			
+rand@0.8.6	X									X			
+rand_chacha@0.3.1	X									X			
+rand_core@0.6.4	X									X			
+reqsign-aliyun-oss@3.1.0	X												
+reqsign-aws-v4@3.0.1	X												
+reqsign-azure-storage@3.0.1	X												
+reqsign-core@3.0.1	X												
+reqsign-file-read-tokio@3.0.1	X												
+reqsign-google@3.0.1	X												
+reqsign-huaweicloud-obs@3.0.1	X												
+reqsign-tencent-cos@3.0.1	X												
+reqwest@0.13.4	X									X			
+rsa@0.9.10	X									X			
+rust-ini@0.21.3										X			
+rustc_version@0.4.1	X									X			
+rustix@1.1.4	X	X								X			
+rustls@0.23.41	X							X		X			
+rustls-native-certs@0.8.4	X							X		X			
+rustls-pki-types@1.15.0	X									X			
+rustls-platform-verifier@0.7.0	X									X			
+rustls-platform-verifier-android@0.1.1	X									X			
+rustls-webpki@0.103.13								X					
+rustversion@1.0.22	X									X			
+ryu@1.0.23	X				X								
+salsa20@0.10.2	X									X			
+same-file@1.0.6										X			X
+schannel@0.1.29										X			
+scrypt@0.11.0	X									X			
+security-framework@3.7.0	X									X			
+security-framework-sys@2.17.0	X									X			
+semver@1.0.28	X									X			
+serde@1.0.228	X									X			
+serde_core@1.0.228	X									X			
+serde_derive@1.0.228	X									X			
+serde_json@1.0.150	X									X			
+serde_urlencoded@0.7.1	X									X			
+sha1@0.11.0	X									X			
+sha2@0.10.9	X									X			
+sha2@0.11.0	X									X			
+shlex@2.0.1	X									X			
+signature@2.2.0	X									X			
+simd_cesu8@1.1.1	X									X			
+simdutf8@0.1.5	X									X			
+slab@0.4.12										X			
+smallvec@1.15.2	X									X			
+socket2@0.6.4	X									X			
+spin@0.10.0										X			
+spin@0.9.8										X			
+spki@0.7.3	X									X			
+stable_deref_trait@1.2.1	X									X			
+subtle@2.6.1				X									
+syn@2.0.118	X									X			
+sync_wrapper@1.0.2	X												
+synstructure@0.13.2										X			
+target-lexicon@0.13.5		X											
+thiserror@2.0.18	X									X			
+thiserror-impl@2.0.18	X									X			
+tiny-keccak@2.0.2						X							
+tinystr@0.8.3												X	
+tokio@1.52.3										X			
+tokio-macros@2.7.0										X			
+tokio-rustls@0.26.4	X									X			
+tokio-util@0.7.18										X			
+tower@0.5.3										X			
+tower-http@0.6.11										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-core@0.1.36										X			
+try-lock@0.2.5										X			
+typenum@1.20.1	X									X			
+unicase@2.9.0	X									X			
+unicode-ident@1.0.24	X									X		X	
+untrusted@0.9.0								X					
+url@2.5.8	X									X			
+utf8_iter@1.0.4	X									X			
+uuid@1.23.4	X									X			
+version_check@0.9.5	X									X			
+walkdir@2.5.0										X			X
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
+wasm-bindgen@0.2.126	X									X			
+wasm-bindgen-futures@0.4.76	X									X			
+wasm-bindgen-macro@0.2.126	X									X			
+wasm-bindgen-macro-support@0.2.126	X									X			
+wasm-bindgen-shared@0.2.126	X									X			
+wasm-streams@0.5.0	X									X			
+web-sys@0.3.103	X									X			
+web-time@1.1.0	X									X			
+webpki-root-certs@1.0.8							X						
+winapi-util@0.1.11										X			X
+windows-link@0.2.1	X									X			
+windows-sys@0.61.2	X									X			
+writeable@0.6.3												X	
+xattr@1.6.1	X									X			
+yoke@0.8.3												X	
+yoke-derive@0.8.2												X	
+zerocopy@0.8.53	X		X							X			
+zerofrom@0.1.8												X	
+zerofrom-derive@0.1.7												X	
+zeroize@1.9.0	X									X			
+zerotrie@0.2.4												X	
+zerovec@0.11.6												X	
+zerovec-derive@0.11.3												X	
+zmij@1.0.21										X			

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.1.7"
+version = "0.1.8"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -2,29 +2,30 @@ crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.
 aes@0.8.4	X									X				
 aho-corasick@1.1.4										X			X	
 allocator-api2@0.2.21	X									X				
-anyhow@1.0.102	X									X				
+anyhow@1.0.103	X									X				
 async-trait@0.1.89	X									X				
 atomic-waker@1.1.2	X									X				
-autocfg@1.5.0	X									X				
-aws-lc-rs@1.17.0	X							X						
-aws-lc-sys@0.41.0	X			X				X		X	X			
+autocfg@1.5.1	X									X				
+aws-lc-rs@1.17.1	X							X						
+aws-lc-sys@0.42.0	X			X				X		X	X			
 backon@1.6.0	X													
 base64@0.22.1	X									X				
 base64ct@1.8.3	X									X				
 bindgen@0.72.1				X										
-bitflags@2.11.1	X									X				
+bitflags@2.13.0	X									X				
 block-buffer@0.10.4	X									X				
-block-buffer@0.12.0	X									X				
+block-buffer@0.12.1	X									X				
 block-padding@0.3.3	X									X				
-bumpalo@3.20.2	X									X				
-bytes@1.11.1										X				
+bumpalo@3.20.3	X									X				
+bytes@1.12.0										X				
 cbc@0.1.2	X									X				
-cc@1.2.62	X									X				
+cc@1.2.66	X									X				
 cexpr@0.6.0	X									X				
 cfg-if@1.0.4	X									X				
 cipher@0.4.4	X									X				
 clang-sys@1.8.1	X													
 cmake@0.1.58	X									X				
+cmov@0.5.4	X									X				
 combine@4.6.7										X				
 const-oid@0.10.2	X									X				
 const-oid@0.9.6	X									X				
@@ -34,18 +35,18 @@ core-foundation@0.10.1	X									X
 core-foundation-sys@0.8.7	X									X				
 cpufeatures@0.2.17	X									X				
 cpufeatures@0.3.0	X									X				
-crc32c@0.6.8	X									X				
-crossbeam-utils@0.8.21	X									X				
+crc-fast@1.10.0	X									X				
+crossbeam-utils@0.8.22	X									X				
 crunchy@0.2.4										X				
 crypto-common@0.1.7	X									X				
 crypto-common@0.2.2	X									X				
-ctor@1.0.6	X									X				
+ctor@1.0.8	X									X				
+ctutils@0.4.2	X									X				
 dashmap@6.2.1										X				
 der@0.7.10	X									X				
-deranged@0.5.8	X									X				
 digest@0.10.7	X									X				
 digest@0.11.3	X									X				
-displaydoc@0.2.5	X									X				
+displaydoc@0.2.6	X									X				
 dlv-list@0.5.2	X									X				
 dunce@1.0.5	X					X					X			
 either@1.16.0	X									X				
@@ -69,7 +70,7 @@ futures-util@0.3.32	X									X
 generic-array@0.14.7										X				
 getrandom@0.2.17	X									X				
 getrandom@0.3.4	X									X				
-getrandom@0.4.2	X									X				
+getrandom@0.4.3	X									X				
 ghac@0.3.0	X													
 glob@0.3.3	X									X				
 gloo-timers@0.3.0	X									X				
@@ -78,87 +79,86 @@ hashbrown@0.14.5	X									X
 hashbrown@0.16.1	X									X				
 hex@0.4.3	X									X				
 hmac@0.12.1	X									X				
-http@1.4.0	X									X				
+hmac@0.13.0	X									X				
+http@1.4.2	X									X				
 http-body@1.0.1										X				
 http-body-util@0.1.3										X				
 httparse@1.10.1	X									X				
-hybrid-array@0.4.12	X									X				
-hyper@1.9.0										X				
+hybrid-array@0.4.13	X									X				
+hyper@1.10.1										X				
 hyper-rustls@0.27.9	X							X		X				
 hyper-util@0.1.20										X				
-icu_collections@2.1.1												X		
-icu_locale_core@2.1.1												X		
-icu_normalizer@2.1.1												X		
-icu_normalizer_data@2.1.1												X		
-icu_properties@2.1.2												X		
-icu_properties_data@2.1.2												X		
-icu_provider@2.1.1												X		
+icu_collections@2.2.0												X		
+icu_locale_core@2.2.0												X		
+icu_normalizer@2.2.0												X		
+icu_normalizer_data@2.2.0												X		
+icu_properties@2.2.0												X		
+icu_properties_data@2.2.0												X		
+icu_provider@2.2.0												X		
 idna@1.1.0	X									X				
-idna_adapter@1.2.1	X									X				
+idna_adapter@1.2.2	X									X				
 inout@0.1.4	X									X				
 ipnet@2.12.0	X									X				
 itertools@0.13.0	X									X				
 itertools@0.14.0	X									X				
 itoa@1.0.18	X									X				
-jiff@0.2.24										X			X	
-jiff-tzdb@0.1.6										X			X	
+jiff@0.2.31										X			X	
+jiff-tzdb@0.1.7										X			X	
 jiff-tzdb-platform@0.1.3										X			X	
 jni@0.22.4	X									X				
 jni-macros@0.22.4	X									X				
 jni-sys@0.4.1	X									X				
 jni-sys-macros@0.4.1	X									X				
-jobserver@0.1.34	X									X				
-js-sys@0.3.98	X									X				
-jsonwebtoken@10.3.0										X				
+jobserver@0.1.35	X									X				
+js-sys@0.3.103	X									X				
 lazy_static@1.5.0	X									X				
 libc@0.2.186	X									X				
 libloading@0.8.9								X						
 libm@0.2.16										X				
-link-section@0.17.2	X									X				
-linktime-proc-macro@0.1.0	X									X				
+link-section@0.19.0	X									X				
+linktime-proc-macro@0.2.0	X									X				
 linux-raw-sys@0.12.1	X	X								X				
 litemap@0.8.2												X		
 lock_api@0.4.14	X									X				
-log@0.4.29	X									X				
+log@0.4.33	X									X				
 magnus@0.8.2										X				
 magnus-macros@0.8.0										X				
 md-5@0.11.0	X									X				
-mea@0.6.3	X													
-memchr@2.8.0										X			X	
+mea@0.6.4	X													
+memchr@2.8.2										X			X	
 minimal-lexical@0.2.1	X									X				
-mio@1.2.0										X				
+mio@1.2.1										X				
 nom@7.1.3										X				
 nonzero_ext@0.3.0	X													
-num-bigint@0.4.6	X									X				
 num-bigint-dig@0.8.6	X									X				
-num-conv@0.2.2	X									X				
 num-integer@0.1.46	X									X				
 num-iter@0.1.45	X									X				
 num-traits@0.2.19	X									X				
 once_cell@1.21.4	X									X				
-opendal@0.57.0	X													
-opendal-core@0.57.0	X													
-opendal-layer-concurrent-limit@0.57.0	X													
-opendal-layer-logging@0.57.0	X													
-opendal-layer-retry@0.57.0	X													
-opendal-layer-throttle@0.57.0	X													
-opendal-layer-timeout@0.57.0	X													
-opendal-ruby@0.1.7	X
-opendal-service-azblob@0.57.0	X													
-opendal-service-azdls@0.57.0	X													
-opendal-service-azfile@0.57.0	X													
-opendal-service-azure-common@0.57.0	X													
-opendal-service-cos@0.57.0	X													
-opendal-service-fs@0.57.0	X													
-opendal-service-gcs@0.57.0	X													
-opendal-service-ghac@0.57.0	X													
-opendal-service-http@0.57.0	X													
-opendal-service-ipmfs@0.57.0	X													
-opendal-service-obs@0.57.0	X													
-opendal-service-oss@0.57.0	X													
-opendal-service-s3@0.57.0	X													
-opendal-service-webdav@0.57.0	X													
-opendal-service-webhdfs@0.57.0	X													
+opendal@0.58.0	X													
+opendal-core@0.58.0	X													
+opendal-http-transport-reqwest@0.58.0	X													
+opendal-layer-concurrent-limit@0.58.0	X													
+opendal-layer-logging@0.58.0	X													
+opendal-layer-retry@0.58.0	X													
+opendal-layer-throttle@0.58.0	X													
+opendal-layer-timeout@0.58.0	X													
+opendal-ruby@0.1.8	X													
+opendal-service-azblob@0.58.0	X													
+opendal-service-azdls@0.58.0	X													
+opendal-service-azfile@0.58.0	X													
+opendal-service-azure-common@0.58.0	X													
+opendal-service-cos@0.58.0	X													
+opendal-service-fs@0.58.0	X													
+opendal-service-gcs@0.58.0	X													
+opendal-service-ghac@0.58.0	X													
+opendal-service-http@0.58.0	X													
+opendal-service-ipmfs@0.58.0	X													
+opendal-service-obs@0.58.0	X													
+opendal-service-oss@0.58.0	X													
+opendal-service-s3@0.58.0	X													
+opendal-service-webdav@0.58.0	X													
+opendal-service-webhdfs@0.58.0	X													
 openssl-probe@0.2.1	X									X				
 ordered-multimap@0.7.3										X				
 parking_lot@0.12.5	X									X				
@@ -171,17 +171,18 @@ pin-project-lite@0.2.17	X									X
 pkcs1@0.7.5	X									X				
 pkcs5@0.7.1	X									X				
 pkcs8@0.10.2	X									X				
+pkg-config@0.3.33	X									X				
 portable-atomic@1.13.1	X									X				
 portable-atomic-util@0.2.7	X									X				
 potential_utf@0.1.5												X		
-powerfmt@0.2.0	X									X				
 ppv-lite86@0.2.21	X									X				
 proc-macro2@1.0.106	X									X				
-prost@0.14.3	X													
-prost-derive@0.14.3	X													
+prost@0.14.4	X													
+prost-derive@0.14.4	X													
 quanta@0.12.6										X				
-quick-xml@0.39.4										X				
-quote@1.0.45	X									X				
+quick-xml@0.40.1										X				
+quick-xml@0.41.0										X				
+quote@1.0.46	X									X				
 r-efi@5.3.0	X								X	X				
 r-efi@6.0.0	X								X	X				
 rand@0.8.6	X									X				
@@ -193,29 +194,28 @@ rand_core@0.9.5	X									X
 raw-cpuid@11.6.0										X				
 rb-sys@0.9.128	X									X				
 rb-sys-build@0.9.128	X									X				
-rb-sys-env@0.1.2	X									X				
 rb-sys-env@0.2.3	X									X				
 redox_syscall@0.5.18										X				
-regex@1.12.3	X									X				
+regex@1.12.4	X									X				
 regex-automata@0.4.14	X									X				
-regex-syntax@0.8.10	X									X				
-reqsign-aliyun-oss@3.0.0	X													
-reqsign-aws-v4@3.0.0	X													
-reqsign-azure-storage@3.0.0	X													
-reqsign-core@3.0.0	X													
-reqsign-file-read-tokio@3.0.0	X													
-reqsign-google@3.0.0	X													
-reqsign-huaweicloud-obs@3.0.0	X													
-reqsign-tencent-cos@3.0.0	X													
-reqwest@0.13.3	X									X				
+regex-syntax@0.8.11	X									X				
+reqsign-aliyun-oss@3.1.0	X													
+reqsign-aws-v4@3.0.1	X													
+reqsign-azure-storage@3.0.1	X													
+reqsign-core@3.0.1	X													
+reqsign-file-read-tokio@3.0.1	X													
+reqsign-google@3.0.1	X													
+reqsign-huaweicloud-obs@3.0.1	X													
+reqsign-tencent-cos@3.0.1	X													
+reqwest@0.13.4	X									X				
 rsa@0.9.10	X									X				
 rust-ini@0.21.3										X				
-rustc-hash@2.1.2	X									X				
+rustc-hash@2.1.3	X									X				
 rustc_version@0.4.1	X									X				
 rustix@1.1.4	X	X								X				
-rustls@0.23.40	X							X		X				
-rustls-native-certs@0.8.3	X							X		X				
-rustls-pki-types@1.14.1	X									X				
+rustls@0.23.41	X							X		X				
+rustls-native-certs@0.8.4	X							X		X				
+rustls-pki-types@1.15.0	X									X				
 rustls-platform-verifier@0.7.0	X									X				
 rustls-platform-verifier-android@0.1.1	X									X				
 rustls-webpki@0.103.13								X						
@@ -235,32 +235,30 @@ serde_core@1.0.228	X									X
 serde_derive@1.0.228	X									X				
 serde_json@1.0.150	X									X				
 serde_urlencoded@0.7.1	X									X				
-sha1@0.10.6	X									X				
+sha1@0.11.0	X									X				
 sha2@0.10.9	X									X				
 sha2@0.11.0	X									X				
 shell-words@1.1.1	X									X				
 shlex@1.3.0	X									X				
+shlex@2.0.1	X									X				
 signal-hook-registry@1.4.8	X									X				
 signature@2.2.0	X									X				
 simd_cesu8@1.1.1	X									X				
 simdutf8@0.1.5	X									X				
-simple_asn1@0.6.4								X						
 slab@0.4.12										X				
-smallvec@1.15.1	X									X				
-socket2@0.6.3	X									X				
+smallvec@1.15.2	X									X				
+socket2@0.6.4	X									X				
+spin@0.10.0										X				
 spin@0.9.8										X				
 spinning_top@0.3.0	X									X				
 spki@0.7.3	X									X				
 stable_deref_trait@1.2.1	X									X				
 subtle@2.6.1				X										
-syn@2.0.117	X									X				
+syn@2.0.118	X									X				
 sync_wrapper@1.0.2	X													
 synstructure@0.13.2										X				
 thiserror@2.0.18	X									X				
 thiserror-impl@2.0.18	X									X				
-time@0.3.47	X									X				
-time-core@0.1.8	X									X				
-time-macros@0.2.27	X									X				
 tiny-keccak@2.0.2						X								
 tinystr@0.8.3												X		
 tokio@1.52.3										X				
@@ -274,44 +272,41 @@ tower-service@0.3.3										X
 tracing@0.1.44										X				
 tracing-core@0.1.36										X				
 try-lock@0.2.5										X				
-typenum@1.20.0	X									X				
+typenum@1.20.1	X									X				
 unicode-ident@1.0.24	X									X		X		
-untrusted@0.7.1								X						
 untrusted@0.9.0								X						
 url@2.5.8	X									X				
 utf8_iter@1.0.4	X									X				
-uuid@1.23.1	X									X				
+uuid@1.23.4	X									X				
 version_check@0.9.5	X									X				
 walkdir@2.5.0										X			X	
 want@0.3.1										X				
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X				
-wasip2@1.0.1+wasi-0.2.4	X	X								X				
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X				
-wasm-bindgen@0.2.121	X									X				
-wasm-bindgen-futures@0.4.71	X									X				
-wasm-bindgen-macro@0.2.121	X									X				
-wasm-bindgen-macro-support@0.2.121	X									X				
-wasm-bindgen-shared@0.2.121	X									X				
+wasip2@1.0.4+wasi-0.2.12	X	X								X				
+wasm-bindgen@0.2.126	X									X				
+wasm-bindgen-futures@0.4.76	X									X				
+wasm-bindgen-macro@0.2.126	X									X				
+wasm-bindgen-macro-support@0.2.126	X									X				
+wasm-bindgen-shared@0.2.126	X									X				
 wasm-streams@0.5.0	X									X				
-web-sys@0.3.98	X									X				
+web-sys@0.3.103	X									X				
 web-time@1.1.0	X									X				
-webpki-root-certs@1.0.7							X							
+webpki-root-certs@1.0.8							X							
 winapi@0.3.9	X									X				
 winapi-i686-pc-windows-gnu@0.4.0	X									X				
 winapi-util@0.1.11										X			X	
 winapi-x86_64-pc-windows-gnu@0.4.0	X									X				
 windows-link@0.2.1	X									X				
 windows-sys@0.61.2	X									X				
-wit-bindgen@0.46.0	X	X								X				
-wit-bindgen@0.51.0	X	X								X				
+wit-bindgen@0.57.1	X	X								X				
 writeable@0.6.3												X		
 xattr@1.6.1	X									X				
-yoke@0.8.2												X		
+yoke@0.8.3												X		
 yoke-derive@0.8.2												X		
-zerocopy@0.8.48	X		X							X				
+zerocopy@0.8.53	X		X							X				
 zerofrom@0.1.8												X		
 zerofrom-derive@0.1.7												X		
-zeroize@1.8.2	X									X				
+zeroize@1.9.0	X									X				
 zerotrie@0.2.4												X		
 zerovec@0.11.6												X		
 zerovec-derive@0.11.3												X		

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_aws_s3_assume_role_with_web_identity"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "logforth",
  "opendal",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_file_write_on_full_disk"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal",
  "rand 0.10.1",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_opfs_wasm32"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "futures",
  "opendal",
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_s3_read_on_wasm"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal",
  "wasm-bindgen",
@@ -6335,7 +6335,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opendal"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6448,7 +6448,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-benchmark-vs-fs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "criterion",
  "opendal",
@@ -6459,7 +6459,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-benchmark-vs-s3"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -6474,7 +6474,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-core"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6502,7 +6502,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-basic"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6510,7 +6510,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-concurrent-upload"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6518,7 +6518,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-getting-started"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6526,7 +6526,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-multipart-upload"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6534,7 +6534,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-fuzz"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -6546,7 +6546,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-http-transport-reqwest"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "futures",
@@ -6558,7 +6558,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-async-backtrace"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "async-backtrace",
  "opendal-core",
@@ -6566,7 +6566,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-await-tree"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "await-tree",
  "futures",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-capability-check"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -6583,7 +6583,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-chaos"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal-core",
  "rand 0.10.1",
@@ -6591,7 +6591,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-concurrent-limit"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "futures",
  "http 1.4.2",
@@ -6602,7 +6602,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-dtrace"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "opendal-core",
@@ -6612,7 +6612,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-fastmetrics"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "fastmetrics",
  "log",
@@ -6623,7 +6623,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-fastrace"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6635,7 +6635,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-foyer"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "foyer",
  "opendal-core",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-hotpath"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "futures",
  "hotpath",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-immutable-index"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "futures",
  "log",
@@ -6668,7 +6668,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-logging"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "log",
  "opendal-core",
@@ -6676,7 +6676,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-metrics"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "metrics",
  "opendal-core",
@@ -6685,7 +6685,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-mime-guess"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "futures",
  "mime_guess",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-observe-metrics-common"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "futures",
  "http 1.4.2",
@@ -6705,7 +6705,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-otelmetrics"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal-core",
  "opendal-layer-observe-metrics-common",
@@ -6714,7 +6714,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-oteltrace"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal-core",
  "opentelemetry",
@@ -6722,7 +6722,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-prometheus"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "log",
  "opendal-core",
@@ -6733,7 +6733,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-prometheus-client"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "log",
  "opendal-core",
@@ -6744,7 +6744,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-retry"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "backon",
  "bytes",
@@ -6759,7 +6759,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-route"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "futures",
  "globset",
@@ -6770,7 +6770,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-tail-cut"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -6778,7 +6778,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-throttle"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "governor",
  "opendal-core",
@@ -6786,7 +6786,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-timeout"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "futures",
  "opendal-core",
@@ -6796,7 +6796,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-tracing"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6814,7 +6814,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-aliyun-drive"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6828,7 +6828,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-alluxio"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6841,7 +6841,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azblob"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6863,7 +6863,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azdls"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -6883,7 +6883,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azfile"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6900,7 +6900,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azure-common"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "http 1.4.2",
  "opendal-core",
@@ -6908,7 +6908,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-b2"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6922,7 +6922,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cacache"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "cacache",
@@ -6933,7 +6933,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cloudflare-kv"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-compfs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "compio",
@@ -6955,7 +6955,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cos"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6971,7 +6971,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-d1"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6983,7 +6983,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dashmap"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "dashmap 6.2.1",
  "log",
@@ -6994,7 +6994,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dbfs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7008,7 +7008,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dropbox"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7021,7 +7021,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-etcd"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "etcd-client",
  "fastpool",
@@ -7032,7 +7032,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-foundationdb"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "foundationdb",
  "opendal-core",
@@ -7042,7 +7042,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-foyer"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "foyer",
  "log",
@@ -7056,7 +7056,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-fs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "log",
@@ -7069,7 +7069,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ftp"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "fastpool",
@@ -7086,7 +7086,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7105,7 +7105,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gdrive"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7119,7 +7119,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ghac"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "ghac",
@@ -7138,7 +7138,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-github"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7152,7 +7152,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-goosefs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "goosefs-sdk",
@@ -7165,7 +7165,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gridfs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "futures",
  "mea",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hdfs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "futures",
@@ -7190,7 +7190,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hdfs-native"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "futures",
@@ -7202,7 +7202,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hf"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7220,7 +7220,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-http"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "http 1.4.2",
  "log",
@@ -7231,7 +7231,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ipfs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7244,7 +7244,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ipmfs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7257,7 +7257,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-koofr"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7271,7 +7271,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-lakefs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7284,7 +7284,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-memcached"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "fastpool",
  "opendal-core",
@@ -7295,7 +7295,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mini-moka"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "log",
  "mini-moka",
@@ -7305,7 +7305,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-moka"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "log",
  "moka",
@@ -7316,7 +7316,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mongodb"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "mea",
@@ -7328,7 +7328,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-monoiofs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "flume 0.12.0",
@@ -7341,7 +7341,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mysql"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7352,7 +7352,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-obs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7368,7 +7368,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-onedrive"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "futures",
@@ -7383,7 +7383,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-opfs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "js-sys",
  "opendal-core",
@@ -7396,7 +7396,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-oss"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7413,7 +7413,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-pcloud"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7426,7 +7426,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-persy"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal-core",
  "persy",
@@ -7436,7 +7436,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-postgresql"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7447,7 +7447,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-redb"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal-core",
  "redb 4.1.0",
@@ -7457,7 +7457,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-redis"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "fastpool",
@@ -7470,7 +7470,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-rocksdb"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal-core",
  "rocksdb",
@@ -7480,7 +7480,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-s3"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7502,7 +7502,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-seafile"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7516,7 +7516,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sftp"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7532,7 +7532,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sled"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "opendal-core",
  "serde",
@@ -7542,7 +7542,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sqlite"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7553,7 +7553,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-surrealdb"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7564,7 +7564,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-swift"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7584,7 +7584,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-tikv"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "mea",
  "opendal-core",
@@ -7595,7 +7595,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-tos"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7610,7 +7610,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-upyun"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -7628,7 +7628,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-vercel-artifacts"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7642,7 +7642,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-vercel-blob"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webdav"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webhdfs"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7687,7 +7687,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-yandex-disk"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7701,7 +7701,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-testkit"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytes",
  "dotenvy",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,7 +39,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.57.0"
+version = "0.58.0"
 
 [workspace.dependencies]
 base64 = "0.22"
@@ -238,102 +238,102 @@ required-features = ["tests"]
 
 [dependencies]
 ctor = { workspace = true, optional = true }
-opendal-core = { path = "core", version = "0.57.0", default-features = false }
-opendal-http-transport-reqwest = { path = "http-transports/reqwest", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-async-backtrace = { path = "layers/async-backtrace", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-await-tree = { path = "layers/await-tree", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-capability-check = { path = "layers/capability-check", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-chaos = { path = "layers/chaos", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-concurrent-limit = { path = "layers/concurrent-limit", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-fastmetrics = { path = "layers/fastmetrics", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-fastrace = { path = "layers/fastrace", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-foyer = { path = "layers/foyer", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-hotpath = { path = "layers/hotpath", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-immutable-index = { path = "layers/immutable-index", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-logging = { path = "layers/logging", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-metrics = { path = "layers/metrics", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-mime-guess = { path = "layers/mime-guess", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-observe-metrics-common = { path = "layers/observe-metrics-common", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-otelmetrics = { path = "layers/otelmetrics", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-oteltrace = { path = "layers/oteltrace", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-prometheus = { path = "layers/prometheus", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-prometheus-client = { path = "layers/prometheus-client", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-retry = { path = "layers/retry", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-route = { path = "layers/route", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-tail-cut = { path = "layers/tail-cut", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-throttle = { path = "layers/throttle", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-timeout = { path = "layers/timeout", version = "0.57.0", optional = true, default-features = false }
-opendal-layer-tracing = { path = "layers/tracing", version = "0.57.0", optional = true, default-features = false }
-opendal-service-aliyun-drive = { path = "services/aliyun-drive", version = "0.57.0", optional = true, default-features = false }
-opendal-service-alluxio = { path = "services/alluxio", version = "0.57.0", optional = true, default-features = false }
-opendal-service-azblob = { path = "services/azblob", version = "0.57.0", optional = true, default-features = false }
-opendal-service-azdls = { path = "services/azdls", version = "0.57.0", optional = true, default-features = false }
-opendal-service-azfile = { path = "services/azfile", version = "0.57.0", optional = true, default-features = false }
-opendal-service-b2 = { path = "services/b2", version = "0.57.0", optional = true, default-features = false }
-opendal-service-cacache = { path = "services/cacache", version = "0.57.0", optional = true, default-features = false }
-opendal-service-cloudflare-kv = { path = "services/cloudflare-kv", version = "0.57.0", optional = true, default-features = false }
-opendal-service-compfs = { path = "services/compfs", version = "0.57.0", optional = true, default-features = false }
-opendal-service-cos = { path = "services/cos", version = "0.57.0", optional = true, default-features = false }
-opendal-service-d1 = { path = "services/d1", version = "0.57.0", optional = true, default-features = false }
-opendal-service-dashmap = { path = "services/dashmap", version = "0.57.0", optional = true, default-features = false }
-opendal-service-dbfs = { path = "services/dbfs", version = "0.57.0", optional = true, default-features = false }
-opendal-service-dropbox = { path = "services/dropbox", version = "0.57.0", optional = true, default-features = false }
-opendal-service-etcd = { path = "services/etcd", version = "0.57.0", optional = true, default-features = false }
-opendal-service-foundationdb = { path = "services/foundationdb", version = "0.57.0", optional = true, default-features = false }
-opendal-service-foyer = { path = "services/foyer", version = "0.57.0", optional = true, default-features = false }
-opendal-service-fs = { path = "services/fs", version = "0.57.0", optional = true, default-features = false }
-opendal-service-ftp = { path = "services/ftp", version = "0.57.0", optional = true, default-features = false }
-opendal-service-gcs = { path = "services/gcs", version = "0.57.0", optional = true, default-features = false }
-opendal-service-gdrive = { path = "services/gdrive", version = "0.57.0", optional = true, default-features = false }
-opendal-service-ghac = { path = "services/ghac", version = "0.57.0", optional = true, default-features = false }
-opendal-service-github = { path = "services/github", version = "0.57.0", optional = true, default-features = false }
-opendal-service-goosefs = { path = "services/goosefs", version = "0.57.0", optional = true, default-features = false }
-opendal-service-gridfs = { path = "services/gridfs", version = "0.57.0", optional = true, default-features = false }
-opendal-service-hdfs = { path = "services/hdfs", version = "0.57.0", optional = true, default-features = false }
-opendal-service-hdfs-native = { path = "services/hdfs-native", version = "0.57.0", optional = true, default-features = false }
-opendal-service-hf = { path = "services/hf", version = "0.57.0", optional = true, default-features = false }
-opendal-service-http = { path = "services/http", version = "0.57.0", optional = true, default-features = false }
-opendal-service-ipfs = { path = "services/ipfs", version = "0.57.0", optional = true, default-features = false }
-opendal-service-ipmfs = { path = "services/ipmfs", version = "0.57.0", optional = true, default-features = false }
-opendal-service-koofr = { path = "services/koofr", version = "0.57.0", optional = true, default-features = false }
-opendal-service-lakefs = { path = "services/lakefs", version = "0.57.0", optional = true, default-features = false }
-opendal-service-memcached = { path = "services/memcached", version = "0.57.0", optional = true, default-features = false }
-opendal-service-mini-moka = { path = "services/mini_moka", version = "0.57.0", optional = true, default-features = false }
-opendal-service-moka = { path = "services/moka", version = "0.57.0", optional = true, default-features = false }
-opendal-service-mongodb = { path = "services/mongodb", version = "0.57.0", optional = true, default-features = false }
-opendal-service-monoiofs = { path = "services/monoiofs", version = "0.57.0", optional = true, default-features = false }
-opendal-service-mysql = { path = "services/mysql", version = "0.57.0", optional = true, default-features = false }
-opendal-service-obs = { path = "services/obs", version = "0.57.0", optional = true, default-features = false }
-opendal-service-onedrive = { path = "services/onedrive", version = "0.57.0", optional = true, default-features = false }
-opendal-service-oss = { path = "services/oss", version = "0.57.0", optional = true, default-features = false }
-opendal-service-pcloud = { path = "services/pcloud", version = "0.57.0", optional = true, default-features = false }
-opendal-service-persy = { path = "services/persy", version = "0.57.0", optional = true, default-features = false }
-opendal-service-postgresql = { path = "services/postgresql", version = "0.57.0", optional = true, default-features = false }
-opendal-service-redb = { path = "services/redb", version = "0.57.0", optional = true, default-features = false }
-opendal-service-redis = { path = "services/redis", version = "0.57.0", optional = true, default-features = false }
-opendal-service-rocksdb = { path = "services/rocksdb", version = "0.57.0", optional = true, default-features = false }
-opendal-service-s3 = { path = "services/s3", version = "0.57.0", optional = true, default-features = false }
-opendal-service-seafile = { path = "services/seafile", version = "0.57.0", optional = true, default-features = false }
-opendal-service-sftp = { path = "services/sftp", version = "0.57.0", optional = true, default-features = false }
-opendal-service-sled = { path = "services/sled", version = "0.57.0", optional = true, default-features = false }
-opendal-service-sqlite = { path = "services/sqlite", version = "0.57.0", optional = true, default-features = false }
-opendal-service-surrealdb = { path = "services/surrealdb", version = "0.57.0", optional = true, default-features = false }
-opendal-service-swift = { path = "services/swift", version = "0.57.0", optional = true, default-features = false }
-opendal-service-tikv = { path = "services/tikv", version = "0.57.0", optional = true, default-features = false }
-opendal-service-tos = { path = "services/tos", version = "0.57.0", optional = true, default-features = false }
-opendal-service-upyun = { path = "services/upyun", version = "0.57.0", optional = true, default-features = false }
-opendal-service-vercel-artifacts = { path = "services/vercel-artifacts", version = "0.57.0", optional = true, default-features = false }
-opendal-service-vercel-blob = { path = "services/vercel-blob", version = "0.57.0", optional = true, default-features = false }
-opendal-service-webdav = { path = "services/webdav", version = "0.57.0", optional = true, default-features = false }
-opendal-service-webhdfs = { path = "services/webhdfs", version = "0.57.0", optional = true, default-features = false }
-opendal-service-yandex-disk = { path = "services/yandex-disk", version = "0.57.0", optional = true, default-features = false }
-opendal-testkit = { path = "testkit", version = "0.57.0", optional = true }
+opendal-core = { path = "core", version = "0.58.0", default-features = false }
+opendal-http-transport-reqwest = { path = "http-transports/reqwest", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-async-backtrace = { path = "layers/async-backtrace", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-await-tree = { path = "layers/await-tree", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-capability-check = { path = "layers/capability-check", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-chaos = { path = "layers/chaos", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-concurrent-limit = { path = "layers/concurrent-limit", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-fastmetrics = { path = "layers/fastmetrics", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-fastrace = { path = "layers/fastrace", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-foyer = { path = "layers/foyer", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-hotpath = { path = "layers/hotpath", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-immutable-index = { path = "layers/immutable-index", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-logging = { path = "layers/logging", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-metrics = { path = "layers/metrics", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-mime-guess = { path = "layers/mime-guess", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-observe-metrics-common = { path = "layers/observe-metrics-common", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-otelmetrics = { path = "layers/otelmetrics", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-oteltrace = { path = "layers/oteltrace", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-prometheus = { path = "layers/prometheus", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-prometheus-client = { path = "layers/prometheus-client", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-retry = { path = "layers/retry", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-route = { path = "layers/route", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-tail-cut = { path = "layers/tail-cut", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-throttle = { path = "layers/throttle", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-timeout = { path = "layers/timeout", version = "0.58.0", optional = true, default-features = false }
+opendal-layer-tracing = { path = "layers/tracing", version = "0.58.0", optional = true, default-features = false }
+opendal-service-aliyun-drive = { path = "services/aliyun-drive", version = "0.58.0", optional = true, default-features = false }
+opendal-service-alluxio = { path = "services/alluxio", version = "0.58.0", optional = true, default-features = false }
+opendal-service-azblob = { path = "services/azblob", version = "0.58.0", optional = true, default-features = false }
+opendal-service-azdls = { path = "services/azdls", version = "0.58.0", optional = true, default-features = false }
+opendal-service-azfile = { path = "services/azfile", version = "0.58.0", optional = true, default-features = false }
+opendal-service-b2 = { path = "services/b2", version = "0.58.0", optional = true, default-features = false }
+opendal-service-cacache = { path = "services/cacache", version = "0.58.0", optional = true, default-features = false }
+opendal-service-cloudflare-kv = { path = "services/cloudflare-kv", version = "0.58.0", optional = true, default-features = false }
+opendal-service-compfs = { path = "services/compfs", version = "0.58.0", optional = true, default-features = false }
+opendal-service-cos = { path = "services/cos", version = "0.58.0", optional = true, default-features = false }
+opendal-service-d1 = { path = "services/d1", version = "0.58.0", optional = true, default-features = false }
+opendal-service-dashmap = { path = "services/dashmap", version = "0.58.0", optional = true, default-features = false }
+opendal-service-dbfs = { path = "services/dbfs", version = "0.58.0", optional = true, default-features = false }
+opendal-service-dropbox = { path = "services/dropbox", version = "0.58.0", optional = true, default-features = false }
+opendal-service-etcd = { path = "services/etcd", version = "0.58.0", optional = true, default-features = false }
+opendal-service-foundationdb = { path = "services/foundationdb", version = "0.58.0", optional = true, default-features = false }
+opendal-service-foyer = { path = "services/foyer", version = "0.58.0", optional = true, default-features = false }
+opendal-service-fs = { path = "services/fs", version = "0.58.0", optional = true, default-features = false }
+opendal-service-ftp = { path = "services/ftp", version = "0.58.0", optional = true, default-features = false }
+opendal-service-gcs = { path = "services/gcs", version = "0.58.0", optional = true, default-features = false }
+opendal-service-gdrive = { path = "services/gdrive", version = "0.58.0", optional = true, default-features = false }
+opendal-service-ghac = { path = "services/ghac", version = "0.58.0", optional = true, default-features = false }
+opendal-service-github = { path = "services/github", version = "0.58.0", optional = true, default-features = false }
+opendal-service-goosefs = { path = "services/goosefs", version = "0.58.0", optional = true, default-features = false }
+opendal-service-gridfs = { path = "services/gridfs", version = "0.58.0", optional = true, default-features = false }
+opendal-service-hdfs = { path = "services/hdfs", version = "0.58.0", optional = true, default-features = false }
+opendal-service-hdfs-native = { path = "services/hdfs-native", version = "0.58.0", optional = true, default-features = false }
+opendal-service-hf = { path = "services/hf", version = "0.58.0", optional = true, default-features = false }
+opendal-service-http = { path = "services/http", version = "0.58.0", optional = true, default-features = false }
+opendal-service-ipfs = { path = "services/ipfs", version = "0.58.0", optional = true, default-features = false }
+opendal-service-ipmfs = { path = "services/ipmfs", version = "0.58.0", optional = true, default-features = false }
+opendal-service-koofr = { path = "services/koofr", version = "0.58.0", optional = true, default-features = false }
+opendal-service-lakefs = { path = "services/lakefs", version = "0.58.0", optional = true, default-features = false }
+opendal-service-memcached = { path = "services/memcached", version = "0.58.0", optional = true, default-features = false }
+opendal-service-mini-moka = { path = "services/mini_moka", version = "0.58.0", optional = true, default-features = false }
+opendal-service-moka = { path = "services/moka", version = "0.58.0", optional = true, default-features = false }
+opendal-service-mongodb = { path = "services/mongodb", version = "0.58.0", optional = true, default-features = false }
+opendal-service-monoiofs = { path = "services/monoiofs", version = "0.58.0", optional = true, default-features = false }
+opendal-service-mysql = { path = "services/mysql", version = "0.58.0", optional = true, default-features = false }
+opendal-service-obs = { path = "services/obs", version = "0.58.0", optional = true, default-features = false }
+opendal-service-onedrive = { path = "services/onedrive", version = "0.58.0", optional = true, default-features = false }
+opendal-service-oss = { path = "services/oss", version = "0.58.0", optional = true, default-features = false }
+opendal-service-pcloud = { path = "services/pcloud", version = "0.58.0", optional = true, default-features = false }
+opendal-service-persy = { path = "services/persy", version = "0.58.0", optional = true, default-features = false }
+opendal-service-postgresql = { path = "services/postgresql", version = "0.58.0", optional = true, default-features = false }
+opendal-service-redb = { path = "services/redb", version = "0.58.0", optional = true, default-features = false }
+opendal-service-redis = { path = "services/redis", version = "0.58.0", optional = true, default-features = false }
+opendal-service-rocksdb = { path = "services/rocksdb", version = "0.58.0", optional = true, default-features = false }
+opendal-service-s3 = { path = "services/s3", version = "0.58.0", optional = true, default-features = false }
+opendal-service-seafile = { path = "services/seafile", version = "0.58.0", optional = true, default-features = false }
+opendal-service-sftp = { path = "services/sftp", version = "0.58.0", optional = true, default-features = false }
+opendal-service-sled = { path = "services/sled", version = "0.58.0", optional = true, default-features = false }
+opendal-service-sqlite = { path = "services/sqlite", version = "0.58.0", optional = true, default-features = false }
+opendal-service-surrealdb = { path = "services/surrealdb", version = "0.58.0", optional = true, default-features = false }
+opendal-service-swift = { path = "services/swift", version = "0.58.0", optional = true, default-features = false }
+opendal-service-tikv = { path = "services/tikv", version = "0.58.0", optional = true, default-features = false }
+opendal-service-tos = { path = "services/tos", version = "0.58.0", optional = true, default-features = false }
+opendal-service-upyun = { path = "services/upyun", version = "0.58.0", optional = true, default-features = false }
+opendal-service-vercel-artifacts = { path = "services/vercel-artifacts", version = "0.58.0", optional = true, default-features = false }
+opendal-service-vercel-blob = { path = "services/vercel-blob", version = "0.58.0", optional = true, default-features = false }
+opendal-service-webdav = { path = "services/webdav", version = "0.58.0", optional = true, default-features = false }
+opendal-service-webhdfs = { path = "services/webhdfs", version = "0.58.0", optional = true, default-features = false }
+opendal-service-yandex-disk = { path = "services/yandex-disk", version = "0.58.0", optional = true, default-features = false }
+opendal-testkit = { path = "testkit", version = "0.58.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-opendal-layer-dtrace = { path = "layers/dtrace", version = "0.57.0", optional = true, default-features = false }
+opendal-layer-dtrace = { path = "layers/dtrace", version = "0.58.0", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-opendal-service-opfs = { path = "services/opfs", version = "0.57.0", optional = true, default-features = false }
+opendal-service-opfs = { path = "services/opfs", version = "0.58.0", optional = true, default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -1,5 +1,6 @@
 crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
-anyhow@1.0.102	X									X			
+aes@0.8.4	X									X			
+anyhow@1.0.103	X									X			
 async-stream@0.3.6										X			
 async-stream-impl@0.3.6										X			
 async-trait@0.1.89	X									X			
@@ -11,15 +12,20 @@ axum@0.7.9										X
 axum-core@0.4.5										X			
 backon@1.6.0	X												
 base64@0.22.1	X									X			
+base64ct@1.8.3	X									X			
 bitflags@2.11.1	X									X			
 block-buffer@0.10.4	X									X			
 block-buffer@0.12.0	X									X			
+block-padding@0.3.3	X									X			
 bumpalo@3.20.2	X									X			
-bytes@1.11.1										X			
+bytes@1.12.0										X			
+cbc@0.1.2	X									X			
 cc@1.2.61	X									X			
 cfg-if@1.0.4	X									X			
 chacha20@0.10.0	X									X			
+cipher@0.4.4	X									X			
 cmake@0.1.58	X									X			
+cmov@0.5.3	X									X			
 combine@4.6.7										X			
 const-oid@0.10.2	X									X			
 const-oid@0.9.6	X									X			
@@ -30,13 +36,17 @@ core-foundation@0.9.4	X									X
 core-foundation-sys@0.8.7	X									X			
 cpufeatures@0.2.17	X									X			
 cpufeatures@0.3.0	X									X			
-crc32c@0.6.8	X									X			
+crc@3.3.0	X									X			
+crc-catalog@2.5.0	X									X			
+crc-fast@1.9.0	X									X			
 crossbeam-utils@0.8.21	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
 crypto-common@0.2.1	X									X			
-ctor@1.0.3	X									X			
-dashmap@6.1.0										X			
+ctor@1.0.7	X									X			
+ctutils@0.4.2	X									X			
+dashmap@6.2.1										X			
+der@0.7.10	X									X			
 digest@0.10.7	X									X			
 digest@0.11.3	X									X			
 displaydoc@0.2.5	X									X			
@@ -46,7 +56,6 @@ dunce@1.0.5	X					X					X
 either@1.15.0	X									X			
 encoding_rs@0.8.35	X			X						X			
 equivalent@1.0.2	X									X			
-erased-serde@0.4.10	X									X			
 errno@0.3.14	X									X			
 fastrand@2.4.1	X									X			
 find-msvc-tools@0.1.9	X									X			
@@ -68,7 +77,7 @@ getrandom@0.2.17	X									X
 getrandom@0.3.4	X									X			
 getrandom@0.4.2	X									X			
 gloo-timers@0.3.0	X									X			
-goosefs-sdk@0.1.2	X												
+goosefs-sdk@0.1.3	X												
 h2@0.4.14										X			
 hashbrown@0.12.3	X									X			
 hashbrown@0.14.5	X									X			
@@ -76,8 +85,9 @@ hashbrown@0.17.0	X									X
 heck@0.5.0	X									X			
 hex@0.4.3	X									X			
 hmac@0.12.1	X									X			
+hmac@0.13.0	X									X			
 hostname@0.3.1										X			
-http@1.4.0	X									X			
+http@1.4.2	X									X			
 http-body@1.0.1										X			
 http-body-util@0.1.3										X			
 httparse@1.10.1	X									X			
@@ -98,10 +108,11 @@ idna@1.1.0	X									X
 idna_adapter@1.2.1	X									X			
 indexmap@1.9.3	X									X			
 indexmap@2.14.0	X									X			
+inout@0.1.4	X									X			
 ipnet@2.12.0	X									X			
 itertools@0.14.0	X									X			
 itoa@1.0.18	X									X			
-jiff@0.2.24										X			X
+jiff@0.2.31										X			X
 jiff-tzdb@0.1.6										X			X
 jiff-tzdb-platform@0.1.3										X			X
 jni@0.22.4	X									X			
@@ -110,42 +121,54 @@ jni-sys@0.4.1	X									X
 jni-sys-macros@0.4.1	X									X			
 jobserver@0.1.34	X									X			
 js-sys@0.3.98	X									X			
+lazy_static@1.5.0	X									X			
 libc@0.2.186	X									X			
-link-section@0.15.0	X									X			
-linktime-proc-macro@0.1.0	X									X			
+libm@0.2.16										X			
+link-section@0.18.2	X									X			
+linktime-proc-macro@0.2.0	X									X			
 linux-raw-sys@0.12.1	X	X								X			
 litemap@0.8.2												X	
 lock_api@0.4.14	X									X			
-log@0.4.29	X									X			
+log@0.4.33	X									X			
 match_cfg@0.1.0	X									X			
 matchit@0.7.3				X						X			
 md-5@0.11.0	X									X			
-mea@0.6.3	X												
-memchr@2.8.0										X			X
+mea@0.6.4	X												
+memchr@2.8.2										X			X
 mime@0.3.17	X									X			
 mio@1.2.0										X			
 multimap@0.10.1	X									X			
+num-bigint-dig@0.8.6	X									X			
+num-integer@0.1.46	X									X			
+num-iter@0.1.45	X									X			
+num-traits@0.2.19	X									X			
 once_cell@1.21.4	X									X			
-opendal@0.57.0	X												
-opendal-core@0.57.0	X												
-opendal-layer-concurrent-limit@0.57.0	X												
-opendal-layer-logging@0.57.0	X												
-opendal-layer-retry@0.57.0	X												
-opendal-layer-timeout@0.57.0	X												
-opendal-service-fs@0.57.0	X												
-opendal-service-goosefs@0.57.0	X												
-opendal-service-opfs@0.57.0	X												
-opendal-service-s3@0.57.0	X												
-opendal-testkit@0.57.0	X												
+opendal@0.58.0	X												
+opendal-core@0.58.0	X												
+opendal-http-transport-reqwest@0.58.0	X												
+opendal-layer-concurrent-limit@0.58.0	X												
+opendal-layer-logging@0.58.0	X												
+opendal-layer-retry@0.58.0	X												
+opendal-layer-timeout@0.58.0	X												
+opendal-service-fs@0.58.0	X												
+opendal-service-goosefs@0.58.0	X												
+opendal-service-opfs@0.58.0	X												
+opendal-service-s3@0.58.0	X												
+opendal-testkit@0.58.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-multimap@0.7.3										X			
 parking_lot@0.12.5	X									X			
 parking_lot_core@0.9.12	X									X			
+pbkdf2@0.12.2	X									X			
+pem-rfc7468@0.7.0	X									X			
 percent-encoding@2.3.2	X									X			
 petgraph@0.7.1	X									X			
 pin-project@1.1.12	X									X			
 pin-project-internal@1.1.12	X									X			
 pin-project-lite@0.2.17	X									X			
+pkcs1@0.7.5	X									X			
+pkcs5@0.7.1	X									X			
+pkcs8@0.10.2	X									X			
 portable-atomic@1.13.1	X									X			
 portable-atomic-util@0.2.7	X									X			
 potential_utf@0.1.5												X	
@@ -156,8 +179,9 @@ prost@0.13.5	X
 prost-build@0.13.5	X												
 prost-derive@0.13.5	X												
 prost-types@0.13.5	X												
-quick-xml@0.39.3										X			
-quote@1.0.45	X									X			
+quick-xml@0.40.1										X			
+quick-xml@0.41.0										X			
+quote@1.0.46	X									X			
 r-efi@5.3.0	X								X	X			
 r-efi@6.0.0	X								X	X			
 rand@0.10.1	X									X			
@@ -169,16 +193,17 @@ redox_syscall@0.5.18										X
 regex@1.12.3	X									X			
 regex-automata@0.4.14	X									X			
 regex-syntax@0.8.10	X									X			
-reqsign-aws-v4@3.0.0	X												
-reqsign-core@3.0.0	X												
-reqsign-file-read-tokio@3.0.0	X												
-reqwest@0.13.3	X									X			
+reqsign-aws-v4@3.0.1	X												
+reqsign-core@3.0.1	X												
+reqsign-file-read-tokio@3.0.1	X												
+reqwest@0.13.4	X									X			
 ring@0.17.14	X							X					
+rsa@0.9.10	X									X			
 rust-ini@0.21.3										X			
 rustc_version@0.4.1	X									X			
 rustix@1.1.4	X	X								X			
 rustls@0.23.40	X							X		X			
-rustls-native-certs@0.8.3	X							X		X			
+rustls-native-certs@0.8.4	X							X		X			
 rustls-pemfile@2.2.0	X							X		X			
 rustls-pki-types@1.14.1	X									X			
 rustls-platform-verifier@0.7.0	X									X			
@@ -186,41 +211,38 @@ rustls-platform-verifier-android@0.1.1	X									X
 rustls-webpki@0.103.13								X					
 rustversion@1.0.22	X									X			
 ryu@1.0.23	X				X								
+salsa20@0.10.2	X									X			
 same-file@1.0.6										X			X
 schannel@0.1.29										X			
 scopeguard@1.2.0	X									X			
+scrypt@0.11.0	X									X			
 security-framework@3.7.0	X									X			
 security-framework-sys@2.17.0	X									X			
 semver@1.0.28	X									X			
 send_wrapper@0.6.0	X									X			
 serde@1.0.228	X									X			
-serde_buf@0.1.2	X									X			
 serde_core@1.0.228	X									X			
 serde_derive@1.0.228	X									X			
-serde_fmt@1.1.0	X									X			
-serde_json@1.0.149	X									X			
+serde_json@1.0.150	X									X			
 serde_urlencoded@0.7.1	X									X			
-sha1@0.10.6	X									X			
+sha1@0.11.0	X									X			
 sha2@0.10.9	X									X			
 sha2@0.11.0	X									X			
 shlex@1.3.0	X									X			
 signal-hook-registry@1.4.8	X									X			
+signature@2.2.0	X									X			
 simd_cesu8@1.1.1	X									X			
 simdutf8@0.1.5	X									X			
 slab@0.4.12										X			
 smallvec@1.15.1	X									X			
 socket2@0.5.10	X									X			
 socket2@0.6.3	X									X			
+spin@0.10.0										X			
+spin@0.9.8										X			
+spki@0.7.3	X									X			
 stable_deref_trait@1.2.1	X									X			
 subtle@2.6.1				X									
-sval@2.19.0	X									X			
-sval_buffer@2.19.0	X									X			
-sval_dynamic@2.19.0	X									X			
-sval_fmt@2.19.0	X									X			
-sval_nested@2.19.0	X									X			
-sval_ref@2.19.0	X									X			
-sval_serde@2.19.0	X									X			
-syn@2.0.117	X									X			
+syn@2.0.118	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
 system-configuration@0.7.0	X									X			
@@ -230,7 +252,7 @@ thiserror@2.0.18	X									X
 thiserror-impl@2.0.18	X									X			
 tiny-keccak@2.0.2						X							
 tinystr@0.8.3												X	
-tokio@1.52.2										X			
+tokio@1.52.3										X			
 tokio-macros@2.7.0										X			
 tokio-rustls@0.26.4	X									X			
 tokio-stream@0.1.18										X			
@@ -246,16 +268,12 @@ tracing@0.1.44										X
 tracing-attributes@0.1.31										X			
 tracing-core@0.1.36										X			
 try-lock@0.2.5										X			
-typeid@1.0.3	X									X			
 typenum@1.20.0	X									X			
 unicode-ident@1.0.24	X									X		X	
 untrusted@0.9.0								X					
 url@2.5.8	X									X			
 utf8_iter@1.0.4	X									X			
-uuid@1.23.1	X									X			
-value-bag@1.12.0	X									X			
-value-bag-serde1@1.12.0	X									X			
-value-bag-sval2@1.12.0	X									X			
+uuid@1.23.4	X									X			
 version_check@0.9.5	X									X			
 walkdir@2.5.0										X			X
 want@0.3.1										X			

--- a/core/benches/vs_fs/Cargo.toml
+++ b/core/benches/vs_fs/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "opendal-benchmark-vs-fs"
 publish = false
 rust-version = "1.86"
-version = "0.57.0"
+version = "0.58.0"
 
 [dependencies]
 criterion = { version = "0.8.2", features = ["async", "async_tokio"] }

--- a/core/benches/vs_s3/Cargo.toml
+++ b/core/benches/vs_s3/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "opendal-benchmark-vs-s3"
 publish = false
 rust-version = "1.86"
-version = "0.57.0"
+version = "0.58.0"
 
 [dependencies]
 aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }

--- a/core/core/src/docs/upgrade.md
+++ b/core/core/src/docs/upgrade.md
@@ -1,3 +1,50 @@
+# Upgrade to v0.58
+
+## Public API
+
+### `Operator::new` returns a finished operator
+
+`Operator::new(builder)` now returns `Result<Operator>` directly. Remove the old `finish()` call from construction code:
+
+```diff
+- let op = Operator::new(builder)?.finish();
++ let op = Operator::new(builder)?;
+```
+
+### Runtime composition APIs consolidated
+
+Operator runtime resources now live in `OperationContext`, which is exported from the crate root instead of `raw`.
+
+- Replace `raw::OperationContext` imports with `opendal::OperationContext`.
+- Replace `Operator::http_transport(...)` and `Operator::executor(...)` with `Operator::with_context(...)`.
+- Replace `Operator::from_service(...)` with `Operator::from_parts(ctx, service)`.
+- Replace `Operator::inner()`, `Operator::into_inner()`, and `Operator::executor_ref()` with `service()`, `context()`, or `into_parts()` depending on whether you need borrowed or owned composed state.
+- `Operator::from_inner(...)` is deprecated; use `Operator::from_parts(...)`.
+
+### Native and full capability APIs removed
+
+`OperatorInfo::native_capability()` has been removed. `OperatorInfo::capability()` is now the public availability contract for the composed operator stack.
+
+### Suffix reads use public `BytesRange`
+
+`BytesRange` is now part of the public type layer. Reader APIs accept values convertible into `BytesRange`, and suffix reads can be requested with `BytesRange::suffix(size)`. Code that imported raw HTTP range helpers should use `opendal::BytesRange` instead.
+
+## Raw API
+
+### Services and layers use the new composition boundary
+
+Out-of-tree services must implement `raw::Service` instead of the old accessor pipeline. Services now return immutable identity through `ServiceInfo`, report availability through `capability()`, and receive `&OperationContext` at each operation boundary.
+
+Out-of-tree layers must implement `Layer::apply_service` and, when they replace runtime resources, `Layer::apply_context`. The old typed layer pipeline, including `TypedLayer`, `RuntimeResourceLayer`, `TypeEraseLayer`, `OperatorBuilder<S>`, and `typed_layer`, has been removed.
+
+### Stateful operation factories are synchronous
+
+`Service` and `ServiceDyn` factories for `read`, `write`, `delete`, `list`, and `copy` now return OIO bodies synchronously. Move asynchronous work into the returned body implementation instead of returning `(Rp*, body)` futures from the factory.
+
+### Removed raw helpers
+
+The unused `raw::AtomicContentLength`, `raw::PathCacher`, and `raw::PathQuery` helpers have been removed. The `internal-path-cache` feature has also been removed.
+
 # Upgrade to v0.57
 
 ## Public API

--- a/core/http-transports/reqwest/Cargo.toml
+++ b/core/http-transports/reqwest/Cargo.toml
@@ -52,7 +52,7 @@ bytes = { workspace = true }
 futures = { workspace = true, features = ["std"] }
 http = { workspace = true }
 http-body = "1"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 reqwest = { version = "0.13.4", features = [
   "stream",
 ], default-features = false }

--- a/core/layers/async-backtrace/Cargo.toml
+++ b/core/layers/async-backtrace/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 async-backtrace = "0.2.6"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }

--- a/core/layers/await-tree/Cargo.toml
+++ b/core/layers/await-tree/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 await-tree = "0.3"
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }

--- a/core/layers/capability-check/Cargo.toml
+++ b/core/layers/capability-check/Cargo.toml
@@ -31,8 +31,8 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/chaos/Cargo.toml
+++ b/core/layers/chaos/Cargo.toml
@@ -31,8 +31,8 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 rand = { workspace = true }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }

--- a/core/layers/concurrent-limit/Cargo.toml
+++ b/core/layers/concurrent-limit/Cargo.toml
@@ -34,8 +34,8 @@ all-features = true
 futures = { workspace = true }
 http = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/core/layers/dtrace/Cargo.toml
+++ b/core/layers/dtrace/Cargo.toml
@@ -32,9 +32,9 @@ all-features = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 bytes = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 probe = "0.5.1"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/fastmetrics/Cargo.toml
+++ b/core/layers/fastmetrics/Cargo.toml
@@ -32,10 +32,10 @@ all-features = true
 
 [dependencies]
 fastmetrics = "0.7"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/fastrace/Cargo.toml
+++ b/core/layers/fastrace/Cargo.toml
@@ -32,12 +32,12 @@ all-features = true
 
 [dependencies]
 fastrace = { version = "0.7.18" }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0"
 dotenvy = "0.15"
 fastrace = { version = "0.7", features = ["enable"] }
 fastrace-jaeger = "0.7"
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/foyer/Cargo.toml
+++ b/core/layers/foyer/Cargo.toml
@@ -32,10 +32,10 @@ all-features = true
 
 [dependencies]
 foyer = { version = "0.22.3" }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", features = [
+opendal-core = { path = "../../core", version = "0.58.0", features = [
   "services-memory",
 ] }
 size = "0.5"

--- a/core/layers/hotpath/Cargo.toml
+++ b/core/layers/hotpath/Cargo.toml
@@ -34,8 +34,8 @@ all-features = true
 futures = { workspace = true }
 hotpath = "0.19.1"
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/immutable-index/Cargo.toml
+++ b/core/layers/immutable-index/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
 log = { workspace = true }
 logforth = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/logging/Cargo.toml
+++ b/core/layers/logging/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }

--- a/core/layers/metrics/Cargo.toml
+++ b/core/layers/metrics/Cargo.toml
@@ -32,8 +32,8 @@ all-features = true
 
 [dependencies]
 metrics = "0.24"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }

--- a/core/layers/mime-guess/Cargo.toml
+++ b/core/layers/mime-guess/Cargo.toml
@@ -32,9 +32,9 @@ all-features = true
 
 [dependencies]
 mime_guess = "2.0.5"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/observe-metrics-common/Cargo.toml
+++ b/core/layers/observe-metrics-common/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 futures = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros"] }

--- a/core/layers/otelmetrics/Cargo.toml
+++ b/core/layers/otelmetrics/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.58.0" }
 opentelemetry = { version = "0.32.0", default-features = false, features = [
   "metrics",
 ] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }

--- a/core/layers/oteltrace/Cargo.toml
+++ b/core/layers/oteltrace/Cargo.toml
@@ -31,10 +31,10 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 opentelemetry = { version = "0.32.0", default-features = false, features = [
   "trace",
 ] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }

--- a/core/layers/prometheus-client/Cargo.toml
+++ b/core/layers/prometheus-client/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.58.0" }
 prometheus-client = { version = "0.25" }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/prometheus/Cargo.toml
+++ b/core/layers/prometheus/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.58.0" }
 prometheus = { version = "0.14", features = ["process"] }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/retry/Cargo.toml
+++ b/core/layers/retry/Cargo.toml
@@ -33,13 +33,13 @@ all-features = true
 [dependencies]
 backon = { version = "1.6", features = ["tokio-sleep"] }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
 bytes = { workspace = true }
 futures = { workspace = true }
 logforth = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0" }
-opendal-layer-logging = { path = "../logging", version = "0.57.0" }
-opendal-layer-timeout = { path = "../timeout", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
+opendal-layer-logging = { path = "../logging", version = "0.58.0" }
+opendal-layer-timeout = { path = "../timeout", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/route/Cargo.toml
+++ b/core/layers/route/Cargo.toml
@@ -32,10 +32,10 @@ all-features = true
 
 [dependencies]
 globset = "0.4.15"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0" }
-opendal-service-fs = { path = "../../services/fs", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
+opendal-service-fs = { path = "../../services/fs", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/tail-cut/Cargo.toml
+++ b/core/layers/tail-cut/Cargo.toml
@@ -31,9 +31,9 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/throttle/Cargo.toml
+++ b/core/layers/throttle/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 governor = "0.10.4"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }

--- a/core/layers/timeout/Cargo.toml
+++ b/core/layers/timeout/Cargo.toml
@@ -31,11 +31,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0" }
-opendal-layer-retry = { path = "../retry", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
+opendal-layer-retry = { path = "../retry", version = "0.58.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/tracing/Cargo.toml
+++ b/core/layers/tracing/Cargo.toml
@@ -33,13 +33,13 @@ all-features = true
 [dependencies]
 futures = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 tracing = "0.1"
 
 [dev-dependencies]
 anyhow = "1.0"
 dotenvy = "0.15"
-opendal-core = { path = "../../core", version = "0.57.0" }
+opendal-core = { path = "../../core", version = "0.58.0" }
 opentelemetry = { version = "0.32.0", default-features = false, features = [
   "trace",
 ] }

--- a/core/services/aliyun-drive/Cargo.toml
+++ b/core/services/aliyun-drive/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/alluxio/Cargo.toml
+++ b/core/services/alluxio/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/azblob/Cargo.toml
+++ b/core/services/azblob/Cargo.toml
@@ -35,10 +35,10 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false, features = [
   "reqsign",
 ] }
-opendal-service-azure-common = { path = "../azure-common", version = "0.57.0" }
+opendal-service-azure-common = { path = "../azure-common", version = "0.58.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.0.1", default-features = false }
 reqsign-core = { version = "3.0.1", default-features = false }

--- a/core/services/azdls/Cargo.toml
+++ b/core/services/azdls/Cargo.toml
@@ -36,10 +36,10 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false, features = [
   "reqsign",
 ] }
-opendal-service-azure-common = { path = "../azure-common", version = "0.57.0" }
+opendal-service-azure-common = { path = "../azure-common", version = "0.58.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.0.1", default-features = false }
 reqsign-core = { version = "3.0.1", default-features = false }

--- a/core/services/azfile/Cargo.toml
+++ b/core/services/azfile/Cargo.toml
@@ -34,10 +34,10 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false, features = [
   "reqsign",
 ] }
-opendal-service-azure-common = { path = "../azure-common", version = "0.57.0" }
+opendal-service-azure-common = { path = "../azure-common", version = "0.58.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.0.1", default-features = false }
 reqsign-core = { version = "3.0.1", default-features = false }

--- a/core/services/azure-common/Cargo.toml
+++ b/core/services/azure-common/Cargo.toml
@@ -32,4 +32,4 @@ all-features = true
 
 [dependencies]
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }

--- a/core/services/b2/Cargo.toml
+++ b/core/services/b2/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/cacache/Cargo.toml
+++ b/core/services/cacache/Cargo.toml
@@ -36,7 +36,7 @@ cacache = { version = "13.0", default-features = false, features = [
   "tokio-runtime",
   "mmap",
 ] }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/cloudflare-kv/Cargo.toml
+++ b/core/services/cloudflare-kv/Cargo.toml
@@ -33,6 +33,6 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/compfs/Cargo.toml
+++ b/core/services/compfs/Cargo.toml
@@ -40,7 +40,7 @@ compio = { version = "0.19.0", features = [
   "runtime",
   "sync",
 ] }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/cos/Cargo.toml
+++ b/core/services/cos/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/d1/Cargo.toml
+++ b/core/services/d1/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/dashmap/Cargo.toml
+++ b/core/services/dashmap/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 dashmap = "6"
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/dbfs/Cargo.toml
+++ b/core/services/dbfs/Cargo.toml
@@ -35,7 +35,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/dropbox/Cargo.toml
+++ b/core/services/dropbox/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/etcd/Cargo.toml
+++ b/core/services/etcd/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 etcd-client = { version = "0.19.0", features = ["tls"] }
 fastpool = "1.0.2"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["time"] }
 

--- a/core/services/foundationdb/Cargo.toml
+++ b/core/services/foundationdb/Cargo.toml
@@ -35,7 +35,7 @@ foundationdb = { version = "0.11.0", features = [
   "embedded-fdb-include",
   "fdb-7_3",
 ] }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/foyer/Cargo.toml
+++ b/core/services/foyer/Cargo.toml
@@ -33,12 +33,12 @@ all-features = true
 [dependencies]
 foyer = { version = "0.22.3" }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-opendal = { path = "../..", version = "0.57.0", features = ["services-memory"] }
-opendal-core = { path = "../../core", version = "0.57.0", features = [
+opendal = { path = "../..", version = "0.58.0", features = ["services-memory"] }
+opendal-core = { path = "../../core", version = "0.58.0", features = [
   "services-memory",
 ] }
 size = "0.5"

--- a/core/services/fs/Cargo.toml
+++ b/core/services/fs/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false, features = [
   "internal-tokio-rt",
 ] }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/ftp/Cargo.toml
+++ b/core/services/ftp/Cargo.toml
@@ -37,7 +37,7 @@ futures = { workspace = true, features = ["std", "async-await"] }
 futures-rustls = "0.26.0"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 rustls-native-certs = "0.8"
 serde = { workspace = true, features = ["derive"] }
 suppaftp = { version = "8.0.3", default-features = false, features = [

--- a/core/services/gcs/Cargo.toml
+++ b/core/services/gcs/Cargo.toml
@@ -35,7 +35,7 @@ async-trait = "0.1"
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false, features = [
   "reqsign",
 ] }
 percent-encoding = "2.3"

--- a/core/services/gdrive/Cargo.toml
+++ b/core/services/gdrive/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/ghac/Cargo.toml
+++ b/core/services/ghac/Cargo.toml
@@ -35,8 +35,8 @@ bytes = { workspace = true }
 ghac = { version = "0.3.0", default-features = false }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
-opendal-service-azblob = { path = "../azblob", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
+opendal-service-azblob = { path = "../azblob", version = "0.58.0", default-features = false }
 prost = { version = "0.14.3", default-features = false }
 reqsign-azure-storage = { version = "3.0.1", default-features = false }
 reqsign-core = { version = "3.0.1", default-features = false }

--- a/core/services/github/Cargo.toml
+++ b/core/services/github/Cargo.toml
@@ -35,7 +35,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/goosefs/Cargo.toml
+++ b/core/services/goosefs/Cargo.toml
@@ -34,12 +34,12 @@ all-features = true
 bytes = { workspace = true }
 goosefs-sdk = "0.1.3"
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true }
 
 [dev-dependencies]
-opendal = { path = "../..", version = "0.57.0", features = [
+opendal = { path = "../..", version = "0.58.0", features = [
   "services-goosefs",
 ] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/gridfs/Cargo.toml
+++ b/core/services/gridfs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 futures = { workspace = true }
 mea = { workspace = true }
 mongodb = "3.3.0"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/hdfs-native/Cargo.toml
+++ b/core/services/hdfs-native/Cargo.toml
@@ -35,5 +35,5 @@ bytes = { workspace = true }
 futures = { workspace = true }
 hdfs-native = { version = "0.13" }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/hdfs/Cargo.toml
+++ b/core/services/hdfs/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 bytes = { workspace = true }
 futures = { workspace = true }

--- a/core/services/hf/Cargo.toml
+++ b/core/services/hf/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 hf-xet = "1.5.0"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 percent-encoding = "2"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -43,6 +43,6 @@ serde_json = { workspace = true }
 [dev-dependencies]
 base64 = { workspace = true }
 futures = { workspace = true }
-opendal-http-transport-reqwest = { path = "../../http-transports/reqwest", version = "0.57.0" }
+opendal-http-transport-reqwest = { path = "../../http-transports/reqwest", version = "0.58.0" }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/http/Cargo.toml
+++ b/core/services/http/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2024"
 license = "Apache-2.0"
 name = "opendal-service-http"
 repository = "https://github.com/apache/opendal"
-version = "0.57.0"
+version = "0.58.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -29,9 +29,9 @@ all-features = true
 [dependencies]
 http = "1.4"
 log = "0.4"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }

--- a/core/services/ipfs/Cargo.toml
+++ b/core/services/ipfs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 prost = "0.14.3"
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/ipmfs/Cargo.toml
+++ b/core/services/ipmfs/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/koofr/Cargo.toml
+++ b/core/services/koofr/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/lakefs/Cargo.toml
+++ b/core/services/lakefs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/memcached/Cargo.toml
+++ b/core/services/memcached/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 fastpool = "1.0.2"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["net", "io-util"] }
 url = { workspace = true }

--- a/core/services/mini_moka/Cargo.toml
+++ b/core/services/mini_moka/Cargo.toml
@@ -33,5 +33,5 @@ all-features = true
 [dependencies]
 log = { workspace = true }
 mini-moka = "0.10"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/moka/Cargo.toml
+++ b/core/services/moka/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 log = { workspace = true }
 moka = { version = "0.12", features = ["future", "sync"] }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/mongodb/Cargo.toml
+++ b/core/services/mongodb/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 mea = { workspace = true }
 mongodb = { version = "3.3.0" }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/monoiofs/Cargo.toml
+++ b/core/services/monoiofs/Cargo.toml
@@ -40,7 +40,7 @@ monoio = { version = "0.2.4", features = [
   "unlinkat",
   "renameat",
 ] }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/mysql/Cargo.toml
+++ b/core/services/mysql/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "mysql"] }
 

--- a/core/services/obs/Cargo.toml
+++ b/core/services/obs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/onedrive/Cargo.toml
+++ b/core/services/onedrive/Cargo.toml
@@ -35,7 +35,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time"] }

--- a/core/services/opfs/Cargo.toml
+++ b/core/services/opfs/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.77"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 send_wrapper = "0.6"
 serde = { workspace = true, features = ["derive"] }
 wasm-bindgen = "0.2.100"

--- a/core/services/oss/Cargo.toml
+++ b/core/services/oss/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/pcloud/Cargo.toml
+++ b/core/services/pcloud/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/persy/Cargo.toml
+++ b/core/services/persy/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 persy = "1.7.1"
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/postgresql/Cargo.toml
+++ b/core/services/postgresql/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "postgres"] }
 

--- a/core/services/redb/Cargo.toml
+++ b/core/services/redb/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 redb = { version = "4" }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/redis/Cargo.toml
+++ b/core/services/redis/Cargo.toml
@@ -39,7 +39,7 @@ rustls = ["redis/tokio-rustls-comp"]
 bytes = { workspace = true }
 fastpool = "1.0.2"
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 redis = { version = "1.2", features = [
   "cluster-async",
   "tokio-comp",

--- a/core/services/rocksdb/Cargo.toml
+++ b/core/services/rocksdb/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 rocksdb = { version = "0.24.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/s3/Cargo.toml
+++ b/core/services/s3/Cargo.toml
@@ -37,7 +37,7 @@ crc-fast = "1.9.0"
 http = { workspace = true }
 log = { workspace = true }
 md-5 = "0.11.0"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/seafile/Cargo.toml
+++ b/core/services/seafile/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/sftp/Cargo.toml
+++ b/core/services/sftp/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 bytes = { workspace = true }
 fastpool = "1.0.2"

--- a/core/services/sled/Cargo.toml
+++ b/core/services/sled/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sled = "0.34.7"
 

--- a/core/services/sqlite/Cargo.toml
+++ b/core/services/sqlite/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "sqlite"] }
 

--- a/core/services/surrealdb/Cargo.toml
+++ b/core/services/surrealdb/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 surrealdb = { version = "3", features = ["protocol-http"] }
 

--- a/core/services/swift/Cargo.toml
+++ b/core/services/swift/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 hmac = "0.13.0"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 percent-encoding = "2"
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/tikv/Cargo.toml
+++ b/core/services/tikv/Cargo.toml
@@ -32,7 +32,7 @@ all-features = true
 
 [dependencies]
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tikv-client = { version = "0.4.0", default-features = false }
 

--- a/core/services/tos/Cargo.toml
+++ b/core/services/tos/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/upyun/Cargo.toml
+++ b/core/services/upyun/Cargo.toml
@@ -37,7 +37,7 @@ hmac = "0.13.0"
 http = { workspace = true }
 log = { workspace = true }
 md-5 = "0.11.0"
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/vercel-artifacts/Cargo.toml
+++ b/core/services/vercel-artifacts/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/vercel-blob/Cargo.toml
+++ b/core/services/vercel-blob/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/webdav/Cargo.toml
+++ b/core/services/webdav/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/webhdfs/Cargo.toml
+++ b/core/services/webhdfs/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
 mea = { workspace = true }
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/core/services/yandex-disk/Cargo.toml
+++ b/core/services/yandex-disk/Cargo.toml
@@ -31,7 +31,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.57.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.58.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/testkit/Cargo.toml
+++ b/core/testkit/Cargo.toml
@@ -33,10 +33,10 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 dotenvy = "0.15"
-opendal-core = { path = "../core", version = "0.57.0", default-features = false }
-opendal-layer-logging = { path = "../layers/logging", version = "0.57.0", default-features = false }
-opendal-layer-retry = { path = "../layers/retry", version = "0.57.0", default-features = false }
-opendal-layer-timeout = { path = "../layers/timeout", version = "0.57.0", default-features = false }
+opendal-core = { path = "../core", version = "0.58.0", default-features = false }
+opendal-layer-logging = { path = "../layers/logging", version = "0.58.0", default-features = false }
+opendal-layer-retry = { path = "../layers/retry", version = "0.58.0", default-features = false }
+opendal-layer-timeout = { path = "../layers/timeout", version = "0.58.0", default-features = false }
 rand = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/dev/src/release/package.rs
+++ b/dev/src/release/package.rs
@@ -61,23 +61,23 @@ fn make_package(path: &str, version: &str, dependencies: Vec<Package>) -> Packag
 
 /// List all packages that are ready for release.
 pub fn all_packages() -> Vec<Package> {
-    let core = make_package("core", "0.57.0", vec![]);
+    let core = make_package("core", "0.58.0", vec![]);
 
     // Integrations
-    let dav_server = make_package("integrations/dav-server", "0.7.2", vec![core.clone()]);
-    let object_store = make_package("integrations/object_store", "0.57.0", vec![core.clone()]);
-    let parquet = make_package("integrations/parquet", "0.8.1", vec![core.clone()]);
-    let unftp_sbe = make_package("integrations/unftp-sbe", "0.4.2", vec![core.clone()]);
+    let dav_server = make_package("integrations/dav-server", "0.7.3", vec![core.clone()]);
+    let object_store = make_package("integrations/object_store", "0.58.0", vec![core.clone()]);
+    let parquet = make_package("integrations/parquet", "0.8.2", vec![core.clone()]);
+    let unftp_sbe = make_package("integrations/unftp-sbe", "0.4.3", vec![core.clone()]);
 
     // Binaries moved to separate repositories; no longer released from this repo
 
     // Bindings
-    let c = make_package("bindings/c", "0.46.6", vec![core.clone()]);
-    let cpp = make_package("bindings/cpp", "0.45.26", vec![core.clone()]);
-    let java = make_package("bindings/java", "0.49.0", vec![core.clone()]);
-    let nodejs = make_package("bindings/nodejs", "0.49.4", vec![core.clone()]);
-    let python = make_package("bindings/python", "0.47.2", vec![core.clone()]);
-    let ruby = make_package("bindings/ruby", "0.1.7", vec![core.clone()]);
+    let c = make_package("bindings/c", "0.47.0", vec![core.clone()]);
+    let cpp = make_package("bindings/cpp", "0.45.27", vec![core.clone()]);
+    let java = make_package("bindings/java", "0.50.0", vec![core.clone()]);
+    let nodejs = make_package("bindings/nodejs", "0.49.5", vec![core.clone()]);
+    let python = make_package("bindings/python", "0.47.3", vec![core.clone()]);
+    let ruby = make_package("bindings/ruby", "0.1.8", vec![core.clone()]);
     let dotnet = make_package("bindings/dotnet", "0.1.0", vec![core.clone()]);
 
     vec![

--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 description = "Use OpenDAL as a backend to access data in various service with WebDAV protocol"
 name = "dav-server-opendalfs"
-version = "0.7.2"
+version = "0.7.3"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2024"
@@ -32,10 +32,10 @@ anyhow = "1"
 bytes = { version = "1.4.0" }
 dav-server = { version = "0.11.0" }
 futures = "0.3"
-opendal = { version = "0.57.0", path = "../../core" }
+opendal = { version = "0.58.0", path = "../../core" }
 
 [dev-dependencies]
-opendal = { version = "0.57.0", path = "../../core", features = [
+opendal = { version = "0.58.0", path = "../../core", features = [
   "services-fs",
 ] }
 tokio = { version = "1.27", features = ["macros", "rt-multi-thread", "io-std"] }

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -1,37 +1,36 @@
 crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib
 allocator-api2@0.2.21	X							X					
 android_system_properties@0.1.5	X							X					
-anyhow@1.0.102	X							X					
+anyhow@1.0.103	X							X					
 atomic-waker@1.1.2	X							X					
-autocfg@1.5.0	X							X					
-aws-lc-rs@1.17.0	X					X							
-aws-lc-sys@0.41.0	X		X			X		X	X				
+autocfg@1.5.1	X							X					
+aws-lc-rs@1.17.1	X					X							
+aws-lc-sys@0.42.0	X		X			X		X	X				
 backon@1.6.0	X												
 base64@0.22.1	X							X					
-bitflags@2.11.1	X							X					
+bitflags@2.13.0	X							X					
 block-buffer@0.10.4	X							X					
-block-buffer@0.12.0	X							X					
-bumpalo@3.20.2	X							X					
-bytes@1.11.1								X					
-cc@1.2.62	X							X					
+block-buffer@0.12.1	X							X					
+bumpalo@3.20.3	X							X					
+bytes@1.12.0								X					
+cc@1.2.66	X							X					
 cfg-if@1.0.4	X							X					
-chrono@0.4.44	X							X					
+chrono@0.4.45	X							X					
 cmake@0.1.58	X							X					
 combine@4.6.7								X					
 const-oid@0.10.2	X							X					
-const-oid@0.9.6	X							X					
 core-foundation@0.10.1	X							X					
 core-foundation-sys@0.8.7	X							X					
 cpufeatures@0.2.17	X							X					
 crypto-common@0.1.7	X							X					
 crypto-common@0.2.2	X							X					
-ctor@1.0.6	X							X					
+ctor@1.0.8	X							X					
 dav-server@0.11.0	X												
-dav-server-opendalfs@0.7.2	X												
+dav-server-opendalfs@0.7.3	X												
 derive-where@1.6.1	X							X					
 digest@0.10.7	X							X					
 digest@0.11.3	X							X					
-displaydoc@0.2.5	X							X					
+displaydoc@0.2.6	X							X					
 dunce@1.0.5	X			X					X				
 dyn-clone@1.0.20	X							X					
 equivalent@1.0.2	X							X					
@@ -51,91 +50,88 @@ futures-sink@0.3.32	X							X
 futures-task@0.3.32	X							X					
 futures-util@0.3.32	X							X					
 generic-array@0.14.7								X					
-getrandom@0.3.4	X							X					
-getrandom@0.4.2	X							X					
+getrandom@0.4.3	X							X					
 gloo-timers@0.3.0	X							X					
 hashbrown@0.16.1	X							X					
 headers@0.4.1								X					
 headers-core@0.3.0								X					
-hex@0.4.3	X							X					
-hmac@0.12.1	X							X					
 htmlescape@0.3.1	X							X		X			
-http@1.4.0	X							X					
+http@1.4.2	X							X					
 http-body@1.0.1								X					
 http-body-util@0.1.3								X					
 httparse@1.10.1	X							X					
 httpdate@1.0.3	X							X					
-hybrid-array@0.4.12	X							X					
-hyper@1.9.0								X					
+hybrid-array@0.4.13	X							X					
+hyper@1.10.1								X					
 hyper-rustls@0.27.9	X					X		X					
 hyper-util@0.1.20								X					
 iana-time-zone@0.1.65	X							X					
 iana-time-zone-haiku@0.1.2	X							X					
-icu_collections@2.1.1											X		
-icu_locale_core@2.1.1											X		
-icu_normalizer@2.1.1											X		
-icu_normalizer_data@2.1.1											X		
-icu_properties@2.1.2											X		
-icu_properties_data@2.1.2											X		
-icu_provider@2.1.1											X		
+icu_collections@2.2.0											X		
+icu_locale_core@2.2.0											X		
+icu_normalizer@2.2.0											X		
+icu_normalizer_data@2.2.0											X		
+icu_properties@2.2.0											X		
+icu_properties_data@2.2.0											X		
+icu_provider@2.2.0											X		
 idna@1.1.0	X							X					
-idna_adapter@1.2.1	X							X					
+idna_adapter@1.2.2	X							X					
 ipnet@2.12.0	X							X					
 itoa@1.0.18	X							X					
-jiff@0.2.24								X				X	
-jiff-tzdb@0.1.6								X				X	
+jiff@0.2.31								X				X	
+jiff-tzdb@0.1.7								X				X	
 jiff-tzdb-platform@0.1.3								X				X	
 jni@0.22.4	X							X					
 jni-macros@0.22.4	X							X					
 jni-sys@0.4.1	X							X					
 jni-sys-macros@0.4.1	X							X					
-jobserver@0.1.34	X							X					
-js-sys@0.3.98	X							X					
+jobserver@0.1.35	X							X					
+js-sys@0.3.103	X							X					
 libc@0.2.186	X							X					
-link-section@0.17.2	X							X					
-linktime-proc-macro@0.1.0	X							X					
+link-section@0.19.0	X							X					
+linktime-proc-macro@0.2.0	X							X					
 linux-raw-sys@0.12.1	X	X						X					
 litemap@0.8.2											X		
 lock_api@0.4.14	X							X					
-log@0.4.29	X							X					
+log@0.4.33	X							X					
 lru@0.16.4								X					
 md-5@0.11.0	X							X					
-mea@0.6.3	X												
-memchr@2.8.0								X				X	
+mea@0.6.4	X												
+memchr@2.8.2								X				X	
 mime@0.3.17	X							X					
 mime_guess@2.0.5								X					
-mio@1.2.0								X					
+mio@1.2.1								X					
 num-traits@0.2.19	X							X					
 once_cell@1.21.4	X							X					
-opendal@0.57.0	X												
-opendal-core@0.57.0	X												
-opendal-layer-concurrent-limit@0.57.0	X												
-opendal-layer-logging@0.57.0	X												
-opendal-layer-retry@0.57.0	X												
-opendal-layer-timeout@0.57.0	X												
-opendal-service-fs@0.57.0	X												
+opendal@0.58.0	X												
+opendal-core@0.58.0	X												
+opendal-http-transport-reqwest@0.58.0	X												
+opendal-layer-concurrent-limit@0.58.0	X												
+opendal-layer-logging@0.58.0	X												
+opendal-layer-retry@0.58.0	X												
+opendal-layer-timeout@0.58.0	X												
+opendal-service-fs@0.58.0	X												
 openssl-probe@0.2.1	X							X					
 parking_lot@0.12.5	X							X					
 parking_lot_core@0.9.12	X							X					
 percent-encoding@2.3.2	X							X					
 pin-project-lite@0.2.17	X							X					
+pkg-config@0.3.33	X							X					
 portable-atomic@1.13.1	X							X					
 portable-atomic-util@0.2.7	X							X					
 potential_utf@0.1.5											X		
 proc-macro2@1.0.106	X							X					
-quick-xml@0.39.4								X					
-quote@1.0.45	X							X					
-r-efi@5.3.0	X						X	X					
+quick-xml@0.41.0								X					
+quote@1.0.46	X							X					
 r-efi@6.0.0	X						X	X					
 redox_syscall@0.5.18								X					
-reflink-copy@0.1.29	X							X					
-reqsign-core@3.0.0	X												
-reqwest@0.13.3	X							X					
+reflink-copy@0.1.30	X							X					
+reqwest@0.13.4	X							X					
 rustc_version@0.4.1	X							X					
 rustix@1.1.4	X	X						X					
-rustls@0.23.40	X					X		X					
-rustls-native-certs@0.8.3	X					X		X					
-rustls-pki-types@1.14.1	X							X					
+rustls@0.23.41	X					X		X					
+rustls-native-certs@0.8.4	X					X		X					
+rustls-pki-types@1.15.0	X							X					
 rustls-platform-verifier@0.7.0	X							X					
 rustls-platform-verifier-android@0.1.1	X							X					
 rustls-webpki@0.103.13						X							
@@ -151,16 +147,15 @@ serde_core@1.0.228	X							X
 serde_derive@1.0.228	X							X					
 serde_json@1.0.150	X							X					
 sha1@0.10.6	X							X					
-sha2@0.10.9	X							X					
-shlex@1.3.0	X							X					
+shlex@2.0.1	X							X					
 simd_cesu8@1.1.1	X							X					
 simdutf8@0.1.5	X							X					
 slab@0.4.12								X					
-smallvec@1.15.1	X							X					
-socket2@0.6.3	X							X					
+smallvec@1.15.2	X							X					
+socket2@0.6.4	X							X					
 stable_deref_trait@1.2.1	X							X					
 subtle@2.6.1			X										
-syn@2.0.117	X							X					
+syn@2.0.118	X							X					
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2								X					
 thiserror@2.0.18	X							X					
@@ -177,28 +172,26 @@ tower-service@0.3.3								X
 tracing@0.1.44								X					
 tracing-core@0.1.36								X					
 try-lock@0.2.5								X					
-typenum@1.20.0	X							X					
+typenum@1.20.1	X							X					
 unicase@2.9.0	X							X					
 unicode-ident@1.0.24	X							X			X		
 untrusted@0.9.0						X							
 url@2.5.8	X							X					
 utf8_iter@1.0.4	X							X					
-uuid@1.23.1	X							X					
+uuid@1.23.4	X							X					
 version_check@0.9.5	X							X					
 walkdir@2.5.0								X				X	
 want@0.3.1								X					
 wasi@0.11.1+wasi-snapshot-preview1	X	X						X					
-wasip2@1.0.1+wasi-0.2.4	X	X						X					
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X						X					
-wasm-bindgen@0.2.121	X							X					
-wasm-bindgen-futures@0.4.71	X							X					
-wasm-bindgen-macro@0.2.121	X							X					
-wasm-bindgen-macro-support@0.2.121	X							X					
-wasm-bindgen-shared@0.2.121	X							X					
+wasm-bindgen@0.2.126	X							X					
+wasm-bindgen-futures@0.4.76	X							X					
+wasm-bindgen-macro@0.2.126	X							X					
+wasm-bindgen-macro-support@0.2.126	X							X					
+wasm-bindgen-shared@0.2.126	X							X					
 wasm-streams@0.5.0	X							X					
-web-sys@0.3.98	X							X					
+web-sys@0.3.103	X							X					
 web-time@1.1.0	X							X					
-webpki-root-certs@1.0.7					X								
+webpki-root-certs@1.0.8					X								
 winapi-util@0.1.11								X				X	
 windows@0.62.2	X							X					
 windows-collections@0.3.2	X							X					
@@ -212,18 +205,16 @@ windows-result@0.4.1	X							X
 windows-strings@0.5.1	X							X					
 windows-sys@0.61.2	X							X					
 windows-threading@0.2.1	X							X					
-wit-bindgen@0.46.0	X	X						X					
-wit-bindgen@0.51.0	X	X						X					
 writeable@0.6.3											X		
 xattr@1.6.1	X							X					
 xml@1.3.0								X					
 xml-rs@1.0.0								X					
 xmltree@0.12.0								X					
-yoke@0.8.2											X		
+yoke@0.8.3											X		
 yoke-derive@0.8.2											X		
 zerofrom@0.1.8											X		
 zerofrom-derive@0.1.7											X		
-zeroize@1.8.2	X							X					
+zeroize@1.9.0	X							X					
 zerotrie@0.2.4											X		
 zerovec@0.11.6											X		
 zerovec-derive@0.11.3											X		

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.57.0"
+version = "0.58.0"
 
 [features]
 send_wrapper = ["dep:send_wrapper"]
@@ -43,7 +43,7 @@ chrono = { version = "0.4.42", features = ["std", "clock"] }
 futures = "0.3"
 mea = "0.6"
 object_store = "0.13.1"
-opendal = { version = "0.57.0", path = "../../core", default-features = false }
+opendal = { version = "0.58.0", path = "../../core", default-features = false }
 pin-project = "1.1"
 send_wrapper = { version = "0.6", features = ["futures"], optional = true }
 tokio = { version = "1", default-features = false }
@@ -52,7 +52,7 @@ tokio = { version = "1", default-features = false }
 anyhow = "1.0.86"
 datafusion = "54.0.0"
 libtest-mimic = "0.8.1"
-opendal = { version = "0.57.0", path = "../../core", features = [
+opendal = { version = "0.58.0", path = "../../core", features = [
   "services-fs",
   "services-memory",
   "services-s3",

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -1,237 +1,266 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
-android_system_properties@0.1.5	X								X			
-anyhow@1.0.102	X								X			
-async-trait@0.1.89	X								X			
-atomic-waker@1.1.2	X								X			
-autocfg@1.5.0	X								X			
-aws-lc-rs@1.17.0	X						X					
-aws-lc-sys@0.41.0	X		X				X		X	X		
-backon@1.6.0	X											
-base64@0.22.1	X								X			
-bitflags@2.11.1	X								X			
-block-buffer@0.10.4	X								X			
-block-buffer@0.12.0	X								X			
-bumpalo@3.20.2	X								X			
-bytes@1.11.1									X			
-cc@1.2.62	X								X			
-cfg-if@1.0.4	X								X			
-chacha20@0.10.0	X								X			
-chrono@0.4.44	X								X			
-cmake@0.1.58	X								X			
-combine@4.6.7									X			
-const-oid@0.10.2	X								X			
-const-oid@0.9.6	X								X			
-const-random@0.1.18	X								X			
-const-random-macro@0.1.16	X								X			
-core-foundation@0.10.1	X								X			
-core-foundation-sys@0.8.7	X								X			
-cpufeatures@0.2.17	X								X			
-cpufeatures@0.3.0	X								X			
-crc32c@0.6.8	X								X			
-crunchy@0.2.4									X			
-crypto-common@0.1.7	X								X			
-crypto-common@0.2.2	X								X			
-ctor@1.0.6	X								X			
-digest@0.10.7	X								X			
-digest@0.11.3	X								X			
-displaydoc@0.2.5	X								X			
-dlv-list@0.5.2	X								X			
-dotenvy@0.15.7									X			
-dunce@1.0.5	X				X					X		
-either@1.16.0	X								X			
-errno@0.3.14	X								X			
-fastrand@2.4.1	X								X			
-find-msvc-tools@0.1.9	X								X			
-form_urlencoded@1.2.2	X								X			
-fs_extra@1.3.0									X			
-futures@0.3.32	X								X			
-futures-channel@0.3.32	X								X			
-futures-core@0.3.32	X								X			
-futures-executor@0.3.32	X								X			
-futures-io@0.3.32	X								X			
-futures-macro@0.3.32	X								X			
-futures-sink@0.3.32	X								X			
-futures-task@0.3.32	X								X			
-futures-util@0.3.32	X								X			
-generic-array@0.14.7									X			
-getrandom@0.2.17	X								X			
-getrandom@0.3.4	X								X			
-getrandom@0.4.2	X								X			
-gloo-timers@0.3.0	X								X			
-hashbrown@0.14.5	X								X			
-hex@0.4.3	X								X			
-hmac@0.12.1	X								X			
-http@1.4.0	X								X			
-http-body@1.0.1									X			
-http-body-util@0.1.3									X			
-httparse@1.10.1	X								X			
-humantime@2.3.0	X								X			
-hybrid-array@0.4.12	X								X			
-hyper@1.9.0									X			
-hyper-rustls@0.27.9	X						X		X			
-hyper-util@0.1.20									X			
-iana-time-zone@0.1.65	X								X			
-iana-time-zone-haiku@0.1.2	X								X			
-icu_collections@2.1.1											X	
-icu_locale_core@2.1.1											X	
-icu_normalizer@2.1.1											X	
-icu_normalizer_data@2.1.1											X	
-icu_properties@2.1.2											X	
-icu_properties_data@2.1.2											X	
-icu_provider@2.1.1											X	
-idna@1.1.0	X								X			
-idna_adapter@1.2.1	X								X			
-ipnet@2.12.0	X								X			
-itertools@0.14.0	X								X			
-itoa@1.0.18	X								X			
-jiff@0.2.24									X			X
-jiff-tzdb@0.1.6									X			X
-jiff-tzdb-platform@0.1.3									X			X
-jni@0.22.4	X								X			
-jni-macros@0.22.4	X								X			
-jni-sys@0.4.1	X								X			
-jni-sys-macros@0.4.1	X								X			
-jobserver@0.1.34	X								X			
-js-sys@0.3.98	X								X			
-libc@0.2.186	X								X			
-libm@0.2.16									X			
-link-section@0.17.2	X								X			
-linktime-proc-macro@0.1.0	X								X			
-linux-raw-sys@0.12.1	X	X							X			
-litemap@0.8.2											X	
-lock_api@0.4.14	X								X			
-log@0.4.29	X								X			
-md-5@0.11.0	X								X			
-mea@0.6.3	X											
-memchr@2.8.0									X			X
-mio@1.2.0									X			
-num-traits@0.2.19	X								X			
-object_store@0.13.2	X								X			
-object_store_opendal@0.57.0	X											
-once_cell@1.21.4	X								X			
-opendal@0.57.0	X											
-opendal-core@0.57.0	X											
-opendal-layer-concurrent-limit@0.57.0	X											
-opendal-layer-logging@0.57.0	X											
-opendal-layer-retry@0.57.0	X											
-opendal-layer-timeout@0.57.0	X											
-opendal-service-fs@0.57.0	X											
-opendal-service-s3@0.57.0	X											
-opendal-testkit@0.57.0	X											
-openssl-probe@0.2.1	X								X			
-ordered-multimap@0.7.3									X			
-parking_lot@0.12.5	X								X			
-parking_lot_core@0.9.12	X								X			
-percent-encoding@2.3.2	X								X			
-pin-project@1.1.13	X								X			
-pin-project-internal@1.1.13	X								X			
-pin-project-lite@0.2.17	X								X			
-portable-atomic@1.13.1	X								X			
-portable-atomic-util@0.2.7	X								X			
-potential_utf@0.1.5											X	
-proc-macro2@1.0.106	X								X			
-quick-xml@0.39.4									X			
-quote@1.0.45	X								X			
-r-efi@5.3.0	X							X	X			
-r-efi@6.0.0	X							X	X			
-rand@0.10.1	X								X			
-rand_core@0.10.1	X								X			
-redox_syscall@0.5.18									X			
-reqsign-aws-v4@3.0.0	X											
-reqsign-core@3.0.0	X											
-reqsign-file-read-tokio@3.0.0	X											
-reqwest@0.13.3	X								X			
-rust-ini@0.21.3									X			
-rustc_version@0.4.1	X								X			
-rustix@1.1.4	X	X							X			
-rustls@0.23.40	X						X		X			
-rustls-native-certs@0.8.3	X						X		X			
-rustls-pki-types@1.14.1	X								X			
-rustls-platform-verifier@0.7.0	X								X			
-rustls-platform-verifier-android@0.1.1	X								X			
-rustls-webpki@0.103.13							X					
-rustversion@1.0.22	X								X			
-ryu@1.0.23	X			X								
-same-file@1.0.6									X			X
-schannel@0.1.29									X			
-scopeguard@1.2.0	X								X			
-security-framework@3.7.0	X								X			
-security-framework-sys@2.17.0	X								X			
-semver@1.0.28	X								X			
-serde@1.0.228	X								X			
-serde_core@1.0.228	X								X			
-serde_derive@1.0.228	X								X			
-serde_json@1.0.150	X								X			
-serde_urlencoded@0.7.1	X								X			
-sha1@0.10.6	X								X			
-sha2@0.10.9	X								X			
-sha2@0.11.0	X								X			
-shlex@1.3.0	X								X			
-simd_cesu8@1.1.1	X								X			
-simdutf8@0.1.5	X								X			
-slab@0.4.12									X			
-smallvec@1.15.1	X								X			
-socket2@0.6.3	X								X			
-stable_deref_trait@1.2.1	X								X			
-subtle@2.6.1			X									
-syn@2.0.117	X								X			
-sync_wrapper@1.0.2	X											
-synstructure@0.13.2									X			
-thiserror@2.0.18	X								X			
-thiserror-impl@2.0.18	X								X			
-tiny-keccak@2.0.2					X							
-tinystr@0.8.3											X	
-tokio@1.52.3									X			
-tokio-macros@2.7.0									X			
-tokio-rustls@0.26.4	X								X			
-tokio-util@0.7.18									X			
-tower@0.5.3									X			
-tower-http@0.6.11									X			
-tower-layer@0.3.3									X			
-tower-service@0.3.3									X			
-tracing@0.1.44									X			
-tracing-attributes@0.1.31									X			
-tracing-core@0.1.36									X			
-try-lock@0.2.5									X			
-typenum@1.20.0	X								X			
-unicode-ident@1.0.24	X								X		X	
-untrusted@0.9.0							X					
-url@2.5.8	X								X			
-utf8_iter@1.0.4	X								X			
-uuid@1.23.1	X								X			
-version_check@0.9.5	X								X			
-walkdir@2.5.0									X			X
-want@0.3.1									X			
-wasi@0.11.1+wasi-snapshot-preview1	X	X							X			
-wasip2@1.0.1+wasi-0.2.4	X	X							X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X							X			
-wasm-bindgen@0.2.121	X								X			
-wasm-bindgen-futures@0.4.71	X								X			
-wasm-bindgen-macro@0.2.121	X								X			
-wasm-bindgen-macro-support@0.2.121	X								X			
-wasm-bindgen-shared@0.2.121	X								X			
-wasm-streams@0.5.0	X								X			
-web-sys@0.3.98	X								X			
-web-time@1.1.0	X								X			
-webpki-root-certs@1.0.7						X						
-winapi-util@0.1.11									X			X
-windows-core@0.62.2	X								X			
-windows-implement@0.60.2	X								X			
-windows-interface@0.59.3	X								X			
-windows-link@0.2.1	X								X			
-windows-result@0.4.1	X								X			
-windows-strings@0.5.1	X								X			
-windows-sys@0.61.2	X								X			
-wit-bindgen@0.46.0	X	X							X			
-wit-bindgen@0.51.0	X	X							X			
-writeable@0.6.3											X	
-xattr@1.6.1	X								X			
-yoke@0.8.2											X	
-yoke-derive@0.8.2											X	
-zerofrom@0.1.8											X	
-zerofrom-derive@0.1.7											X	
-zeroize@1.8.2	X								X			
-zerotrie@0.2.4											X	
-zerovec@0.11.6											X	
-zerovec-derive@0.11.3											X	
-zmij@1.0.21									X			
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
+aes@0.8.4	X									X			
+android_system_properties@0.1.5	X									X			
+anyhow@1.0.103	X									X			
+async-trait@0.1.89	X									X			
+atomic-waker@1.1.2	X									X			
+autocfg@1.5.1	X									X			
+aws-lc-rs@1.17.1	X							X					
+aws-lc-sys@0.42.0	X			X				X		X	X		
+backon@1.6.0	X												
+base64@0.22.1	X									X			
+base64ct@1.8.3	X									X			
+bitflags@2.13.0	X									X			
+block-buffer@0.10.4	X									X			
+block-buffer@0.12.1	X									X			
+block-padding@0.3.3	X									X			
+bumpalo@3.20.3	X									X			
+bytes@1.12.0										X			
+cbc@0.1.2	X									X			
+cc@1.2.66	X									X			
+cfg-if@1.0.4	X									X			
+chacha20@0.10.1	X									X			
+chrono@0.4.45	X									X			
+cipher@0.4.4	X									X			
+cmake@0.1.58	X									X			
+cmov@0.5.4	X									X			
+combine@4.6.7										X			
+const-oid@0.10.2	X									X			
+const-oid@0.9.6	X									X			
+const-random@0.1.18	X									X			
+const-random-macro@0.1.16	X									X			
+core-foundation@0.10.1	X									X			
+core-foundation-sys@0.8.7	X									X			
+cpufeatures@0.2.17	X									X			
+cpufeatures@0.3.0	X									X			
+crc-fast@1.10.0	X									X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7	X									X			
+crypto-common@0.2.2	X									X			
+ctor@1.0.8	X									X			
+ctutils@0.4.2	X									X			
+der@0.7.10	X									X			
+digest@0.10.7	X									X			
+digest@0.11.3	X									X			
+displaydoc@0.2.6	X									X			
+dlv-list@0.5.2	X									X			
+dotenvy@0.15.7										X			
+dunce@1.0.5	X					X					X		
+either@1.16.0	X									X			
+errno@0.3.14	X									X			
+fastrand@2.4.1	X									X			
+find-msvc-tools@0.1.9	X									X			
+form_urlencoded@1.2.2	X									X			
+fs_extra@1.3.0										X			
+futures@0.3.32	X									X			
+futures-channel@0.3.32	X									X			
+futures-core@0.3.32	X									X			
+futures-executor@0.3.32	X									X			
+futures-io@0.3.32	X									X			
+futures-macro@0.3.32	X									X			
+futures-sink@0.3.32	X									X			
+futures-task@0.3.32	X									X			
+futures-util@0.3.32	X									X			
+generic-array@0.14.7										X			
+getrandom@0.2.17	X									X			
+getrandom@0.4.3	X									X			
+gloo-timers@0.3.0	X									X			
+hashbrown@0.14.5	X									X			
+hex@0.4.3	X									X			
+hmac@0.12.1	X									X			
+hmac@0.13.0	X									X			
+http@1.4.2	X									X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1	X									X			
+humantime@2.4.0	X									X			
+hybrid-array@0.4.13	X									X			
+hyper@1.10.1										X			
+hyper-rustls@0.27.9	X							X		X			
+hyper-util@0.1.20										X			
+iana-time-zone@0.1.65	X									X			
+iana-time-zone-haiku@0.1.2	X									X			
+icu_collections@2.2.0												X	
+icu_locale_core@2.2.0												X	
+icu_normalizer@2.2.0												X	
+icu_normalizer_data@2.2.0												X	
+icu_properties@2.2.0												X	
+icu_properties_data@2.2.0												X	
+icu_provider@2.2.0												X	
+idna@1.1.0	X									X			
+idna_adapter@1.2.2	X									X			
+inout@0.1.4	X									X			
+ipnet@2.12.0	X									X			
+itertools@0.14.0	X									X			
+itoa@1.0.18	X									X			
+jiff@0.2.31										X			X
+jiff-tzdb@0.1.7										X			X
+jiff-tzdb-platform@0.1.3										X			X
+jni@0.22.4	X									X			
+jni-macros@0.22.4	X									X			
+jni-sys@0.4.1	X									X			
+jni-sys-macros@0.4.1	X									X			
+jobserver@0.1.35	X									X			
+js-sys@0.3.103	X									X			
+lazy_static@1.5.0	X									X			
+libc@0.2.186	X									X			
+libm@0.2.16										X			
+link-section@0.19.0	X									X			
+linktime-proc-macro@0.2.0	X									X			
+linux-raw-sys@0.12.1	X	X								X			
+litemap@0.8.2												X	
+lock_api@0.4.14	X									X			
+log@0.4.33	X									X			
+md-5@0.11.0	X									X			
+mea@0.6.4	X												
+memchr@2.8.2										X			X
+mio@1.2.1										X			
+num-bigint-dig@0.8.6	X									X			
+num-integer@0.1.46	X									X			
+num-iter@0.1.45	X									X			
+num-traits@0.2.19	X									X			
+object_store@0.13.2	X									X			
+object_store_opendal@0.58.0	X												
+once_cell@1.21.4	X									X			
+opendal@0.58.0	X												
+opendal-core@0.58.0	X												
+opendal-http-transport-reqwest@0.58.0	X												
+opendal-layer-concurrent-limit@0.58.0	X												
+opendal-layer-logging@0.58.0	X												
+opendal-layer-retry@0.58.0	X												
+opendal-layer-timeout@0.58.0	X												
+opendal-service-fs@0.58.0	X												
+opendal-service-s3@0.58.0	X												
+opendal-testkit@0.58.0	X												
+openssl-probe@0.2.1	X									X			
+ordered-multimap@0.7.3										X			
+parking_lot@0.12.5	X									X			
+parking_lot_core@0.9.12	X									X			
+pbkdf2@0.12.2	X									X			
+pem-rfc7468@0.7.0	X									X			
+percent-encoding@2.3.2	X									X			
+pin-project@1.1.13	X									X			
+pin-project-internal@1.1.13	X									X			
+pin-project-lite@0.2.17	X									X			
+pkcs1@0.7.5	X									X			
+pkcs5@0.7.1	X									X			
+pkcs8@0.10.2	X									X			
+pkg-config@0.3.33	X									X			
+portable-atomic@1.13.1	X									X			
+portable-atomic-util@0.2.7	X									X			
+potential_utf@0.1.5												X	
+ppv-lite86@0.2.21	X									X			
+proc-macro2@1.0.106	X									X			
+quick-xml@0.40.1										X			
+quick-xml@0.41.0										X			
+quote@1.0.46	X									X			
+r-efi@6.0.0	X								X	X			
+rand@0.10.2	X									X			
+rand@0.8.6	X									X			
+rand_chacha@0.3.1	X									X			
+rand_core@0.10.1	X									X			
+rand_core@0.6.4	X									X			
+redox_syscall@0.5.18										X			
+reqsign-aws-v4@3.0.1	X												
+reqsign-core@3.0.1	X												
+reqsign-file-read-tokio@3.0.1	X												
+reqwest@0.13.4	X									X			
+rsa@0.9.10	X									X			
+rust-ini@0.21.3										X			
+rustc_version@0.4.1	X									X			
+rustix@1.1.4	X	X								X			
+rustls@0.23.41	X							X		X			
+rustls-native-certs@0.8.4	X							X		X			
+rustls-pki-types@1.15.0	X									X			
+rustls-platform-verifier@0.7.0	X									X			
+rustls-platform-verifier-android@0.1.1	X									X			
+rustls-webpki@0.103.13								X					
+rustversion@1.0.22	X									X			
+ryu@1.0.23	X				X								
+salsa20@0.10.2	X									X			
+same-file@1.0.6										X			X
+schannel@0.1.29										X			
+scopeguard@1.2.0	X									X			
+scrypt@0.11.0	X									X			
+security-framework@3.7.0	X									X			
+security-framework-sys@2.17.0	X									X			
+semver@1.0.28	X									X			
+serde@1.0.228	X									X			
+serde_core@1.0.228	X									X			
+serde_derive@1.0.228	X									X			
+serde_json@1.0.150	X									X			
+serde_urlencoded@0.7.1	X									X			
+sha1@0.11.0	X									X			
+sha2@0.10.9	X									X			
+sha2@0.11.0	X									X			
+shlex@2.0.1	X									X			
+signature@2.2.0	X									X			
+simd_cesu8@1.1.1	X									X			
+simdutf8@0.1.5	X									X			
+slab@0.4.12										X			
+smallvec@1.15.2	X									X			
+socket2@0.6.4	X									X			
+spin@0.10.0										X			
+spin@0.9.8										X			
+spki@0.7.3	X									X			
+stable_deref_trait@1.2.1	X									X			
+subtle@2.6.1				X									
+syn@2.0.118	X									X			
+sync_wrapper@1.0.2	X												
+synstructure@0.13.2										X			
+thiserror@2.0.18	X									X			
+thiserror-impl@2.0.18	X									X			
+tiny-keccak@2.0.2						X							
+tinystr@0.8.3												X	
+tokio@1.52.3										X			
+tokio-macros@2.7.0										X			
+tokio-rustls@0.26.4	X									X			
+tokio-util@0.7.18										X			
+tower@0.5.3										X			
+tower-http@0.6.11										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-attributes@0.1.31										X			
+tracing-core@0.1.36										X			
+try-lock@0.2.5										X			
+typenum@1.20.1	X									X			
+unicode-ident@1.0.24	X									X		X	
+untrusted@0.9.0								X					
+url@2.5.8	X									X			
+utf8_iter@1.0.4	X									X			
+uuid@1.23.4	X									X			
+version_check@0.9.5	X									X			
+walkdir@2.5.0										X			X
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
+wasm-bindgen@0.2.126	X									X			
+wasm-bindgen-futures@0.4.76	X									X			
+wasm-bindgen-macro@0.2.126	X									X			
+wasm-bindgen-macro-support@0.2.126	X									X			
+wasm-bindgen-shared@0.2.126	X									X			
+wasm-streams@0.5.0	X									X			
+web-sys@0.3.103	X									X			
+web-time@1.1.0	X									X			
+webpki-root-certs@1.0.8							X						
+winapi-util@0.1.11										X			X
+windows-core@0.62.2	X									X			
+windows-implement@0.60.2	X									X			
+windows-interface@0.59.3	X									X			
+windows-link@0.2.1	X									X			
+windows-result@0.4.1	X									X			
+windows-strings@0.5.1	X									X			
+windows-sys@0.61.2	X									X			
+writeable@0.6.3												X	
+xattr@1.6.1	X									X			
+yoke@0.8.3												X	
+yoke-derive@0.8.2												X	
+zerocopy@0.8.53	X		X							X			
+zerocopy-derive@0.8.53	X		X							X			
+zerofrom@0.1.8												X	
+zerofrom-derive@0.1.7												X	
+zeroize@1.9.0	X									X			
+zerotrie@0.2.4												X	
+zerovec@0.11.6												X	
+zerovec-derive@0.11.3												X	
+zmij@1.0.21										X			

--- a/integrations/parquet/Cargo.toml
+++ b/integrations/parquet/Cargo.toml
@@ -25,13 +25,13 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.8.1"
+version = "0.8.2"
 
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
-opendal = { version = "0.57.0", path = "../../core" }
+opendal = { version = "0.58.0", path = "../../core" }
 parquet = { version = "58.0", default-features = false, features = [
   "async",
   "arrow",
@@ -39,7 +39,7 @@ parquet = { version = "58.0", default-features = false, features = [
 
 [dev-dependencies]
 arrow = { version = "58.0" }
-opendal = { version = "0.57.0", path = "../../core", features = [
+opendal = { version = "0.58.0", path = "../../core", features = [
   "services-memory",
   "services-s3",
 ] }

--- a/integrations/parquet/DEPENDENCIES.rust.tsv
+++ b/integrations/parquet/DEPENDENCIES.rust.tsv
@@ -1,7 +1,8 @@
 crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
+aes@0.8.4	X									X			
 ahash@0.8.12	X									X			
 android_system_properties@0.1.5	X									X			
-anyhow@1.0.102	X									X			
+anyhow@1.0.103	X									X			
 arrow-array@58.3.0	X									X			
 arrow-buffer@58.3.0	X												
 arrow-data@58.3.0	X												
@@ -10,21 +11,26 @@ arrow-schema@58.3.0	X
 arrow-select@58.3.0	X												
 async-trait@0.1.89	X									X			
 atomic-waker@1.1.2	X									X			
-autocfg@1.5.0	X									X			
-aws-lc-rs@1.17.0	X							X					
-aws-lc-sys@0.41.0	X			X				X		X	X		
+autocfg@1.5.1	X									X			
+aws-lc-rs@1.17.1	X							X					
+aws-lc-sys@0.42.0	X			X				X		X	X		
 backon@1.6.0	X												
 base64@0.22.1	X									X			
-bitflags@2.11.1	X									X			
+base64ct@1.8.3	X									X			
+bitflags@2.13.0	X									X			
 block-buffer@0.10.4	X									X			
-block-buffer@0.12.0	X									X			
-bumpalo@3.20.2	X									X			
+block-buffer@0.12.1	X									X			
+block-padding@0.3.3	X									X			
+bumpalo@3.20.3	X									X			
 byteorder@1.5.0										X			X
-bytes@1.11.1										X			
-cc@1.2.62	X									X			
+bytes@1.12.0										X			
+cbc@0.1.2	X									X			
+cc@1.2.66	X									X			
 cfg-if@1.0.4	X									X			
-chrono@0.4.44	X									X			
+chrono@0.4.45	X									X			
+cipher@0.4.4	X									X			
 cmake@0.1.58	X									X			
+cmov@0.5.4	X									X			
 combine@4.6.7										X			
 const-oid@0.10.2	X									X			
 const-oid@0.9.6	X									X			
@@ -33,14 +39,17 @@ const-random-macro@0.1.16	X									X
 core-foundation@0.10.1	X									X			
 core-foundation-sys@0.8.7	X									X			
 cpufeatures@0.2.17	X									X			
-crc32c@0.6.8	X									X			
+cpufeatures@0.3.0	X									X			
+crc-fast@1.10.0	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
 crypto-common@0.2.2	X									X			
-ctor@1.0.6	X									X			
+ctor@1.0.8	X									X			
+ctutils@0.4.2	X									X			
+der@0.7.10	X									X			
 digest@0.10.7	X									X			
 digest@0.11.3	X									X			
-displaydoc@0.2.5	X									X			
+displaydoc@0.2.6	X									X			
 dlv-list@0.5.2	X									X			
 dunce@1.0.5	X					X					X		
 fastrand@2.4.1	X									X			
@@ -60,99 +69,119 @@ futures-util@0.3.32	X									X
 generic-array@0.14.7										X			
 getrandom@0.2.17	X									X			
 getrandom@0.3.4	X									X			
-getrandom@0.4.2	X									X			
+getrandom@0.4.3	X									X			
 gloo-timers@0.3.0	X									X			
 half@2.7.1	X									X			
 hashbrown@0.14.5	X									X			
 hashbrown@0.17.1	X									X			
 hex@0.4.3	X									X			
 hmac@0.12.1	X									X			
-http@1.4.0	X									X			
+hmac@0.13.0	X									X			
+http@1.4.2	X									X			
 http-body@1.0.1										X			
 http-body-util@0.1.3										X			
 httparse@1.10.1	X									X			
-hybrid-array@0.4.12	X									X			
-hyper@1.9.0										X			
+hybrid-array@0.4.13	X									X			
+hyper@1.10.1										X			
 hyper-rustls@0.27.9	X							X		X			
 hyper-util@0.1.20										X			
 iana-time-zone@0.1.65	X									X			
 iana-time-zone-haiku@0.1.2	X									X			
-icu_collections@2.1.1												X	
-icu_locale_core@2.1.1												X	
-icu_normalizer@2.1.1												X	
-icu_normalizer_data@2.1.1												X	
-icu_properties@2.1.2												X	
-icu_properties_data@2.1.2												X	
-icu_provider@2.1.1												X	
+icu_collections@2.2.0												X	
+icu_locale_core@2.2.0												X	
+icu_normalizer@2.2.0												X	
+icu_normalizer_data@2.2.0												X	
+icu_properties@2.2.0												X	
+icu_properties_data@2.2.0												X	
+icu_provider@2.2.0												X	
 idna@1.1.0	X									X			
-idna_adapter@1.2.1	X									X			
+idna_adapter@1.2.2	X									X			
+inout@0.1.4	X									X			
 integer-encoding@3.0.4										X			
 ipnet@2.12.0	X									X			
 itoa@1.0.18	X									X			
-jiff@0.2.24										X			X
-jiff-tzdb@0.1.6										X			X
+jiff@0.2.31										X			X
+jiff-tzdb@0.1.7										X			X
 jiff-tzdb-platform@0.1.3										X			X
 jni@0.22.4	X									X			
 jni-macros@0.22.4	X									X			
 jni-sys@0.4.1	X									X			
 jni-sys-macros@0.4.1	X									X			
-jobserver@0.1.34	X									X			
-js-sys@0.3.98	X									X			
+jobserver@0.1.35	X									X			
+js-sys@0.3.103	X									X			
+lazy_static@1.5.0	X									X			
 libc@0.2.186	X									X			
 libm@0.2.16										X			
-link-section@0.17.2	X									X			
-linktime-proc-macro@0.1.0	X									X			
+link-section@0.19.0	X									X			
+linktime-proc-macro@0.2.0	X									X			
 litemap@0.8.2												X	
-log@0.4.29	X									X			
+log@0.4.33	X									X			
 md-5@0.11.0	X									X			
-mea@0.6.3	X												
-memchr@2.8.0										X			X
-mio@1.2.0										X			
-num-bigint@0.4.6	X									X			
+mea@0.6.4	X												
+memchr@2.8.2										X			X
+mio@1.2.1										X			
+num-bigint@0.4.8	X									X			
+num-bigint-dig@0.8.6	X									X			
 num-complex@0.4.6	X									X			
 num-integer@0.1.46	X									X			
+num-iter@0.1.45	X									X			
 num-traits@0.2.19	X									X			
 once_cell@1.21.4	X									X			
-opendal@0.57.0	X												
-opendal-core@0.57.0	X												
-opendal-layer-concurrent-limit@0.57.0	X												
-opendal-layer-logging@0.57.0	X												
-opendal-layer-retry@0.57.0	X												
-opendal-layer-timeout@0.57.0	X												
-opendal-service-s3@0.57.0	X												
+opendal@0.58.0	X												
+opendal-core@0.58.0	X												
+opendal-http-transport-reqwest@0.58.0	X												
+opendal-layer-concurrent-limit@0.58.0	X												
+opendal-layer-logging@0.58.0	X												
+opendal-layer-retry@0.58.0	X												
+opendal-layer-timeout@0.58.0	X												
+opendal-service-s3@0.58.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-float@2.10.1										X			
 ordered-multimap@0.7.3										X			
 parquet@58.3.0	X												
-parquet_opendal@0.8.1	X												
+parquet_opendal@0.8.2	X												
 paste@1.0.15	X									X			
+pbkdf2@0.12.2	X									X			
+pem-rfc7468@0.7.0	X									X			
 percent-encoding@2.3.2	X									X			
 pin-project-lite@0.2.17	X									X			
+pkcs1@0.7.5	X									X			
+pkcs5@0.7.1	X									X			
+pkcs8@0.10.2	X									X			
+pkg-config@0.3.33	X									X			
 portable-atomic@1.13.1	X									X			
 portable-atomic-util@0.2.7	X									X			
 potential_utf@0.1.5												X	
+ppv-lite86@0.2.21	X									X			
 proc-macro2@1.0.106	X									X			
-quick-xml@0.39.4										X			
-quote@1.0.45	X									X			
+quick-xml@0.40.1										X			
+quick-xml@0.41.0										X			
+quote@1.0.46	X									X			
 r-efi@5.3.0	X								X	X			
 r-efi@6.0.0	X								X	X			
+rand@0.8.6	X									X			
+rand_chacha@0.3.1	X									X			
 rand_core@0.10.1	X									X			
-reqsign-aws-v4@3.0.0	X												
-reqsign-core@3.0.0	X												
-reqsign-file-read-tokio@3.0.0	X												
-reqwest@0.13.3	X									X			
+rand_core@0.6.4	X									X			
+reqsign-aws-v4@3.0.1	X												
+reqsign-core@3.0.1	X												
+reqsign-file-read-tokio@3.0.1	X												
+reqwest@0.13.4	X									X			
+rsa@0.9.10	X									X			
 rust-ini@0.21.3										X			
 rustc_version@0.4.1	X									X			
-rustls@0.23.40	X							X		X			
-rustls-native-certs@0.8.3	X							X		X			
-rustls-pki-types@1.14.1	X									X			
+rustls@0.23.41	X							X		X			
+rustls-native-certs@0.8.4	X							X		X			
+rustls-pki-types@1.15.0	X									X			
 rustls-platform-verifier@0.7.0	X									X			
 rustls-platform-verifier-android@0.1.1	X									X			
 rustls-webpki@0.103.13								X					
 rustversion@1.0.22	X									X			
 ryu@1.0.23	X				X								
+salsa20@0.10.2	X									X			
 same-file@1.0.6										X			X
 schannel@0.1.29										X			
+scrypt@0.11.0	X									X			
 security-framework@3.7.0	X									X			
 security-framework-sys@2.17.0	X									X			
 semver@1.0.28	X									X			
@@ -162,17 +191,22 @@ serde_core@1.0.228	X									X
 serde_derive@1.0.228	X									X			
 serde_json@1.0.150	X									X			
 serde_urlencoded@0.7.1	X									X			
-sha1@0.10.6	X									X			
+sha1@0.11.0	X									X			
 sha2@0.10.9	X									X			
-shlex@1.3.0	X									X			
+sha2@0.11.0	X									X			
+shlex@2.0.1	X									X			
+signature@2.2.0	X									X			
 simd_cesu8@1.1.1	X									X			
 simdutf8@0.1.5	X									X			
 slab@0.4.12										X			
-smallvec@1.15.1	X									X			
-socket2@0.6.3	X									X			
+smallvec@1.15.2	X									X			
+socket2@0.6.4	X									X			
+spin@0.10.0										X			
+spin@0.9.8										X			
+spki@0.7.3	X									X			
 stable_deref_trait@1.2.1	X									X			
 subtle@2.6.1				X									
-syn@2.0.117	X									X			
+syn@2.0.118	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
 thiserror@2.0.18	X									X			
@@ -192,27 +226,26 @@ tracing@0.1.44										X
 tracing-core@0.1.36										X			
 try-lock@0.2.5										X			
 twox-hash@2.1.2										X			
-typenum@1.20.0	X									X			
+typenum@1.20.1	X									X			
 unicode-ident@1.0.24	X									X		X	
 untrusted@0.9.0								X					
 url@2.5.8	X									X			
 utf8_iter@1.0.4	X									X			
-uuid@1.23.1	X									X			
+uuid@1.23.4	X									X			
 version_check@0.9.5	X									X			
 walkdir@2.5.0										X			X
 want@0.3.1										X			
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
-wasip2@1.0.1+wasi-0.2.4	X	X								X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X								X			
-wasm-bindgen@0.2.121	X									X			
-wasm-bindgen-futures@0.4.71	X									X			
-wasm-bindgen-macro@0.2.121	X									X			
-wasm-bindgen-macro-support@0.2.121	X									X			
-wasm-bindgen-shared@0.2.121	X									X			
+wasip2@1.0.4+wasi-0.2.12	X	X								X			
+wasm-bindgen@0.2.126	X									X			
+wasm-bindgen-futures@0.4.76	X									X			
+wasm-bindgen-macro@0.2.126	X									X			
+wasm-bindgen-macro-support@0.2.126	X									X			
+wasm-bindgen-shared@0.2.126	X									X			
 wasm-streams@0.5.0	X									X			
-web-sys@0.3.98	X									X			
+web-sys@0.3.103	X									X			
 web-time@1.1.0	X									X			
-webpki-root-certs@1.0.7							X						
+webpki-root-certs@1.0.8							X						
 winapi-util@0.1.11										X			X
 windows-core@0.62.2	X									X			
 windows-implement@0.60.2	X									X			
@@ -221,16 +254,15 @@ windows-link@0.2.1	X									X
 windows-result@0.4.1	X									X			
 windows-strings@0.5.1	X									X			
 windows-sys@0.61.2	X									X			
-wit-bindgen@0.46.0	X	X								X			
-wit-bindgen@0.51.0	X	X								X			
+wit-bindgen@0.57.1	X	X								X			
 writeable@0.6.3												X	
-yoke@0.8.2												X	
+yoke@0.8.3												X	
 yoke-derive@0.8.2												X	
-zerocopy@0.8.48	X		X							X			
-zerocopy-derive@0.8.48	X		X							X			
+zerocopy@0.8.53	X		X							X			
+zerocopy-derive@0.8.53	X		X							X			
 zerofrom@0.1.8												X	
 zerofrom-derive@0.1.7												X	
-zeroize@1.8.2	X									X			
+zeroize@1.9.0	X									X			
 zerotrie@0.2.4												X	
 zerovec@0.11.6												X	
 zerovec-derive@0.11.3												X	

--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -24,11 +24,11 @@ license = "Apache-2.0"
 name = "unftp-sbe-opendal"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.4.2"
+version = "0.4.3"
 
 [dependencies]
 async-trait = "0.1.88"
-opendal = { version = "0.57.0", path = "../../core" }
+opendal = { version = "0.58.0", path = "../../core" }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.7.11", features = ["compat"] }
 unftp-core = "0.1.0"
@@ -36,7 +36,7 @@ unftp-core = "0.1.0"
 [dev-dependencies]
 anyhow = "1"
 libunftp = "0.23.0"
-opendal = { version = "0.57.0", path = "../../core", features = [
+opendal = { version = "0.58.0", path = "../../core", features = [
   "services-s3",
 ] }
 tokio = { version = "1.38.0", default-features = false, features = [

--- a/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
+++ b/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
@@ -1,240 +1,269 @@
-crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
-android_system_properties@0.1.5	X								X			
-anyhow@1.0.102	X								X			
-asn1-rs@0.7.2	X								X			
-asn1-rs-derive@0.6.0	X								X			
-asn1-rs-impl@0.2.0	X								X			
-async-trait@0.1.89	X								X			
-atomic-waker@1.1.2	X								X			
-autocfg@1.5.0	X								X			
-aws-lc-rs@1.17.0	X						X					
-aws-lc-sys@0.41.0	X		X				X		X	X		
-backon@1.6.0	X											
-base64@0.22.1	X								X			
-bitflags@2.11.1	X								X			
-block-buffer@0.10.4	X								X			
-block-buffer@0.12.0	X								X			
-bumpalo@3.20.2	X								X			
-bytes@1.11.1									X			
-cc@1.2.62	X								X			
-cfg-if@1.0.4	X								X			
-chrono@0.4.44	X								X			
-cmake@0.1.58	X								X			
-combine@4.6.7									X			
-const-oid@0.10.2	X								X			
-const-oid@0.9.6	X								X			
-const-random@0.1.18	X								X			
-const-random-macro@0.1.16	X								X			
-convert_case@0.10.0									X			
-core-foundation@0.10.1	X								X			
-core-foundation-sys@0.8.7	X								X			
-cpufeatures@0.2.17	X								X			
-crc32c@0.6.8	X								X			
-crunchy@0.2.4									X			
-crypto-common@0.1.7	X								X			
-crypto-common@0.2.2	X								X			
-ctor@1.0.6	X								X			
-data-encoding@2.11.0									X			
-der-parser@10.0.0	X								X			
-deranged@0.5.8	X								X			
-derive_more@2.1.1									X			
-derive_more-impl@2.1.1									X			
-digest@0.10.7	X								X			
-digest@0.11.3	X								X			
-displaydoc@0.2.5	X								X			
-dlv-list@0.5.2	X								X			
-dunce@1.0.5	X				X					X		
-errno@0.3.14	X								X			
-fastrand@2.4.1	X								X			
-find-msvc-tools@0.1.9	X								X			
-form_urlencoded@1.2.2	X								X			
-fs_extra@1.3.0									X			
-futures@0.3.32	X								X			
-futures-channel@0.3.32	X								X			
-futures-core@0.3.32	X								X			
-futures-executor@0.3.32	X								X			
-futures-io@0.3.32	X								X			
-futures-macro@0.3.32	X								X			
-futures-sink@0.3.32	X								X			
-futures-task@0.3.32	X								X			
-futures-util@0.3.32	X								X			
-generic-array@0.14.7									X			
-getrandom@0.2.17	X								X			
-getrandom@0.3.4	X								X			
-getrandom@0.4.2	X								X			
-gloo-timers@0.3.0	X								X			
-hashbrown@0.14.5	X								X			
-hex@0.4.3	X								X			
-hmac@0.12.1	X								X			
-http@1.4.0	X								X			
-http-body@1.0.1									X			
-http-body-util@0.1.3									X			
-httparse@1.10.1	X								X			
-hybrid-array@0.4.12	X								X			
-hyper@1.9.0									X			
-hyper-rustls@0.27.9	X						X		X			
-hyper-util@0.1.20									X			
-iana-time-zone@0.1.65	X								X			
-iana-time-zone-haiku@0.1.2	X								X			
-icu_collections@2.1.1											X	
-icu_locale_core@2.1.1											X	
-icu_normalizer@2.1.1											X	
-icu_normalizer_data@2.1.1											X	
-icu_properties@2.1.2											X	
-icu_properties_data@2.1.2											X	
-icu_provider@2.1.1											X	
-idna@1.1.0	X								X			
-idna_adapter@1.2.1	X								X			
-ipnet@2.12.0	X								X			
-itoa@1.0.18	X								X			
-jiff@0.2.24									X			X
-jiff-tzdb@0.1.6									X			X
-jiff-tzdb-platform@0.1.3									X			X
-jni@0.22.4	X								X			
-jni-macros@0.22.4	X								X			
-jni-sys@0.4.1	X								X			
-jni-sys-macros@0.4.1	X								X			
-jobserver@0.1.34	X								X			
-js-sys@0.3.98	X								X			
-lazy_static@1.5.0	X								X			
-libc@0.2.186	X								X			
-link-section@0.17.2	X								X			
-linktime-proc-macro@0.1.0	X								X			
-litemap@0.8.2											X	
-log@0.4.29	X								X			
-md-5@0.10.6	X								X			
-md-5@0.11.0	X								X			
-mea@0.6.3	X											
-memchr@2.8.0									X			X
-minimal-lexical@0.2.1	X								X			
-mio@1.2.0									X			
-nom@7.1.3									X			
-num-bigint@0.4.6	X								X			
-num-conv@0.1.0	X								X			
-num-integer@0.1.46	X								X			
-num-traits@0.2.19	X								X			
-oid-registry@0.8.1	X								X			
-once_cell@1.21.4	X								X			
-opendal@0.57.0	X											
-opendal-core@0.57.0	X											
-opendal-layer-concurrent-limit@0.57.0	X											
-opendal-layer-logging@0.57.0	X											
-opendal-layer-retry@0.57.0	X											
-opendal-layer-timeout@0.57.0	X											
-opendal-service-s3@0.57.0	X											
-openssl-probe@0.2.1	X								X			
-ordered-multimap@0.7.3									X			
-percent-encoding@2.3.2	X								X			
-pin-project-lite@0.2.17	X								X			
-portable-atomic@1.13.1	X								X			
-portable-atomic-util@0.2.7	X								X			
-potential_utf@0.1.5											X	
-powerfmt@0.2.0	X								X			
-proc-macro2@1.0.106	X								X			
-quick-xml@0.39.4									X			
-quote@1.0.45	X								X			
-r-efi@5.3.0	X							X	X			
-r-efi@6.0.0	X							X	X			
-reqsign-aws-v4@3.0.0	X											
-reqsign-core@3.0.0	X											
-reqsign-file-read-tokio@3.0.0	X											
-reqwest@0.13.3	X								X			
-rust-ini@0.21.3									X			
-rustc_version@0.4.1	X								X			
-rusticata-macros@4.1.0	X								X			
-rustls@0.23.40	X						X		X			
-rustls-native-certs@0.8.3	X						X		X			
-rustls-pki-types@1.14.1	X								X			
-rustls-platform-verifier@0.7.0	X								X			
-rustls-platform-verifier-android@0.1.1	X								X			
-rustls-webpki@0.103.13							X					
-rustversion@1.0.22	X								X			
-ryu@1.0.23	X			X								
-same-file@1.0.6									X			X
-schannel@0.1.29									X			
-security-framework@3.7.0	X								X			
-security-framework-sys@2.17.0	X								X			
-semver@1.0.28	X								X			
-serde@1.0.228	X								X			
-serde_core@1.0.228	X								X			
-serde_derive@1.0.228	X								X			
-serde_json@1.0.150	X								X			
-serde_urlencoded@0.7.1	X								X			
-sha1@0.10.6	X								X			
-sha2@0.10.9	X								X			
-shlex@1.3.0	X								X			
-signal-hook-registry@1.4.8	X								X			
-simd_cesu8@1.1.1	X								X			
-simdutf8@0.1.5	X								X			
-slab@0.4.12									X			
-smallvec@1.15.1	X								X			
-socket2@0.6.3	X								X			
-stable_deref_trait@1.2.1	X								X			
-subtle@2.6.1			X									
-syn@2.0.117	X								X			
-sync_wrapper@1.0.2	X											
-synstructure@0.13.2									X			
-thiserror@2.0.18	X								X			
-thiserror-impl@2.0.18	X								X			
-time@0.3.45	X								X			
-time-core@0.1.7	X								X			
-time-macros@0.2.25	X								X			
-tiny-keccak@2.0.2					X							
-tinystr@0.8.3											X	
-tokio@1.52.3									X			
-tokio-macros@2.7.0									X			
-tokio-rustls@0.26.4	X								X			
-tokio-util@0.7.18									X			
-tower@0.5.3									X			
-tower-http@0.6.11									X			
-tower-layer@0.3.3									X			
-tower-service@0.3.3									X			
-tracing@0.1.44									X			
-tracing-core@0.1.36									X			
-try-lock@0.2.5									X			
-typenum@1.20.0	X								X			
-unftp-core@0.1.0	X											
-unftp-sbe-opendal@0.4.2	X											
-unicode-ident@1.0.24	X								X		X	
-unicode-segmentation@1.13.2	X								X			
-unicode-xid@0.2.6	X								X			
-untrusted@0.9.0							X					
-url@2.5.8	X								X			
-utf8_iter@1.0.4	X								X			
-uuid@1.23.1	X								X			
-version_check@0.9.5	X								X			
-walkdir@2.5.0									X			X
-want@0.3.1									X			
-wasi@0.11.1+wasi-snapshot-preview1	X	X							X			
-wasip2@1.0.1+wasi-0.2.4	X	X							X			
-wasip3@0.4.0+wasi-0.3.0-rc-2026-01-06	X	X							X			
-wasm-bindgen@0.2.121	X								X			
-wasm-bindgen-futures@0.4.71	X								X			
-wasm-bindgen-macro@0.2.121	X								X			
-wasm-bindgen-macro-support@0.2.121	X								X			
-wasm-bindgen-shared@0.2.121	X								X			
-wasm-streams@0.5.0	X								X			
-web-sys@0.3.98	X								X			
-web-time@1.1.0	X								X			
-webpki-root-certs@1.0.7						X						
-winapi-util@0.1.11									X			X
-windows-core@0.62.2	X								X			
-windows-implement@0.60.2	X								X			
-windows-interface@0.59.3	X								X			
-windows-link@0.2.1	X								X			
-windows-result@0.4.1	X								X			
-windows-strings@0.5.1	X								X			
-windows-sys@0.61.2	X								X			
-wit-bindgen@0.46.0	X	X							X			
-wit-bindgen@0.51.0	X	X							X			
-writeable@0.6.3											X	
-x509-parser@0.18.1	X								X			
-yoke@0.8.2											X	
-yoke-derive@0.8.2											X	
-zerofrom@0.1.8											X	
-zerofrom-derive@0.1.7											X	
-zeroize@1.8.2	X								X			
-zerotrie@0.2.4											X	
-zerovec@0.11.6											X	
-zerovec-derive@0.11.3											X	
-zmij@1.0.21									X			
+crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense
+aes@0.8.4	X									X			
+android_system_properties@0.1.5	X									X			
+anyhow@1.0.103	X									X			
+asn1-rs@0.7.2	X									X			
+asn1-rs-derive@0.6.0	X									X			
+asn1-rs-impl@0.2.0	X									X			
+async-trait@0.1.89	X									X			
+atomic-waker@1.1.2	X									X			
+autocfg@1.5.1	X									X			
+aws-lc-rs@1.17.1	X							X					
+aws-lc-sys@0.42.0	X			X				X		X	X		
+backon@1.6.0	X												
+base64@0.22.1	X									X			
+base64ct@1.8.3	X									X			
+bitflags@2.13.0	X									X			
+block-buffer@0.10.4	X									X			
+block-buffer@0.12.1	X									X			
+block-padding@0.3.3	X									X			
+bumpalo@3.20.3	X									X			
+bytes@1.12.0										X			
+cbc@0.1.2	X									X			
+cc@1.2.66	X									X			
+cfg-if@1.0.4	X									X			
+chrono@0.4.45	X									X			
+cipher@0.4.4	X									X			
+cmake@0.1.58	X									X			
+cmov@0.5.4	X									X			
+combine@4.6.7										X			
+const-oid@0.10.2	X									X			
+const-oid@0.9.6	X									X			
+const-random@0.1.18	X									X			
+const-random-macro@0.1.16	X									X			
+convert_case@0.10.0										X			
+core-foundation@0.10.1	X									X			
+core-foundation-sys@0.8.7	X									X			
+cpufeatures@0.2.17	X									X			
+cpufeatures@0.3.0	X									X			
+crc-fast@1.10.0	X									X			
+crunchy@0.2.4										X			
+crypto-common@0.1.7	X									X			
+crypto-common@0.2.2	X									X			
+ctor@1.0.8	X									X			
+ctutils@0.4.2	X									X			
+data-encoding@2.11.0										X			
+der@0.7.10	X									X			
+der-parser@10.0.0	X									X			
+deranged@0.5.8	X									X			
+derive_more@2.1.1										X			
+derive_more-impl@2.1.1										X			
+digest@0.10.7	X									X			
+digest@0.11.3	X									X			
+displaydoc@0.2.6	X									X			
+dlv-list@0.5.2	X									X			
+dunce@1.0.5	X					X					X		
+errno@0.3.14	X									X			
+fastrand@2.4.1	X									X			
+find-msvc-tools@0.1.9	X									X			
+form_urlencoded@1.2.2	X									X			
+fs_extra@1.3.0										X			
+futures@0.3.32	X									X			
+futures-channel@0.3.32	X									X			
+futures-core@0.3.32	X									X			
+futures-executor@0.3.32	X									X			
+futures-io@0.3.32	X									X			
+futures-macro@0.3.32	X									X			
+futures-sink@0.3.32	X									X			
+futures-task@0.3.32	X									X			
+futures-util@0.3.32	X									X			
+generic-array@0.14.7										X			
+getrandom@0.2.17	X									X			
+getrandom@0.4.3	X									X			
+gloo-timers@0.3.0	X									X			
+hashbrown@0.14.5	X									X			
+hex@0.4.3	X									X			
+hmac@0.12.1	X									X			
+hmac@0.13.0	X									X			
+http@1.4.2	X									X			
+http-body@1.0.1										X			
+http-body-util@0.1.3										X			
+httparse@1.10.1	X									X			
+hybrid-array@0.4.13	X									X			
+hyper@1.10.1										X			
+hyper-rustls@0.27.9	X							X		X			
+hyper-util@0.1.20										X			
+iana-time-zone@0.1.65	X									X			
+iana-time-zone-haiku@0.1.2	X									X			
+icu_collections@2.2.0												X	
+icu_locale_core@2.2.0												X	
+icu_normalizer@2.2.0												X	
+icu_normalizer_data@2.2.0												X	
+icu_properties@2.2.0												X	
+icu_properties_data@2.2.0												X	
+icu_provider@2.2.0												X	
+idna@1.1.0	X									X			
+idna_adapter@1.2.2	X									X			
+inout@0.1.4	X									X			
+ipnet@2.12.0	X									X			
+itoa@1.0.18	X									X			
+jiff@0.2.31										X			X
+jiff-tzdb@0.1.7										X			X
+jiff-tzdb-platform@0.1.3										X			X
+jni@0.22.4	X									X			
+jni-macros@0.22.4	X									X			
+jni-sys@0.4.1	X									X			
+jni-sys-macros@0.4.1	X									X			
+jobserver@0.1.35	X									X			
+js-sys@0.3.103	X									X			
+lazy_static@1.5.0	X									X			
+libc@0.2.186	X									X			
+libm@0.2.16										X			
+link-section@0.19.0	X									X			
+linktime-proc-macro@0.2.0	X									X			
+litemap@0.8.2												X	
+log@0.4.33	X									X			
+md-5@0.10.6	X									X			
+md-5@0.11.0	X									X			
+mea@0.6.4	X												
+memchr@2.8.2										X			X
+minimal-lexical@0.2.1	X									X			
+mio@1.2.1										X			
+nom@7.1.3										X			
+num-bigint@0.4.8	X									X			
+num-bigint-dig@0.8.6	X									X			
+num-conv@0.2.2	X									X			
+num-integer@0.1.46	X									X			
+num-iter@0.1.45	X									X			
+num-traits@0.2.19	X									X			
+oid-registry@0.8.1	X									X			
+once_cell@1.21.4	X									X			
+opendal@0.58.0	X												
+opendal-core@0.58.0	X												
+opendal-http-transport-reqwest@0.58.0	X												
+opendal-layer-concurrent-limit@0.58.0	X												
+opendal-layer-logging@0.58.0	X												
+opendal-layer-retry@0.58.0	X												
+opendal-layer-timeout@0.58.0	X												
+opendal-service-s3@0.58.0	X												
+openssl-probe@0.2.1	X									X			
+ordered-multimap@0.7.3										X			
+pbkdf2@0.12.2	X									X			
+pem-rfc7468@0.7.0	X									X			
+percent-encoding@2.3.2	X									X			
+pin-project-lite@0.2.17	X									X			
+pkcs1@0.7.5	X									X			
+pkcs5@0.7.1	X									X			
+pkcs8@0.10.2	X									X			
+pkg-config@0.3.33	X									X			
+portable-atomic@1.13.1	X									X			
+portable-atomic-util@0.2.7	X									X			
+potential_utf@0.1.5												X	
+powerfmt@0.2.0	X									X			
+ppv-lite86@0.2.21	X									X			
+proc-macro2@1.0.106	X									X			
+quick-xml@0.40.1										X			
+quick-xml@0.41.0										X			
+quote@1.0.46	X									X			
+r-efi@6.0.0	X								X	X			
+rand@0.8.6	X									X			
+rand_chacha@0.3.1	X									X			
+rand_core@0.6.4	X									X			
+reqsign-aws-v4@3.0.1	X												
+reqsign-core@3.0.1	X												
+reqsign-file-read-tokio@3.0.1	X												
+reqwest@0.13.4	X									X			
+rsa@0.9.10	X									X			
+rust-ini@0.21.3										X			
+rustc_version@0.4.1	X									X			
+rusticata-macros@4.1.0	X									X			
+rustls@0.23.41	X							X		X			
+rustls-native-certs@0.8.4	X							X		X			
+rustls-pki-types@1.15.0	X									X			
+rustls-platform-verifier@0.7.0	X									X			
+rustls-platform-verifier-android@0.1.1	X									X			
+rustls-webpki@0.103.13								X					
+rustversion@1.0.22	X									X			
+ryu@1.0.23	X				X								
+salsa20@0.10.2	X									X			
+same-file@1.0.6										X			X
+schannel@0.1.29										X			
+scrypt@0.11.0	X									X			
+security-framework@3.7.0	X									X			
+security-framework-sys@2.17.0	X									X			
+semver@1.0.28	X									X			
+serde@1.0.228	X									X			
+serde_core@1.0.228	X									X			
+serde_derive@1.0.228	X									X			
+serde_json@1.0.150	X									X			
+serde_urlencoded@0.7.1	X									X			
+sha1@0.11.0	X									X			
+sha2@0.10.9	X									X			
+sha2@0.11.0	X									X			
+shlex@2.0.1	X									X			
+signal-hook-registry@1.4.8	X									X			
+signature@2.2.0	X									X			
+simd_cesu8@1.1.1	X									X			
+simdutf8@0.1.5	X									X			
+slab@0.4.12										X			
+smallvec@1.15.2	X									X			
+socket2@0.6.4	X									X			
+spin@0.10.0										X			
+spin@0.9.8										X			
+spki@0.7.3	X									X			
+stable_deref_trait@1.2.1	X									X			
+subtle@2.6.1				X									
+syn@2.0.118	X									X			
+sync_wrapper@1.0.2	X												
+synstructure@0.13.2										X			
+thiserror@2.0.18	X									X			
+thiserror-impl@2.0.18	X									X			
+time@0.3.53	X									X			
+time-core@0.1.9	X									X			
+time-macros@0.2.31	X									X			
+tiny-keccak@2.0.2						X							
+tinystr@0.8.3												X	
+tokio@1.52.3										X			
+tokio-macros@2.7.0										X			
+tokio-rustls@0.26.4	X									X			
+tokio-util@0.7.18										X			
+tower@0.5.3										X			
+tower-http@0.6.11										X			
+tower-layer@0.3.3										X			
+tower-service@0.3.3										X			
+tracing@0.1.44										X			
+tracing-core@0.1.36										X			
+try-lock@0.2.5										X			
+typenum@1.20.1	X									X			
+unftp-core@0.1.0	X												
+unftp-sbe-opendal@0.4.3	X												
+unicode-ident@1.0.24	X									X		X	
+unicode-segmentation@1.13.3	X									X			
+unicode-xid@0.2.6	X									X			
+untrusted@0.9.0								X					
+url@2.5.8	X									X			
+utf8_iter@1.0.4	X									X			
+uuid@1.23.4	X									X			
+version_check@0.9.5	X									X			
+walkdir@2.5.0										X			X
+want@0.3.1										X			
+wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
+wasm-bindgen@0.2.126	X									X			
+wasm-bindgen-futures@0.4.76	X									X			
+wasm-bindgen-macro@0.2.126	X									X			
+wasm-bindgen-macro-support@0.2.126	X									X			
+wasm-bindgen-shared@0.2.126	X									X			
+wasm-streams@0.5.0	X									X			
+web-sys@0.3.103	X									X			
+web-time@1.1.0	X									X			
+webpki-root-certs@1.0.8							X						
+winapi-util@0.1.11										X			X
+windows-core@0.62.2	X									X			
+windows-implement@0.60.2	X									X			
+windows-interface@0.59.3	X									X			
+windows-link@0.2.1	X									X			
+windows-result@0.4.1	X									X			
+windows-strings@0.5.1	X									X			
+windows-sys@0.61.2	X									X			
+writeable@0.6.3												X	
+x509-parser@0.18.1	X									X			
+yoke@0.8.3												X	
+yoke-derive@0.8.2												X	
+zerocopy@0.8.53	X		X							X			
+zerofrom@0.1.8												X	
+zerofrom-derive@0.1.7												X	
+zeroize@1.9.0	X									X			
+zerotrie@0.2.4												X	
+zerovec@0.11.6												X	
+zerovec-derive@0.11.3												X	
+zmij@1.0.21										X			


### PR DESCRIPTION
# Which issue does this PR close?

Related to #7866.

# Rationale for this change

Prepare the Apache OpenDAL v0.58.0 release after the release discussion in #7865.

# What changes are included in this PR?

- Bump release-managed package versions for v0.58.0.
- Update `CHANGELOG.md`, Rust upgrade notes, and Java upgrade notes.
- Regenerate Rust dependency lists.

Package version map:

- `core`: `0.58.0`
- `integrations/dav-server`: `0.7.3`
- `integrations/object_store`: `0.58.0`
- `integrations/parquet`: `0.8.2`
- `integrations/unftp-sbe`: `0.4.3`
- `bindings/c`: `0.47.0`
- `bindings/cpp`: `0.45.27`
- `bindings/java`: `0.50.0`
- `bindings/nodejs`: `0.49.5`
- `bindings/python`: `0.47.3`
- `bindings/ruby`: `0.1.8`
- `bindings/dotnet`: `0.1.0`

Release gate notes:

- Ruby RC tags build gem artifacts only and do not publish to RubyGems.
- Dotnet RC tags build and upload NuGet package artifacts only; the publish job is not triggered by RC tags.
- Go binding release remains a separate module tag path and is not part of `dev/src/release/package.rs`. If included in this release cycle, use a separate Go binding RC tag.

# Are there any user-facing changes?

Yes. This PR prepares the release and documents v0.58.0 breaking changes, including Rust core runtime composition changes and the Java `OperatorInfo.capability` migration.

# AI Usage Statement

AI assistance was used to prepare this release-management PR.
