### PR TITLE
docs(website): add publications page for papers using OpenDAL

### DIFF
--- a/website/community/index.mdx
+++ b/website/community/index.mdx
@@ -18,6 +18,7 @@ You can:
 * Provide us with the use-cases.
 * Report bugs and submit patches.
 * Contribute code, documentation.
+* Read about [publications](/community/publications) that use OpenDAL.
 
 ## Mailing list
 

--- a/website/community/publications.md
+++ b/website/community/publications.md
@@ -10,20 +10,18 @@ These are independent works that build on OpenDAL, not papers about OpenDAL itse
 
 ## Bioinformatics
 
-- [polars-bio—fast, scalable, and out-of-core operations on large genomic interval datasets](https://doi.org/10.1093/bioinformatics/btaf640) — *Bioinformatics* (2025), DOI [10.1093/bioinformatics/btaf640](https://doi.org/10.1093/bioinformatics/btaf640).
+- [polars-bio—fast, scalable, and out-of-core operations on large genomic interval datasets][1] — *Bioinformatics* (2025).
   Uses OpenDAL for cloud object-storage access (for example S3 and GCS).
 
 ## arXiv
 
-- [Vidformer: Drop-in Declarative Optimization for Rendering Video-Native Query Results](https://arxiv.org/abs/2601.17221) — [arXiv:2601.17221](https://arxiv.org/abs/2601.17221).
+- [Vidformer: Drop-in Declarative Optimization for Rendering Video-Native Query Results][2] — arXiv preprint (2026).
   Routes video I/O through OpenDAL to support many storage protocols.
 
-## Wikipedia display
+## References
 
-:::note
+1. <https://doi.org/10.1093/bioinformatics/btaf640>
+2. <https://arxiv.org/abs/2601.17221>
 
-English Wikipedia prefers independent, reliable sources—typically peer-reviewed journal articles—for article references.
-arXiv preprints are generally weaker for notability and reference purposes.
-See [Wikipedia:Reliable sources](https://en.wikipedia.org/wiki/Wikipedia:Reliable_sources) for details.
-
-:::
+[1]: https://doi.org/10.1093/bioinformatics/btaf640
+[2]: https://arxiv.org/abs/2601.17221

--- a/website/community/publications.md
+++ b/website/community/publications.md
@@ -1,0 +1,29 @@
+---
+title: Publications
+sidebar_position: 2
+---
+
+# Publications
+
+This page lists papers and projects that use Apache OpenDAL™.
+These are independent works that build on OpenDAL, not papers about OpenDAL itself.
+
+## Bioinformatics
+
+- [polars-bio—fast, scalable, and out-of-core operations on large genomic interval datasets](https://doi.org/10.1093/bioinformatics/btaf640) — *Bioinformatics* (2025), DOI [10.1093/bioinformatics/btaf640](https://doi.org/10.1093/bioinformatics/btaf640).
+  Uses OpenDAL for cloud object-storage access (for example S3 and GCS).
+
+## arXiv
+
+- [Vidformer: Drop-in Declarative Optimization for Rendering Video-Native Query Results](https://arxiv.org/abs/2601.17221) — [arXiv:2601.17221](https://arxiv.org/abs/2601.17221).
+  Routes video I/O through OpenDAL to support many storage protocols.
+
+## Wikipedia display
+
+:::note
+
+English Wikipedia prefers independent, reliable sources—typically peer-reviewed journal articles—for article references.
+arXiv preprints are generally weaker for notability and reference purposes.
+See [Wikipedia:Reliable sources](https://en.wikipedia.org/wiki/Wikipedia:Reliable_sources) for details.
+
+:::


### PR DESCRIPTION
### Which issue does this PR close?

Closes #7913 

### Rationale for this change

Apache OpenDAL™ is used by independent research projects, but the website had no place listing those publications. A Community page makes that usage visible and notes how English Wikipedia treats journal vs preprint sources for references.

### What changes are included in this PR?

- Add `website/community/publications.md` with:
  - Bioinformatics: polars-bio (DOI 10.1093/bioinformatics/btaf640)
  - arXiv: Vidformer (arXiv:2601.17221)
  - A short aside on Wikipedia reliable sources
- Link Publications from the Community hub (`website/community/index.mdx`)
- Route: `/community/publications/` (autogenerated Community sidebar)

### Are there any user-facing changes?

Yes, new Community docs page and hub link. Docs-only; no API or runtime changes.

### AI Usage Statement

Assisted with Cursor (Grok).