### PR TITLE
fix(bindings/python): enable hdfs-native on arm

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -61,6 +61,7 @@ services-all = [
   'services-gdrive',
   'services-goosefs',
   'services-gridfs',
+  'services-hdfs-native',
   'services-hf',
   'services-ipfs',
   'services-koofr',
@@ -188,10 +189,6 @@ abi3 = ["pyo3/abi3-py311"]
 # Conditionally include sftp only on non-windows targets
 [target.'cfg(not(windows))'.features]
 services-all = ["services-sftp"]
-
-# Conditionally include hdfs-native only on non-arm targets
-[target.'cfg(not(target_arch = "arm"))'.features]
-services-all = ["services-hdfs-native"]
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6791.

# Rationale for this change

OpenDAL excluded `hdfs-native` from ARM Python wheels in #6792 because hdfs-native 0.13.0 contained bindgen layout assertions generated for 64-bit targets. The upstream fix removed those assertions and verified armv7 under QEMU in Kimahriman/hdfs-native#271, resolving Kimahriman/hdfs-native#270. OpenDAL currently resolves hdfs-native 0.13.5, which contains that fix.

Related dependency upgrade: #7910 upgrades hdfs-native to 0.14.2. This PR is independent because the ARM fix is already included in 0.13.5.

# What changes are included in this PR?

- Add `services-hdfs-native` back to the unconditional Python `services-all` feature.
- Remove the ARM-specific exclusion.

# Are there any user-facing changes?

Yes. Python wheels built for ARM targets include the hdfs-native service again.

# Verification

- `cargo check --features services-all` in `bindings/python`
- `just lint` in `bindings/python`
- `taplo format --check Cargo.toml` in `bindings/python`
- Native `linux/arm/v7` Docker: `cargo check --locked -p opendal-service-hdfs-native` completed successfully.
- Reproduced the failing release workflow command in native `linux/arm/v7` Docker with Rust 1.91.1: `cargo rustc --locked --profile release --features pyo3/extension-module,services-all,abi3 --lib --crate-type cdylib -- -C strip=symbols`.
- The release command compiled `hdfs-native 0.13.5`, `opendal-service-hdfs-native`, and all `services-all` dependencies, then reached final `opendal-python` compilation without the E0080 layout errors from #6791. Final fat-LTO linking under QEMU exceeded the local execution timeout.

# AI Usage Statement

This PR was prepared with OpenCode using GPT-5.6.