### PR TITLE
ci(bindings/dotnet): reduce native library size and simplify test workflow

### DIFF
--- a/.github/workflows/ci_bindings_dotnet.yml
+++ b/.github/workflows/ci_bindings_dotnet.yml
@@ -44,10 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Setup dotnet toolchain
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.0.x'
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
         with:
@@ -74,15 +70,14 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        dotnet-version:
-          - '8.0.x'
-          - '10.0.x'
     steps:
       - uses: actions/checkout@v7
       - name: Setup dotnet toolchain
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ matrix.dotnet-version }}
+          dotnet-version: |
+            8.0.x
+            10.0.x
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
         with:
@@ -91,11 +86,13 @@ jobs:
           need-rocksdb: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build & Test
+      - name: Build native library
         working-directory: "bindings/dotnet"
-        run: |
-          cargo build
-          dotnet test -f ${{ matrix.dotnet-version == '8.0.x' && 'net8.0' || 'net10.0' }}
+        run: cargo build
+
+      - name: Test
+        working-directory: "bindings/dotnet"
+        run: dotnet test
         env:
           OPENDAL_TEST: memory
 
@@ -104,5 +101,7 @@ jobs:
       # bad docs. It uses the in-memory service, so it needs no credentials.
       - name: Run guide example
         working-directory: "bindings/dotnet"
+        shell: bash
         run: |
-          dotnet run --project examples/GettingStarted -f ${{ matrix.dotnet-version == '8.0.x' && 'net8.0' || 'net10.0' }}
+          dotnet run --project examples/GettingStarted -f net8.0
+          dotnet run --project examples/GettingStarted -f net10.0

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -120,3 +120,9 @@ features = [
   "services-sftp",
 ]
 path = "../../core"
+
+[profile.release]
+codegen-units = 1
+lto = "fat"
+panic = "abort"
+strip = true


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The native library shipped by the .NET binding is too large.
The crate never set a release profile, so it was built with cargo's defaults at 68.16 MB.


# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds a release profile to `bindings/dotnet/Cargo.toml`:

```toml
[profile.release]
codegen-units = 1
lto = "fat"
panic = "abort"
strip = true
```

Measured on Windows x86_64:

| | size |
| --- | --- |
| before | 68.16 MB |
| after | **30.72 MB** (-54.9%) |

CI is also simplified.
A single job now runs both the net8.0 and net10.0 tests, so the native library no longer has to be rebuilt once per target framework.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

None

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->

Written with Claude Code (Opus 5).