### PR TITLE
ci: upgrade nodejs release to npm 12

### DIFF
--- a/.github/workflows/release_nodejs.yml
+++ b/.github/workflows/release_nodejs.yml
@@ -204,7 +204,7 @@ jobs:
 
       - name: Update npm
         # Trusted publishing requires npm CLI version 11.5.1 or later.
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Add LICENSE & NOTICE
         # Set working directory to root to copy LICENSE & NOTICE

--- a/.github/workflows/release_nodejs.yml
+++ b/.github/workflows/release_nodejs.yml
@@ -49,7 +49,7 @@ env:
 
 jobs:
   build:
-    name: stable - ${{ matrix.settings.target }} - node@20
+    name: stable - ${{ matrix.settings.target }} - node@24
     runs-on: ${{ matrix.settings.host }}
     defaults:
       run:
@@ -112,7 +112,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: pnpm
           cache-dependency-path: "bindings/nodejs/pnpm-lock.yaml"
       - name: Install
@@ -185,7 +185,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: pnpm
           cache-dependency-path: "bindings/nodejs/pnpm-lock.yaml"
       - name: Install dependencies
@@ -204,7 +204,7 @@ jobs:
 
       - name: Update npm
         # Trusted publishing requires npm CLI version 11.5.1 or later.
-        run: npm install -g npm@11
+        run: npm install -g npm@12
 
       - name: Add LICENSE & NOTICE
         # Set working directory to root to copy LICENSE & NOTICE


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7897.

# Rationale for this change

The NodeJS release workflow was running on Node 20 while installing `npm@latest`. During the 0.58.0 release, `npm@latest` resolved to npm 12, which requires a newer Node runtime and caused the publish job to fail.

Instead of pinning the release workflow to an older npm major, this PR upgrades the NodeJS release workflow to run on Node 24 and installs npm 12 explicitly.

# What changes are included in this PR?

- Upgrade the NodeJS release build and publish jobs from Node 20 to Node 24.
- Install `npm@12` in the publish job.
- Update the release job name from `node@20` to `node@24`.

# Are there any user-facing changes?

No.

# AI Usage Statement

AI assistance was used to prepare this PR.
