### PR TITLE
fix(services/hf): stop advertising append support

### DIFF
--- a/core/services/hf/src/backend.rs
+++ b/core/services/hf/src/backend.rs
@@ -249,7 +249,6 @@ impl Builder for HfBuilder {
             read: true,
             write: token.is_some(),
             write_can_multi: token.is_some(),
-            write_can_append: token.is_some(),
             delete: token.is_some(),
             delete_max_size: Some(100),
             list: true,


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up to #7992.

# Rationale for this change

`write_can_append` means that a write appends new data to the end of an existing object. The Hugging Face writer ignores the append option, starts a new XET upload, and registers that upload as the file, so advertising append support is incorrect.

# What changes are included in this PR?

Stop advertising `write_can_append` for authenticated Hugging Face operators. Keep `write_can_multi`, which describes multiple write calls through the same writer.

# Are there any user-facing changes?

Hugging Face operators now report `write_can_append` as false. Append requests return `Unsupported` instead of being accepted as a supported operation.

# AI Usage Statement

Used OpenAI Codex (GPT-5) to inspect the capability contract and Hugging Face write path and prepare this fix.
