### PR TITLE
feat(bindings/cpp): expose options to cpp bindings

### DIFF
--- a/bindings/cpp/include/data_structure.hpp
+++ b/bindings/cpp/include/data_structure.hpp
@@ -128,13 +128,17 @@ class Metadata {
    * @brief Content MD5 hash
    * @return Optional MD5 hash string
    */
-  const std::optional<std::string>& ContentMd5() const { return content_md5; }
+  const std::optional<std::string>& ContentMd5() const {
+    return content_md5;
+  }
 
   /**
    * @brief Content type (MIME type)
    * @return Optional content type string
    */
-  const std::optional<std::string>& ContentType() const { return content_type; }
+  const std::optional<std::string>& ContentType() const {
+    return content_type;
+  }
 
   /**
    * @brief Content encoding
@@ -368,4 +372,4 @@ class Capability {
   bool presign_write;
   bool shared;
 };
-}  // namespace opendal
+}

--- a/bindings/cpp/include/data_structure.hpp
+++ b/bindings/cpp/include/data_structure.hpp
@@ -20,9 +20,11 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <unordered_map>
 
 namespace opendal {
 
@@ -126,17 +128,13 @@ class Metadata {
    * @brief Content MD5 hash
    * @return Optional MD5 hash string
    */
-  const std::optional<std::string>& ContentMd5() const {
-    return content_md5;
-  }
+  const std::optional<std::string>& ContentMd5() const { return content_md5; }
 
   /**
    * @brief Content type (MIME type)
    * @return Optional content type string
    */
-  const std::optional<std::string>& ContentType() const {
-    return content_type;
-  }
+  const std::optional<std::string>& ContentType() const { return content_type; }
 
   /**
    * @brief Content encoding
@@ -190,6 +188,149 @@ class Entry {
   std::string path;
 };
 
+/**
+ * @struct ReadRange
+ * @brief Byte range used by read operations.
+ */
+struct ReadRange {
+  enum class Type : std::uint8_t {
+    FULL = 0,
+    OFFSET = 1,
+    RANGE = 2,
+    SUFFIX = 3,
+  };
+
+  Type type{Type::FULL};
+  std::uint64_t start{0};
+  std::uint64_t end{0};
+
+  static ReadRange Full() { return {}; }
+
+  static ReadRange Offset(std::uint64_t offset) {
+    return {Type::OFFSET, offset, 0};
+  }
+
+  static ReadRange Range(std::uint64_t start, std::uint64_t end) {
+    return {Type::RANGE, start, end};
+  }
+
+  static ReadRange Suffix(std::uint64_t size) {
+    return {Type::SUFFIX, 0, size};
+  }
+};
+
+/**
+ * @struct StatOptions
+ * @brief Options for stat operations.
+ */
+struct StatOptions {
+  std::optional<std::string> version;
+  std::optional<std::string> if_match;
+  std::optional<std::string> if_none_match;
+  std::optional<std::chrono::system_clock::time_point> if_modified_since;
+  std::optional<std::chrono::system_clock::time_point> if_unmodified_since;
+  std::optional<std::string> override_content_type;
+  std::optional<std::string> override_cache_control;
+  std::optional<std::string> override_content_disposition;
+};
+
+/**
+ * @struct ReadOptions
+ * @brief Options for read operations.
+ */
+struct ReadOptions {
+  ReadRange range;
+  std::optional<std::string> version;
+  std::optional<std::string> if_match;
+  std::optional<std::string> if_none_match;
+  std::optional<std::chrono::system_clock::time_point> if_modified_since;
+  std::optional<std::chrono::system_clock::time_point> if_unmodified_since;
+  std::optional<std::uint64_t> content_length_hint;
+  std::size_t concurrent{0};
+  std::optional<std::size_t> chunk;
+  std::optional<std::size_t> gap;
+  std::optional<std::string> override_content_type;
+  std::optional<std::string> override_cache_control;
+  std::optional<std::string> override_content_disposition;
+};
+
+/**
+ * @struct ReaderOptions
+ * @brief Options for creating readers.
+ */
+struct ReaderOptions {
+  std::optional<std::string> version;
+  std::optional<std::string> if_match;
+  std::optional<std::string> if_none_match;
+  std::optional<std::chrono::system_clock::time_point> if_modified_since;
+  std::optional<std::chrono::system_clock::time_point> if_unmodified_since;
+  std::optional<std::uint64_t> content_length_hint;
+  std::size_t concurrent{0};
+  std::optional<std::size_t> chunk;
+  std::optional<std::size_t> gap;
+  std::size_t prefetch{0};
+};
+
+/**
+ * @struct WriteOptions
+ * @brief Options for write and writer operations.
+ */
+struct WriteOptions {
+  bool append{false};
+  std::optional<std::string> cache_control;
+  std::optional<std::string> content_type;
+  std::optional<std::string> content_disposition;
+  std::optional<std::string> content_encoding;
+  std::optional<std::unordered_map<std::string, std::string>> user_metadata;
+  std::optional<std::string> if_match;
+  std::optional<std::string> if_none_match;
+  bool if_not_exists{false};
+  std::size_t concurrent{0};
+  std::optional<std::size_t> chunk;
+};
+
+/**
+ * @struct CopyOptions
+ * @brief Options for copy operations.
+ */
+struct CopyOptions {
+  bool if_not_exists{false};
+  std::optional<std::string> if_match;
+  std::optional<std::string> source_version;
+  std::optional<std::uint64_t> source_content_length_hint;
+  std::size_t concurrent{0};
+  std::optional<std::size_t> chunk;
+};
+
+/**
+ * @struct RenameOptions
+ * @brief Options for rename operations.
+ */
+struct RenameOptions {
+  bool if_not_exists{false};
+};
+
+/**
+ * @struct DeleteOptions
+ * @brief Options for delete operations.
+ */
+struct DeleteOptions {
+  std::optional<std::string> version;
+  bool recursive{false};
+};
+
+/**
+ * @struct ListOptions
+ * @brief Options for list and lister operations.
+ */
+struct ListOptions {
+  std::optional<std::size_t> limit;
+  std::optional<std::string> start_after;
+  bool recursive{false};
+  bool versions{false};
+  bool deleted{false};
+};
+
 }  // namespace opendal
 namespace opendal {
 class Capability {
@@ -227,4 +368,4 @@ class Capability {
   bool presign_write;
   bool shared;
 };
-}
+}  // namespace opendal

--- a/bindings/cpp/include/opendal.hpp
+++ b/bindings/cpp/include/opendal.hpp
@@ -133,7 +133,8 @@ class Operator {
    * @param path The path to check
    * @return true if the path exists, false otherwise
    */
-  [[deprecated("Use Exists() instead.")]] bool IsExist(std::string_view path);
+  [[deprecated("Use Exists() instead.")]]
+  bool IsExist(std::string_view path);
 
   /**
    * @brief Check if the path exists
@@ -201,11 +202,11 @@ class Operator {
   Lister GetLister(std::string_view path, const ListOptions &options);
   Capability Info();
 
- private:
-  void Destroy() noexcept;
+  private:
+   void Destroy() noexcept;
 
-  ffi::Operator *operator_{nullptr};
-};
+   ffi::Operator *operator_{nullptr};
+ };
 
 /**
  * @class Reader
@@ -330,8 +331,7 @@ class ReaderStream : public std::istream {
                            std::ios_base::openmode which) override {
       if (dir == std::ios_base::cur && off == 0) {
         // tellg() case - return current position
-        return buffer_start_pos_ +
-               static_cast<std::streamoff>(gptr() - eback());
+        return buffer_start_pos_ + static_cast<std::streamoff>(gptr() - eback());
       }
 
       // Actual seek operation

--- a/bindings/cpp/include/opendal.hpp
+++ b/bindings/cpp/include/opendal.hpp
@@ -90,6 +90,15 @@ class Operator {
   std::string Read(std::string_view path);
 
   /**
+   * @brief Read data from the operator with extra options
+   *
+   * @param path The path of the data
+   * @param options The read options
+   * @return The data read from the operator
+   */
+  std::string Read(std::string_view path, const ReadOptions &options);
+
+  /**
    * @brief Write data to the operator
    *
    * @param path The path of the data
@@ -98,13 +107,25 @@ class Operator {
   void Write(std::string_view path, std::string_view data);
 
   /**
+   * @brief Write data to the operator with extra options
+   *
+   * @param path The path of the data
+   * @param data The data to write
+   * @param options The write options
+   */
+  void Write(std::string_view path, std::string_view data,
+             const WriteOptions &options);
+
+  /**
    * @brief Read data from the operator
    *
    * @param path The path of the data
    * @return The reader of the data
    */
   Reader GetReader(std::string_view path);
+  Reader GetReader(std::string_view path, const ReaderOptions &options);
   Writer GetWriter(std::string_view path);
+  Writer GetWriter(std::string_view path, const WriteOptions &options);
 
   /**
    * @brief Check if the path exists
@@ -112,8 +133,7 @@ class Operator {
    * @param path The path to check
    * @return true if the path exists, false otherwise
    */
-  [[deprecated("Use Exists() instead.")]]
-  bool IsExist(std::string_view path);
+  [[deprecated("Use Exists() instead.")]] bool IsExist(std::string_view path);
 
   /**
    * @brief Check if the path exists
@@ -137,6 +157,8 @@ class Operator {
    * @param dst The destination path
    */
   void Copy(std::string_view src, std::string_view dst);
+  void Copy(std::string_view src, std::string_view dst,
+            const CopyOptions &options);
 
   /**
    * @brief Rename a file from src to dst.
@@ -145,6 +167,8 @@ class Operator {
    * @param dst The destination path
    */
   void Rename(std::string_view src, std::string_view dst);
+  void Rename(std::string_view src, std::string_view dst,
+              const RenameOptions &options);
 
   /**
    * @brief Remove a file or directory
@@ -152,6 +176,7 @@ class Operator {
    * @param path The path of the file or directory
    */
   void Remove(std::string_view path);
+  void Remove(std::string_view path, const DeleteOptions &options);
 
   /**
    * @brief Get the metadata of a file or directory
@@ -160,6 +185,7 @@ class Operator {
    * @return The metadata of the file or directory
    */
   Metadata Stat(std::string_view path);
+  Metadata Stat(std::string_view path, const StatOptions &options);
 
   /**
    * @brief List the entries of a directory
@@ -169,15 +195,17 @@ class Operator {
    * @return The entries of the directory
    */
   std::vector<Entry> List(std::string_view path);
+  std::vector<Entry> List(std::string_view path, const ListOptions &options);
 
   Lister GetLister(std::string_view path);
+  Lister GetLister(std::string_view path, const ListOptions &options);
   Capability Info();
- 
-  private:
-   void Destroy() noexcept;
- 
-   ffi::Operator *operator_{nullptr};
- };
+
+ private:
+  void Destroy() noexcept;
+
+  ffi::Operator *operator_{nullptr};
+};
 
 /**
  * @class Reader
@@ -302,7 +330,8 @@ class ReaderStream : public std::istream {
                            std::ios_base::openmode which) override {
       if (dir == std::ios_base::cur && off == 0) {
         // tellg() case - return current position
-        return buffer_start_pos_ + static_cast<std::streamoff>(gptr() - eback());
+        return buffer_start_pos_ +
+               static_cast<std::streamoff>(gptr() - eback());
       }
 
       // Actual seek operation

--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -33,6 +33,7 @@ use std::sync::LazyLock;
 
 use anyhow::Result;
 use lister::Lister;
+use od::raw::Timestamp;
 use opendal as od;
 use reader::Reader;
 use writer::Writer;
@@ -49,6 +50,109 @@ mod ffi {
     struct HashMapValue {
         key: String,
         value: String,
+    }
+
+    struct OptionalU64 {
+        has_value: bool,
+        value: u64,
+    }
+
+    struct OptionalUsize {
+        has_value: bool,
+        value: usize,
+    }
+
+    struct OptionalTimestamp {
+        has_value: bool,
+        seconds: i64,
+        nanoseconds: u32,
+    }
+
+    struct FfiBytesRange {
+        kind: u8,
+        start: u64,
+        end: u64,
+    }
+
+    struct FfiStatOptions {
+        version: OptionalString,
+        if_match: OptionalString,
+        if_none_match: OptionalString,
+        if_modified_since: OptionalTimestamp,
+        if_unmodified_since: OptionalTimestamp,
+        override_content_type: OptionalString,
+        override_cache_control: OptionalString,
+        override_content_disposition: OptionalString,
+    }
+
+    struct FfiReadOptions {
+        range: FfiBytesRange,
+        version: OptionalString,
+        if_match: OptionalString,
+        if_none_match: OptionalString,
+        if_modified_since: OptionalTimestamp,
+        if_unmodified_since: OptionalTimestamp,
+        content_length_hint: OptionalU64,
+        concurrent: usize,
+        chunk: OptionalUsize,
+        gap: OptionalUsize,
+        override_content_type: OptionalString,
+        override_cache_control: OptionalString,
+        override_content_disposition: OptionalString,
+    }
+
+    struct FfiReaderOptions {
+        version: OptionalString,
+        if_match: OptionalString,
+        if_none_match: OptionalString,
+        if_modified_since: OptionalTimestamp,
+        if_unmodified_since: OptionalTimestamp,
+        content_length_hint: OptionalU64,
+        concurrent: usize,
+        chunk: OptionalUsize,
+        gap: OptionalUsize,
+        prefetch: usize,
+    }
+
+    struct FfiWriteOptions {
+        append: bool,
+        cache_control: OptionalString,
+        content_type: OptionalString,
+        content_disposition: OptionalString,
+        content_encoding: OptionalString,
+        has_user_metadata: bool,
+        user_metadata: Vec<HashMapValue>,
+        if_match: OptionalString,
+        if_none_match: OptionalString,
+        if_not_exists: bool,
+        concurrent: usize,
+        chunk: OptionalUsize,
+    }
+
+    struct FfiCopyOptions {
+        if_not_exists: bool,
+        if_match: OptionalString,
+        source_version: OptionalString,
+        source_content_length_hint: OptionalU64,
+        concurrent: usize,
+        chunk: OptionalUsize,
+    }
+
+    struct FfiRenameOptions {
+        if_not_exists: bool,
+    }
+
+    struct FfiDeleteOptions {
+        version: OptionalString,
+        recursive: bool,
+    }
+
+    struct FfiListOptions {
+        limit: OptionalUsize,
+        start_after: OptionalString,
+        recursive: bool,
+        versions: bool,
+        deleted: bool,
     }
 
     #[cxx_name = "SeekDir"]
@@ -161,17 +265,46 @@ mod ffi {
         unsafe fn delete_operator(op: *mut Operator);
 
         fn read(self: &Operator, path: &str) -> Result<Vec<u8>>;
+        fn read_options(self: &Operator, path: &str, opts: FfiReadOptions) -> Result<Vec<u8>>;
         fn write(self: &Operator, path: &str, bs: Vec<u8>) -> Result<()>;
+        fn write_options(
+            self: &Operator,
+            path: &str,
+            bs: Vec<u8>,
+            opts: FfiWriteOptions,
+        ) -> Result<()>;
         fn exists(self: &Operator, path: &str) -> Result<bool>;
         fn create_dir(self: &Operator, path: &str) -> Result<()>;
         fn copy(self: &Operator, src: &str, dst: &str) -> Result<()>;
+        fn copy_options(self: &Operator, src: &str, dst: &str, opts: FfiCopyOptions) -> Result<()>;
         fn rename(self: &Operator, src: &str, dst: &str) -> Result<()>;
+        fn rename_options(
+            self: &Operator,
+            src: &str,
+            dst: &str,
+            opts: FfiRenameOptions,
+        ) -> Result<()>;
         fn remove(self: &Operator, path: &str) -> Result<()>;
+        fn remove_options(self: &Operator, path: &str, opts: FfiDeleteOptions) -> Result<()>;
         fn stat(self: &Operator, path: &str) -> Result<Metadata>;
+        fn stat_options(self: &Operator, path: &str, opts: FfiStatOptions) -> Result<Metadata>;
         fn list(self: &Operator, path: &str) -> Result<Vec<Entry>>;
+        fn list_options(self: &Operator, path: &str, opts: FfiListOptions) -> Result<Vec<Entry>>;
         fn reader(self: &Operator, path: &str) -> Result<*mut Reader>;
+        fn reader_options(
+            self: &Operator,
+            path: &str,
+            opts: FfiReaderOptions,
+        ) -> Result<*mut Reader>;
         fn lister(self: &Operator, path: &str) -> Result<*mut Lister>;
+        fn lister_options(self: &Operator, path: &str, opts: FfiListOptions)
+        -> Result<*mut Lister>;
         fn writer(self: &Operator, path: &str) -> Result<*mut Writer>;
+        fn writer_options(
+            self: &Operator,
+            path: &str,
+            opts: FfiWriteOptions,
+        ) -> Result<*mut Writer>;
         fn info(self: &Operator) -> Result<Capability>;
 
         unsafe fn delete_reader(reader: *mut Reader);
@@ -276,13 +409,161 @@ unsafe fn delete_lister(lister: *mut Lister) {
     }
 }
 
+fn optional_string(v: ffi::OptionalString) -> Option<String> {
+    v.has_value.then_some(v.value)
+}
+
+fn optional_u64(v: ffi::OptionalU64) -> Option<u64> {
+    v.has_value.then_some(v.value)
+}
+
+fn optional_usize(v: ffi::OptionalUsize) -> Option<usize> {
+    v.has_value.then_some(v.value)
+}
+
+fn optional_timestamp(v: ffi::OptionalTimestamp) -> Result<Option<Timestamp>> {
+    if v.has_value {
+        Ok(Some(Timestamp::new(v.seconds, v.nanoseconds as i32)?))
+    } else {
+        Ok(None)
+    }
+}
+
+fn bytes_range(v: ffi::FfiBytesRange) -> od::BytesRange {
+    match v.kind {
+        1 => od::BytesRange::new(v.start, None),
+        2 => od::BytesRange::new(v.start, Some(v.end.saturating_sub(v.start))),
+        3 => od::BytesRange::suffix(v.end),
+        _ => od::BytesRange::default(),
+    }
+}
+
+fn user_metadata(
+    has_value: bool,
+    values: Vec<ffi::HashMapValue>,
+) -> Option<HashMap<String, String>> {
+    has_value.then(|| {
+        values
+            .into_iter()
+            .map(|value| (value.key, value.value))
+            .collect()
+    })
+}
+
+fn stat_options(opts: ffi::FfiStatOptions) -> Result<od::options::StatOptions> {
+    Ok(od::options::StatOptions {
+        version: optional_string(opts.version),
+        if_match: optional_string(opts.if_match),
+        if_none_match: optional_string(opts.if_none_match),
+        if_modified_since: optional_timestamp(opts.if_modified_since)?,
+        if_unmodified_since: optional_timestamp(opts.if_unmodified_since)?,
+        override_content_type: optional_string(opts.override_content_type),
+        override_cache_control: optional_string(opts.override_cache_control),
+        override_content_disposition: optional_string(opts.override_content_disposition),
+    })
+}
+
+fn read_options(opts: ffi::FfiReadOptions) -> Result<od::options::ReadOptions> {
+    Ok(od::options::ReadOptions {
+        range: bytes_range(opts.range),
+        version: optional_string(opts.version),
+        if_match: optional_string(opts.if_match),
+        if_none_match: optional_string(opts.if_none_match),
+        if_modified_since: optional_timestamp(opts.if_modified_since)?,
+        if_unmodified_since: optional_timestamp(opts.if_unmodified_since)?,
+        content_length_hint: optional_u64(opts.content_length_hint),
+        concurrent: opts.concurrent,
+        chunk: optional_usize(opts.chunk),
+        gap: optional_usize(opts.gap),
+        override_content_type: optional_string(opts.override_content_type),
+        override_cache_control: optional_string(opts.override_cache_control),
+        override_content_disposition: optional_string(opts.override_content_disposition),
+    })
+}
+
+fn reader_options(opts: ffi::FfiReaderOptions) -> Result<od::options::ReaderOptions> {
+    Ok(od::options::ReaderOptions {
+        version: optional_string(opts.version),
+        if_match: optional_string(opts.if_match),
+        if_none_match: optional_string(opts.if_none_match),
+        if_modified_since: optional_timestamp(opts.if_modified_since)?,
+        if_unmodified_since: optional_timestamp(opts.if_unmodified_since)?,
+        content_length_hint: optional_u64(opts.content_length_hint),
+        concurrent: opts.concurrent,
+        chunk: optional_usize(opts.chunk),
+        gap: optional_usize(opts.gap),
+        prefetch: opts.prefetch,
+    })
+}
+
+fn write_options(opts: ffi::FfiWriteOptions) -> od::options::WriteOptions {
+    od::options::WriteOptions {
+        append: opts.append,
+        cache_control: optional_string(opts.cache_control),
+        content_type: optional_string(opts.content_type),
+        content_disposition: optional_string(opts.content_disposition),
+        content_encoding: optional_string(opts.content_encoding),
+        user_metadata: user_metadata(opts.has_user_metadata, opts.user_metadata),
+        if_match: optional_string(opts.if_match),
+        if_none_match: optional_string(opts.if_none_match),
+        if_not_exists: opts.if_not_exists,
+        concurrent: opts.concurrent,
+        chunk: optional_usize(opts.chunk),
+    }
+}
+
+fn copy_options(opts: ffi::FfiCopyOptions) -> od::options::CopyOptions {
+    od::options::CopyOptions {
+        if_not_exists: opts.if_not_exists,
+        if_match: optional_string(opts.if_match),
+        source_version: optional_string(opts.source_version),
+        source_content_length_hint: optional_u64(opts.source_content_length_hint),
+        concurrent: opts.concurrent,
+        chunk: optional_usize(opts.chunk),
+    }
+}
+
+fn rename_options(opts: ffi::FfiRenameOptions) -> od::options::RenameOptions {
+    od::options::RenameOptions {
+        if_not_exists: opts.if_not_exists,
+    }
+}
+
+fn delete_options(opts: ffi::FfiDeleteOptions) -> od::options::DeleteOptions {
+    od::options::DeleteOptions {
+        version: optional_string(opts.version),
+        recursive: opts.recursive,
+    }
+}
+
+fn list_options(opts: ffi::FfiListOptions) -> od::options::ListOptions {
+    od::options::ListOptions {
+        limit: optional_usize(opts.limit),
+        start_after: optional_string(opts.start_after),
+        recursive: opts.recursive,
+        versions: opts.versions,
+        deleted: opts.deleted,
+    }
+}
+
 impl Operator {
     fn read(&self, path: &str) -> Result<Vec<u8>> {
         Ok(self.0.read(path)?.to_vec())
     }
 
+    fn read_options(&self, path: &str, opts: ffi::FfiReadOptions) -> Result<Vec<u8>> {
+        Ok(self.0.read_options(path, read_options(opts)?)?.to_vec())
+    }
+
     fn write(&self, path: &str, bs: Vec<u8>) -> Result<()> {
         Ok(self.0.write(path, bs).map(|_| ())?)
+    }
+
+    fn write_options(&self, path: &str, bs: Vec<u8>, opts: ffi::FfiWriteOptions) -> Result<()> {
+        Ok(self
+            .0
+            .write_options(path, bs, write_options(opts))
+            .map(|_| ())?)
     }
 
     fn exists(&self, path: &str) -> Result<bool> {
@@ -298,8 +579,17 @@ impl Operator {
         Ok(())
     }
 
+    fn copy_options(&self, src: &str, dst: &str, opts: ffi::FfiCopyOptions) -> Result<()> {
+        self.0.copy_options(src, dst, copy_options(opts))?;
+        Ok(())
+    }
+
     fn rename(&self, src: &str, dst: &str) -> Result<()> {
         Ok(self.0.rename(src, dst)?)
+    }
+
+    fn rename_options(&self, src: &str, dst: &str, opts: ffi::FfiRenameOptions) -> Result<()> {
+        Ok(self.0.rename_options(src, dst, rename_options(opts))?)
     }
 
     // We can't name it to delete because it's a keyword in C++
@@ -307,12 +597,29 @@ impl Operator {
         Ok(self.0.delete(path)?)
     }
 
+    fn remove_options(&self, path: &str, opts: ffi::FfiDeleteOptions) -> Result<()> {
+        Ok(self.0.delete_options(path, delete_options(opts))?)
+    }
+
     fn stat(&self, path: &str) -> Result<ffi::Metadata> {
         Ok(self.0.stat(path)?.into())
     }
 
+    fn stat_options(&self, path: &str, opts: ffi::FfiStatOptions) -> Result<ffi::Metadata> {
+        Ok(self.0.stat_options(path, stat_options(opts)?)?.into())
+    }
+
     fn list(&self, path: &str) -> Result<Vec<ffi::Entry>> {
         Ok(self.0.list(path)?.into_iter().map(Into::into).collect())
+    }
+
+    fn list_options(&self, path: &str, opts: ffi::FfiListOptions) -> Result<Vec<ffi::Entry>> {
+        Ok(self
+            .0
+            .list_options(path, list_options(opts))?
+            .into_iter()
+            .map(Into::into)
+            .collect())
     }
 
     fn reader(&self, path: &str) -> Result<*mut Reader> {
@@ -325,13 +632,51 @@ impl Operator {
         Ok(reader)
     }
 
+    fn reader_options(&self, path: &str, opts: ffi::FfiReaderOptions) -> Result<*mut Reader> {
+        let opts = reader_options(opts)?;
+        let content_length = match opts.content_length_hint {
+            Some(v) => v,
+            None => {
+                let stat_opts = od::options::StatOptions {
+                    version: opts.version.clone(),
+                    if_match: opts.if_match.clone(),
+                    if_none_match: opts.if_none_match.clone(),
+                    if_modified_since: opts.if_modified_since,
+                    if_unmodified_since: opts.if_unmodified_since,
+                    ..Default::default()
+                };
+                self.0.stat_options(path, stat_opts)?.content_length()
+            }
+        };
+        let reader = Box::into_raw(Box::new(Reader(
+            self.0
+                .reader_options(path, opts)?
+                .into_std_read(0..content_length)?,
+        )));
+        Ok(reader)
+    }
+
     fn lister(&self, path: &str) -> Result<*mut Lister> {
         let lister = Box::into_raw(Box::new(Lister(self.0.lister(path)?)));
         Ok(lister)
     }
 
+    fn lister_options(&self, path: &str, opts: ffi::FfiListOptions) -> Result<*mut Lister> {
+        let lister = Box::into_raw(Box::new(Lister(
+            self.0.lister_options(path, list_options(opts))?,
+        )));
+        Ok(lister)
+    }
+
     fn writer(&self, path: &str) -> Result<*mut Writer> {
         let writer = Box::into_raw(Box::new(Writer(self.0.writer(path)?)));
+        Ok(writer)
+    }
+
+    fn writer_options(&self, path: &str, opts: ffi::FfiWriteOptions) -> Result<*mut Writer> {
+        let writer = Box::into_raw(Box::new(Writer(
+            self.0.writer_options(path, write_options(opts))?,
+        )));
         Ok(writer)
     }
 

--- a/bindings/cpp/src/operator.cpp
+++ b/bindings/cpp/src/operator.cpp
@@ -442,12 +442,10 @@ opendal::Capability opendal::Operator::Info() {
       .read = op_info.read,
       .read_with_if_match = op_info.read_with_if_match,
       .read_with_if_none_match = op_info.read_with_if_none_match,
-      .read_with_override_cache_control =
-          op_info.read_with_override_cache_control,
+      .read_with_override_cache_control = op_info.read_with_override_cache_control,
       .read_with_override_content_disposition =
           op_info.read_with_override_content_disposition,
-      .read_with_override_content_type =
-          op_info.read_with_override_content_type,
+      .read_with_override_content_type = op_info.read_with_override_content_type,
       .write = op_info.write,
       .write_can_multi = op_info.write_can_multi,
       .write_can_empty = op_info.write_can_empty,

--- a/bindings/cpp/src/operator.cpp
+++ b/bindings/cpp/src/operator.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <ctime>
 
@@ -27,6 +28,165 @@
 #include "utils/rust_converter.hpp"
 
 namespace opendal {
+
+namespace {
+
+ffi::OptionalString ToFfiOptionalString(
+    const std::optional<std::string> &value) {
+  if (value.has_value()) {
+    return ffi::OptionalString{true, utils::rust_string(*value)};
+  }
+  return ffi::OptionalString{false, rust::String()};
+}
+
+ffi::OptionalU64 ToFfiOptionalU64(const std::optional<std::uint64_t> &value) {
+  if (value.has_value()) {
+    return ffi::OptionalU64{true, *value};
+  }
+  return ffi::OptionalU64{false, 0};
+}
+
+ffi::OptionalUsize ToFfiOptionalUsize(const std::optional<std::size_t> &value) {
+  if (value.has_value()) {
+    return ffi::OptionalUsize{true, *value};
+  }
+  return ffi::OptionalUsize{false, 0};
+}
+
+ffi::OptionalTimestamp ToFfiOptionalTimestamp(
+    const std::optional<std::chrono::system_clock::time_point> &value) {
+  if (!value.has_value()) {
+    return ffi::OptionalTimestamp{false, 0, 0};
+  }
+
+  auto duration = value->time_since_epoch();
+  auto seconds_duration =
+      std::chrono::duration_cast<std::chrono::seconds>(duration);
+  auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                         duration - seconds_duration)
+                         .count();
+  auto seconds = seconds_duration.count();
+  if (nanoseconds < 0) {
+    --seconds;
+    nanoseconds += 1000000000;
+  }
+
+  return ffi::OptionalTimestamp{true, static_cast<std::int64_t>(seconds),
+                                static_cast<std::uint32_t>(nanoseconds)};
+}
+
+ffi::FfiBytesRange ToFfiBytesRange(const ReadRange &range) {
+  return ffi::FfiBytesRange{static_cast<std::uint8_t>(range.type), range.start,
+                            range.end};
+}
+
+rust::Vec<ffi::HashMapValue> ToFfiHashMap(
+    const std::unordered_map<std::string, std::string> &map) {
+  rust::Vec<ffi::HashMapValue> values;
+  values.reserve(map.size());
+  for (const auto &[key, value] : map) {
+    values.push_back({utils::rust_string(key), utils::rust_string(value)});
+  }
+  return values;
+}
+
+ffi::FfiStatOptions ToFfiOptions(const StatOptions &options) {
+  return ffi::FfiStatOptions{
+      ToFfiOptionalString(options.version),
+      ToFfiOptionalString(options.if_match),
+      ToFfiOptionalString(options.if_none_match),
+      ToFfiOptionalTimestamp(options.if_modified_since),
+      ToFfiOptionalTimestamp(options.if_unmodified_since),
+      ToFfiOptionalString(options.override_content_type),
+      ToFfiOptionalString(options.override_cache_control),
+      ToFfiOptionalString(options.override_content_disposition),
+  };
+}
+
+ffi::FfiReadOptions ToFfiOptions(const ReadOptions &options) {
+  return ffi::FfiReadOptions{
+      ToFfiBytesRange(options.range),
+      ToFfiOptionalString(options.version),
+      ToFfiOptionalString(options.if_match),
+      ToFfiOptionalString(options.if_none_match),
+      ToFfiOptionalTimestamp(options.if_modified_since),
+      ToFfiOptionalTimestamp(options.if_unmodified_since),
+      ToFfiOptionalU64(options.content_length_hint),
+      options.concurrent,
+      ToFfiOptionalUsize(options.chunk),
+      ToFfiOptionalUsize(options.gap),
+      ToFfiOptionalString(options.override_content_type),
+      ToFfiOptionalString(options.override_cache_control),
+      ToFfiOptionalString(options.override_content_disposition),
+  };
+}
+
+ffi::FfiReaderOptions ToFfiOptions(const ReaderOptions &options) {
+  return ffi::FfiReaderOptions{
+      ToFfiOptionalString(options.version),
+      ToFfiOptionalString(options.if_match),
+      ToFfiOptionalString(options.if_none_match),
+      ToFfiOptionalTimestamp(options.if_modified_since),
+      ToFfiOptionalTimestamp(options.if_unmodified_since),
+      ToFfiOptionalU64(options.content_length_hint),
+      options.concurrent,
+      ToFfiOptionalUsize(options.chunk),
+      ToFfiOptionalUsize(options.gap),
+      options.prefetch,
+  };
+}
+
+ffi::FfiWriteOptions ToFfiOptions(const WriteOptions &options) {
+  auto metadata = options.user_metadata.has_value()
+                      ? ToFfiHashMap(*options.user_metadata)
+                      : rust::Vec<ffi::HashMapValue>();
+  return ffi::FfiWriteOptions{
+      options.append,
+      ToFfiOptionalString(options.cache_control),
+      ToFfiOptionalString(options.content_type),
+      ToFfiOptionalString(options.content_disposition),
+      ToFfiOptionalString(options.content_encoding),
+      options.user_metadata.has_value(),
+      std::move(metadata),
+      ToFfiOptionalString(options.if_match),
+      ToFfiOptionalString(options.if_none_match),
+      options.if_not_exists,
+      options.concurrent,
+      ToFfiOptionalUsize(options.chunk),
+  };
+}
+
+ffi::FfiCopyOptions ToFfiOptions(const CopyOptions &options) {
+  return ffi::FfiCopyOptions{
+      options.if_not_exists,
+      ToFfiOptionalString(options.if_match),
+      ToFfiOptionalString(options.source_version),
+      ToFfiOptionalU64(options.source_content_length_hint),
+      options.concurrent,
+      ToFfiOptionalUsize(options.chunk),
+  };
+}
+
+ffi::FfiRenameOptions ToFfiOptions(const RenameOptions &options) {
+  return ffi::FfiRenameOptions{options.if_not_exists};
+}
+
+ffi::FfiDeleteOptions ToFfiOptions(const DeleteOptions &options) {
+  return ffi::FfiDeleteOptions{ToFfiOptionalString(options.version),
+                               options.recursive};
+}
+
+ffi::FfiListOptions ToFfiOptions(const ListOptions &options) {
+  return ffi::FfiListOptions{
+      ToFfiOptionalUsize(options.limit),
+      ToFfiOptionalString(options.start_after),
+      options.recursive,
+      options.versions,
+      options.deleted,
+  };
+}
+
+}  // namespace
 
 std::optional<std::string> parse_optional_string(ffi::OptionalString &&s) {
   if (s.has_value) {
@@ -152,10 +312,23 @@ std::string Operator::Read(std::string_view path) {
   return {rust_vec.begin(), rust_vec.end()};
 }
 
+std::string Operator::Read(std::string_view path, const ReadOptions &options) {
+  auto rust_vec =
+      operator_->read_options(utils::rust_str(path), ToFfiOptions(options));
+  return {rust_vec.begin(), rust_vec.end()};
+}
+
 void Operator::Write(std::string_view path, std::string_view data) {
   rust::Vec<uint8_t> vec;
   std::copy(data.begin(), data.end(), std::back_inserter(vec));
   operator_->write(utils::rust_str(path), vec);
+}
+
+void Operator::Write(std::string_view path, std::string_view data,
+                     const WriteOptions &options) {
+  rust::Vec<uint8_t> vec;
+  std::copy(data.begin(), data.end(), std::back_inserter(vec));
+  operator_->write_options(utils::rust_str(path), vec, ToFfiOptions(options));
 }
 
 bool Operator::Exists(std::string_view path) {
@@ -172,16 +345,37 @@ void Operator::Copy(std::string_view src, std::string_view dst) {
   operator_->copy(utils::rust_str(src), utils::rust_str(dst));
 }
 
+void Operator::Copy(std::string_view src, std::string_view dst,
+                    const CopyOptions &options) {
+  operator_->copy_options(utils::rust_str(src), utils::rust_str(dst),
+                          ToFfiOptions(options));
+}
+
 void Operator::Rename(std::string_view src, std::string_view dst) {
   operator_->rename(utils::rust_str(src), utils::rust_str(dst));
+}
+
+void Operator::Rename(std::string_view src, std::string_view dst,
+                      const RenameOptions &options) {
+  operator_->rename_options(utils::rust_str(src), utils::rust_str(dst),
+                            ToFfiOptions(options));
 }
 
 void Operator::Remove(std::string_view path) {
   operator_->remove(utils::rust_str(path));
 }
 
+void Operator::Remove(std::string_view path, const DeleteOptions &options) {
+  operator_->remove_options(utils::rust_str(path), ToFfiOptions(options));
+}
+
 Metadata Operator::Stat(std::string_view path) {
   return parse_meta_data(operator_->stat(utils::rust_str(path)));
+}
+
+Metadata Operator::Stat(std::string_view path, const StatOptions &options) {
+  return parse_meta_data(
+      operator_->stat_options(utils::rust_str(path), ToFfiOptions(options)));
 }
 
 std::vector<Entry> Operator::List(std::string_view path) {
@@ -196,16 +390,46 @@ std::vector<Entry> Operator::List(std::string_view path) {
   return entries;
 }
 
+std::vector<Entry> Operator::List(std::string_view path,
+                                  const ListOptions &options) {
+  auto rust_vec =
+      operator_->list_options(utils::rust_str(path), ToFfiOptions(options));
+
+  std::vector<Entry> entries;
+  entries.reserve(rust_vec.size());
+  for (auto &&entry : rust_vec) {
+    entries.emplace_back(utils::parse_entry(std::move(entry)));
+  }
+
+  return entries;
+}
+
 Lister Operator::GetLister(std::string_view path) {
   return operator_->lister(utils::rust_str(path));
+}
+
+Lister Operator::GetLister(std::string_view path, const ListOptions &options) {
+  return operator_->lister_options(utils::rust_str(path),
+                                   ToFfiOptions(options));
 }
 
 Reader Operator::GetReader(std::string_view path) {
   return operator_->reader(utils::rust_str(path));
 }
 
+Reader Operator::GetReader(std::string_view path,
+                           const ReaderOptions &options) {
+  return operator_->reader_options(utils::rust_str(path),
+                                   ToFfiOptions(options));
+}
+
 Writer Operator::GetWriter(std::string_view path) {
   return operator_->writer(utils::rust_str(path));
+}
+
+Writer Operator::GetWriter(std::string_view path, const WriteOptions &options) {
+  return operator_->writer_options(utils::rust_str(path),
+                                   ToFfiOptions(options));
 }
 
 }  // namespace opendal
@@ -218,10 +442,12 @@ opendal::Capability opendal::Operator::Info() {
       .read = op_info.read,
       .read_with_if_match = op_info.read_with_if_match,
       .read_with_if_none_match = op_info.read_with_if_none_match,
-      .read_with_override_cache_control = op_info.read_with_override_cache_control,
+      .read_with_override_cache_control =
+          op_info.read_with_override_cache_control,
       .read_with_override_content_disposition =
           op_info.read_with_override_content_disposition,
-      .read_with_override_content_type = op_info.read_with_override_content_type,
+      .read_with_override_content_type =
+          op_info.read_with_override_content_type,
       .write = op_info.write,
       .write_can_multi = op_info.write_can_multi,
       .write_can_empty = op_info.write_can_empty,

--- a/bindings/cpp/tests/basic_test.cpp
+++ b/bindings/cpp/tests/basic_test.cpp
@@ -19,9 +19,9 @@
 
 #include <ctime>
 #include <random>
-#include <set>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "framework/test_framework.hpp"
@@ -79,7 +79,7 @@ OPENDAL_TEST_F(OpenDALTest, BasicTest) {
   op_.Write(list_file_path, data);
   auto entries = op_.List(dir_path);
   EXPECT_EQ(entries.size(), 2);
-  std::set<std::string> paths;
+  std::unordered_set<std::string> paths;
   for (const auto &entry : entries) {
     paths.insert(entry.path);
   }
@@ -159,7 +159,7 @@ OPENDAL_TEST_F(OpenDALTest, ListerTest) {
 
   auto lister = op_.GetLister("test_dir/");
 
-  std::set<std::string> paths;
+  std::unordered_set<std::string> paths;
   for (const auto &entry : lister) {
     paths.insert(entry.path);
   }
@@ -169,4 +169,132 @@ OPENDAL_TEST_F(OpenDALTest, ListerTest) {
   EXPECT_TRUE(paths.find(test2_path) != paths.end());
 }
 
-} // namespace opendal::test
+TEST(OpenDALOptionsTest, ReadOptions) {
+  opendal::Operator op("memory");
+  op.Write("read_options", "0123456789");
+
+  opendal::ReadOptions options;
+  options.range = opendal::ReadRange::Range(2, 5);
+  EXPECT_EQ(op.Read("read_options", options), "234");
+
+  options.range = opendal::ReadRange::Offset(7);
+  EXPECT_EQ(op.Read("read_options", options), "789");
+
+  options.range = opendal::ReadRange::Suffix(2);
+  EXPECT_EQ(op.Read("read_options", options), "89");
+}
+
+TEST(OpenDALOptionsTest, ReaderOptions) {
+  opendal::Operator op("memory");
+  op.Write("reader_options", "0123456789");
+
+  opendal::ReaderOptions options;
+  options.content_length_hint = 10;
+  options.concurrent = 2;
+  options.chunk = 4;
+  options.prefetch = 1;
+
+  auto reader = op.GetReader("reader_options", options);
+  std::string data(4, 0);
+  EXPECT_EQ(reader.Read(data.data(), data.size()), 4);
+  EXPECT_EQ(data, "0123");
+}
+
+TEST(OpenDALOptionsTest, WriteOptions) {
+  opendal::Operator op("memory");
+
+  opendal::WriteOptions options;
+  options.cache_control = "max-age=60";
+  options.content_type = "text/plain";
+  options.content_disposition = "inline";
+  options.content_encoding = "identity";
+  options.user_metadata = std::unordered_map<std::string, std::string>{
+      {"owner", "cpp-test"},
+  };
+  options.if_not_exists = true;
+  options.concurrent = 2;
+  options.chunk = 1024;
+
+  op.Write("write_options", "hello", options);
+
+  auto metadata = op.Stat("write_options");
+  ASSERT_TRUE(metadata.cache_control.has_value());
+  EXPECT_EQ(*metadata.cache_control, "max-age=60");
+  ASSERT_TRUE(metadata.content_type.has_value());
+  EXPECT_EQ(*metadata.content_type, "text/plain");
+  ASSERT_TRUE(metadata.content_disposition.has_value());
+  EXPECT_EQ(*metadata.content_disposition, "inline");
+  ASSERT_TRUE(metadata.content_encoding.has_value());
+  EXPECT_EQ(*metadata.content_encoding, "identity");
+
+  EXPECT_THROW(op.Write("write_options", "overwrite", options), std::exception);
+}
+
+TEST(OpenDALOptionsTest, WriterOptions) {
+  opendal::Operator op("memory");
+
+  opendal::WriteOptions options;
+  options.content_type = "application/octet-stream";
+  options.chunk = 1024;
+
+  auto writer = op.GetWriter("writer_options", options);
+  writer.Write("hello ");
+  writer.Write("world");
+  writer.Close();
+
+  EXPECT_EQ(op.Read("writer_options"), "hello world");
+  auto metadata = op.Stat("writer_options");
+  ASSERT_TRUE(metadata.content_type.has_value());
+  EXPECT_EQ(*metadata.content_type, "application/octet-stream");
+}
+
+TEST(OpenDALOptionsTest, ListOptions) {
+  opendal::Operator op("memory");
+  op.CreateDir("list_options/");
+  op.CreateDir("list_options/nested/");
+  op.Write("list_options/nested/file", "hello");
+
+  opendal::ListOptions options;
+  options.recursive = true;
+  options.limit = 16;
+  options.start_after = "list_options/";
+  options.versions = true;
+  options.deleted = true;
+
+  auto entries = op.List("list_options/", options);
+  std::unordered_set<std::string> paths;
+  for (const auto &entry : entries) {
+    paths.insert(entry.path);
+  }
+  EXPECT_TRUE(paths.find("list_options/nested/file") != paths.end());
+
+  auto lister = op.GetLister("list_options/", options);
+  paths.clear();
+  for (const auto &entry : lister) {
+    paths.insert(entry.path);
+  }
+  EXPECT_TRUE(paths.find("list_options/nested/file") != paths.end());
+}
+
+TEST(OpenDALOptionsTest, DeleteOptions) {
+  opendal::Operator op("memory");
+  op.CreateDir("delete_options/");
+  op.Write("delete_options/file", "hello");
+
+  opendal::DeleteOptions options;
+  options.recursive = true;
+  op.Remove("delete_options/", options);
+
+  EXPECT_FALSE(op.Exists("delete_options/file"));
+}
+
+TEST(OpenDALOptionsTest, StatOptions) {
+  opendal::Operator op("memory");
+  op.Write("stat_options", "hello");
+
+  opendal::StatOptions stat_options;
+  auto metadata = op.Stat("stat_options", stat_options);
+  EXPECT_EQ(metadata.content_length, 5);
+}
+
+}  // namespace opendal::test

--- a/bindings/cpp/tests/basic_test.cpp
+++ b/bindings/cpp/tests/basic_test.cpp
@@ -297,4 +297,4 @@ TEST(OpenDALOptionsTest, StatOptions) {
   EXPECT_EQ(metadata.content_length, 5);
 }
 
-}  // namespace opendal::test
+} // namespace opendal::test


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/7987

# Rationale for this change

C++ binding should have the same feature sets as rust core.

# What changes are included in this PR?

This PR exposes all operations options to **synchronous** C++ operations.

# Are there any user-facing changes?

Yes, new APIs are added to C++ binding.

# AI Usage Statement

GPT-5.5 made the code change, GPT-5.6 and manual review.
