### PR TITLE
feat(binding/cpp): Expose writer api

### DIFF
--- a/bindings/cpp/include/opendal.hpp
+++ b/bindings/cpp/include/opendal.hpp
@@ -36,10 +36,12 @@ namespace ffi {
 class Operator;
 class Reader;
 class Lister;
+class Writer;
 }  // namespace ffi
 
 class Reader;
 class Lister;
+class Writer;
 
 /**
  * @class Operator
@@ -102,6 +104,7 @@ class Operator {
    * @return The reader of the data
    */
   Reader GetReader(std::string_view path);
+  Writer GetWriter(std::string_view path);
 
   /**
    * @brief Check if the path exists
@@ -203,6 +206,35 @@ class Reader {
   void Destroy() noexcept;
 
   ffi::Reader *reader_{nullptr};
+};
+
+/**
+ * @class Writer
+ * @brief Writer is designed to write a sequence of byte buffers to an object.
+ *
+ * Call Close to commit the object. OpenDAL selects the service's appropriate
+ * implementation, including multipart uploads when supported.
+ */
+class Writer {
+ public:
+  Writer(Writer &&other) noexcept;
+
+  ~Writer() noexcept;
+
+  void Write(std::string_view data);
+
+  void Flush();
+
+  void Close();
+
+ private:
+  friend class Operator;
+
+  Writer(ffi::Writer *pointer) noexcept;
+
+  void Destroy() noexcept;
+
+  ffi::Writer *writer_{nullptr};
 };
 
 /**

--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -21,6 +21,7 @@ mod layer;
 mod lister;
 mod reader;
 mod types;
+mod writer;
 
 #[cfg(feature = "testing")]
 mod test_support;
@@ -34,6 +35,7 @@ use anyhow::Result;
 use lister::Lister;
 use opendal as od;
 use reader::Reader;
+use writer::Writer;
 
 static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
     tokio::runtime::Builder::new_multi_thread()
@@ -136,6 +138,7 @@ mod ffi {
         type Operator;
         type Reader;
         type Lister;
+        type Writer;
         type LayerBuilder;
 
         fn layer_builder_new() -> Box<LayerBuilder>;
@@ -168,11 +171,17 @@ mod ffi {
         fn list(self: &Operator, path: &str) -> Result<Vec<Entry>>;
         fn reader(self: &Operator, path: &str) -> Result<*mut Reader>;
         fn lister(self: &Operator, path: &str) -> Result<*mut Lister>;
+        fn writer(self: &Operator, path: &str) -> Result<*mut Writer>;
         fn info(self: &Operator) -> Result<Capability>;
 
         unsafe fn delete_reader(reader: *mut Reader);
         fn read(self: &mut Reader, buf: &mut [u8]) -> Result<usize>;
         fn seek(self: &mut Reader, offset: u64, dir: SeekFrom) -> Result<u64>;
+
+        unsafe fn delete_writer(writer: *mut Writer);
+        fn write(self: &mut Writer, bs: Vec<u8>) -> Result<()>;
+        fn flush(self: &mut Writer) -> Result<()>;
+        fn close(self: &mut Writer) -> Result<()>;
 
         unsafe fn delete_lister(lister: *mut Lister);
         fn next(self: &mut Lister) -> Result<OptionalEntry>;
@@ -251,6 +260,14 @@ unsafe fn delete_reader(reader: *mut Reader) {
     }
 }
 
+unsafe fn delete_writer(writer: *mut Writer) {
+    if !writer.is_null() {
+        unsafe {
+            drop(Box::from_raw(writer));
+        }
+    }
+}
+
 unsafe fn delete_lister(lister: *mut Lister) {
     if !lister.is_null() {
         unsafe {
@@ -311,6 +328,11 @@ impl Operator {
     fn lister(&self, path: &str) -> Result<*mut Lister> {
         let lister = Box::into_raw(Box::new(Lister(self.0.lister(path)?)));
         Ok(lister)
+    }
+
+    fn writer(&self, path: &str) -> Result<*mut Writer> {
+        let writer = Box::into_raw(Box::new(Writer(self.0.writer(path)?.into_std_write())));
+        Ok(writer)
     }
 
     fn info(&self) -> Result<ffi::Capability> {

--- a/bindings/cpp/src/operator.cpp
+++ b/bindings/cpp/src/operator.cpp
@@ -204,6 +204,10 @@ Reader Operator::GetReader(std::string_view path) {
   return operator_->reader(utils::rust_str(path));
 }
 
+Writer Operator::GetWriter(std::string_view path) {
+  return operator_->writer(utils::rust_str(path));
+}
+
 }  // namespace opendal
 opendal::Capability opendal::Operator::Info() {
   auto op_info = operator_->info();

--- a/bindings/cpp/src/writer.cpp
+++ b/bindings/cpp/src/writer.cpp
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <algorithm>
+#include <iterator>
+
+#include "lib.rs.h"
+#include "opendal.hpp"
+
+namespace opendal {
+
+void Writer::Destroy() noexcept {
+  if (writer_) {
+    ffi::delete_writer(writer_);
+    writer_ = nullptr;
+  }
+}
+
+Writer::Writer(ffi::Writer *writer) noexcept : writer_{writer} {}
+
+Writer::Writer(Writer &&other) noexcept : writer_{other.writer_} {
+  other.writer_ = nullptr;
+}
+
+Writer::~Writer() noexcept { Destroy(); }
+
+void Writer::Write(std::string_view data) {
+  rust::Vec<uint8_t> bytes;
+  bytes.reserve(data.size());
+  std::copy(data.begin(), data.end(), std::back_inserter(bytes));
+  writer_->write(bytes);
+}
+
+void Writer::Flush() { writer_->flush(); }
+
+void Writer::Close() { writer_->close(); }
+
+}  // namespace opendal

--- a/bindings/cpp/src/writer.rs
+++ b/bindings/cpp/src/writer.rs
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use anyhow::Result;
+use opendal as od;
+use std::io::Write;
+
+pub struct Writer(pub od::blocking::StdWriter);
+
+impl Writer {
+    pub fn write(&mut self, bs: Vec<u8>) -> Result<()> {
+        self.0.write_all(&bs)?;
+        Ok(())
+    }
+
+    pub fn flush(&mut self) -> Result<()> {
+        self.0.flush()?;
+        Ok(())
+    }
+
+    pub fn close(&mut self) -> Result<()> {
+        self.0.close()?;
+        Ok(())
+    }
+}

--- a/bindings/cpp/tests/basic_test.cpp
+++ b/bindings/cpp/tests/basic_test.cpp
@@ -139,6 +139,16 @@ OPENDAL_TEST_F(OpenDALTest, ReaderTest) {
   EXPECT_EQ(reader_data, data);
 }
 
+OPENDAL_TEST_F(OpenDALTest, WriterTest) {
+  auto writer = op_.GetWriter("writer_test");
+  writer.Write("hello ");
+  writer.Write("world");
+  writer.Flush();
+  writer.Close();
+
+  EXPECT_EQ(op_.Read("writer_test"), "hello world");
+}
+
 OPENDAL_TEST_F(OpenDALTest, ListerTest) {
   std::string dir_path = "test_dir/";
   op_.CreateDir(dir_path);


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7980

# Rationale for this change

Currently the only exposed writer API in C++ binding is operator one, which only allows blocking write, so downstream users have to buffer content in memory before flush out.

# What changes are included in this PR?

This PR exposes rust writer API from operator into C++ binding, so users could leverage multi-part upload.

# Are there any user-facing changes?

Yes, new API added for C++ binding.

# AI Usage Statement

GPT-5.5 made code change for me.