### PR TITLE
ci: include http transports in rust release plan

### DIFF
--- a/.github/scripts/release_rust/plan.py
+++ b/.github/scripts/release_rust/plan.py
@@ -31,6 +31,7 @@ PUBLISH_GLOBS = (
     "core/Cargo.toml",
     "core/core/Cargo.toml",
     "core/testkit/Cargo.toml",
+    "core/http-transports/*/Cargo.toml",
     "core/layers/*/Cargo.toml",
     "core/services/*/Cargo.toml",
     "integrations/*/Cargo.toml",

--- a/.github/workflows/release_rust.yml
+++ b/.github/workflows/release_rust.yml
@@ -30,6 +30,7 @@ on:
       - ".github/workflows/release_rust.yml"
       - ".github/scripts/release_rust/**"
       - "core/testkit/Cargo.toml"
+      - "core/http-transports/*/Cargo.toml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7898.

# Rationale for this change

The Rust release publish plan did not include publishable crates under `core/http-transports/*`. During the 0.58.0 release, the top-level `opendal` crate failed to publish because `opendal-http-transport-reqwest` had not been published to crates.io first.

# What changes are included in this PR?

Add `core/http-transports/*/Cargo.toml` to the Rust release package discovery globs and to the workflow PR path filter so changes to these manifests validate the release plan.

# Are there any user-facing changes?

No.

# AI Usage Statement

AI assistance was used to prepare this PR.
