### PR TITLE
fix: CI prints clippy version and clippy fix

### DIFF
--- a/.github/workflows/ci_bindings_c.yml
+++ b/.github/workflows/ci_bindings_c.yml
@@ -42,6 +42,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v7
 
@@ -53,12 +54,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential pkg-config uuid-dev libcurl4-gnutls-dev
 
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: "bindings/c"
+        run: cargo clippy --version
+
       - name: Clippy Check
         working-directory: "bindings/c"
 
         run: |
           cargo clippy -- -D warnings
-
 
       - name: Build C binding
         working-directory: "bindings/c"

--- a/.github/workflows/ci_bindings_cpp.yml
+++ b/.github/workflows/ci_bindings_cpp.yml
@@ -43,6 +43,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-24.04
+
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -52,11 +53,15 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
-      
+
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: "bindings/cpp"
+        run: cargo clippy --version
+
       - name: Clippy Check
         working-directory: "bindings/cpp"
-        run: |
-          cargo clippy -- -D warnings
+        run: cargo clippy -- -D warnings
 
       - name: Build Cpp binding && Run tests
         working-directory: "bindings/cpp"

--- a/.github/workflows/ci_bindings_dart.yml
+++ b/.github/workflows/ci_bindings_dart.yml
@@ -77,6 +77,11 @@ jobs:
         working-directory: bindings/dart
         run: flutter pub get
 
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: bindings/dart/rust
+        run: cargo clippy --version
+
       - name: Check Clippy
         working-directory: bindings/dart/rust
         run: cargo clippy -- -D warnings

--- a/.github/workflows/ci_bindings_dotnet.yml
+++ b/.github/workflows/ci_bindings_dotnet.yml
@@ -55,11 +55,15 @@ jobs:
           need-protoc: true
           need-rocksdb: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      
+
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: "bindings/dotnet"
+        run: cargo clippy --version
+
       - name: Clippy Check
         working-directory: "bindings/dotnet"
-        run: |
-          cargo clippy -- -D warnings
+        run: cargo clippy -- -D warnings
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci_bindings_haskell.yml
+++ b/.github/workflows/ci_bindings_haskell.yml
@@ -60,10 +60,14 @@ jobs:
           cabal update
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: "bindings/haskell"
+        run: cargo clippy --version
+
       - name: Clippy Check
         working-directory: "bindings/haskell"
-        run: |
-          cargo clippy -- -D warnings
+        run: cargo clippy -- -D warnings
       - name: Restore haskell cache
         uses: actions/cache/restore@v6
         with:

--- a/.github/workflows/ci_bindings_java.yml
+++ b/.github/workflows/ci_bindings_java.yml
@@ -94,6 +94,11 @@ jobs:
         working-directory: bindings/java
         run: |
           ./mvnw clean compile spotless:check
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: bindings/java
+        run: cargo clippy --version
+
       - name: Check Clippy
         working-directory: bindings/java
         run: cargo clippy -- -D warnings

--- a/.github/workflows/ci_bindings_lua.yml
+++ b/.github/workflows/ci_bindings_lua.yml
@@ -42,23 +42,32 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v7
       - name: Setup lua toolchain
         run: |
           sudo apt-get update
           sudo apt-get install -y lua-busted luarocks liblua5.2-dev
+
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
+
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: "bindings/lua"
+        run: cargo clippy --version
+
       - name: Clippy Check
         working-directory: "bindings/lua"
-        run: |
-          cargo clippy -- -D warnings
+        run: cargo clippy -- -D warnings
+
       - name: Build & Test
         working-directory: "bindings/lua"
         run: |
           sudo "PATH=$PATH" luarocks make
           busted test/opendal_test.lua
+
       - name: Run getting-started example
         working-directory: "bindings/lua"
         run: |

--- a/.github/workflows/ci_bindings_nodejs.yml
+++ b/.github/workflows/ci_bindings_nodejs.yml
@@ -76,6 +76,10 @@ jobs:
       - name: Check format
         run: pnpm exec prettier --check .
 
+      # Useful for debugging
+      - name: Print Clippy version
+        run: cargo clippy --version
+
       - name: Check Clippy
         run: cargo clippy -- -D warnings
 

--- a/.github/workflows/ci_bindings_ocaml.yml
+++ b/.github/workflows/ci_bindings_ocaml.yml
@@ -50,10 +50,14 @@ jobs:
           need-depext: true
           need-pin: true
 
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: "bindings/ocaml"
+        run: cargo clippy --version
+
       - name: Clippy Check
         working-directory: "bindings/ocaml"
-        run: |
-          cargo clippy -- -D warnings
+        run: cargo clippy -- -D warnings
 
   test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci_bindings_php.yml
+++ b/.github/workflows/ci_bindings_php.yml
@@ -62,10 +62,14 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
 
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: "bindings/php"
+        run: cargo clippy --version
+
       - name: Clippy Check
         working-directory: "bindings/php"
-        run: |
-          cargo clippy -- -D warnings
+        run: cargo clippy -- -D warnings
 
       - name: Build opendal-php extension
         working-directory: "bindings/php"

--- a/.github/workflows/ci_bindings_python.yml
+++ b/.github/workflows/ci_bindings_python.yml
@@ -39,13 +39,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
+
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           working-directory: "bindings/python"
+
       - uses: taiki-e/install-action@just
+
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: "bindings/python"
+        run: cargo clippy --version
+
       - name: Run Lints
         working-directory: "bindings/python"
         run: just lint
@@ -54,22 +63,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
+
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           working-directory: "bindings/python"
+
       - uses: taiki-e/install-action@just
+
       - name: Setup taplo
         uses: taiki-e/install-action@v2
         with:
           tool: taplo-cli
+
       - name: Setup hawkeye
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/korandoru/hawkeye/releases/download/v6.5.1/hawkeye-installer.sh | sh
+
       - name: Regenerate stubs
         working-directory: "bindings/python"
         run: just stub-gen
+
       - name: Check diff
         run: git diff --exit-code
 
@@ -77,15 +93,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
         with:
           need-protoc: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           working-directory: bindings/python
+
       - name: Build with maturin
         shell: bash
         working-directory: "bindings/python"
@@ -93,6 +112,7 @@ jobs:
           uv venv --python=python3.11
           uv sync --all-extras
           uv run -- maturin develop
+
       # Examples back the snippets shown in the website guide. Running them keeps
       # the docs honest: a broken example fails CI instead of shipping bad docs.
       - name: Run guide examples

--- a/.github/workflows/ci_bindings_ruby.yml
+++ b/.github/workflows/ci_bindings_ruby.yml
@@ -57,10 +57,14 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
 
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: "bindings/ruby"
+        run: cargo clippy --version
+
       - name: Clippy Check
         working-directory: "bindings/ruby"
-        run: |
-          cargo clippy -- -D warnings
+        run: cargo clippy -- -D warnings
 
       - name: Run lint
         working-directory: bindings/ruby

--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -73,6 +73,11 @@ jobs:
           distribution: zulu
           java-version: 25
 
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: core
+        run: cargo clippy --version
+
       - name: Cargo clippy
         working-directory: core
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
@@ -88,6 +93,12 @@ jobs:
         run: |
           rustup toolchain install ${OPENDAL_MSRV}
           rustup component add clippy --toolchain ${OPENDAL_MSRV}
+
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: core
+        run: cargo +${OPENDAL_MSRV} clippy --version
+
       - name: Check
         working-directory: core
         run: cargo +${OPENDAL_MSRV} clippy -- -D warnings
@@ -102,10 +113,12 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v7
+
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build
         working-directory: core
         run: cargo build --locked
@@ -114,10 +127,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
       # Examples back the snippets shown in the website guide. Running them keeps
       # the docs honest: a broken example fails CI instead of shipping bad docs.
       - name: Run guide examples
@@ -128,10 +143,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
       - name: Checkout python env
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+
       - name: Checkout java env
         uses: actions/setup-java@v5
         with:
@@ -157,12 +174,15 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+
     steps:
       - uses: actions/checkout@v7
+
       - name: Checkout python env
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+
       - name: Checkout java env
         uses: actions/setup-java@v5
         with:
@@ -231,12 +251,15 @@ jobs:
   # We only support some services(see `available_services` below) for now.
   build_under_wasm:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v7
+
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build
         working-directory: core
         run: |
@@ -252,6 +275,7 @@ jobs:
 
   unit:
     runs-on: ubuntu-latest
+
     steps:
       - name: cleanup
         run: |
@@ -267,11 +291,14 @@ jobs:
 
           sudo docker image prune --all --force
           sudo docker builder prune -a
+
       - uses: actions/checkout@v7
+
       - name: Checkout python env
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+
       - name: Checkout java env
         uses: actions/setup-java@v5
         with:
@@ -297,6 +324,7 @@ jobs:
 
   doc-test:
     runs-on: ubuntu-latest
+
     steps:
       - name: cleanup
         run: |
@@ -312,11 +340,14 @@ jobs:
 
           sudo docker image prune --all --force
           sudo docker builder prune -a
+
       - uses: actions/checkout@v7
+
       - name: Checkout python env
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
+
       - name: Checkout java env
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/ci_integration_dav_server.yml
+++ b/.github/workflows/ci_integration_dav_server.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
 
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: integrations/dav-server
+        run: cargo clippy --version
+
       - name: Cargo clippy
         working-directory: integrations/dav-server
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/ci_integration_object_store.yml
+++ b/.github/workflows/ci_integration_object_store.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
 
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: integrations/object_store
+        run: cargo clippy --version
+
       - name: Cargo clippy
         working-directory: integrations/object_store
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/ci_integration_parquet.yml
+++ b/.github/workflows/ci_integration_parquet.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
 
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: integrations/parquet
+        run: cargo clippy --version
+
       - name: Cargo clippy
         working-directory: integrations/parquet
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/ci_integration_unftp_sbe.yml
+++ b/.github/workflows/ci_integration_unftp_sbe.yml
@@ -46,6 +46,11 @@ jobs:
           need-protoc: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: integrations/unftp-sbe
+        run: cargo clippy --version
+
       - name: Cargo clippy
         working-directory: integrations/unftp-sbe
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/ci_odev.yml
+++ b/.github/workflows/ci_odev.yml
@@ -43,6 +43,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Useful for debugging
+      - name: Print Clippy version
+        working-directory: dev
+        run: cargo clippy --version
+
       - name: Cargo clippy
         working-directory: dev
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -135,7 +135,7 @@ pub enum Scheme {
 impl Scheme {
     #[getter]
     pub fn name(&self) -> String {
-        format!("{:?}", self)
+        format!("{:?}", &self)
     }
 
     #[getter]

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -135,7 +135,7 @@ pub enum Scheme {
 impl Scheme {
     #[getter]
     pub fn name(&self) -> String {
-        format!("{:?}", &self)
+        format!("{:?}", self)
     }
 
     #[getter]

--- a/core/services/aliyun-drive/src/backend.rs
+++ b/core/services/aliyun-drive/src/backend.rs
@@ -100,10 +100,10 @@ impl Builder for AliyunDriveBuilder {
     type Config = AliyunDriveConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
-        debug!("backend use root {}", &root);
+        debug!("backend use root {}", root);
 
         let sign = match self.config.access_token.clone() {
             Some(access_token) if !access_token.is_empty() => {

--- a/core/services/aliyun-drive/src/lister.rs
+++ b/core/services/aliyun-drive/src/lister.rs
@@ -131,10 +131,10 @@ impl oio::PageList for AliyunDriveLister {
 
         for item in result.items {
             let (path, mut md) = if item.path_type == "folder" {
-                let path = format!("{}{}/", &parent.path.trim_start_matches('/'), &item.name);
+                let path = format!("{}{}/", parent.path.trim_start_matches('/'), item.name);
                 (path, Metadata::new(EntryMode::DIR))
             } else {
-                let path = format!("{}{}", &parent.path.trim_start_matches('/'), &item.name);
+                let path = format!("{}{}", parent.path.trim_start_matches('/'), item.name);
                 (path, Metadata::new(EntryMode::FILE))
             };
 

--- a/core/services/alluxio/src/backend.rs
+++ b/core/services/alluxio/src/backend.rs
@@ -78,10 +78,10 @@ impl Builder for AlluxioBuilder {
 
     /// Builds the backend and returns the result of AlluxioBackend.
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
-        debug!("backend use root {}", &root);
+        debug!("backend use root {}", root);
 
         let endpoint = match &self.config.endpoint {
             Some(endpoint) => Ok(endpoint.clone()),
@@ -89,7 +89,7 @@ impl Builder for AlluxioBuilder {
                 .with_operation("Builder::build")
                 .with_context("service", ALLUXIO_SCHEME)),
         }?;
-        debug!("backend use endpoint {}", &endpoint);
+        debug!("backend use endpoint {}", endpoint);
 
         Ok(AlluxioBackend {
             core: Arc::new(AlluxioCore {

--- a/core/services/azblob/src/backend.rs
+++ b/core/services/azblob/src/backend.rs
@@ -292,7 +292,7 @@ impl Builder for AzblobBuilder {
     type Config = AzblobConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
         debug!("backend use root {root}");
@@ -304,7 +304,7 @@ impl Builder for AzblobBuilder {
                 .with_operation("Builder::build")
                 .with_context("service", AZBLOB_SCHEME)),
         }?;
-        debug!("backend use container {}", &container);
+        debug!("backend use container {}", container);
 
         let endpoint = match &self.config.endpoint {
             Some(endpoint) => Ok(endpoint.clone()),
@@ -312,7 +312,7 @@ impl Builder for AzblobBuilder {
                 .with_operation("Builder::build")
                 .with_context("service", AZBLOB_SCHEME)),
         }?;
-        debug!("backend use endpoint {}", &container);
+        debug!("backend use endpoint {}", container);
 
         let account_name = self
             .config

--- a/core/services/azblob/src/core.rs
+++ b/core/services/azblob/src/core.rs
@@ -422,7 +422,7 @@ impl AzblobCore {
         size: u64,
         body: Buffer,
     ) -> Result<Request<Buffer>> {
-        let url = format!("{}?comp=appendblock", &self.build_path_url(path));
+        let url = format!("{}?comp=appendblock", self.build_path_url(path));
 
         let mut req = Request::put(&url)
             .header(CONTENT_LENGTH, size)
@@ -576,7 +576,7 @@ impl AzblobCore {
         block_ids: Vec<Uuid>,
         args: &OpWrite,
     ) -> Result<Request<Buffer>> {
-        let url = format!("{}?comp=blocklist", &self.build_path_url(path));
+        let url = format!("{}?comp=blocklist", self.build_path_url(path));
 
         let req = Request::put(&url);
 
@@ -626,7 +626,7 @@ impl AzblobCore {
         block_ids: Vec<Uuid>,
         args: &OpCopy,
     ) -> Result<Request<Buffer>> {
-        let url = format!("{}?comp=blocklist", &self.build_path_url(path));
+        let url = format!("{}?comp=blocklist", self.build_path_url(path));
 
         let mut req = Request::put(&url);
 

--- a/core/services/azdls/src/backend.rs
+++ b/core/services/azdls/src/backend.rs
@@ -238,7 +238,7 @@ impl Builder for AzdlsBuilder {
     type Config = AzdlsConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
         debug!("backend use root {root}");
@@ -250,7 +250,7 @@ impl Builder for AzdlsBuilder {
                 .with_operation("Builder::build")
                 .with_context("service", AZDLS_SCHEME)),
         }?;
-        debug!("backend use filesystem {}", &filesystem);
+        debug!("backend use filesystem {}", filesystem);
 
         let endpoint = match &self.config.endpoint {
             Some(endpoint) => Ok(endpoint.clone().trim_end_matches('/').to_string()),
@@ -258,7 +258,7 @@ impl Builder for AzdlsBuilder {
                 .with_operation("Builder::build")
                 .with_context("service", AZDLS_SCHEME)),
         }?;
-        debug!("backend use endpoint {}", &endpoint);
+        debug!("backend use endpoint {}", endpoint);
 
         let account_name = self
             .config

--- a/core/services/azdls/src/lister.rs
+++ b/core/services/azdls/src/lister.rs
@@ -99,7 +99,7 @@ impl oio::PageList for AzdlsLister {
 
             let meta = Metadata::new(mode)
                 // Keep fit with ETag header.
-                .with_etag(format!("\"{}\"", &object.etag))
+                .with_etag(format!("\"{}\"", object.etag))
                 .with_content_length(object.content_length.parse().map_err(|err| {
                     Error::new(ErrorKind::Unexpected, "content length is not valid integer")
                         .set_source(err)

--- a/core/services/azfile/src/backend.rs
+++ b/core/services/azfile/src/backend.rs
@@ -164,7 +164,7 @@ impl Builder for AzfileBuilder {
     type Config = AzfileConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
         debug!("backend use root {root}");
@@ -175,7 +175,7 @@ impl Builder for AzfileBuilder {
                 .with_operation("Builder::build")
                 .with_context("service", AZFILE_SCHEME)),
         }?;
-        debug!("backend use endpoint {}", &endpoint);
+        debug!("backend use endpoint {}", endpoint);
 
         let account_name_option = self
             .config

--- a/core/services/b2/src/backend.rs
+++ b/core/services/b2/src/backend.rs
@@ -111,10 +111,10 @@ impl Builder for B2Builder {
 
     /// Builds the backend and returns the result of B2Backend.
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
-        debug!("backend use root {}", &root);
+        debug!("backend use root {}", root);
 
         // Handle bucket.
         if self.config.bucket.is_empty() {
@@ -123,7 +123,7 @@ impl Builder for B2Builder {
                 .with_context("service", B2_SCHEME));
         }
 
-        debug!("backend use bucket {}", &self.config.bucket);
+        debug!("backend use bucket {}", self.config.bucket);
 
         // Handle bucket_id.
         if self.config.bucket_id.is_empty() {
@@ -132,7 +132,7 @@ impl Builder for B2Builder {
                 .with_context("service", B2_SCHEME));
         }
 
-        debug!("backend bucket_id {}", &self.config.bucket_id);
+        debug!("backend bucket_id {}", self.config.bucket_id);
 
         let application_key_id = match &self.config.application_key_id {
             Some(application_key_id) => Ok(application_key_id.clone()),

--- a/core/services/cos/src/backend.rs
+++ b/core/services/cos/src/backend.rs
@@ -167,7 +167,7 @@ impl Builder for CosBuilder {
     type Config = CosConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
         debug!("backend use root {root}");
@@ -179,7 +179,7 @@ impl Builder for CosBuilder {
                     .with_context("service", COS_SCHEME),
             ),
         }?;
-        debug!("backend use bucket {}", &bucket);
+        debug!("backend use bucket {}", bucket);
 
         let uri = match &self.config.endpoint {
             Some(endpoint) => endpoint.parse::<Uri>().map_err(|err| {
@@ -199,7 +199,7 @@ impl Builder for CosBuilder {
 
         // If endpoint contains bucket name, we should trim them.
         let endpoint = uri.host().unwrap().replace(&format!("//{bucket}."), "//");
-        debug!("backend use endpoint {}", &endpoint);
+        debug!("backend use endpoint {}", endpoint);
 
         let os_env = OsEnv;
         let ctx = Context::new()
@@ -294,7 +294,7 @@ impl Builder for CosBuilder {
                 capability,
                 bucket: bucket.clone(),
                 root,
-                endpoint: format!("{}://{}.{}", &scheme, &bucket, &endpoint),
+                endpoint: format!("{}://{}.{}", scheme, bucket, endpoint),
                 signer,
             }),
         })

--- a/core/services/dashmap/src/backend.rs
+++ b/core/services/dashmap/src/backend.rs
@@ -54,7 +54,7 @@ impl Builder for DashmapBuilder {
     type Config = DashmapConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(
             self.config

--- a/core/services/dbfs/src/backend.rs
+++ b/core/services/dbfs/src/backend.rs
@@ -82,7 +82,7 @@ impl Builder for DbfsBuilder {
 
     /// Build a DbfsBackend.
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
         debug!("backend use root {root}");
@@ -93,7 +93,7 @@ impl Builder for DbfsBuilder {
                 .with_operation("Builder::build")
                 .with_context("service", DBFS_SCHEME)),
         }?;
-        debug!("backend use endpoint: {}", &endpoint);
+        debug!("backend use endpoint: {}", endpoint);
 
         let token = match self.config.token {
             Some(token) => token,

--- a/core/services/dbfs/src/core.rs
+++ b/core/services/dbfs/src/core.rs
@@ -196,7 +196,7 @@ impl DbfsCore {
 
         let url = format!(
             "{}/api/2.0/dbfs/get-status?path={}",
-            &self.endpoint,
+            self.endpoint,
             percent_encode_path(&p)
         );
 

--- a/core/services/dbfs/src/lister.rs
+++ b/core/services/dbfs/src/lister.rs
@@ -61,7 +61,7 @@ impl oio::PageList for DbfsLister {
         for status in decoded_response.files {
             let entry: oio::Entry = match status.is_dir {
                 true => {
-                    let normalized_path = format!("{}/", &status.path);
+                    let normalized_path = format!("{}/", status.path);
                     let mut meta = Metadata::new(EntryMode::DIR);
                     meta.set_last_modified(Timestamp::from_millisecond(status.modification_time)?);
                     oio::Entry::new(&normalized_path, meta)

--- a/core/services/foyer/src/backend.rs
+++ b/core/services/foyer/src/backend.rs
@@ -182,7 +182,7 @@ impl Builder for FoyerBuilder {
     type Config = FoyerConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(
             self.config

--- a/core/services/fs/src/backend.rs
+++ b/core/services/fs/src/backend.rs
@@ -67,7 +67,7 @@ impl Builder for FsBuilder {
     type Config = FsConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = match self.config.root.map(PathBuf::from) {
             Some(root) => Ok(root),

--- a/core/services/ftp/src/backend.rs
+++ b/core/services/ftp/src/backend.rs
@@ -93,7 +93,7 @@ impl Builder for FtpBuilder {
     type Config = FtpConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("ftp backend build started: {:?}", &self);
+        debug!("ftp backend build started: {:?}", self);
         let endpoint = match &self.config.endpoint {
             None => return Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")),
             Some(v) => v,

--- a/core/services/ftp/src/lister.rs
+++ b/core/services/ftp/src/lister.rs
@@ -62,7 +62,7 @@ impl oio::List for FtpLister {
         let entry = if de.is_file() {
             oio::Entry::new(&path, meta)
         } else if de.is_directory() {
-            oio::Entry::new(&format!("{}/", &path), meta)
+            oio::Entry::new(&format!("{}/", path), meta)
         } else {
             oio::Entry::new(&path, meta)
         };

--- a/core/services/gdrive/src/lister.rs
+++ b/core/services/gdrive/src/lister.rs
@@ -248,7 +248,7 @@ impl oio::PageList for GdriveLister {
                 file.name += "/";
             }
 
-            let path = format!("{}{}", &self.path, file.name);
+            let path = format!("{}{}", self.path, file.name);
             let metadata = metadata_from_gdrive_file(&file)?;
             self.apply_recent_entry(ctx, path, metadata).await?;
         }
@@ -396,7 +396,7 @@ impl GdriveFlatLister {
     async fn initialize(&mut self) -> Result<()> {
         log::debug!(
             "GdriveFlatLister: initializing with root path: {:?}",
-            &self.root_path
+            self.root_path
         );
 
         if let GdriveRecentPathState::Deleted =
@@ -408,7 +408,7 @@ impl GdriveFlatLister {
 
         let root_id = match self.core.resolve_path(&self.ctx, &self.root_path).await? {
             Some(id) => {
-                log::debug!("GdriveFlatLister: root path resolved to ID: {:?}", &id);
+                log::debug!("GdriveFlatLister: root path resolved to ID: {:?}", id);
                 id
             }
             None => match self
@@ -417,13 +417,13 @@ impl GdriveFlatLister {
                 .await?
             {
                 Some(id) => {
-                    log::debug!("GdriveFlatLister: root path resolved to ID: {:?}", &id);
+                    log::debug!("GdriveFlatLister: root path resolved to ID: {:?}", id);
                     id
                 }
                 None => {
                     log::debug!(
                         "GdriveFlatLister: root path not found: {:?}",
-                        &self.root_path
+                        self.root_path
                     );
                     if self.root_path.ends_with('/') {
                         self.done = true;
@@ -612,7 +612,7 @@ impl GdriveFlatLister {
         log::debug!(
             "GdriveFlatLister: processing batch of {} directories: {:?}",
             self.current_batch.len(),
-            &self.current_batch
+            self.current_batch
         );
 
         let mut resp = self

--- a/core/services/github/src/backend.rs
+++ b/core/services/github/src/backend.rs
@@ -94,10 +94,10 @@ impl Builder for GithubBuilder {
 
     /// Builds the backend and returns the result of GithubBackend.
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
-        debug!("backend use root {}", &root);
+        debug!("backend use root {}", root);
 
         // Handle owner.
         if self.config.owner.is_empty() {
@@ -106,7 +106,7 @@ impl Builder for GithubBuilder {
                 .with_context("service", GITHUB_SCHEME));
         }
 
-        debug!("backend use owner {}", &self.config.owner);
+        debug!("backend use owner {}", self.config.owner);
 
         // Handle repo.
         if self.config.repo.is_empty() {
@@ -115,7 +115,7 @@ impl Builder for GithubBuilder {
                 .with_context("service", GITHUB_SCHEME));
         }
 
-        debug!("backend use repo {}", &self.config.repo);
+        debug!("backend use repo {}", self.config.repo);
 
         Ok(GithubBackend {
             core: Arc::new(GithubCore {

--- a/core/services/goosefs/src/backend.rs
+++ b/core/services/goosefs/src/backend.rs
@@ -128,10 +128,10 @@ impl Builder for GoosefsBuilder {
 
     /// Build the backend and return a GoosefsBackend.
     fn build(self) -> Result<impl Service> {
-        debug!("GoosefsBuilder::build started: {:?}", &self);
+        debug!("GoosefsBuilder::build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
-        debug!("GoosefsBuilder use root {}", &root);
+        debug!("GoosefsBuilder use root {}", root);
 
         // ── Step 1: establish the base SDK config ─────────────────────────────
         //
@@ -210,7 +210,7 @@ impl Builder for GoosefsBuilder {
         }
         debug!(
             "GoosefsBuilder use master_addr {} (addrs={:?})",
-            &goosefs_config.master_addr, &goosefs_config.master_addrs
+            goosefs_config.master_addr, goosefs_config.master_addrs
         );
 
         if let Some(block_size) = self.config.block_size {

--- a/core/services/hdfs-native/src/backend.rs
+++ b/core/services/hdfs-native/src/backend.rs
@@ -92,7 +92,7 @@ impl Builder for HdfsNativeBuilder {
     type Config = HdfsNativeConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let name_node = match &self.config.name_node {
             Some(v) => v,

--- a/core/services/hdfs/src/backend.rs
+++ b/core/services/hdfs/src/backend.rs
@@ -110,7 +110,7 @@ impl Builder for HdfsBuilder {
     type Config = HdfsConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let name_node = match &self.config.name_node {
             Some(v) => v,

--- a/core/services/hf/src/backend.rs
+++ b/core/services/hf/src/backend.rs
@@ -209,7 +209,7 @@ impl Builder for HfBuilder {
     type Config = HfConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let token = self.hf_token();
         let endpoint = self.hf_endpoint();
@@ -220,25 +220,25 @@ impl Builder for HfBuilder {
                 .with_operation("Builder::build")
                 .with_context("service", HF_SCHEME)
         })?;
-        debug!("backend use repo_type: {:?}", &repo_type);
+        debug!("backend use repo_type: {:?}", repo_type);
 
         let repo_id = self.config.repo_id.ok_or_else(|| {
             Error::new(ErrorKind::ConfigInvalid, "repo_id is required")
                 .with_operation("Builder::build")
                 .with_context("service", HF_SCHEME)
         })?;
-        debug!("backend use repo_id: {}", &repo_id);
+        debug!("backend use repo_id: {}", repo_id);
 
         let revision = match &self.config.revision {
             Some(revision) => revision.clone(),
             None => "main".to_string(),
         };
-        debug!("backend use revision: {}", &revision);
+        debug!("backend use revision: {}", revision);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root: {}", &root);
+        debug!("backend use root: {}", root);
         debug!("backend use token: {}", token.is_some());
-        debug!("backend use endpoint: {}", &endpoint);
+        debug!("backend use endpoint: {}", endpoint);
         debug!("backend use download_mode: {:?}", download_mode);
 
         let info = ServiceInfo::new(HF_SCHEME, "", "");

--- a/core/services/hf/src/core.rs
+++ b/core/services/hf/src/core.rs
@@ -916,14 +916,14 @@ mod uri {
         pub fn paths_info_url(&self, endpoint: &str) -> String {
             match self.repo_type {
                 HfRepoType::Bucket => {
-                    format!("{}/api/buckets/{}/paths-info", endpoint, &self.repo_id)
+                    format!("{}/api/buckets/{}/paths-info", endpoint, self.repo_id)
                 }
                 _ => {
                     format!(
                         "{}/api/{}/{}/paths-info/{}",
                         endpoint,
                         self.repo_type.as_plural_str(),
-                        &self.repo_id,
+                        self.repo_id,
                         percent_encode_revision(self.revision()),
                     )
                 }
@@ -936,7 +936,7 @@ mod uri {
                 HfRepoType::Bucket => {
                     format!(
                         "{}/api/buckets/{}/xet-{}-token",
-                        endpoint, &self.repo_id, token_type
+                        endpoint, self.repo_id, token_type
                     )
                 }
                 _ => {
@@ -944,7 +944,7 @@ mod uri {
                         "{}/api/{}/{}/xet-{}-token/{}",
                         endpoint,
                         self.repo_type.as_plural_str(),
-                        &self.repo_id,
+                        self.repo_id,
                         token_type,
                         self.revision(),
                     )
@@ -954,7 +954,7 @@ mod uri {
 
         /// Build the bucket batch API URL for this repository.
         pub fn bucket_batch_url(&self, endpoint: &str) -> String {
-            format!("{}/api/buckets/{}/batch", endpoint, &self.repo_id)
+            format!("{}/api/buckets/{}/batch", endpoint, self.repo_id)
         }
 
         /// Build the git commit API URL for this repository.
@@ -963,7 +963,7 @@ mod uri {
                 "{}/api/{}/{}/commit/{}",
                 endpoint,
                 self.repo_type.as_plural_str(),
-                &self.repo_id,
+                self.repo_id,
                 percent_encode_revision(self.revision()),
             )
         }
@@ -1095,25 +1095,25 @@ mod uri {
                 HfRepoType::Model => {
                     format!(
                         "{}/{}/resolve/{}/{}",
-                        endpoint, &self.repo.repo_id, revision, path
+                        endpoint, self.repo.repo_id, revision, path
                     )
                 }
                 HfRepoType::Dataset => {
                     format!(
                         "{}/datasets/{}/resolve/{}/{}",
-                        endpoint, &self.repo.repo_id, revision, path
+                        endpoint, self.repo.repo_id, revision, path
                     )
                 }
                 HfRepoType::Space => {
                     format!(
                         "{}/spaces/{}/resolve/{}/{}",
-                        endpoint, &self.repo.repo_id, revision, path
+                        endpoint, self.repo.repo_id, revision, path
                     )
                 }
                 HfRepoType::Bucket => {
                     format!(
                         "{}/buckets/{}/resolve/{}",
-                        endpoint, &self.repo.repo_id, path
+                        endpoint, self.repo.repo_id, path
                     )
                 }
             }
@@ -1135,7 +1135,7 @@ mod uri {
                 format!(
                     "{}/api/buckets/{}/tree/{}?expand=True",
                     endpoint,
-                    &self.repo.repo_id,
+                    self.repo.repo_id,
                     percent_encode_path(&self.path),
                 )
             } else {
@@ -1143,7 +1143,7 @@ mod uri {
                     "{}/api/{}/{}/tree/{}/{}?expand=True",
                     endpoint,
                     self.repo.repo_type.as_plural_str(),
-                    &self.repo.repo_id,
+                    self.repo.repo_id,
                     percent_encode_revision(self.revision()),
                     percent_encode_path(&self.path),
                 )

--- a/core/services/hf/src/lister.rs
+++ b/core/services/hf/src/lister.rs
@@ -137,7 +137,7 @@ impl oio::PageList for HfLister {
         for info in response.files {
             let meta = info.metadata()?;
             let path = if meta.mode() == EntryMode::DIR {
-                format!("{}/", &info.path)
+                format!("{}/", info.path)
             } else {
                 info.path.clone()
             };

--- a/core/services/http/src/backend.rs
+++ b/core/services/http/src/backend.rs
@@ -104,7 +104,7 @@ impl Builder for HttpBuilder {
     type Config = HttpConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let endpoint = match &self.config.endpoint {
             Some(v) => v,

--- a/core/services/ipfs/src/backend.rs
+++ b/core/services/ipfs/src/backend.rs
@@ -89,7 +89,7 @@ impl Builder for IpfsBuilder {
     type Config = IpfsConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
         if !root.starts_with("/ipfs/") && !root.starts_with("/ipns/") {
@@ -108,7 +108,7 @@ impl Builder for IpfsBuilder {
                 .with_context("service", IPFS_SCHEME)
                 .with_context("root", &root)),
         }?;
-        debug!("backend use endpoint {}", &endpoint);
+        debug!("backend use endpoint {}", endpoint);
 
         let info = ServiceInfo::new(IPFS_SCHEME, &root, "");
         let capability = Capability {

--- a/core/services/ipmfs/src/lister.rs
+++ b/core/services/ipmfs/src/lister.rs
@@ -80,8 +80,8 @@ impl oio::PageList for IpmfsLister {
 
         for object in entries_body.entries.unwrap_or_default() {
             let path = match object.mode() {
-                EntryMode::FILE => format!("{}{}", &self.path, object.name),
-                EntryMode::DIR => format!("{}{}/", &self.path, object.name),
+                EntryMode::FILE => format!("{}{}", self.path, object.name),
+                EntryMode::DIR => format!("{}{}/", self.path, object.name),
                 EntryMode::Unknown => unreachable!(),
             };
 

--- a/core/services/koofr/src/backend.rs
+++ b/core/services/koofr/src/backend.rs
@@ -111,10 +111,10 @@ impl Builder for KoofrBuilder {
 
     /// Builds the backend and returns the result of KoofrBackend.
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
-        debug!("backend use root {}", &root);
+        debug!("backend use root {}", root);
 
         if self.config.endpoint.is_empty() {
             return Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
@@ -122,7 +122,7 @@ impl Builder for KoofrBuilder {
                 .with_context("service", KOOFR_SCHEME));
         }
 
-        debug!("backend use endpoint {}", &self.config.endpoint);
+        debug!("backend use endpoint {}", self.config.endpoint);
 
         if self.config.email.is_empty() {
             return Err(Error::new(ErrorKind::ConfigInvalid, "email is empty")
@@ -130,7 +130,7 @@ impl Builder for KoofrBuilder {
                 .with_context("service", KOOFR_SCHEME));
         }
 
-        debug!("backend use email {}", &self.config.email);
+        debug!("backend use email {}", self.config.email);
 
         let password = match &self.config.password {
             Some(password) => Ok(password.clone()),

--- a/core/services/lakefs/src/backend.rs
+++ b/core/services/lakefs/src/backend.rs
@@ -111,7 +111,7 @@ impl Builder for LakefsBuilder {
 
     /// Build a LakefsBackend.
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let endpoint = match self.config.endpoint {
             Some(endpoint) => Ok(endpoint.clone()),
@@ -119,7 +119,7 @@ impl Builder for LakefsBuilder {
                 .with_operation("Builder::build")
                 .with_context("service", LAKEFS_SCHEME)),
         }?;
-        debug!("backend use endpoint: {:?}", &endpoint);
+        debug!("backend use endpoint: {:?}", endpoint);
 
         let repository = match &self.config.repository {
             Some(repository) => Ok(repository.clone()),
@@ -127,16 +127,16 @@ impl Builder for LakefsBuilder {
                 .with_operation("Builder::build")
                 .with_context("service", LAKEFS_SCHEME)),
         }?;
-        debug!("backend use repository: {}", &repository);
+        debug!("backend use repository: {}", repository);
 
         let branch = match &self.config.branch {
             Some(branch) => branch.clone(),
             None => "main".to_string(),
         };
-        debug!("backend use branch: {}", &branch);
+        debug!("backend use branch: {}", branch);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
-        debug!("backend use root: {}", &root);
+        debug!("backend use root: {}", root);
 
         let username = match &self.config.username {
             Some(username) => Ok(username.clone()),

--- a/core/services/lakefs/src/lister.rs
+++ b/core/services/lakefs/src/lister.rs
@@ -106,7 +106,7 @@ impl oio::PageList for LakefsLister {
             }
 
             let path = if entry_type == EntryMode::DIR {
-                format!("{}/", &status.path)
+                format!("{}/", status.path)
             } else {
                 status.path.clone()
             };

--- a/core/services/mini_moka/src/backend.rs
+++ b/core/services/mini_moka/src/backend.rs
@@ -88,7 +88,7 @@ impl Builder for MiniMokaBuilder {
     type Config = MiniMokaConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let mut builder: mini_moka::sync::CacheBuilder<String, MiniMokaValue, _> =
             mini_moka::sync::Cache::builder();

--- a/core/services/moka/src/backend.rs
+++ b/core/services/moka/src/backend.rs
@@ -143,7 +143,7 @@ impl Builder for MokaBuilder {
     type Config = MokaConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(
             self.config

--- a/core/services/obs/src/backend.rs
+++ b/core/services/obs/src/backend.rs
@@ -135,7 +135,7 @@ impl Builder for ObsBuilder {
     type Config = ObsConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
         debug!("backend use root {root}");
@@ -147,7 +147,7 @@ impl Builder for ObsBuilder {
                     .with_context("service", OBS_SCHEME),
             ),
         }?;
-        debug!("backend use bucket {}", &bucket);
+        debug!("backend use bucket {}", bucket);
 
         let uri = match &self.config.endpoint {
             Some(endpoint) => endpoint.parse::<Uri>().map_err(|err| {
@@ -174,7 +174,7 @@ impl Builder for ObsBuilder {
                 (host, false)
             }
         };
-        debug!("backend use endpoint {}", &endpoint);
+        debug!("backend use endpoint {}", endpoint);
 
         let ctx = Context::new().with_file_read(TokioFileRead).with_env(OsEnv);
 
@@ -252,7 +252,7 @@ impl Builder for ObsBuilder {
                 capability,
                 bucket,
                 root,
-                endpoint: format!("{}://{}", &scheme, &endpoint),
+                endpoint: format!("{}://{}", scheme, endpoint),
                 signer,
             }),
         })

--- a/core/services/oss/src/backend.rs
+++ b/core/services/oss/src/backend.rs
@@ -410,13 +410,13 @@ impl Builder for OssBuilder {
     type Config = OssConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         #[allow(deprecated)]
         let skip_signature = self.config.skip_signature || self.config.allow_anonymous;
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
-        debug!("backend use root {}", &root);
+        debug!("backend use root {}", root);
 
         // Handle endpoint, region and bucket name.
         let bucket = match self.config.bucket.is_empty() {
@@ -434,7 +434,7 @@ impl Builder for OssBuilder {
             bucket,
             (&self.config.addressing_style).try_into()?,
         )?;
-        debug!("backend use bucket {}, endpoint: {}", &bucket, &endpoint);
+        debug!("backend use bucket {}, endpoint: {}", bucket, endpoint);
 
         let presign_endpoint = if self.config.presign_endpoint.is_some() {
             self.parse_endpoint(
@@ -446,7 +446,7 @@ impl Builder for OssBuilder {
         } else {
             endpoint.clone()
         };
-        debug!("backend use presign_endpoint: {}", &presign_endpoint);
+        debug!("backend use presign_endpoint: {}", presign_endpoint);
 
         let server_side_encryption = match &self.config.server_side_encryption {
             None => None,

--- a/core/services/pcloud/src/backend.rs
+++ b/core/services/pcloud/src/backend.rs
@@ -107,10 +107,10 @@ impl Builder for PcloudBuilder {
 
     /// Builds the backend and returns the result of PcloudBackend.
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
-        debug!("backend use root {}", &root);
+        debug!("backend use root {}", root);
 
         // Handle endpoint.
         if self.config.endpoint.is_empty() {
@@ -119,7 +119,7 @@ impl Builder for PcloudBuilder {
                 .with_context("service", PCLOUD_SCHEME));
         }
 
-        debug!("backend use endpoint {}", &self.config.endpoint);
+        debug!("backend use endpoint {}", self.config.endpoint);
 
         let username = match &self.config.username {
             Some(username) => Ok(username.clone()),

--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -725,7 +725,7 @@ impl Builder for S3Builder {
     type Config = S3Config;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let S3Builder {
             mut config,
@@ -738,7 +738,7 @@ impl Builder for S3Builder {
         }
 
         let root = normalize_root(&config.root.clone().unwrap_or_default());
-        debug!("backend use root {}", &root);
+        debug!("backend use root {}", root);
 
         // Handle bucket name.
         let bucket = if Self::is_bucket_valid(&config) {
@@ -749,7 +749,7 @@ impl Builder for S3Builder {
                     .with_context("service", S3_SCHEME),
             )
         }?;
-        debug!("backend use bucket {}", &bucket);
+        debug!("backend use bucket {}", bucket);
 
         let default_storage_class = match &config.default_storage_class {
             None => None,

--- a/core/services/seafile/src/backend.rs
+++ b/core/services/seafile/src/backend.rs
@@ -118,10 +118,10 @@ impl Builder for SeafileBuilder {
 
     /// Builds the backend and returns the result of SeafileBackend.
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
-        debug!("backend use root {}", &root);
+        debug!("backend use root {}", root);
 
         // Handle bucket.
         if self.config.repo_name.is_empty() {
@@ -130,7 +130,7 @@ impl Builder for SeafileBuilder {
                 .with_context("service", SEAFILE_SCHEME));
         }
 
-        debug!("backend use repo_name {}", &self.config.repo_name);
+        debug!("backend use repo_name {}", self.config.repo_name);
 
         let endpoint = match &self.config.endpoint {
             Some(endpoint) => Ok(endpoint.clone()),

--- a/core/services/sftp/src/backend.rs
+++ b/core/services/sftp/src/backend.rs
@@ -124,7 +124,7 @@ impl Builder for SftpBuilder {
     type Config = SftpConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("sftp backend build started: {:?}", &self);
+        debug!("sftp backend build started: {:?}", self);
         let endpoint = match self.config.endpoint.clone() {
             Some(v) => v,
             None => return Err(Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")),
@@ -192,7 +192,7 @@ impl Builder for SftpBuilder {
             known_hosts_strategy,
         ));
 
-        debug!("sftp backend finished: {:?}", &self);
+        debug!("sftp backend finished: {:?}", self);
         Ok(SftpBackend { core })
     }
 }

--- a/core/services/swift/src/backend.rs
+++ b/core/services/swift/src/backend.rs
@@ -126,7 +126,7 @@ impl Builder for SwiftBuilder {
 
     /// Build a SwiftBackend.
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.unwrap_or_default());
         debug!("backend use root {root}");
@@ -146,7 +146,7 @@ impl Builder for SwiftBuilder {
                 ));
             }
         };
-        debug!("backend use endpoint: {}", &endpoint);
+        debug!("backend use endpoint: {}", endpoint);
 
         let container = match self.config.container {
             Some(container) => container,

--- a/core/services/swift/src/core.rs
+++ b/core/services/swift/src/core.rs
@@ -134,8 +134,8 @@ impl SwiftCore {
 
         let url = format!(
             "{}/{}/{}",
-            &self.endpoint,
-            &self.container,
+            self.endpoint,
+            self.container,
             percent_encode_path(&p)
         );
 
@@ -163,7 +163,7 @@ impl SwiftCore {
         paths: &[(String, OpDelete)],
     ) -> Result<Response<Buffer>> {
         // The bulk-delete endpoint is on the account URL (the endpoint itself).
-        let url = format!("{}?bulk-delete", &self.endpoint);
+        let url = format!("{}?bulk-delete", self.endpoint);
 
         let mut req = Request::post(&url);
 
@@ -177,7 +177,7 @@ impl SwiftCore {
             .iter()
             .map(|(path, _)| {
                 let abs = build_abs_path(&self.root, path);
-                format!("{}/{}", &self.container, percent_encode_path(&abs))
+                format!("{}/{}", self.container, percent_encode_path(&abs))
             })
             .collect::<Vec<_>>()
             .join("\n");
@@ -205,7 +205,7 @@ impl SwiftCore {
 
         // The delimiter is used to disable recursive listing.
         // Swift returns a 200 status code when there is no such pseudo directory in prefix.
-        let mut url = QueryPairsWriter::new(&format!("{}/{}/", &self.endpoint, &self.container,))
+        let mut url = QueryPairsWriter::new(&format!("{}/{}/", self.endpoint, self.container,))
             .push("prefix", &percent_encode_path(&p))
             .push("delimiter", delimiter)
             .push("format", "json");
@@ -241,8 +241,8 @@ impl SwiftCore {
         let p = build_abs_path(&self.root, path);
         let url = format!(
             "{}/{}/{}",
-            &self.endpoint,
-            &self.container,
+            self.endpoint,
+            self.container,
             percent_encode_path(&p)
         );
 
@@ -293,8 +293,8 @@ impl SwiftCore {
 
         let url = format!(
             "{}/{}/{}",
-            &self.endpoint,
-            &self.container,
+            self.endpoint,
+            self.container,
             percent_encode_path(&p)
         );
 
@@ -348,8 +348,8 @@ impl SwiftCore {
 
         let url = format!(
             "{}/{}/{}",
-            &self.endpoint,
-            &self.container,
+            self.endpoint,
+            self.container,
             percent_encode_path(&dst_p)
         );
 
@@ -384,8 +384,8 @@ impl SwiftCore {
 
         let url = format!(
             "{}/{}/{}",
-            &self.endpoint,
-            &self.container,
+            self.endpoint,
+            self.container,
             percent_encode_path(&p)
         );
 
@@ -443,8 +443,8 @@ impl SwiftCore {
         let segment = self.slo_segment_path(path, upload_id, part_number);
         let url = format!(
             "{}/{}/{}",
-            &self.endpoint,
-            &self.container,
+            self.endpoint,
+            self.container,
             percent_encode_path(&segment)
         );
 
@@ -477,8 +477,8 @@ impl SwiftCore {
         let abs = build_abs_path(&self.root, path);
         let url = format!(
             "{}/{}/{}?multipart-manifest=put",
-            &self.endpoint,
-            &self.container,
+            self.endpoint,
+            self.container,
             percent_encode_path(&abs)
         );
 
@@ -524,7 +524,7 @@ impl SwiftCore {
         let prefix = format!(".segments/{}{}/", abs.trim_end_matches('/'), upload_id);
 
         // List all segments with this prefix.
-        let url = QueryPairsWriter::new(&format!("{}/{}/", &self.endpoint, &self.container))
+        let url = QueryPairsWriter::new(&format!("{}/{}/", self.endpoint, self.container))
             .push("prefix", &percent_encode_path(&prefix))
             .push("format", "json")
             .finish();
@@ -551,8 +551,8 @@ impl SwiftCore {
             if let ListOpResponse::FileInfo { name, .. } = seg {
                 let seg_url = format!(
                     "{}/{}/{}",
-                    &self.endpoint,
-                    &self.container,
+                    self.endpoint,
+                    self.container,
                     percent_encode_path(&name)
                 );
 
@@ -606,7 +606,7 @@ impl SwiftCore {
         let signing_path = format!(
             "{}/{}/{}",
             account_path,
-            &self.container,
+            self.container,
             abs.trim_start_matches('/')
         );
 
@@ -629,10 +629,10 @@ impl SwiftCore {
 
         Ok(format!(
             "{}/{}/{}?temp_url_sig={}&temp_url_expires={}",
-            &self.endpoint,
-            &self.container,
+            self.endpoint,
+            self.container,
             percent_encode_path(&abs),
-            &encoded_sig,
+            encoded_sig,
             expires
         ))
     }

--- a/core/services/swift/src/deleter.rs
+++ b/core/services/swift/src/deleter.rs
@@ -73,7 +73,7 @@ impl oio::BatchDelete for SwiftDeleter {
             // The error paths from Swift include the container prefix, so we need
             // to reconstruct the full path for comparison.
             let abs = build_abs_path(&self.core.root, &path);
-            let full_path = format!("{}/{}", &self.core.container, abs);
+            let full_path = format!("{}/{}", self.core.container, abs);
 
             if let Some(error_entry) = result.errors.iter().find(|e| {
                 e.first()

--- a/core/services/swift/src/writer.rs
+++ b/core/services/swift/src/writer.rs
@@ -129,7 +129,7 @@ impl oio::MultipartWrite for SwiftWriter {
                     .core
                     .slo_segment_path(&self.path, upload_id, part.part_number);
                 SloManifestEntry {
-                    path: format!("{}/{}", &self.core.container, segment),
+                    path: format!("{}/{}", self.core.container, segment),
                     etag: part.etag.trim_matches('"').to_string(),
                     size_bytes: part.size.unwrap_or(0),
                 }

--- a/core/services/tikv/src/backend.rs
+++ b/core/services/tikv/src/backend.rs
@@ -94,7 +94,7 @@ impl Builder for TikvBuilder {
                 || self.config.key_path.is_some()
                 || self.config.cert_path.is_some())
         {
-            return Err(
+            Err(
                 Error::new(ErrorKind::ConfigInvalid, "invalid tls configuration")
                     .with_context("service", TIKV_SCHEME)
                     .with_context("endpoints", format!("{endpoints:?}")),

--- a/core/services/upyun/src/backend.rs
+++ b/core/services/upyun/src/backend.rs
@@ -103,10 +103,10 @@ impl Builder for UpyunBuilder {
 
     /// Builds the backend and returns the result of UpyunBackend.
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
-        debug!("backend use root {}", &root);
+        debug!("backend use root {}", root);
 
         // Handle bucket.
         if self.config.bucket.is_empty() {
@@ -115,7 +115,7 @@ impl Builder for UpyunBuilder {
                 .with_context("service", UPYUN_SCHEME));
         }
 
-        debug!("backend use bucket {}", &self.config.bucket);
+        debug!("backend use bucket {}", self.config.bucket);
 
         let operator = match &self.config.operator {
             Some(operator) => Ok(operator.clone()),

--- a/core/services/vercel-blob/src/backend.rs
+++ b/core/services/vercel-blob/src/backend.rs
@@ -82,10 +82,10 @@ impl Builder for VercelBlobBuilder {
 
     /// Builds the backend and returns the result of VercelBlobBackend.
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
-        debug!("backend use root {}", &root);
+        debug!("backend use root {}", root);
 
         // Handle token.
         let Some(token) = self.config.token.clone() else {

--- a/core/services/webdav/src/backend.rs
+++ b/core/services/webdav/src/backend.rs
@@ -177,7 +177,7 @@ impl Builder for WebdavBuilder {
     type Config = WebdavConfig;
 
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let endpoint = match &self.config.endpoint {
             Some(v) => v,

--- a/core/services/yandex-disk/src/backend.rs
+++ b/core/services/yandex-disk/src/backend.rs
@@ -79,10 +79,10 @@ impl Builder for YandexDiskBuilder {
 
     /// Builds the backend and returns the result of YandexDiskBackend.
     fn build(self) -> Result<impl Service> {
-        debug!("backend build started: {:?}", &self);
+        debug!("backend build started: {:?}", self);
 
         let root = normalize_root(&self.config.root.clone().unwrap_or_default());
-        debug!("backend use root {}", &root);
+        debug!("backend use root {}", root);
 
         // Handle oauth access_token.
         if self.config.access_token.is_empty() {

--- a/core/tests/behavior/async_list.rs
+++ b/core/tests/behavior/async_list.rs
@@ -81,7 +81,7 @@ pub async fn test_check(op: Operator) -> Result<()> {
 pub async fn test_list_dir(op: Operator) -> Result<()> {
     let parent = uuid::Uuid::new_v4().to_string();
     let path = format!("{parent}/{}", uuid::Uuid::new_v4());
-    debug!("Generate a random file: {}", &path);
+    debug!("Generate a random file: {}", path);
     let (content, size) = gen_bytes(op.info().capability());
 
     op.write(&path, content).await.expect("write must succeed");
@@ -106,7 +106,7 @@ pub async fn test_list_dir(op: Operator) -> Result<()> {
 /// List prefix should return newly created file.
 pub async fn test_list_prefix(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
-    debug!("Generate a random file: {}", &path);
+    debug!("Generate a random file: {}", path);
     let (content, _) = gen_bytes(op.info().capability());
 
     op.write(&path, content).await.expect("write must succeed");

--- a/core/tests/behavior/async_presign.rs
+++ b/core/tests/behavior/async_presign.rs
@@ -43,7 +43,7 @@ pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
 /// Presign write should succeed.
 pub async fn test_presign_write(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
-    debug!("Generate a random file: {}", &path);
+    debug!("Generate a random file: {}", path);
     let (content, size) = gen_bytes(op.info().capability());
 
     let signed_req = op.presign_write(&path, Duration::from_secs(3600)).await?;
@@ -75,7 +75,7 @@ pub async fn test_presign_write(op: Operator) -> Result<()> {
 
 pub async fn test_presign_stat(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
-    debug!("Generate a random file: {}", &path);
+    debug!("Generate a random file: {}", path);
     let (content, size) = gen_bytes(op.info().capability());
     op.write(&path, content.clone())
         .await
@@ -105,7 +105,7 @@ pub async fn test_presign_stat(op: Operator) -> Result<()> {
 // Presign read should read content successfully.
 pub async fn test_presign_read(op: Operator) -> Result<()> {
     let path = uuid::Uuid::new_v4().to_string();
-    debug!("Generate a random file: {}", &path);
+    debug!("Generate a random file: {}", path);
     let (content, size) = gen_bytes(op.info().capability());
 
     op.write(&path, content.clone())
@@ -142,7 +142,7 @@ pub async fn test_presign_delete(op: Operator) -> Result<()> {
     }
 
     let path = uuid::Uuid::new_v4().to_string();
-    debug!("Generate a random file: {}", &path);
+    debug!("Generate a random file: {}", path);
     let (content, _size) = gen_bytes(op.info().capability());
     // create a file
     op.write(&path, content.clone())

--- a/core/tests/behavior/async_stat.rs
+++ b/core/tests/behavior/async_stat.rs
@@ -148,7 +148,7 @@ pub async fn test_stat_not_cleaned_path(op: Operator) -> Result<()> {
 
     op.write(&path, content).await.expect("write must succeed");
 
-    let meta = op.stat(&format!("//{}", &path)).await?;
+    let meta = op.stat(&format!("//{}", path)).await?;
     assert_eq!(meta.mode(), EntryMode::FILE);
     assert_eq!(meta.content_length(), size as u64);
 

--- a/dev/src/generate/python.j2
+++ b/dev/src/generate/python.j2
@@ -39,7 +39,7 @@ pub enum Scheme {
 impl Scheme {
     #[getter]
     pub fn name(&self) -> String {
-        format!("{:?}", &self)
+        format!("{:?}", self)
     }
 
     #[getter]

--- a/integrations/object_store/README.md
+++ b/integrations/object_store/README.md
@@ -145,7 +145,7 @@ async fn main() -> Result<()> {
     // Dynamic query using the file path directly
     let ctx = ctx.enable_url_table();
     let df = ctx
-        .sql(format!(r#"SELECT * FROM '{}' LIMIT 10"#, &path).as_str())
+        .sql(format!(r#"SELECT * FROM '{}' LIMIT 10"#, path).as_str())
         .await?;
     // Print the results
     df.show().await?;

--- a/integrations/object_store/examples/datafusion.rs
+++ b/integrations/object_store/examples/datafusion.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
     // Dynamic query using the file path directly
     let ctx = ctx.enable_url_table();
     let df = ctx
-        .sql(format!(r#"SELECT * FROM '{}' LIMIT 10"#, &path).as_str())
+        .sql(format!(r#"SELECT * FROM '{}' LIMIT 10"#, path).as_str())
         .await?;
     // Print the results
     df.show().await?;


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change

During dependabot run, CI prints new errors. The error is:

clippy::useless_borrows_in_formatting

I suspect it came from that ubuntu image updated clippy stable.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- print clippy version for debugging
- fix CI errors

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->

GPT-5.5