### PR TITLE
fix: Update missing HuggingFace write capabilities

### DIFF
--- a/core/services/hf/src/backend.rs
+++ b/core/services/hf/src/backend.rs
@@ -248,6 +248,8 @@ impl Builder for HfBuilder {
             stat: true,
             read: true,
             write: token.is_some(),
+            write_can_multi: token.is_some(),
+            write_can_append: token.is_some(),
             delete: token.is_some(),
             delete_max_size: Some(100),
             list: true,


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #7991 .

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This change updates the missing capabilities of the HuggingFace service regarding `write_can_multi` and `write_can_append`.

According to the definitions of both flags, the writes provided by HuggingFace fit the criteria for "multiple writes allowed for the same object", and subsequent buffers are written sequentially fitting the criteria for append.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The addition of the capabilities gated by token, matching that of the base write capability.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

N/A

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->

N/A