### PR TITLE
feat(bindings/python): add TimeoutLayer

### DIFF
--- a/bindings/python/docs/api/layers.md
+++ b/bindings/python/docs/api/layers.md
@@ -4,31 +4,36 @@ This page documents all layers in OpenDAL.
 
 ::: opendal.layers.Layer
     options:
-      heading: "opendal.layers.Layer"
+      heading: "Layer"
       heading_level: 2
+      show_root_heading: true
       show_source: false
       show_bases: false
 
 ::: opendal.layers.RetryLayer
     options:
-      heading: "opendal.layers.RetryLayer"
+      heading: "RetryLayer"
       heading_level: 2
+      show_root_heading: true
       show_source: false
 
 ::: opendal.layers.ConcurrentLimitLayer
     options:
-      heading: "opendal.layers.ConcurrentLimitLayer"
+      heading: "ConcurrentLimitLayer"
       heading_level: 2
+      show_root_heading: true
       show_source: false
 
 ::: opendal.layers.MimeGuessLayer
     options:
-      heading: "opendal.layers.MimeGuessLayer"
+      heading: "MimeGuessLayer"
       heading_level: 2
+      show_root_heading: true
       show_source: false
 
 ::: opendal.layers.TimeoutLayer
     options:
-      heading: "opendal.layers.TimeoutLayer"
+      heading: "TimeoutLayer"
       heading_level: 2
+      show_root_heading: true
       show_source: false

--- a/bindings/python/docs/api/layers.md
+++ b/bindings/python/docs/api/layers.md
@@ -26,3 +26,9 @@ This page documents all layers in OpenDAL.
       heading: "opendal.layers.MimeGuessLayer"
       heading_level: 2
       show_source: false
+
+::: opendal.layers.TimeoutLayer
+    options:
+      heading: "opendal.layers.TimeoutLayer"
+      heading_level: 2
+      show_source: false

--- a/bindings/python/python/opendal/layers.pyi
+++ b/bindings/python/python/opendal/layers.pyi
@@ -63,7 +63,17 @@ class ConcurrentLimitLayer(Layer):
         """
 
 class Layer:
-    """Layers are used to intercept the operations on the underlying storage."""
+    """
+    Base class for all layers.
+
+    A layer wraps an operator to intercept operations on the underlying
+    storage, adding behavior such as retries, timeouts, concurrency limits,
+    or content-type detection.
+
+    This class is not meant to be instantiated directly. Use a concrete
+    subclass such as `RetryLayer` or `TimeoutLayer` and apply it with
+    `Operator.layer` or `AsyncOperator.layer`.
+    """
 
 @final
 class MimeGuessLayer(Layer):

--- a/bindings/python/python/opendal/layers.pyi
+++ b/bindings/python/python/opendal/layers.pyi
@@ -146,3 +146,46 @@ class RetryLayer(Layer):
         ConfigInvalid
             If ``factor``, ``max_delay``, or ``min_delay`` is out of range.
         """
+
+@final
+class TimeoutLayer(Layer):
+    """
+    A layer that adds timeouts to operations.
+
+    Timeouts prevent slow or stalled work from hanging indefinitely, for
+    example when a TCP connection stops emitting IO events. Control
+    operations (such as `stat` and `delete`) and IO operations (such as
+    `read` and `write`) are bounded by separate timeouts.
+
+    Notes
+    -----
+    A small amount of overhead is added to IO operations to implement the
+    timeout correctly.
+    """
+
+    def __new__(
+        cls, /, timeout: float | None = None, io_timeout: float | None = None
+    ) -> TimeoutLayer:
+        """
+        Create a new TimeoutLayer.
+
+        Parameters
+        ----------
+        timeout : Optional[float]
+            Timeout (in seconds) for control operations like ``stat`` and
+            ``delete``. Must be finite and non-negative. Defaults to
+            ``60.0``.
+        io_timeout : Optional[float]
+            Timeout (in seconds) for IO operations like ``read`` and
+            ``write``. Must be finite and non-negative. Defaults to
+            ``10.0``.
+
+        Returns
+        -------
+        TimeoutLayer
+
+        Raises
+        ------
+        ConfigInvalid
+            If ``timeout`` or ``io_timeout`` is out of range.
+        """

--- a/bindings/python/python/opendal/layers.pyi
+++ b/bindings/python/python/opendal/layers.pyi
@@ -183,12 +183,14 @@ class TimeoutLayer(Layer):
         ----------
         timeout : Optional[float]
             Timeout (in seconds) for control operations like ``stat`` and
-            ``delete``. Must be finite and non-negative. Defaults to
-            ``60.0``.
+            ``delete``. Must be a positive, finite number. A value of ``0``
+            is rejected because it would make every operation time out
+            immediately. Defaults to ``60.0``.
         io_timeout : Optional[float]
             Timeout (in seconds) for IO operations like ``read`` and
-            ``write``. Must be finite and non-negative. Defaults to
-            ``10.0``.
+            ``write``. Must be a positive, finite number. A value of ``0``
+            is rejected because it would make every operation time out
+            immediately. Defaults to ``10.0``.
 
         Returns
         -------

--- a/bindings/python/src/layers/mod.rs
+++ b/bindings/python/src/layers/mod.rs
@@ -26,11 +26,13 @@ mod capability_override;
 mod concurrent_limit;
 mod mime_guess;
 mod retry;
+mod timeout;
 
 pub use capability_override::CapabilityOverrideLayer;
 pub use concurrent_limit::ConcurrentLimitLayer;
 pub use mime_guess::MimeGuessLayer;
 pub use retry::RetryLayer;
+pub use timeout::TimeoutLayer;
 
 use opendal::Operator;
 use pyo3::prelude::*;

--- a/bindings/python/src/layers/mod.rs
+++ b/bindings/python/src/layers/mod.rs
@@ -43,6 +43,14 @@ pub trait PythonLayer: Send + Sync {
     fn layer(&self, op: Operator) -> Operator;
 }
 
-/// Layers are used to intercept the operations on the underlying storage.
+/// Base class for all layers.
+///
+/// A layer wraps an operator to intercept operations on the underlying
+/// storage, adding behavior such as retries, timeouts, concurrency limits,
+/// or content-type detection.
+///
+/// This class is not meant to be instantiated directly. Use a concrete
+/// subclass such as `RetryLayer` or `TimeoutLayer` and apply it with
+/// `Operator.layer` or `AsyncOperator.layer`.
 #[pyclass(module = "opendal.layers", subclass)]
 pub struct Layer(pub Box<dyn PythonLayer>);

--- a/bindings/python/src/layers/timeout.rs
+++ b/bindings/python/src/layers/timeout.rs
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::time::Duration;
+
+use super::Layer;
+use super::PythonLayer;
+use crate::*;
+use opendal::Operator;
+
+/// A layer that adds timeouts to operations.
+///
+/// Timeouts prevent slow or stalled work from hanging indefinitely, for
+/// example when a TCP connection stops emitting IO events. Control
+/// operations (such as `stat` and `delete`) and IO operations (such as
+/// `read` and `write`) are bounded by separate timeouts.
+///
+/// Notes
+/// -----
+/// A small amount of overhead is added to IO operations to implement the
+/// timeout correctly.
+#[pyclass(module = "opendal.layers", extends = Layer, skip_from_py_object)]
+#[derive(Clone)]
+pub struct TimeoutLayer(ocore::layers::TimeoutLayer);
+
+impl PythonLayer for TimeoutLayer {
+    fn layer(&self, op: Operator) -> Operator {
+        op.layer(self.0.clone())
+    }
+}
+#[pymethods]
+impl TimeoutLayer {
+    /// Create a new TimeoutLayer.
+    ///
+    /// Parameters
+    /// ----------
+    /// timeout : Optional[float]
+    ///     Timeout (in seconds) for control operations like ``stat`` and
+    ///     ``delete``. Must be finite and non-negative. Defaults to
+    ///     ``60.0``.
+    /// io_timeout : Optional[float]
+    ///     Timeout (in seconds) for IO operations like ``read`` and
+    ///     ``write``. Must be finite and non-negative. Defaults to
+    ///     ``10.0``.
+    ///
+    /// Returns
+    /// -------
+    /// TimeoutLayer
+    ///
+    /// Raises
+    /// ------
+    /// ConfigInvalid
+    ///     If ``timeout`` or ``io_timeout`` is out of range.
+    #[new]
+    #[pyo3(signature = (timeout = None, io_timeout = None))]
+    fn new(timeout: Option<f64>, io_timeout: Option<f64>) -> PyResult<PyClassInitializer<Self>> {
+        let mut timeout_layer = ocore::layers::TimeoutLayer::default();
+        if let Some(timeout) = timeout {
+            let timeout = Duration::try_from_secs_f64(timeout).map_err(|_| {
+                ConfigInvalid::new_err("timeout must be a finite, non-negative number of seconds")
+            })?;
+            timeout_layer = timeout_layer.with_timeout(timeout);
+        }
+        if let Some(io_timeout) = io_timeout {
+            let io_timeout = Duration::try_from_secs_f64(io_timeout).map_err(|_| {
+                ConfigInvalid::new_err(
+                    "io_timeout must be a finite, non-negative number of seconds",
+                )
+            })?;
+            timeout_layer = timeout_layer.with_io_timeout(io_timeout);
+        }
+
+        let timeout_layer = Self(timeout_layer);
+        let class = PyClassInitializer::from(Layer(Box::new(timeout_layer.clone())))
+            .add_subclass(timeout_layer);
+
+        Ok(class)
+    }
+}

--- a/bindings/python/src/layers/timeout.rs
+++ b/bindings/python/src/layers/timeout.rs
@@ -22,6 +22,23 @@ use super::PythonLayer;
 use crate::*;
 use opendal::Operator;
 
+/// Parse a timeout given in seconds into a [`Duration`].
+///
+/// Rejects non-positive, non-finite, or out-of-range values. A zero timeout
+/// is rejected because it would make every operation time out immediately.
+fn parse_timeout_secs(name: &str, secs: f64) -> PyResult<Duration> {
+    if !secs.is_finite() || secs <= 0.0 {
+        return Err(ConfigInvalid::new_err(format!(
+            "{name} must be a positive, finite number of seconds"
+        )));
+    }
+    Duration::try_from_secs_f64(secs).map_err(|_| {
+        ConfigInvalid::new_err(format!(
+            "{name} must be a positive, finite number of seconds"
+        ))
+    })
+}
+
 /// A layer that adds timeouts to operations.
 ///
 /// Timeouts prevent slow or stalled work from hanging indefinitely, for
@@ -50,12 +67,14 @@ impl TimeoutLayer {
     /// ----------
     /// timeout : Optional[float]
     ///     Timeout (in seconds) for control operations like ``stat`` and
-    ///     ``delete``. Must be finite and non-negative. Defaults to
-    ///     ``60.0``.
+    ///     ``delete``. Must be a positive, finite number. A value of ``0``
+    ///     is rejected because it would make every operation time out
+    ///     immediately. Defaults to ``60.0``.
     /// io_timeout : Optional[float]
     ///     Timeout (in seconds) for IO operations like ``read`` and
-    ///     ``write``. Must be finite and non-negative. Defaults to
-    ///     ``10.0``.
+    ///     ``write``. Must be a positive, finite number. A value of ``0``
+    ///     is rejected because it would make every operation time out
+    ///     immediately. Defaults to ``10.0``.
     ///
     /// Returns
     /// -------
@@ -70,17 +89,11 @@ impl TimeoutLayer {
     fn new(timeout: Option<f64>, io_timeout: Option<f64>) -> PyResult<PyClassInitializer<Self>> {
         let mut timeout_layer = ocore::layers::TimeoutLayer::default();
         if let Some(timeout) = timeout {
-            let timeout = Duration::try_from_secs_f64(timeout).map_err(|_| {
-                ConfigInvalid::new_err("timeout must be a finite, non-negative number of seconds")
-            })?;
+            let timeout = parse_timeout_secs("timeout", timeout)?;
             timeout_layer = timeout_layer.with_timeout(timeout);
         }
         if let Some(io_timeout) = io_timeout {
-            let io_timeout = Duration::try_from_secs_f64(io_timeout).map_err(|_| {
-                ConfigInvalid::new_err(
-                    "io_timeout must be a finite, non-negative number of seconds",
-                )
-            })?;
+            let io_timeout = parse_timeout_secs("io_timeout", io_timeout)?;
             timeout_layer = timeout_layer.with_io_timeout(io_timeout);
         }
 

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -86,6 +86,7 @@ mod _opendal {
         #[pymodule_export]
         use crate::{
             CapabilityOverrideLayer, ConcurrentLimitLayer, Layer, MimeGuessLayer, RetryLayer,
+            TimeoutLayer,
         };
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

The Python binding exposes several layers but not `TimeoutLayer`. Timeouts prevent slow or stalled requests from hanging a thread or the asyncio event loop. `layers-timeout` is already in the core `default` features, so this only needs a binding.

# What changes are included in this PR?

- Add `TimeoutLayer` wrapping `opendal::layers::TimeoutLayer`, with `timeout` (control ops, default 60s) and `io_timeout` (IO ops, default 10s) as optional seconds; invalid values raise `ConfigInvalid`.
- Register and re-export it in the `opendal.layers` module.
- Regenerate `layers.pyi` and add the layer to the docs API reference.
- Fix layer doc headings and improve the `Layer` base-class docstring.

# Are there any user-facing changes?

New `opendal.layers.TimeoutLayer`, no breaking changes:

```python
import opendal
from opendal.layers import TimeoutLayer

op = opendal.Operator("memory").layer(TimeoutLayer(timeout=30.0, io_timeout=5.0))
```

# AI Usage Statement

Prepared with the assistance of an AI coding agent (OpenCode, Anthropic Claude) and reviewed by the author.
