### PR TITLE
fix(bindings/dotnet): forward read options to the streaming reader

### DIFF
--- a/bindings/dotnet/OpenDAL.Tests/Behavior/OperatorBehaviorTest.cs
+++ b/bindings/dotnet/OpenDAL.Tests/Behavior/OperatorBehaviorTest.cs
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-using OpenDAL.Options;
-
 namespace OpenDAL.Tests;
 
 [Collection("BehaviorOperator")]
@@ -46,80 +44,6 @@ public sealed class OperatorBehaviorTest : BehaviorTestBase
 
         duplicated.Write(path, content);
         Assert.Equal(content, Op.Read(path));
-    }
-
-    [Fact]
-    public void OperatorBehavior_StreamRoundtrip_Works()
-    {
-        if (!Supports(c => c.Read && c.Write))
-        {
-            return;
-        }
-
-        var path = NewPath("stream-sync");
-        var content = RandomBytes(64);
-
-        using (var output = Op.OpenWriteStream(path))
-        {
-            output.Write(content, 0, content.Length);
-            output.Flush();
-        }
-
-        using var input = Op.OpenReadStream(path);
-        var buffer = new byte[content.Length];
-        var read = input.Read(buffer, 0, buffer.Length);
-
-        Assert.Equal(content.Length, read);
-        Assert.Equal(content, buffer);
-    }
-
-    [Fact]
-    public async Task OperatorBehavior_StreamRoundtripAsync_Works()
-    {
-        if (!Supports(c => c.Read && c.Write))
-        {
-            return;
-        }
-
-        var path = NewPath("stream-async");
-        var content = RandomBytes(64);
-
-        using (var output = Op.OpenWriteStream(path))
-        {
-            await output.WriteAsync(content, 0, content.Length, CT);
-            await output.FlushAsync(CT);
-        }
-
-        using var input = Op.OpenReadStream(path);
-        var buffer = new byte[content.Length];
-        var read = await input.ReadAsync(buffer, 0, buffer.Length, CT);
-
-        Assert.Equal(content.Length, read);
-        Assert.Equal(content, buffer);
-    }
-
-    [Fact]
-    public void OperatorBehavior_OpenReadStream_WithRange_ReadsSelectedSlice()
-    {
-        if (!Supports(c => c.Read && c.Write))
-        {
-            return;
-        }
-
-        var path = NewPath("stream-range");
-        Op.Write(path, System.Text.Encoding.UTF8.GetBytes("0123456789"));
-
-        using var input = Op.OpenReadStream(path, new ReadOptions
-        {
-            Offset = 3,
-            Length = 4,
-        });
-
-        var buffer = new byte[8];
-        var read = input.Read(buffer, 0, buffer.Length);
-
-        Assert.Equal(4, read);
-        Assert.Equal("3456", System.Text.Encoding.UTF8.GetString(buffer, 0, read));
     }
 
     [Fact]

--- a/bindings/dotnet/OpenDAL.Tests/Behavior/StreamBehaviorTest.cs
+++ b/bindings/dotnet/OpenDAL.Tests/Behavior/StreamBehaviorTest.cs
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using OpenDAL.Options;
+
+namespace OpenDAL.Tests;
+
+[Collection("BehaviorOperator")]
+public sealed class StreamBehaviorTest : BehaviorTestBase
+{
+    private static CancellationToken CT => TestContext.Current.CancellationToken;
+
+    public StreamBehaviorTest(BehaviorOperatorFixture fixture)
+        : base(fixture)
+    {
+    }
+
+    [Fact]
+    public void StreamBehavior_Roundtrip_Works()
+    {
+        if (!Supports(c => c.Read && c.Write))
+        {
+            return;
+        }
+
+        var path = NewPath("stream-sync");
+        var content = RandomBytes(64);
+
+        using (var output = Op.OpenWriteStream(path))
+        {
+            output.Write(content, 0, content.Length);
+            output.Flush();
+        }
+
+        using var input = Op.OpenReadStream(path);
+        var buffer = new byte[content.Length];
+        var read = input.Read(buffer, 0, buffer.Length);
+
+        Assert.Equal(content.Length, read);
+        Assert.Equal(content, buffer);
+    }
+
+    [Fact]
+    public async Task StreamBehavior_RoundtripAsync_Works()
+    {
+        if (!Supports(c => c.Read && c.Write))
+        {
+            return;
+        }
+
+        var path = NewPath("stream-async");
+        var content = RandomBytes(64);
+
+        using (var output = Op.OpenWriteStream(path))
+        {
+            await output.WriteAsync(content, 0, content.Length, CT);
+            await output.FlushAsync(CT);
+        }
+
+        using var input = Op.OpenReadStream(path);
+        var buffer = new byte[content.Length];
+        var read = await input.ReadAsync(buffer, 0, buffer.Length, CT);
+
+        Assert.Equal(content.Length, read);
+        Assert.Equal(content, buffer);
+    }
+
+    [Fact]
+    public void StreamBehavior_OpenReadStream_WithRange_ReadsSelectedSlice()
+    {
+        if (!Supports(c => c.Read && c.Write))
+        {
+            return;
+        }
+
+        var path = NewPath("stream-range");
+        Op.Write(path, System.Text.Encoding.UTF8.GetBytes("0123456789"));
+
+        using var input = Op.OpenReadStream(path, new ReadOptions
+        {
+            Offset = 3,
+            Length = 4,
+        });
+
+        var buffer = new byte[8];
+        var read = input.Read(buffer, 0, buffer.Length);
+
+        Assert.Equal(4, read);
+        Assert.Equal("3456", System.Text.Encoding.UTF8.GetString(buffer, 0, read));
+    }
+
+    [Fact]
+    public void StreamBehavior_OpenReadStream_WithIfMatch_AppliesCondition()
+    {
+        if (!Supports(c => c.Read && c.Write && c.Stat && c.ReadWithIfMatch))
+        {
+            return;
+        }
+
+        var path = NewPath("stream-if-match");
+        var content = RandomBytes(64);
+        Op.Write(path, content);
+        var etag = Op.Stat(path).ETag;
+        Assert.NotNull(etag);
+
+        var ex = Assert.Throws<OpenDALException>(() =>
+        {
+            using var mismatched = Op.OpenReadStream(path, new ReadOptions { IfMatch = "\"invalid-etag\"" });
+            mismatched.ReadByte();
+        });
+        Assert.Equal(ErrorCode.ConditionNotMatch, ex.Code);
+
+        using var input = Op.OpenReadStream(path, new ReadOptions { IfMatch = etag });
+        using var actual = new MemoryStream();
+        input.CopyTo(actual);
+
+        Assert.Equal(content, actual.ToArray());
+    }
+
+    [Fact]
+    public void StreamBehavior_OpenReadStream_WithVersion_ReadsSpecifiedVersion()
+    {
+        if (!Supports(c => c.Read && c.Write && c.Stat && c.ReadWithVersion))
+        {
+            return;
+        }
+
+        var path = NewPath("stream-version");
+        var first = RandomBytes(64);
+        Op.Write(path, first);
+        var version = Op.Stat(path).Version;
+        Assert.NotNull(version);
+
+        Op.Write(path, RandomBytes(64));
+
+        using var input = Op.OpenReadStream(path, new ReadOptions { Version = version });
+        using var actual = new MemoryStream();
+        input.CopyTo(actual);
+
+        Assert.Equal(first, actual.ToArray());
+    }
+
+    [Fact]
+    public void StreamBehavior_OpenReadStream_IfMatchUnsupported_SurfacesUnsupported()
+    {
+        if (!Supports(c => c.Read && c.Write && !c.ReadWithIfMatch))
+        {
+            return;
+        }
+
+        var path = NewPath("stream-if-match-unsupported");
+        Op.Write(path, RandomBytes(16));
+
+        // An Unsupported error proves the condition was handed to the reader;
+        // a stream that dropped the option would read the data without complaint.
+        var ex = Assert.Throws<OpenDALException>(() =>
+        {
+            using var input = Op.OpenReadStream(path, new ReadOptions { IfMatch = "\"any-etag\"" });
+            input.ReadByte();
+        });
+
+        Assert.Equal(ErrorCode.Unsupported, ex.Code);
+    }
+
+    [Fact]
+    public void StreamBehavior_OpenReadStream_VersionUnsupported_SurfacesUnsupported()
+    {
+        if (!Supports(c => c.Read && c.Write && !c.ReadWithVersion))
+        {
+            return;
+        }
+
+        var path = NewPath("stream-version-unsupported");
+        Op.Write(path, RandomBytes(16));
+
+        var ex = Assert.Throws<OpenDALException>(() =>
+        {
+            using var input = Op.OpenReadStream(path, new ReadOptions { Version = "any-version" });
+            input.ReadByte();
+        });
+
+        Assert.Equal(ErrorCode.Unsupported, ex.Code);
+    }
+}

--- a/bindings/dotnet/OpenDAL/OperatorOutputStream.cs
+++ b/bindings/dotnet/OpenDAL/OperatorOutputStream.cs
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-using OpenDAL.Interop.Result;
-
 namespace OpenDAL;
 
 /// <summary>

--- a/bindings/dotnet/src/operator.rs
+++ b/bindings/dotnet/src/operator.rs
@@ -1275,13 +1275,27 @@ fn operator_input_stream_create_inner(
 
     let _guard = executor.enter();
 
+    let range = options.range.to_range();
+    let reader_options = opendal::options::ReaderOptions {
+        version: options.version,
+        if_match: options.if_match,
+        if_none_match: options.if_none_match,
+        if_modified_since: options.if_modified_since,
+        if_unmodified_since: options.if_unmodified_since,
+        content_length_hint: options.content_length_hint,
+        concurrent: options.concurrent,
+        chunk: options.chunk,
+        gap: options.gap,
+        ..Default::default()
+    };
+
     let blocking_op =
         opendal::blocking::Operator::new(op.clone()).map_err(OpenDALError::from_opendal_error)?;
     let reader = blocking_op
-        .reader_options(&path, opendal::options::ReaderOptions::default())
+        .reader_options(&path, reader_options)
         .map_err(OpenDALError::from_opendal_error)?;
     let stream = reader
-        .into_bytes_iterator(options.range.to_range())
+        .into_bytes_iterator(range)
         .map_err(OpenDALError::from_opendal_error)?;
 
     Ok(Box::into_raw(Box::new(stream)) as *mut c_void)


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

In the .NET binding, `operator_input_stream_create` builds its reader with `ReaderOptions::default()`, so every `ReadOptions` field except `range` (version, conditional headers, concurrent, chunk, gap) was silently ignored on the streaming path, while one-shot reads honored them.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Forward the applicable `ReadOptions` fields onto `ReaderOptions` when creating the stream reader.
- Move stream behavior tests into a new `StreamBehaviorTest`, with new cases asserting the options now reach the reader.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

`OpenReadStream` now honors the read options listed above instead of silently dropping them.

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->

This PR was developed with Claude Code (model: Claude Fable 5).