### PR TITLE
fix(services/s3): encode version id for stat and read

### DIFF
--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -1359,4 +1359,59 @@ mod tests {
             "application/json"
         );
     }
+
+    #[tokio::test]
+    async fn test_presign_stat_encodes_version_id() {
+        let backend = S3Builder::default()
+            .bucket("test")
+            .region("us-east-1")
+            .skip_signature()
+            .disable_config_load()
+            .disable_ec2_metadata()
+            .build()
+            .expect("build");
+
+        let op = OpStat::default().with_version("a+b/c=d%25&e");
+        let args = OpPresign::new(op, Duration::from_secs(3600));
+        let ctx = OperationContext::new();
+        let presigned = backend
+            .presign(&ctx, "test.txt", args)
+            .await
+            .expect("presign")
+            .into_presigned_request();
+
+        assert_eq!(
+            presigned.uri().to_string(),
+            "https://s3.us-east-1.amazonaws.com/test/test.txt?versionId=a%2Bb/c%3Dd%2525%26e"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_presign_read_encodes_version_id() {
+        let backend = S3Builder::default()
+            .bucket("test")
+            .region("us-east-1")
+            .skip_signature()
+            .disable_config_load()
+            .disable_ec2_metadata()
+            .build()
+            .expect("build");
+
+        let op = OpRead::default().with_version("a+b/c=d%25&e");
+        let args = OpPresign::new(
+            PresignOperation::Read(BytesRange::default(), op),
+            Duration::from_secs(3600),
+        );
+        let ctx = OperationContext::new();
+        let presigned = backend
+            .presign(&ctx, "test.txt", args)
+            .await
+            .expect("presign")
+            .into_presigned_request();
+
+        assert_eq!(
+            presigned.uri().to_string(),
+            "https://s3.us-east-1.amazonaws.com/test/test.txt?versionId=a%2Bb/c%3Dd%2525%26e"
+        );
+    }
 }

--- a/core/services/s3/src/core.rs
+++ b/core/services/s3/src/core.rs
@@ -420,7 +420,7 @@ impl S3Core {
             query_args.push(format!(
                 "{}={}",
                 constants::S3_QUERY_VERSION_ID,
-                percent_decode_path(version)
+                percent_encode_path(version)
             ))
         }
         if !query_args.is_empty() {
@@ -496,7 +496,7 @@ impl S3Core {
             query_args.push(format!(
                 "{}={}",
                 constants::S3_QUERY_VERSION_ID,
-                percent_decode_path(version)
+                percent_encode_path(version)
             ))
         }
         if !query_args.is_empty() {


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

S3 stat and read requests built `versionId` query values with `percent_decode_path`. If a version id contains reserved query characters like `+`, `=`, `%`, or `&`, the generated URI can contain an unescaped query value. This can split the query incorrectly or make signing use a different query structure.

# What changes are included in this PR?

This PR encodes `versionId` for S3 stat and read requests with `percent_encode_path`, matching delete, copy, and list-version handling.

It also adds regression tests for presigned stat and read URLs with special characters in the version id.

# Are there any user-facing changes?

Yes. S3 `stat`, `read`, `presign_stat`, and `presign_read` now work correctly with version ids that contain reserved query characters.

# AI Usage Statement

I used OpenAI Codex to implement the test in this change.