### PR TITLE
fix(services): reject absolute paths in confined_join and prepare_path

### DIFF
--- a/core/services/compfs/src/core.rs
+++ b/core/services/compfs/src/core.rs
@@ -64,21 +64,23 @@ pub(super) struct CompfsCore {
 }
 
 impl CompfsCore {
-    /// Reject `..` traversal in a key so it cannot escape `root`, matching the
-    /// `fs` backend (#7684). Confinement lives here because `normalize_path`
-    /// deliberately leaves `.`/`..` unresolved (RFC 0112).
+    /// Reject `..` traversal and absolute keys so they cannot escape `root`,
+    /// matching the `fs` backend (#7684). Confinement lives here because
+    /// `normalize_path` deliberately leaves `.`/`..` unresolved (RFC 0112) and
+    /// `PathBuf::join` discards the base when the key is absolute.
     pub fn prepare_path(&self, path: &str) -> Result<PathBuf> {
         use std::path::Component;
         let trimmed = path.trim_end_matches('/');
-        if Path::new(trimmed)
-            .components()
-            .any(|c| matches!(c, Component::ParentDir))
-        {
-            return Err(Error::new(
-                ErrorKind::NotFound,
-                "path escapes the configured root via `..`",
+        if Path::new(trimmed).components().any(|c| {
+            matches!(
+                c,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
             )
-            .with_context("path", path));
+        }) {
+            return Err(
+                Error::new(ErrorKind::NotFound, "path escapes the configured root")
+                    .with_context("path", path),
+            );
         }
         Ok(self.root.join(trimmed))
     }
@@ -167,6 +169,20 @@ mod tests {
     fn test_prepare_path_rejects_parent_dir() {
         let core = new_test_core();
         for key in ["../etc/passwd", "../../etc/passwd", "a/../../b", "a/.."] {
+            let err = core.prepare_path(key).unwrap_err();
+            assert_eq!(
+                err.kind(),
+                ErrorKind::NotFound,
+                "key should be rejected: {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_prepare_path_rejects_absolute_path() {
+        let core = new_test_core();
+        // `PathBuf::join` drops the root when the key is absolute.
+        for key in ["/etc/passwd", "//etc/passwd"] {
             let err = core.prepare_path(key).unwrap_err();
             assert_eq!(
                 err.kind(),

--- a/core/services/fs/src/core.rs
+++ b/core/services/fs/src/core.rs
@@ -41,24 +41,28 @@ impl FsCore {
     /// lexical, so a key such as `../../etc/passwd` would otherwise escape the
     /// configured `root` at syscall time. The fs backend documents that "all
     /// operations will happen under this root", so we reject any key whose
-    /// components include a `..` (parent-dir) traversal.
+    /// components include a `..` (parent-dir) traversal, a root directory, or a
+    /// path prefix: `PathBuf::join` discards the base when the key is absolute,
+    /// which covers `/etc/passwd` plus the Windows `C:\`, `\\?\` and UNC forms
+    /// that `normalize_path` leaves untouched.
     pub fn confined_join(base: &Path, path: &str) -> Result<PathBuf> {
         use std::path::Component;
         let trimmed = path.trim_end_matches('/');
-        if Path::new(trimmed)
-            .components()
-            .any(|c| matches!(c, Component::ParentDir))
-        {
-            return Err(Error::new(
-                ErrorKind::NotFound,
-                "path escapes the configured root via `..`",
+        if Path::new(trimmed).components().any(|c| {
+            matches!(
+                c,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
             )
-            .with_context("path", path));
+        }) {
+            return Err(
+                Error::new(ErrorKind::NotFound, "path escapes the configured root")
+                    .with_context("path", path),
+            );
         }
         Ok(base.join(trimmed))
     }
 
-    /// Join a caller-supplied key onto `self.root`, rejecting `..` traversal.
+    /// Join a caller-supplied key onto `self.root`, keeping the result confined.
     #[inline]
     pub fn root_join(&self, path: &str) -> Result<PathBuf> {
         Self::confined_join(&self.root, path)
@@ -363,5 +367,60 @@ mod tests {
 
         let got = FsCore::get_user_metadata(&dst_path).unwrap();
         assert_eq!(got.get("key").map(String::as_str), Some("preserved123"));
+    }
+
+    #[test]
+    fn test_confined_join_rejects_escaping_keys() {
+        let base = Path::new("/data/root");
+        for key in ["../etc/passwd", "a/../../b", "/etc/passwd", "//etc/passwd"] {
+            let err = FsCore::confined_join(base, key).unwrap_err();
+            assert_eq!(
+                err.kind(),
+                ErrorKind::NotFound,
+                "key should be rejected: {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_confined_join_allows_normal_keys() {
+        let base = Path::new("/data/root");
+        assert_eq!(
+            FsCore::confined_join(base, "a/b.txt").unwrap(),
+            PathBuf::from("/data/root/a/b.txt")
+        );
+        assert_eq!(
+            FsCore::confined_join(base, "a/b/").unwrap(),
+            PathBuf::from("/data/root/a/b")
+        );
+        // The root path `/` trims to empty and resolves to the base itself.
+        assert_eq!(
+            FsCore::confined_join(base, "/").unwrap(),
+            PathBuf::from("/data/root")
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_delete_iter_rejects_absolute_path_outside_root() {
+        use opendal_core::Operator;
+
+        let root_dir = tempfile::TempDir::new().unwrap();
+        let outside_dir = tempfile::TempDir::new().unwrap();
+
+        let outside = outside_dir.path().join("outside.txt");
+        std::fs::write(&outside, b"content").unwrap();
+
+        let op =
+            Operator::new(crate::Fs::default().root(root_dir.path().to_str().unwrap())).unwrap();
+
+        // `Deleter` takes the caller's key verbatim, so an absolute key reaches
+        // `root_join` without `normalize_path` having stripped the leading `/`.
+        let err = op
+            .delete_iter([outside.to_str().unwrap().to_string()])
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::NotFound);
+        assert!(outside.exists());
     }
 }

--- a/core/services/monoiofs/src/core.rs
+++ b/core/services/monoiofs/src/core.rs
@@ -91,21 +91,23 @@ impl MonoiofsCore {
         }
     }
 
-    /// Reject `..` traversal in a key so it cannot escape `root`, matching the
-    /// `fs` backend (#7684). Confinement lives here because `normalize_path`
-    /// deliberately leaves `.`/`..` unresolved (RFC 0112).
+    /// Reject `..` traversal and absolute keys so they cannot escape `root`,
+    /// matching the `fs` backend (#7684). Confinement lives here because
+    /// `normalize_path` deliberately leaves `.`/`..` unresolved (RFC 0112) and
+    /// `PathBuf::join` discards the base when the key is absolute.
     pub fn prepare_path(&self, path: &str) -> Result<PathBuf> {
         use std::path::Component;
         let trimmed = path.trim_end_matches('/');
-        if Path::new(trimmed)
-            .components()
-            .any(|c| matches!(c, Component::ParentDir))
-        {
-            return Err(Error::new(
-                ErrorKind::NotFound,
-                "path escapes the configured root via `..`",
+        if Path::new(trimmed).components().any(|c| {
+            matches!(
+                c,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
             )
-            .with_context("path", path));
+        }) {
+            return Err(
+                Error::new(ErrorKind::NotFound, "path escapes the configured root")
+                    .with_context("path", path),
+            );
         }
         Ok(self.root.join(trimmed))
     }
@@ -324,6 +326,20 @@ mod tests {
     async fn test_prepare_path_rejects_parent_dir() {
         let core = Arc::new(MonoiofsCore::new(PathBuf::from("/data/root"), 1, 1024));
         for key in ["../etc/passwd", "../../etc/passwd", "a/../../b", "a/.."] {
+            let err = core.prepare_path(key).unwrap_err();
+            assert_eq!(
+                err.kind(),
+                ErrorKind::NotFound,
+                "key should be rejected: {key}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_prepare_path_rejects_absolute_path() {
+        let core = Arc::new(MonoiofsCore::new(PathBuf::from("/data/root"), 1, 1024));
+        // `PathBuf::join` drops the root when the key is absolute.
+        for key in ["/etc/passwd", "//etc/passwd"] {
             let err = core.prepare_path(key).unwrap_err();
             assert_eq!(
                 err.kind(),


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

RFC 7799 specifies the local filesystem root check as rejecting `Component::ParentDir`, `Component::RootDir` and `Component::Prefix(_)`, and gives the reason for the last two: they prevent absolute paths from replacing the root via `PathBuf::join`. The shipped guard matches only the `ParentDir` arm, so an absolute key walks straight through it and `root.join("/etc/passwd")` evaluates to `/etc/passwd`.

`Operator::delete_with` runs `normalize_path` first, which strips the leading `/`, so the single-path API is fine. `Deleter` does not: `Deleter::delete` passes the caller's key to the service verbatim. With an `Fs` operator rooted at a temp dir, `op.delete_iter(["<absolute path outside root>"])` deletes the target, and with `recursive` set it is `remove_dir_all`. `delete_try_iter`, `delete_stream`, `delete_try_stream` and the `Sink` impl all reach the same place. On Windows the exposure is not limited to delete: `normalize_path` only splits on `/`, so `C:/…`, a leading `\`, `\\?\…` and UNC paths survive it unchanged and are absolute to `std::path`, which escapes the root on every operation.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Adds the two missing component arms to `FsCore::confined_join` and to the `prepare_path` copies in `compfs` and `monoiofs`, which carry the same guard. The error message loses its parent-dir wording and matches the RFC text, since the check now covers more than `..`.

Keeping the check inside the join helper means every caller is covered whether or not the path reached it through `normalize_path`, which is what the `Deleter` case turns on.

Regression tests go in next to the existing `..` ones: `test_prepare_path_rejects_absolute_path` for `compfs` and `monoiofs`, `test_confined_join_rejects_escaping_keys` for `fs`, plus an end-to-end `fs` test that drives `delete_iter` with an absolute path and asserts the outside file survives. The end-to-end test fails on the current tree.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

An absolute key passed to `fs`, `compfs` or `monoiofs` now returns `ErrorKind::NotFound` instead of resolving outside the configured root. Paths that arrive through the normal `Operator` methods are unaffected, since `normalize_path` has already stripped the leading `/` by then. `"/"` still resolves to the root itself.

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
