### PR TITLE
feat(bindings/dotnet): add throttle and mime-guess layers, HTTP concurrent limit

### DIFF
--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -40,7 +40,9 @@ opendal = { version = ">=0", path = "../../core", features = [
   # enabled layers
   "layers-concurrent-limit",
   "layers-logging",
+  "layers-mime-guess",
   "layers-retry",
+  "layers-throttle",
   "layers-timeout",
 
   # enabled services

--- a/bindings/dotnet/OpenDAL.Tests/LayerTest.cs
+++ b/bindings/dotnet/OpenDAL.Tests/LayerTest.cs
@@ -41,6 +41,44 @@ public class LayerTest
     }
 
     [Fact]
+    public void WithConcurrentLimit_HttpPermits_ReturnsNewOperator()
+    {
+        using var op = new Operator("memory");
+        var before = op.Op;
+        using var layered = op.WithLayer(new ConcurrentLimitLayer(4, 2));
+
+        Assert.NotEqual(IntPtr.Zero, layered.Op);
+        Assert.NotSame(op, layered);
+        Assert.Equal(before, op.Op);
+        Assert.NotEqual(before, layered.Op);
+
+        layered.Write("layer-concurrent-http", [1, 2, 3]);
+        var value = layered.Read("layer-concurrent-http");
+        Assert.Equal([1, 2, 3], value);
+    }
+
+    [Fact]
+    public void WithConcurrentLimit_ZeroPermits_ThrowsArgumentOutOfRangeException()
+    {
+        using var op = new Operator("memory");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => op.WithLayer(new ConcurrentLimitLayer(0)));
+    }
+
+    [Fact]
+    public void WithConcurrentLimit_OmittedHttpPermits_LeavesHttpLimitUnset()
+    {
+        Assert.Null(new ConcurrentLimitLayer(4).HttpPermits);
+        Assert.Equal((nuint)2, new ConcurrentLimitLayer(4, 2).HttpPermits);
+    }
+
+    [Fact]
+    public void WithConcurrentLimit_ZeroHttpPermits_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ConcurrentLimitLayer(4, 0));
+    }
+
+    [Fact]
     public void WithRetry_ReturnsNewOperator()
     {
         using var op = new Operator("memory");
@@ -62,14 +100,6 @@ public class LayerTest
         layered.Write("layer-retry", [4, 5, 6]);
         var value = layered.Read("layer-retry");
         Assert.Equal([4, 5, 6], value);
-    }
-
-    [Fact]
-    public void WithConcurrentLimit_ZeroPermits_ThrowsArgumentOutOfRangeException()
-    {
-        using var op = new Operator("memory");
-
-        Assert.Throws<ArgumentOutOfRangeException>(() => op.WithLayer(new ConcurrentLimitLayer(0)));
     }
 
     [Fact]
@@ -113,6 +143,74 @@ public class LayerTest
         {
             Timeout = TimeSpan.Zero,
         }));
+    }
+
+    [Fact]
+    public void WithThrottle_ReturnsNewOperator()
+    {
+        using var op = new Operator("memory");
+        var before = op.Op;
+        using var layered = op.WithLayer(new ThrottleLayer(10 * 1024, 10 * 1024 * 1024));
+
+        Assert.NotEqual(IntPtr.Zero, layered.Op);
+        Assert.NotSame(op, layered);
+        Assert.Equal(before, op.Op);
+        Assert.NotEqual(before, layered.Op);
+
+        layered.Write("layer-throttle", [1, 2, 3]);
+        var value = layered.Read("layer-throttle");
+        Assert.Equal([1, 2, 3], value);
+    }
+
+    [Theory]
+    [InlineData(0u, 1024u)]
+    [InlineData(1024u, 0u)]
+    public void WithThrottle_ZeroArgument_ThrowsArgumentOutOfRangeException(uint bandwidth, uint burst)
+    {
+        using var op = new Operator("memory");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => op.WithLayer(new ThrottleLayer(bandwidth, burst)));
+    }
+
+    [Fact]
+    public void WithMimeGuess_FillsContentTypeFromExtension()
+    {
+        using var op = new Operator("memory");
+        var before = op.Op;
+        using var layered = op.WithLayer(new MimeGuessLayer());
+
+        Assert.NotEqual(IntPtr.Zero, layered.Op);
+        Assert.NotSame(op, layered);
+        Assert.Equal(before, op.Op);
+        Assert.NotEqual(before, layered.Op);
+
+        layered.Write("layer-mime-guess.json", [1, 2, 3]);
+        Assert.Equal("application/json", layered.Stat("layer-mime-guess.json").ContentType);
+    }
+
+    [Fact]
+    public void WithMimeGuess_DoesNotOverrideExplicitContentType()
+    {
+        using var op = new Operator("memory");
+        using var layered = op.WithLayer(new MimeGuessLayer());
+
+        layered.Write(
+            "layer-mime-guess-explicit.json",
+            [1, 2, 3],
+            new OpenDAL.Options.WriteOptions { ContentType = "text/plain" });
+
+        Assert.Equal("text/plain", layered.Stat("layer-mime-guess-explicit.json").ContentType);
+    }
+
+    [Fact]
+    public void WithMimeGuess_UnknownExtension_LeavesContentTypeUnset()
+    {
+        using var op = new Operator("memory");
+        using var layered = op.WithLayer(new MimeGuessLayer());
+
+        layered.Write("layer-mime-guess.no-such-ext", [1, 2, 3]);
+
+        Assert.Null(layered.Stat("layer-mime-guess.no-such-ext").ContentType);
     }
 
     [Fact]

--- a/bindings/dotnet/OpenDAL/Layer/ConcurrentLimitLayer.cs
+++ b/bindings/dotnet/OpenDAL/Layer/ConcurrentLimitLayer.cs
@@ -32,16 +32,36 @@ public sealed class ConcurrentLimitLayer : ILayer
     public nuint Permits { get; }
 
     /// <summary>
+    /// Gets maximum concurrent HTTP requests, or null when the HTTP limit is unset.
+    /// </summary>
+    /// <remarks>
+    /// This limit is independent of <see cref="Permits"/>: a single operation may issue
+    /// several HTTP requests, so limiting operations does not bound HTTP concurrency.
+    /// </remarks>
+    public nuint? HttpPermits { get; }
+
+    /// <summary>
     /// Creates a concurrent-limit layer.
     /// </summary>
     /// <param name="permits">Maximum number of concurrent permits. Must be greater than zero.</param>
-    public ConcurrentLimitLayer(nuint permits)
+    /// <param name="httpPermits">
+    /// Maximum number of concurrent HTTP requests, or null to leave the HTTP limit unset.
+    /// Must be greater than zero when specified.
+    /// </param>
+    public ConcurrentLimitLayer(nuint permits, nuint? httpPermits = null)
     {
         if (permits == 0)
         {
             throw new ArgumentOutOfRangeException(nameof(permits), "Permits must be greater than zero.");
         }
+
+        if (httpPermits == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(httpPermits), "HttpPermits must be greater than zero when specified.");
+        }
+
         Permits = permits;
+        HttpPermits = httpPermits;
     }
 
     /// <summary>
@@ -54,7 +74,11 @@ public sealed class ConcurrentLimitLayer : ILayer
         ArgumentNullException.ThrowIfNull(op);
         ObjectDisposedException.ThrowIf(op.IsInvalid, op);
 
-        var result = NativeMethods.operator_layer_concurrent_limit(op, Permits);
+        var result = NativeMethods.operator_layer_concurrent_limit(
+            op,
+            Permits,
+            HttpPermits ?? 0,
+            HttpPermits.HasValue);
         return op.ApplyLayerResult(result);
     }
 }

--- a/bindings/dotnet/OpenDAL/Layer/MimeGuessLayer.cs
+++ b/bindings/dotnet/OpenDAL/Layer/MimeGuessLayer.cs
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using OpenDAL.Layer.Abstractions;
+
+namespace OpenDAL.Layer;
+
+/// <summary>
+/// Layer that derives <c>Content-Type</c> from the file extension in the operation path.
+/// </summary>
+/// <remarks>
+/// An existing content type always wins: the layer fills in a value only when the caller
+/// did not set one on write, and only when the service did not report one on stat.
+/// Paths whose extension cannot be resolved are left untouched.
+/// </remarks>
+public sealed class MimeGuessLayer : ILayer
+{
+    /// <summary>
+    /// Applies MIME-guess behavior to the specified operator.
+    /// </summary>
+    /// <param name="op">Operator to layer.</param>
+    /// <returns>The layered operator instance.</returns>
+    public Operator Apply(Operator op)
+    {
+        ArgumentNullException.ThrowIfNull(op);
+        ObjectDisposedException.ThrowIf(op.IsInvalid, op);
+
+        var result = NativeMethods.operator_layer_mime_guess(op);
+        return op.ApplyLayerResult(result);
+    }
+}

--- a/bindings/dotnet/OpenDAL/Layer/ThrottleLayer.cs
+++ b/bindings/dotnet/OpenDAL/Layer/ThrottleLayer.cs
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using OpenDAL.Layer.Abstractions;
+
+namespace OpenDAL.Layer;
+
+/// <summary>
+/// Layer that rate-limits the byte flow of read and write operations.
+/// </summary>
+/// <remarks>
+/// Throttling applies to the reader and writer byte streams only. It does not limit
+/// the number of requests, so it composes with <see cref="ConcurrentLimitLayer"/>
+/// rather than replacing it.
+/// </remarks>
+public sealed class ThrottleLayer : ILayer
+{
+    /// <summary>
+    /// Gets the maximum number of bytes allowed through per second.
+    /// </summary>
+    public uint Bandwidth { get; }
+
+    /// <summary>
+    /// Gets the maximum number of bytes allowed through at once.
+    /// </summary>
+    public uint Burst { get; }
+
+    /// <summary>
+    /// Creates a throttle layer.
+    /// </summary>
+    /// <param name="bandwidth">Maximum bytes per second. Must be greater than zero.</param>
+    /// <param name="burst">
+    /// Maximum bytes allowed through at once. Must be greater than zero, and must exceed the
+    /// largest possible operation size: an operation larger than the burst size can never
+    /// acquire enough quota and will block indefinitely.
+    /// </param>
+    public ThrottleLayer(uint bandwidth, uint burst)
+    {
+        if (bandwidth == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(bandwidth), "Bandwidth must be greater than zero.");
+        }
+
+        if (burst == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(burst), "Burst must be greater than zero.");
+        }
+
+        Bandwidth = bandwidth;
+        Burst = burst;
+    }
+
+    /// <summary>
+    /// Applies throttle behavior to the specified operator.
+    /// </summary>
+    /// <param name="op">Operator to layer.</param>
+    /// <returns>The layered operator instance.</returns>
+    public Operator Apply(Operator op)
+    {
+        ArgumentNullException.ThrowIfNull(op);
+        ObjectDisposedException.ThrowIf(op.IsInvalid, op);
+
+        var result = NativeMethods.operator_layer_throttle(op, Bandwidth, Burst);
+        return op.ApplyLayerResult(result);
+    }
+}

--- a/bindings/dotnet/OpenDAL/NativeMethods.cs
+++ b/bindings/dotnet/OpenDAL/NativeMethods.cs
@@ -151,7 +151,9 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALOperatorResult operator_layer_concurrent_limit(
         Operator op,
-        nuint permits
+        nuint permits,
+        nuint httpPermits,
+        [MarshalAs(UnmanagedType.I1)] bool hasHttpPermits
     );
 
     [LibraryImport(__DllName, EntryPoint = "operator_layer_capability_override", StringMarshalling = StringMarshalling.Utf8)]
@@ -167,6 +169,20 @@ internal partial class NativeMethods
         Operator op,
         ulong timeoutNanos,
         ulong ioTimeoutNanos
+    );
+
+    [LibraryImport(__DllName, EntryPoint = "operator_layer_throttle")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial OpenDALOperatorResult operator_layer_throttle(
+        Operator op,
+        uint bandwidth,
+        uint burst
+    );
+
+    [LibraryImport(__DllName, EntryPoint = "operator_layer_mime_guess")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial OpenDALOperatorResult operator_layer_mime_guess(
+        Operator op
     );
 
     #endregion

--- a/bindings/dotnet/src/operator.rs
+++ b/bindings/dotnet/src/operator.rs
@@ -31,7 +31,8 @@ use crate::{
     },
     utils::{collect_options, require_callback, require_cstr, require_data_ptr, require_operator},
     validators::prelude::{
-        validate_concurrent_limit_options, validate_retry_options, validate_timeout_options,
+        validate_concurrent_limit_options, validate_retry_options, validate_throttle_options,
+        validate_timeout_options,
     },
 };
 
@@ -385,6 +386,10 @@ fn operator_layer_retry_inner(
 ///
 /// The current operator is not modified. Returned pointer must be released with
 /// `operator_free`.
+///
+/// `http_permits` limits concurrent HTTP requests independently of `permits`,
+/// which limits concurrent operations. It is read only when `has_http_permits`
+/// is true; otherwise the HTTP limit is left unset.
 /// # Safety
 ///
 /// - `op` must be a valid operator pointer from `operator_construct`.
@@ -392,8 +397,11 @@ fn operator_layer_retry_inner(
 pub extern "C" fn operator_layer_concurrent_limit(
     op: *const opendal::Operator,
     permits: usize,
+    http_permits: usize,
+    has_http_permits: bool,
 ) -> OpendalOperatorResult {
-    match operator_layer_concurrent_limit_inner(op, permits) {
+    let http_permits = has_http_permits.then_some(http_permits);
+    match operator_layer_concurrent_limit_inner(op, permits, http_permits) {
         Ok(value) => OpendalOperatorResult::ok(value),
         Err(error) => OpendalOperatorResult::from_error(error),
     }
@@ -402,11 +410,16 @@ pub extern "C" fn operator_layer_concurrent_limit(
 fn operator_layer_concurrent_limit_inner(
     op: *const opendal::Operator,
     permits: usize,
+    http_permits: Option<usize>,
 ) -> Result<*mut c_void, OpenDALError> {
     let op = require_operator(op)?;
-    validate_concurrent_limit_options(permits)?;
+    validate_concurrent_limit_options(permits, http_permits)?;
 
-    let concurrent_limit = opendal::layers::ConcurrentLimitLayer::new(permits);
+    let mut concurrent_limit = opendal::layers::ConcurrentLimitLayer::new(permits);
+    if let Some(http_permits) = http_permits {
+        concurrent_limit = concurrent_limit.with_http_concurrent_limit(http_permits);
+    }
+
     Ok(Box::into_raw(Box::new(op.clone().layer(concurrent_limit))) as *mut c_void)
 }
 
@@ -473,6 +486,66 @@ fn operator_layer_timeout_inner(
         .with_io_timeout(Duration::from_nanos(io_timeout_nanos));
 
     Ok(Box::into_raw(Box::new(op.clone().layer(timeout))) as *mut c_void)
+}
+
+/// Create a new operator layered with throttle behavior.
+///
+/// The current operator is not modified. Returned pointer must be released with
+/// `operator_free`.
+///
+/// `bandwidth` is the maximum number of bytes allowed through per second, and
+/// `burst` is the maximum number of bytes allowed through at once. `burst` must
+/// exceed the largest possible operation size, otherwise that operation can
+/// never acquire enough quota to proceed.
+/// # Safety
+///
+/// - `op` must be a valid operator pointer from `operator_construct`.
+#[unsafe(no_mangle)]
+pub extern "C" fn operator_layer_throttle(
+    op: *const opendal::Operator,
+    bandwidth: u32,
+    burst: u32,
+) -> OpendalOperatorResult {
+    match operator_layer_throttle_inner(op, bandwidth, burst) {
+        Ok(value) => OpendalOperatorResult::ok(value),
+        Err(error) => OpendalOperatorResult::from_error(error),
+    }
+}
+
+fn operator_layer_throttle_inner(
+    op: *const opendal::Operator,
+    bandwidth: u32,
+    burst: u32,
+) -> Result<*mut c_void, OpenDALError> {
+    let op = require_operator(op)?;
+    validate_throttle_options(bandwidth, burst)?;
+
+    let throttle = opendal::layers::ThrottleLayer::new(bandwidth, burst);
+    Ok(Box::into_raw(Box::new(op.clone().layer(throttle))) as *mut c_void)
+}
+
+/// Create a new operator layered with MIME-guess behavior.
+///
+/// The current operator is not modified. Returned pointer must be released with
+/// `operator_free`.
+/// # Safety
+///
+/// - `op` must be a valid operator pointer from `operator_construct`.
+#[unsafe(no_mangle)]
+pub extern "C" fn operator_layer_mime_guess(op: *const opendal::Operator) -> OpendalOperatorResult {
+    match operator_layer_mime_guess_inner(op) {
+        Ok(value) => OpendalOperatorResult::ok(value),
+        Err(error) => OpendalOperatorResult::from_error(error),
+    }
+}
+
+fn operator_layer_mime_guess_inner(
+    op: *const opendal::Operator,
+) -> Result<*mut c_void, OpenDALError> {
+    let op = require_operator(op)?;
+
+    let mime_guess = opendal::layers::MimeGuessLayer::default();
+    Ok(Box::into_raw(Box::new(op.clone().layer(mime_guess))) as *mut c_void)
 }
 
 /// Duplicate an operator instance.

--- a/bindings/dotnet/src/validators.rs
+++ b/bindings/dotnet/src/validators.rs
@@ -31,6 +31,16 @@ pub(crate) fn validate_non_zero_u64(value: u64, field: &str) -> Result<(), OpenD
     Ok(())
 }
 
+pub(crate) fn validate_non_zero_u32(value: u32, field: &str) -> Result<(), OpenDALError> {
+    if value == 0 {
+        return Err(config_invalid_error(format!(
+            "{field} must be greater than zero"
+        )));
+    }
+
+    Ok(())
+}
+
 pub(crate) fn validate_non_zero_usize(value: usize, field: &str) -> Result<(), OpenDALError> {
     if value == 0 {
         return Err(config_invalid_error(format!(
@@ -62,7 +72,8 @@ pub(crate) fn validate_checked_add_u64(
 
 pub(crate) mod prelude {
     pub(crate) use super::layer::{
-        validate_concurrent_limit_options, validate_retry_options, validate_timeout_options,
+        validate_concurrent_limit_options, validate_retry_options, validate_throttle_options,
+        validate_timeout_options,
     };
     pub(crate) use super::options::{
         validate_list_limit, validate_read_chunk, validate_read_concurrent, validate_read_gap,

--- a/bindings/dotnet/src/validators/layer.rs
+++ b/bindings/dotnet/src/validators/layer.rs
@@ -18,7 +18,8 @@
 use crate::error::OpenDALError;
 use crate::utils::config_invalid_error;
 use crate::validators::{
-    validate_non_zero_u64, validate_non_zero_usize, validate_positive_finite_f32,
+    validate_non_zero_u32, validate_non_zero_u64, validate_non_zero_usize,
+    validate_positive_finite_f32,
 };
 
 /// Validate retry layer options.
@@ -50,8 +51,25 @@ pub fn validate_timeout_options(
 }
 
 /// Validate concurrent-limit layer options.
-pub fn validate_concurrent_limit_options(permits: usize) -> Result<(), OpenDALError> {
+pub fn validate_concurrent_limit_options(
+    permits: usize,
+    http_permits: Option<usize>,
+) -> Result<(), OpenDALError> {
     validate_non_zero_usize(permits, "permits")?;
+    if let Some(http_permits) = http_permits {
+        validate_non_zero_usize(http_permits, "http_permits")?;
+    }
+
+    Ok(())
+}
+
+/// Validate throttle layer options.
+///
+/// `ThrottleLayer::new` asserts on zero values, and a panic across the `extern "C"`
+/// boundary aborts the process, so both values must be rejected here first.
+pub fn validate_throttle_options(bandwidth: u32, burst: u32) -> Result<(), OpenDALError> {
+    validate_non_zero_u32(bandwidth, "bandwidth")?;
+    validate_non_zero_u32(burst, "burst")?;
 
     Ok(())
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

Add `ThrottleLayer` and `MimeGuessLayer` to the .NET binding, and fill in the
HTTP concurrent limit option that `ConcurrentLimitLayer` was missing.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Add `ThrottleLayer` and `MimeGuessLayer`, with the matching FFI entry points.
- Add an optional HTTP concurrent limit to `ConcurrentLimitLayer`.
- Enable the `layers-throttle` and `layers-mime-guess` features.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

`ConcurrentLimitLayer` now takes an optional second argument for the HTTP
concurrent limit. Existing `new ConcurrentLimitLayer(permits)` calls keep working
unchanged.

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->

Written with Claude Code (Opus 5).