### PR TITLE
fix(bindings/java): incorrect Java declarations

### DIFF
--- a/bindings/java/src/main/java/org/apache/opendal/Operator.java
+++ b/bindings/java/src/main/java/org/apache/opendal/Operator.java
@@ -171,11 +171,11 @@ public class Operator extends NativeObject {
 
     private static native Metadata stat(long op, String path, StatOptions options);
 
-    private static native long createDir(long op, String path);
+    private static native void createDir(long op, String path);
 
-    private static native long copy(long op, String sourcePath, String targetPath);
+    private static native void copy(long op, String sourcePath, String targetPath);
 
-    private static native long rename(long op, String sourcePath, String targetPath);
+    private static native void rename(long op, String sourcePath, String targetPath);
 
     private static native void removeAll(long op, String path);
 

--- a/bindings/java/src/main/java/org/apache/opendal/OperatorInputStream.java
+++ b/bindings/java/src/main/java/org/apache/opendal/OperatorInputStream.java
@@ -101,7 +101,7 @@ public class OperatorInputStream extends InputStream {
 
     private static native long constructReader(long op, String path, ReadOptions options);
 
-    private static native long disposeReader(long reader);
+    private static native void disposeReader(long reader);
 
     private static native byte[] readNextBytes(long reader);
 }

--- a/bindings/java/src/main/java/org/apache/opendal/OperatorOutputStream.java
+++ b/bindings/java/src/main/java/org/apache/opendal/OperatorOutputStream.java
@@ -85,7 +85,7 @@ public class OperatorOutputStream extends OutputStream {
 
     private static native long constructWriter(long op, String path, WriteOptions options);
 
-    private static native long disposeWriter(long writer);
+    private static native void disposeWriter(long writer);
 
-    private static native byte[] writeBytes(long writer, byte[] bytes);
+    private static native void writeBytes(long writer, byte[] bytes);
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7905

# What changes are included in this PR?

OperatorOutputStream: byte[] writeBytes(long, byte[]) → void
OperatorOutputStream: long disposeWriter(long) → void
OperatorInputStream: long disposeReader(long) → void
Operator: long createDir(long, String) → void
Operator: long copy(long, String, String) → void
Operator: long rename(long, String, String) → void

# Are there any user-facing changes?


No

# AI Usage Statement

No, but your AI bot did confirm my findings were correct.