### PR TITLE
fix: defer default reqwest client initialization

### DIFF
--- a/core/http-transports/reqwest/src/lib.rs
+++ b/core/http-transports/reqwest/src/lib.rs
@@ -78,11 +78,13 @@ use opendal_core::Error;
 use opendal_core::ErrorKind;
 use opendal_core::HttpBody;
 use opendal_core::HttpTransport;
+use opendal_core::HttpTransporter;
 use opendal_core::Result;
 use opendal_core::raw::parse_content_encoding;
 use opendal_core::raw::parse_content_length;
 
-static DEFAULT_REQWEST_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+static DEFAULT_REQWEST_TRANSPORT: LazyLock<ReqwestTransport> =
+    LazyLock::new(|| ReqwestTransport::new(reqwest::Client::new()));
 
 /// A HTTP transport with [`reqwest::Client`].
 #[derive(Clone)]
@@ -98,7 +100,7 @@ impl Debug for ReqwestTransport {
 
 impl Default for ReqwestTransport {
     fn default() -> Self {
-        Self::new(DEFAULT_REQWEST_CLIENT.clone())
+        DEFAULT_REQWEST_TRANSPORT.clone()
     }
 }
 
@@ -206,6 +208,23 @@ impl HttpTransport for ReqwestTransport {
     }
 }
 
+/// Install the process-wide default reqwest transport.
+///
+/// The reqwest client is initialized when the transport handles its first
+/// request.
+#[doc(hidden)]
+pub fn install_default() {
+    HttpTransporter::install_default(LazyReqwestTransport);
+}
+
+struct LazyReqwestTransport;
+
+impl HttpTransport for LazyReqwestTransport {
+    async fn fetch(&self, req: Request<Buffer>) -> Result<Response<HttpBody>> {
+        DEFAULT_REQWEST_TRANSPORT.fetch(req).await
+    }
+}
+
 #[inline]
 fn is_temporary_error(err: &reqwest::Error) -> bool {
     // error sending request
@@ -246,6 +265,11 @@ impl http_body::Body for HttpBufferBody {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_install_default_is_lazy() {
+        install_default();
+    }
 
     #[cfg(any(feature = "rustls", feature = "native-tls"))]
     #[test]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -48,7 +48,7 @@ pub fn install_default() {
     init_default_registry();
 
     #[cfg(feature = "http-transport-reqwest")]
-    HttpTransporter::install_default(opendal_http_transport_reqwest::ReqwestTransport::default());
+    opendal_http_transport_reqwest::install_default();
 }
 
 /// Initialize the global [`OperatorRegistry`] with enabled services.


### PR DESCRIPTION
# Which issue does this PR close?

Closes #7923.

# Rationale for this change

With `auto-register-services` enabled, the facade constructor installs the default HTTP transport before `main`. Constructing `ReqwestTransport::default()` there also constructs the reqwest client, which can enter macOS system proxy discovery from a dyld initializer and abort the process before the Rust test harness starts.

# What changes are included in this PR?

The reqwest transport crate now installs a private lazy proxy as the process-wide default. The proxy initializes the single shared default `ReqwestTransport` on the first HTTP request, while the public transport and custom-client paths remain unchanged.

A regression test covers lazy default installation. The change was also validated with the exact Lance reproduction from #7923.

# Are there any user-facing changes?

Yes. Facade startup no longer initializes the reqwest client before `main`. HTTP request behavior and shared connection pooling remain unchanged.

# AI Usage Statement

Codex with an OpenAI GPT-5 model was used to help analyze, implement, and validate this change.
