### PR TITLE
feat(core): expose registered schemes via OperatorRegistry::schemes

### DIFF
--- a/core/core/src/types/operator/registry.rs
+++ b/core/core/src/types/operator/registry.rs
@@ -85,19 +85,27 @@ impl OperatorRegistry {
         let parsed = uri.into_operator_uri()?;
         let scheme = parsed.scheme();
 
-        let factory = self
-            .factories
-            .lock()
-            .expect("operator registry mutex poisoned")
-            .get(scheme)
-            .copied()
-            .ok_or_else(|| {
-                let mut available: Vec<String> = self.schemes().into_iter().collect();
-                available.sort();
-                Error::new(ErrorKind::Unsupported, "scheme is not registered")
-                    .with_context("scheme", scheme.to_string())
-                    .with_context("available", available.join(", "))
-            })?;
+        let factory = {
+            let guard = self
+                .factories
+                .lock()
+                .expect("operator registry mutex poisoned");
+
+            match guard.get(scheme).copied() {
+                Some(factory) => factory,
+                None => {
+                    // Collect the available schemes from the guard we already hold
+                    // to avoid re-locking the mutex (which would self-deadlock).
+                    let mut available: Vec<String> = guard.keys().cloned().collect();
+                    available.sort();
+                    return Err(
+                        Error::new(ErrorKind::Unsupported, "scheme is not registered")
+                            .with_context("scheme", scheme.to_string())
+                            .with_context("available", available.join(", ")),
+                    );
+                }
+            }
+        };
 
         factory(&parsed)
     }

--- a/core/core/src/types/operator/registry.rs
+++ b/core/core/src/types/operator/registry.rs
@@ -18,7 +18,7 @@
 use crate::types::builder::{Builder, Configurator};
 use crate::types::{IntoOperatorUri, OperatorUri};
 use crate::{Error, ErrorKind, Operator, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{LazyLock, Mutex};
 
 /// Factory signature used to construct [`Operator`] from a URI and extra options.
@@ -59,6 +59,27 @@ impl OperatorRegistry {
         guard.insert(key, factory::<B::Config>);
     }
 
+    /// Return the set of schemes currently registered.
+    ///
+    /// For the global registry returned by [`OperatorRegistry::get`], this is
+    /// exactly the set of schemes that [`Operator::from_uri`] can construct, as
+    /// determined by the compiled-in `services-*` features.
+    ///
+    /// ```
+    /// use opendal_core::OperatorRegistry;
+    ///
+    /// let schemes = OperatorRegistry::get().schemes();
+    /// assert!(schemes.contains("memory"));
+    /// ```
+    pub fn schemes(&self) -> HashSet<String> {
+        self.factories
+            .lock()
+            .expect("operator registry mutex poisoned")
+            .keys()
+            .cloned()
+            .collect()
+    }
+
     /// Load an [`Operator`] via the factory registered for the URI's scheme.
     pub fn load(&self, uri: impl IntoOperatorUri) -> Result<Operator> {
         let parsed = uri.into_operator_uri()?;
@@ -71,8 +92,11 @@ impl OperatorRegistry {
             .get(scheme)
             .copied()
             .ok_or_else(|| {
+                let mut available: Vec<String> = self.schemes().into_iter().collect();
+                available.sort();
                 Error::new(ErrorKind::Unsupported, "scheme is not registered")
                     .with_context("scheme", scheme.to_string())
+                    .with_context("available", available.join(", "))
             })?;
 
         factory(&parsed)
@@ -83,4 +107,30 @@ impl OperatorRegistry {
 fn factory<C: Configurator>(uri: &OperatorUri) -> Result<Operator> {
     let cfg = C::from_uri(uri)?;
     Operator::from_config(cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn global_registry_exposes_memory_scheme() {
+        let schemes = OperatorRegistry::get().schemes();
+        assert!(schemes.contains("memory"));
+    }
+
+    #[test]
+    fn unregistered_scheme_error_lists_available_schemes() {
+        let err = OperatorRegistry::get()
+            .load("no-such-scheme://bucket/path")
+            .unwrap_err();
+
+        assert_eq!(err.kind(), ErrorKind::Unsupported);
+
+        let msg = err.to_string();
+        assert!(msg.contains("scheme is not registered"));
+        assert!(msg.contains("no-such-scheme"));
+        assert!(msg.contains("available"));
+        assert!(msg.contains("memory"));
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7904.

# Rationale for this change

`OperatorRegistry` already stores every registered scheme in its internal `factories: Mutex<HashMap<String, OperatorFactory>>`, but there was no public way to read those keys back. For the global registry, that set is exactly what `Operator::from_uri` can construct, and it is otherwise unobservable at runtime (it is fully determined by the compiled-in `services-*` features).

Without it, a common mistake — a wrong dialect (`s3a://`, `gs://` vs `gcs://`) or a missing `services-*` feature — yields a bare `scheme is not registered` error with no hint about which schemes *are* available.

# What changes are included in this PR?

- Add `OperatorRegistry::schemes() -> HashSet<String>`, a thin read over the existing `factories` map under the current lock.
- Enrich the `from_uri` `scheme is not registered` error with an `available` context that lists the registered schemes (sorted), turning a bare error into an actionable hint.
- Add unit tests covering the accessor and the enriched error, plus a doctest on `schemes()`.

## Output (py bindings)
```bash
>>> import opendal
>>> opendal.Operator("asd",)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
opendal.exceptions.Unsupported: Unsupported (permanent) at  => scheme is not registered

Context:
   scheme: asd
   available: azblob, azdls, cos, cosn, file, fs, gcs, ghac, http, https, ipmfs, memory, obs, oss, s3, webdav, webhdfs
```

# Are there any user-facing changes?

Yes, additive only:

- New public method `OperatorRegistry::schemes()`.
- The `from_uri` unsupported-scheme error now carries an additional `available` context field listing registered schemes. No existing field or error kind changes; not a breaking change.

# AI Usage Statement

This PR was prepared with the assistance of an AI coding agent (OpenCode, using an Anthropic Claude model) for implementation and drafting. All changes were reviewed by a human before submission.
