### PR TITLE
ci(services/s3): run behavior tests against SeaweedFS

### DIFF
--- a/.github/services/s3/seaweedfs_s3/action.yml
+++ b/.github/services/s3/seaweedfs_s3/action.yml
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: seaweedfs_s3
+description: 'Behavior test for SeaweedFS S3.'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup SeaweedFS Server
+      shell: bash
+      working-directory: fixtures/s3
+      run: docker compose -f docker-compose-seaweedfs.yml up -d --wait
+
+    - name: Setup
+      shell: bash
+      run: |
+        cat << EOF >> $GITHUB_ENV
+        OPENDAL_S3_BUCKET=test
+        OPENDAL_S3_ENDPOINT=http://127.0.0.1:8333
+        OPENDAL_S3_ACCESS_KEY_ID=seaweedfsadmin
+        OPENDAL_S3_SECRET_ACCESS_KEY=seaweedfsadmin
+        OPENDAL_S3_REGION=us-east-1
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=stat_with_version=false,read_with_version=false,delete_with_version=false,list_with_versions=false,list_with_deleted=false,copy_with_source_version=false,write_can_append=false
+        EOF

--- a/fixtures/s3/docker-compose-seaweedfs.yml
+++ b/fixtures/s3/docker-compose-seaweedfs.yml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+services:
+  seaweedfs:
+    image: chrislusf/seaweedfs:4.40
+    ports:
+      - 8333:8333
+    # `mini` runs the whole cluster in one process. Only the S3 gateway is used
+    # here, and telemetry is off so CI runs are not reported as clusters.
+    command: >
+      mini
+      -dir=/data
+      -bucket=test
+      -master.telemetry=false
+      -webdav=false
+      -admin.ui=false
+      -s3.port.iceberg=0
+    environment:
+      AWS_ACCESS_KEY_ID: "seaweedfsadmin"
+      AWS_SECRET_ACCESS_KEY: "seaweedfsadmin"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8333/status"]
+      interval: 2s
+      timeout: 5s
+      retries: 30


### PR DESCRIPTION
# Which issue does this PR close?

No issue. This adds behavior-test coverage for an S3-compatible service.

# Rationale for this change

SeaweedFS is a widely deployed self-hosted S3 backend with no CI signal in OpenDAL today. It runs as a single container, so covering it costs one job.

# What changes are included in this PR?

- `fixtures/s3/docker-compose-seaweedfs.yml`: SeaweedFS 4.40, pinned. `weed mini` runs the whole cluster in one process; `-bucket=test` creates the test bucket on startup, so no extra CLI step is needed, and the healthcheck lets `up --wait` do the waiting. Telemetry is off so CI runs are not reported as clusters upstream.
- `.github/services/s3/seaweedfs_s3/action.yml`: endpoint, credentials and capability overrides.

Verified locally exactly as CI runs it: `docker compose -f docker-compose-seaweedfs.yml up -d --wait` to healthy, then `OPENDAL_TEST=s3 cargo test behavior --features tests,services-s3` with the env from the action: 124 passed, 0 failed.

The overrides are the same as `0_minio_s3` minus `copy_with_if_not_exists` and `copy_with_if_match`, which SeaweedFS supports. Object versioning is per-bucket and off by default, hence the version overrides here; a `seaweedfs_s3_with_versioning` setup is worth adding once a SeaweedFS release carries seaweedfs/seaweedfs#10496 and seaweedfs/seaweedfs#10497.

# Are there any user-facing changes?

No.

# AI Usage Statement

Prepared with Claude Code (Claude Opus 5). The fixture and action were exercised locally end to end and the results checked by hand.