### PR TITLE
ci: Fix Haskell CI cabal index update

### DIFF
--- a/.github/workflows/ci_bindings_haskell.yml
+++ b/.github/workflows/ci_bindings_haskell.yml
@@ -54,10 +54,17 @@ jobs:
         run: |
           export PATH="${GHCUP_INSTALL_BASE_PREFIX}/.ghcup/bin:${PATH}"
           echo "${GHCUP_INSTALL_BASE_PREFIX}/.ghcup/bin" >> "${GITHUB_PATH}"
-          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+          mkdir -p "${HOME}/.cabal"
+          cat > "${HOME}/.cabal/config" <<'EOF'
+          repository hackage-direct
+            url: https://hackage.haskell.org/
+            secure: False
+          active-repositories: hackage-direct
+          EOF
+          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_MINIMAL=1 sh
           ghcup install ghc 9.4.8 --set
           ghcup install cabal --set
-          cabal update
+          cabal update --ignore-project
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
       # Useful for debugging
@@ -115,10 +122,17 @@ jobs:
         run: |
           export PATH="${GHCUP_INSTALL_BASE_PREFIX}/.ghcup/bin:${PATH}"
           echo "${GHCUP_INSTALL_BASE_PREFIX}/.ghcup/bin" >> "${GITHUB_PATH}"
-          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+          mkdir -p "${HOME}/.cabal"
+          cat > "${HOME}/.cabal/config" <<'EOF'
+          repository hackage-direct
+            url: https://hackage.haskell.org/
+            secure: False
+          active-repositories: hackage-direct
+          EOF
+          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_MINIMAL=1 sh
           ghcup install ghc 9.2.8 --set
           ghcup install cabal --set
-          cabal update
+          cabal update --ignore-project
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
       - name: Restore haskell cache

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -256,10 +256,17 @@ jobs:
         run: |
           export PATH="${GHCUP_INSTALL_BASE_PREFIX}/.ghcup/bin:${PATH}"
           echo "${GHCUP_INSTALL_BASE_PREFIX}/.ghcup/bin" >> "${GITHUB_PATH}"
-          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
+          mkdir -p "${HOME}/.cabal"
+          cat > "${HOME}/.cabal/config" <<'EOF'
+          repository hackage-direct
+            url: https://hackage.haskell.org/
+            secure: False
+          active-repositories: hackage-direct
+          EOF
+          curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_MINIMAL=1 sh
           ghcup install ghc 9.2.8 --set
           ghcup install cabal --set
-          cabal update
+          cabal update --ignore-project
 
       - name: Setup cache
         uses: actions/cache@v6
@@ -272,6 +279,16 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+
+      - name: Configure Cabal repository
+        run: |
+          mkdir -p "${HOME}/.cabal"
+          cat > "${HOME}/.cabal/config" <<'EOF'
+          repository hackage-direct
+            url: https://hackage.haskell.org/
+            secure: False
+          active-repositories: hackage-direct
+          EOF
 
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

Current haskell CI is broken

# What changes are included in this PR?

Fix Haskell-related CI failures caused by Cabal selecting a stale Hackage mirror.

This updates both the Haskell bindings workflow and the Haskell docs workflow to:
- run GHCup bootstrap in minimal non-interactive mode
- configure Cabal to use Hackage directly
- run `cabal update --ignore-project`
- reapply the Cabal config after docs cache restore

# Are there any user-facing changes?

N/A

# AI Usage Statement

GPT-5.6