### PR TITLE
docs(python): fix broken Python API reference links (404)

### DIFF
--- a/website/docs/20-bindings/python/01-overview.md
+++ b/website/docs/20-bindings/python/01-overview.md
@@ -52,5 +52,5 @@ pip install opendal
 3. [Common tasks](./04-tasks.md) — read, write, stream, list, presign, and more.
 4. [Going to production](./05-production.md) — retries, errors, and capability checks.
 
-[`Operator`]: https://opendal.apache.org/docs/python/opendal.html#opendal.Operator
-[`AsyncOperator`]: https://opendal.apache.org/docs/python/opendal.html#opendal.AsyncOperator
+[`Operator`]: https://opendal.apache.org/docs/python/api/operator/#opendal.Operator
+[`AsyncOperator`]: https://opendal.apache.org/docs/python/api/async_operator/#opendal.AsyncOperator

--- a/website/docs/20-bindings/python/02-getting-started.md
+++ b/website/docs/20-bindings/python/02-getting-started.md
@@ -60,4 +60,4 @@ asyncio.run(main())
 Both operators expose the same operations. Convert between them with
 `op.to_async_operator()` and `op.to_operator()` when you need the other form.
 
-[`AsyncOperator`]: https://opendal.apache.org/docs/python/opendal.html#opendal.AsyncOperator
+[`AsyncOperator`]: https://opendal.apache.org/docs/python/api/async_operator/#opendal.AsyncOperator


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7870.

# Rationale for this change

Links to the Python API reference on the website 404. They point to a flat `opendal.html`, but the MkDocs `nav` emits per-page directory URLs, so no such page exists.

# What changes are included in this PR?

Point the `Operator` and `AsyncOperator` reference links at the paths the build serves:

- `docs/python/opendal.html#opendal.Operator` → `docs/python/api/operator/#opendal.Operator`
- `docs/python/opendal.html#opendal.AsyncOperator` → `docs/python/api/async_operator/#opendal.AsyncOperator`

Verified with `mkdocs build`: the target pages and anchors exist; `opendal.html` does not.

# Are there any user-facing changes?

Docs links only. No API or behavior changes.

# AI Usage Statement

Implemented with an AI coding agent (opencode, Claude Opus). Validated locally with `mkdocs build`.
