### PR TITLE
feat(bindings/python): add from_uri constructor for Operator and AsyncOperator

### DIFF
--- a/bindings/python/python/opendal/_opendal.pyi
+++ b/bindings/python/python/opendal/_opendal.pyi
@@ -19,6 +19,8 @@ from typing import Final, final
 
 from _typeshed import Incomplete
 
+from .operator import AsyncOperator, Operator
+
 __version__: Final[str]
 
 @final
@@ -35,5 +37,24 @@ class StatOptions: ...
 
 @final
 class WriteOptions: ...
+
+def _reconstruct_async_operator(
+    from_uri: bool, scheme: str, map: dict[str, str]
+) -> AsyncOperator:
+    """
+    Rebuild an [`AsyncOperator`] while unpickling.
+
+    See [`_reconstruct_operator`] for why a dedicated reconstructor is used.
+    """
+
+def _reconstruct_operator(from_uri: bool, scheme: str, map: dict[str, str]) -> Operator:
+    """
+    Rebuild a blocking [`Operator`] while unpickling.
+
+    `from_uri` operators store a full URI in `__scheme` and must be rebuilt via
+    `from_uri`; scheme operators are rebuilt via `via_iter`. Routing both through
+    this reconstructor keeps a single pickle entry point and avoids the scheme
+    normalization in `__new__` that would corrupt a stored URI.
+    """
 
 def __getattr__(name: str) -> Incomplete: ...

--- a/bindings/python/python/opendal/_opendal.pyi
+++ b/bindings/python/python/opendal/_opendal.pyi
@@ -38,23 +38,21 @@ class StatOptions: ...
 @final
 class WriteOptions: ...
 
-def _reconstruct_async_operator(
-    from_uri: bool, scheme: str, map: dict[str, str]
-) -> AsyncOperator:
+def _reconstruct_async_operator(scheme: str, map: dict[str, str]) -> AsyncOperator:
     """
     Rebuild an [`AsyncOperator`] while unpickling.
 
     See [`_reconstruct_operator`] for why a dedicated reconstructor is used.
     """
 
-def _reconstruct_operator(from_uri: bool, scheme: str, map: dict[str, str]) -> Operator:
+def _reconstruct_operator(scheme: str, map: dict[str, str]) -> Operator:
     """
     Rebuild a blocking [`Operator`] while unpickling.
 
-    `from_uri` operators store a full URI in `__scheme` and must be rebuilt via
-    `from_uri`; scheme operators are rebuilt via `via_iter`. Routing both through
-    this reconstructor keeps a single pickle entry point and avoids the scheme
-    normalization in `__new__` that would corrupt a stored URI.
+    Reconstruction goes through `from_uri` (not the scheme-based `__new__`)
+    because `__scheme` may hold a full URI that `__new__` would normalize and
+    corrupt. A bare scheme is also accepted here, since the core resolves both
+    bare schemes and full URIs through the same path.
     """
 
 def __getattr__(name: str) -> Incomplete: ...

--- a/bindings/python/python/opendal/_opendal.pyi
+++ b/bindings/python/python/opendal/_opendal.pyi
@@ -49,10 +49,9 @@ def _reconstruct_operator(scheme: str, map: dict[str, str]) -> Operator:
     """
     Rebuild a blocking [`Operator`] while unpickling.
 
-    Reconstruction goes through `from_uri` (not the scheme-based `__new__`)
-    because `__scheme` may hold a full URI that `__new__` would normalize and
-    corrupt. A bare scheme is also accepted here, since the core resolves both
-    bare schemes and full URIs through the same path.
+    Routes through `from_uri`, not the scheme-based `__new__`, whose scheme
+    normalization would corrupt a URI held in `__scheme`. Bare schemes work too:
+    the core resolves both through the same path.
     """
 
 def __getattr__(name: str) -> Incomplete: ...

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -38,7 +38,6 @@ class AsyncOperator:
     Operator
     """
 
-    def __getnewargs_ex__(self, /) -> Any: ...
     def __new__(cls, /, scheme: str | Scheme, **kwargs) -> AsyncOperator:
         """
         Create a new `AsyncOperator`.
@@ -55,6 +54,7 @@ class AsyncOperator:
         AsyncOperator
             The new async operator.
         """
+    def __reduce__(self, /) -> Any: ...
     def capability(self, /) -> Capability:
         """
         Get all capabilities of this operator.
@@ -160,6 +160,35 @@ class AsyncOperator:
         -------
         coroutine
             An awaitable that returns True if the path exists, False otherwise.
+        """
+    @classmethod
+    def from_uri(cls, /, uri: str, **kwargs) -> AsyncOperator:
+        """
+        Create a new `AsyncOperator` from a URI string.
+
+        The URI encodes the scheme and configuration in a single string, e.g.
+        ``memory://`` or ``s3://bucket/path?region=us-east-1``. The scheme must
+        belong to a service enabled in this build.
+
+        Parameters
+        ----------
+        uri : str
+            The URI of the service.
+        **kwargs : dict
+            Extra options that override or supplement values encoded in the URI.
+
+        Returns
+        -------
+        AsyncOperator
+            The new async operator.
+
+        Examples
+        --------
+        >>> import opendal
+        >>> op = opendal.AsyncOperator.from_uri("memory://")
+        >>> op = opendal.AsyncOperator.from_uri(
+        ...     "s3://bucket/path", region="us-east-1"
+        ... )
         """
     def layer(self, /, layer: Layer) -> AsyncOperator:
         """
@@ -647,7 +676,6 @@ class Operator:
     AsyncOperator
     """
 
-    def __getnewargs_ex__(self, /) -> Any: ...
     def __new__(cls, /, scheme: str | Scheme, **kwargs) -> Operator:
         """
         Create a new blocking `Operator`.
@@ -664,6 +692,7 @@ class Operator:
         Operator
             The new operator.
         """
+    def __reduce__(self, /) -> Any: ...
     def capability(self, /) -> Capability:
         """
         Get all capabilities of this operator.
@@ -745,6 +774,35 @@ class Operator:
         -------
         bool
             True if the path exists, False otherwise.
+        """
+    @classmethod
+    def from_uri(cls, /, uri: str, **kwargs) -> Operator:
+        """
+        Create a new blocking `Operator` from a URI string.
+
+        The URI encodes the scheme and configuration in a single string, e.g.
+        ``memory://`` or ``s3://bucket/path?region=us-east-1``. The scheme must
+        belong to a service enabled in this build.
+
+        Parameters
+        ----------
+        uri : str
+            The URI of the service.
+        **kwargs : dict
+            Extra options that override or supplement values encoded in the URI.
+
+        Returns
+        -------
+        Operator
+            The new operator.
+
+        Examples
+        --------
+        >>> import opendal
+        >>> op = opendal.Operator.from_uri("memory://")
+        >>> op = opendal.Operator.from_uri(
+        ...     "s3://bucket/path", region="us-east-1"
+        ... )
         """
     def layer(self, /, layer: Layer) -> Operator:
         """

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -177,9 +177,7 @@ class AsyncOperator:
         uri : str
             The URI of the service, including any options as query parameters.
         **kwargs : dict
-            Optional overrides for options already encoded in the URI. Prefer
-            encoding options in the URI itself; these are for the rare case where
-            an option is more convenient to pass separately.
+            Overrides for URI options. Prefer the URI query string.
 
         Returns
         -------
@@ -797,9 +795,7 @@ class Operator:
         uri : str
             The URI of the service, including any options as query parameters.
         **kwargs : dict
-            Optional overrides for options already encoded in the URI. Prefer
-            encoding options in the URI itself; these are for the rare case where
-            an option is more convenient to pass separately.
+            Overrides for URI options. Prefer the URI query string.
 
         Returns
         -------

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -168,14 +168,18 @@ class AsyncOperator:
 
         The URI encodes the scheme and configuration in a single string, e.g.
         ``memory://`` or ``s3://bucket/path?region=us-east-1``. The scheme must
-        belong to a service enabled in this build.
+        belong to a service enabled in this build. Encode service options as
+        query parameters; use ``urllib.parse.urlencode`` when building the URI
+        dynamically.
 
         Parameters
         ----------
         uri : str
-            The URI of the service.
+            The URI of the service, including any options as query parameters.
         **kwargs : dict
-            Extra options that override or supplement values encoded in the URI.
+            Optional overrides for options already encoded in the URI. Prefer
+            encoding options in the URI itself; these are for the rare case where
+            an option is more convenient to pass separately.
 
         Returns
         -------
@@ -184,10 +188,12 @@ class AsyncOperator:
 
         Examples
         --------
+        >>> from urllib.parse import urlencode
         >>> import opendal
         >>> op = opendal.AsyncOperator.from_uri("memory://")
+        >>> query = urlencode({"region": "us-east-1"})
         >>> op = opendal.AsyncOperator.from_uri(
-        ...     "s3://bucket/path", region="us-east-1"
+        ...     f"s3://bucket/path?{query}"
         ... )
         """
     def layer(self, /, layer: Layer) -> AsyncOperator:
@@ -782,14 +788,18 @@ class Operator:
 
         The URI encodes the scheme and configuration in a single string, e.g.
         ``memory://`` or ``s3://bucket/path?region=us-east-1``. The scheme must
-        belong to a service enabled in this build.
+        belong to a service enabled in this build. Encode service options as
+        query parameters; use ``urllib.parse.urlencode`` when building the URI
+        dynamically.
 
         Parameters
         ----------
         uri : str
-            The URI of the service.
+            The URI of the service, including any options as query parameters.
         **kwargs : dict
-            Extra options that override or supplement values encoded in the URI.
+            Optional overrides for options already encoded in the URI. Prefer
+            encoding options in the URI itself; these are for the rare case where
+            an option is more convenient to pass separately.
 
         Returns
         -------
@@ -798,11 +808,11 @@ class Operator:
 
         Examples
         --------
+        >>> from urllib.parse import urlencode
         >>> import opendal
         >>> op = opendal.Operator.from_uri("memory://")
-        >>> op = opendal.Operator.from_uri(
-        ...     "s3://bucket/path", region="us-east-1"
-        ... )
+        >>> query = urlencode({"region": "us-east-1"})
+        >>> op = opendal.Operator.from_uri(f"s3://bucket/path?{query}")
         """
     def layer(self, /, layer: Layer) -> Operator:
         """

--- a/bindings/python/python/opendal/operator.pyi
+++ b/bindings/python/python/opendal/operator.pyi
@@ -186,13 +186,16 @@ class AsyncOperator:
 
         Examples
         --------
-        >>> from urllib.parse import urlencode
-        >>> import opendal
-        >>> op = opendal.AsyncOperator.from_uri("memory://")
-        >>> query = urlencode({"region": "us-east-1"})
-        >>> op = opendal.AsyncOperator.from_uri(
-        ...     f"s3://bucket/path?{query}"
-        ... )
+        ```python
+        from urllib.parse import urlencode
+        import opendal
+
+        op = opendal.AsyncOperator.from_uri("memory://")
+        query = urlencode({"region": "us-east-1"})
+        op = opendal.AsyncOperator.from_uri(
+            f"s3://bucket/path?{query}"
+        )
+        ```
         """
     def layer(self, /, layer: Layer) -> AsyncOperator:
         """
@@ -804,11 +807,14 @@ class Operator:
 
         Examples
         --------
-        >>> from urllib.parse import urlencode
-        >>> import opendal
-        >>> op = opendal.Operator.from_uri("memory://")
-        >>> query = urlencode({"region": "us-east-1"})
-        >>> op = opendal.Operator.from_uri(f"s3://bucket/path?{query}")
+        ```python
+        from urllib.parse import urlencode
+        import opendal
+
+        op = opendal.Operator.from_uri("memory://")
+        query = urlencode({"region": "us-east-1"})
+        op = opendal.Operator.from_uri(f"s3://bucket/path?{query}")
+        ```
         """
     def layer(self, /, layer: Layer) -> Operator:
         """

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -57,6 +57,12 @@ mod _opendal {
         use crate::{AsyncOperator, Operator};
     }
 
+    // Pickle reconstructors for operators built via `from_uri`. They must live
+    // on the top-level `_opendal` module so `__reduce__` can reference them by
+    // their qualified name during unpickling.
+    #[pymodule_export]
+    use crate::{_reconstruct_async_operator, _reconstruct_operator};
+
     #[pymodule]
     mod file {
         #[pymodule_export]

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -67,15 +67,6 @@ fn normalize_scheme(raw: &str) -> String {
     raw.trim().to_ascii_lowercase().replace('_', "-")
 }
 
-/// Extract service options from `**kwargs`, propagating a Python exception if a
-/// value is not a `str -> str` mapping instead of panicking.
-fn extract_kwargs(kwargs: Option<&Bound<PyDict>>) -> PyResult<HashMap<String, String>> {
-    match kwargs {
-        Some(v) => v.extract::<HashMap<String, String>>(),
-        None => Ok(HashMap::new()),
-    }
-}
-
 /// Rebuild a blocking [`Operator`] while unpickling.
 ///
 /// Routes through `from_uri`, not the scheme-based `__new__`, whose scheme
@@ -135,7 +126,7 @@ impl Operator {
     ///     The new operator.
     #[new]
     #[pyo3(signature = (scheme: "str | Scheme", *, **kwargs))]
-    pub fn new(scheme: Bound<PyAny>, kwargs: Option<&Bound<PyDict>>) -> PyResult<Self> {
+    pub fn new(scheme: Bound<PyAny>, kwargs: Option<HashMap<String, String>>) -> PyResult<Self> {
         let scheme = if let Ok(scheme_str) = scheme.extract::<&str>() {
             scheme_str.to_string()
         } else if let Ok(py_scheme) = scheme.extract::<Scheme>() {
@@ -146,7 +137,7 @@ impl Operator {
             ));
         };
         let scheme = normalize_scheme(&scheme);
-        let map = extract_kwargs(kwargs)?;
+        let map = kwargs.unwrap_or_default();
 
         Ok(Operator {
             core: build_blocking_operator(&scheme, map.clone())?,
@@ -190,9 +181,9 @@ impl Operator {
     pub fn from_uri(
         _cls: &Bound<PyType>,
         uri: &str,
-        kwargs: Option<&Bound<PyDict>>,
+        kwargs: Option<HashMap<String, String>>,
     ) -> PyResult<Self> {
-        let map = extract_kwargs(kwargs)?;
+        let map = kwargs.unwrap_or_default();
 
         Ok(Operator {
             core: build_blocking_operator_from_uri(uri, map.clone())?,
@@ -828,7 +819,7 @@ impl AsyncOperator {
     ///     The new async operator.
     #[new]
     #[pyo3(signature = (scheme: "str | Scheme", * ,**kwargs))]
-    pub fn new(scheme: Bound<PyAny>, kwargs: Option<&Bound<PyDict>>) -> PyResult<Self> {
+    pub fn new(scheme: Bound<PyAny>, kwargs: Option<HashMap<String, String>>) -> PyResult<Self> {
         let scheme = if let Ok(scheme_str) = scheme.extract::<&str>() {
             scheme_str.to_string()
         } else if let Ok(py_scheme) = scheme.extract::<Scheme>() {
@@ -840,7 +831,7 @@ impl AsyncOperator {
         };
         let scheme = normalize_scheme(&scheme);
 
-        let map = extract_kwargs(kwargs)?;
+        let map = kwargs.unwrap_or_default();
 
         Ok(AsyncOperator {
             core: build_operator(&scheme, map.clone())?,
@@ -884,9 +875,9 @@ impl AsyncOperator {
     pub fn from_uri(
         _cls: &Bound<PyType>,
         uri: &str,
-        kwargs: Option<&Bound<PyDict>>,
+        kwargs: Option<HashMap<String, String>>,
     ) -> PyResult<Self> {
-        let map = extract_kwargs(kwargs)?;
+        let map = kwargs.unwrap_or_default();
 
         Ok(AsyncOperator {
             core: build_operator_from_uri(uri, map.clone())?,

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -78,31 +78,17 @@ fn extract_kwargs(kwargs: Option<&Bound<PyDict>>) -> PyResult<HashMap<String, St
 
 /// Rebuild a blocking [`Operator`] while unpickling.
 ///
-/// `from_uri` operators store a full URI in `__scheme` and must be rebuilt via
-/// `from_uri`; scheme operators are rebuilt via `via_iter`. Routing both through
-/// this reconstructor keeps a single pickle entry point and avoids the scheme
-/// normalization in `__new__` that would corrupt a stored URI.
+/// Reconstruction goes through `from_uri` (not the scheme-based `__new__`)
+/// because `__scheme` may hold a full URI that `__new__` would normalize and
+/// corrupt. A bare scheme is also accepted here, since the core resolves both
+/// bare schemes and full URIs through the same path.
 #[pyfunction]
-pub fn _reconstruct_operator(
-    from_uri: bool,
-    scheme: &str,
-    map: HashMap<String, String>,
-) -> PyResult<Operator> {
-    if from_uri {
-        Ok(Operator {
-            core: build_blocking_operator_from_uri(scheme, map.clone())?,
-            __scheme: scheme.to_string(),
-            __map: map,
-            __from_uri: true,
-        })
-    } else {
-        Ok(Operator {
-            core: build_blocking_operator(scheme, map.clone())?,
-            __scheme: scheme.to_string(),
-            __map: map,
-            __from_uri: false,
-        })
-    }
+pub fn _reconstruct_operator(scheme: &str, map: HashMap<String, String>) -> PyResult<Operator> {
+    Ok(Operator {
+        core: build_blocking_operator_from_uri(scheme, map.clone())?,
+        __scheme: scheme.to_string(),
+        __map: map,
+    })
 }
 
 /// Rebuild an [`AsyncOperator`] while unpickling.
@@ -110,25 +96,14 @@ pub fn _reconstruct_operator(
 /// See [`_reconstruct_operator`] for why a dedicated reconstructor is used.
 #[pyfunction]
 pub fn _reconstruct_async_operator(
-    from_uri: bool,
     scheme: &str,
     map: HashMap<String, String>,
 ) -> PyResult<AsyncOperator> {
-    if from_uri {
-        Ok(AsyncOperator {
-            core: build_operator_from_uri(scheme, map.clone())?,
-            __scheme: scheme.to_string(),
-            __map: map,
-            __from_uri: true,
-        })
-    } else {
-        Ok(AsyncOperator {
-            core: build_operator(scheme, map.clone())?,
-            __scheme: scheme.to_string(),
-            __map: map,
-            __from_uri: false,
-        })
-    }
+    Ok(AsyncOperator {
+        core: build_operator_from_uri(scheme, map.clone())?,
+        __scheme: scheme.to_string(),
+        __map: map,
+    })
 }
 
 /// The blocking equivalent of `AsyncOperator`.
@@ -143,10 +118,6 @@ pub struct Operator {
     core: ocore::blocking::Operator,
     __scheme: String,
     __map: HashMap<String, String>,
-    // When true, `__scheme` holds a full URI: reconstruct via `from_uri`, not
-    // scheme-based `__new__` (which normalizes and corrupts the URI). See
-    // `__reduce__`.
-    __from_uri: bool,
 }
 #[pymethods]
 impl Operator {
@@ -182,7 +153,6 @@ impl Operator {
             core: build_blocking_operator(&scheme, map.clone())?,
             __scheme: scheme,
             __map: map,
-            __from_uri: false,
         })
     }
 
@@ -190,14 +160,18 @@ impl Operator {
     ///
     /// The URI encodes the scheme and configuration in a single string, e.g.
     /// ``memory://`` or ``s3://bucket/path?region=us-east-1``. The scheme must
-    /// belong to a service enabled in this build.
+    /// belong to a service enabled in this build. Encode service options as
+    /// query parameters; use ``urllib.parse.urlencode`` when building the URI
+    /// dynamically.
     ///
     /// Parameters
     /// ----------
     /// uri : str
-    ///     The URI of the service.
+    ///     The URI of the service, including any options as query parameters.
     /// **kwargs : dict
-    ///     Extra options that override or supplement values encoded in the URI.
+    ///     Optional overrides for options already encoded in the URI. Prefer
+    ///     encoding options in the URI itself; these are for the rare case where
+    ///     an option is more convenient to pass separately.
     ///
     /// Returns
     /// -------
@@ -206,9 +180,11 @@ impl Operator {
     ///
     /// Examples
     /// --------
+    /// >>> from urllib.parse import urlencode
     /// >>> import opendal
     /// >>> op = opendal.Operator.from_uri("memory://")
-    /// >>> op = opendal.Operator.from_uri("s3://bucket/path", region="us-east-1")
+    /// >>> query = urlencode({"region": "us-east-1"})
+    /// >>> op = opendal.Operator.from_uri(f"s3://bucket/path?{query}")
     #[classmethod]
     #[pyo3(signature = (uri, **kwargs))]
     pub fn from_uri(
@@ -222,7 +198,6 @@ impl Operator {
             core: build_blocking_operator_from_uri(uri, map.clone())?,
             __scheme: uri.to_string(),
             __map: map,
-            __from_uri: true,
         })
     }
 
@@ -247,7 +222,6 @@ impl Operator {
             core: op,
             __scheme: self.__scheme.clone(),
             __map: self.__map.clone(),
-            __from_uri: self.__from_uri,
         })
     }
 
@@ -799,7 +773,6 @@ impl Operator {
             core: self.core.clone().into(),
             __scheme: self.__scheme.clone(),
             __map: self.__map.clone(),
-            __from_uri: self.__from_uri,
         })
     }
 
@@ -820,7 +793,7 @@ impl Operator {
         let reconstructor = py
             .import("opendal._opendal")?
             .getattr("_reconstruct_operator")?;
-        let args = (self.__from_uri, self.__scheme.clone(), self.__map.clone()).into_py_any(py)?;
+        let args = (self.__scheme.clone(), self.__map.clone()).into_py_any(py)?;
         PyTuple::new(py, [reconstructor.into_py_any(py)?, args])?.into_py_any(py)
     }
 }
@@ -837,8 +810,6 @@ pub struct AsyncOperator {
     core: ocore::Operator,
     __scheme: String,
     __map: HashMap<String, String>,
-    // See `Operator.__from_uri`.
-    __from_uri: bool,
 }
 #[pymethods]
 impl AsyncOperator {
@@ -875,7 +846,6 @@ impl AsyncOperator {
             core: build_operator(&scheme, map.clone())?,
             __scheme: scheme,
             __map: map,
-            __from_uri: false,
         })
     }
 
@@ -883,14 +853,18 @@ impl AsyncOperator {
     ///
     /// The URI encodes the scheme and configuration in a single string, e.g.
     /// ``memory://`` or ``s3://bucket/path?region=us-east-1``. The scheme must
-    /// belong to a service enabled in this build.
+    /// belong to a service enabled in this build. Encode service options as
+    /// query parameters; use ``urllib.parse.urlencode`` when building the URI
+    /// dynamically.
     ///
     /// Parameters
     /// ----------
     /// uri : str
-    ///     The URI of the service.
+    ///     The URI of the service, including any options as query parameters.
     /// **kwargs : dict
-    ///     Extra options that override or supplement values encoded in the URI.
+    ///     Optional overrides for options already encoded in the URI. Prefer
+    ///     encoding options in the URI itself; these are for the rare case where
+    ///     an option is more convenient to pass separately.
     ///
     /// Returns
     /// -------
@@ -899,9 +873,11 @@ impl AsyncOperator {
     ///
     /// Examples
     /// --------
+    /// >>> from urllib.parse import urlencode
     /// >>> import opendal
     /// >>> op = opendal.AsyncOperator.from_uri("memory://")
-    /// >>> op = opendal.AsyncOperator.from_uri("s3://bucket/path", region="us-east-1")
+    /// >>> query = urlencode({"region": "us-east-1"})
+    /// >>> op = opendal.AsyncOperator.from_uri(f"s3://bucket/path?{query}")
     #[classmethod]
     #[pyo3(signature = (uri, **kwargs))]
     pub fn from_uri(
@@ -915,7 +891,6 @@ impl AsyncOperator {
             core: build_operator_from_uri(uri, map.clone())?,
             __scheme: uri.to_string(),
             __map: map,
-            __from_uri: true,
         })
     }
 
@@ -936,7 +911,6 @@ impl AsyncOperator {
             core: op,
             __scheme: self.__scheme.clone(),
             __map: self.__map.clone(),
-            __from_uri: self.__from_uri,
         })
     }
 
@@ -1860,7 +1834,6 @@ impl AsyncOperator {
             core: op,
             __scheme: self.__scheme.clone(),
             __map: self.__map.clone(),
-            __from_uri: self.__from_uri,
         })
     }
 
@@ -1885,7 +1858,7 @@ impl AsyncOperator {
         let reconstructor = py
             .import("opendal._opendal")?
             .getattr("_reconstruct_async_operator")?;
-        let args = (self.__from_uri, self.__scheme.clone(), self.__map.clone()).into_py_any(py)?;
+        let args = (self.__scheme.clone(), self.__map.clone()).into_py_any(py)?;
         PyTuple::new(py, [reconstructor.into_py_any(py)?, args])?.into_py_any(py)
     }
 }

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -24,6 +24,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::types::PyDict;
 use pyo3::types::PyTuple;
+use pyo3::types::PyType;
 use pyo3_async_runtimes::tokio::future_into_py;
 
 use crate::*;
@@ -45,8 +46,80 @@ fn build_blocking_operator(
     Ok(op)
 }
 
+fn build_operator_from_uri(uri: &str, map: HashMap<String, String>) -> PyResult<ocore::Operator> {
+    let op = ocore::Operator::from_uri((uri, map)).map_err(format_pyerr)?;
+    Ok(op)
+}
+
+fn build_blocking_operator_from_uri(
+    uri: &str,
+    map: HashMap<String, String>,
+) -> PyResult<ocore::blocking::Operator> {
+    let op = build_operator_from_uri(uri, map)?;
+
+    let runtime = pyo3_async_runtimes::tokio::get_runtime();
+    let _guard = runtime.enter();
+    let op = ocore::blocking::Operator::new(op).map_err(format_pyerr)?;
+    Ok(op)
+}
+
 fn normalize_scheme(raw: &str) -> String {
     raw.trim().to_ascii_lowercase().replace('_', "-")
+}
+
+/// Rebuild a blocking [`Operator`] while unpickling.
+///
+/// `from_uri` operators store a full URI in `__scheme` and must be rebuilt via
+/// `from_uri`; scheme operators are rebuilt via `via_iter`. Routing both through
+/// this reconstructor keeps a single pickle entry point and avoids the scheme
+/// normalization in `__new__` that would corrupt a stored URI.
+#[pyfunction]
+pub fn _reconstruct_operator(
+    from_uri: bool,
+    scheme: &str,
+    map: HashMap<String, String>,
+) -> PyResult<Operator> {
+    if from_uri {
+        Ok(Operator {
+            core: build_blocking_operator_from_uri(scheme, map.clone())?,
+            __scheme: scheme.to_string(),
+            __map: map,
+            __from_uri: true,
+        })
+    } else {
+        Ok(Operator {
+            core: build_blocking_operator(scheme, map.clone())?,
+            __scheme: scheme.to_string(),
+            __map: map,
+            __from_uri: false,
+        })
+    }
+}
+
+/// Rebuild an [`AsyncOperator`] while unpickling.
+///
+/// See [`_reconstruct_operator`] for why a dedicated reconstructor is used.
+#[pyfunction]
+pub fn _reconstruct_async_operator(
+    from_uri: bool,
+    scheme: &str,
+    map: HashMap<String, String>,
+) -> PyResult<AsyncOperator> {
+    if from_uri {
+        Ok(AsyncOperator {
+            core: build_operator_from_uri(scheme, map.clone())?,
+            __scheme: scheme.to_string(),
+            __map: map,
+            __from_uri: true,
+        })
+    } else {
+        Ok(AsyncOperator {
+            core: build_operator(scheme, map.clone())?,
+            __scheme: scheme.to_string(),
+            __map: map,
+            __from_uri: false,
+        })
+    }
 }
 
 /// The blocking equivalent of `AsyncOperator`.
@@ -61,6 +134,10 @@ pub struct Operator {
     core: ocore::blocking::Operator,
     __scheme: String,
     __map: HashMap<String, String>,
+    // When true, `__scheme` holds a full URI: reconstruct via `from_uri`, not
+    // scheme-based `__new__` (which normalizes and corrupts the URI). See
+    // `__reduce__`.
+    __from_uri: bool,
 }
 #[pymethods]
 impl Operator {
@@ -101,6 +178,52 @@ impl Operator {
             core: build_blocking_operator(&scheme, map.clone())?,
             __scheme: scheme,
             __map: map,
+            __from_uri: false,
+        })
+    }
+
+    /// Create a new blocking `Operator` from a URI string.
+    ///
+    /// The URI encodes the scheme and configuration in a single string, e.g.
+    /// ``memory://`` or ``s3://bucket/path?region=us-east-1``. The scheme must
+    /// belong to a service enabled in this build.
+    ///
+    /// Parameters
+    /// ----------
+    /// uri : str
+    ///     The URI of the service.
+    /// **kwargs : dict
+    ///     Extra options that override or supplement values encoded in the URI.
+    ///
+    /// Returns
+    /// -------
+    /// Operator
+    ///     The new operator.
+    ///
+    /// Examples
+    /// --------
+    /// >>> import opendal
+    /// >>> op = opendal.Operator.from_uri("memory://")
+    /// >>> op = opendal.Operator.from_uri("s3://bucket/path", region="us-east-1")
+    #[classmethod]
+    #[pyo3(signature = (uri, **kwargs))]
+    pub fn from_uri(
+        _cls: &Bound<PyType>,
+        uri: &str,
+        kwargs: Option<&Bound<PyDict>>,
+    ) -> PyResult<Self> {
+        let map = kwargs
+            .map(|v| {
+                v.extract::<HashMap<String, String>>()
+                    .expect("must be valid hashmap")
+            })
+            .unwrap_or_default();
+
+        Ok(Operator {
+            core: build_blocking_operator_from_uri(uri, map.clone())?,
+            __scheme: uri.to_string(),
+            __map: map,
+            __from_uri: true,
         })
     }
 
@@ -125,6 +248,7 @@ impl Operator {
             core: op,
             __scheme: self.__scheme.clone(),
             __map: self.__map.clone(),
+            __from_uri: self.__from_uri,
         })
     }
 
@@ -676,6 +800,7 @@ impl Operator {
             core: self.core.clone().into(),
             __scheme: self.__scheme.clone(),
             __map: self.__map.clone(),
+            __from_uri: self.__from_uri,
         })
     }
 
@@ -692,11 +817,12 @@ impl Operator {
             )
         }
     }
-    fn __getnewargs_ex__(&self, py: Python) -> PyResult<Py<PyAny>> {
-        let args = vec![self.__scheme.clone()];
-        let args = PyTuple::new(py, args)?.into_py_any(py)?;
-        let kwargs = self.__map.clone().into_py_any(py)?;
-        PyTuple::new(py, [args, kwargs])?.into_py_any(py)
+    fn __reduce__(&self, py: Python) -> PyResult<Py<PyAny>> {
+        let reconstructor = py
+            .import("opendal._opendal")?
+            .getattr("_reconstruct_operator")?;
+        let args = (self.__from_uri, self.__scheme.clone(), self.__map.clone()).into_py_any(py)?;
+        PyTuple::new(py, [reconstructor.into_py_any(py)?, args])?.into_py_any(py)
     }
 }
 
@@ -712,6 +838,8 @@ pub struct AsyncOperator {
     core: ocore::Operator,
     __scheme: String,
     __map: HashMap<String, String>,
+    // See `Operator.__from_uri`.
+    __from_uri: bool,
 }
 #[pymethods]
 impl AsyncOperator {
@@ -753,6 +881,52 @@ impl AsyncOperator {
             core: build_operator(&scheme, map.clone())?,
             __scheme: scheme,
             __map: map,
+            __from_uri: false,
+        })
+    }
+
+    /// Create a new `AsyncOperator` from a URI string.
+    ///
+    /// The URI encodes the scheme and configuration in a single string, e.g.
+    /// ``memory://`` or ``s3://bucket/path?region=us-east-1``. The scheme must
+    /// belong to a service enabled in this build.
+    ///
+    /// Parameters
+    /// ----------
+    /// uri : str
+    ///     The URI of the service.
+    /// **kwargs : dict
+    ///     Extra options that override or supplement values encoded in the URI.
+    ///
+    /// Returns
+    /// -------
+    /// AsyncOperator
+    ///     The new async operator.
+    ///
+    /// Examples
+    /// --------
+    /// >>> import opendal
+    /// >>> op = opendal.AsyncOperator.from_uri("memory://")
+    /// >>> op = opendal.AsyncOperator.from_uri("s3://bucket/path", region="us-east-1")
+    #[classmethod]
+    #[pyo3(signature = (uri, **kwargs))]
+    pub fn from_uri(
+        _cls: &Bound<PyType>,
+        uri: &str,
+        kwargs: Option<&Bound<PyDict>>,
+    ) -> PyResult<Self> {
+        let map = kwargs
+            .map(|v| {
+                v.extract::<HashMap<String, String>>()
+                    .expect("must be valid hashmap")
+            })
+            .unwrap_or_default();
+
+        Ok(AsyncOperator {
+            core: build_operator_from_uri(uri, map.clone())?,
+            __scheme: uri.to_string(),
+            __map: map,
+            __from_uri: true,
         })
     }
 
@@ -773,6 +947,7 @@ impl AsyncOperator {
             core: op,
             __scheme: self.__scheme.clone(),
             __map: self.__map.clone(),
+            __from_uri: self.__from_uri,
         })
     }
 
@@ -1696,6 +1871,7 @@ impl AsyncOperator {
             core: op,
             __scheme: self.__scheme.clone(),
             __map: self.__map.clone(),
+            __from_uri: self.__from_uri,
         })
     }
 
@@ -1716,11 +1892,12 @@ impl AsyncOperator {
             )
         }
     }
-    fn __getnewargs_ex__(&self, py: Python) -> PyResult<Py<PyAny>> {
-        let args = vec![self.__scheme.clone()];
-        let args = PyTuple::new(py, args)?.into_py_any(py)?;
-        let kwargs = self.__map.clone().into_py_any(py)?;
-        PyTuple::new(py, [args, kwargs])?.into_py_any(py)
+    fn __reduce__(&self, py: Python) -> PyResult<Py<PyAny>> {
+        let reconstructor = py
+            .import("opendal._opendal")?
+            .getattr("_reconstruct_async_operator")?;
+        let args = (self.__from_uri, self.__scheme.clone(), self.__map.clone()).into_py_any(py)?;
+        PyTuple::new(py, [reconstructor.into_py_any(py)?, args])?.into_py_any(py)
     }
 }
 

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -67,6 +67,15 @@ fn normalize_scheme(raw: &str) -> String {
     raw.trim().to_ascii_lowercase().replace('_', "-")
 }
 
+/// Extract service options from `**kwargs`, propagating a Python exception if a
+/// value is not a `str -> str` mapping instead of panicking.
+fn extract_kwargs(kwargs: Option<&Bound<PyDict>>) -> PyResult<HashMap<String, String>> {
+    match kwargs {
+        Some(v) => v.extract::<HashMap<String, String>>(),
+        None => Ok(HashMap::new()),
+    }
+}
+
 /// Rebuild a blocking [`Operator`] while unpickling.
 ///
 /// `from_uri` operators store a full URI in `__scheme` and must be rebuilt via
@@ -167,12 +176,7 @@ impl Operator {
             ));
         };
         let scheme = normalize_scheme(&scheme);
-        let map = kwargs
-            .map(|v| {
-                v.extract::<HashMap<String, String>>()
-                    .expect("must be valid hashmap")
-            })
-            .unwrap_or_default();
+        let map = extract_kwargs(kwargs)?;
 
         Ok(Operator {
             core: build_blocking_operator(&scheme, map.clone())?,
@@ -212,12 +216,7 @@ impl Operator {
         uri: &str,
         kwargs: Option<&Bound<PyDict>>,
     ) -> PyResult<Self> {
-        let map = kwargs
-            .map(|v| {
-                v.extract::<HashMap<String, String>>()
-                    .expect("must be valid hashmap")
-            })
-            .unwrap_or_default();
+        let map = extract_kwargs(kwargs)?;
 
         Ok(Operator {
             core: build_blocking_operator_from_uri(uri, map.clone())?,
@@ -870,12 +869,7 @@ impl AsyncOperator {
         };
         let scheme = normalize_scheme(&scheme);
 
-        let map = kwargs
-            .map(|v| {
-                v.extract::<HashMap<String, String>>()
-                    .expect("must be valid hashmap")
-            })
-            .unwrap_or_default();
+        let map = extract_kwargs(kwargs)?;
 
         Ok(AsyncOperator {
             core: build_operator(&scheme, map.clone())?,
@@ -915,12 +909,7 @@ impl AsyncOperator {
         uri: &str,
         kwargs: Option<&Bound<PyDict>>,
     ) -> PyResult<Self> {
-        let map = kwargs
-            .map(|v| {
-                v.extract::<HashMap<String, String>>()
-                    .expect("must be valid hashmap")
-            })
-            .unwrap_or_default();
+        let map = extract_kwargs(kwargs)?;
 
         Ok(AsyncOperator {
             core: build_operator_from_uri(uri, map.clone())?,

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -78,10 +78,9 @@ fn extract_kwargs(kwargs: Option<&Bound<PyDict>>) -> PyResult<HashMap<String, St
 
 /// Rebuild a blocking [`Operator`] while unpickling.
 ///
-/// Reconstruction goes through `from_uri` (not the scheme-based `__new__`)
-/// because `__scheme` may hold a full URI that `__new__` would normalize and
-/// corrupt. A bare scheme is also accepted here, since the core resolves both
-/// bare schemes and full URIs through the same path.
+/// Routes through `from_uri`, not the scheme-based `__new__`, whose scheme
+/// normalization would corrupt a URI held in `__scheme`. Bare schemes work too:
+/// the core resolves both through the same path.
 #[pyfunction]
 pub fn _reconstruct_operator(scheme: &str, map: HashMap<String, String>) -> PyResult<Operator> {
     Ok(Operator {
@@ -169,9 +168,7 @@ impl Operator {
     /// uri : str
     ///     The URI of the service, including any options as query parameters.
     /// **kwargs : dict
-    ///     Optional overrides for options already encoded in the URI. Prefer
-    ///     encoding options in the URI itself; these are for the rare case where
-    ///     an option is more convenient to pass separately.
+    ///     Overrides for URI options. Prefer the URI query string.
     ///
     /// Returns
     /// -------
@@ -862,9 +859,7 @@ impl AsyncOperator {
     /// uri : str
     ///     The URI of the service, including any options as query parameters.
     /// **kwargs : dict
-    ///     Optional overrides for options already encoded in the URI. Prefer
-    ///     encoding options in the URI itself; these are for the rare case where
-    ///     an option is more convenient to pass separately.
+    ///     Overrides for URI options. Prefer the URI query string.
     ///
     /// Returns
     /// -------

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -177,11 +177,14 @@ impl Operator {
     ///
     /// Examples
     /// --------
-    /// >>> from urllib.parse import urlencode
-    /// >>> import opendal
-    /// >>> op = opendal.Operator.from_uri("memory://")
-    /// >>> query = urlencode({"region": "us-east-1"})
-    /// >>> op = opendal.Operator.from_uri(f"s3://bucket/path?{query}")
+    /// ```python
+    /// from urllib.parse import urlencode
+    /// import opendal
+    ///
+    /// op = opendal.Operator.from_uri("memory://")
+    /// query = urlencode({"region": "us-east-1"})
+    /// op = opendal.Operator.from_uri(f"s3://bucket/path?{query}")
+    /// ```
     #[classmethod]
     #[pyo3(signature = (uri, **kwargs))]
     pub fn from_uri(
@@ -868,11 +871,14 @@ impl AsyncOperator {
     ///
     /// Examples
     /// --------
-    /// >>> from urllib.parse import urlencode
-    /// >>> import opendal
-    /// >>> op = opendal.AsyncOperator.from_uri("memory://")
-    /// >>> query = urlencode({"region": "us-east-1"})
-    /// >>> op = opendal.AsyncOperator.from_uri(f"s3://bucket/path?{query}")
+    /// ```python
+    /// from urllib.parse import urlencode
+    /// import opendal
+    ///
+    /// op = opendal.AsyncOperator.from_uri("memory://")
+    /// query = urlencode({"region": "us-east-1"})
+    /// op = opendal.AsyncOperator.from_uri(f"s3://bucket/path?{query}")
+    /// ```
     #[classmethod]
     #[pyo3(signature = (uri, **kwargs))]
     pub fn from_uri(

--- a/bindings/python/tests/test_from_uri.py
+++ b/bindings/python/tests/test_from_uri.py
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import pickle
+from random import randint
+from uuid import uuid4
+
+import pytest
+
+import opendal
+from opendal.exceptions import Unsupported
+
+
+@pytest.fixture(scope="session")
+def uri_async_operator(service_name, setup_config):
+    # Mirror the `async_operator` fixture but construct via `from_uri`: a bare
+    # `scheme://` URI plus the same config passed as keyword options. This gives
+    # `from_uri` parity with the `via_iter`-based constructor across every
+    # service the suite runs against.
+    return opendal.AsyncOperator.from_uri(f"{service_name}://", **setup_config)
+
+
+@pytest.fixture(scope="session")
+def uri_operator(uri_async_operator):
+    return uri_async_operator.to_operator()
+
+
+def test_from_uri_returns_expected_types(uri_operator, uri_async_operator):
+    assert isinstance(uri_operator, opendal.Operator)
+    assert isinstance(uri_async_operator, opendal.AsyncOperator)
+
+
+def test_from_uri_matches_constructor_capability(
+    uri_operator, operator, uri_async_operator, async_operator
+):
+    # `from_uri("scheme://", **config)` and `Operator(scheme, **config)` resolve
+    # to the same service, so their capabilities must match.
+    assert uri_operator.capability().write == operator.capability().write
+    assert uri_operator.capability().read == operator.capability().read
+    assert uri_async_operator.capability().write == async_operator.capability().write
+
+
+@pytest.mark.need_capability("write", "delete", "stat")
+def test_sync_from_uri_write(service_name, uri_operator):
+    size = randint(1, 1024)
+    filename = f"test_file_{uuid4()}.txt"
+    content = os.urandom(size)
+    uri_operator.write(filename, content)
+    metadata = uri_operator.stat(filename)
+    assert metadata is not None
+    assert metadata.mode.is_file()
+    assert metadata.content_length == size
+
+    uri_operator.delete(filename)
+
+
+@pytest.mark.asyncio
+@pytest.mark.need_capability("write", "delete", "stat")
+async def test_async_from_uri_write(service_name, uri_async_operator):
+    size = randint(1, 1024)
+    filename = f"test_file_{uuid4()}.txt"
+    content = os.urandom(size)
+    await uri_async_operator.write(filename, content)
+    metadata = await uri_async_operator.stat(filename)
+    assert metadata is not None
+    assert metadata.mode.is_file()
+    assert metadata.content_length == size
+
+    await uri_async_operator.delete(filename)
+
+
+@pytest.mark.need_capability("read", "write", "delete", "shared")
+def test_from_uri_operator_pickle(uri_operator):
+    # Match `test_operator_pickle`: an operator built via `from_uri` must survive
+    # a pickle round-trip and remain able to read data written before pickling.
+    size = randint(1, 1024)
+    filename = f"random_file_{uuid4()}"
+    content = os.urandom(size)
+    uri_operator.write(filename, content)
+
+    deserialized = pickle.loads(pickle.dumps(uri_operator))
+    assert deserialized.read(filename) == content
+
+    uri_operator.delete(filename)
+
+
+def test_from_uri_unsupported_scheme_raises():
+    with pytest.raises(Unsupported):
+        opendal.Operator.from_uri("thisdoesnotexist://bucket/path")

--- a/bindings/python/tests/test_from_uri.py
+++ b/bindings/python/tests/test_from_uri.py
@@ -29,10 +29,19 @@ from opendal.exceptions import Unsupported
 @pytest.fixture(scope="session")
 def uri_async_operator(service_name, setup_config):
     # Mirror the `async_operator` fixture but construct via `from_uri`: a bare
-    # `scheme://` URI plus the same config passed as keyword options. This gives
-    # `from_uri` parity with the `via_iter`-based constructor across every
-    # service the suite runs against.
-    return opendal.AsyncOperator.from_uri(f"{service_name}://", **setup_config)
+    # `scheme://` URI plus the same config passed as keyword options. Apply the
+    # same layers and capability overrides so capability gating and equality
+    # assertions match the constructor-based operator the suite uses.
+    operator = (
+        opendal.AsyncOperator.from_uri(f"{service_name}://", **setup_config)
+        .layer(opendal.layers.RetryLayer())
+        .layer(opendal.layers.ConcurrentLimitLayer(1024))
+        .layer(opendal.layers.MimeGuessLayer())
+    )
+    overrides = os.environ.get("OPENDAL_TEST_CAPABILITY_OVERRIDES")
+    if overrides:
+        operator = operator.layer(opendal.layers.CapabilityOverrideLayer(overrides))
+    return operator
 
 
 @pytest.fixture(scope="session")

--- a/bindings/python/tests/test_from_uri.py
+++ b/bindings/python/tests/test_from_uri.py
@@ -93,6 +93,31 @@ async def test_async_from_uri_write(service_name, uri_async_operator):
     await uri_async_operator.delete(filename)
 
 
+@pytest.mark.need_capability("read", "write", "delete")
+def test_sync_from_uri_read_write_roundtrip(uri_operator):
+    # Write then read back through a from_uri-built operator and assert the
+    # content survives the round trip unchanged.
+    size = randint(1, 1024)
+    filename = f"test_file_{uuid4()}.txt"
+    content = os.urandom(size)
+    uri_operator.write(filename, content)
+    assert uri_operator.read(filename) == content
+
+    uri_operator.delete(filename)
+
+
+@pytest.mark.asyncio
+@pytest.mark.need_capability("read", "write", "delete")
+async def test_async_from_uri_read_write_roundtrip(uri_async_operator):
+    size = randint(1, 1024)
+    filename = f"test_file_{uuid4()}.txt"
+    content = os.urandom(size)
+    await uri_async_operator.write(filename, content)
+    assert (await uri_async_operator.read(filename)) == content
+
+    await uri_async_operator.delete(filename)
+
+
 @pytest.mark.need_capability("read", "write", "delete", "shared")
 def test_from_uri_operator_pickle(uri_operator):
     # Match `test_operator_pickle`: an operator built via `from_uri` must survive


### PR DESCRIPTION
# Which issue does this PR close?

No tracking issue. New feature for the Python binding.

# Rationale for this change

The Rust core and the Node.js binding (`Operator.fromUri`) support URI-based construction (e.g. `s3://bucket/path?region=us-east-1`). The Python binding only supported scheme + kwargs (`Operator("s3", ...)`). This adds the URI path.

# What changes are included in this PR?

- Add `Operator.from_uri` / `AsyncOperator.from_uri` classmethods backed by core `Operator::from_uri`. Options go in the URI query string; `**kwargs` are override-only.
- Switch pickling from `__getnewargs_ex__` to `__reduce__` so URI-built operators (which store a raw URI) reconstruct correctly instead of going through the scheme-normalizing `__new__`.
- Add `tests/test_from_uri.py`, wired into the shared service fixtures so it runs across all services in CI (pickle test gated on `shared`).
- Regenerated type stubs.

# Are there any user-facing changes?

New `Operator.from_uri(uri, **kwargs)` and `AsyncOperator.from_uri(uri, **kwargs)`. No breaking changes; existing constructors unaffected.

# AI Usage Statement

Implemented with an AI coding agent (opencode, Claude Opus). Validated locally: `cargo clippy`, `cargo fmt`, `ruff`, `ty`, `pytest`.
