### PR TITLE
docs: add READMEs for split crates

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -63,6 +63,7 @@ uuid = { version = "1", default-features = false }
 exclude = ["/tests/"]
 keywords = ["storage", "fs", "s3", "azblob", "gcs"]
 name = "opendal"
+readme = "README.md"
 
 authors = { workspace = true }
 categories = { workspace = true }

--- a/core/core/Cargo.toml
+++ b/core/core/Cargo.toml
@@ -21,6 +21,7 @@ description = "Apache OpenDAL™: One Layer, All Storage."
 exclude = ["/tests/"]
 keywords = ["storage", "fs", "s3", "azblob", "gcs"]
 name = "opendal-core"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/core/README.md
+++ b/core/core/README.md
@@ -1,0 +1,93 @@
+# Apache OpenDAL™ Core
+
+`opendal-core` contains the storage abstraction, operator APIs, extension
+traits, and shared infrastructure used by Apache OpenDAL™.
+
+Most applications should depend on the [`opendal`](https://crates.io/crates/opendal)
+facade. The facade re-exports the core APIs and wires optional service, layer,
+executor, and HTTP transport crates behind feature flags.
+
+Depend on `opendal-core` directly when implementing an OpenDAL service or layer,
+building a minimal integration from the split crates, or managing service
+registration and HTTP transport explicitly.
+
+## Quick start
+
+The in-memory service is always available:
+
+```shell
+cargo add opendal-core
+```
+
+```rust
+use opendal_core::services;
+use opendal_core::Operator;
+use opendal_core::Result;
+
+fn build_operator() -> Result<Operator> {
+    Operator::new(services::Memory::default())
+}
+```
+
+Storage services and optional layers live in separate
+`opendal-service-*` and `opendal-layer-*` crates. Applications using the facade
+can enable them through `services-*` and `layers-*` features instead.
+
+## Compose split crates
+
+Applications that depend on `opendal-core` directly compose storage and runtime
+behavior explicitly:
+
+- A service crate exports a builder that implements `opendal_core::Builder`.
+  Pass the configured builder to `Operator::new`.
+- A layer crate exports a type that implements `opendal_core::Layer`. Pass the
+  configured layer to `Operator::layer`.
+- An HTTP transport crate exports an `opendal_core::HttpTransport`
+  implementation. Wrap it in `HttpTransporter` and place it in the operator's
+  `OperationContext`.
+
+For example, the following dependencies compose S3, retry, and the reqwest HTTP
+transport without the `opendal` facade:
+
+```shell
+cargo add opendal-core opendal-service-s3 opendal-layer-retry
+cargo add opendal-http-transport-reqwest
+```
+
+```rust
+use opendal_core::HttpTransporter;
+use opendal_core::OperationContext;
+use opendal_core::Operator;
+use opendal_core::Result;
+use opendal_http_transport_reqwest::ReqwestTransport;
+use opendal_layer_retry::RetryLayer;
+use opendal_service_s3::S3;
+
+fn build_operator(builder: S3) -> Result<Operator> {
+    let context = OperationContext::new()
+        .with_http_transport(HttpTransporter::new(ReqwestTransport::default()));
+
+    Ok(Operator::new(builder)?
+        .with_context(context)
+        .layer(RetryLayer::default()))
+}
+```
+
+Configure `builder` for the target S3-compatible service before passing it to
+`build_operator`.
+
+`Operator::new` uses the builder directly and does not require service
+registration. Call the service crate's `register_*_service` function with
+`OperatorRegistry::get()` only when using scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-core)
+- [Apache OpenDAL Rust guide](https://opendal.apache.org/docs/core)
+- [Services and configuration](https://opendal.apache.org/services)
+- [Apache OpenDAL project](https://opendal.apache.org/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/http-transports/reqwest/Cargo.toml
+++ b/core/http-transports/reqwest/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL reqwest HTTP transport implementation"
 name = "opendal-http-transport-reqwest"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/http-transports/reqwest/README.md
+++ b/core/http-transports/reqwest/README.md
@@ -60,17 +60,45 @@ Most users depend on the `opendal` facade crate:
 ```toml
 [dependencies]
 # Default: reqwest transport with rustls.
-opendal = { version = "0.57" }
+opendal = { version = "0.58" }
 ```
 
 To select one transport TLS feature explicitly, disable default features:
 
 ```toml
 [dependencies]
-opendal = { version = "0.57", default-features = false, features = [
+opendal = { version = "0.58", default-features = false, features = [
     "http-transport-reqwest-rustls",
 ] }
 ```
+
+## Use with `opendal-core`
+
+Applications that use the split crates can attach reqwest to an operator
+without installing a process-wide default transport:
+
+```shell
+cargo add opendal-core opendal-http-transport-reqwest
+```
+
+```rust
+use opendal_core::Builder;
+use opendal_core::HttpTransporter;
+use opendal_core::OperationContext;
+use opendal_core::Operator;
+use opendal_core::Result;
+use opendal_http_transport_reqwest::ReqwestTransport;
+
+fn build_operator<B: Builder>(builder: B) -> Result<Operator> {
+    let transport = HttpTransporter::new(ReqwestTransport::default());
+    let context = OperationContext::new().with_http_transport(transport);
+
+    Ok(Operator::new(builder)?.with_context(context))
+}
+```
+
+Pass a configured service builder to `build_operator`. The resulting operator
+uses this reqwest transport for HTTP-backed services.
 
 ## Build different TLS backends
 
@@ -80,7 +108,7 @@ Use reqwest's Rustls backend explicitly when you build the client:
 
 ```toml
 [dependencies]
-opendal = { version = "0.57", default-features = false, features = [
+opendal = { version = "0.58", default-features = false, features = [
     "http-transport-reqwest-rustls",
 ] }
 reqwest = { version = "0.13.4", default-features = false, features = [
@@ -111,7 +139,7 @@ Use `native-tls` when you want reqwest to delegate TLS to the platform stack:
 
 ```toml
 [dependencies]
-opendal = { version = "0.57", default-features = false, features = [
+opendal = { version = "0.58", default-features = false, features = [
     "http-transport-reqwest-native-tls",
 ] }
 reqwest = { version = "0.13.4", default-features = false, features = [
@@ -144,7 +172,7 @@ startup.
 
 ```toml
 [dependencies]
-opendal = { version = "0.57", default-features = false, features = [
+opendal = { version = "0.58", default-features = false, features = [
     "http-transport-reqwest-rustls-no-provider",
 ] }
 reqwest = { version = "0.13.4", default-features = false, features = [

--- a/core/layers/async-backtrace/Cargo.toml
+++ b/core/layers/async-backtrace/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL async-backtrace layer"
 name = "opendal-layer-async-backtrace"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/async-backtrace/README.md
+++ b/core/layers/async-backtrace/README.md
@@ -1,0 +1,48 @@
+# Apache OpenDAL™ Async Backtrace Layer
+
+`opendal-layer-async-backtrace` records logical stack traces for asynchronous service
+operations with `async-backtrace`.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-async-backtrace` feature:
+
+```shell
+cargo add opendal --features layers-async-backtrace
+```
+
+The layer is available as `opendal::layers::AsyncBacktraceLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-async-backtrace
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_async_backtrace::AsyncBacktraceLayer;
+
+fn add_layer(operator: Operator, layer: AsyncBacktraceLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-async-backtrace)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/await-tree/Cargo.toml
+++ b/core/layers/await-tree/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL await-tree layer"
 name = "opendal-layer-await-tree"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/await-tree/README.md
+++ b/core/layers/await-tree/README.md
@@ -1,0 +1,48 @@
+# Apache OpenDAL™ Await Tree Layer
+
+`opendal-layer-await-tree` instruments service operations so `await-tree` can expose
+their execution trees.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-await-tree` feature:
+
+```shell
+cargo add opendal --features layers-await-tree
+```
+
+The layer is available as `opendal::layers::AwaitTreeLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-await-tree
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_await_tree::AwaitTreeLayer;
+
+fn add_layer(operator: Operator, layer: AwaitTreeLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-await-tree)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/capability-check/Cargo.toml
+++ b/core/layers/capability-check/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL capability-check layer"
 name = "opendal-layer-capability-check"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/capability-check/README.md
+++ b/core/layers/capability-check/README.md
@@ -1,0 +1,48 @@
+# Apache OpenDAL™ Capability Check Layer
+
+`opendal-layer-capability-check` validates optional operation arguments against the
+capabilities reported by a storage service.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-capability-check` feature:
+
+```shell
+cargo add opendal --features layers-capability-check
+```
+
+The layer is available as `opendal::layers::CapabilityCheckLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-capability-check
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_capability_check::CapabilityCheckLayer;
+
+fn add_layer(operator: Operator, layer: CapabilityCheckLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-capability-check)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/chaos/Cargo.toml
+++ b/core/layers/chaos/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL chaos layer for robustness testing"
 name = "opendal-layer-chaos"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/chaos/README.md
+++ b/core/layers/chaos/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ Chaos Layer
+
+`opendal-layer-chaos` injects configurable read failures for robustness testing.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-chaos` feature:
+
+```shell
+cargo add opendal --features layers-chaos
+```
+
+The layer is available as `opendal::layers::ChaosLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-chaos
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_chaos::ChaosLayer;
+
+fn add_layer(operator: Operator, layer: ChaosLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-chaos)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/concurrent-limit/Cargo.toml
+++ b/core/layers/concurrent-limit/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL concurrent limit layer"
 name = "opendal-layer-concurrent-limit"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/concurrent-limit/README.md
+++ b/core/layers/concurrent-limit/README.md
@@ -1,0 +1,48 @@
+# Apache OpenDAL™ Concurrent Limit Layer
+
+`opendal-layer-concurrent-limit` limits concurrent storage and HTTP requests and can
+share one limit across operators.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-concurrent-limit` feature:
+
+```shell
+cargo add opendal --features layers-concurrent-limit
+```
+
+The layer is available as `opendal::layers::ConcurrentLimitLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-concurrent-limit
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_concurrent_limit::ConcurrentLimitLayer;
+
+fn add_layer(operator: Operator, layer: ConcurrentLimitLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-concurrent-limit)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/dtrace/Cargo.toml
+++ b/core/layers/dtrace/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL dtrace layer"
 name = "opendal-layer-dtrace"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/dtrace/README.md
+++ b/core/layers/dtrace/README.md
@@ -1,0 +1,52 @@
+# Apache OpenDAL™ DTrace Layer
+
+`opendal-layer-dtrace` emits User Statically-Defined Tracing probes for OpenDAL operations.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-dtrace` feature:
+
+```shell
+cargo add opendal --features layers-dtrace
+```
+
+The layer is available as `opendal::layers::DtraceLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-dtrace
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+#[cfg(target_os = "linux")]
+use opendal_core::Operator;
+#[cfg(target_os = "linux")]
+use opendal_layer_dtrace::DtraceLayer;
+
+#[cfg(target_os = "linux")]
+fn add_layer(operator: Operator, layer: DtraceLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+This experimental layer is available on Linux.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-dtrace)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/fastmetrics/Cargo.toml
+++ b/core/layers/fastmetrics/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL metrics layer using fastmetrics"
 name = "opendal-layer-fastmetrics"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/fastmetrics/README.md
+++ b/core/layers/fastmetrics/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ Fastmetrics Layer
+
+`opendal-layer-fastmetrics` records OpenDAL operation and HTTP metrics with `fastmetrics`.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-fastmetrics` feature:
+
+```shell
+cargo add opendal --features layers-fastmetrics
+```
+
+The layer is available as `opendal::layers::FastmetricsLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-fastmetrics
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_fastmetrics::FastmetricsLayer;
+
+fn add_layer(operator: Operator, layer: FastmetricsLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-fastmetrics)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/fastrace/Cargo.toml
+++ b/core/layers/fastrace/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL fastrace layer"
 name = "opendal-layer-fastrace"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/fastrace/README.md
+++ b/core/layers/fastrace/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ Fastrace Layer
+
+`opendal-layer-fastrace` traces OpenDAL operations and deferred I/O bodies with `fastrace`.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-fastrace` feature:
+
+```shell
+cargo add opendal --features layers-fastrace
+```
+
+The layer is available as `opendal::layers::FastraceLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-fastrace
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_fastrace::FastraceLayer;
+
+fn add_layer(operator: Operator, layer: FastraceLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-fastrace)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/foyer/Cargo.toml
+++ b/core/layers/foyer/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL foyer hybrid cache layer"
 name = "opendal-layer-foyer"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/foyer/README.md
+++ b/core/layers/foyer/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ Foyer Cache Layer
+
+`opendal-layer-foyer` caches OpenDAL reads and writes in a Foyer hybrid cache.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-foyer` feature:
+
+```shell
+cargo add opendal --features layers-foyer
+```
+
+The layer is available as `opendal::layers::FoyerLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-foyer
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_foyer::FoyerLayer;
+
+fn add_layer(operator: Operator, layer: FoyerLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-foyer)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/hotpath/Cargo.toml
+++ b/core/layers/hotpath/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL hotpath layer"
 name = "opendal-layer-hotpath"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/hotpath/README.md
+++ b/core/layers/hotpath/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ Hotpath Layer
+
+`opendal-layer-hotpath` profiles OpenDAL operations and HTTP work with `hotpath`.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-hotpath` feature:
+
+```shell
+cargo add opendal --features layers-hotpath
+```
+
+The layer is available as `opendal::layers::HotpathLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-hotpath
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_hotpath::HotpathLayer;
+
+fn add_layer(operator: Operator, layer: HotpathLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-hotpath)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/immutable-index/Cargo.toml
+++ b/core/layers/immutable-index/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL immutable-index layer"
 name = "opendal-layer-immutable-index"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/immutable-index/README.md
+++ b/core/layers/immutable-index/README.md
@@ -1,0 +1,48 @@
+# Apache OpenDAL™ Immutable Index Layer
+
+`opendal-layer-immutable-index` adds an immutable in-memory listing index to services
+that lack native list support.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-immutable-index` feature:
+
+```shell
+cargo add opendal --features layers-immutable-index
+```
+
+The layer is available as `opendal::layers::ImmutableIndexLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-immutable-index
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_immutable_index::ImmutableIndexLayer;
+
+fn add_layer(operator: Operator, layer: ImmutableIndexLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-immutable-index)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/logging/Cargo.toml
+++ b/core/layers/logging/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL logging layer"
 name = "opendal-layer-logging"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/logging/README.md
+++ b/core/layers/logging/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ Logging Layer
+
+`opendal-layer-logging` records OpenDAL operation lifecycles with the `log` facade.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-logging` feature:
+
+```shell
+cargo add opendal --features layers-logging
+```
+
+The layer is available as `opendal::layers::LoggingLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-logging
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_logging::LoggingLayer;
+
+fn add_layer(operator: Operator, layer: LoggingLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-logging)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/metrics/Cargo.toml
+++ b/core/layers/metrics/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL metrics layer built on metrics crate"
 name = "opendal-layer-metrics"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/metrics/README.md
+++ b/core/layers/metrics/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ Metrics Layer
+
+`opendal-layer-metrics` records OpenDAL operation and HTTP metrics with the `metrics` facade.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-metrics` feature:
+
+```shell
+cargo add opendal --features layers-metrics
+```
+
+The layer is available as `opendal::layers::MetricsLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-metrics
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_metrics::MetricsLayer;
+
+fn add_layer(operator: Operator, layer: MetricsLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-metrics)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/mime-guess/Cargo.toml
+++ b/core/layers/mime-guess/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL mime-guess layer"
 name = "opendal-layer-mime-guess"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/mime-guess/README.md
+++ b/core/layers/mime-guess/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ MIME Guess Layer
+
+`opendal-layer-mime-guess` infers missing content types from object path extensions.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-mime-guess` feature:
+
+```shell
+cargo add opendal --features layers-mime-guess
+```
+
+The layer is available as `opendal::layers::MimeGuessLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-mime-guess
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_mime_guess::MimeGuessLayer;
+
+fn add_layer(operator: Operator, layer: MimeGuessLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-mime-guess)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/observe-metrics-common/Cargo.toml
+++ b/core/layers/observe-metrics-common/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL observe metrics common components"
 name = "opendal-layer-observe-metrics-common"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/observe-metrics-common/README.md
+++ b/core/layers/observe-metrics-common/README.md
@@ -1,0 +1,27 @@
+# Apache OpenDAL™ Observability Metrics Common
+
+`opendal-layer-observe-metrics-common` contains the shared metric definitions,
+labels, histogram boundaries, and instrumentation adapters used by Apache
+OpenDAL™ metrics layers.
+
+This crate is an implementation building block. Applications should normally
+select a public metrics layer through the `opendal` facade, such as:
+
+- `layers-metrics`;
+- `layers-otel-metrics`;
+- `layers-prometheus`;
+- `layers-prometheus-client`;
+- `layers-fastmetrics`.
+
+Metrics-layer implementers can depend on this crate directly to preserve the
+same operation and HTTP metric semantics.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-observe-metrics-common)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/otelmetrics/Cargo.toml
+++ b/core/layers/otelmetrics/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL OpenTelemetry metrics layer"
 name = "opendal-layer-otelmetrics"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/otelmetrics/README.md
+++ b/core/layers/otelmetrics/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ OpenTelemetry Metrics Layer
+
+`opendal-layer-otelmetrics` records OpenDAL operation and HTTP metrics with OpenTelemetry.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-otel-metrics` feature:
+
+```shell
+cargo add opendal --features layers-otel-metrics
+```
+
+The layer is available as `opendal::layers::OtelMetricsLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-otelmetrics
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_otelmetrics::OtelMetricsLayer;
+
+fn add_layer(operator: Operator, layer: OtelMetricsLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-otelmetrics)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/oteltrace/Cargo.toml
+++ b/core/layers/oteltrace/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL OpenTelemetry trace layer"
 name = "opendal-layer-oteltrace"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/oteltrace/README.md
+++ b/core/layers/oteltrace/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ OpenTelemetry Trace Layer
+
+`opendal-layer-oteltrace` traces OpenDAL operations with OpenTelemetry.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-otel-trace` feature:
+
+```shell
+cargo add opendal --features layers-otel-trace
+```
+
+The layer is available as `opendal::layers::OtelTraceLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-oteltrace
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_oteltrace::OtelTraceLayer;
+
+fn add_layer(operator: Operator, layer: OtelTraceLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-oteltrace)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/prometheus-client/Cargo.toml
+++ b/core/layers/prometheus-client/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL metrics layer using prometheus-client"
 name = "opendal-layer-prometheus-client"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/prometheus-client/README.md
+++ b/core/layers/prometheus-client/README.md
@@ -1,0 +1,48 @@
+# Apache OpenDAL™ Prometheus Client Layer
+
+`opendal-layer-prometheus-client` registers OpenDAL operation and HTTP metrics with
+`prometheus-client`.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-prometheus-client` feature:
+
+```shell
+cargo add opendal --features layers-prometheus-client
+```
+
+The layer is available as `opendal::layers::PrometheusClientLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-prometheus-client
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_prometheus_client::PrometheusClientLayer;
+
+fn add_layer(operator: Operator, layer: PrometheusClientLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-prometheus-client)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/prometheus/Cargo.toml
+++ b/core/layers/prometheus/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Prometheus metrics layer"
 name = "opendal-layer-prometheus"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/prometheus/README.md
+++ b/core/layers/prometheus/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ Prometheus Layer
+
+`opendal-layer-prometheus` registers OpenDAL operation and HTTP metrics with the `prometheus` crate.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-prometheus` feature:
+
+```shell
+cargo add opendal --features layers-prometheus
+```
+
+The layer is available as `opendal::layers::PrometheusLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-prometheus
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_prometheus::PrometheusLayer;
+
+fn add_layer(operator: Operator, layer: PrometheusLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-prometheus)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/retry/Cargo.toml
+++ b/core/layers/retry/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL retry layer"
 name = "opendal-layer-retry"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/retry/README.md
+++ b/core/layers/retry/README.md
@@ -1,0 +1,50 @@
+# Apache OpenDAL™ Retry Layer
+
+`opendal-layer-retry` retries temporarily failed operations and stateful I/O bodies.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-retry` feature:
+
+```shell
+cargo add opendal --features layers-retry
+```
+
+The layer is available as `opendal::layers::RetryLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-retry
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_retry::RetryLayer;
+
+fn add_layer(operator: Operator, layer: RetryLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+Layer order matters when retry is combined with timeout. Review the API documentation
+before composing both layers.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-retry)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/route/Cargo.toml
+++ b/core/layers/route/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL route layer"
 name = "opendal-layer-route"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/route/README.md
+++ b/core/layers/route/README.md
@@ -1,0 +1,48 @@
+# Apache OpenDAL™ Route Layer
+
+`opendal-layer-route` routes operations to different operators by matching paths against
+glob patterns.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-route` feature:
+
+```shell
+cargo add opendal --features layers-route
+```
+
+The layer is available as `opendal::layers::RouteLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-route
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_route::RouteLayer;
+
+fn add_layer(operator: Operator, layer: RouteLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-route)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/tail-cut/Cargo.toml
+++ b/core/layers/tail-cut/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL tail-cut layer"
 name = "opendal-layer-tail-cut"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/tail-cut/README.md
+++ b/core/layers/tail-cut/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ Tail Cut Layer
+
+`opendal-layer-tail-cut` uses observed latency to cancel long-tail requests with adaptive deadlines.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-tail-cut` feature:
+
+```shell
+cargo add opendal --features layers-tail-cut
+```
+
+The layer is available as `opendal::layers::TailCutLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-tail-cut
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_tail_cut::TailCutLayer;
+
+fn add_layer(operator: Operator, layer: TailCutLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-tail-cut)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/throttle/Cargo.toml
+++ b/core/layers/throttle/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL throttle layer"
 name = "opendal-layer-throttle"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/throttle/README.md
+++ b/core/layers/throttle/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ Throttle Layer
+
+`opendal-layer-throttle` limits storage bandwidth with configurable rate and burst bounds.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-throttle` feature:
+
+```shell
+cargo add opendal --features layers-throttle
+```
+
+The layer is available as `opendal::layers::ThrottleLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-throttle
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_throttle::ThrottleLayer;
+
+fn add_layer(operator: Operator, layer: ThrottleLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-throttle)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/timeout/Cargo.toml
+++ b/core/layers/timeout/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL timeout layer"
 name = "opendal-layer-timeout"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/timeout/README.md
+++ b/core/layers/timeout/README.md
@@ -1,0 +1,50 @@
+# Apache OpenDAL™ Timeout Layer
+
+`opendal-layer-timeout` applies deadlines to control operations and stateful I/O bodies.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-timeout` feature:
+
+```shell
+cargo add opendal --features layers-timeout
+```
+
+The layer is available as `opendal::layers::TimeoutLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-timeout
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_timeout::TimeoutLayer;
+
+fn add_layer(operator: Operator, layer: TimeoutLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+Layer order matters when timeout is combined with retry. Review the API documentation
+before composing both layers.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-timeout)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/layers/tracing/Cargo.toml
+++ b/core/layers/tracing/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL tracing layer"
 name = "opendal-layer-tracing"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/layers/tracing/README.md
+++ b/core/layers/tracing/README.md
@@ -1,0 +1,47 @@
+# Apache OpenDAL™ Tracing Layer
+
+`opendal-layer-tracing` emits spans for OpenDAL operations and deferred I/O bodies with `tracing`.
+
+## Use through `opendal`
+
+Applications should normally enable this layer through the `opendal` facade with the
+`layers-tracing` feature:
+
+```shell
+cargo add opendal --features layers-tracing
+```
+
+The layer is available as `opendal::layers::TracingLayer` and can be
+composed with an operator through `opendal::Operator::layer`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-layer-tracing
+```
+
+Pass a configured layer to `Operator::layer`:
+
+```rust
+use opendal_core::Operator;
+use opendal_layer_tracing::TracingLayer;
+
+fn add_layer(operator: Operator, layer: TracingLayer) -> Operator {
+    operator.layer(layer)
+}
+```
+
+Construct and configure `layer` as described in the API documentation before
+composing it with an operator.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-layer-tracing)
+- [Apache OpenDAL production guide](https://opendal.apache.org/docs/core/production)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/aliyun-drive/Cargo.toml
+++ b/core/services/aliyun-drive/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Aliyun Drive service implementation"
 name = "opendal-service-aliyun-drive"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/aliyun-drive/README.md
+++ b/core/services/aliyun-drive/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Aliyun Drive Service
+
+`opendal-service-aliyun-drive` provides access to Aliyun Drive for applications built
+with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-aliyun-drive` feature:
+
+```shell
+cargo add opendal --features services-aliyun-drive
+```
+
+The service is available as `opendal::services::AliyunDrive`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-aliyun-drive
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_aliyun_drive::{register_aliyun_drive_service, AliyunDrive};
+
+fn build_operator(builder: AliyunDrive) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_aliyun_drive_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/aliyun-drive)
+- [Rust API documentation](https://docs.rs/opendal-service-aliyun-drive)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/alluxio/Cargo.toml
+++ b/core/services/alluxio/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Alluxio service implementation"
 name = "opendal-service-alluxio"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/alluxio/README.md
+++ b/core/services/alluxio/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Alluxio Service
+
+`opendal-service-alluxio` provides access to Alluxio storage for applications built with
+Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-alluxio` feature:
+
+```shell
+cargo add opendal --features services-alluxio
+```
+
+The service is available as `opendal::services::Alluxio`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-alluxio
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_alluxio::{register_alluxio_service, Alluxio};
+
+fn build_operator(builder: Alluxio) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_alluxio_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/alluxio)
+- [Rust API documentation](https://docs.rs/opendal-service-alluxio)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/azblob/Cargo.toml
+++ b/core/services/azblob/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Azure Blob Storage service implementation"
 name = "opendal-service-azblob"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/azblob/README.md
+++ b/core/services/azblob/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Azure Blob Storage Service
+
+`opendal-service-azblob` provides access to Azure Blob Storage for applications built
+with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-azblob` feature:
+
+```shell
+cargo add opendal --features services-azblob
+```
+
+The service is available as `opendal::services::Azblob`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-azblob
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_azblob::{register_azblob_service, Azblob};
+
+fn build_operator(builder: Azblob) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_azblob_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/azblob)
+- [Rust API documentation](https://docs.rs/opendal-service-azblob)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/azdls/Cargo.toml
+++ b/core/services/azdls/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Azure Data Lake Storage Gen2 service implementation"
 name = "opendal-service-azdls"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/azdls/README.md
+++ b/core/services/azdls/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Azure Data Lake Storage Gen2 Service
+
+`opendal-service-azdls` provides access to Azure Data Lake Storage Gen2 for applications
+built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-azdls` feature:
+
+```shell
+cargo add opendal --features services-azdls
+```
+
+The service is available as `opendal::services::Azdls`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-azdls
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_azdls::{register_azdls_service, Azdls};
+
+fn build_operator(builder: Azdls) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_azdls_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/azdls)
+- [Rust API documentation](https://docs.rs/opendal-service-azdls)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/azfile/Cargo.toml
+++ b/core/services/azfile/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Azure File Storage service implementation"
 name = "opendal-service-azfile"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/azfile/README.md
+++ b/core/services/azfile/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Azure Files Service
+
+`opendal-service-azfile` provides access to Azure Files for applications built with
+Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-azfile` feature:
+
+```shell
+cargo add opendal --features services-azfile
+```
+
+The service is available as `opendal::services::Azfile`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-azfile
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_azfile::{register_azfile_service, Azfile};
+
+fn build_operator(builder: Azfile) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_azfile_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/azfile)
+- [Rust API documentation](https://docs.rs/opendal-service-azfile)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/azure-common/Cargo.toml
+++ b/core/services/azure-common/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Shared Azure helpers for Apache OpenDAL services"
 name = "opendal-service-azure-common"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/azure-common/README.md
+++ b/core/services/azure-common/README.md
@@ -1,0 +1,26 @@
+# Apache OpenDAL™ Azure Common
+
+`opendal-service-azure-common` provides shared Azure Storage configuration,
+authentication, request, and response helpers for Apache OpenDAL™ service
+implementations.
+
+This crate is an implementation building block rather than a standalone storage
+service. Applications should normally use one of the public Azure services
+through the `opendal` facade:
+
+- `services-azblob` for Azure Blob Storage;
+- `services-azdls` for Azure Data Lake Storage Gen2;
+- `services-azfile` for Azure Files.
+
+Service implementers can depend on this crate directly when they need the same
+Azure connection-string and authentication behavior.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-service-azure-common)
+- [Services and configuration](https://opendal.apache.org/services)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/b2/Cargo.toml
+++ b/core/services/b2/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL B2 service implementation"
 name = "opendal-service-b2"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/b2/README.md
+++ b/core/services/b2/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Backblaze B2 Service
+
+`opendal-service-b2` provides access to Backblaze B2 object storage for applications
+built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-b2` feature:
+
+```shell
+cargo add opendal --features services-b2
+```
+
+The service is available as `opendal::services::B2`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-b2
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_b2::{register_b2_service, B2};
+
+fn build_operator(builder: B2) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_b2_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/b2)
+- [Rust API documentation](https://docs.rs/opendal-service-b2)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/cacache/Cargo.toml
+++ b/core/services/cacache/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Cacache service implementation"
 name = "opendal-service-cacache"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/cacache/README.md
+++ b/core/services/cacache/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Cacache Service
+
+`opendal-service-cacache` provides a content-addressable cache backend powered by
+`cacache` for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-cacache` feature:
+
+```shell
+cargo add opendal --features services-cacache
+```
+
+The service is available as `opendal::services::Cacache`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-cacache
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_cacache::{register_cacache_service, Cacache};
+
+fn build_operator(builder: Cacache) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_cacache_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/cacache)
+- [Rust API documentation](https://docs.rs/opendal-service-cacache)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/cloudflare-kv/Cargo.toml
+++ b/core/services/cloudflare-kv/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Cloudflare KV service implementation"
 name = "opendal-service-cloudflare-kv"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/cloudflare-kv/README.md
+++ b/core/services/cloudflare-kv/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Cloudflare Workers KV Service
+
+`opendal-service-cloudflare-kv` provides access to Cloudflare Workers KV for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-cloudflare-kv` feature:
+
+```shell
+cargo add opendal --features services-cloudflare-kv
+```
+
+The service is available as `opendal::services::CloudflareKv`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-cloudflare-kv
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_cloudflare_kv::{register_cloudflare_kv_service, CloudflareKv};
+
+fn build_operator(builder: CloudflareKv) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_cloudflare_kv_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/cloudflare-kv)
+- [Rust API documentation](https://docs.rs/opendal-service-cloudflare-kv)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/compfs/Cargo.toml
+++ b/core/services/compfs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Compfs service implementation"
 name = "opendal-service-compfs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/compfs/README.md
+++ b/core/services/compfs/README.md
@@ -1,0 +1,58 @@
+# Apache OpenDAL™ Compfs Service
+
+`opendal-service-compfs` provides local filesystem access powered by `compio` for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-compfs` feature:
+
+```shell
+cargo add opendal --features services-compfs
+```
+
+The service is available as `opendal::services::Compfs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-compfs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_compfs::{register_compfs_service, Compfs};
+
+fn build_operator(builder: Compfs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_compfs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+This service is useful when an application wants `compio`-based filesystem I/O.
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/compfs)
+- [Rust API documentation](https://docs.rs/opendal-service-compfs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/cos/Cargo.toml
+++ b/core/services/cos/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL COS service implementation"
 name = "opendal-service-cos"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/cos/README.md
+++ b/core/services/cos/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Tencent Cloud COS Service
+
+`opendal-service-cos` provides access to Tencent Cloud Object Storage for applications
+built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-cos` feature:
+
+```shell
+cargo add opendal --features services-cos
+```
+
+The service is available as `opendal::services::Cos`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-cos
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_cos::{register_cos_service, Cos};
+
+fn build_operator(builder: Cos) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_cos_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/cos)
+- [Rust API documentation](https://docs.rs/opendal-service-cos)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/d1/Cargo.toml
+++ b/core/services/d1/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL D1 service implementation"
 name = "opendal-service-d1"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/d1/README.md
+++ b/core/services/d1/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Cloudflare D1 Service
+
+`opendal-service-d1` provides a storage backend backed by Cloudflare D1 for applications
+built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-d1` feature:
+
+```shell
+cargo add opendal --features services-d1
+```
+
+The service is available as `opendal::services::D1`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-d1
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_d1::{register_d1_service, D1};
+
+fn build_operator(builder: D1) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_d1_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/d1)
+- [Rust API documentation](https://docs.rs/opendal-service-d1)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/dashmap/Cargo.toml
+++ b/core/services/dashmap/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Dashmap service implementation"
 name = "opendal-service-dashmap"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/dashmap/README.md
+++ b/core/services/dashmap/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ DashMap Service
+
+`opendal-service-dashmap` provides an in-process key-value backend backed by `DashMap`
+for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-dashmap` feature:
+
+```shell
+cargo add opendal --features services-dashmap
+```
+
+The service is available as `opendal::services::Dashmap`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-dashmap
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_dashmap::{register_dashmap_service, Dashmap};
+
+fn build_operator(builder: Dashmap) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_dashmap_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/dashmap)
+- [Rust API documentation](https://docs.rs/opendal-service-dashmap)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/dbfs/Cargo.toml
+++ b/core/services/dbfs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Dbfs service implementation"
 name = "opendal-service-dbfs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/dbfs/README.md
+++ b/core/services/dbfs/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Databricks DBFS Service
+
+`opendal-service-dbfs` provides access to the Databricks File System for applications
+built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-dbfs` feature:
+
+```shell
+cargo add opendal --features services-dbfs
+```
+
+The service is available as `opendal::services::Dbfs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-dbfs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_dbfs::{register_dbfs_service, Dbfs};
+
+fn build_operator(builder: Dbfs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_dbfs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/dbfs)
+- [Rust API documentation](https://docs.rs/opendal-service-dbfs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/dropbox/Cargo.toml
+++ b/core/services/dropbox/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Dropbox service implementation"
 name = "opendal-service-dropbox"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/dropbox/README.md
+++ b/core/services/dropbox/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Dropbox Service
+
+`opendal-service-dropbox` provides access to Dropbox storage for applications built with
+Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-dropbox` feature:
+
+```shell
+cargo add opendal --features services-dropbox
+```
+
+The service is available as `opendal::services::Dropbox`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-dropbox
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_dropbox::{register_dropbox_service, Dropbox};
+
+fn build_operator(builder: Dropbox) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_dropbox_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/dropbox)
+- [Rust API documentation](https://docs.rs/opendal-service-dropbox)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/etcd/Cargo.toml
+++ b/core/services/etcd/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Etcd service implementation"
 name = "opendal-service-etcd"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/etcd/README.md
+++ b/core/services/etcd/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ etcd Service
+
+`opendal-service-etcd` provides a key-value storage backend backed by etcd for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-etcd` feature:
+
+```shell
+cargo add opendal --features services-etcd
+```
+
+The service is available as `opendal::services::Etcd`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-etcd
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_etcd::{register_etcd_service, Etcd};
+
+fn build_operator(builder: Etcd) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_etcd_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/etcd)
+- [Rust API documentation](https://docs.rs/opendal-service-etcd)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/foundationdb/Cargo.toml
+++ b/core/services/foundationdb/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Foundationdb service implementation"
 name = "opendal-service-foundationdb"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/foundationdb/README.md
+++ b/core/services/foundationdb/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ FoundationDB Service
+
+`opendal-service-foundationdb` provides a key-value storage backend backed by
+FoundationDB for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-foundationdb` feature:
+
+```shell
+cargo add opendal --features services-foundationdb
+```
+
+The service is available as `opendal::services::Foundationdb`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-foundationdb
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_foundationdb::{register_foundationdb_service, Foundationdb};
+
+fn build_operator(builder: Foundationdb) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_foundationdb_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/foundationdb)
+- [Rust API documentation](https://docs.rs/opendal-service-foundationdb)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/foyer/Cargo.toml
+++ b/core/services/foyer/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Foyer service implementation"
 name = "opendal-service-foyer"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/foyer/README.md
+++ b/core/services/foyer/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Foyer Service
+
+`opendal-service-foyer` provides a storage backend backed by the Foyer hybrid cache for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-foyer` feature:
+
+```shell
+cargo add opendal --features services-foyer
+```
+
+The service is available as `opendal::services::Foyer`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-foyer
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_foyer::{register_foyer_service, Foyer};
+
+fn build_operator(builder: Foyer) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_foyer_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/foyer)
+- [Rust API documentation](https://docs.rs/opendal-service-foyer)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/fs/Cargo.toml
+++ b/core/services/fs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Fs service implementation"
 name = "opendal-service-fs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/fs/README.md
+++ b/core/services/fs/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Filesystem Service
+
+`opendal-service-fs` provides access to the local filesystem for applications built with
+Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-fs` feature:
+
+```shell
+cargo add opendal --features services-fs
+```
+
+The service is available as `opendal::services::Fs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-fs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_fs::{register_fs_service, Fs};
+
+fn build_operator(builder: Fs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_fs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/fs)
+- [Rust API documentation](https://docs.rs/opendal-service-fs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/ftp/Cargo.toml
+++ b/core/services/ftp/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL FTP service implementation"
 name = "opendal-service-ftp"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/ftp/README.md
+++ b/core/services/ftp/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ FTP Service
+
+`opendal-service-ftp` provides access to files over FTP for applications built with
+Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-ftp` feature:
+
+```shell
+cargo add opendal --features services-ftp
+```
+
+The service is available as `opendal::services::Ftp`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-ftp
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_ftp::{register_ftp_service, Ftp};
+
+fn build_operator(builder: Ftp) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_ftp_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/ftp)
+- [Rust API documentation](https://docs.rs/opendal-service-ftp)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/gcs/Cargo.toml
+++ b/core/services/gcs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Google Cloud Storage service implementation"
 name = "opendal-service-gcs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/gcs/README.md
+++ b/core/services/gcs/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Google Cloud Storage Service
+
+`opendal-service-gcs` provides access to Google Cloud Storage for applications built
+with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-gcs` feature:
+
+```shell
+cargo add opendal --features services-gcs
+```
+
+The service is available as `opendal::services::Gcs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-gcs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_gcs::{register_gcs_service, Gcs};
+
+fn build_operator(builder: Gcs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_gcs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/gcs)
+- [Rust API documentation](https://docs.rs/opendal-service-gcs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/gdrive/Cargo.toml
+++ b/core/services/gdrive/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL gdrive service implementation"
 name = "opendal-service-gdrive"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/gdrive/README.md
+++ b/core/services/gdrive/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Google Drive Service
+
+`opendal-service-gdrive` provides access to Google Drive for applications built with
+Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-gdrive` feature:
+
+```shell
+cargo add opendal --features services-gdrive
+```
+
+The service is available as `opendal::services::Gdrive`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-gdrive
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_gdrive::{register_gdrive_service, Gdrive};
+
+fn build_operator(builder: Gdrive) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_gdrive_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/gdrive)
+- [Rust API documentation](https://docs.rs/opendal-service-gdrive)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/ghac/Cargo.toml
+++ b/core/services/ghac/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL GitHub Actions Cache service implementation"
 name = "opendal-service-ghac"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/ghac/README.md
+++ b/core/services/ghac/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ GitHub Actions Cache Service
+
+`opendal-service-ghac` provides access to GitHub Actions Cache storage for applications
+built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-ghac` feature:
+
+```shell
+cargo add opendal --features services-ghac
+```
+
+The service is available as `opendal::services::Ghac`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-ghac
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_ghac::{register_ghac_service, Ghac};
+
+fn build_operator(builder: Ghac) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_ghac_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/ghac)
+- [Rust API documentation](https://docs.rs/opendal-service-ghac)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/github/Cargo.toml
+++ b/core/services/github/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL GitHub service implementation"
 name = "opendal-service-github"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/github/README.md
+++ b/core/services/github/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ GitHub Contents Service
+
+`opendal-service-github` provides access to repository files through the GitHub Contents
+API for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-github` feature:
+
+```shell
+cargo add opendal --features services-github
+```
+
+The service is available as `opendal::services::Github`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-github
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_github::{register_github_service, Github};
+
+fn build_operator(builder: Github) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_github_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/github)
+- [Rust API documentation](https://docs.rs/opendal-service-github)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/goosefs/Cargo.toml
+++ b/core/services/goosefs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL GooseFS service implementation via native gRPC"
 name = "opendal-service-goosefs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/goosefs/README.md
+++ b/core/services/goosefs/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ GooseFS Service
+
+`opendal-service-goosefs` provides access to GooseFS through its native gRPC API for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-goosefs` feature:
+
+```shell
+cargo add opendal --features services-goosefs
+```
+
+The service is available as `opendal::services::GooseFs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-goosefs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_goosefs::{register_goosefs_service, GooseFs};
+
+fn build_operator(builder: GooseFs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_goosefs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/goosefs)
+- [Rust API documentation](https://docs.rs/opendal-service-goosefs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/gridfs/Cargo.toml
+++ b/core/services/gridfs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL GridFS service implementation"
 name = "opendal-service-gridfs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/gridfs/README.md
+++ b/core/services/gridfs/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ MongoDB GridFS Service
+
+`opendal-service-gridfs` provides access to files stored in MongoDB GridFS for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-gridfs` feature:
+
+```shell
+cargo add opendal --features services-gridfs
+```
+
+The service is available as `opendal::services::Gridfs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-gridfs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_gridfs::{register_gridfs_service, Gridfs};
+
+fn build_operator(builder: Gridfs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_gridfs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/gridfs)
+- [Rust API documentation](https://docs.rs/opendal-service-gridfs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/hdfs-native/Cargo.toml
+++ b/core/services/hdfs-native/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL HDFS Native service implementation"
 name = "opendal-service-hdfs-native"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/hdfs-native/README.md
+++ b/core/services/hdfs-native/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ HDFS Native Service
+
+`opendal-service-hdfs-native` provides access to Hadoop Distributed File System through
+the native Rust `hdfs-native` client for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-hdfs-native` feature:
+
+```shell
+cargo add opendal --features services-hdfs-native
+```
+
+The service is available as `opendal::services::HdfsNative`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-hdfs-native
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_hdfs_native::{register_hdfs_native_service, HdfsNative};
+
+fn build_operator(builder: HdfsNative) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_hdfs_native_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/hdfs-native)
+- [Rust API documentation](https://docs.rs/opendal-service-hdfs-native)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/hdfs/Cargo.toml
+++ b/core/services/hdfs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL hdfs service implementation"
 name = "opendal-service-hdfs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/hdfs/README.md
+++ b/core/services/hdfs/README.md
@@ -1,0 +1,58 @@
+# Apache OpenDAL™ HDFS Service
+
+`opendal-service-hdfs` provides access to Hadoop Distributed File System through
+`libhdfs` for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-hdfs` feature:
+
+```shell
+cargo add opendal --features services-hdfs
+```
+
+The service is available as `opendal::services::Hdfs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-hdfs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_hdfs::{register_hdfs_service, Hdfs};
+
+fn build_operator(builder: Hdfs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_hdfs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+For an HDFS client that does not depend on `libhdfs`, use the `hdfs-native` service.
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/hdfs)
+- [Rust API documentation](https://docs.rs/opendal-service-hdfs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/hf/Cargo.toml
+++ b/core/services/hf/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Hugging Face service implementation"
 name = "opendal-service-hf"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/hf/README.md
+++ b/core/services/hf/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Hugging Face Hub Service
+
+`opendal-service-hf` provides access to files hosted on the Hugging Face Hub for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-hf` feature:
+
+```shell
+cargo add opendal --features services-hf
+```
+
+The service is available as `opendal::services::Hf`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-hf
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_hf::{register_hf_service, Hf};
+
+fn build_operator(builder: Hf) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_hf_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/hf)
+- [Rust API documentation](https://docs.rs/opendal-service-hf)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/http/Cargo.toml
+++ b/core/services/http/Cargo.toml
@@ -20,6 +20,7 @@ description = "Apache OpenDAL HTTP service implementation"
 edition = "2024"
 license = "Apache-2.0"
 name = "opendal-service-http"
+readme = "README.md"
 repository = "https://github.com/apache/opendal"
 version = "0.58.1"
 

--- a/core/services/http/README.md
+++ b/core/services/http/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ HTTP Service
+
+`opendal-service-http` provides access to objects over HTTP and HTTPS for applications
+built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-http` feature:
+
+```shell
+cargo add opendal --features services-http
+```
+
+The service is available as `opendal::services::Http`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-http
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_http::{register_http_service, Http};
+
+fn build_operator(builder: Http) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_http_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/http)
+- [Rust API documentation](https://docs.rs/opendal-service-http)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/ipfs/Cargo.toml
+++ b/core/services/ipfs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL IPFS service implementation"
 name = "opendal-service-ipfs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/ipfs/README.md
+++ b/core/services/ipfs/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ IPFS Service
+
+`opendal-service-ipfs` provides access to content through IPFS for applications built
+with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-ipfs` feature:
+
+```shell
+cargo add opendal --features services-ipfs
+```
+
+The service is available as `opendal::services::Ipfs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-ipfs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_ipfs::{register_ipfs_service, Ipfs};
+
+fn build_operator(builder: Ipfs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_ipfs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/ipfs)
+- [Rust API documentation](https://docs.rs/opendal-service-ipfs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/ipmfs/Cargo.toml
+++ b/core/services/ipmfs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL ipmfs service implementation"
 name = "opendal-service-ipmfs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/ipmfs/README.md
+++ b/core/services/ipmfs/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ IPFS Mutable File System Service
+
+`opendal-service-ipmfs` provides access to the IPFS Mutable File System API for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-ipmfs` feature:
+
+```shell
+cargo add opendal --features services-ipmfs
+```
+
+The service is available as `opendal::services::Ipmfs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-ipmfs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_ipmfs::{register_ipmfs_service, Ipmfs};
+
+fn build_operator(builder: Ipmfs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_ipmfs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/ipmfs)
+- [Rust API documentation](https://docs.rs/opendal-service-ipmfs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/koofr/Cargo.toml
+++ b/core/services/koofr/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL koofr service implementation"
 name = "opendal-service-koofr"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/koofr/README.md
+++ b/core/services/koofr/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Koofr Service
+
+`opendal-service-koofr` provides access to Koofr storage for applications built with
+Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-koofr` feature:
+
+```shell
+cargo add opendal --features services-koofr
+```
+
+The service is available as `opendal::services::Koofr`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-koofr
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_koofr::{register_koofr_service, Koofr};
+
+fn build_operator(builder: Koofr) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_koofr_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/koofr)
+- [Rust API documentation](https://docs.rs/opendal-service-koofr)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/lakefs/Cargo.toml
+++ b/core/services/lakefs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL lakeFS service implementation"
 name = "opendal-service-lakefs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/lakefs/README.md
+++ b/core/services/lakefs/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ lakeFS Service
+
+`opendal-service-lakefs` provides access to repositories managed by lakeFS for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-lakefs` feature:
+
+```shell
+cargo add opendal --features services-lakefs
+```
+
+The service is available as `opendal::services::Lakefs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-lakefs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_lakefs::{register_lakefs_service, Lakefs};
+
+fn build_operator(builder: Lakefs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_lakefs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/lakefs)
+- [Rust API documentation](https://docs.rs/opendal-service-lakefs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/memcached/Cargo.toml
+++ b/core/services/memcached/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Memcached service implementation"
 name = "opendal-service-memcached"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/memcached/README.md
+++ b/core/services/memcached/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Memcached Service
+
+`opendal-service-memcached` provides a key-value storage backend backed by Memcached for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-memcached` feature:
+
+```shell
+cargo add opendal --features services-memcached
+```
+
+The service is available as `opendal::services::Memcached`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-memcached
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_memcached::{register_memcached_service, Memcached};
+
+fn build_operator(builder: Memcached) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_memcached_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/memcached)
+- [Rust API documentation](https://docs.rs/opendal-service-memcached)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/mini_moka/Cargo.toml
+++ b/core/services/mini_moka/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL mini-moka service implementation"
 name = "opendal-service-mini-moka"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/mini_moka/README.md
+++ b/core/services/mini_moka/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Mini Moka Service
+
+`opendal-service-mini-moka` provides an in-process cache backend backed by `mini-moka`
+for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-mini-moka` feature:
+
+```shell
+cargo add opendal --features services-mini-moka
+```
+
+The service is available as `opendal::services::MiniMoka`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-mini-moka
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_mini_moka::{register_mini_moka_service, MiniMoka};
+
+fn build_operator(builder: MiniMoka) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_mini_moka_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/mini-moka)
+- [Rust API documentation](https://docs.rs/opendal-service-mini-moka)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/moka/Cargo.toml
+++ b/core/services/moka/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Moka service implementation"
 name = "opendal-service-moka"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/moka/README.md
+++ b/core/services/moka/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Moka Service
+
+`opendal-service-moka` provides an in-process cache backend backed by `moka` for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-moka` feature:
+
+```shell
+cargo add opendal --features services-moka
+```
+
+The service is available as `opendal::services::Moka`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-moka
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_moka::{register_moka_service, Moka};
+
+fn build_operator(builder: Moka) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_moka_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/moka)
+- [Rust API documentation](https://docs.rs/opendal-service-moka)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/mongodb/Cargo.toml
+++ b/core/services/mongodb/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Mongodb service implementation"
 name = "opendal-service-mongodb"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/mongodb/README.md
+++ b/core/services/mongodb/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ MongoDB Service
+
+`opendal-service-mongodb` provides a key-value storage backend backed by MongoDB for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-mongodb` feature:
+
+```shell
+cargo add opendal --features services-mongodb
+```
+
+The service is available as `opendal::services::Mongodb`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-mongodb
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_mongodb::{register_mongodb_service, Mongodb};
+
+fn build_operator(builder: Mongodb) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_mongodb_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/mongodb)
+- [Rust API documentation](https://docs.rs/opendal-service-mongodb)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/monoiofs/Cargo.toml
+++ b/core/services/monoiofs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Monoiofs service implementation"
 name = "opendal-service-monoiofs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/monoiofs/README.md
+++ b/core/services/monoiofs/README.md
@@ -1,0 +1,58 @@
+# Apache OpenDAL™ Monoio Filesystem Service
+
+`opendal-service-monoiofs` provides local filesystem access powered by `monoio` for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-monoiofs` feature:
+
+```shell
+cargo add opendal --features services-monoiofs
+```
+
+The service is available as `opendal::services::Monoiofs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-monoiofs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_monoiofs::{register_monoiofs_service, Monoiofs};
+
+fn build_operator(builder: Monoiofs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_monoiofs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+This service is useful when an application wants `monoio`-based filesystem I/O.
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/monoiofs)
+- [Rust API documentation](https://docs.rs/opendal-service-monoiofs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/mysql/Cargo.toml
+++ b/core/services/mysql/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL MySQL service implementation"
 name = "opendal-service-mysql"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/mysql/README.md
+++ b/core/services/mysql/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ MySQL Service
+
+`opendal-service-mysql` provides a key-value storage backend backed by MySQL for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-mysql` feature:
+
+```shell
+cargo add opendal --features services-mysql
+```
+
+The service is available as `opendal::services::Mysql`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-mysql
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_mysql::{register_mysql_service, Mysql};
+
+fn build_operator(builder: Mysql) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_mysql_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/mysql)
+- [Rust API documentation](https://docs.rs/opendal-service-mysql)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/obs/Cargo.toml
+++ b/core/services/obs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Huawei Cloud OBS service implementation"
 name = "opendal-service-obs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/obs/README.md
+++ b/core/services/obs/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Huawei Cloud OBS Service
+
+`opendal-service-obs` provides access to Huawei Cloud Object Storage Service for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-obs` feature:
+
+```shell
+cargo add opendal --features services-obs
+```
+
+The service is available as `opendal::services::Obs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-obs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_obs::{register_obs_service, Obs};
+
+fn build_operator(builder: Obs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_obs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/obs)
+- [Rust API documentation](https://docs.rs/opendal-service-obs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/onedrive/Cargo.toml
+++ b/core/services/onedrive/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL OneDrive service implementation"
 name = "opendal-service-onedrive"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/onedrive/README.md
+++ b/core/services/onedrive/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Microsoft OneDrive Service
+
+`opendal-service-onedrive` provides access to Microsoft OneDrive for applications built
+with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-onedrive` feature:
+
+```shell
+cargo add opendal --features services-onedrive
+```
+
+The service is available as `opendal::services::Onedrive`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-onedrive
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_onedrive::{register_onedrive_service, Onedrive};
+
+fn build_operator(builder: Onedrive) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_onedrive_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/onedrive)
+- [Rust API documentation](https://docs.rs/opendal-service-onedrive)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/opfs/Cargo.toml
+++ b/core/services/opfs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL OPFS service implementation"
 name = "opendal-service-opfs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/opfs/README.md
+++ b/core/services/opfs/README.md
@@ -1,0 +1,63 @@
+# Apache OpenDAL™ Origin Private File System Service
+
+`opendal-service-opfs` provides access to the browser Origin Private File System for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-opfs` feature:
+
+```shell
+cargo add opendal --features services-opfs
+```
+
+The service is available as `opendal::services::Opfs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-opfs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+#[cfg(target_arch = "wasm32")]
+use opendal_core::{Operator, OperatorRegistry, Result};
+#[cfg(target_arch = "wasm32")]
+use opendal_service_opfs::{register_opfs_service, Opfs};
+
+#[cfg(target_arch = "wasm32")]
+fn build_operator(builder: Opfs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn register_for_uri() {
+    register_opfs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+This service targets `wasm32` applications running in environments that expose the
+browser OPFS APIs.
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/opfs)
+- [Rust API documentation](https://docs.rs/opendal-service-opfs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/oss/Cargo.toml
+++ b/core/services/oss/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Aliyun OSS service implementation"
 name = "opendal-service-oss"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/oss/README.md
+++ b/core/services/oss/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Alibaba Cloud OSS Service
+
+`opendal-service-oss` provides access to Alibaba Cloud Object Storage Service for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-oss` feature:
+
+```shell
+cargo add opendal --features services-oss
+```
+
+The service is available as `opendal::services::Oss`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-oss
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_oss::{register_oss_service, Oss};
+
+fn build_operator(builder: Oss) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_oss_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/oss)
+- [Rust API documentation](https://docs.rs/opendal-service-oss)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/pcloud/Cargo.toml
+++ b/core/services/pcloud/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL pCloud service implementation"
 name = "opendal-service-pcloud"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/pcloud/README.md
+++ b/core/services/pcloud/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ pCloud Service
+
+`opendal-service-pcloud` provides access to pCloud storage for applications built with
+Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-pcloud` feature:
+
+```shell
+cargo add opendal --features services-pcloud
+```
+
+The service is available as `opendal::services::Pcloud`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-pcloud
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_pcloud::{register_pcloud_service, Pcloud};
+
+fn build_operator(builder: Pcloud) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_pcloud_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/pcloud)
+- [Rust API documentation](https://docs.rs/opendal-service-pcloud)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/persy/Cargo.toml
+++ b/core/services/persy/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Persy service implementation"
 name = "opendal-service-persy"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/persy/README.md
+++ b/core/services/persy/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Persy Service
+
+`opendal-service-persy` provides a storage backend backed by the Persy transactional
+engine for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-persy` feature:
+
+```shell
+cargo add opendal --features services-persy
+```
+
+The service is available as `opendal::services::Persy`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-persy
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_persy::{register_persy_service, Persy};
+
+fn build_operator(builder: Persy) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_persy_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/persy)
+- [Rust API documentation](https://docs.rs/opendal-service-persy)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/postgresql/Cargo.toml
+++ b/core/services/postgresql/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL PostgreSQL service implementation"
 name = "opendal-service-postgresql"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/postgresql/README.md
+++ b/core/services/postgresql/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ PostgreSQL Service
+
+`opendal-service-postgresql` provides a key-value storage backend backed by PostgreSQL
+for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-postgresql` feature:
+
+```shell
+cargo add opendal --features services-postgresql
+```
+
+The service is available as `opendal::services::Postgresql`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-postgresql
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_postgresql::{register_postgresql_service, Postgresql};
+
+fn build_operator(builder: Postgresql) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_postgresql_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/postgresql)
+- [Rust API documentation](https://docs.rs/opendal-service-postgresql)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/redb/Cargo.toml
+++ b/core/services/redb/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Redb service implementation"
 name = "opendal-service-redb"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/redb/README.md
+++ b/core/services/redb/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ redb Service
+
+`opendal-service-redb` provides an embedded key-value storage backend backed by `redb`
+for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-redb` feature:
+
+```shell
+cargo add opendal --features services-redb
+```
+
+The service is available as `opendal::services::Redb`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-redb
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_redb::{register_redb_service, Redb};
+
+fn build_operator(builder: Redb) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_redb_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/redb)
+- [Rust API documentation](https://docs.rs/opendal-service-redb)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/redis/Cargo.toml
+++ b/core/services/redis/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Redis service implementation"
 name = "opendal-service-redis"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/redis/README.md
+++ b/core/services/redis/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Redis Service
+
+`opendal-service-redis` provides a key-value storage backend backed by Redis for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-redis` feature:
+
+```shell
+cargo add opendal --features services-redis
+```
+
+The service is available as `opendal::services::Redis`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-redis
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_redis::{register_redis_service, Redis};
+
+fn build_operator(builder: Redis) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_redis_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/redis)
+- [Rust API documentation](https://docs.rs/opendal-service-redis)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/rocksdb/Cargo.toml
+++ b/core/services/rocksdb/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL RocksDB service implementation"
 name = "opendal-service-rocksdb"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/rocksdb/README.md
+++ b/core/services/rocksdb/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ RocksDB Service
+
+`opendal-service-rocksdb` provides an embedded key-value storage backend backed by
+RocksDB for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-rocksdb` feature:
+
+```shell
+cargo add opendal --features services-rocksdb
+```
+
+The service is available as `opendal::services::Rocksdb`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-rocksdb
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_rocksdb::{register_rocksdb_service, Rocksdb};
+
+fn build_operator(builder: Rocksdb) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_rocksdb_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/rocksdb)
+- [Rust API documentation](https://docs.rs/opendal-service-rocksdb)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/s3/Cargo.toml
+++ b/core/services/s3/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL S3 service implementation"
 name = "opendal-service-s3"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/s3/README.md
+++ b/core/services/s3/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Amazon S3 Service
+
+`opendal-service-s3` provides access to Amazon S3 and S3-compatible object storage for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-s3` feature:
+
+```shell
+cargo add opendal --features services-s3
+```
+
+The service is available as `opendal::services::S3`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-s3
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_s3::{register_s3_service, S3};
+
+fn build_operator(builder: S3) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_s3_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/s3)
+- [Rust API documentation](https://docs.rs/opendal-service-s3)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/seafile/Cargo.toml
+++ b/core/services/seafile/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL seafile service implementation"
 name = "opendal-service-seafile"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/seafile/README.md
+++ b/core/services/seafile/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Seafile Service
+
+`opendal-service-seafile` provides access to Seafile storage for applications built with
+Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-seafile` feature:
+
+```shell
+cargo add opendal --features services-seafile
+```
+
+The service is available as `opendal::services::Seafile`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-seafile
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_seafile::{register_seafile_service, Seafile};
+
+fn build_operator(builder: Seafile) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_seafile_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/seafile)
+- [Rust API documentation](https://docs.rs/opendal-service-seafile)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/sftp/Cargo.toml
+++ b/core/services/sftp/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL SFTP service implementation"
 name = "opendal-service-sftp"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/sftp/README.md
+++ b/core/services/sftp/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ SFTP Service
+
+`opendal-service-sftp` provides access to files over SFTP for applications built with
+Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-sftp` feature:
+
+```shell
+cargo add opendal --features services-sftp
+```
+
+The service is available as `opendal::services::Sftp`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-sftp
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_sftp::{register_sftp_service, Sftp};
+
+fn build_operator(builder: Sftp) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_sftp_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/sftp)
+- [Rust API documentation](https://docs.rs/opendal-service-sftp)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/sled/Cargo.toml
+++ b/core/services/sled/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL sled service implementation"
 name = "opendal-service-sled"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/sled/README.md
+++ b/core/services/sled/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ sled Service
+
+`opendal-service-sled` provides an embedded key-value storage backend backed by `sled`
+for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-sled` feature:
+
+```shell
+cargo add opendal --features services-sled
+```
+
+The service is available as `opendal::services::Sled`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-sled
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_sled::{register_sled_service, Sled};
+
+fn build_operator(builder: Sled) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_sled_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/sled)
+- [Rust API documentation](https://docs.rs/opendal-service-sled)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/sqlite/Cargo.toml
+++ b/core/services/sqlite/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL SQLite service implementation"
 name = "opendal-service-sqlite"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/sqlite/README.md
+++ b/core/services/sqlite/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ SQLite Service
+
+`opendal-service-sqlite` provides a key-value storage backend backed by SQLite for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-sqlite` feature:
+
+```shell
+cargo add opendal --features services-sqlite
+```
+
+The service is available as `opendal::services::Sqlite`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-sqlite
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_sqlite::{register_sqlite_service, Sqlite};
+
+fn build_operator(builder: Sqlite) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_sqlite_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/sqlite)
+- [Rust API documentation](https://docs.rs/opendal-service-sqlite)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/surrealdb/Cargo.toml
+++ b/core/services/surrealdb/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Surrealdb service implementation"
 name = "opendal-service-surrealdb"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/surrealdb/README.md
+++ b/core/services/surrealdb/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ SurrealDB Service
+
+`opendal-service-surrealdb` provides a key-value storage backend backed by SurrealDB for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-surrealdb` feature:
+
+```shell
+cargo add opendal --features services-surrealdb
+```
+
+The service is available as `opendal::services::Surrealdb`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-surrealdb
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_surrealdb::{register_surrealdb_service, Surrealdb};
+
+fn build_operator(builder: Surrealdb) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_surrealdb_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/surrealdb)
+- [Rust API documentation](https://docs.rs/opendal-service-surrealdb)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/swift/Cargo.toml
+++ b/core/services/swift/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Swift service implementation"
 name = "opendal-service-swift"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/swift/README.md
+++ b/core/services/swift/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ OpenStack Swift Service
+
+`opendal-service-swift` provides access to OpenStack Swift object storage for
+applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-swift` feature:
+
+```shell
+cargo add opendal --features services-swift
+```
+
+The service is available as `opendal::services::Swift`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-swift
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_swift::{register_swift_service, Swift};
+
+fn build_operator(builder: Swift) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_swift_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/swift)
+- [Rust API documentation](https://docs.rs/opendal-service-swift)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/tikv/Cargo.toml
+++ b/core/services/tikv/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL TiKV service implementation"
 name = "opendal-service-tikv"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/tikv/README.md
+++ b/core/services/tikv/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ TiKV Service
+
+`opendal-service-tikv` provides a distributed key-value storage backend backed by TiKV
+for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-tikv` feature:
+
+```shell
+cargo add opendal --features services-tikv
+```
+
+The service is available as `opendal::services::Tikv`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-tikv
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_tikv::{register_tikv_service, Tikv};
+
+fn build_operator(builder: Tikv) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_tikv_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/tikv)
+- [Rust API documentation](https://docs.rs/opendal-service-tikv)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/tos/Cargo.toml
+++ b/core/services/tos/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Volcengine TOS service implementation for Apache OpenDAL"
 name = "opendal-service-tos"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/tos/README.md
+++ b/core/services/tos/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Volcengine TOS Service
+
+`opendal-service-tos` provides access to Volcengine TOS object storage for applications
+built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-tos` feature:
+
+```shell
+cargo add opendal --features services-tos
+```
+
+The service is available as `opendal::services::Tos`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-tos
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_tos::{register_tos_service, Tos};
+
+fn build_operator(builder: Tos) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_tos_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/tos)
+- [Rust API documentation](https://docs.rs/opendal-service-tos)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/upyun/Cargo.toml
+++ b/core/services/upyun/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Upyun service implementation"
 name = "opendal-service-upyun"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/upyun/README.md
+++ b/core/services/upyun/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Upyun Service
+
+`opendal-service-upyun` provides access to Upyun storage for applications built with
+Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-upyun` feature:
+
+```shell
+cargo add opendal --features services-upyun
+```
+
+The service is available as `opendal::services::Upyun`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-upyun
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_upyun::{register_upyun_service, Upyun};
+
+fn build_operator(builder: Upyun) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_upyun_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/upyun)
+- [Rust API documentation](https://docs.rs/opendal-service-upyun)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/vercel-artifacts/Cargo.toml
+++ b/core/services/vercel-artifacts/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Vercel Artifacts service implementation"
 name = "opendal-service-vercel-artifacts"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/vercel-artifacts/README.md
+++ b/core/services/vercel-artifacts/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Vercel Artifacts Service
+
+`opendal-service-vercel-artifacts` provides access to the Vercel Remote Cache artifact
+service for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-vercel-artifacts` feature:
+
+```shell
+cargo add opendal --features services-vercel-artifacts
+```
+
+The service is available as `opendal::services::VercelArtifacts`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-vercel-artifacts
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_vercel_artifacts::{register_vercel_artifacts_service, VercelArtifacts};
+
+fn build_operator(builder: VercelArtifacts) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_vercel_artifacts_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/vercel-artifacts)
+- [Rust API documentation](https://docs.rs/opendal-service-vercel-artifacts)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/vercel-blob/Cargo.toml
+++ b/core/services/vercel-blob/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Vercel Blob service implementation"
 name = "opendal-service-vercel-blob"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/vercel-blob/README.md
+++ b/core/services/vercel-blob/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Vercel Blob Service
+
+`opendal-service-vercel-blob` provides access to Vercel Blob storage for applications
+built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-vercel-blob` feature:
+
+```shell
+cargo add opendal --features services-vercel-blob
+```
+
+The service is available as `opendal::services::VercelBlob`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-vercel-blob
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_vercel_blob::{register_vercel_blob_service, VercelBlob};
+
+fn build_operator(builder: VercelBlob) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_vercel_blob_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/vercel-blob)
+- [Rust API documentation](https://docs.rs/opendal-service-vercel-blob)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/webdav/Cargo.toml
+++ b/core/services/webdav/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Webdav service implementation"
 name = "opendal-service-webdav"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/webdav/README.md
+++ b/core/services/webdav/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ WebDAV Service
+
+`opendal-service-webdav` provides access to storage over WebDAV for applications built
+with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-webdav` feature:
+
+```shell
+cargo add opendal --features services-webdav
+```
+
+The service is available as `opendal::services::Webdav`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-webdav
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_webdav::{register_webdav_service, Webdav};
+
+fn build_operator(builder: Webdav) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_webdav_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/webdav)
+- [Rust API documentation](https://docs.rs/opendal-service-webdav)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/webhdfs/Cargo.toml
+++ b/core/services/webhdfs/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL WebHDFS service implementation"
 name = "opendal-service-webhdfs"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/webhdfs/README.md
+++ b/core/services/webhdfs/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ WebHDFS Service
+
+`opendal-service-webhdfs` provides access to Hadoop Distributed File System through
+WebHDFS for applications built with Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-webhdfs` feature:
+
+```shell
+cargo add opendal --features services-webhdfs
+```
+
+The service is available as `opendal::services::Webhdfs`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-webhdfs
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_webhdfs::{register_webhdfs_service, Webhdfs};
+
+fn build_operator(builder: Webhdfs) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_webhdfs_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/webhdfs)
+- [Rust API documentation](https://docs.rs/opendal-service-webhdfs)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/services/yandex-disk/Cargo.toml
+++ b/core/services/yandex-disk/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Apache OpenDAL Yandex Disk service implementation"
 name = "opendal-service-yandex-disk"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/services/yandex-disk/README.md
+++ b/core/services/yandex-disk/README.md
@@ -1,0 +1,56 @@
+# Apache OpenDAL™ Yandex Disk Service
+
+`opendal-service-yandex-disk` provides access to Yandex Disk for applications built with
+Apache OpenDAL™.
+
+## Use through `opendal`
+
+Applications should normally enable this service through the `opendal` facade with the
+`services-yandex-disk` feature:
+
+```shell
+cargo add opendal --features services-yandex-disk
+```
+
+The service is available as `opendal::services::YandexDisk`. Configure the
+service builder, then pass it to `opendal::Operator::new`.
+
+## Use with `opendal-core`
+
+Add the split crates directly:
+
+```shell
+cargo add opendal-core opendal-service-yandex-disk
+```
+
+Pass a configured service builder to `Operator::new`:
+
+```rust
+use opendal_core::{Operator, OperatorRegistry, Result};
+use opendal_service_yandex_disk::{register_yandex_disk_service, YandexDisk};
+
+fn build_operator(builder: YandexDisk) -> Result<Operator> {
+    Operator::new(builder)
+}
+
+fn register_for_uri() {
+    register_yandex_disk_service(OperatorRegistry::get());
+}
+```
+
+`register_for_uri` is only needed for scheme-driven construction through
+`Operator::from_uri` or `Operator::via_iter`.
+
+Services that send HTTP requests also require an HTTP transport in
+`OperationContext`. See the
+[`opendal-core` composition example](https://crates.io/crates/opendal-core).
+
+## Documentation
+
+- [Service configuration and examples](https://opendal.apache.org/services/yandex-disk)
+- [Rust API documentation](https://docs.rs/opendal-service-yandex-disk)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.

--- a/core/testkit/Cargo.toml
+++ b/core/testkit/Cargo.toml
@@ -18,6 +18,7 @@
 [package]
 description = "Test harness and utilities for Apache OpenDAL"
 name = "opendal-testkit"
+readme = "README.md"
 
 authors = { workspace = true }
 edition = { workspace = true }

--- a/core/testkit/README.md
+++ b/core/testkit/README.md
@@ -1,0 +1,25 @@
+# Apache OpenDAL™ Testkit
+
+`opendal-testkit` provides reusable test actions, data checkers, runtime setup,
+and service initialization helpers for Apache OpenDAL™ storage implementations.
+
+This crate is intended for service and integration tests. It is not required by
+applications using an OpenDAL operator.
+
+Add it as a development dependency:
+
+```shell
+cargo add --dev opendal-testkit
+```
+
+The `opendal` facade also re-exports the testkit behind its `tests` feature.
+
+## Documentation
+
+- [Rust API documentation](https://docs.rs/opendal-testkit)
+- [Behavior test guide](https://github.com/apache/opendal/tree/main/core/tests/behavior)
+- [Apache OpenDAL documentation](https://opendal.apache.org/docs/)
+
+## License
+
+Licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
# Which issue does this PR close?

N/A. This is a documentation-only improvement.

# Rationale for this change

OpenDAL's split core, service, layer, and HTTP transport crates are published independently, but most of them do not provide a crate-level README on crates.io. This makes it difficult to understand whether an application should enable the crate through the `opendal` facade or compose it directly with `opendal-core`.

# What changes are included in this PR?

This PR adds standalone READMEs for all publishable split crates and explicitly sets `readme = "README.md"` in their package metadata.

The `opendal-core` README demonstrates how to compose a service builder, layer, and HTTP transport. Public service and layer READMEs show both the corresponding `opendal` feature and direct `opendal-core` integration. The reqwest transport README shows how to attach the transport through `OperationContext`. Internal common crates are identified as implementation building blocks.

# Are there any user-facing changes?

Yes. crates.io pages for the split crates now provide an entry point, direct integration examples, and links to the detailed API and service documentation. There are no API or runtime behavior changes.

# Validation

- Verified that all 94 publishable crates declare and package `README.md`.
- Checked all 64 public service feature, type, and registration mappings against the source.
- Compiled the core composition, reqwest transport, S3 service, and all 24 public layer integration patterns.
- Ran `taplo format --check` and `git diff --check`.

# AI Usage Statement

AI was used to help draft and verify the documentation.
