### PR TITLE
ci: derive Python RC versions from tags

### DIFF
--- a/.github/scripts/release_python/README.md
+++ b/.github/scripts/release_python/README.md
@@ -1,0 +1,20 @@
+# Python Release Candidate Versions
+
+The Python release workflow publishes release candidate tags to TestPyPI and
+stable tags to PyPI.
+
+Each source release keeps a stable Python version in
+`bindings/python/Cargo.toml`. For a tag such as `v0.58.1-rc.5`, `prepare.py`
+temporarily changes the PEP 621 metadata in `bindings/python/pyproject.toml`
+from a dynamic Cargo version to the PEP 440 version `0.47.5rc5`. The workflow
+runs this preparation independently before building the sdist and every wheel.
+It does not commit the generated metadata or change the stable release version.
+
+Stable tags skip this preparation, so maturin continues to read the version
+from `bindings/python/Cargo.toml`.
+
+Run the unit tests with:
+
+```bash
+python3 -m unittest discover -s .github/scripts/release_python -p "test_*.py"
+```

--- a/.github/scripts/release_python/prepare.py
+++ b/.github/scripts/release_python/prepare.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import argparse
+import os
+import re
+import tomllib
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+PROJECT_DIR = SCRIPT_PATH.parents[3]
+PYTHON_BINDING_DIR = PROJECT_DIR / "bindings" / "python"
+DEFAULT_CARGO_MANIFEST = PYTHON_BINDING_DIR / "Cargo.toml"
+DEFAULT_PYPROJECT = PYTHON_BINDING_DIR / "pyproject.toml"
+
+RC_TAG_PATTERN = re.compile(
+    r"^v(?P<release>[0-9]+\.[0-9]+\.[0-9]+)-rc\.(?P<candidate>[1-9][0-9]*)$"
+)
+STABLE_VERSION_PATTERN = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+PROJECT_SECTION_PATTERN = re.compile(
+    r"(?ms)^\[project\][^\S\r\n]*(?:\r?\n)(?P<body>.*?)(?=^\[|\Z)"
+)
+DYNAMIC_VERSION_PATTERN = re.compile(
+    r"(?m)^(?P<indent>[ \t]*)dynamic[ \t]*=[ \t]*"
+    r"\[[^\r\n]*\][ \t]*(?:#[^\r\n]*)?(?P<newline>\r?\n|\Z)"
+)
+
+
+class PreparationError(ValueError):
+    pass
+
+
+def load_stable_version(cargo_manifest: Path) -> str:
+    with cargo_manifest.open("rb") as fp:
+        manifest = tomllib.load(fp)
+
+    package = manifest.get("package")
+    version = package.get("version") if isinstance(package, dict) else None
+    if not isinstance(version, str) or not STABLE_VERSION_PATTERN.fullmatch(version):
+        raise PreparationError(
+            f"{cargo_manifest} must define a stable package version in X.Y.Z form"
+        )
+
+    return version
+
+
+def release_candidate_version(stable_version: str, tag: str) -> str:
+    match = RC_TAG_PATTERN.fullmatch(tag)
+    if match is None:
+        raise PreparationError(
+            f"tag {tag!r} must use the vX.Y.Z-rc.N release candidate format"
+        )
+
+    return f"{stable_version}rc{match.group('candidate')}"
+
+
+def render_pyproject(content: str, version: str) -> str:
+    metadata = tomllib.loads(content)
+    project = metadata.get("project")
+    if not isinstance(project, dict):
+        raise PreparationError("pyproject.toml must define a [project] table")
+
+    dynamic = project.get("dynamic")
+    current_version = project.get("version")
+    if current_version is not None:
+        if current_version != version or dynamic is not None:
+            raise PreparationError(
+                "pyproject.toml already defines unexpected project version metadata"
+            )
+        return content
+
+    if dynamic != ["version"]:
+        raise PreparationError(
+            "pyproject.toml must declare only version as dynamic project metadata"
+        )
+
+    project_section = PROJECT_SECTION_PATTERN.search(content)
+    if project_section is None:
+        raise PreparationError("could not locate the [project] table")
+
+    body = project_section.group("body")
+    assignments = list(DYNAMIC_VERSION_PATTERN.finditer(body))
+    if len(assignments) != 1:
+        raise PreparationError(
+            "the [project] dynamic version declaration must be on one line"
+        )
+
+    assignment = assignments[0]
+    replacement = (
+        f'{assignment.group("indent")}version = "{version}"'
+        f"{assignment.group('newline')}"
+    )
+    rendered_body = body[: assignment.start()] + replacement + body[assignment.end() :]
+    return (
+        content[: project_section.start("body")]
+        + rendered_body
+        + content[project_section.end("body") :]
+    )
+
+
+def prepare(
+    tag: str,
+    cargo_manifest: Path = DEFAULT_CARGO_MANIFEST,
+    pyproject: Path = DEFAULT_PYPROJECT,
+) -> str:
+    stable_version = load_stable_version(cargo_manifest)
+    version = release_candidate_version(stable_version, tag)
+
+    content = pyproject.read_text(encoding="utf-8")
+    rendered = render_pyproject(content, version)
+    if rendered != content:
+        pyproject.write_text(rendered, encoding="utf-8")
+
+    return version
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Prepare PEP 440 version metadata for a Python release candidate."
+    )
+    parser.add_argument(
+        "--tag",
+        default=os.environ.get("GITHUB_REF_NAME"),
+        help="Release candidate tag. Defaults to GITHUB_REF_NAME.",
+    )
+    parser.add_argument(
+        "--cargo-manifest",
+        type=Path,
+        default=DEFAULT_CARGO_MANIFEST,
+        help="Path to the Python binding Cargo.toml.",
+    )
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=DEFAULT_PYPROJECT,
+        help="Path to the Python binding pyproject.toml.",
+    )
+    args = parser.parse_args()
+
+    if not args.tag:
+        parser.error("--tag is required when GITHUB_REF_NAME is not set")
+
+    try:
+        version = prepare(args.tag, args.cargo_manifest, args.pyproject)
+    except (OSError, PreparationError, tomllib.TOMLDecodeError) as error:
+        parser.error(str(error))
+
+    print(f"Prepared Python release candidate version {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/release_python/test_prepare.py
+++ b/.github/scripts/release_python/test_prepare.py
@@ -1,0 +1,183 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tempfile
+import textwrap
+import tomllib
+import unittest
+from pathlib import Path
+
+from prepare import (
+    PreparationError,
+    prepare,
+    release_candidate_version,
+    render_pyproject,
+)
+
+
+def write_fixture(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+
+
+class ReleasePythonPrepareTest(unittest.TestCase):
+    def test_prepare_renders_pep_440_release_candidate_version(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cargo_manifest = root / "Cargo.toml"
+            pyproject = root / "pyproject.toml"
+            write_fixture(
+                cargo_manifest,
+                """
+                [package]
+                name = "opendal-python"
+                version = "0.47.5"
+                """,
+            )
+            write_fixture(
+                pyproject,
+                """
+                [project]
+                name = "opendal"
+                dynamic = ['version']
+
+                [tool.maturin]
+                module-name = "opendal._opendal"
+                """,
+            )
+            original_cargo_manifest = cargo_manifest.read_text(encoding="utf-8")
+
+            version = prepare("v0.58.1-rc.5", cargo_manifest, pyproject)
+
+            self.assertEqual(version, "0.47.5rc5")
+            self.assertEqual(
+                cargo_manifest.read_text(encoding="utf-8"), original_cargo_manifest
+            )
+            with pyproject.open("rb") as fp:
+                project = tomllib.load(fp)["project"]
+            self.assertEqual(project["version"], "0.47.5rc5")
+            self.assertNotIn("dynamic", project)
+
+    def test_release_candidates_map_to_distinct_versions(self):
+        first = release_candidate_version("0.47.5", "v0.58.1-rc.1")
+        second = release_candidate_version("0.47.5", "v0.58.1-rc.2")
+
+        self.assertEqual(first, "0.47.5rc1")
+        self.assertEqual(second, "0.47.5rc2")
+        self.assertNotEqual(first, second)
+
+    def test_prepare_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cargo_manifest = root / "Cargo.toml"
+            pyproject = root / "pyproject.toml"
+            write_fixture(
+                cargo_manifest,
+                """
+                [package]
+                version = "0.47.5"
+                """,
+            )
+            write_fixture(
+                pyproject,
+                """
+                [project]
+                name = "opendal"
+                version = "0.47.5rc5"
+                """,
+            )
+            original = pyproject.read_text(encoding="utf-8")
+
+            version = prepare("v0.58.1-rc.5", cargo_manifest, pyproject)
+
+            self.assertEqual(version, "0.47.5rc5")
+            self.assertEqual(pyproject.read_text(encoding="utf-8"), original)
+
+    def test_prepare_rejects_non_release_candidate_tag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cargo_manifest = root / "Cargo.toml"
+            pyproject = root / "pyproject.toml"
+            write_fixture(
+                cargo_manifest,
+                """
+                [package]
+                version = "0.47.5"
+                """,
+            )
+            write_fixture(
+                pyproject,
+                """
+                [project]
+                dynamic = ['version']
+                """,
+            )
+
+            with self.assertRaisesRegex(
+                PreparationError, "vX.Y.Z-rc.N release candidate format"
+            ):
+                prepare("v0.58.1-beta.1", cargo_manifest, pyproject)
+
+    def test_prepare_rejects_non_stable_cargo_version(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cargo_manifest = root / "Cargo.toml"
+            pyproject = root / "pyproject.toml"
+            write_fixture(
+                cargo_manifest,
+                """
+                [package]
+                version = "0.47.5-rc.1"
+                """,
+            )
+            write_fixture(
+                pyproject,
+                """
+                [project]
+                dynamic = ['version']
+                """,
+            )
+
+            with self.assertRaisesRegex(PreparationError, "stable package version"):
+                prepare("v0.58.1-rc.1", cargo_manifest, pyproject)
+
+    def test_render_rejects_additional_dynamic_metadata(self):
+        content = textwrap.dedent(
+            """
+            [project]
+            dynamic = ["version", "readme"]
+            """
+        ).lstrip()
+
+        with self.assertRaisesRegex(PreparationError, "only version as dynamic"):
+            render_pyproject(content, "0.47.5rc1")
+
+    def test_render_rejects_multiline_dynamic_version(self):
+        content = textwrap.dedent(
+            """
+            [project]
+            dynamic = [
+              "version",
+            ]
+            """
+        ).lstrip()
+
+        with self.assertRaisesRegex(PreparationError, "must be on one line"):
+            render_pyproject(content, "0.47.5rc1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/release_python.yml
+++ b/.github/workflows/release_python.yml
@@ -26,6 +26,7 @@ on:
       - main
     paths:
       - ".github/workflows/release_python.yml"
+      - ".github/scripts/release_python/**"
   workflow_dispatch:
 
 concurrency:
@@ -40,6 +41,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Test release helper
+        run: python3 -m unittest discover -s .github/scripts/release_python -p "test_*.py"
+      - name: Prepare release candidate version
+        if: ${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-') }}
+        run: python3 .github/scripts/release_python/prepare.py
       - uses: PyO3/maturin-action@v1
         with:
           working-directory: "bindings/python"
@@ -67,6 +73,9 @@ jobs:
           - { os: ubuntu-latest, target: "armv7-unknown-linux-musleabihf", manylinux: "musllinux_1_1" }
     steps:
       - uses: actions/checkout@v7
+      - name: Prepare release candidate version
+        if: ${{ startsWith(github.ref, 'refs/tags/') && contains(github.ref, '-') }}
+        run: python .github/scripts/release_python/prepare.py
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
       - uses: PyO3/maturin-action@v1

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -25,8 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-# PyPI and TestPyPI disallow re-upload the same version of a package distribution.
-# During Release Candidate releases or public releases, always bump the version.
+# Release candidate builds derive prerelease versions from tags in release_python.yml.
 version = "0.47.5"
 
 [features]


### PR DESCRIPTION
# Which issue does this PR close?

Part of #7920.

# Rationale for this change

TestPyPI distribution files are immutable. The Python release workflow currently builds every OpenDAL release candidate with the stable version from `bindings/python/Cargo.toml`, so a partially published RC leaves files that make later RCs attempt to upload the same filenames. The failure is visible in [this Release Python Binding run](https://github.com/apache/opendal/actions/runs/30277695905/job/90035653949).

Bumping the Python source version for every RC avoids one collision but makes release-attempt state a source change. Each RC should instead have its own PEP 440 prerelease version while the final release keeps the stable package version.

# What changes are included in this PR?

For tags in the `vX.Y.Z-rc.N` form, the workflow now reads the stable Python binding version and temporarily sets the PEP 621 package version to `<stable>rcN` before building the sdist and every wheel. Stable tags continue to use the unchanged Cargo version. Unsupported prerelease tag formats fail before artifacts are built.

The change retains the `0.47.5` stable version selected in #7974 and replaces its per-RC bump instruction with the tag-derived rule. The helper has focused coverage for unique candidates, idempotency, invalid tags, stable source versions, and unexpected project metadata.

Validation performed:

- `python3 -m unittest discover -s .github/scripts/release_python -p "test_*.py"`
- `ruff check .github/scripts/release_python`
- `ruff format --check .github/scripts/release_python`
- Parsed `.github/workflows/release_python.yml` as YAML.
- Built a real maturin sdist for `v0.58.1-rc.5` and verified `opendal-0.47.5rc5.tar.gz` contains `Version: 0.47.5rc5`.

# Are there any user-facing changes?

There are no API changes. TestPyPI release candidates now use PEP 440 prerelease versions such as `0.47.5rc5`; the final PyPI release remains `0.47.5`.

# AI Usage Statement

This PR was prepared with OpenAI Codex using GPT-5. The resulting changes and validation were reviewed by the author.
