### PR TITLE
fix(integrations/dav-server): improve WebDAV handling

### DIFF
--- a/integrations/dav-server/src/file.rs
+++ b/integrations/dav-server/src/file.rs
@@ -73,6 +73,7 @@ impl OpendalFile {
             let w = op
                 .writer_with(&path)
                 .append(options.append)
+                .if_not_exists(options.create_new)
                 .await
                 .map_err(convert_error)?
                 .into_futures_async_write();

--- a/integrations/dav-server/src/fs.rs
+++ b/integrations/dav-server/src/fs.rs
@@ -23,7 +23,8 @@ use dav_server::fs::{DavFile, FsStream};
 use dav_server::fs::{DavFileSystem, ReadDirMeta};
 use futures::FutureExt;
 use futures::StreamExt;
-use opendal_core::Operator;
+use opendal_core::raw::normalize_path;
+use opendal_core::{ErrorKind, Operator};
 use std::path::Path;
 
 use super::dir::OpendalStream;
@@ -68,7 +69,24 @@ impl OpendalFs {
     }
 
     fn fs_path(&self, path: &DavPath) -> Result<String, FsError> {
-        String::from_utf8(path.as_bytes().to_vec()).map_err(|_| FsError::GeneralFailure)
+        String::from_utf8(path.as_bytes().to_vec())
+            .map(|path| normalize_path(path.as_str()))
+            .map_err(|_| FsError::GeneralFailure)
+    }
+
+    fn fs_dir_path(&self, path: &DavPath) -> Result<String, FsError> {
+        Ok(Self::into_dir_path(self.fs_path(path)?))
+    }
+
+    fn into_dir_path(mut path: String) -> String {
+        if !Self::is_dir_path(&path) {
+            path.push('/');
+        }
+        path
+    }
+
+    fn is_dir_path(path: &str) -> bool {
+        path.is_empty() || path.ends_with('/')
     }
 }
 
@@ -92,7 +110,7 @@ impl DavFileSystem for OpendalFs {
         _meta: ReadDirMeta,
     ) -> FsFuture<'a, FsStream<Box<dyn DavDirEntry>>> {
         async move {
-            let path = self.fs_path(path)?;
+            let path = self.fs_dir_path(path)?;
             self.op
                 .lister(path.as_str())
                 .await
@@ -105,21 +123,26 @@ impl DavFileSystem for OpendalFs {
     fn metadata<'a>(&'a self, path: &'a DavPath) -> FsFuture<'a, Box<dyn DavMetaData>> {
         async move {
             let path = self.fs_path(path)?;
-            let opendal_metadata = self.op.stat(path.as_str()).await;
-            match opendal_metadata {
-                Ok(metadata) => {
-                    let webdav_metadata = OpendalMetaData::new(metadata);
-                    Ok(Box::new(webdav_metadata) as Box<dyn DavMetaData>)
+            let metadata = match self.op.stat(path.as_str()).await {
+                Ok(metadata) => metadata,
+                Err(e)
+                    if !Self::is_dir_path(&path)
+                        && matches!(e.kind(), ErrorKind::NotFound | ErrorKind::IsADirectory) =>
+                {
+                    let path = Self::into_dir_path(path);
+                    self.op.stat(path.as_str()).await.map_err(convert_error)?
                 }
-                Err(e) => Err(convert_error(e)),
-            }
+                Err(e) => return Err(convert_error(e)),
+            };
+
+            Ok(Box::new(OpendalMetaData::new(metadata)) as Box<dyn DavMetaData>)
         }
         .boxed()
     }
 
     fn create_dir<'a>(&'a self, path: &'a DavPath) -> FsFuture<'a, ()> {
         async move {
-            let path = self.fs_path(path)?;
+            let path = self.fs_dir_path(path)?;
 
             // check if the parent path is exist.
             // During MKCOL processing, a server MUST make the Request-URI a member of its parent collection, unless the Request-URI is "/".  If no such ancestor exists, the method MUST fail.
@@ -161,7 +184,11 @@ impl DavFileSystem for OpendalFs {
     }
 
     fn remove_dir<'a>(&'a self, path: &'a DavPath) -> FsFuture<'a, ()> {
-        self.remove_file(path)
+        async move {
+            let path = self.fs_dir_path(path)?;
+            self.op.delete(&path).await.map_err(convert_error)
+        }
+        .boxed()
     }
 
     fn remove_file<'a>(&'a self, path: &'a DavPath) -> FsFuture<'a, ()> {
@@ -174,16 +201,54 @@ impl DavFileSystem for OpendalFs {
 
     fn rename<'a>(&'a self, from: &'a DavPath, to: &'a DavPath) -> FsFuture<'a, ()> {
         async move {
-            let from_path = from
-                .as_rel_ospath()
-                .to_str()
-                .ok_or(FsError::GeneralFailure)?;
-            let to_path = to.as_rel_ospath().to_str().ok_or(FsError::GeneralFailure)?;
             if from.is_collection() {
-                let _ = self.remove_file(to).await;
+                let from_path = self.fs_dir_path(from)?;
+                let to_path = self.fs_dir_path(to)?;
+
+                if self
+                    .op
+                    .exists(to_path.as_str())
+                    .await
+                    .map_err(convert_error)?
+                {
+                    return Err(FsError::Exists);
+                }
+
+                let mut lister = self
+                    .op
+                    .lister_with(from_path.as_str())
+                    .limit(2)
+                    .await
+                    .map_err(convert_error)?;
+                let mut found = false;
+                while let Some(entry) = lister.next().await {
+                    let entry = entry.map_err(convert_error)?;
+                    if entry.path() == from_path {
+                        found = true;
+                    } else {
+                        // Only empty directory moves are supported.
+                        return Err(FsError::NotImplemented);
+                    }
+                }
+                if !found {
+                    return Err(FsError::NotFound);
+                }
+
+                self.op
+                    .create_dir(to_path.as_str())
+                    .await
+                    .map_err(convert_error)?;
+                return self
+                    .op
+                    .delete(from_path.as_str())
+                    .await
+                    .map_err(convert_error);
             }
+
+            let from_path = self.fs_path(from)?;
+            let to_path = self.fs_path(to)?;
             self.op
-                .rename(from_path, to_path)
+                .rename(from_path.as_str(), to_path.as_str())
                 .await
                 .map_err(convert_error)
         }
@@ -192,13 +257,10 @@ impl DavFileSystem for OpendalFs {
 
     fn copy<'a>(&'a self, from: &'a DavPath, to: &'a DavPath) -> FsFuture<'a, ()> {
         async move {
-            let from_path = from
-                .as_rel_ospath()
-                .to_str()
-                .ok_or(FsError::GeneralFailure)?;
-            let to_path = to.as_rel_ospath().to_str().ok_or(FsError::GeneralFailure)?;
+            let from_path = self.fs_path(from)?;
+            let to_path = self.fs_path(to)?;
             self.op
-                .copy(from_path, to_path)
+                .copy(from_path.as_str(), to_path.as_str())
                 .await
                 .map(|_| ())
                 .map_err(convert_error)

--- a/integrations/dav-server/src/utils.rs
+++ b/integrations/dav-server/src/utils.rs
@@ -17,10 +17,14 @@
 
 pub fn convert_error(opendal_error: opendal_core::Error) -> dav_server::fs::FsError {
     match opendal_error.kind() {
-        opendal_core::ErrorKind::AlreadyExists | opendal_core::ErrorKind::IsSameFile => {
-            dav_server::fs::FsError::Exists
-        }
+        opendal_core::ErrorKind::Unsupported => dav_server::fs::FsError::NotImplemented,
         opendal_core::ErrorKind::NotFound => dav_server::fs::FsError::NotFound,
+        opendal_core::ErrorKind::PermissionDenied
+        | opendal_core::ErrorKind::IsADirectory
+        | opendal_core::ErrorKind::NotADirectory => dav_server::fs::FsError::Forbidden,
+        opendal_core::ErrorKind::AlreadyExists
+        | opendal_core::ErrorKind::IsSameFile
+        | opendal_core::ErrorKind::ConditionNotMatch => dav_server::fs::FsError::Exists,
         _ => dav_server::fs::FsError::GeneralFailure,
     }
 }


### PR DESCRIPTION

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->
Fixes #7881.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

Normalize DavPath values before using them for comparisons against
OpenDAL paths. OpenDAL normalizes operation paths internally, so the DAV
integration compares paths in that same form when checking lister output
and collection moves.

Use directory-shaped paths for collection metadata, listing, creation, and
deletion. Slashless collection requests now fall back to trailing slash
paths.

Support moving empty collections by creating the destination collection and
deleting the source after a limited listing confirms the source is empty.
This is needed so Windows Explorer can create a folder by renaming the
initial New folder collection. Non-empty directory moves still return
NotImplemented.

Honor DAV create_new requests by enabling if-not-exists on the OpenDAL
writer. Map more OpenDAL errors to WebDAV errors, including Unsupported,
path-type errors, and conditional conflicts.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
WebDAV integration works better.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement
I used Codex with GPT-5.5 to help draft and refine the change. I manually reviewed the generated code and tested the resulting behavior from Windows Explorer against a WebDAV path backed by OpenDAL.
<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
