### PR TITLE
ci: remove unsupported python 3.13t release wheel

### DIFF
--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -85,15 +85,6 @@ jobs:
           args: --release -o dist -i python3.10 --features=pyo3/extension-module,services-all
           sccache: true
           manylinux: ${{ matrix.manylinux || 'auto' }}
-      - name: Build free-threaded wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          working-directory: "bindings/python"
-          target: "${{ matrix.target }}"
-          command: build
-          args: --release -o dist -i python3.13t --features=pyo3/extension-module,services-all
-          sccache: true
-          manylinux: ${{ matrix.manylinux || 'auto' }}
       - name: Build python 3.14t
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
# Which issue does this PR close?

Part of #7866.

# Rationale for this change

The v0.58.0-rc.1 `Release Python Binding` workflow failed while building `python3.13t` wheels. maturin now rejects free-threaded Python interpreters before 3.14, so the 3.13t build is not releaseable.

# What changes are included in this PR?

Remove the `python3.13t` free-threaded wheel build from the Python release workflow. The `python3.14t` free-threaded wheel build remains enabled.

# Are there any user-facing changes?

No.

# AI Usage Statement

N/A.
