### PR TITLE
docs(python): fix duplicated headings on layers and types API pages

### DIFF
--- a/bindings/python/docs/api/layers.md
+++ b/bindings/python/docs/api/layers.md
@@ -2,7 +2,6 @@
 
 This page documents all layers in OpenDAL.
 
-## Layer
 ::: opendal.layers.Layer
     options:
       heading: "opendal.layers.Layer"
@@ -10,21 +9,18 @@ This page documents all layers in OpenDAL.
       show_source: false
       show_bases: false
 
-## RetryLayer   
 ::: opendal.layers.RetryLayer
     options:
       heading: "opendal.layers.RetryLayer"
       heading_level: 2
       show_source: false
 
-## ConcurrentLimitLayer   
 ::: opendal.layers.ConcurrentLimitLayer
     options:
       heading: "opendal.layers.ConcurrentLimitLayer"
       heading_level: 2
       show_source: false
 
-## MimeGuessLayer   
 ::: opendal.layers.MimeGuessLayer
     options:
       heading: "opendal.layers.MimeGuessLayer"

--- a/bindings/python/docs/api/types.md
+++ b/bindings/python/docs/api/types.md
@@ -2,7 +2,6 @@
 
 This page documents all types in OpenDAL.
 
-## Entry
 ::: opendal.types.Entry
     options:
       heading: "opendal.types.Entry"
@@ -10,13 +9,11 @@ This page documents all types in OpenDAL.
       show_source: false
       show_bases: false
 
-## EntryMode   
 ::: opendal.types.EntryMode
     options:
       heading: "opendal.types.EntryMode"
       heading_level: 2
 
-## Metadata   
 ::: opendal.types.Metadata
     options:
       heading: "opendal.types.Metadata"
@@ -24,7 +21,6 @@ This page documents all types in OpenDAL.
       show_source: false
       show_bases: false
 
-## PresignedRequest   
 ::: opendal.types.PresignedRequest
     options:
       heading: "opendal.types.PresignedRequest"

--- a/bindings/python/docs/index.md
+++ b/bindings/python/docs/index.md
@@ -9,7 +9,7 @@ pip install opendal
 ## Local Usage
 Developer must set two required arguments to work with files locally:
 - `scheme`: which should be specified as `fs`
-- `root`: where OpenDAl considers the root of the directory for operations will be.
+- `root`: where OpenDAL considers the root of the directory for operations will be.
 
 For example in the following operator:
 `opendal.Operator("fs", root="/foo")`


### PR DESCRIPTION
# Which issue does this PR close?

No tracking issue.

# Rationale for this change

The layers and types API pages render each class twice. Each entry has a manual Markdown `## <Name>` heading before the mkdocstrings block, and mkdocstrings also renders its own heading for the class, producing two headings (and two table-of-contents entries) per class. The single-class pages (e.g. `operator.md`) omit the manual heading and render once.

# What changes are included in this PR?

Remove the redundant manual `## <Name>` headings from `docs/api/layers.md` and `docs/api/types.md` so each class renders a single heading via mkdocstrings.

# Are there any user-facing changes?

Docs only. Each class now appears once on its API page.

# AI Usage Statement

Implemented with an AI coding agent (opencode, Claude Opus). Validated with `mkdocs build`.
