### PR TITLE
feat(binding/go): add deleter

### DIFF
--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -923,6 +923,50 @@ typedef struct opendal_result_operator_copier {
 } opendal_result_operator_copier;
 
 /**
+ * \brief opendal_deleter removes many paths from storage.
+ *
+ * opendal_deleter queues paths and hands them to the service, using batch
+ * deletion when the service supports it. `opendal_deleter_delete` only queues a
+ * path: the delete may still be pending when the call returns, and it is
+ * `opendal_deleter_close` that flushes the queue and waits for every queued
+ * path to be removed. Treat a path as deleted only after
+ * `opendal_deleter_close` returns NULL.
+ *
+ * Users construct a deleter by `opendal_operator_deleter` and release it with
+ * `opendal_deleter_free`.
+ *
+ * @see opendal_operator_deleter()
+ * @see opendal_deleter_delete()
+ * @see opendal_deleter_close()
+ */
+typedef struct opendal_deleter {
+  /**
+   * The pointer to the opendal::blocking::Deleter in the Rust code.
+   * Only used to check whether the deleter is NULL.
+   */
+  void *inner;
+} opendal_deleter;
+
+/**
+ * \brief The result type returned by opendal_operator_deleter().
+ *
+ * Fields:
+ * * `deleter`: the deleter used to remove many paths by calling
+ *   opendal_deleter_delete() repeatedly; only valid when `error` is null.
+ * * `error`: the error of the operation; null when the operation succeeds.
+ */
+typedef struct opendal_result_operator_deleter {
+  /**
+   * The pointer for opendal_deleter
+   */
+  struct opendal_deleter *deleter;
+  /**
+   * The error, if ok, it is null
+   */
+  struct opendal_error *error;
+} opendal_result_operator_deleter;
+
+/**
  * \brief Metadata for **operator**, users can use this metadata to get information
  * of operator.
  */
@@ -2387,6 +2431,25 @@ struct opendal_result_operator_copier opendal_operator_copier_with(const struct 
                                                                    const struct opendal_copy_options *opts);
 
 /**
+ * \brief Blocking create a deleter to remove many paths.
+ *
+ * The returned deleter queues paths and uses the batch deletion support of the
+ * service when it has any. Call `opendal_deleter_delete` for every path, then
+ * `opendal_deleter_close` to flush the queue and wait for the deletions, and
+ * `opendal_deleter_free` to release it.
+ *
+ * @param op The opendal_operator created previously
+ * @see opendal_operator
+ * @see opendal_deleter
+ * @see opendal_result_operator_deleter
+ * @return opendal_result_operator_deleter, containing a deleter and an opendal_error.
+ * If the operation succeeds, the `deleter` field holds a valid deleter and the `error`
+ * field is null. Otherwise, the `deleter` will be null and the `error` will be set
+ * correspondingly.
+ */
+struct opendal_result_operator_deleter opendal_operator_deleter(const struct opendal_operator *op);
+
+/**
  * \brief Get information of underlying accessor.
  *
  * # Example
@@ -3108,6 +3171,73 @@ struct opendal_error *opendal_copier_abort(struct opendal_copier *self);
  * \brief Free the heap memory used by the opendal_copier.
  */
 void opendal_copier_free(struct opendal_copier *ptr);
+
+/**
+ * \brief Queue `path` for deletion.
+ *
+ * The path is not necessarily removed when this function returns: call
+ * `opendal_deleter_close` to flush the queue and wait for the deletions to
+ * complete.
+ *
+ * @param path The designated path you want to delete
+ * @return NULL if the path is queued, otherwise it contains the error code and
+ * error message.
+ *
+ * # Safety
+ *
+ * * The memory pointed to by `path` must contain a valid nul terminator at the
+ *   end of the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics
+ */
+struct opendal_error *opendal_deleter_delete(struct opendal_deleter *self, const char *path);
+
+/**
+ * \brief Queue `path` for deletion with options.
+ *
+ * This is the same as `opendal_deleter_delete` but accepts an
+ * `opendal_delete_options` to delete a specific version or to delete
+ * recursively. Pass NULL to use defaults.
+ *
+ * @param path The designated path you want to delete
+ * @param opts The options for this path; pass NULL to use defaults
+ * @see opendal_delete_options
+ * @return NULL if the path is queued, otherwise it contains the error code and
+ * error message.
+ *
+ * # Safety
+ *
+ * * The memory pointed to by `path` must contain a valid nul terminator at the
+ *   end of the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics
+ */
+struct opendal_error *opendal_deleter_delete_with(struct opendal_deleter *self,
+                                                  const char *path,
+                                                  const struct opendal_delete_options *opts);
+
+/**
+ * \brief Flush the deleter and wait until all queued paths are deleted.
+ *
+ * Call this before freeing the deleter to make sure the queued deletions
+ * happened. The deleter stays usable after a successful close.
+ *
+ * @return NULL if all queued paths are deleted, otherwise it contains the error
+ * code and error message.
+ */
+struct opendal_error *opendal_deleter_close(struct opendal_deleter *self);
+
+/**
+ * \brief Free the heap memory used by the opendal_deleter.
+ *
+ * Freeing a deleter drops the queued paths that were never flushed: call
+ * `opendal_deleter_close` first unless you mean to discard them.
+ */
+void opendal_deleter_free(struct opendal_deleter *ptr);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -945,6 +945,7 @@ typedef struct opendal_result_operator_copier {
  *
  * @see opendal_operator_deleter()
  * @see opendal_deleter_delete()
+ * @see opendal_deleter_delete_many()
  * @see opendal_deleter_delete_with()
  * @see opendal_deleter_flush()
  */
@@ -3202,6 +3203,44 @@ void opendal_copier_free(struct opendal_copier *ptr);
  * * If the `path` points to NULL, this function panics
  */
 struct opendal_error *opendal_deleter_delete(struct opendal_deleter *self, const char *path);
+
+/**
+ * \brief Queue multiple paths for deletion.
+ *
+ * This function queues every path in one call. Callers deleting a known set
+ * of paths should prefer it over calling `opendal_deleter_delete` in a loop:
+ * it crosses the C boundary once instead of once per path, and it queues the
+ * whole set inside a single blocking call rather than one per path. The paths
+ * are not necessarily removed when this function returns: call
+ * `opendal_deleter_flush` to hand the queue to the service and wait for the
+ * deletions to complete.
+ *
+ * Every path is queued with default options. Use `opendal_deleter_delete_with`
+ * for a path that needs its own version or recursive flag.
+ *
+ * Queueing stops at the first path the service rejects, so the paths after it
+ * are never queued.
+ *
+ * @param paths The designated paths you want to delete
+ * @param paths_len The number of paths in `paths`
+ * @return NULL if all paths are queued, otherwise it contains the error code
+ * and error message.
+ *
+ * # Safety
+ *
+ * * When `paths_len` is greater than zero, `paths` must point to an array of
+ *   `paths_len` pointers.
+ * * Every pointer in `paths` must point to a string with a valid nul
+ *   terminator.
+ *
+ * # Panic
+ *
+ * * If `paths` or any pointer in `paths` is NULL when `paths_len` is greater
+ *   than zero, this function panics.
+ */
+struct opendal_error *opendal_deleter_delete_many(struct opendal_deleter *self,
+                                                  const char *const *paths,
+                                                  uintptr_t paths_len);
 
 /**
  * \brief Queue `path` for deletion with options.

--- a/bindings/c/include/opendal.h
+++ b/bindings/c/include/opendal.h
@@ -927,6 +927,55 @@ typedef struct opendal_result_operator_copier {
 } opendal_result_operator_copier;
 
 /**
+ * \brief opendal_deleter removes many paths from storage.
+ *
+ * opendal_deleter queues paths and hands them to the service, using batch
+ * deletion when the service supports it. `opendal_deleter_delete` only queues a
+ * path: the delete may still be pending when the call returns, and it is
+ * `opendal_deleter_flush` that hands the queue to the service and waits for
+ * every queued path to be removed. Treat a path as deleted only after
+ * `opendal_deleter_flush` returns NULL.
+ *
+ * Flushing does not end the deleter's life: it stays usable afterwards, and a
+ * failed flush keeps the paths it could not delete queued so the caller can
+ * retry them.
+ *
+ * Users construct a deleter by `opendal_operator_deleter` and release it with
+ * `opendal_deleter_free`.
+ *
+ * @see opendal_operator_deleter()
+ * @see opendal_deleter_delete()
+ * @see opendal_deleter_delete_with()
+ * @see opendal_deleter_flush()
+ */
+typedef struct opendal_deleter {
+  /**
+   * The pointer to the opendal::blocking::Deleter in the Rust code.
+   * Only used to check whether the deleter is NULL.
+   */
+  void *inner;
+} opendal_deleter;
+
+/**
+ * \brief The result type returned by opendal_operator_deleter().
+ *
+ * Fields:
+ * * `deleter`: the deleter used to remove many paths by calling
+ *   opendal_deleter_delete() repeatedly; only valid when `error` is null.
+ * * `error`: the error of the operation; null when the operation succeeds.
+ */
+typedef struct opendal_result_operator_deleter {
+  /**
+   * The pointer for opendal_deleter
+   */
+  struct opendal_deleter *deleter;
+  /**
+   * The error, if ok, it is null
+   */
+  struct opendal_error *error;
+} opendal_result_operator_deleter;
+
+/**
  * \brief Metadata for **operator**, users can use this metadata to get information
  * of operator.
  */
@@ -2391,6 +2440,25 @@ struct opendal_result_operator_copier opendal_operator_copier_with(const struct 
                                                                    const struct opendal_copy_options *opts);
 
 /**
+ * \brief Blocking create a deleter to remove many paths.
+ *
+ * The returned deleter queues paths and uses the batch deletion support of the
+ * service when it has any. Call `opendal_deleter_delete` for every path, then
+ * `opendal_deleter_flush` to hand the queue to the service and wait for the
+ * deletions, and `opendal_deleter_free` to release it.
+ *
+ * @param op The opendal_operator created previously
+ * @see opendal_operator
+ * @see opendal_deleter
+ * @see opendal_result_operator_deleter
+ * @return opendal_result_operator_deleter, containing a deleter and an opendal_error.
+ * If the operation succeeds, the `deleter` field holds a valid deleter and the `error`
+ * field is null. Otherwise, the `deleter` will be null and the `error` will be set
+ * correspondingly.
+ */
+struct opendal_result_operator_deleter opendal_operator_deleter(const struct opendal_operator *op);
+
+/**
  * \brief Get information of underlying accessor.
  *
  * # Example
@@ -3112,6 +3180,76 @@ struct opendal_error *opendal_copier_abort(struct opendal_copier *self);
  * \brief Free the heap memory used by the opendal_copier.
  */
 void opendal_copier_free(struct opendal_copier *ptr);
+
+/**
+ * \brief Queue `path` for deletion.
+ *
+ * The path is not necessarily removed when this function returns: call
+ * `opendal_deleter_flush` to hand the queue to the service and wait for the
+ * deletions to complete.
+ *
+ * @param path The designated path you want to delete
+ * @return NULL if the path is queued, otherwise it contains the error code and
+ * error message.
+ *
+ * # Safety
+ *
+ * * The memory pointed to by `path` must contain a valid nul terminator at the
+ *   end of the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics
+ */
+struct opendal_error *opendal_deleter_delete(struct opendal_deleter *self, const char *path);
+
+/**
+ * \brief Queue `path` for deletion with options.
+ *
+ * This is the same as `opendal_deleter_delete` but accepts an
+ * `opendal_delete_options` to delete a specific version or to delete
+ * recursively. Pass NULL to use defaults.
+ *
+ * @param path The designated path you want to delete
+ * @param opts The options for this path; pass NULL to use defaults
+ * @see opendal_delete_options
+ * @return NULL if the path is queued, otherwise it contains the error code and
+ * error message.
+ *
+ * # Safety
+ *
+ * * The memory pointed to by `path` must contain a valid nul terminator at the
+ *   end of the string.
+ *
+ * # Panic
+ *
+ * * If the `path` points to NULL, this function panics
+ */
+struct opendal_error *opendal_deleter_delete_with(struct opendal_deleter *self,
+                                                  const char *path,
+                                                  const struct opendal_delete_options *opts);
+
+/**
+ * \brief Hand the queued paths to the service and wait until they are deleted.
+ *
+ * Call this before freeing the deleter to make sure the queued deletions
+ * happened. This function flushes the queue; it does not end the deleter's
+ * life, and `opendal_deleter_free` still has to be called. The deleter stays
+ * usable afterwards, and a failed flush keeps the paths it could not delete
+ * queued, so the caller can retry them by calling this function again.
+ *
+ * @return NULL if all queued paths are deleted, otherwise it contains the error
+ * code and error message.
+ */
+struct opendal_error *opendal_deleter_flush(struct opendal_deleter *self);
+
+/**
+ * \brief Free the heap memory used by the opendal_deleter.
+ *
+ * Freeing a deleter drops the queued paths that were never flushed: call
+ * `opendal_deleter_flush` first unless you mean to discard them.
+ */
+void opendal_deleter_free(struct opendal_deleter *ptr);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/bindings/c/src/deleter.rs
+++ b/bindings/c/src/deleter.rs
@@ -1,0 +1,172 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use ::opendal as core;
+use std::ffi::c_void;
+use std::os::raw::c_char;
+
+use super::*;
+
+/// \brief opendal_deleter removes many paths from storage.
+///
+/// opendal_deleter queues paths and hands them to the service, using batch
+/// deletion when the service supports it. `opendal_deleter_delete` only queues a
+/// path: the delete may still be pending when the call returns, and it is
+/// `opendal_deleter_close` that flushes the queue and waits for every queued
+/// path to be removed. Treat a path as deleted only after
+/// `opendal_deleter_close` returns NULL.
+///
+/// Users construct a deleter by `opendal_operator_deleter` and release it with
+/// `opendal_deleter_free`.
+///
+/// @see opendal_operator_deleter()
+/// @see opendal_deleter_delete()
+/// @see opendal_deleter_close()
+#[repr(C)]
+pub struct opendal_deleter {
+    /// The pointer to the opendal::blocking::Deleter in the Rust code.
+    /// Only used to check whether the deleter is NULL.
+    inner: *mut c_void,
+}
+
+impl opendal_deleter {
+    fn deref_mut(&mut self) -> &mut core::blocking::Deleter {
+        // Safety: the inner should never be null once constructed
+        // The use-after-free is undefined behavior
+        unsafe { &mut *(self.inner as *mut core::blocking::Deleter) }
+    }
+}
+
+impl opendal_deleter {
+    pub(crate) fn new(deleter: core::blocking::Deleter) -> Self {
+        Self {
+            inner: Box::into_raw(Box::new(deleter)) as _,
+        }
+    }
+
+    /// \brief Queue `path` for deletion.
+    ///
+    /// The path is not necessarily removed when this function returns: call
+    /// `opendal_deleter_close` to flush the queue and wait for the deletions to
+    /// complete.
+    ///
+    /// @param path The designated path you want to delete
+    /// @return NULL if the path is queued, otherwise it contains the error code and
+    /// error message.
+    ///
+    /// # Safety
+    ///
+    /// * The memory pointed to by `path` must contain a valid nul terminator at the
+    ///   end of the string.
+    ///
+    /// # Panic
+    ///
+    /// * If the `path` points to NULL, this function panics
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_deleter_delete(
+        &mut self,
+        path: *const c_char,
+    ) -> *mut opendal_error {
+        assert!(!path.is_null());
+        let path = std::ffi::CStr::from_ptr(path)
+            .to_str()
+            .expect("malformed path");
+        match self.deref_mut().delete(path) {
+            Ok(()) => std::ptr::null_mut(),
+            Err(e) => opendal_error::new(e),
+        }
+    }
+
+    /// \brief Queue `path` for deletion with options.
+    ///
+    /// This is the same as `opendal_deleter_delete` but accepts an
+    /// `opendal_delete_options` to delete a specific version or to delete
+    /// recursively. Pass NULL to use defaults.
+    ///
+    /// @param path The designated path you want to delete
+    /// @param opts The options for this path; pass NULL to use defaults
+    /// @see opendal_delete_options
+    /// @return NULL if the path is queued, otherwise it contains the error code and
+    /// error message.
+    ///
+    /// # Safety
+    ///
+    /// * The memory pointed to by `path` must contain a valid nul terminator at the
+    ///   end of the string.
+    ///
+    /// # Panic
+    ///
+    /// * If the `path` points to NULL, this function panics
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_deleter_delete_with(
+        &mut self,
+        path: *const c_char,
+        opts: *const opendal_delete_options,
+    ) -> *mut opendal_error {
+        assert!(!path.is_null());
+        let path = std::ffi::CStr::from_ptr(path)
+            .to_str()
+            .expect("malformed path");
+        let delete_opts = if opts.is_null() {
+            core::options::DeleteOptions::default()
+        } else {
+            core::options::DeleteOptions::from(&*opts)
+        };
+
+        // DeleteInput is #[non_exhaustive], so it can only be built field by field.
+        let mut input = core::DeleteInput::default();
+        input.path = path.to_string();
+        input.version = delete_opts.version;
+        input.recursive = delete_opts.recursive;
+
+        match self.deref_mut().delete(input) {
+            Ok(()) => std::ptr::null_mut(),
+            Err(e) => opendal_error::new(e),
+        }
+    }
+
+    /// \brief Flush the deleter and wait until all queued paths are deleted.
+    ///
+    /// Call this before freeing the deleter to make sure the queued deletions
+    /// happened. The deleter stays usable after a successful close.
+    ///
+    /// @return NULL if all queued paths are deleted, otherwise it contains the error
+    /// code and error message.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_deleter_close(&mut self) -> *mut opendal_error {
+        match self.deref_mut().close() {
+            Ok(()) => std::ptr::null_mut(),
+            Err(e) => opendal_error::new(e),
+        }
+    }
+
+    /// \brief Free the heap memory used by the opendal_deleter.
+    ///
+    /// Freeing a deleter drops the queued paths that were never flushed: call
+    /// `opendal_deleter_close` first unless you mean to discard them.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_deleter_free(ptr: *mut opendal_deleter) {
+        unsafe {
+            if !ptr.is_null() {
+                drop(Box::from_raw((*ptr).inner as *mut core::blocking::Deleter));
+                // A use-after-free crashes on NULL instead of reading stale memory.
+                (*ptr).inner = std::ptr::null_mut();
+                drop(Box::from_raw(ptr));
+            }
+        }
+    }
+}

--- a/bindings/c/src/deleter.rs
+++ b/bindings/c/src/deleter.rs
@@ -39,6 +39,7 @@ use super::*;
 ///
 /// @see opendal_operator_deleter()
 /// @see opendal_deleter_delete()
+/// @see opendal_deleter_delete_many()
 /// @see opendal_deleter_delete_with()
 /// @see opendal_deleter_flush()
 #[repr(C)]
@@ -89,6 +90,66 @@ impl opendal_deleter {
         // Deleting with default options is the same operation, so keep one copy
         // of the path decoding and dispatch.
         self.opendal_deleter_delete_with(path, std::ptr::null())
+    }
+
+    /// \brief Queue multiple paths for deletion.
+    ///
+    /// This function queues every path in one call. Callers deleting a known set
+    /// of paths should prefer it over calling `opendal_deleter_delete` in a loop:
+    /// it crosses the C boundary once instead of once per path, and it queues the
+    /// whole set inside a single blocking call rather than one per path. The paths
+    /// are not necessarily removed when this function returns: call
+    /// `opendal_deleter_flush` to hand the queue to the service and wait for the
+    /// deletions to complete.
+    ///
+    /// Every path is queued with default options. Use `opendal_deleter_delete_with`
+    /// for a path that needs its own version or recursive flag.
+    ///
+    /// Queueing stops at the first path the service rejects, so the paths after it
+    /// are never queued.
+    ///
+    /// @param paths The designated paths you want to delete
+    /// @param paths_len The number of paths in `paths`
+    /// @return NULL if all paths are queued, otherwise it contains the error code
+    /// and error message.
+    ///
+    /// # Safety
+    ///
+    /// * When `paths_len` is greater than zero, `paths` must point to an array of
+    ///   `paths_len` pointers.
+    /// * Every pointer in `paths` must point to a string with a valid nul
+    ///   terminator.
+    ///
+    /// # Panic
+    ///
+    /// * If `paths` or any pointer in `paths` is NULL when `paths_len` is greater
+    ///   than zero, this function panics.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_deleter_delete_many(
+        &mut self,
+        paths: *const *const c_char,
+        paths_len: usize,
+    ) -> *mut opendal_error {
+        if paths_len == 0 {
+            return std::ptr::null_mut();
+        }
+
+        assert!(!paths.is_null());
+        let paths = std::slice::from_raw_parts(paths, paths_len)
+            .iter()
+            .map(|path| {
+                assert!(!path.is_null());
+                std::ffi::CStr::from_ptr(*path)
+                    .to_str()
+                    .expect("malformed path")
+                    .to_owned()
+            })
+            .collect::<Vec<_>>();
+
+        match self.deref_mut().delete_iter(paths) {
+            Ok(()) => std::ptr::null_mut(),
+            Err(e) => opendal_error::new(e),
+        }
     }
 
     /// \brief Queue `path` for deletion with options.

--- a/bindings/c/src/deleter.rs
+++ b/bindings/c/src/deleter.rs
@@ -1,0 +1,167 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use ::opendal as core;
+use std::ffi::c_void;
+use std::os::raw::c_char;
+
+use super::*;
+
+/// \brief opendal_deleter removes many paths from storage.
+///
+/// opendal_deleter queues paths and hands them to the service, using batch
+/// deletion when the service supports it. `opendal_deleter_delete` only queues a
+/// path: the delete may still be pending when the call returns, and it is
+/// `opendal_deleter_flush` that hands the queue to the service and waits for
+/// every queued path to be removed. Treat a path as deleted only after
+/// `opendal_deleter_flush` returns NULL.
+///
+/// Flushing does not end the deleter's life: it stays usable afterwards, and a
+/// failed flush keeps the paths it could not delete queued so the caller can
+/// retry them.
+///
+/// Users construct a deleter by `opendal_operator_deleter` and release it with
+/// `opendal_deleter_free`.
+///
+/// @see opendal_operator_deleter()
+/// @see opendal_deleter_delete()
+/// @see opendal_deleter_delete_with()
+/// @see opendal_deleter_flush()
+#[repr(C)]
+pub struct opendal_deleter {
+    /// The pointer to the opendal::blocking::Deleter in the Rust code.
+    /// Only used to check whether the deleter is NULL.
+    inner: *mut c_void,
+}
+
+impl opendal_deleter {
+    fn deref_mut(&mut self) -> &mut core::blocking::Deleter {
+        // Safety: the inner should never be null once constructed
+        // The use-after-free is undefined behavior
+        unsafe { &mut *(self.inner as *mut core::blocking::Deleter) }
+    }
+}
+
+impl opendal_deleter {
+    pub(crate) fn new(deleter: core::blocking::Deleter) -> Self {
+        Self {
+            inner: Box::into_raw(Box::new(deleter)) as _,
+        }
+    }
+
+    /// \brief Queue `path` for deletion.
+    ///
+    /// The path is not necessarily removed when this function returns: call
+    /// `opendal_deleter_flush` to hand the queue to the service and wait for the
+    /// deletions to complete.
+    ///
+    /// @param path The designated path you want to delete
+    /// @return NULL if the path is queued, otherwise it contains the error code and
+    /// error message.
+    ///
+    /// # Safety
+    ///
+    /// * The memory pointed to by `path` must contain a valid nul terminator at the
+    ///   end of the string.
+    ///
+    /// # Panic
+    ///
+    /// * If the `path` points to NULL, this function panics
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_deleter_delete(
+        &mut self,
+        path: *const c_char,
+    ) -> *mut opendal_error {
+        // Deleting with default options is the same operation, so keep one copy
+        // of the path decoding and dispatch.
+        self.opendal_deleter_delete_with(path, std::ptr::null())
+    }
+
+    /// \brief Queue `path` for deletion with options.
+    ///
+    /// This is the same as `opendal_deleter_delete` but accepts an
+    /// `opendal_delete_options` to delete a specific version or to delete
+    /// recursively. Pass NULL to use defaults.
+    ///
+    /// @param path The designated path you want to delete
+    /// @param opts The options for this path; pass NULL to use defaults
+    /// @see opendal_delete_options
+    /// @return NULL if the path is queued, otherwise it contains the error code and
+    /// error message.
+    ///
+    /// # Safety
+    ///
+    /// * The memory pointed to by `path` must contain a valid nul terminator at the
+    ///   end of the string.
+    ///
+    /// # Panic
+    ///
+    /// * If the `path` points to NULL, this function panics
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_deleter_delete_with(
+        &mut self,
+        path: *const c_char,
+        opts: *const opendal_delete_options,
+    ) -> *mut opendal_error {
+        assert!(!path.is_null());
+        let path = std::ffi::CStr::from_ptr(path)
+            .to_str()
+            .expect("malformed path");
+        let delete_opts = if opts.is_null() {
+            core::options::DeleteOptions::default()
+        } else {
+            core::options::DeleteOptions::from(&*opts)
+        };
+
+        match self.deref_mut().delete((path.to_string(), delete_opts)) {
+            Ok(()) => std::ptr::null_mut(),
+            Err(e) => opendal_error::new(e),
+        }
+    }
+
+    /// \brief Hand the queued paths to the service and wait until they are deleted.
+    ///
+    /// Call this before freeing the deleter to make sure the queued deletions
+    /// happened. This function flushes the queue; it does not end the deleter's
+    /// life, and `opendal_deleter_free` still has to be called. The deleter stays
+    /// usable afterwards, and a failed flush keeps the paths it could not delete
+    /// queued, so the caller can retry them by calling this function again.
+    ///
+    /// @return NULL if all queued paths are deleted, otherwise it contains the error
+    /// code and error message.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_deleter_flush(&mut self) -> *mut opendal_error {
+        match self.deref_mut().close() {
+            Ok(()) => std::ptr::null_mut(),
+            Err(e) => opendal_error::new(e),
+        }
+    }
+
+    /// \brief Free the heap memory used by the opendal_deleter.
+    ///
+    /// Freeing a deleter drops the queued paths that were never flushed: call
+    /// `opendal_deleter_flush` first unless you mean to discard them.
+    #[no_mangle]
+    pub unsafe extern "C" fn opendal_deleter_free(ptr: *mut opendal_deleter) {
+        unsafe {
+            if !ptr.is_null() {
+                drop(Box::from_raw((*ptr).inner as *mut core::blocking::Deleter));
+                drop(Box::from_raw(ptr));
+            }
+        }
+    }
+}

--- a/bindings/c/src/lib.rs
+++ b/bindings/c/src/lib.rs
@@ -64,6 +64,7 @@ pub use result::opendal_result_is_exist;
 pub use result::opendal_result_list;
 pub use result::opendal_result_lister_next;
 pub use result::opendal_result_operator_copier;
+pub use result::opendal_result_operator_deleter;
 pub use result::opendal_result_operator_new;
 pub use result::opendal_result_operator_reader;
 pub use result::opendal_result_operator_writer;
@@ -96,3 +97,6 @@ pub use writer::opendal_writer;
 
 mod copier;
 pub use copier::opendal_copier;
+
+mod deleter;
+pub use deleter::opendal_deleter;

--- a/bindings/c/src/operator.rs
+++ b/bindings/c/src/operator.rs
@@ -805,21 +805,7 @@ pub unsafe extern "C" fn opendal_operator_delete_with(
     let delete_opts = if opts.is_null() {
         core::options::DeleteOptions::default()
     } else {
-        let o = &*opts;
-        let version = if o.version.is_null() {
-            None
-        } else {
-            Some(
-                std::ffi::CStr::from_ptr(o.version)
-                    .to_str()
-                    .expect("malformed version")
-                    .to_owned(),
-            )
-        };
-        core::options::DeleteOptions {
-            version,
-            recursive: o.recursive,
-        }
+        core::options::DeleteOptions::from(&*opts)
     };
     match op.deref().delete_options(path, delete_opts) {
         Ok(_) => std::ptr::null_mut(),
@@ -1535,6 +1521,37 @@ pub unsafe extern "C" fn opendal_operator_copier_with(
         },
         Err(err) => opendal_result_operator_copier {
             copier: std::ptr::null_mut(),
+            error: opendal_error::new(err),
+        },
+    }
+}
+
+/// \brief Blocking create a deleter to remove many paths.
+///
+/// The returned deleter queues paths and uses the batch deletion support of the
+/// service when it has any. Call `opendal_deleter_delete` for every path, then
+/// `opendal_deleter_close` to flush the queue and wait for the deletions, and
+/// `opendal_deleter_free` to release it.
+///
+/// @param op The opendal_operator created previously
+/// @see opendal_operator
+/// @see opendal_deleter
+/// @see opendal_result_operator_deleter
+/// @return opendal_result_operator_deleter, containing a deleter and an opendal_error.
+/// If the operation succeeds, the `deleter` field holds a valid deleter and the `error`
+/// field is null. Otherwise, the `deleter` will be null and the `error` will be set
+/// correspondingly.
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_deleter(
+    op: &opendal_operator,
+) -> opendal_result_operator_deleter {
+    match op.deref().deleter() {
+        Ok(deleter) => opendal_result_operator_deleter {
+            deleter: Box::into_raw(Box::new(opendal_deleter::new(deleter))),
+            error: std::ptr::null_mut(),
+        },
+        Err(err) => opendal_result_operator_deleter {
+            deleter: std::ptr::null_mut(),
             error: opendal_error::new(err),
         },
     }

--- a/bindings/c/src/operator.rs
+++ b/bindings/c/src/operator.rs
@@ -805,23 +805,7 @@ pub unsafe extern "C" fn opendal_operator_delete_with(
     let delete_opts = if opts.is_null() {
         core::options::DeleteOptions::default()
     } else {
-        let o = &*opts;
-        let version = if o.version.is_null() {
-            None
-        } else {
-            Some(
-                std::ffi::CStr::from_ptr(o.version)
-                    .to_str()
-                    .expect("malformed version")
-                    .to_owned(),
-            )
-        };
-        core::options::DeleteOptions {
-            version,
-            recursive: o.recursive,
-            if_match: None,
-            ..Default::default()
-        }
+        core::options::DeleteOptions::from(&*opts)
     };
     match op.deref().delete_options(path, delete_opts) {
         Ok(_) => std::ptr::null_mut(),
@@ -1537,6 +1521,37 @@ pub unsafe extern "C" fn opendal_operator_copier_with(
         },
         Err(err) => opendal_result_operator_copier {
             copier: std::ptr::null_mut(),
+            error: opendal_error::new(err),
+        },
+    }
+}
+
+/// \brief Blocking create a deleter to remove many paths.
+///
+/// The returned deleter queues paths and uses the batch deletion support of the
+/// service when it has any. Call `opendal_deleter_delete` for every path, then
+/// `opendal_deleter_flush` to hand the queue to the service and wait for the
+/// deletions, and `opendal_deleter_free` to release it.
+///
+/// @param op The opendal_operator created previously
+/// @see opendal_operator
+/// @see opendal_deleter
+/// @see opendal_result_operator_deleter
+/// @return opendal_result_operator_deleter, containing a deleter and an opendal_error.
+/// If the operation succeeds, the `deleter` field holds a valid deleter and the `error`
+/// field is null. Otherwise, the `deleter` will be null and the `error` will be set
+/// correspondingly.
+#[no_mangle]
+pub unsafe extern "C" fn opendal_operator_deleter(
+    op: &opendal_operator,
+) -> opendal_result_operator_deleter {
+    match op.deref().deleter() {
+        Ok(deleter) => opendal_result_operator_deleter {
+            deleter: Box::into_raw(Box::new(opendal_deleter::new(deleter))),
+            error: std::ptr::null_mut(),
+        },
+        Err(err) => opendal_result_operator_deleter {
+            deleter: std::ptr::null_mut(),
             error: opendal_error::new(err),
         },
     }

--- a/bindings/c/src/presign.rs
+++ b/bindings/c/src/presign.rs
@@ -227,23 +227,7 @@ pub unsafe extern "C" fn opendal_operator_presign_delete_with(
     let opts = if opts.is_null() {
         core::options::DeleteOptions::default()
     } else {
-        let opts = &*opts;
-        let version = if opts.version.is_null() {
-            None
-        } else {
-            Some(
-                CStr::from_ptr(opts.version)
-                    .to_str()
-                    .expect("malformed version")
-                    .to_owned(),
-            )
-        };
-        core::options::DeleteOptions {
-            version,
-            recursive: opts.recursive,
-            if_match: None,
-            ..Default::default()
-        }
+        core::options::DeleteOptions::from(&*opts)
     };
 
     make_presign_result(op.presign_delete_options(path, duration, opts))

--- a/bindings/c/src/result.rs
+++ b/bindings/c/src/result.rs
@@ -209,6 +209,20 @@ pub struct opendal_result_operator_copier {
     pub error: *mut opendal_error,
 }
 
+/// \brief The result type returned by opendal_operator_deleter().
+///
+/// Fields:
+/// * `deleter`: the deleter used to remove many paths by calling
+///   opendal_deleter_delete() repeatedly; only valid when `error` is null.
+/// * `error`: the error of the operation; null when the operation succeeds.
+#[repr(C)]
+pub struct opendal_result_operator_deleter {
+    /// The pointer for opendal_deleter
+    pub deleter: *mut opendal_deleter,
+    /// The error, if ok, it is null
+    pub error: *mut opendal_error,
+}
+
 /// \brief The result type returned by opendal_copier_next().
 ///
 /// A copy is driven by calling opendal_copier_next() repeatedly: each call

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -348,6 +348,16 @@ impl opendal_delete_options {
     }
 }
 
+impl From<&opendal_delete_options> for options::DeleteOptions {
+    fn from(value: &opendal_delete_options) -> Self {
+        Self {
+            version: unsafe { optional_cstr(value.version) },
+            recursive: value.recursive,
+            ..Default::default()
+        }
+    }
+}
+
 /// \brief A key-value pair for write user metadata.
 #[repr(C)]
 pub struct opendal_write_user_metadata_pair {

--- a/bindings/c/src/types.rs
+++ b/bindings/c/src/types.rs
@@ -348,6 +348,15 @@ impl opendal_delete_options {
     }
 }
 
+impl From<&opendal_delete_options> for options::DeleteOptions {
+    fn from(value: &opendal_delete_options) -> Self {
+        Self {
+            version: unsafe { optional_cstr(value.version) },
+            recursive: value.recursive,
+        }
+    }
+}
+
 /// \brief A key-value pair for write user metadata.
 #[repr(C)]
 pub struct opendal_write_user_metadata_pair {

--- a/bindings/go/deleter.go
+++ b/bindings/go/deleter.go
@@ -1,0 +1,367 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package opendal
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"unsafe"
+
+	"github.com/jupiterrider/ffi"
+)
+
+// ErrDeleterClosed reports that a Deleter is used after it is released by Close
+// or Discard.
+var ErrDeleterClosed = errors.New("opendal: deleter is closed")
+
+// Deleter removes many paths from storage.
+//
+// Deleter queues paths and hands them to the service, using batch deletion when
+// the service supports it. Delete only queues a path: the deletion may still be
+// pending when Delete returns, and it is Flush or Close that hands the queue to
+// the service and waits for every queued path to be removed. Treat a path as
+// deleted only after Flush or Close returns nil.
+//
+// Prefer Operator.Delete for a single path; a Deleter pays off when removing
+// many paths from a service with batch delete support, such as S3, and it is the
+// only way to delete a specific version of each path in one pass.
+//
+// Operator.WithDeleter drives this lifecycle for the caller and is the preferred
+// entry point. Callers that build a Deleter directly must release it with Close
+// or Discard; the binding installs no finalizer, so an unreleased Deleter leaks
+// its native handle.
+//
+// A Deleter is safe for concurrent use: its methods serialize against each
+// other, so a delete never overlaps a flush or a release.
+//
+// # Example
+//
+//	func exampleDeleter(op *opendal.Operator) {
+//		err := op.WithDeleter(func(d *opendal.Deleter) error {
+//			for _, path := range []string{"a.txt", "b.txt", "c.txt"} {
+//				if err := d.Delete(path); err != nil {
+//					return err
+//				}
+//			}
+//			return nil
+//		})
+//		if err != nil {
+//			log.Fatal(err)
+//		}
+//	}
+type Deleter struct {
+	// mu serializes access to inner. The C deleter hands out a &mut to the
+	// underlying Rust deleter, so two goroutines calling in at once would alias
+	// it, which is undefined behavior rather than merely a data race.
+	mu    sync.Mutex
+	inner *opendalDeleter
+	ctx   context.Context
+}
+
+// Deleter creates a Deleter that removes many paths.
+//
+// Deleter is a wrapper around the C-binding function `opendal_operator_deleter`.
+//
+// # Returns
+//
+//   - *Deleter: A Deleter used to queue deletions, or an error if the operation fails.
+//
+// # Behavior
+//
+//   - The returned Deleter must be released, either with Close, which flushes the
+//     queued deletions first, or with Discard, which drops them.
+//   - Prefer Operator.WithDeleter, which pairs the release with the queueing for
+//     the caller.
+func (op *Operator) Deleter() (*Deleter, error) {
+	inner, err := ffiOperatorDeleter.symbol(op.ctx)(op.inner)
+	if err != nil {
+		return nil, err
+	}
+	return &Deleter{inner: inner, ctx: op.ctx}, nil
+}
+
+// Delete queues path for deletion.
+//
+// The path is not necessarily removed when Delete returns: Flush or Close hands
+// the queue to the service and waits for the deletions to complete. Delete
+// returns ErrDeleterClosed once the Deleter is released.
+//
+// Services without batch delete support remove each path as Delete queues it, so
+// how much of the work Delete has already done when it returns depends on the
+// service.
+//
+// # Parameters
+//
+//   - path: The path of the file or directory to delete.
+//   - opts: Optional functional options, shared with Operator.Delete, to delete a
+//     specific version or to delete recursively.
+func (d *Deleter) Delete(path string, opts ...WithDeleteFn) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.inner == nil {
+		return ErrDeleterClosed
+	}
+	if len(opts) == 0 {
+		return ffiDeleterDelete.symbol(d.ctx)(d.inner, path)
+	}
+
+	o := parseDeleteOptions(opts...)
+	cOpts, keepAlive, err := newOpendalDeleteOptions(d.ctx, o)
+	if err != nil {
+		return err
+	}
+	defer ffiDeleteOptionsFree.symbol(d.ctx)(cOpts)
+	err = ffiDeleterDeleteWith.symbol(d.ctx)(d.inner, path, cOpts)
+	// The C option setters copy their arguments into Rust-owned memory, so cOpts
+	// borrows no Go memory; keepAlive pins the buffers through the setter calls.
+	runtime.KeepAlive(keepAlive)
+	return err
+}
+
+// Flush hands the queued deletions to the service, waits for them to complete,
+// and keeps the Deleter usable.
+//
+// A failed flush keeps the paths it could not delete queued, so the caller can
+// retry them by calling Flush again. Flush returns ErrDeleterClosed once the
+// Deleter is released.
+func (d *Deleter) Flush() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.inner == nil {
+		return ErrDeleterClosed
+	}
+	return ffiDeleterFlush.symbol(d.ctx)(d.inner)
+}
+
+// Close flushes the queued deletions, waits for them to complete, and releases
+// the resources held by the Deleter.
+//
+// Close releases the Deleter whether or not the flush succeeds, so the error it
+// returns is the only report that the queued deletions failed: check it rather
+// than deferring Close. Close drops whatever it could not delete, so retry with
+// Flush, which keeps those paths queued, and call Close once it succeeds. Close
+// is safe to call more than once; further calls return nil.
+func (d *Deleter) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.inner == nil {
+		return nil
+	}
+	defer d.releaseLocked()
+	return ffiDeleterFlush.symbol(d.ctx)(d.inner)
+}
+
+// Discard releases the Deleter without flushing, dropping every path that is
+// still queued.
+//
+// Use Discard to abandon queued deletions, and to release a Deleter on a path
+// where flushing is not wanted. Discarding does not undo the deletions the
+// service already performed. Discard is safe to call more than once, and after
+// Close; further calls are no-ops.
+func (d *Deleter) Discard() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.inner == nil {
+		return
+	}
+	d.releaseLocked()
+}
+
+// releaseLocked frees the native deleter and blocks further use. The caller must
+// hold d.mu and must have checked that d.inner is not nil.
+func (d *Deleter) releaseLocked() {
+	ffiDeleterFree.symbol(d.ctx)(d.inner)
+	d.inner = nil
+}
+
+// WithDeleter runs fn with a Deleter and releases it before returning.
+//
+// WithDeleter flushes the queue once fn returns nil, so fn only has to queue the
+// paths it wants removed. When fn returns an error, WithDeleter releases the
+// Deleter without flushing and returns that error, so it queues nothing further.
+// The Deleter is released even if fn panics. fn must not retain it past its
+// return, because it is released by then.
+//
+// Skipping the flush does not undo the deletions the service already performed.
+// A service without batch delete support removes each path as Delete queues it,
+// and a batch service flushes on its own once a batch fills, so treat a failed
+// WithDeleter as "some of these paths may be gone" rather than as a rollback.
+//
+// # Parameters
+//
+//   - fn: The function that queues paths on the Deleter.
+//
+// # Returns
+//
+//   - error: The error from fn, from creating the Deleter, or from the flush.
+//
+// # Example
+//
+//	func exampleWithDeleter(op *opendal.Operator) {
+//		err := op.WithDeleter(func(d *opendal.Deleter) error {
+//			return d.Delete("a.txt", opendal.DeleteWithVersion("v1"))
+//		})
+//		if err != nil {
+//			log.Printf("delete failed: %v", err)
+//		}
+//	}
+func (op *Operator) WithDeleter(fn func(d *Deleter) error) error {
+	deleter, err := op.Deleter()
+	if err != nil {
+		return err
+	}
+	// Discard is a no-op once Close has released the deleter, and unlike the
+	// straight-line calls it also runs when fn panics.
+	defer deleter.Discard()
+	if err := fn(deleter); err != nil {
+		return err
+	}
+	return deleter.Close()
+}
+
+// Remove deletes the given paths.
+//
+// Remove drives a Deleter for the caller: it queues every path, then flushes and
+// waits for the deletions. Services that support batch deletion remove the paths
+// in batches.
+//
+// Remove is not atomic. Queueing stops at the first path the service rejects, but
+// the service may already have deleted an earlier batch, so a failed Remove can
+// still leave some paths gone. Every path is deleted with default options; use
+// WithDeleter to delete a specific version of each path.
+//
+// # Parameters
+//
+//   - paths: The paths to delete.
+//
+// # Returns
+//
+//   - error: An error if any deletion fails, or nil if all paths are removed.
+//
+// # Example
+//
+//	func exampleRemove(op *opendal.Operator) {
+//		err := op.Remove([]string{"a.txt", "b.txt"})
+//		if err != nil {
+//			log.Printf("Remove operation failed: %v", err)
+//		}
+//	}
+func (op *Operator) Remove(paths []string) error {
+	if len(paths) == 0 {
+		return nil
+	}
+	return op.WithDeleter(func(d *Deleter) error {
+		for _, path := range paths {
+			if err := d.Delete(path); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+var ffiOperatorDeleter = newFFI(ffiOpts{
+	sym:    "opendal_operator_deleter",
+	rType:  &typeResultOperatorDeleter,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(op *opendalOperator) (*opendalDeleter, error) {
+	return func(op *opendalOperator) (*opendalDeleter, error) {
+		var result resultOperatorDeleter
+		ffiCall(
+			unsafe.Pointer(&result),
+			unsafe.Pointer(&op),
+		)
+		if result.error != nil {
+			return nil, parseError(ctx, result.error)
+		}
+		return result.deleter, nil
+	}
+})
+
+var ffiDeleterDelete = newFFI(ffiOpts{
+	sym:    "opendal_deleter_delete",
+	rType:  &ffi.TypePointer,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(d *opendalDeleter, path string) error {
+	return func(d *opendalDeleter, path string) error {
+		bytePath, err := BytePtrFromString(path)
+		if err != nil {
+			return err
+		}
+		var e *opendalError
+		ffiCall(
+			unsafe.Pointer(&e),
+			unsafe.Pointer(&d),
+			unsafe.Pointer(&bytePath),
+		)
+		return parseError(ctx, e)
+	}
+})
+
+var ffiDeleterDeleteWith = newFFI(ffiOpts{
+	sym:    "opendal_deleter_delete_with",
+	rType:  &ffi.TypePointer,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(d *opendalDeleter, path string, opts *opendalDeleteOptions) error {
+	return func(d *opendalDeleter, path string, opts *opendalDeleteOptions) error {
+		bytePath, err := BytePtrFromString(path)
+		if err != nil {
+			return err
+		}
+		var e *opendalError
+		ffiCall(
+			unsafe.Pointer(&e),
+			unsafe.Pointer(&d),
+			unsafe.Pointer(&bytePath),
+			unsafe.Pointer(&opts),
+		)
+		return parseError(ctx, e)
+	}
+})
+
+var ffiDeleterFlush = newFFI(ffiOpts{
+	sym:    "opendal_deleter_flush",
+	rType:  &ffi.TypePointer,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(d *opendalDeleter) error {
+	return func(d *opendalDeleter) error {
+		var e *opendalError
+		ffiCall(
+			unsafe.Pointer(&e),
+			unsafe.Pointer(&d),
+		)
+		return parseError(ctx, e)
+	}
+})
+
+var ffiDeleterFree = newFFI(ffiOpts{
+	sym:    "opendal_deleter_free",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(d *opendalDeleter) {
+	return func(d *opendalDeleter) {
+		ffiCall(
+			nil,
+			unsafe.Pointer(&d),
+		)
+	}
+})

--- a/bindings/go/deleter.go
+++ b/bindings/go/deleter.go
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package opendal
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"unsafe"
+
+	"github.com/jupiterrider/ffi"
+)
+
+// ErrDeleterClosed reports that a Deleter is used after Close.
+var ErrDeleterClosed = errors.New("opendal: deleter is closed")
+
+// Deleter removes many paths from storage.
+//
+// Deleter queues paths and hands them to the service, using batch deletion when
+// the service supports it. Delete only queues a path: the deletion may still be
+// pending when Delete returns, and it is Close that flushes the queue and waits
+// for every queued path to be removed. Treat a path as deleted only after Close
+// returns nil.
+//
+// Prefer Operator.Delete for a single path; a Deleter pays off when removing
+// many paths from a service with batch delete support, such as S3.
+//
+// # Example
+//
+//	func exampleDeleter(op *opendal.Operator) {
+//		deleter, err := op.Deleter()
+//		if err != nil {
+//			log.Fatal(err)
+//		}
+//		for _, path := range []string{"a.txt", "b.txt", "c.txt"} {
+//			if err := deleter.Delete(path); err != nil {
+//				log.Fatal(err)
+//			}
+//		}
+//		// Close reports whether the queued deletions succeeded.
+//		if err := deleter.Close(); err != nil {
+//			log.Fatal(err)
+//		}
+//	}
+type Deleter struct {
+	inner *opendalDeleter
+	ctx   context.Context
+}
+
+// Deleter creates a Deleter that removes many paths.
+//
+// Deleter is a wrapper around the C-binding function `opendal_operator_deleter`.
+//
+// # Returns
+//
+//   - *Deleter: A Deleter used to queue deletions, or an error if the operation fails.
+//
+// # Behavior
+//
+//   - The returned Deleter must be released with Close, which also flushes the
+//     queued deletions.
+func (op *Operator) Deleter() (*Deleter, error) {
+	inner, err := ffiOperatorDeleter.symbol(op.ctx)(op.inner)
+	if err != nil {
+		return nil, err
+	}
+	return &Deleter{inner: inner, ctx: op.ctx}, nil
+}
+
+// Delete queues path for deletion.
+//
+// The path is not necessarily removed when Delete returns: Close flushes the
+// queue and waits for the deletions to complete. Delete returns
+// ErrDeleterClosed once the Deleter is closed.
+//
+// # Parameters
+//
+//   - path: The path of the file or directory to delete.
+//   - opts: Optional functional options, shared with Operator.Delete, to delete a
+//     specific version or to delete recursively.
+func (d *Deleter) Delete(path string, opts ...WithDeleteFn) error {
+	if d.inner == nil {
+		return ErrDeleterClosed
+	}
+	if len(opts) == 0 {
+		return ffiDeleterDelete.symbol(d.ctx)(d.inner, path)
+	}
+
+	o := parseDeleteOptions(opts...)
+	cOpts, keepAlive, err := newOpendalDeleteOptions(d.ctx, o)
+	if err != nil {
+		return err
+	}
+	defer ffiDeleteOptionsFree.symbol(d.ctx)(cOpts)
+	err = ffiDeleterDeleteWith.symbol(d.ctx)(d.inner, path, cOpts)
+	// cOpts holds raw pointers into the Go buffers tracked by keepAlive.
+	// Keep them reachable until the native call above has returned.
+	runtime.KeepAlive(keepAlive)
+	return err
+}
+
+// Close flushes the queued deletions, waits for them to complete, and releases
+// the resources held by the Deleter.
+//
+// The error reports whether the queued deletions succeeded, so callers that care
+// about the outcome must check it rather than defer Close. The Deleter is
+// released even when the flush fails, and further calls are no-ops that return
+// nil.
+func (d *Deleter) Close() error {
+	if d.inner == nil {
+		return nil
+	}
+	err := ffiDeleterClose.symbol(d.ctx)(d.inner)
+	ffiDeleterFree.symbol(d.ctx)(d.inner)
+	d.inner = nil
+	return err
+}
+
+// Remove deletes the given paths.
+//
+// Remove drives a Deleter for the caller: it queues every path, then flushes and
+// waits for the deletions. Services that support batch deletion remove the paths
+// in batches.
+//
+// # Parameters
+//
+//   - paths: The paths to delete.
+//
+// # Returns
+//
+//   - error: An error if any deletion fails, or nil if all paths are removed.
+//
+// # Example
+//
+//	func exampleRemove(op *opendal.Operator) {
+//		err := op.Remove([]string{"a.txt", "b.txt"})
+//		if err != nil {
+//			log.Printf("Remove operation failed: %v", err)
+//		}
+//	}
+func (op *Operator) Remove(paths []string) error {
+	if len(paths) == 0 {
+		return nil
+	}
+	deleter, err := op.Deleter()
+	if err != nil {
+		return err
+	}
+	for _, path := range paths {
+		if err := deleter.Delete(path); err != nil {
+			// Close releases the deleter; the queued paths are dropped.
+			_ = deleter.Close()
+			return err
+		}
+	}
+	return deleter.Close()
+}
+
+var ffiOperatorDeleter = newFFI(ffiOpts{
+	sym:    "opendal_operator_deleter",
+	rType:  &typeResultOperatorDeleter,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(op *opendalOperator) (*opendalDeleter, error) {
+	return func(op *opendalOperator) (*opendalDeleter, error) {
+		var result resultOperatorDeleter
+		ffiCall(
+			unsafe.Pointer(&result),
+			unsafe.Pointer(&op),
+		)
+		if result.error != nil {
+			return nil, parseError(ctx, result.error)
+		}
+		return result.deleter, nil
+	}
+})
+
+var ffiDeleterDelete = newFFI(ffiOpts{
+	sym:    "opendal_deleter_delete",
+	rType:  &ffi.TypePointer,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(d *opendalDeleter, path string) error {
+	return func(d *opendalDeleter, path string) error {
+		bytePath, err := BytePtrFromString(path)
+		if err != nil {
+			return err
+		}
+		var e *opendalError
+		ffiCall(
+			unsafe.Pointer(&e),
+			unsafe.Pointer(&d),
+			unsafe.Pointer(&bytePath),
+		)
+		return parseError(ctx, e)
+	}
+})
+
+var ffiDeleterDeleteWith = newFFI(ffiOpts{
+	sym:    "opendal_deleter_delete_with",
+	rType:  &ffi.TypePointer,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(d *opendalDeleter, path string, opts *opendalDeleteOptions) error {
+	return func(d *opendalDeleter, path string, opts *opendalDeleteOptions) error {
+		bytePath, err := BytePtrFromString(path)
+		if err != nil {
+			return err
+		}
+		var e *opendalError
+		ffiCall(
+			unsafe.Pointer(&e),
+			unsafe.Pointer(&d),
+			unsafe.Pointer(&bytePath),
+			unsafe.Pointer(&opts),
+		)
+		return parseError(ctx, e)
+	}
+})
+
+var ffiDeleterClose = newFFI(ffiOpts{
+	sym:    "opendal_deleter_close",
+	rType:  &ffi.TypePointer,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(d *opendalDeleter) error {
+	return func(d *opendalDeleter) error {
+		var e *opendalError
+		ffiCall(
+			unsafe.Pointer(&e),
+			unsafe.Pointer(&d),
+		)
+		return parseError(ctx, e)
+	}
+})
+
+var ffiDeleterFree = newFFI(ffiOpts{
+	sym:    "opendal_deleter_free",
+	rType:  &ffi.TypeVoid,
+	aTypes: []*ffi.Type{&ffi.TypePointer},
+}, func(_ context.Context, ffiCall ffiCall) func(d *opendalDeleter) {
+	return func(d *opendalDeleter) {
+		ffiCall(
+			nil,
+			unsafe.Pointer(&d),
+		)
+	}
+})

--- a/bindings/go/deleter.go
+++ b/bindings/go/deleter.go
@@ -137,6 +137,23 @@ func (d *Deleter) Delete(path string, opts ...WithDeleteFn) error {
 	return err
 }
 
+// deleteMany queues every path in one crossing of the FFI boundary.
+//
+// Queueing paths one at a time costs a boundary crossing and a blocking call per
+// path, which dominates on services whose queueing is just a buffer insert. This
+// hands the whole slice over at once. Every path is queued with default options,
+// so callers that need per-path options must use Delete.
+func (d *Deleter) deleteMany(paths []string) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.inner == nil {
+		return ErrDeleterClosed
+	}
+	// An empty slice is handled by the FFI wrapper and the C side; Remove, the
+	// only caller, already skips creating a deleter for it.
+	return ffiDeleterDeleteMany.symbol(d.ctx)(d.inner, paths)
+}
+
 // Flush hands the queued deletions to the service, waits for them to complete,
 // and keeps the Deleter usable.
 //
@@ -244,6 +261,9 @@ func (op *Operator) WithDeleter(fn func(d *Deleter) error) error {
 // waits for the deletions. Services that support batch deletion remove the paths
 // in batches.
 //
+// Remove queues the whole slice in one crossing of the FFI boundary rather than
+// one per path.
+//
 // Remove is not atomic. Queueing stops at the first path the service rejects, but
 // the service may already have deleted an earlier batch, so a failed Remove can
 // still leave some paths gone. Every path is deleted with default options; use
@@ -270,12 +290,7 @@ func (op *Operator) Remove(paths []string) error {
 		return nil
 	}
 	return op.WithDeleter(func(d *Deleter) error {
-		for _, path := range paths {
-			if err := d.Delete(path); err != nil {
-				return err
-			}
-		}
-		return nil
+		return d.deleteMany(paths)
 	})
 }
 
@@ -313,6 +328,43 @@ var ffiDeleterDelete = newFFI(ffiOpts{
 			unsafe.Pointer(&d),
 			unsafe.Pointer(&bytePath),
 		)
+		return parseError(ctx, e)
+	}
+})
+
+var ffiDeleterDeleteMany = newFFI(ffiOpts{
+	sym:    "opendal_deleter_delete_many",
+	rType:  &ffi.TypePointer,
+	aTypes: []*ffi.Type{&ffi.TypePointer, &ffi.TypePointer, &ffi.TypePointer},
+}, func(ctx context.Context, ffiCall ffiCall) func(d *opendalDeleter, paths []string) error {
+	return func(d *opendalDeleter, paths []string) error {
+		pathData := make([][]byte, len(paths))
+		pathPointers := make([]*byte, len(paths))
+		for i, path := range paths {
+			data, err := byteSliceFromString(path)
+			if err != nil {
+				return err
+			}
+			pathData[i] = data
+			pathPointers[i] = &data[0]
+		}
+
+		var pathsPtr **byte
+		if len(pathPointers) > 0 {
+			pathsPtr = &pathPointers[0]
+		}
+		var e *opendalError
+		pathsLen := uint(len(paths))
+		ffiCall(
+			unsafe.Pointer(&e),
+			unsafe.Pointer(&d),
+			unsafe.Pointer(&pathsPtr),
+			unsafe.Pointer(&pathsLen),
+		)
+		// The C side reads through pathsPtr into the Go buffers behind pathData.
+		// Keep both reachable until the native call above has returned.
+		runtime.KeepAlive(pathData)
+		runtime.KeepAlive(pathPointers)
 		return parseError(ctx, e)
 	}
 })

--- a/bindings/go/string_ownership_test.go
+++ b/bindings/go/string_ownership_test.go
@@ -21,6 +21,7 @@ package opendal
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -1609,4 +1610,238 @@ func assertDeleteOptionsPointerFromArgs(t *testing.T, want *opendalDeleteOptions
 		t.Fatalf("delete option setter received %d arguments, want 2", len(aValues))
 	}
 	assertDeleteOptionsPointer(t, want, *(**opendalDeleteOptions)(aValues[0]))
+}
+
+func TestFfiDeleterSignatures(t *testing.T) {
+	// A mismatch here corrupts memory at runtime: nothing else checks the Go
+	// descriptors against the C signatures.
+	descriptors := []struct {
+		name       string
+		opts       ffiOpts
+		rType      *ffi.Type
+		aTypesLen  int
+		returnsErr bool
+	}{
+		{name: "ffiOperatorDeleter", opts: ffiOperatorDeleter.opts, rType: &typeResultOperatorDeleter, aTypesLen: 1},
+		{name: "ffiDeleterDelete", opts: ffiDeleterDelete.opts, rType: &ffi.TypePointer, aTypesLen: 2},
+		{name: "ffiDeleterDeleteWith", opts: ffiDeleterDeleteWith.opts, rType: &ffi.TypePointer, aTypesLen: 3},
+		{name: "ffiDeleterClose", opts: ffiDeleterClose.opts, rType: &ffi.TypePointer, aTypesLen: 1},
+		{name: "ffiDeleterFree", opts: ffiDeleterFree.opts, rType: &ffi.TypeVoid, aTypesLen: 1},
+	}
+	for _, tc := range descriptors {
+		if tc.opts.rType != tc.rType {
+			t.Fatalf("%s rType = %v, want %v", tc.name, tc.opts.rType, tc.rType)
+		}
+		if len(tc.opts.aTypes) != tc.aTypesLen {
+			t.Fatalf("%s aTypes len = %d, want %d", tc.name, len(tc.opts.aTypes), tc.aTypesLen)
+		}
+		for i, at := range tc.opts.aTypes {
+			if at != &ffi.TypePointer {
+				t.Fatalf("%s aTypes[%d] = %v, want TypePointer", tc.name, i, at)
+			}
+		}
+	}
+}
+
+func TestDeleterDeleteWithOptionsKeepsStringsUntilCall(t *testing.T) {
+	deleterInner := &opendalDeleter{}
+	cOpts := &opendalDeleteOptions{}
+	var versionPtr *byte
+	var recursive bool
+	optionsFreed := 0
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ffiDeleteOptionsNew.opts.sym, func() *opendalDeleteOptions { return cOpts })
+	ctx = context.WithValue(ctx, ffiDeleteOptionsFree.opts.sym, func(opts *opendalDeleteOptions) {
+		assertDeleteOptionsPointer(t, cOpts, opts)
+		optionsFreed++
+	})
+	ctx = context.WithValue(ctx, ffiDeleteOptionsSetRecursive.opts.sym, func(opts *opendalDeleteOptions, value bool) {
+		assertDeleteOptionsPointer(t, cOpts, opts)
+		recursive = value
+	})
+	ctx = context.WithValue(ctx, ffiDeleteOptionsSetVersion.opts.sym, ffiDeleteOptionsSetVersion.withFunc(ctx, func(_ unsafe.Pointer, aValues ...unsafe.Pointer) {
+		assertDeleteOptionsPointerFromArgs(t, cOpts, aValues...)
+		versionPtr = *(**byte)(aValues[1])
+	}))
+	ctx = context.WithValue(ctx, ffiDeleterDeleteWith.opts.sym, func(d *opendalDeleter, path string, opts *opendalDeleteOptions) error {
+		if d != deleterInner {
+			t.Fatalf("deleter = %p, want %p", d, deleterInner)
+		}
+		if path != "file.txt" {
+			t.Fatalf("path = %q, want file.txt", path)
+		}
+		assertDeleteOptionsPointer(t, cOpts, opts)
+		if !recursive {
+			t.Fatal("delete recursive = false, want true")
+		}
+		if got := BytePtrToString(versionPtr); got != "v1" {
+			t.Fatalf("delete version pointer = %q, want v1", got)
+		}
+		return nil
+	})
+
+	deleter := &Deleter{inner: deleterInner, ctx: ctx}
+	if err := deleter.Delete("file.txt", DeleteWithVersion("v1"), DeleteWithRecursive(true)); err != nil {
+		t.Fatalf("Delete with options failed: %v", err)
+	}
+	if optionsFreed != 1 {
+		t.Fatalf("delete options freed %d times, want 1", optionsFreed)
+	}
+}
+
+func TestDeleterCloseFlushesFreesAndBlocksReuse(t *testing.T) {
+	deleterInner := &opendalDeleter{}
+	closed := 0
+	freed := 0
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ffiDeleterClose.opts.sym, func(d *opendalDeleter) error {
+		if d != deleterInner {
+			t.Fatalf("closed deleter = %p, want %p", d, deleterInner)
+		}
+		closed++
+		return nil
+	})
+	ctx = context.WithValue(ctx, ffiDeleterFree.opts.sym, func(d *opendalDeleter) {
+		if d != deleterInner {
+			t.Fatalf("freed deleter = %p, want %p", d, deleterInner)
+		}
+		freed++
+	})
+
+	deleter := &Deleter{inner: deleterInner, ctx: ctx}
+	if err := deleter.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+	if err := deleter.Close(); err != nil {
+		t.Fatalf("second Close failed: %v", err)
+	}
+	if closed != 1 {
+		t.Fatalf("deleter closed %d times, want 1", closed)
+	}
+	if freed != 1 {
+		t.Fatalf("deleter freed %d times, want 1", freed)
+	}
+	if err := deleter.Delete("file.txt"); !errors.Is(err, ErrDeleterClosed) {
+		t.Fatalf("Delete after Close = %v, want ErrDeleterClosed", err)
+	}
+}
+
+func TestDeleterCloseFreesAfterFailedFlush(t *testing.T) {
+	deleterInner := &opendalDeleter{}
+	flushErr := errors.New("flush failed")
+	freed := 0
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ffiDeleterClose.opts.sym, func(*opendalDeleter) error { return flushErr })
+	ctx = context.WithValue(ctx, ffiDeleterFree.opts.sym, func(*opendalDeleter) { freed++ })
+
+	deleter := &Deleter{inner: deleterInner, ctx: ctx}
+	if err := deleter.Close(); !errors.Is(err, flushErr) {
+		t.Fatalf("Close = %v, want flush error", err)
+	}
+	if freed != 1 {
+		t.Fatalf("deleter freed %d times after failed flush, want 1", freed)
+	}
+}
+
+func TestRemoveQueuesEveryPathThenCloses(t *testing.T) {
+	deleterInner := &opendalDeleter{}
+	var deleted []string
+	closed := 0
+	freed := 0
+
+	ctx := newDeleterTestContext(t, deleterInner, &deleted, &closed, &freed, nil)
+
+	op := &Operator{ctx: ctx, inner: &opendalOperator{}}
+	if err := op.Remove([]string{"a.txt", "b.txt", "c.txt"}); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	want := []string{"a.txt", "b.txt", "c.txt"}
+	if len(deleted) != len(want) {
+		t.Fatalf("queued %v, want %v", deleted, want)
+	}
+	for i := range want {
+		if deleted[i] != want[i] {
+			t.Fatalf("queued[%d] = %q, want %q", i, deleted[i], want[i])
+		}
+	}
+	if closed != 1 || freed != 1 {
+		t.Fatalf("deleter closed %d times and freed %d times, want 1 and 1", closed, freed)
+	}
+}
+
+func TestRemoveReleasesDeleterWhenDeleteFails(t *testing.T) {
+	deleterInner := &opendalDeleter{}
+	var deleted []string
+	closed := 0
+	freed := 0
+	deleteErr := errors.New("delete failed")
+
+	ctx := newDeleterTestContext(t, deleterInner, &deleted, &closed, &freed, func(path string) error {
+		if path == "b.txt" {
+			return deleteErr
+		}
+		return nil
+	})
+
+	op := &Operator{ctx: ctx, inner: &opendalOperator{}}
+	if err := op.Remove([]string{"a.txt", "b.txt", "c.txt"}); !errors.Is(err, deleteErr) {
+		t.Fatalf("Remove = %v, want delete error", err)
+	}
+	if len(deleted) != 2 {
+		t.Fatalf("queued %v, want the paths up to the failure", deleted)
+	}
+	if freed != 1 {
+		t.Fatalf("deleter freed %d times, want 1", freed)
+	}
+}
+
+func TestRemoveWithoutPathsSkipsDeleter(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ffiOperatorDeleter.opts.sym, func(*opendalOperator) (*opendalDeleter, error) {
+		t.Fatal("Remove(nil) created a deleter")
+		return nil, nil
+	})
+
+	op := &Operator{ctx: ctx, inner: &opendalOperator{}}
+	if err := op.Remove(nil); err != nil {
+		t.Fatalf("Remove(nil) = %v, want nil", err)
+	}
+}
+
+func newDeleterTestContext(t *testing.T, inner *opendalDeleter, deleted *[]string, closed, freed *int, deleteFn func(string) error) context.Context {
+	t.Helper()
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ffiOperatorDeleter.opts.sym, func(op *opendalOperator) (*opendalDeleter, error) {
+		if op == nil {
+			t.Fatal("Deleter() passed nil operator")
+		}
+		return inner, nil
+	})
+	ctx = context.WithValue(ctx, ffiDeleterDelete.opts.sym, func(d *opendalDeleter, path string) error {
+		if d != inner {
+			t.Fatalf("deleter = %p, want %p", d, inner)
+		}
+		*deleted = append(*deleted, path)
+		if deleteFn != nil {
+			return deleteFn(path)
+		}
+		return nil
+	})
+	ctx = context.WithValue(ctx, ffiDeleterClose.opts.sym, func(d *opendalDeleter) error {
+		if d != inner {
+			t.Fatalf("closed deleter = %p, want %p", d, inner)
+		}
+		*closed++
+		return nil
+	})
+	ctx = context.WithValue(ctx, ffiDeleterFree.opts.sym, func(d *opendalDeleter) {
+		if d != inner {
+			t.Fatalf("freed deleter = %p, want %p", d, inner)
+		}
+		*freed++
+	})
+	return ctx
 }

--- a/bindings/go/string_ownership_test.go
+++ b/bindings/go/string_ownership_test.go
@@ -21,7 +21,9 @@ package opendal
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"slices"
 	"testing"
 	"time"
 	"unsafe"
@@ -1609,4 +1611,373 @@ func assertDeleteOptionsPointerFromArgs(t *testing.T, want *opendalDeleteOptions
 		t.Fatalf("delete option setter received %d arguments, want 2", len(aValues))
 	}
 	assertDeleteOptionsPointer(t, want, *(**opendalDeleteOptions)(aValues[0]))
+}
+
+func TestFfiDeleterSignatures(t *testing.T) {
+	// A mismatch here corrupts memory at runtime: nothing else checks the Go
+	// descriptors against the C signatures.
+	descriptors := []struct {
+		name      string
+		opts      ffiOpts
+		rType     *ffi.Type
+		aTypesLen int
+	}{
+		{name: "ffiOperatorDeleter", opts: ffiOperatorDeleter.opts, rType: &typeResultOperatorDeleter, aTypesLen: 1},
+		{name: "ffiDeleterDelete", opts: ffiDeleterDelete.opts, rType: &ffi.TypePointer, aTypesLen: 2},
+		{name: "ffiDeleterDeleteWith", opts: ffiDeleterDeleteWith.opts, rType: &ffi.TypePointer, aTypesLen: 3},
+		{name: "ffiDeleterFlush", opts: ffiDeleterFlush.opts, rType: &ffi.TypePointer, aTypesLen: 1},
+		{name: "ffiDeleterFree", opts: ffiDeleterFree.opts, rType: &ffi.TypeVoid, aTypesLen: 1},
+	}
+	for _, tc := range descriptors {
+		if tc.opts.rType != tc.rType {
+			t.Fatalf("%s rType = %v, want %v", tc.name, tc.opts.rType, tc.rType)
+		}
+		if len(tc.opts.aTypes) != tc.aTypesLen {
+			t.Fatalf("%s aTypes len = %d, want %d", tc.name, len(tc.opts.aTypes), tc.aTypesLen)
+		}
+		for i, at := range tc.opts.aTypes {
+			if at != &ffi.TypePointer {
+				t.Fatalf("%s aTypes[%d] = %v, want TypePointer", tc.name, i, at)
+			}
+		}
+	}
+}
+
+func TestDeleterDeleteWithOptionsKeepsStringsUntilCall(t *testing.T) {
+	deleterInner := newTestDeleterHandle()
+	cOpts := &opendalDeleteOptions{}
+	var versionPtr *byte
+	var recursive bool
+	optionsFreed := 0
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ffiDeleteOptionsNew.opts.sym, func() *opendalDeleteOptions { return cOpts })
+	ctx = context.WithValue(ctx, ffiDeleteOptionsFree.opts.sym, func(opts *opendalDeleteOptions) {
+		assertDeleteOptionsPointer(t, cOpts, opts)
+		optionsFreed++
+	})
+	ctx = context.WithValue(ctx, ffiDeleteOptionsSetRecursive.opts.sym, func(opts *opendalDeleteOptions, value bool) {
+		assertDeleteOptionsPointer(t, cOpts, opts)
+		recursive = value
+	})
+	ctx = context.WithValue(ctx, ffiDeleteOptionsSetVersion.opts.sym, ffiDeleteOptionsSetVersion.withFunc(ctx, func(_ unsafe.Pointer, aValues ...unsafe.Pointer) {
+		assertDeleteOptionsPointerFromArgs(t, cOpts, aValues...)
+		versionPtr = *(**byte)(aValues[1])
+	}))
+	ctx = context.WithValue(ctx, ffiDeleterDeleteWith.opts.sym, func(d *opendalDeleter, path string, opts *opendalDeleteOptions) error {
+		if d != deleterInner {
+			t.Fatalf("deleter = %p, want %p", d, deleterInner)
+		}
+		if path != "file.txt" {
+			t.Fatalf("path = %q, want file.txt", path)
+		}
+		assertDeleteOptionsPointer(t, cOpts, opts)
+		if !recursive {
+			t.Fatal("delete recursive = false, want true")
+		}
+		if got := BytePtrToString(versionPtr); got != "v1" {
+			t.Fatalf("delete version pointer = %q, want v1", got)
+		}
+		return nil
+	})
+
+	deleter := &Deleter{inner: deleterInner, ctx: ctx}
+	if err := deleter.Delete("file.txt", DeleteWithVersion("v1"), DeleteWithRecursive(true)); err != nil {
+		t.Fatalf("Delete with options failed: %v", err)
+	}
+	if optionsFreed != 1 {
+		t.Fatalf("delete options freed %d times, want 1", optionsFreed)
+	}
+}
+
+func TestDeleterCloseFlushesFreesAndBlocksReuse(t *testing.T) {
+	deleterInner := newTestDeleterHandle()
+	var calls deleterCalls
+
+	ctx := newDeleterTestContext(t, deleterInner, &calls, nil, nil)
+
+	deleter := &Deleter{inner: deleterInner, ctx: ctx}
+	if err := deleter.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+	if err := deleter.Close(); err != nil {
+		t.Fatalf("second Close failed: %v", err)
+	}
+	if calls.flushes != 1 {
+		t.Fatalf("deleter flushed %d times, want 1", calls.flushes)
+	}
+	if calls.freed != 1 {
+		t.Fatalf("deleter freed %d times, want 1", calls.freed)
+	}
+	if err := deleter.Delete("file.txt"); !errors.Is(err, ErrDeleterClosed) {
+		t.Fatalf("Delete after Close = %v, want ErrDeleterClosed", err)
+	}
+}
+
+func TestDeleterCloseReleasesAndReportsFailedFlush(t *testing.T) {
+	// Close releases unconditionally, like every other Close in this package, so
+	// a deferred Close cannot leak the handle. Retrying is Flush's job.
+	deleterInner := newTestDeleterHandle()
+	flushErr := errors.New("flush failed")
+	var calls deleterCalls
+
+	ctx := newDeleterTestContext(t, deleterInner, &calls, nil, func() error { return flushErr })
+
+	deleter := &Deleter{inner: deleterInner, ctx: ctx}
+	if err := deleter.Close(); !errors.Is(err, flushErr) {
+		t.Fatalf("Close = %v, want flush error", err)
+	}
+	if calls.freed != 1 {
+		t.Fatalf("deleter freed %d times after failed flush, want 1", calls.freed)
+	}
+	if err := deleter.Close(); err != nil {
+		t.Fatalf("second Close = %v, want nil", err)
+	}
+	if calls.freed != 1 {
+		t.Fatalf("deleter freed %d times after the second Close, want 1", calls.freed)
+	}
+}
+
+func TestDeleterFlushRetriesThenCloseReleases(t *testing.T) {
+	// Flush keeps the deleter alive so a failed flush can be retried; only the
+	// Close that follows releases it.
+	deleterInner := newTestDeleterHandle()
+	flushErr := errors.New("flush failed")
+	var calls deleterCalls
+
+	ctx := newDeleterTestContext(t, deleterInner, &calls, nil, func() error {
+		if calls.flushes == 1 {
+			return flushErr
+		}
+		return nil
+	})
+
+	deleter := &Deleter{inner: deleterInner, ctx: ctx}
+	if err := deleter.Flush(); !errors.Is(err, flushErr) {
+		t.Fatalf("Flush = %v, want flush error", err)
+	}
+	if calls.freed != 0 {
+		t.Fatalf("Flush freed the deleter %d times, want 0", calls.freed)
+	}
+	if err := deleter.Flush(); err != nil {
+		t.Fatalf("Flush retry failed: %v", err)
+	}
+	if err := deleter.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+	if calls.flushes != 3 {
+		t.Fatalf("flushed %d times, want 3", calls.flushes)
+	}
+	if calls.freed != 1 {
+		t.Fatalf("deleter freed %d times, want 1", calls.freed)
+	}
+}
+
+func TestDeleterDiscardReleasesWithoutFlushing(t *testing.T) {
+	deleterInner := newTestDeleterHandle()
+	var calls deleterCalls
+
+	ctx := newDeleterTestContext(t, deleterInner, &calls, nil, nil)
+
+	deleter := &Deleter{inner: deleterInner, ctx: ctx}
+	deleter.Discard()
+	deleter.Discard()
+	if calls.flushes != 0 {
+		t.Fatalf("Discard flushed %d times, want 0", calls.flushes)
+	}
+	if calls.freed != 1 {
+		t.Fatalf("deleter freed %d times, want 1", calls.freed)
+	}
+	if err := deleter.Delete("file.txt"); !errors.Is(err, ErrDeleterClosed) {
+		t.Fatalf("Delete after Discard = %v, want ErrDeleterClosed", err)
+	}
+}
+
+func TestDeleterFlushKeepsDeleterUsable(t *testing.T) {
+	deleterInner := newTestDeleterHandle()
+	var calls deleterCalls
+
+	ctx := newDeleterTestContext(t, deleterInner, &calls, nil, nil)
+
+	deleter := &Deleter{inner: deleterInner, ctx: ctx}
+	if err := deleter.Flush(); err != nil {
+		t.Fatalf("Flush failed: %v", err)
+	}
+	if calls.freed != 0 {
+		t.Fatalf("Flush freed the deleter %d times, want 0", calls.freed)
+	}
+	if err := deleter.Delete("file.txt"); err != nil {
+		t.Fatalf("Delete after Flush failed: %v", err)
+	}
+	if err := deleter.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+	if calls.flushes != 2 {
+		t.Fatalf("flushed %d times, want 2", calls.flushes)
+	}
+	if err := deleter.Flush(); !errors.Is(err, ErrDeleterClosed) {
+		t.Fatalf("Flush after Close = %v, want ErrDeleterClosed", err)
+	}
+}
+
+func TestRemoveQueuesEveryPathThenCloses(t *testing.T) {
+	deleterInner := newTestDeleterHandle()
+	var calls deleterCalls
+
+	ctx := newDeleterTestContext(t, deleterInner, &calls, nil, nil)
+
+	op := &Operator{ctx: ctx, inner: &opendalOperator{}}
+	if err := op.Remove([]string{"a.txt", "b.txt", "c.txt"}); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+	assertPaths(t, calls.deleted, []string{"a.txt", "b.txt", "c.txt"})
+	if calls.perPath != 3 {
+		t.Fatalf("Remove queued %d paths, want 3", calls.perPath)
+	}
+	if calls.flushes != 1 || calls.freed != 1 {
+		t.Fatalf("deleter flushed %d times and freed %d times, want 1 and 1", calls.flushes, calls.freed)
+	}
+}
+
+func TestRemoveDiscardsQueueWhenQueueingFails(t *testing.T) {
+	deleterInner := newTestDeleterHandle()
+	var calls deleterCalls
+	deleteErr := errors.New("delete failed")
+
+	ctx := newDeleterTestContext(t, deleterInner, &calls, func([]string) error { return deleteErr }, nil)
+
+	op := &Operator{ctx: ctx, inner: &opendalOperator{}}
+	if err := op.Remove([]string{"a.txt", "b.txt", "c.txt"}); !errors.Is(err, deleteErr) {
+		t.Fatalf("Remove = %v, want delete error", err)
+	}
+	// Flushing here would delete whatever was queued before the failure while
+	// reporting that Remove failed.
+	if calls.flushes != 0 {
+		t.Fatalf("Remove flushed %d times on its error path, want 0", calls.flushes)
+	}
+	if calls.freed != 1 {
+		t.Fatalf("deleter freed %d times, want 1", calls.freed)
+	}
+}
+
+func assertPaths(t *testing.T, got, want []string) {
+	t.Helper()
+	if !slices.Equal(got, want) {
+		t.Fatalf("queued %v, want %v", got, want)
+	}
+}
+
+func TestWithDeleterReportsAndReleasesOnFailedFlush(t *testing.T) {
+	deleterInner := newTestDeleterHandle()
+	flushErr := errors.New("flush failed")
+	var calls deleterCalls
+
+	ctx := newDeleterTestContext(t, deleterInner, &calls, nil, func() error { return flushErr })
+
+	op := &Operator{ctx: ctx, inner: &opendalOperator{}}
+	err := op.WithDeleter(func(d *Deleter) error { return d.Delete("a.txt") })
+	if !errors.Is(err, flushErr) {
+		t.Fatalf("WithDeleter = %v, want flush error", err)
+	}
+	if calls.freed != 1 {
+		t.Fatalf("deleter freed %d times, want 1", calls.freed)
+	}
+}
+
+func TestWithDeleterReleasesWhenFnPanics(t *testing.T) {
+	// ffiDeleterDelete.symbol is an unchecked type assertion, so a panic out of fn
+	// is reachable from the binding itself, not only from caller bugs.
+	deleterInner := newTestDeleterHandle()
+	var calls deleterCalls
+
+	ctx := newDeleterTestContext(t, deleterInner, &calls, nil, nil)
+
+	op := &Operator{ctx: ctx, inner: &opendalOperator{}}
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("WithDeleter swallowed the panic")
+			}
+		}()
+		_ = op.WithDeleter(func(*Deleter) error { panic("boom") })
+	}()
+
+	if calls.freed != 1 {
+		t.Fatalf("deleter freed %d times after a panic, want 1", calls.freed)
+	}
+	if calls.flushes != 0 {
+		t.Fatalf("flushed %d times after a panic, want 0", calls.flushes)
+	}
+}
+
+func TestRemoveWithoutPathsSkipsDeleter(t *testing.T) {
+	ctx := context.WithValue(context.Background(), ffiOperatorDeleter.opts.sym, func(*opendalOperator) (*opendalDeleter, error) {
+		t.Fatal("Remove(nil) created a deleter")
+		return nil, nil
+	})
+
+	op := &Operator{ctx: ctx, inner: &opendalOperator{}}
+	if err := op.Remove(nil); err != nil {
+		t.Fatalf("Remove(nil) = %v, want nil", err)
+	}
+}
+
+// newTestDeleterHandle returns a distinct stand-in for a C deleter handle.
+//
+// opendalDeleter is zero-sized, so every &opendalDeleter{} shares runtime.zerobase
+// and the "is this the handle I was given?" assertions below would hold no matter
+// which handle the code passed. Backing each handle with a byte gives it its own
+// address and makes those assertions real.
+func newTestDeleterHandle() *opendalDeleter {
+	return (*opendalDeleter)(unsafe.Pointer(new(byte)))
+}
+
+// deleterCalls records what the stubbed deleter FFI saw.
+type deleterCalls struct {
+	deleted []string
+	perPath int
+	flushes int
+	freed   int
+}
+
+func newDeleterTestContext(t *testing.T, inner *opendalDeleter, calls *deleterCalls, deleteFn func([]string) error, flushFn func() error) context.Context {
+	t.Helper()
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ffiOperatorDeleter.opts.sym, func(op *opendalOperator) (*opendalDeleter, error) {
+		if op == nil {
+			t.Fatal("Deleter() passed nil operator")
+		}
+		return inner, nil
+	})
+	ctx = context.WithValue(ctx, ffiDeleterDelete.opts.sym, func(d *opendalDeleter, path string) error {
+		if d != inner {
+			t.Fatalf("deleter = %p, want %p", d, inner)
+		}
+		calls.perPath++
+		calls.deleted = append(calls.deleted, path)
+		if deleteFn != nil {
+			return deleteFn([]string{path})
+		}
+		return nil
+	})
+	ctx = context.WithValue(ctx, ffiDeleterFlush.opts.sym, func(d *opendalDeleter) error {
+		if d != inner {
+			t.Fatalf("flushed deleter = %p, want %p", d, inner)
+		}
+		// calls.flushes is incremented before flushFn runs, so a flushFn can key
+		// its behavior off the attempt number.
+		calls.flushes++
+		if flushFn != nil {
+			return flushFn()
+		}
+		return nil
+	})
+	ctx = context.WithValue(ctx, ffiDeleterFree.opts.sym, func(d *opendalDeleter) {
+		if d != inner {
+			t.Fatalf("freed deleter = %p, want %p", d, inner)
+		}
+		calls.freed++
+	})
+	return ctx
 }

--- a/bindings/go/string_ownership_test.go
+++ b/bindings/go/string_ownership_test.go
@@ -1624,6 +1624,7 @@ func TestFfiDeleterSignatures(t *testing.T) {
 	}{
 		{name: "ffiOperatorDeleter", opts: ffiOperatorDeleter.opts, rType: &typeResultOperatorDeleter, aTypesLen: 1},
 		{name: "ffiDeleterDelete", opts: ffiDeleterDelete.opts, rType: &ffi.TypePointer, aTypesLen: 2},
+		{name: "ffiDeleterDeleteMany", opts: ffiDeleterDeleteMany.opts, rType: &ffi.TypePointer, aTypesLen: 3},
 		{name: "ffiDeleterDeleteWith", opts: ffiDeleterDeleteWith.opts, rType: &ffi.TypePointer, aTypesLen: 3},
 		{name: "ffiDeleterFlush", opts: ffiDeleterFlush.opts, rType: &ffi.TypePointer, aTypesLen: 1},
 		{name: "ffiDeleterFree", opts: ffiDeleterFree.opts, rType: &ffi.TypeVoid, aTypesLen: 1},
@@ -1640,6 +1641,58 @@ func TestFfiDeleterSignatures(t *testing.T) {
 				t.Fatalf("%s aTypes[%d] = %v, want TypePointer", tc.name, i, at)
 			}
 		}
+	}
+}
+
+func TestFfiDeleterDeleteManyMarshalsPaths(t *testing.T) {
+	deleterInner := newTestDeleterHandle()
+	want := []string{"a.txt", "b.txt", "nested/c.txt"}
+	calls := 0
+
+	deleteMany := ffiDeleterDeleteMany.withFunc(context.Background(), func(rValue unsafe.Pointer, aValues ...unsafe.Pointer) {
+		calls++
+		if len(aValues) != 3 {
+			t.Fatalf("delete many received %d arguments, want 3", len(aValues))
+		}
+		if got := *(**opendalDeleter)(aValues[0]); got != deleterInner {
+			t.Fatalf("deleter = %p, want %p", got, deleterInner)
+		}
+
+		pathsLen := *(*uint)(aValues[2])
+		if pathsLen != uint(len(want)) {
+			t.Fatalf("paths len = %d, want %d", pathsLen, len(want))
+		}
+		pathsPtr := *(***byte)(aValues[1])
+		paths := unsafe.Slice(pathsPtr, int(pathsLen))
+		for i, path := range paths {
+			if got := BytePtrToString(path); got != want[i] {
+				t.Fatalf("path[%d] = %q, want %q", i, got, want[i])
+			}
+		}
+		*(**opendalError)(rValue) = nil
+	})
+
+	if err := deleteMany(deleterInner, want); err != nil {
+		t.Fatalf("delete many failed: %v", err)
+	}
+	// One crossing for the whole slice is the point of this entry point.
+	if calls != 1 {
+		t.Fatalf("delete many called FFI %d times, want 1", calls)
+	}
+}
+
+func TestFfiDeleterDeleteManyRejectsNulBeforeCall(t *testing.T) {
+	called := false
+	deleteMany := ffiDeleterDeleteMany.withFunc(context.Background(), func(unsafe.Pointer, ...unsafe.Pointer) {
+		called = true
+	})
+
+	err := deleteMany(newTestDeleterHandle(), []string{"a.txt", "bad\x00path"})
+	if err == nil {
+		t.Fatal("delete many with a nul path succeeded")
+	}
+	if called {
+		t.Fatal("delete many called FFI after path validation failed")
 	}
 }
 
@@ -1820,7 +1873,7 @@ func TestDeleterFlushKeepsDeleterUsable(t *testing.T) {
 	}
 }
 
-func TestRemoveQueuesEveryPathThenCloses(t *testing.T) {
+func TestRemoveQueuesEveryPathInOneCrossingThenCloses(t *testing.T) {
 	deleterInner := newTestDeleterHandle()
 	var calls deleterCalls
 
@@ -1831,8 +1884,13 @@ func TestRemoveQueuesEveryPathThenCloses(t *testing.T) {
 		t.Fatalf("Remove failed: %v", err)
 	}
 	assertPaths(t, calls.deleted, []string{"a.txt", "b.txt", "c.txt"})
-	if calls.perPath != 3 {
-		t.Fatalf("Remove queued %d paths, want 3", calls.perPath)
+	// Remove exists to hand the whole slice over at once. Queueing per path would
+	// still pass the assertion above, so pin the crossing count down too.
+	if calls.bulk != 1 {
+		t.Fatalf("Remove made %d bulk calls, want 1", calls.bulk)
+	}
+	if calls.perPath != 0 {
+		t.Fatalf("Remove queued %d paths one at a time, want 0", calls.perPath)
 	}
 	if calls.flushes != 1 || calls.freed != 1 {
 		t.Fatalf("deleter flushed %d times and freed %d times, want 1 and 1", calls.flushes, calls.freed)
@@ -1932,9 +1990,12 @@ func newTestDeleterHandle() *opendalDeleter {
 	return (*opendalDeleter)(unsafe.Pointer(new(byte)))
 }
 
-// deleterCalls records what the stubbed deleter FFI saw.
+// deleterCalls records what the stubbed deleter FFI saw. Separating bulk from
+// perPath is what lets a test tell "queued the slice at once" apart from "queued
+// the same paths one crossing at a time".
 type deleterCalls struct {
 	deleted []string
+	bulk    int
 	perPath int
 	flushes int
 	freed   int
@@ -1958,6 +2019,17 @@ func newDeleterTestContext(t *testing.T, inner *opendalDeleter, calls *deleterCa
 		calls.deleted = append(calls.deleted, path)
 		if deleteFn != nil {
 			return deleteFn([]string{path})
+		}
+		return nil
+	})
+	ctx = context.WithValue(ctx, ffiDeleterDeleteMany.opts.sym, func(d *opendalDeleter, paths []string) error {
+		if d != inner {
+			t.Fatalf("deleter = %p, want %p", d, inner)
+		}
+		calls.bulk++
+		calls.deleted = append(calls.deleted, paths...)
+		if deleteFn != nil {
+			return deleteFn(paths)
 		}
 		return nil
 	})

--- a/bindings/go/tests/behavior_tests/delete_test.go
+++ b/bindings/go/tests/behavior_tests/delete_test.go
@@ -36,9 +36,13 @@ func testsDelete(cap *opendal.Capability) []behaviorTest {
 		testDeleteEmptyDir,
 		testDeleteWithSpecialChars,
 		testDeleteNotExisting,
+		testDeleterDeleteFiles,
+		testDeleterDeleteNotExisting,
+		testRemoveFiles,
+		testRemoveNoPaths,
 	}
 	if cap.DeleteWithRecursive() {
-		tests = append(tests, testDeleteWithRecursive)
+		tests = append(tests, testDeleteWithRecursive, testDeleterDeleteWithRecursive)
 	}
 	if cap.DeleteWithVersion() {
 		tests = append(tests, testDeleteWithVersion)
@@ -110,6 +114,88 @@ func testDeleteWithRecursive(assert *require.Assertions, op *opendal.Operator, f
 	for _, p := range filePaths {
 		assert.False(op.IsExist(p))
 	}
+}
+
+func testDeleterDeleteFiles(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	var paths []string
+	for range 3 {
+		path, content, _ := fixture.NewFile()
+		_, err := op.Write(path, content)
+		assert.Nil(err, "write must succeed")
+		paths = append(paths, path)
+	}
+
+	deleter, err := op.Deleter()
+	assert.Nil(err, "create deleter must succeed")
+	for _, path := range paths {
+		assert.Nil(deleter.Delete(path), "queue delete must succeed")
+	}
+	// The deletions are only guaranteed to have happened once Close returns.
+	assert.Nil(deleter.Close(), "close deleter must succeed")
+
+	for _, path := range paths {
+		assert.False(op.IsExist(path))
+	}
+
+	// Close is idempotent, and a closed deleter rejects further paths.
+	assert.Nil(deleter.Close())
+	assert.NotNil(deleter.Delete(paths[0]))
+}
+
+func testDeleterDeleteNotExisting(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	deleter, err := op.Deleter()
+	assert.Nil(err, "create deleter must succeed")
+
+	assert.Nil(deleter.Delete(uuid.NewString()))
+	assert.Nil(deleter.Close())
+}
+
+func testDeleterDeleteWithRecursive(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	if !op.Info().GetCapability().CreateDir() {
+		return
+	}
+
+	dir := fixture.NewDirPath()
+	assert.Nil(op.CreateDir(dir), "create dir must succeed")
+
+	var filePaths []string
+	for i := range 3 {
+		path, content, _ := fixture.NewFileWithPath(fmt.Sprintf("%sfile-%d.txt", dir, i))
+		_, err := op.Write(path, content)
+		assert.Nil(err, "write must succeed")
+		filePaths = append(filePaths, path)
+	}
+
+	deleter, err := op.Deleter()
+	assert.Nil(err, "create deleter must succeed")
+	assert.Nil(deleter.Delete(dir, opendal.DeleteWithRecursive(true)))
+	assert.Nil(deleter.Close(), "close deleter must succeed")
+
+	assert.False(op.IsExist(dir))
+	for _, path := range filePaths {
+		assert.False(op.IsExist(path))
+	}
+}
+
+func testRemoveFiles(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	var paths []string
+	for range 3 {
+		path, content, _ := fixture.NewFile()
+		_, err := op.Write(path, content)
+		assert.Nil(err, "write must succeed")
+		paths = append(paths, path)
+	}
+
+	assert.Nil(op.Remove(paths), "remove must succeed")
+
+	for _, path := range paths {
+		assert.False(op.IsExist(path))
+	}
+}
+
+func testRemoveNoPaths(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	assert.Nil(op.Remove(nil))
+	assert.Nil(op.Remove([]string{}))
 }
 
 func testDeleteWithVersion(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {

--- a/bindings/go/tests/behavior_tests/delete_test.go
+++ b/bindings/go/tests/behavior_tests/delete_test.go
@@ -36,9 +36,12 @@ func testsDelete(cap *opendal.Capability) []behaviorTest {
 		testDeleteEmptyDir,
 		testDeleteWithSpecialChars,
 		testDeleteNotExisting,
+		testDeleterDeleteFiles,
+		testDeleterDeleteNotExisting,
+		testRemoveFiles,
 	}
 	if cap.DeleteWithRecursive() {
-		tests = append(tests, testDeleteWithRecursive)
+		tests = append(tests, testDeleteWithRecursive, testDeleterDeleteWithRecursive)
 	}
 	if cap.DeleteWithVersion() {
 		tests = append(tests, testDeleteWithVersion)
@@ -87,29 +90,102 @@ func testDeleteNotExisting(assert *require.Assertions, op *opendal.Operator, fix
 	assert.Nil(op.Delete(path))
 }
 
-func testDeleteWithRecursive(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+// writeTestFiles writes n fixture files and returns their paths.
+func writeTestFiles(assert *require.Assertions, op *opendal.Operator, fixture *fixture, n int) []string {
+	var paths []string
+	for range n {
+		path, content, _ := fixture.NewFile()
+		_, err := op.Write(path, content)
+		assert.Nil(err, "write must succeed")
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+// setupRecursiveDir creates a directory holding three files and returns it, or
+// ok=false when the service cannot create directories.
+func setupRecursiveDir(assert *require.Assertions, op *opendal.Operator, fixture *fixture) (dir string, filePaths []string, ok bool) {
 	if !op.Info().GetCapability().CreateDir() {
-		return
+		return "", nil, false
 	}
 
-	dir := fixture.NewDirPath()
+	dir = fixture.NewDirPath()
 	assert.Nil(op.CreateDir(dir), "create dir must succeed")
 
-	// Write a few files under the directory.
-	var filePaths []string
 	for i := range 3 {
 		path, content, _ := fixture.NewFileWithPath(fmt.Sprintf("%sfile-%d.txt", dir, i))
 		_, err := op.Write(path, content)
 		assert.Nil(err, "write must succeed")
 		filePaths = append(filePaths, path)
 	}
+	return dir, filePaths, true
+}
+
+func assertAllGone(assert *require.Assertions, op *opendal.Operator, paths ...string) {
+	for _, path := range paths {
+		assert.False(op.IsExist(path))
+	}
+}
+
+func testDeleteWithRecursive(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	dir, filePaths, ok := setupRecursiveDir(assert, op, fixture)
+	if !ok {
+		return
+	}
 
 	assert.Nil(op.Delete(dir, opendal.DeleteWithRecursive(true)))
 
-	assert.False(op.IsExist(dir))
-	for _, p := range filePaths {
-		assert.False(op.IsExist(p))
+	assertAllGone(assert, op, dir)
+	assertAllGone(assert, op, filePaths...)
+}
+
+func testDeleterDeleteFiles(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	paths := writeTestFiles(assert, op, fixture, 3)
+
+	deleter, err := op.Deleter()
+	assert.Nil(err, "create deleter must succeed")
+	// Release the deleter even when an assertion below fails the test early.
+	defer deleter.Discard()
+	for _, path := range paths {
+		assert.Nil(deleter.Delete(path), "queue delete must succeed")
 	}
+	// The deletions are only guaranteed to have happened once Close returns.
+	assert.Nil(deleter.Close(), "close deleter must succeed")
+
+	assertAllGone(assert, op, paths...)
+}
+
+func testDeleterDeleteNotExisting(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	deleter, err := op.Deleter()
+	assert.Nil(err, "create deleter must succeed")
+	defer deleter.Discard()
+
+	assert.Nil(deleter.Delete(uuid.NewString()))
+	assert.Nil(deleter.Close())
+}
+
+func testDeleterDeleteWithRecursive(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	dir, filePaths, ok := setupRecursiveDir(assert, op, fixture)
+	if !ok {
+		return
+	}
+
+	deleter, err := op.Deleter()
+	assert.Nil(err, "create deleter must succeed")
+	defer deleter.Discard()
+	assert.Nil(deleter.Delete(dir, opendal.DeleteWithRecursive(true)))
+	assert.Nil(deleter.Close(), "close deleter must succeed")
+
+	assertAllGone(assert, op, dir)
+	assertAllGone(assert, op, filePaths...)
+}
+
+func testRemoveFiles(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {
+	paths := writeTestFiles(assert, op, fixture, 3)
+
+	assert.Nil(op.Remove(paths), "remove must succeed")
+
+	assertAllGone(assert, op, paths...)
 }
 
 func testDeleteWithVersion(assert *require.Assertions, op *opendal.Operator, fixture *fixture) {

--- a/bindings/go/types.go
+++ b/bindings/go/types.go
@@ -126,6 +126,15 @@ var (
 		}[0],
 	}
 
+	typeResultOperatorDeleter = ffi.Type{
+		Type: ffi.Struct,
+		Elements: &[]*ffi.Type{
+			&ffi.TypePointer,
+			&ffi.TypePointer,
+			nil,
+		}[0],
+	}
+
 	typeResultCopierNext = ffi.Type{
 		Type: ffi.Struct,
 		Elements: &[]*ffi.Type{
@@ -339,6 +348,13 @@ type resultCopierNext struct {
 	size     uint
 	has_next uint8
 	error    *opendalError
+}
+
+type opendalDeleter struct{}
+
+type resultOperatorDeleter struct {
+	deleter *opendalDeleter
+	error   *opendalError
 }
 
 type resultReaderRead struct {

--- a/website/docs/20-bindings/go/04-tasks.md
+++ b/website/docs/20-bindings/go/04-tasks.md
@@ -158,6 +158,86 @@ err = op.Delete("dir/", opendal.DeleteWithRecursive(true))    // path and everyt
 
 `Delete` succeeds even if the path does not exist.
 
+## Delete many paths
+
+```go
+err := op.Remove([]string{"a.txt", "b.txt", "c.txt"})
+```
+
+`Remove` deletes the paths in batches on services that support batch deletion,
+such as S3. It is not atomic: queueing stops at the first path the service
+rejects, but an earlier batch may already be gone.
+
+Use `WithDeleter` when you queue paths as you discover them, or when you need
+per-path options. It flushes the queue when your function returns nil, skips the
+flush when your function returns an error, and releases the deleter either way —
+including when your function panics:
+
+```go
+err := op.WithDeleter(func(d *opendal.Deleter) error {
+	for _, path := range paths {
+		// Delete only queues a path; nothing is removed until the flush.
+		if err := d.Delete(path); err != nil {
+			return err
+		}
+	}
+	return nil
+})
+```
+
+Skipping the flush is not a rollback. Services without batch delete support
+remove each path as `Delete` queues it, and batch services flush on their own
+once a batch fills, so treat a failed `WithDeleter` as "some of these paths may
+be gone."
+
+Per-path options are the reason to reach for a `Deleter` rather than `Remove`.
+`Remove` always deletes the current version of each path, so deleting specific
+versions needs a deleter:
+
+```go
+err := op.WithDeleter(func(d *opendal.Deleter) error {
+	return d.Delete("a.txt", opendal.DeleteWithVersion("v1"))
+})
+```
+
+Driving the deleter yourself gives you `Flush`, which reports the deletions
+without releasing the deleter, so you can retry a failed batch. Queue paths one
+at a time only when you discover them as you go; for a slice you already hold,
+prefer `Remove`:
+
+```go
+func deleteAsDiscovered(op *opendal.Operator, paths []string) error {
+	deleter, err := op.Deleter()
+	if err != nil {
+		return err
+	}
+	// Release the deleter on every path out of this function. It is a no-op
+	// after Close, which releases on its own. Without it the handle leaks: the
+	// binding installs no finalizer.
+	defer deleter.Discard()
+
+	for _, path := range paths {
+		if err := deleter.Delete(path); err != nil {
+			return err
+		}
+	}
+	// Flush keeps the paths it could not delete queued, so retrying it does not
+	// rebuild the queue.
+	var flushErr error
+	for range 3 {
+		if flushErr = deleter.Flush(); flushErr == nil {
+			break
+		}
+	}
+	if flushErr != nil {
+		return flushErr
+	}
+	// Close flushes once more and always releases, so its error is your last
+	// report that the deletions failed. Check it instead of deferring it.
+	return deleter.Close()
+}
+```
+
 ## Create a directory
 
 ```go

--- a/website/docs/20-bindings/go/04-tasks.md
+++ b/website/docs/20-bindings/go/04-tasks.md
@@ -165,8 +165,9 @@ err := op.Remove([]string{"a.txt", "b.txt", "c.txt"})
 ```
 
 `Remove` deletes the paths in batches on services that support batch deletion,
-such as S3. It is not atomic: queueing stops at the first path the service
-rejects, but an earlier batch may already be gone.
+such as S3. It hands the whole slice to the C library in one call, so prefer it
+over looping when you already know the paths. It is not atomic: queueing stops at
+the first path the service rejects, but an earlier batch may already be gone.
 
 Use `WithDeleter` when you queue paths as you discover them, or when you need
 per-path options. It flushes the queue when your function returns nil, skips the
@@ -203,7 +204,7 @@ err := op.WithDeleter(func(d *opendal.Deleter) error {
 Driving the deleter yourself gives you `Flush`, which reports the deletions
 without releasing the deleter, so you can retry a failed batch. Queue paths one
 at a time only when you discover them as you go; for a slice you already hold,
-prefer `Remove`:
+`Remove` crosses into the C library once instead of once per path:
 
 ```go
 func deleteAsDiscovered(op *opendal.Operator, paths []string) error {

--- a/website/docs/20-bindings/go/04-tasks.md
+++ b/website/docs/20-bindings/go/04-tasks.md
@@ -158,6 +158,33 @@ err = op.Delete("dir/", opendal.DeleteWithRecursive(true))    // path and everyt
 
 `Delete` succeeds even if the path does not exist.
 
+## Delete many paths
+
+```go
+err := op.Remove([]string{"a.txt", "b.txt", "c.txt"})
+```
+
+`Remove` deletes the paths in batches on services that support batch deletion,
+such as S3. Drive a `Deleter` yourself when you queue paths as you discover them
+or need per-path options:
+
+```go
+deleter, err := op.Deleter()
+if err != nil {
+	log.Fatal(err)
+}
+for _, path := range paths {
+	if err := deleter.Delete(path); err != nil {
+		log.Fatal(err)
+	}
+}
+// Delete only queues a path. Close flushes the queue, waits for the deletions,
+// and reports whether they succeeded, so check its error instead of deferring it.
+if err := deleter.Close(); err != nil {
+	log.Fatal(err)
+}
+```
+
 ## Create a directory
 
 ```go


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

Core exposes `Operator::deleter()`, which queues paths and uses the service's batch deletion. Neither binding exposed it, so Go users deleted one path per request.

# What changes are included in this PR?

```go
// Delete a known set of paths in one crossing of the FFI boundary.
err := op.Remove([]string{"a.txt", "b.txt", "c.txt"})

// Or queue paths as you discover them, or with per-path options.
err = op.WithDeleter(func(d *opendal.Deleter) error {
    return d.Delete("a.txt", opendal.DeleteWithVersion("v1"))
})
```

- C: `opendal_operator_deleter` returns an `opendal_deleter` handle, driven by `opendal_deleter_delete`, `_delete_with`, `_delete_many`, `_flush` and `_free`. `_flush` hands the queued paths to the service and waits for them; it does not end the deleter's life, and it keeps whatever it could not delete queued so a failed flush can be retried.
- C: `opendal_deleter_delete_many` queues a whole array of paths in one call, so a known set costs one boundary crossing and one blocking call instead of one per path.
- C: `opendal_delete_options` gains a `From` impl for `options::DeleteOptions`, shared with `opendal_operator_delete_with` and `opendal_operator_presign_delete_with`.
- Go: `Operator.Deleter` returns a `Deleter` with `Delete(path, opts...)`, `Flush`, `Close` and `Discard`. `Delete` queues a path; `Flush` waits for the queued deletions and keeps the deleter usable; `Close` flushes and releases it; `Discard` releases it without flushing.
- Go: `Operator.WithDeleter` pairs queueing with release, including when the caller's function panics. `Operator.Remove(paths)` uses it and hands the whole slice over at once.
- Go: `Deleter` serializes its methods. The C deleter hands out a `&mut` to the Rust deleter, so concurrent calls would alias it.
- Behavior tests, FFI ownership and signature tests, and a "Delete many paths" docs section.

# Are there any user-facing changes?

New `Operator.Deleter`, `Operator.WithDeleter` and `Operator.Remove` in the Go binding, with `Deleter.Delete`, `Flush`, `Close` and `Discard`, plus the `opendal_operator_deleter` and `opendal_deleter_*` C functions. No breaking changes; docs updated.

# AI Usage Statement

Claude Code with Opus 5. (I understand the code that I told claude to write)
