### PR TITLE
perf(binding/cpp): reduce copy on write paths

### DIFF
--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -331,7 +331,7 @@ impl Operator {
     }
 
     fn writer(&self, path: &str) -> Result<*mut Writer> {
-        let writer = Box::into_raw(Box::new(Writer(self.0.writer(path)?.into_std_write())));
+        let writer = Box::into_raw(Box::new(Writer(self.0.writer(path)?)));
         Ok(writer)
     }
 

--- a/bindings/cpp/src/writer.rs
+++ b/bindings/cpp/src/writer.rs
@@ -17,18 +17,15 @@
 
 use anyhow::Result;
 use opendal as od;
-use std::io::Write;
-
-pub struct Writer(pub od::blocking::StdWriter);
+pub struct Writer(pub od::blocking::Writer);
 
 impl Writer {
     pub fn write(&mut self, bs: Vec<u8>) -> Result<()> {
-        self.0.write_all(&bs)?;
+        self.0.write(bs)?;
         Ok(())
     }
 
     pub fn flush(&mut self) -> Result<()> {
-        self.0.flush()?;
         Ok(())
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

In the current C++ binding implementation, [`StdWriter`](https://github.com/apache/opendal/blob/05dfd63856bfa8b8f86af22a7437a3f0330d9582/bindings/cpp/src/writer.rs#L22) is used, which takes a [buffer reference](https://github.com/apache/opendal/blob/05dfd63856bfa8b8f86af22a7437a3f0330d9582/core/core/src/blocking/write/std_writer.rs#L58) and copies into buffer [here](https://github.com/apache/opendal/blob/05dfd63856bfa8b8f86af22a7437a3f0330d9582/core/core/src/types/write/futures_async_writer.rs#L60). But since `Writer` is already taking a vector (which owns memory), we're doing an unnecessary copy for all write paths.

# What changes are included in this PR?

In this PR, I switch to rust native [`Writer`](https://github.com/apache/opendal/blob/05dfd63856bfa8b8f86af22a7437a3f0330d9582/core/core/src/blocking/write/writer.rs#L68), which takes `Vec<u8>`

# Are there any user-facing changes?

No

# AI Usage Statement

GPT-5.5