### PR TITLE
fix(s3): set content length for copy object

### DIFF
--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -770,6 +770,9 @@ impl S3Core {
             .extension(Operation::Copy)
             .extension(ServiceOperation("CopyObject"))
             .header(constants::X_AMZ_COPY_SOURCE, &source)
+            // AWS S3 accepts CopyObject without Content-Length, but some S3-compatible
+            // providers, such as NetApp, require `Content-Length: 0` for its empty body.
+            .header(CONTENT_LENGTH, 0)
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7821.

# Rationale for this change

Some S3-compatible services require `Content-Length` to be present on `CopyObject` requests, even when the request body is empty. OpenDAL already sends an empty body for S3 copy, so this makes the request explicit by setting `Content-Length: 0`.

# What changes are included in this PR?

- Set `Content-Length: 0` when building S3 `CopyObject` requests.
- Split CopyObject request construction into `s3_copy_object_request`, matching existing request-builder patterns.
- Add a unit test that verifies the CopyObject request method, headers, and empty body.

# Are there any user-facing changes?

No API changes. This improves compatibility with S3-compatible services.

# AI Usage Statement

I used OpenAI Codex to help implement and test this change.