### PR TITLE
feat(core): not translate to "interrupted" std IO error

### DIFF
--- a/core/core/src/raw/std_io_util.rs
+++ b/core/core/src/raw/std_io_util.rs
@@ -58,8 +58,40 @@ pub(crate) fn format_std_io_error(err: Error) -> io::Error {
     let kind = match err.kind() {
         ErrorKind::NotFound => io::ErrorKind::NotFound,
         ErrorKind::PermissionDenied => io::ErrorKind::PermissionDenied,
-        _ => io::ErrorKind::Interrupted,
+        _ => io::ErrorKind::Other,
     };
 
     io::Error::new(kind, err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_to_end_stops_on_persistent_error() {
+        struct ErrorThenEof {
+            calls: usize,
+        }
+
+        impl io::Read for ErrorThenEof {
+            fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
+                self.calls += 1;
+                if self.calls == 1 {
+                    return Err(format_std_io_error(
+                        Error::new(ErrorKind::Unexpected, "retry exhausted").set_persistent(),
+                    ));
+                }
+                Ok(0)
+            }
+        }
+
+        let mut reader = ErrorThenEof { calls: 0 };
+        let mut buf = Vec::new();
+        assert!(
+            io::Read::read_to_end(&mut reader, &mut buf).is_err(),
+            "calls: {}",
+            reader.calls
+        );
+    }
 }


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

Hi team, I found when I'm using synchronous IO, it often retries more than I expected. See my regression test for details.

I think the root cause is
- For now, we map most of the OpenDAL errors into Interrupted error
- `std::io::Read` is documented to retry on interrupted error: https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/std/io/trait.Read.html#errors
- code reference: https://doc.rust-lang.org/src/std/io/mod.rs.html#479

```rs
// Note that we don't track already initialized bytes here, but this is fine
// because we explicitly limit the read size
  let mut cursor = read_buf.unfilled();
  let result = loop {
    match r.read_buf(cursor.reborrow()) {
      Err(e) if e.is_interrupted() => continue,
        // Do not stop now in case of error: we might have received both data
        // and an error
        res => break res,
      }
};
```

I think it's not ideal because
- Extra retries are attempted even for persistent errors, which we shouldn't retry upon
- When retry layer is injected, extra retries are proceeded, even retry attempts have been exhausted
- There's no retry limit control -- it just retries forever

# What changes are included in this PR?

In this PR, I updated the std IO error from "interrupted" to "other", so it's directly propagated up; I checked [OpenDAL errors](https://github.com/apache/opendal/blob/19e028238cdc11398099bd25a8ef7895a15d68a7/core/core/src/types/error.rs#L48-L89), no errors should be mapped to "interrupted".
If retry is necessary, users could configure retry wrapper.

# Are there any user-facing changes?

No

# AI Usage Statement

AI helped me find out the source code.