### PR TITLE
feat(bindings/python): enable github service

### DIFF
--- a/.github/services/github/read_only/action.yml
+++ b/.github/services/github/read_only/action.yml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: read_only
+description: 'Behavior test for github service in read-only mode'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup
+      shell: bash
+      run: |
+        # Run the read-only behavior tests against the fixtures in
+        # `core/tests/data` of the apache/opendal repository itself, so no
+        # extra backend or write permission is required.
+        cat << EOF >> $GITHUB_ENV
+        OPENDAL_GITHUB_OWNER=apache
+        OPENDAL_GITHUB_REPO=opendal
+        OPENDAL_GITHUB_ROOT=core/tests/data
+        OPENDAL_DISABLE_RANDOM_ROOT=true
+        OPENDAL_TEST_CAPABILITY_OVERRIDES=write=false,delete=false,create_dir=false
+        EOF
+
+        # GITHUB_TOKEN is injected by the caller workflow; forward it to raise
+        # the GitHub API rate limit for the read-only behavior tests.
+        if [ -n "${GITHUB_TOKEN:-}" ]; then
+          echo "OPENDAL_GITHUB_TOKEN=$GITHUB_TOKEN" >> $GITHUB_ENV
+        fi

--- a/.github/workflows/test_behavior_binding_python.yml
+++ b/.github/workflows/test_behavior_binding_python.yml
@@ -98,3 +98,7 @@ jobs:
           setup: ${{ matrix.cases.setup }}
           service: ${{ matrix.cases.service }}
           feature: ${{ matrix.cases.feature }}
+        env:
+          # Forward the workflow token so read-only service tests (e.g. the
+          # github service) can raise their API rate limit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_behavior_core.yml
+++ b/.github/workflows/test_behavior_core.yml
@@ -58,3 +58,7 @@ jobs:
           setup: ${{ matrix.cases.setup }}
           service: ${{ matrix.cases.service }}
           feature: ${{ matrix.cases.feature }}
+        env:
+          # Forward the workflow token so read-only service tests (e.g. the
+          # github service) can raise their API rate limit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -36,6 +36,7 @@ default = [
   "services-fs",
   "services-gcs",
   "services-ghac",
+  "services-github",
   "services-http",
   "services-ipmfs",
   "services-memory",
@@ -118,9 +119,7 @@ services-ftp = ["opendal/services-ftp"]
 services-gcs = ["opendal/services-gcs"]
 services-gdrive = ["opendal/services-gdrive"]
 services-ghac = ["opendal/services-ghac"]
-services-github = [
-  "opendal/services-github",
-] # FIXME EXCLUDED: Needs tests/ maintenance
+services-github = ["opendal/services-github"]
 services-goosefs = [
   "opendal/services-goosefs",
 ] # FIXME EXCLUDED: armhf build failure because of tokiofs dependency

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -133,6 +133,7 @@ opendal-service-cos@0.58.1	X
 opendal-service-fs@0.58.1	X												
 opendal-service-gcs@0.58.1	X												
 opendal-service-ghac@0.58.1	X												
+opendal-service-github@0.58.1	X												
 opendal-service-http@0.58.1	X												
 opendal-service-ipmfs@0.58.1	X												
 opendal-service-obs@0.58.1	X												

--- a/bindings/python/python/opendal/config.py
+++ b/bindings/python/python/opendal/config.py
@@ -342,6 +342,21 @@ class GhacConfig(TypedDict):
     """The version that used by cache."""
 
 
+class GithubConfig(TypedDict):
+    """Configuration for the `github` service."""
+
+    scheme: Required[Literal["github"]]
+    """The service scheme; fixed to `"github"`."""
+    owner: Required[str]
+    """GitHub repo owner.  required."""
+    repo: Required[str]
+    """GitHub repo name.  required."""
+    root: NotRequired[str | os.PathLike[str]]
+    """root of this backend.  All operations will happen under this root."""
+    token: NotRequired[str]
+    """GitHub access_token.  optional. If not provided, the backend will only support read operations for public repositories. And rate limit will be limited to 60 requests per hour."""
+
+
 class GridfsConfig(TypedDict):
     """Configuration for the `gridfs` service."""
 
@@ -1000,6 +1015,7 @@ ServiceConfig = (
     | GcsConfig
     | GdriveConfig
     | GhacConfig
+    | GithubConfig
     | GridfsConfig
     | HdfsNativeConfig
     | HfConfig
@@ -1054,6 +1070,7 @@ __all__ = [
     "GcsConfig",
     "GdriveConfig",
     "GhacConfig",
+    "GithubConfig",
     "GridfsConfig",
     "HdfsNativeConfig",
     "HfConfig",

--- a/bindings/python/python/opendal/services.pyi
+++ b/bindings/python/python/opendal/services.pyi
@@ -35,6 +35,7 @@ class Scheme:
     Gcs: Final[Scheme]
     Gdrive: Final[Scheme]
     Ghac: Final[Scheme]
+    Github: Final[Scheme]
     Gridfs: Final[Scheme]
     HdfsNative: Final[Scheme]
     Hf: Final[Scheme]

--- a/bindings/python/src/services.rs
+++ b/bindings/python/src/services.rs
@@ -61,6 +61,8 @@ pub enum Scheme {
     Gdrive,
     #[cfg(feature = "services-ghac")]
     Ghac,
+    #[cfg(feature = "services-github")]
+    Github,
     #[cfg(feature = "services-gridfs")]
     Gridfs,
     #[cfg(feature = "services-hdfs-native")]
@@ -201,6 +203,8 @@ impl_enum_to_str!(
         Gdrive => "gdrive",
         #[cfg(feature = "services-ghac")]
         Ghac => "ghac",
+        #[cfg(feature = "services-github")]
+        Github => "github",
         #[cfg(feature = "services-gridfs")]
         Gridfs => "gridfs",
         #[cfg(feature = "services-hdfs-native")]

--- a/core/services/github/src/config.rs
+++ b/core/services/github/src/config.rs
@@ -63,36 +63,46 @@ impl Configurator for GithubConfig {
     type Builder = GithubBuilder;
 
     fn from_uri(uri: &OperatorUri) -> Result<Self> {
-        let owner = uri.name().ok_or_else(|| {
-            Error::new(ErrorKind::ConfigInvalid, "uri host must contain owner")
-                .with_context("service", GITHUB_SCHEME)
-        })?;
+        let mut map = uri.options().clone();
 
-        let raw_path = uri.root().ok_or_else(|| {
-            Error::new(ErrorKind::ConfigInvalid, "uri path must contain repository")
-                .with_context("service", GITHUB_SCHEME)
-        })?;
-
-        let (repo, remainder) = match raw_path.split_once('/') {
-            Some((repo, rest)) => (repo, Some(rest)),
-            None => (raw_path, None),
-        };
-
-        if repo.is_empty() {
-            return Err(
-                Error::new(ErrorKind::ConfigInvalid, "repository name is required")
-                    .with_context("service", GITHUB_SCHEME),
-            );
+        // `github://<owner>/<repo>/<root>` URIs provide owner, repo and root
+        // through the URI itself. A bare scheme like `github` (used by
+        // `Operator::via_iter`) must fall back to the options so that
+        // `OPENDAL_GITHUB_OWNER` / `OPENDAL_GITHUB_REPO` environment variables
+        // work like they do for other services.
+        if let Some(owner) = uri.name() {
+            map.insert("owner".to_string(), owner.to_string());
         }
 
-        let mut map = uri.options().clone();
-        map.insert("owner".to_string(), owner.to_string());
-        map.insert("repo".to_string(), repo.to_string());
+        if let Some(raw_path) = uri.root() {
+            let (repo, remainder) = match raw_path.split_once('/') {
+                Some((repo, rest)) => (repo, Some(rest)),
+                None => (raw_path, None),
+            };
 
-        if let Some(rest) = remainder
-            && !rest.is_empty()
-        {
-            map.insert("root".to_string(), rest.to_string());
+            if !repo.is_empty() {
+                map.insert("repo".to_string(), repo.to_string());
+            }
+
+            if let Some(rest) = remainder
+                && !rest.is_empty()
+            {
+                map.insert("root".to_string(), rest.to_string());
+            }
+        }
+
+        // Owner and repository must be provided either via the URI or the
+        // options; `#[serde(default)]` would otherwise silently turn a missing
+        // field into an empty string.
+        if map.get("owner").is_none_or(String::is_empty) {
+            return Err(Error::new(ErrorKind::ConfigInvalid, "owner is required")
+                .with_context("service", GITHUB_SCHEME));
+        }
+        if map.get("repo").is_none_or(String::is_empty) {
+            return Err(
+                Error::new(ErrorKind::ConfigInvalid, "repository is required")
+                    .with_context("service", GITHUB_SCHEME),
+            );
         }
 
         Self::from_iter(map)
@@ -128,5 +138,23 @@ mod tests {
         let uri = OperatorUri::new("github://apache", Vec::<(String, String)>::new()).unwrap();
 
         assert!(GithubConfig::from_uri(&uri).is_err());
+    }
+
+    #[test]
+    fn from_uri_sets_owner_repo_and_root_from_options() {
+        let uri = OperatorUri::new(
+            "github",
+            vec![
+                ("owner".to_string(), "apache".to_string()),
+                ("repo".to_string(), "opendal".to_string()),
+                ("root".to_string(), "core/tests/data".to_string()),
+            ],
+        )
+        .unwrap();
+
+        let cfg = GithubConfig::from_uri(&uri).unwrap();
+        assert_eq!(cfg.owner, "apache".to_string());
+        assert_eq!(cfg.repo, "opendal".to_string());
+        assert_eq!(cfg.root.as_deref(), Some("core/tests/data"));
     }
 }

--- a/core/services/github/src/reader.rs
+++ b/core/services/github/src/reader.rs
@@ -53,10 +53,29 @@ impl oio::StreamRead for GithubReader {
         let status = resp.status();
 
         let (rp, stream) = match status {
-            StatusCode::OK | StatusCode::PARTIAL_CONTENT => (
-                RpRead::new(parse_into_metadata(path, resp.headers())?),
-                resp.into_body(),
-            ),
+            StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
+                let (part, mut body) = resp.into_parts();
+                let meta = parse_into_metadata(path, &part.headers)?;
+
+                // GitHub ignores the Range header on authenticated requests
+                // and returns the full content with 200, so slice the body
+                // client-side when the server did not honor the range.
+                if status == StatusCode::PARTIAL_CONTENT || range.is_full() {
+                    (
+                        RpRead::new(meta),
+                        Box::new(body) as Box<dyn oio::ReadStreamDyn>,
+                    )
+                } else {
+                    let bs = body.to_buffer().await?;
+                    let total_size = bs.len() as u64;
+                    let sliced = bs.slice(range.to_content_range(bs.len())?);
+                    let meta = Metadata::new(EntryMode::FILE).with_content_length(total_size);
+                    (
+                        RpRead::new(meta),
+                        Box::new(sliced) as Box<dyn oio::ReadStreamDyn>,
+                    )
+                }
+            }
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
@@ -64,6 +83,6 @@ impl oio::StreamRead for GithubReader {
             }
         };
 
-        Ok((rp, Box::new(stream) as Box<dyn oio::ReadStreamDyn>))
+        Ok((rp, stream))
     }
 }

--- a/dev/src/generate/python.rs
+++ b/dev/src/generate/python.rs
@@ -25,8 +25,8 @@ use std::path::PathBuf;
 fn enabled_service(srv: &str) -> bool {
     match srv {
         // not enabled in bindings/python/Cargo.toml
-        "etcd" | "foundationdb" | "hdfs" | "rocksdb" | "tikv" | "github" | "cloudflare_kv"
-        | "monoiofs" | "dbfs" | "surrealdb" | "d1" | "opfs" | "compfs" | "lakefs" | "pcloud"
+        "etcd" | "foundationdb" | "hdfs" | "rocksdb" | "tikv" | "cloudflare_kv" | "monoiofs"
+        | "dbfs" | "surrealdb" | "d1" | "opfs" | "compfs" | "lakefs" | "pcloud"
         | "vercel_blob" | "foyer" | "goosefs" => false,
         _ => true,
     }


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

Enable the github service in the python binding by default. The service is a pure-HTTP implementation with no special backend requirements, so it fits the default feature set.

# What changes are included in this PR?

- Add `services-github` to the default features in `bindings/python/Cargo.toml` and drop the `FIXME EXCLUDED` marker.
- Enable the github service in the python code generator (`dev/src/generate/python.rs`).
- Regenerate `src/services.rs`, `python/opendal/config.py` and `python/opendal/services.pyi` so `Scheme.Github` and `GithubConfig` are available.
- Update `DEPENDENCIES.rust.tsv` with `opendal-service-github`.

# Are there any user-facing changes?

`opendal.Scheme.Github` and `opendal.config.GithubConfig` become available, and `github://` URIs work with `Operator.from_uri`.

# Depends on

- #8010 (fix(services/github): support env-driven construction and add read-only behavior tests) — the python behavior test matrix picks up the github case only after #8010 adds `.github/services/github/`.

# AI Usage Statement

This PR was developed with the assistance of an AI coding agent (pi) for implementation, testing, and PR preparation; the changes were reviewed by the author.