### PR TITLE
feat(integrations/parquet): upgrade Arrow and Parquet to 59

### DIFF
--- a/integrations/parquet/Cargo.toml
+++ b/integrations/parquet/Cargo.toml
@@ -25,20 +25,20 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.8.2"
+version = "0.9.0"
 
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
 opendal = { version = "0.58.0", path = "../../core" }
-parquet = { version = "58.0", default-features = false, features = [
+parquet = { version = "59.0", default-features = false, features = [
   "async",
   "arrow",
 ] }
 
 [dev-dependencies]
-arrow = { version = "58.0" }
+arrow = { version = "59.0" }
 opendal = { version = "0.58.0", path = "../../core", features = [
   "services-memory",
   "services-s3",

--- a/integrations/parquet/upgrade.md
+++ b/integrations/parquet/upgrade.md
@@ -1,3 +1,9 @@
+# Upgrade to v0.9
+
+## Bump Arrow and Parquet versions to v59
+
+`parquet_opendal` now requires `arrow` and `parquet` version 59.0.0 or higher.
+
 # Upgrade to v0.8
 
 ## Bump arrow version to v58


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

`parquet_opendal` currently targets Arrow and Parquet 58, which prevents downstream projects using Arrow and Parquet 59 from sharing the same types and traits with this integration.

# What changes are included in this PR?

Upgrade the `parquet` dependency and the `arrow` development dependency to 59, bump `parquet_opendal` to 0.9.0, and document the new compatibility requirement.

# Are there any user-facing changes?

Yes. `parquet_opendal` 0.9.0 requires Arrow and Parquet 59. Downstream projects pinned to version 58 must upgrade these dependencies together.

# AI Usage Statement

OpenAI Codex with GPT-5 was used to update the dependencies, prepare the upgrade note, and run validation.

# Testing

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `taplo format --check integrations/parquet/Cargo.toml`
