### PR TITLE
docs(services/s3): document SeaweedFS as a compatible service

### DIFF
--- a/core/services/s3/src/compatible_services.md
+++ b/core/services/s3/src/compatible_services.md
@@ -151,3 +151,26 @@ R2 has the following capability differences from S3:
 Ceph supports a RESTful API that is compatible with the basic data access model of the Amazon S3 API.
 
 For more information, refer: <https://docs.ceph.com/en/latest/radosgw/s3/>
+
+### SeaweedFS
+
+[SeaweedFS](https://github.com/seaweedfs/seaweedfs) is an open-source distributed storage system that serves an S3 API from its gateway.
+
+To connect to SeaweedFS, we need to set:
+
+- `endpoint`: The endpoint of the SeaweedFS S3 gateway, for example: `http://127.0.0.1:8333`
+- `region`: The region of SeaweedFS. SeaweedFS ignores it, so set it to `us-east-1` when a region is required.
+- `bucket`: The bucket name.
+
+```rust,ignore
+builder.endpoint("http://127.0.0.1:8333");
+builder.region("us-east-1");
+builder.bucket("<bucket_name>");
+```
+
+Credentials are standard S3 access keys. A gateway started without any configured identity accepts anonymous requests, so `allow_anonymous` also works.
+
+SeaweedFS has the following capability differences from S3:
+
+- `write_can_append`: SeaweedFS doesn't support appending to an existing object through the S3 API. Please override it to `false`.
+- Object versioning is per-bucket and off by default. Enable it with `PutBucketVersioning` before relying on the version capabilities, or override them to `false`.


### PR DESCRIPTION
# Which issue does this PR close?

No issue. This documents an S3-compatible service that already works with the `s3` service.

# Rationale for this change

SeaweedFS serves an S3 API from its gateway and is commonly deployed as a self-hosted S3 backend, but it is not listed under Compatible Services, so users have to work out the endpoint, region and credential setup themselves.

# What changes are included in this PR?

A SeaweedFS section in `core/services/s3/src/compatible_services.md` covering the endpoint/region/bucket settings, credentials, and the differences from S3.

The capability notes come from running the behavior suite against SeaweedFS 4.40: 124/124 pass with `write_can_append=false` plus the version-related overrides, which apply because bucket versioning is off by default. With versioning enabled on the bucket, two tests still fail against 4.40; both are SeaweedFS bugs and have fixes open upstream (seaweedfs/seaweedfs#10496 and seaweedfs/seaweedfs#10497).

# Are there any user-facing changes?

Documentation only. No API or behavior change.

# AI Usage Statement

Prepared with Claude Code (Claude Opus 5). The behavior-test runs backing the capability notes were executed locally and their results checked by hand.