### PR TITLE
fix(bindings/cpp): construct reader with options

### DIFF
--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -648,10 +648,9 @@ impl Operator {
                 self.0.stat_options(path, stat_opts)?.content_length()
             }
         };
-        let reader = Box::into_raw(Box::new(Reader(
-            self.0
-                .reader_options(path, opts)?
-                .into_std_read(0..content_length)?,
+        let reader = Box::into_raw(Box::new(Reader::new(
+            self.0.reader_options(path, opts)?,
+            content_length,
         )));
         Ok(reader)
     }


### PR DESCRIPTION
# Which issue does this PR close?

None. This fixes the main-branch regression introduced when #7989 was merged after #7986.

# Rationale for this change

`Bindings Cpp CI` fails while compiling `reader_options` because it still constructs `Reader` using the old tuple-struct representation. #7986 replaced that representation with a stateful reader and a `Reader::new` constructor.

# What changes are included in this PR?

Construct the options-based reader with `Reader::new`, passing the blocking reader and the resolved content length. This matches the existing non-options reader path.

# Are there any user-facing changes?

No. This restores the C++ binding build and the existing `ReaderOptions` functionality.

# Tests

- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- Synchronous C++ build and tests: 81 passed.
- Async-enabled C++ build and tests: 87 passed.

# AI Usage Statement

OpenAI Codex (GPT-5) was used to diagnose, implement, and validate this change.
