### PR TITLE
fix(dev): sync parquet release version to 0.9.0

### DIFF
--- a/dev/src/release/package.rs
+++ b/dev/src/release/package.rs
@@ -66,7 +66,7 @@ pub fn all_packages() -> Vec<Package> {
     // Integrations
     let dav_server = make_package("integrations/dav-server", "0.7.3", vec![core.clone()]);
     let object_store = make_package("integrations/object_store", "0.58.0", vec![core.clone()]);
-    let parquet = make_package("integrations/parquet", "0.8.2", vec![core.clone()]);
+    let parquet = make_package("integrations/parquet", "0.9.0", vec![core.clone()]);
     let unftp_sbe = make_package("integrations/unftp-sbe", "0.4.3", vec![core.clone()]);
 
     // Binaries moved to separate repositories; no longer released from this repo


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

`odev`'s release package list still pinned `integrations/parquet` to `0.8.2`, but #7934 upgraded `parquet_opendal` to `0.9.0`. The `parquet_release_version_matches_manifest` test compares the hardcoded release version against `integrations/parquet/Cargo.toml`, so it now fails on `main`:

```
thread 'release::package::tests::parquet_release_version_matches_manifest' panicked at src/release/package.rs:601:9:
assertion `left == right` failed
  left: Version { major: 0, minor: 8, patch: 2 }
 right: Version { major: 0, minor: 9, patch: 0 }
```

# What changes are included in this PR?

Bump the hardcoded `integrations/parquet` release version in `dev/src/release/package.rs` from `0.8.2` to `0.9.0` to match `integrations/parquet/Cargo.toml`.

# Are there any user-facing changes?

No. This only fixes the `odev` release tooling test.

# AI Usage Statement

This PR was prepared with assistance from an AI coding agent (Claude). The change and `cargo test --bin odev` / `cargo fmt -- --check` verification were reviewed locally.
