### PR TITLE
docs: require searching for similar work before opening PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ When adding or changing a public optional layer:
 
 ## Pull Requests
 
+- Before opening a PR, search for similar open PRs, issues, and in-progress branches that already address the same problem. Prefer contributing to or coordinating with existing work over opening a duplicate.
 - Always use `.github/pull_request_template.md` when creating a PR.
 - Keep PR titles and descriptions factual and concise.
 - Do not add AI-tool branding or co-author trailers.


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

Agents can open duplicate PRs when similar work is already in progress. This guidance requires a search for open PRs, issues, and related branches before opening a new PR.

# What changes are included in this PR?

- Add a Pull Requests rule in `AGENTS.md` requiring agents to search for similar existing work before opening a PR.

# Are there any user-facing changes?

No. Agent guidance only.

# AI Usage Statement

Assisted by AI tools for drafting and editing.
