### PR TITLE
feat(binding/cpp): expose batch deletion API to C++

### DIFF
--- a/bindings/cpp/include/opendal.hpp
+++ b/bindings/cpp/include/opendal.hpp
@@ -179,6 +179,7 @@ class Operator {
    */
   void Remove(std::string_view path);
   void Remove(std::string_view path, const DeleteOptions &options);
+  void RemoveAll(const std::vector<std::string> &paths);
 
   /**
    * @brief Get the metadata of a file or directory

--- a/bindings/cpp/src/lib.rs
+++ b/bindings/cpp/src/lib.rs
@@ -286,6 +286,7 @@ mod ffi {
         ) -> Result<()>;
         fn remove(self: &Operator, path: &str) -> Result<()>;
         fn remove_options(self: &Operator, path: &str, opts: FfiDeleteOptions) -> Result<()>;
+        fn remove_all(self: &Operator, paths: Vec<String>) -> Result<()>;
         fn stat(self: &Operator, path: &str) -> Result<Metadata>;
         fn stat_options(self: &Operator, path: &str, opts: FfiStatOptions) -> Result<Metadata>;
         fn list(self: &Operator, path: &str) -> Result<Vec<Entry>>;
@@ -600,6 +601,10 @@ impl Operator {
 
     fn remove_options(&self, path: &str, opts: ffi::FfiDeleteOptions) -> Result<()> {
         Ok(self.0.delete_options(path, delete_options(opts))?)
+    }
+
+    fn remove_all(&self, paths: Vec<String>) -> Result<()> {
+        Ok(self.0.delete_iter(paths)?)
     }
 
     fn stat(&self, path: &str) -> Result<ffi::Metadata> {

--- a/bindings/cpp/src/operator.cpp
+++ b/bindings/cpp/src/operator.cpp
@@ -369,6 +369,15 @@ void Operator::Remove(std::string_view path, const DeleteOptions &options) {
   operator_->remove_options(utils::rust_str(path), ToFfiOptions(options));
 }
 
+void Operator::RemoveAll(const std::vector<std::string> &paths) {
+  rust::Vec<rust::String> rust_paths;
+  rust_paths.reserve(paths.size());
+  for (const auto &path : paths) {
+    rust_paths.push_back(utils::rust_string(path));
+  }
+  operator_->remove_all(std::move(rust_paths));
+}
+
 Metadata Operator::Stat(std::string_view path) {
   return parse_meta_data(operator_->stat(utils::rust_str(path)));
 }

--- a/bindings/cpp/tests/basic_test.cpp
+++ b/bindings/cpp/tests/basic_test.cpp
@@ -296,6 +296,23 @@ TEST(OpenDALOptionsTest, DeleteOptions) {
   EXPECT_FALSE(op.Exists("delete_options/file"));
 }
 
+TEST(OpenDALOptionsTest, RemoveAll) {
+  opendal::Operator op("memory");
+  std::vector<std::string> paths;
+  for (int index = 0; index < 8; ++index) {
+    auto path = "remove_all/file_" + std::to_string(index);
+    op.Write(path, "hello");
+    EXPECT_TRUE(op.Exists(path));
+    paths.push_back(path);
+  }
+
+  op.RemoveAll(paths);
+
+  for (const auto &path : paths) {
+    EXPECT_FALSE(op.Exists(path));
+  }
+}
+
 TEST(OpenDALOptionsTest, StatOptions) {
   opendal::Operator op("memory");
   op.Write("stat_options", "hello");


### PR DESCRIPTION
# Which issue does this PR close?

Closes https://github.com/apache/opendal/issues/8014

# Rationale for this change

Hi team, I'm working on DuckDB extension, which integrates OpenDAL with DuckDB filesystem.
One gap for C++ binding is batch deletion, so I don't need to implement the batch deletion (i.e., S3) or parallel deletion (i.e., local filesystem) myself.

# What changes are included in this PR?

This PR exposes batch deletion API to C++ side.

# Are there any user-facing changes?

Yes, new API added.

# AI Usage Statement

GPT-5.5 made the code change.