### PR TITLE
refactor(bindings/dotnet): rework the FFI boundary and add zero-copy IO paths

### DIFF
--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -32,6 +32,8 @@ doc = false
 
 [dependencies]
 # this crate won't be published, we always use the local version
+bytes = "1.12.1"
+futures = "0.3"
 opendal = { version = ">=0", path = "../../core", features = [
   "blocking",
   "http-transport-reqwest",
@@ -104,8 +106,6 @@ opendal = { version = ">=0", path = "../../core", features = [
   "services-upyun",
   "services-yandex-disk",
 ] }
-bytes = "1.12.1"
-futures = "0.3"
 tokio = { version = "1.49.0", features = ["full"] }
 
 # This is not optimal. See also the Cargo issue:

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -104,12 +104,8 @@ opendal = { version = ">=0", path = "../../core", features = [
   "services-upyun",
   "services-yandex-disk",
 ] }
-tokio = { version = "1.49.0", features = ["full"] }
-
-[dev-dependencies]
-# Only needed to build multi-part buffers in the buffer copy tests. Already an
-# indirect dependency through opendal, so this adds nothing to the shipped library.
 bytes = "1.12.1"
+tokio = { version = "1.49.0", features = ["full"] }
 
 # This is not optimal. See also the Cargo issue:
 # https://github.com/rust-lang/cargo/issues/1197#issuecomment-1641086954

--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -105,6 +105,7 @@ opendal = { version = ">=0", path = "../../core", features = [
   "services-yandex-disk",
 ] }
 bytes = "1.12.1"
+futures = "0.3"
 tokio = { version = "1.49.0", features = ["full"] }
 
 # This is not optimal. See also the Cargo issue:

--- a/bindings/dotnet/OpenDAL.Tests/Behavior/ReadBehaviorTest.cs
+++ b/bindings/dotnet/OpenDAL.Tests/Behavior/ReadBehaviorTest.cs
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+using System.Buffers;
 using OpenDAL.Options;
 
 namespace OpenDAL.Tests;
@@ -163,5 +164,130 @@ public sealed class ReadBehaviorTest : BehaviorTestBase
         var ex = await Assert.ThrowsAsync<OpenDALException>(() => Op.ReadAsync(NewPath("missing-async"), CT));
 
         Assert.True(IsMissingError(ex));
+    }
+
+    [Fact]
+    public async Task ReadBehavior_ConsumeCallback_ReturnsConsumerResult()
+    {
+        if (!Supports(c => c.Read && c.Write))
+        {
+            return;
+        }
+
+        var path = NewPath("read-consume");
+        var content = RandomBytes(100_000);
+        await Op.WriteAsync(path, content, CT);
+
+        var length = 0L;
+        var actual = Op.Read(path, sequence =>
+        {
+            length = sequence.Length;
+            return sequence.ToArray();
+        });
+
+        Assert.Equal(content.Length, length);
+        Assert.Equal(content, actual);
+
+        var asyncActual = await Op.ReadAsync(path, sequence => sequence.ToArray(), cancellationToken: CT);
+        Assert.Equal(content, asyncActual);
+    }
+
+    [Fact]
+    public async Task ReadBehavior_ConsumeCallback_ChunkedPayloadRoundtrips()
+    {
+        if (!Supports(c => c.Read && c.Write))
+        {
+            return;
+        }
+
+        // Written in many small pieces, so backends that store the payload as
+        // written hand the consumer a sequence spanning several segments.
+        var path = NewPath("read-consume-chunked");
+        var content = RandomBytes(200_000);
+
+        await Op.WriteAsync(path, writer => FillInChunks(writer, content), cancellationToken: CT);
+
+        var actual = await Op.ReadAsync(path, sequence => sequence.ToArray(), cancellationToken: CT);
+        Assert.Equal(content, actual);
+
+        static void FillInChunks(IBufferWriter<byte> writer, byte[] content)
+        {
+            var remaining = content.AsSpan();
+            while (!remaining.IsEmpty)
+            {
+                var chunk = remaining[..Math.Min(999, remaining.Length)];
+                chunk.CopyTo(writer.GetSpan(chunk.Length));
+                writer.Advance(chunk.Length);
+                remaining = remaining[chunk.Length..];
+            }
+        }
+    }
+
+    [Fact]
+    public async Task ReadBehavior_ConsumeCallback_ParsesJsonDirectly()
+    {
+        if (!Supports(c => c.Read && c.Write))
+        {
+            return;
+        }
+
+        var path = NewPath("read-consume-json");
+        var expected = new Dictionary<string, int[]>
+        {
+            ["values"] = Enumerable.Range(0, 5_000).ToArray(),
+        };
+
+        await Op.WriteAsync(path, writer =>
+        {
+            using var json = new System.Text.Json.Utf8JsonWriter(writer);
+            System.Text.Json.JsonSerializer.Serialize(json, expected);
+        }, cancellationToken: CT);
+
+        var actual = await Op.ReadAsync(path, Deserialize, cancellationToken: CT);
+
+        Assert.NotNull(actual);
+        Assert.Equal(expected["values"], actual!["values"]);
+
+        static Dictionary<string, int[]>? Deserialize(ReadOnlySequence<byte> sequence)
+        {
+            var reader = new System.Text.Json.Utf8JsonReader(sequence);
+            return System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, int[]>>(ref reader);
+        }
+    }
+
+    [Fact]
+    public async Task ReadBehavior_ConsumeCallback_ConsumerFailurePropagates()
+    {
+        if (!Supports(c => c.Read && c.Write))
+        {
+            return;
+        }
+
+        var path = NewPath("read-consume-throw");
+        var content = RandomBytes(1024);
+        await Op.WriteAsync(path, content, CT);
+
+        Assert.Throws<InvalidOperationException>(() => Op.Read<byte[]>(
+            path, _ => throw new InvalidOperationException("consumer failed")));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Op.ReadAsync<byte[]>(
+            path, _ => throw new InvalidOperationException("consumer failed"), cancellationToken: CT));
+
+        Assert.Equal(content, Op.Read(path));
+    }
+
+    [Fact]
+    public async Task ReadBehavior_ConsumeCallback_RejectsNullConsumer()
+    {
+        if (!Supports(c => c.Read))
+        {
+            return;
+        }
+
+        var path = NewPath("read-consume-arguments");
+
+        Assert.Throws<ArgumentNullException>(() => Op.Read(
+            path, (Func<ReadOnlySequence<byte>, byte[]>)null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => Op.ReadAsync(
+            path, (Func<ReadOnlySequence<byte>, byte[]>)null!, cancellationToken: CT));
     }
 }

--- a/bindings/dotnet/OpenDAL.Tests/Behavior/StreamBehaviorTest.cs
+++ b/bindings/dotnet/OpenDAL.Tests/Behavior/StreamBehaviorTest.cs
@@ -82,6 +82,105 @@ public sealed class StreamBehaviorTest : BehaviorTestBase
     }
 
     [Fact]
+    public async Task StreamBehavior_LargeRoundtripAsync_Works()
+    {
+        if (!Supports(c => c.Read && c.Write))
+        {
+            return;
+        }
+
+        // Large enough to cross the output stream's internal buffer many times
+        // and to come back over several chunks, so both async paths make
+        // repeated native round-trips instead of completing on the first call.
+        var path = NewPath("stream-async-large");
+        var content = RandomBytes(200_000);
+
+        using (var output = Op.OpenWriteStream(path, bufferSize: 8 * 1024))
+        {
+            await output.WriteAsync(content.AsMemory(), CT);
+            await output.FlushAsync(CT);
+        }
+
+        using var input = Op.OpenReadStream(path);
+        var actual = new byte[content.Length];
+        var filled = 0;
+        while (filled < actual.Length)
+        {
+            var read = await input.ReadAsync(
+                actual.AsMemory(filled, Math.Min(7_777, actual.Length - filled)), CT);
+            if (read == 0)
+            {
+                break;
+            }
+
+            filled += read;
+        }
+
+        Assert.Equal(content.Length, filled);
+        Assert.Equal(content, actual);
+        Assert.Equal(0, await input.ReadAsync(actual.AsMemory(0, 1), CT));
+    }
+
+    [Fact]
+    public void StreamBehavior_Complete_PersistsAndSealsTheStream()
+    {
+        if (!Supports(c => c.Read && c.Write))
+        {
+            return;
+        }
+
+        var path = NewPath("stream-complete");
+        var content = RandomBytes(256);
+
+        using var output = Op.OpenWriteStream(path);
+        output.Write(content, 0, content.Length);
+        output.Complete();
+
+        Assert.Equal(content, Op.Read(path));
+        Assert.Throws<InvalidOperationException>(() => output.Write(content, 0, 1));
+        Assert.Throws<InvalidOperationException>(output.Complete);
+    }
+
+    [Fact]
+    public async Task StreamBehavior_CompleteAsync_PersistsViaAwaitUsing()
+    {
+        if (!Supports(c => c.Read && c.Write))
+        {
+            return;
+        }
+
+        var path = NewPath("stream-complete-async");
+        var content = RandomBytes(100_000);
+
+        await using (var output = Op.OpenWriteStream(path, bufferSize: 8 * 1024))
+        {
+            await output.WriteAsync(content.AsMemory(), CT);
+            await output.CompleteAsync(CT);
+        }
+
+        Assert.Equal(content, await Op.ReadAsync(path, CT));
+    }
+
+    [Fact]
+    public async Task StreamBehavior_DisposeAsync_ClosesBestEffort()
+    {
+        if (!Supports(c => c.Read && c.Write))
+        {
+            return;
+        }
+
+        var path = NewPath("stream-dispose-async");
+        var content = RandomBytes(4096);
+
+        await using (var output = Op.OpenWriteStream(path))
+        {
+            await output.WriteAsync(content.AsMemory(), CT);
+        }
+
+        Assert.Equal(content, await Op.ReadAsync(path, CT));
+    }
+
+    [Fact]
     public void StreamBehavior_OpenReadStream_WithRange_ReadsSelectedSlice()
     {
         if (!Supports(c => c.Read && c.Write))

--- a/bindings/dotnet/OpenDAL.Tests/Behavior/WriteBehaviorTest.cs
+++ b/bindings/dotnet/OpenDAL.Tests/Behavior/WriteBehaviorTest.cs
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+using System.Buffers;
 using OpenDAL.Options;
 
 namespace OpenDAL.Tests;
@@ -63,6 +64,219 @@ public sealed class WriteBehaviorTest : BehaviorTestBase
         var actual = await Op.ReadAsync(path, CT);
 
         Assert.Equal(content, actual);
+    }
+
+    [Fact]
+    public void WriteBehavior_SyncWriteCopiesTheSource()
+    {
+        if (!Supports(c => c.Write && c.Read))
+        {
+            return;
+        }
+
+        // Guards against the write path lending the caller's array to the
+        // backend: with aliasing, mutating the source after Write changes
+        // what in-process backends hand back on the next read, and the
+        // stored pointer dangles once the GC collects the array.
+        var path = NewPath("write-copies-source");
+        var content = RandomBytes(1024);
+        var expected = (byte[])content.Clone();
+
+        Op.Write(path, content);
+        content.AsSpan().Fill(0xEE);
+
+        Assert.Equal(expected, Op.Read(path));
+    }
+
+    [Fact]
+    public async Task WriteBehavior_LargeContentRoundtripAsync()
+    {
+        if (!Supports(c => c.Write && c.Read))
+        {
+            return;
+        }
+
+        var path = NewPath("write-async-large");
+        var content = RandomBytes(256 * 1024);
+
+        await Op.WriteAsync(path, content, CT);
+        var actual = await Op.ReadAsync(path, CT);
+
+        Assert.Equal(content, actual);
+    }
+
+    [Fact]
+    public async Task WriteBehavior_FillCallback_Roundtrips()
+    {
+        if (!Supports(c => c.Write && c.Read))
+        {
+            return;
+        }
+
+        var path = NewPath("write-fill");
+        var content = RandomBytes(256 * 1024);
+
+        await Op.WriteAsync(path, writer =>
+        {
+            content.CopyTo(writer.GetSpan(content.Length));
+            writer.Advance(content.Length);
+        }, sizeHint: content.Length, cancellationToken: CT);
+
+        var actual = await Op.ReadAsync(path, CT);
+        Assert.Equal(content, actual);
+
+        var syncPath = NewPath("write-fill-sync");
+        Op.Write(syncPath, writer =>
+        {
+            content.CopyTo(writer.GetSpan(content.Length));
+            writer.Advance(content.Length);
+        }, sizeHint: content.Length);
+
+        Assert.Equal(content, Op.Read(syncPath));
+    }
+
+    [Fact]
+    public async Task WriteBehavior_FillCallback_ChunkedFillRoundtrips()
+    {
+        if (!Supports(c => c.Write && c.Read))
+        {
+            return;
+        }
+
+        // Produced in many small pieces and large enough that the writer must
+        // grow while filling, which is how serializers without a known output
+        // size behave.
+        var path = NewPath("write-fill-chunked");
+        var content = RandomBytes(200_000);
+
+        await Op.WriteAsync(path, writer => FillInChunks(writer, content), cancellationToken: CT);
+
+        var actual = await Op.ReadAsync(path, CT);
+        Assert.Equal(content, actual);
+
+        static void FillInChunks(IBufferWriter<byte> writer, byte[] content)
+        {
+            var remaining = content.AsSpan();
+            while (!remaining.IsEmpty)
+            {
+                var chunk = remaining[..Math.Min(1000, remaining.Length)];
+                chunk.CopyTo(writer.GetSpan(chunk.Length));
+                writer.Advance(chunk.Length);
+                remaining = remaining[chunk.Length..];
+            }
+        }
+    }
+
+    [Fact]
+    public async Task WriteBehavior_FillCallback_SerializesJsonDirectly()
+    {
+        if (!Supports(c => c.Write && c.Read))
+        {
+            return;
+        }
+
+        var path = NewPath("write-fill-json");
+        var expected = new Dictionary<string, int[]>
+        {
+            ["values"] = Enumerable.Range(0, 10_000).ToArray(),
+        };
+
+        await Op.WriteAsync(path, writer =>
+        {
+            using var json = new System.Text.Json.Utf8JsonWriter(writer);
+            System.Text.Json.JsonSerializer.Serialize(json, expected);
+        }, cancellationToken: CT);
+
+        var actual = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, int[]>>(
+            await Op.ReadAsync(path, CT));
+        Assert.NotNull(actual);
+        Assert.Equal(expected["values"], actual!["values"]);
+    }
+
+    [Fact]
+    public async Task WriteBehavior_FillCallback_FillFailureWritesNothing()
+    {
+        if (!Supports(c => c.Write && c.Stat))
+        {
+            return;
+        }
+
+        var path = NewPath("write-fill-throw");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Op.WriteAsync(
+            path, _ => throw new InvalidOperationException("producer failed"), cancellationToken: CT));
+
+        var ex = Assert.Throws<OpenDALException>(() => Op.Stat(path));
+        Assert.True(IsMissingError(ex));
+    }
+
+    [Fact]
+    public void WriteBehavior_FillCallback_SyncFillFailureWritesNothing()
+    {
+        if (!Supports(c => c.Write && c.Stat))
+        {
+            return;
+        }
+
+        var path = NewPath("write-fill-throw-sync");
+
+        Assert.Throws<InvalidOperationException>(() => Op.Write(
+            path, _ => throw new InvalidOperationException("producer failed")));
+
+        var ex = Assert.Throws<OpenDALException>(() => Op.Stat(path));
+        Assert.True(IsMissingError(ex));
+    }
+
+    [Fact]
+    public async Task WriteBehavior_FillCallback_PreCanceledTokenWritesNothing()
+    {
+        if (!Supports(c => c.Write && c.Stat))
+        {
+            return;
+        }
+
+        var path = NewPath("write-fill-pre-canceled");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => Op.WriteAsync(
+            path, _ => { }, cancellationToken: cts.Token));
+
+        var ex = Assert.Throws<OpenDALException>(() => Op.Stat(path));
+        Assert.True(IsMissingError(ex));
+    }
+
+    [Fact]
+    public async Task WriteBehavior_EmptyContentRoundtrips()
+    {
+        if (!Supports(c => c.Write && c.Read && c.WriteCanEmpty))
+        {
+            return;
+        }
+
+        var path = NewPath("write-empty");
+        Op.Write(path, Array.Empty<byte>());
+        Assert.Empty(Op.Read(path));
+
+        var asyncPath = NewPath("write-empty-async");
+        await Op.WriteAsync(asyncPath, Array.Empty<byte>(), CT);
+        Assert.Empty(await Op.ReadAsync(asyncPath, CT));
+    }
+
+    [Fact]
+    public async Task WriteBehavior_FillCallback_RejectsInvalidArguments()
+    {
+        if (!Supports(c => c.Write))
+        {
+            return;
+        }
+
+        var path = NewPath("write-fill-arguments");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => Op.WriteAsync(
+            path, (Action<IBufferWriter<byte>>)null!, cancellationToken: CT));
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => Op.WriteAsync(
+            path, _ => { }, sizeHint: -1, cancellationToken: CT));
     }
 
     [Fact]

--- a/bindings/dotnet/OpenDAL.Tests/ConstructorTest.cs
+++ b/bindings/dotnet/OpenDAL.Tests/ConstructorTest.cs
@@ -84,7 +84,7 @@ public class ConstructorTest
 
         using var op = new Operator("memory", options);
 
-        Assert.NotEqual(IntPtr.Zero, op.Op);
+        Assert.NotEqual(IntPtr.Zero, op.DangerousGetHandle());
     }
 
     [Fact]
@@ -97,6 +97,6 @@ public class ConstructorTest
 
         using var op = new Operator(config);
 
-        Assert.NotEqual(IntPtr.Zero, op.Op);
+        Assert.NotEqual(IntPtr.Zero, op.DangerousGetHandle());
     }
 }

--- a/bindings/dotnet/OpenDAL.Tests/LayerTest.cs
+++ b/bindings/dotnet/OpenDAL.Tests/LayerTest.cs
@@ -27,13 +27,13 @@ public class LayerTest
     public void WithConcurrentLimit_ReturnsNewOperator()
     {
         using var op = new Operator("memory");
-        var before = op.Op;
+        var before = op.DangerousGetHandle();
         using var layered = op.WithLayer(new ConcurrentLimitLayer(4));
 
-        Assert.NotEqual(IntPtr.Zero, layered.Op);
+        Assert.NotEqual(IntPtr.Zero, layered.DangerousGetHandle());
         Assert.NotSame(op, layered);
-        Assert.Equal(before, op.Op);
-        Assert.NotEqual(before, layered.Op);
+        Assert.Equal(before, op.DangerousGetHandle());
+        Assert.NotEqual(before, layered.DangerousGetHandle());
 
         layered.Write("layer-concurrent", [1, 2, 3]);
         var value = layered.Read("layer-concurrent");
@@ -44,13 +44,13 @@ public class LayerTest
     public void WithConcurrentLimit_HttpPermits_ReturnsNewOperator()
     {
         using var op = new Operator("memory");
-        var before = op.Op;
+        var before = op.DangerousGetHandle();
         using var layered = op.WithLayer(new ConcurrentLimitLayer(4, 2));
 
-        Assert.NotEqual(IntPtr.Zero, layered.Op);
+        Assert.NotEqual(IntPtr.Zero, layered.DangerousGetHandle());
         Assert.NotSame(op, layered);
-        Assert.Equal(before, op.Op);
-        Assert.NotEqual(before, layered.Op);
+        Assert.Equal(before, op.DangerousGetHandle());
+        Assert.NotEqual(before, layered.DangerousGetHandle());
 
         layered.Write("layer-concurrent-http", [1, 2, 3]);
         var value = layered.Read("layer-concurrent-http");
@@ -82,7 +82,7 @@ public class LayerTest
     public void WithRetry_ReturnsNewOperator()
     {
         using var op = new Operator("memory");
-        var before = op.Op;
+        var before = op.DangerousGetHandle();
         using var layered = op.WithLayer(new RetryLayer
         {
             Jitter = false,
@@ -92,10 +92,10 @@ public class LayerTest
             MaxTimes = 2,
         });
 
-        Assert.NotEqual(IntPtr.Zero, layered.Op);
+        Assert.NotEqual(IntPtr.Zero, layered.DangerousGetHandle());
         Assert.NotSame(op, layered);
-        Assert.Equal(before, op.Op);
-        Assert.NotEqual(before, layered.Op);
+        Assert.Equal(before, op.DangerousGetHandle());
+        Assert.NotEqual(before, layered.DangerousGetHandle());
 
         layered.Write("layer-retry", [4, 5, 6]);
         var value = layered.Read("layer-retry");
@@ -117,17 +117,17 @@ public class LayerTest
     public void WithTimeout_ReturnsNewOperator()
     {
         using var op = new Operator("memory");
-        var before = op.Op;
+        var before = op.DangerousGetHandle();
         using var layered = op.WithLayer(new TimeoutLayer
         {
             Timeout = TimeSpan.FromSeconds(5),
             IoTimeout = TimeSpan.FromSeconds(2),
         });
 
-        Assert.NotEqual(IntPtr.Zero, layered.Op);
+        Assert.NotEqual(IntPtr.Zero, layered.DangerousGetHandle());
         Assert.NotSame(op, layered);
-        Assert.Equal(before, op.Op);
-        Assert.NotEqual(before, layered.Op);
+        Assert.Equal(before, op.DangerousGetHandle());
+        Assert.NotEqual(before, layered.DangerousGetHandle());
 
         layered.Write("layer-timeout", [7, 8, 9]);
         var value = layered.Read("layer-timeout");
@@ -149,13 +149,13 @@ public class LayerTest
     public void WithThrottle_ReturnsNewOperator()
     {
         using var op = new Operator("memory");
-        var before = op.Op;
+        var before = op.DangerousGetHandle();
         using var layered = op.WithLayer(new ThrottleLayer(10 * 1024, 10 * 1024 * 1024));
 
-        Assert.NotEqual(IntPtr.Zero, layered.Op);
+        Assert.NotEqual(IntPtr.Zero, layered.DangerousGetHandle());
         Assert.NotSame(op, layered);
-        Assert.Equal(before, op.Op);
-        Assert.NotEqual(before, layered.Op);
+        Assert.Equal(before, op.DangerousGetHandle());
+        Assert.NotEqual(before, layered.DangerousGetHandle());
 
         layered.Write("layer-throttle", [1, 2, 3]);
         var value = layered.Read("layer-throttle");
@@ -176,13 +176,13 @@ public class LayerTest
     public void WithMimeGuess_FillsContentTypeFromExtension()
     {
         using var op = new Operator("memory");
-        var before = op.Op;
+        var before = op.DangerousGetHandle();
         using var layered = op.WithLayer(new MimeGuessLayer());
 
-        Assert.NotEqual(IntPtr.Zero, layered.Op);
+        Assert.NotEqual(IntPtr.Zero, layered.DangerousGetHandle());
         Assert.NotSame(op, layered);
-        Assert.Equal(before, op.Op);
-        Assert.NotEqual(before, layered.Op);
+        Assert.Equal(before, op.DangerousGetHandle());
+        Assert.NotEqual(before, layered.DangerousGetHandle());
 
         layered.Write("layer-mime-guess.json", [1, 2, 3]);
         Assert.Equal("application/json", layered.Stat("layer-mime-guess.json").ContentType);

--- a/bindings/dotnet/OpenDAL/AsyncState.cs
+++ b/bindings/dotnet/OpenDAL/AsyncState.cs
@@ -65,7 +65,7 @@ internal static class AsyncStateRegistry
     }
 }
 
-public sealed class AsyncState<T>
+internal sealed class AsyncState<T>
 {
     internal long Context { get; set; }
 

--- a/bindings/dotnet/OpenDAL/Executor.cs
+++ b/bindings/dotnet/OpenDAL/Executor.cs
@@ -25,6 +25,11 @@ namespace OpenDAL;
 /// <summary>
 /// Managed wrapper over an OpenDAL native executor handle.
 /// </summary>
+/// <remarks>
+/// Dispose only after every operation submitted with this executor has
+/// completed: disposal tears down the runtime, and tasks it cancels never
+/// complete their awaiters.
+/// </remarks>
 public sealed class Executor : SafeHandle
 {
     /// <summary>

--- a/bindings/dotnet/OpenDAL/Interop/Buffers/NativeMemoryManager.cs
+++ b/bindings/dotnet/OpenDAL/Interop/Buffers/NativeMemoryManager.cs
@@ -17,35 +17,41 @@
  * under the License.
  */
 
-using System.Runtime.InteropServices;
-using OpenDAL.Interop.NativeObject;
-using OpenDAL.Interop.Result.Abstractions;
+using System.Buffers;
 
-namespace OpenDAL.Interop.Result;
+namespace OpenDAL.Interop.Buffers;
 
-[StructLayout(LayoutKind.Sequential)]
 /// <summary>
-/// Result wrapper for operations that return a byte buffer payload.
+/// Presents a fixed region of native memory as <see cref="Memory{T}"/>.
+/// The region never moves, so pinning is a no-op; the caller guarantees the
+/// memory outlives every handed-out view.
 /// </summary>
-internal struct OpenDALReadResult : INativeResult
+internal sealed unsafe class NativeMemoryManager : MemoryManager<byte>
 {
-    /// <summary>
-    /// Byte buffer payload on success.
-    /// </summary>
-    public OpenDALReadBuffer Buffer;
+    private readonly byte* pointer;
+    private readonly int length;
 
-    /// <summary>
-    /// Error details for the operation.
-    /// </summary>
-    public OpenDALError Error;
-
-    public readonly void Release()
+    public NativeMemoryManager(byte* pointer, int length)
     {
-        NativeMethods.opendal_read_result_release(this);
+        this.pointer = pointer;
+        this.length = length;
     }
 
-    public readonly OpenDALError GetError()
+    public override Span<byte> GetSpan()
     {
-        return Error;
+        return new Span<byte>(pointer, length);
+    }
+
+    public override MemoryHandle Pin(int elementIndex = 0)
+    {
+        return new MemoryHandle(pointer + elementIndex);
+    }
+
+    public override void Unpin()
+    {
+    }
+
+    protected override void Dispose(bool disposing)
+    {
     }
 }

--- a/bindings/dotnet/OpenDAL/Interop/Buffers/ReadBuffer.cs
+++ b/bindings/dotnet/OpenDAL/Interop/Buffers/ReadBuffer.cs
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Buffers;
+using System.Runtime.InteropServices;
+using OpenDAL.Interop.NativeObject;
+using OpenDAL.Interop.Result;
+
+namespace OpenDAL.Interop.Buffers;
+
+/// <summary>
+/// Read payload kept in native memory and exposed as a
+/// <see cref="ReadOnlySequence{T}"/>, without copying.
+/// </summary>
+/// <remarks>
+/// Returned by <see cref="Operator.ReadBuffer"/> and
+/// <see cref="Operator.ReadBufferAsync"/>; consumers such as
+/// <c>Utf8JsonReader</c> parse straight over native memory. The memory stays
+/// valid until <see cref="Dispose"/> and must not be used afterwards.
+/// Instances are not thread-safe.
+/// </remarks>
+internal sealed class ReadBuffer : IDisposable
+{
+    private OpenDALReadResult result;
+    private ReadOnlySequence<byte> sequence;
+    private bool disposed;
+
+    private ReadBuffer(OpenDALReadResult result)
+    {
+        this.result = result;
+        Length = (long)result.Buffer.Len;
+        sequence = BuildSequence(result.Buffer);
+    }
+
+    /// <summary>
+    /// Gets the payload length in bytes.
+    /// </summary>
+    public long Length { get; }
+
+    /// <summary>
+    /// Gets the payload as a read-only sequence over native memory.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">The buffer has been disposed.</exception>
+    public ReadOnlySequence<byte> Sequence
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            return sequence;
+        }
+    }
+
+    /// <summary>
+    /// Takes ownership of a successful native read result; throws and
+    /// releases it on error.
+    /// </summary>
+    internal static ReadBuffer FromResult(OpenDALReadResult result)
+    {
+        var error = result.GetError();
+        if (error.IsError)
+        {
+            var exception = new OpenDALException(error);
+            result.Release();
+            throw exception;
+        }
+
+        try
+        {
+            return new ReadBuffer(result);
+        }
+        catch
+        {
+            result.Release();
+            throw;
+        }
+    }
+
+    private static unsafe ReadOnlySequence<byte> BuildSequence(OpenDALReadBuffer buffer)
+    {
+        if (buffer.Handle == IntPtr.Zero || buffer.Len == 0)
+        {
+            return ReadOnlySequence<byte>.Empty;
+        }
+
+        var count = (int)NativeMethods.read_buffer_chunks(buffer.Handle, null, 0);
+        if (count == 0)
+        {
+            return ReadOnlySequence<byte>.Empty;
+        }
+
+        var chunks = new OpenDALChunk[count];
+        fixed (OpenDALChunk* chunksPtr = chunks)
+        {
+            _ = NativeMethods.read_buffer_chunks(buffer.Handle, chunksPtr, (nuint)count);
+        }
+
+        if (count == 1)
+        {
+            var memory = new NativeMemoryManager((byte*)chunks[0].Data, checked((int)chunks[0].Len)).Memory;
+            return new ReadOnlySequence<byte>(memory);
+        }
+
+        ChunkSegment? first = null;
+        ChunkSegment? previous = null;
+        long runningIndex = 0;
+        foreach (var chunk in chunks)
+        {
+            var memory = new NativeMemoryManager((byte*)chunk.Data, checked((int)chunk.Len)).Memory;
+            var segment = new ChunkSegment(memory, runningIndex);
+            runningIndex += memory.Length;
+
+            first ??= segment;
+            previous?.SetNext(segment);
+            previous = segment;
+        }
+
+        return new ReadOnlySequence<byte>(first!, 0, previous!, previous!.Memory.Length);
+    }
+
+    public void Dispose()
+    {
+        if (!disposed)
+        {
+            disposed = true;
+            sequence = ReadOnlySequence<byte>.Empty;
+            result.Release();
+            result = default;
+        }
+    }
+
+    /// <summary>
+    /// Links one native chunk into the sequence.
+    /// </summary>
+    private sealed class ChunkSegment : ReadOnlySequenceSegment<byte>
+    {
+        public ChunkSegment(Memory<byte> memory, long runningIndex)
+        {
+            Memory = memory;
+            RunningIndex = runningIndex;
+        }
+
+        public void SetNext(ChunkSegment next)
+        {
+            Next = next;
+        }
+    }
+}
+
+[StructLayout(LayoutKind.Sequential)]
+/// <summary>
+/// Descriptor of one contiguous chunk inside a native read payload.
+/// <see cref="Data"/> stays valid until the owning buffer handle is released.
+/// </summary>
+internal struct OpenDALChunk
+{
+    public IntPtr Data;
+
+    public nuint Len;
+}

--- a/bindings/dotnet/OpenDAL/Interop/Buffers/WriteBuffer.cs
+++ b/bindings/dotnet/OpenDAL/Interop/Buffers/WriteBuffer.cs
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Buffers;
+using OpenDAL.Interop.NativeObject;
+using OpenDAL.Interop.Result;
+
+namespace OpenDAL.Interop.Buffers;
+
+/// <summary>
+/// Native <see cref="IBufferWriter{T}"/> whose contents transfer to the
+/// OpenDAL layer when a write consumes them, without copying.
+/// </summary>
+/// <remarks>
+/// Allocate with <see cref="Operator.AllocateWriteBuffer"/>, produce through the
+/// standard <see cref="IBufferWriter{T}"/> contract (for example with
+/// <c>Utf8JsonWriter</c>), then hand it to a write. The write consumes the
+/// buffer: every later access throws. Growth adds native segments that never
+/// move, so earlier memory stays valid until <see cref="Dispose"/>. Instances
+/// are not thread-safe; disposing an unconsumed buffer returns the memory.
+/// </remarks>
+internal sealed class WriteBuffer : IBufferWriter<byte>, IDisposable
+{
+    internal const int DefaultInitialCapacity = 64 * 1024;
+
+    // New segments double the previous capacity up to this bound, mirroring
+    // ArrayBufferWriter's growth curve while keeping segments coarse enough
+    // that a large payload stays a handful of chunks.
+    private const int MaxSegmentCapacity = 8 * 1024 * 1024;
+
+    private IntPtr handle;
+    private IntPtr data;
+    private int capacity;
+    private int tailWritten;
+    private long totalWritten;
+    private bool consumed;
+    private NativeMemoryManager? memoryManager;
+
+    internal WriteBuffer(IntPtr handle, IntPtr data, int capacity)
+    {
+        this.handle = handle;
+        this.data = data;
+        this.capacity = capacity;
+    }
+
+    /// <summary>
+    /// Gets the total number of bytes committed with <see cref="Advance"/>.
+    /// </summary>
+    public long WrittenCount => totalWritten;
+
+    internal IntPtr Handle
+    {
+        get
+        {
+            ThrowIfNotUsable();
+            return handle;
+        }
+    }
+
+    internal int TailWritten => tailWritten;
+
+    internal void MarkConsumed()
+    {
+        consumed = true;
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="ObjectDisposedException">The buffer has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">The buffer contents were already consumed by a write.</exception>
+    /// <exception cref="OpenDALException">Growing the buffer fails natively.</exception>
+    public unsafe Span<byte> GetSpan(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return new Span<byte>((byte*)data + tailWritten, capacity - tailWritten);
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="ObjectDisposedException">The buffer has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">The buffer contents were already consumed by a write.</exception>
+    /// <exception cref="OpenDALException">Growing the buffer fails natively.</exception>
+    public unsafe Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        memoryManager ??= new NativeMemoryManager((byte*)data, capacity);
+        return memoryManager.Memory[tailWritten..];
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="ObjectDisposedException">The buffer has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">The buffer contents were already consumed by a write.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="count"/> is negative or exceeds the last acquired span.
+    /// </exception>
+    public void Advance(int count)
+    {
+        ThrowIfNotUsable();
+        if (count < 0 || count > capacity - tailWritten)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count), count,
+                "Advance count must be between 0 and the size of the last acquired buffer.");
+        }
+
+        tailWritten += count;
+        totalWritten += count;
+    }
+
+    private void EnsureCapacity(int sizeHint)
+    {
+        ThrowIfNotUsable();
+        ArgumentOutOfRangeException.ThrowIfNegative(sizeHint);
+        var needed = sizeHint == 0 ? 1 : sizeHint;
+        if (capacity - tailWritten >= needed)
+        {
+            return;
+        }
+
+        var nextCapacity = (int)Math.Max(needed, Math.Min((long)capacity * 2, MaxSegmentCapacity));
+        var result = NativeMethods.write_buffer_add_segment(handle, (nuint)tailWritten, (nuint)nextCapacity);
+        var segment = Operator.ToValueOrThrowAndRelease<OpenDALWriteBuffer, OpenDALWriteBufferResult>(result);
+
+        data = segment.Data;
+        capacity = checked((int)segment.Capacity);
+        tailWritten = 0;
+        // The old manager's memory stays valid because sealed segments never
+        // move; the new segment simply needs its own view.
+        memoryManager = null;
+    }
+
+    private void ThrowIfNotUsable()
+    {
+        ObjectDisposedException.ThrowIf(handle == IntPtr.Zero, this);
+        if (consumed)
+        {
+            throw new InvalidOperationException(
+                "The write buffer contents were already consumed by a write; they now belong to the native layer. Allocate a new buffer for the next write.");
+        }
+    }
+
+    public void Dispose()
+    {
+        if (handle != IntPtr.Zero)
+        {
+            NativeMethods.write_buffer_free(handle);
+            handle = IntPtr.Zero;
+            data = IntPtr.Zero;
+            memoryManager = null;
+        }
+    }
+}

--- a/bindings/dotnet/OpenDAL/Interop/Buffers/WriteBuffer.cs
+++ b/bindings/dotnet/OpenDAL/Interop/Buffers/WriteBuffer.cs
@@ -37,12 +37,12 @@ namespace OpenDAL.Interop.Buffers;
 /// </remarks>
 internal sealed class WriteBuffer : IBufferWriter<byte>, IDisposable
 {
-    internal const int DefaultInitialCapacity = 64 * 1024;
+    internal const int DefaultInitialCapacity = 64 * 1024; // 64 KiB
 
     // New segments double the previous capacity up to this bound, mirroring
     // ArrayBufferWriter's growth curve while keeping segments coarse enough
     // that a large payload stays a handful of chunks.
-    private const int MaxSegmentCapacity = 8 * 1024 * 1024;
+    private const int MaxSegmentCapacity = 8 * 1024 * 1024; // 8 MiB
 
     private IntPtr handle;
     private IntPtr data;

--- a/bindings/dotnet/OpenDAL/Interop/Marshalling/EntryMarshaller.cs
+++ b/bindings/dotnet/OpenDAL/Interop/Marshalling/EntryMarshaller.cs
@@ -55,21 +55,10 @@ internal static class EntryMarshaller
             return results;
         }
 
-        var entryPointers = new ReadOnlySpan<IntPtr>((void*)payload.Entries, count);
+        var entries = new ReadOnlySpan<OpenDALEntry>((void*)payload.Entries, count);
         for (var index = 0; index < count; index++)
         {
-            var entryPtr = entryPointers[index];
-            if (entryPtr == IntPtr.Zero)
-            {
-                continue;
-            }
-
-            var entryPayload = Unsafe.Read<OpenDALEntry>((void*)entryPtr);
-            if (entryPayload.Metadata == IntPtr.Zero)
-            {
-                continue;
-            }
-
+            ref readonly var entryPayload = ref entries[index];
             var path = Utilities.ReadUtf8(entryPayload.Path);
             var metadata = MetadataMarshaller.ToMetadata(entryPayload.Metadata);
             results.Add(new Entry(path, metadata));

--- a/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALEntry.cs
+++ b/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALEntry.cs
@@ -26,5 +26,5 @@ internal struct OpenDALEntry
 {
     public IntPtr Path;
 
-    public IntPtr Metadata;
+    public OpenDALMetadata Metadata;
 }

--- a/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALReadBuffer.cs
+++ b/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALReadBuffer.cs
@@ -26,11 +26,11 @@ namespace OpenDAL.Interop.NativeObject;
 /// Read payload still owned by the native side.
 /// </summary>
 /// <remarks>
-/// Holds the native buffer itself rather than a flattened copy, so
-/// <see cref="ToManagedBytes"/> can copy straight into its final array. Released
-/// through the owning result's release call, not from here.
+/// Holds the native buffer itself rather than a flattened copy, so consumers
+/// copy or view chunks straight from native memory. Released through the
+/// owning result's release call, not from here.
 /// </remarks>
-internal struct OpenDALBuffer
+internal struct OpenDALReadBuffer
 {
     /// <summary>
     /// Opaque handle to the native buffer, or zero when there is no payload.
@@ -43,32 +43,26 @@ internal struct OpenDALBuffer
     public nuint Len;
 
     /// <summary>
-    /// Copies the payload into a new managed array.
+    /// Copies payload bytes starting at <paramref name="sourceOffset"/> into the
+    /// destination span.
     /// </summary>
-    /// <returns>The payload, or an empty array when there is none.</returns>
-    public readonly unsafe byte[] ToManagedBytes()
+    /// <param name="sourceOffset">Byte offset into the payload to copy from.</param>
+    /// <param name="destination">Destination span receiving the bytes.</param>
+    /// <returns>
+    /// The number of bytes copied; 0 when the offset is at or past the end of the
+    /// payload or when there is no payload.
+    /// </returns>
+    public readonly unsafe int CopyTo(nuint sourceOffset, Span<byte> destination)
     {
-        if (Handle == IntPtr.Zero || Len == 0)
+        if (Handle == IntPtr.Zero || destination.Length == 0)
         {
-            return Array.Empty<byte>();
+            return 0;
         }
 
-        var size = checked((int)Len);
-        var managed = GC.AllocateUninitializedArray<byte>(size);
-        nuint written;
-        fixed (byte* destination = managed)
+        fixed (byte* dest = destination)
         {
-            written = NativeMethods.buffer_copy_to(Handle, destination, (nuint)size);
+            return checked((int)NativeMethods.read_buffer_copy_to(
+                Handle, sourceOffset, dest, (nuint)destination.Length));
         }
-
-        // The array is uninitialized, so a short copy would hand back whatever the
-        // heap held rather than the payload.
-        if (written != (nuint)size)
-        {
-            throw new InvalidOperationException(
-                $"Native buffer reported {Len} bytes but produced {written}.");
-        }
-
-        return managed;
     }
 }

--- a/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALWriteBuffer.cs
+++ b/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALWriteBuffer.cs
@@ -18,34 +18,33 @@
  */
 
 using System.Runtime.InteropServices;
-using OpenDAL.Interop.NativeObject;
-using OpenDAL.Interop.Result.Abstractions;
 
-namespace OpenDAL.Interop.Result;
+namespace OpenDAL.Interop.NativeObject;
 
 [StructLayout(LayoutKind.Sequential)]
 /// <summary>
-/// Result wrapper for operations that return a byte buffer payload.
+/// Writable native segment returned by <c>write_buffer_create</c> or
+/// <c>write_buffer_add_segment</c>.
 /// </summary>
-internal struct OpenDALReadResult : INativeResult
+/// <remarks>
+/// <see cref="Data"/> points at <see cref="Capacity"/> writable bytes owned by
+/// <see cref="Handle"/>. The handle must be released exactly once through
+/// <c>write_buffer_free</c>.
+/// </remarks>
+internal struct OpenDALWriteBuffer
 {
     /// <summary>
-    /// Byte buffer payload on success.
+    /// Opaque handle owning every segment of the buffer.
     /// </summary>
-    public OpenDALReadBuffer Buffer;
+    public IntPtr Handle;
 
     /// <summary>
-    /// Error details for the operation.
+    /// Raw pointer to the newest segment, valid until the handle is freed.
     /// </summary>
-    public OpenDALError Error;
+    public IntPtr Data;
 
-    public readonly void Release()
-    {
-        NativeMethods.opendal_read_result_release(this);
-    }
-
-    public readonly OpenDALError GetError()
-    {
-        return Error;
-    }
+    /// <summary>
+    /// Writable bytes behind <see cref="Data"/>.
+    /// </summary>
+    public nuint Capacity;
 }

--- a/bindings/dotnet/OpenDAL/Interop/Result/OpenDALWriteBufferResult.cs
+++ b/bindings/dotnet/OpenDAL/Interop/Result/OpenDALWriteBufferResult.cs
@@ -25,14 +25,19 @@ namespace OpenDAL.Interop.Result;
 
 [StructLayout(LayoutKind.Sequential)]
 /// <summary>
-/// Result wrapper for operations that return a byte buffer payload.
+/// Result wrapper for operations returning a freshly allocated native write buffer.
 /// </summary>
-internal struct OpenDALReadResult : INativeResult
+/// <remarks>
+/// On success the caller takes over the buffer handle, so
+/// <see cref="Release"/> only frees the error message; the handle itself is
+/// released later through <c>write_buffer_free</c>.
+/// </remarks>
+internal struct OpenDALWriteBufferResult : INativeValueResult<OpenDALWriteBuffer>
 {
     /// <summary>
-    /// Byte buffer payload on success.
+    /// Allocated buffer payload on success.
     /// </summary>
-    public OpenDALReadBuffer Buffer;
+    public OpenDALWriteBuffer Buffer;
 
     /// <summary>
     /// Error details for the operation.
@@ -41,11 +46,16 @@ internal struct OpenDALReadResult : INativeResult
 
     public readonly void Release()
     {
-        NativeMethods.opendal_read_result_release(this);
+        NativeMethods.opendal_error_release(Error);
     }
 
     public readonly OpenDALError GetError()
     {
         return Error;
+    }
+
+    public readonly OpenDALWriteBuffer ToValue()
+    {
+        return Buffer;
     }
 }

--- a/bindings/dotnet/OpenDAL/NativeMethods.cs
+++ b/bindings/dotnet/OpenDAL/NativeMethods.cs
@@ -529,6 +529,14 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALReadResult operator_input_stream_read_next(IntPtr stream);
 
+    [LibraryImport(__DllName, EntryPoint = "operator_input_stream_read_next_async")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static unsafe partial OpenDALResult operator_input_stream_read_next_async(
+        IntPtr stream,
+        delegate* unmanaged[Cdecl]<long, OpenDALReadResult, void> callback,
+        long context
+    );
+
     [LibraryImport(__DllName, EntryPoint = "operator_input_stream_free")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial void operator_input_stream_free(IntPtr stream);
@@ -550,6 +558,16 @@ internal partial class NativeMethods
         nuint len
     );
 
+    [LibraryImport(__DllName, EntryPoint = "operator_output_stream_write_async")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static unsafe partial OpenDALResult operator_output_stream_write_async(
+        IntPtr stream,
+        [In] byte[] data,
+        nuint len,
+        delegate* unmanaged[Cdecl]<long, OpenDALResult, void> callback,
+        long context
+    );
+
     [LibraryImport(__DllName, EntryPoint = "operator_output_stream_flush")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALResult operator_output_stream_flush(IntPtr stream);
@@ -557,6 +575,14 @@ internal partial class NativeMethods
     [LibraryImport(__DllName, EntryPoint = "operator_output_stream_close")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALResult operator_output_stream_close(IntPtr stream);
+
+    [LibraryImport(__DllName, EntryPoint = "operator_output_stream_close_async")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static unsafe partial OpenDALResult operator_output_stream_close_async(
+        IntPtr stream,
+        delegate* unmanaged[Cdecl]<long, OpenDALResult, void> callback,
+        long context
+    );
 
     [LibraryImport(__DllName, EntryPoint = "operator_output_stream_free")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/bindings/dotnet/OpenDAL/NativeMethods.cs
+++ b/bindings/dotnet/OpenDAL/NativeMethods.cs
@@ -20,7 +20,6 @@
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using OpenDAL.Interop.Buffers;
-using OpenDAL.Interop.NativeObject;
 using OpenDAL.Interop.Result;
 
 namespace OpenDAL;
@@ -57,10 +56,6 @@ internal partial class NativeMethods
     [LibraryImport(__DllName, EntryPoint = "operator_info_get")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALOperatorInfoResult operator_info_get(Operator op);
-
-    [LibraryImport(__DllName, EntryPoint = "operator_info_free")]
-    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static partial void operator_info_free(IntPtr info);
 
     [LibraryImport(__DllName, EntryPoint = "operator_duplicate")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/bindings/dotnet/OpenDAL/NativeMethods.cs
+++ b/bindings/dotnet/OpenDAL/NativeMethods.cs
@@ -19,6 +19,8 @@
 
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using OpenDAL.Interop.Buffers;
+using OpenDAL.Interop.NativeObject;
 using OpenDAL.Interop.Result;
 
 namespace OpenDAL;
@@ -189,13 +191,38 @@ internal partial class NativeMethods
 
     #region Buffer
 
-    [LibraryImport(__DllName, EntryPoint = "buffer_copy_to")]
+    [LibraryImport(__DllName, EntryPoint = "read_buffer_copy_to")]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    internal static unsafe partial nuint buffer_copy_to(
+    internal static unsafe partial nuint read_buffer_copy_to(
         IntPtr handle,
+        nuint sourceOffset,
         byte* destination,
         nuint destinationLen
     );
+
+    [LibraryImport(__DllName, EntryPoint = "read_buffer_chunks")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static unsafe partial nuint read_buffer_chunks(
+        IntPtr handle,
+        OpenDALChunk* chunks,
+        nuint cap
+    );
+
+    [LibraryImport(__DllName, EntryPoint = "write_buffer_create")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial OpenDALWriteBufferResult write_buffer_create(nuint capacity);
+
+    [LibraryImport(__DllName, EntryPoint = "write_buffer_add_segment")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial OpenDALWriteBufferResult write_buffer_add_segment(
+        IntPtr handle,
+        nuint committedInCurrent,
+        nuint minCapacity
+    );
+
+    [LibraryImport(__DllName, EntryPoint = "write_buffer_free")]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial void write_buffer_free(IntPtr handle);
 
     #endregion
 
@@ -203,14 +230,38 @@ internal partial class NativeMethods
 
     #region Write
 
+    [LibraryImport(__DllName, EntryPoint = "operator_write_bytes_with_options", StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static partial OpenDALResult operator_write_bytes_with_options(
+        Operator op,
+        IntPtr executor,
+        string path,
+        [In] byte[] data,
+        nuint len,
+        IntPtr options
+    );
+
+    [LibraryImport(__DllName, EntryPoint = "operator_write_bytes_with_options_async", StringMarshalling = StringMarshalling.Utf8)]
+    [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    internal static unsafe partial OpenDALResult operator_write_bytes_with_options_async(
+        Operator op,
+        IntPtr executor,
+        string path,
+        [In] byte[] data,
+        nuint len,
+        IntPtr options,
+        delegate* unmanaged[Cdecl]<long, OpenDALResult, void> callback,
+        long context
+    );
+
     [LibraryImport(__DllName, EntryPoint = "operator_write_with_options", StringMarshalling = StringMarshalling.Utf8)]
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALResult operator_write_with_options(
         Operator op,
         IntPtr executor,
         string path,
-        [In] byte[] data,
-        nuint len,
+        IntPtr buffer,
+        nuint committedInCurrent,
         IntPtr options
     );
 
@@ -220,8 +271,8 @@ internal partial class NativeMethods
         Operator op,
         IntPtr executor,
         string path,
-        [In] byte[] data,
-        nuint len,
+        IntPtr buffer,
+        nuint committedInCurrent,
         IntPtr options,
         delegate* unmanaged[Cdecl]<long, OpenDALResult, void> callback,
         long context

--- a/bindings/dotnet/OpenDAL/Operator.cs
+++ b/bindings/dotnet/OpenDAL/Operator.cs
@@ -69,11 +69,6 @@ public partial class Operator : SafeHandle
     }
 
     /// <summary>
-    /// Gets the underlying native operator pointer.
-    /// </summary>
-    public IntPtr Op => DangerousGetHandle();
-
-    /// <summary>
     /// Gets whether the native handle is invalid.
     /// </summary>
     public override bool IsInvalid => handle == IntPtr.Zero;

--- a/bindings/dotnet/OpenDAL/Operator.cs
+++ b/bindings/dotnet/OpenDAL/Operator.cs
@@ -17,8 +17,11 @@
  * under the License.
  */
 
+using System.Buffers;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
+using OpenDAL.Interop.Buffers;
+using OpenDAL.Interop.NativeObject;
 using OpenDAL.Interop.Result;
 using OpenDAL.Interop.Result.Abstractions;
 using OpenDAL.Layer.Abstractions;
@@ -178,8 +181,7 @@ public partial class Operator : SafeHandle
         var executorHandle = GetExecutorHandle(executor);
 
         using var nativeOptionsHandle = options?.BuildNativeOptionsHandle();
-
-        OpenDALResult result = NativeMethods.operator_write_with_options(
+        var result = NativeMethods.operator_write_bytes_with_options(
             this,
             executorHandle,
             path,
@@ -187,6 +189,95 @@ public partial class Operator : SafeHandle
             (nuint)content.Length,
             GetOptionsHandle(nativeOptionsHandle)
         );
+
+        ThrowIfErrorAndRelease(result);
+    }
+
+    /// <summary>
+    /// Writes a payload produced directly into native memory, without a
+    /// managed copy.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="fill"/> runs synchronously against a native-backed
+    /// <see cref="IBufferWriter{T}"/>, so standard producers such as
+    /// <c>System.Text.Json.Utf8JsonWriter</c> serialize straight into the
+    /// write payload. Everything committed when it returns becomes the
+    /// payload of a single write. The buffer never leaves this call: it
+    /// grows on demand while filling and is released once the backend
+    /// finishes with the payload.
+    /// </remarks>
+    /// <param name="path">Target path in the configured backend.</param>
+    /// <param name="fill">Producer invoked once to fill the payload.</param>
+    /// <param name="sizeHint">
+    /// Expected payload size in bytes, or 0 for the default. A positive hint
+    /// sizes the first native segment so a well-estimated payload fills it
+    /// without growing; it is an estimate, not a limit.
+    /// </param>
+    /// <param name="options">Additional write options, or <see langword="null"/> for default behavior.</param>
+    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="fill"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="sizeHint"/> is negative.</exception>
+    /// <exception cref="ObjectDisposedException">The operator or executor has been disposed.</exception>
+    /// <exception cref="OpenDALException">Native write fails.</exception>
+    public void Write(
+        string path,
+        Action<IBufferWriter<byte>> fill,
+        int sizeHint = 0,
+        WriteOptions? options = null,
+        Executor? executor = null)
+    {
+        ArgumentNullException.ThrowIfNull(fill);
+        ArgumentOutOfRangeException.ThrowIfNegative(sizeHint);
+
+        using var buffer = AllocateWriteBuffer(
+            sizeHint > 0 ? sizeHint : WriteBuffer.DefaultInitialCapacity);
+        fill(buffer);
+        Write(path, buffer, options, executor);
+    }
+
+    /// <summary>
+    /// Writes the bytes committed to an allocated native buffer to a path
+    /// synchronously, transferring ownership of its contents to the native
+    /// layer without copying.
+    /// </summary>
+    /// <remarks>
+    /// On success the write consumes the buffer contents: every later access
+    /// throws, and the memory is released once the buffer is disposed and
+    /// the backend finishes with the payload. An error raised before the
+    /// payload is taken leaves the buffer usable, but a backend failure
+    /// after that point has already consumed it, so treat a failed buffer
+    /// as spent.
+    /// </remarks>
+    /// <param name="path">Target path in the configured backend.</param>
+    /// <param name="content">Allocated buffer holding the bytes to write.</param>
+    /// <param name="options">Additional write options, or <see langword="null"/> for default behavior.</param>
+    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
+    /// <exception cref="ObjectDisposedException">The operator or buffer has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">The buffer contents were already consumed by a write.</exception>
+    /// <exception cref="OpenDALException">Native write fails.</exception>
+    internal void Write(string path, WriteBuffer content, WriteOptions? options = null, Executor? executor = null)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ObjectDisposedException.ThrowIf(IsInvalid, this);
+        var executorHandle = GetExecutorHandle(executor);
+
+        var bufferHandle = content.Handle;
+        var committedInTail = content.TailWritten;
+
+        using var nativeOptionsHandle = options?.BuildNativeOptionsHandle();
+        var result = NativeMethods.operator_write_with_options(
+            this,
+            executorHandle,
+            path,
+            bufferHandle,
+            (nuint)committedInTail,
+            GetOptionsHandle(nativeOptionsHandle)
+        );
+
+        if (!result.Error.IsError)
+        {
+            content.MarkConsumed();
+        }
 
         ThrowIfErrorAndRelease(result);
     }
@@ -263,13 +354,13 @@ public partial class Operator : SafeHandle
         ObjectDisposedException.ThrowIf(IsInvalid, this);
         var executorHandle = GetExecutorHandle(executor);
 
-        return SubmitAsyncOperation<bool, WriteOptions>(options, SubmitWriteAsync, cancellationToken);
+        return SubmitAsyncOperation<bool, WriteOptions>(options, DispatchWriteBytesAsync, cancellationToken);
 
-        OpenDALResult SubmitWriteAsync(long context, IntPtr optionsHandle)
+        OpenDALResult DispatchWriteBytesAsync(long context, IntPtr optionsHandle)
         {
             unsafe
             {
-                return NativeMethods.operator_write_with_options_async(
+                return NativeMethods.operator_write_bytes_with_options_async(
                     this,
                     executorHandle,
                     path,
@@ -281,6 +372,146 @@ public partial class Operator : SafeHandle
                 );
             }
         }
+    }
+
+    /// <summary>
+    /// Allocates a native <see cref="System.Buffers.IBufferWriter{T}"/> for a
+    /// zero-copy write.
+    /// </summary>
+    /// <remarks>
+    /// Produce into the buffer through the <see cref="System.Buffers.IBufferWriter{T}"/>
+    /// contract — for example with <c>System.Text.Json.Utf8JsonWriter</c> —
+    /// then hand it to <c>Write(path, buffer)</c> or
+    /// <c>WriteAsync(path, buffer)</c>. The buffer grows on demand, so
+    /// <paramref name="initialCapacity"/> is a hint, not a limit. The write
+    /// consumes the buffer; allocate a new one for the next write. Dispose
+    /// an unconsumed buffer to return the memory.
+    /// </remarks>
+    /// <param name="initialCapacity">Size of the first segment in bytes.</param>
+    /// <returns>An empty native buffer writer.</returns>
+    /// <exception cref="ObjectDisposedException">The operator has been disposed.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="initialCapacity"/> is not positive.</exception>
+    /// <exception cref="OpenDALException">Native buffer allocation fails.</exception>
+    internal WriteBuffer AllocateWriteBuffer(int initialCapacity = WriteBuffer.DefaultInitialCapacity)
+    {
+        ObjectDisposedException.ThrowIf(IsInvalid, this);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(initialCapacity);
+
+        var result = NativeMethods.write_buffer_create((nuint)initialCapacity);
+        var buffer = ToValueOrThrowAndRelease<OpenDALWriteBuffer, OpenDALWriteBufferResult>(result);
+        return new WriteBuffer(buffer.Handle, buffer.Data, checked((int)buffer.Capacity));
+    }
+
+    /// <summary>
+    /// Writes the bytes committed to an allocated native buffer to a path
+    /// asynchronously, transferring ownership of its contents to the native
+    /// layer without copying.
+    /// </summary>
+    /// <remarks>
+    /// Everything committed with <see cref="WriteBuffer.Advance"/> is
+    /// written, in order. On success the buffer is consumed: every later
+    /// access to it throws, and its memory is released once the buffer is
+    /// disposed and the backend finishes with the payload. When dispatch
+    /// fails immediately, ownership does not transfer and the buffer stays
+    /// usable.
+    /// </remarks>
+    /// <param name="path">Target path in the configured backend.</param>
+    /// <param name="content">Allocated buffer holding the bytes to write.</param>
+    /// <param name="options">Additional write options, or <see langword="null"/> for default behavior.</param>
+    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
+    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
+    /// <returns>A task that completes when the native callback reports completion.</returns>
+    /// <exception cref="ObjectDisposedException">The operator or buffer has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">The buffer contents were already consumed by a write.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> is already canceled.</exception>
+    /// <exception cref="OpenDALException">Native write submission fails immediately.</exception>
+    internal Task WriteAsync(
+        string path,
+        WriteBuffer content,
+        WriteOptions? options = null,
+        Executor? executor = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ObjectDisposedException.ThrowIf(IsInvalid, this);
+        var executorHandle = GetExecutorHandle(executor);
+
+        // Surfaces disposed/already-consumed as managed exceptions before the
+        // native call; the native slot enforces the same contract again.
+        var bufferHandle = content.Handle;
+        var committedInTail = content.TailWritten;
+
+        return SubmitAsyncOperation<bool, WriteOptions>(options, DispatchWriteBufferAsync, cancellationToken);
+
+        OpenDALResult DispatchWriteBufferAsync(long context, IntPtr optionsHandle)
+        {
+            unsafe
+            {
+                var result = NativeMethods.operator_write_with_options_async(
+                    this,
+                    executorHandle,
+                    path,
+                    bufferHandle,
+                    (nuint)committedInTail,
+                    optionsHandle,
+                    &OnWriteCompleted,
+                    context
+                );
+
+                if (!result.Error.IsError)
+                {
+                    content.MarkConsumed();
+                }
+
+                return result;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Writes a payload produced directly into native memory, without a
+    /// managed copy.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="fill"/> runs synchronously against a native-backed
+    /// <see cref="IBufferWriter{T}"/>, so standard producers such as
+    /// <c>System.Text.Json.Utf8JsonWriter</c> serialize straight into the
+    /// write payload. Everything committed when it returns becomes the
+    /// payload of a single write. The buffer never leaves this call: it
+    /// grows on demand while filling and is released once the backend
+    /// finishes with the payload.
+    /// </remarks>
+    /// <param name="path">Target path in the configured backend.</param>
+    /// <param name="fill">Producer invoked once to fill the payload.</param>
+    /// <param name="sizeHint">
+    /// Expected payload size in bytes, or 0 for the default. A positive hint
+    /// sizes the first native segment so a well-estimated payload fills it
+    /// without growing; it is an estimate, not a limit.
+    /// </param>
+    /// <param name="options">Additional write options, or <see langword="null"/> for default behavior.</param>
+    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
+    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
+    /// <returns>A task that completes when the native callback reports completion.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="fill"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="sizeHint"/> is negative.</exception>
+    /// <exception cref="ObjectDisposedException">The operator or executor has been disposed.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> is already canceled.</exception>
+    /// <exception cref="OpenDALException">Native write submission fails immediately.</exception>
+    public async Task WriteAsync(
+        string path,
+        Action<IBufferWriter<byte>> fill,
+        int sizeHint = 0,
+        WriteOptions? options = null,
+        Executor? executor = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fill);
+        ArgumentOutOfRangeException.ThrowIfNegative(sizeHint);
+
+        using var buffer = AllocateWriteBuffer(
+            sizeHint > 0 ? sizeHint : WriteBuffer.DefaultInitialCapacity);
+        fill(buffer);
+        await WriteAsync(path, buffer, options, executor, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -328,14 +559,7 @@ public partial class Operator : SafeHandle
     /// <returns>The content bytes.</returns>
     public byte[] Read(string path, ReadOptions? options, Executor? executor)
     {
-        ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
-
-        OpenDALReadResult result;
-        using var nativeOptionsHandle = options?.BuildNativeOptionsHandle();
-        result = NativeMethods.operator_read_with_options(this, executorHandle, path, GetOptionsHandle(nativeOptionsHandle));
-
-        return ToValueOrThrowAndRelease<byte[], OpenDALReadResult>(result);
+        return Read(path, static sequence => sequence.ToArray(), options, executor);
     }
 
     /// <summary>
@@ -393,24 +617,168 @@ public partial class Operator : SafeHandle
         Executor? executor,
         CancellationToken cancellationToken = default)
     {
+        return ReadAsync(path, static sequence => sequence.ToArray(), options, executor, cancellationToken);
+    }
+
+    /// <summary>
+    /// Reads a path into a native buffer exposed as a
+    /// <see cref="System.Buffers.ReadOnlySequence{T}"/>, without copying into
+    /// a managed array.
+    /// </summary>
+    /// <remarks>
+    /// Dispose the returned buffer to release the native memory; the sequence
+    /// must not be used afterwards.
+    /// </remarks>
+    /// <param name="path">Source path in the configured backend.</param>
+    /// <param name="options">Additional read options, or <see langword="null"/> for default behavior.</param>
+    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
+    /// <returns>The content as a disposable native buffer.</returns>
+    /// <exception cref="ObjectDisposedException">The operator or executor has been disposed.</exception>
+    /// <exception cref="OpenDALException">Native read fails.</exception>
+    internal ReadBuffer ReadBuffer(string path, ReadOptions? options = null, Executor? executor = null)
+    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
         var executorHandle = GetExecutorHandle(executor);
 
-        return SubmitAsyncOperation<byte[], ReadOptions>(options, SubmitReadAsync, cancellationToken);
+        using var nativeOptionsHandle = options?.BuildNativeOptionsHandle();
+        var result = NativeMethods.operator_read_with_options(
+            this, executorHandle, path, GetOptionsHandle(nativeOptionsHandle));
 
-        OpenDALResult SubmitReadAsync(long context, IntPtr optionsHandle)
+        return Interop.Buffers.ReadBuffer.FromResult(result);
+    }
+
+    /// <summary>
+    /// Reads a path asynchronously into a native buffer exposed as a
+    /// <see cref="System.Buffers.ReadOnlySequence{T}"/>, without copying into
+    /// a managed array.
+    /// </summary>
+    /// <remarks>
+    /// Dispose the returned buffer to release the native memory; the sequence
+    /// must not be used afterwards.
+    /// </remarks>
+    /// <param name="path">Source path in the configured backend.</param>
+    /// <param name="options">Additional read options, or <see langword="null"/> for default behavior.</param>
+    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
+    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
+    /// <returns>A task that resolves with the content as a disposable native buffer.</returns>
+    /// <exception cref="ObjectDisposedException">The operator or executor has been disposed.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> is already canceled.</exception>
+    /// <exception cref="OpenDALException">Native read submission fails immediately.</exception>
+    internal async Task<ReadBuffer> ReadBufferAsync(
+        string path,
+        ReadOptions? options = null,
+        Executor? executor = null,
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(IsInvalid, this);
+        cancellationToken.ThrowIfCancellationRequested();
+        var executorHandle = GetExecutorHandle(executor);
+
+        var context = AsyncStateRegistry.Register<OpenDALReadResult>(out var state);
+        OpenDALResult submit;
+        using (var nativeOptionsHandle = options?.BuildNativeOptionsHandle())
         {
             unsafe
             {
-                return NativeMethods.operator_read_with_options_async(
+                submit = NativeMethods.operator_read_with_options_async(
                     this,
                     executorHandle,
                     path,
-                    optionsHandle,
-                    &OnReadCompleted,
+                    GetOptionsHandle(nativeOptionsHandle),
+                    &OnReadResultRetained,
                     context
                 );
             }
+        }
+
+        try
+        {
+            ThrowIfErrorAndRelease(submit);
+        }
+        catch
+        {
+            AsyncStateRegistry.Unregister(context);
+            throw;
+        }
+
+        state.BindCancellation(cancellationToken);
+        var result = await state.Completion.Task.ConfigureAwait(false);
+        return Interop.Buffers.ReadBuffer.FromResult(result);
+    }
+
+    /// <summary>
+    /// Reads a path and consumes the payload in place as a
+    /// <see cref="ReadOnlySequence{T}"/> over native memory, without copying
+    /// into a managed array.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="consume"/> runs synchronously, so standard consumers
+    /// such as <c>System.Text.Json.Utf8JsonReader</c> parse straight from
+    /// native memory. The memory is released when it returns: the sequence,
+    /// and anything pointing into it, must not escape the callback.
+    /// </remarks>
+    /// <typeparam name="T">Result produced by the consumer.</typeparam>
+    /// <param name="path">Source path in the configured backend.</param>
+    /// <param name="consume">Consumer invoked once with the payload.</param>
+    /// <param name="options">Additional read options, or <see langword="null"/> for default behavior.</param>
+    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
+    /// <returns>The value returned by <paramref name="consume"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="consume"/> is null.</exception>
+    /// <exception cref="ObjectDisposedException">The operator or executor has been disposed.</exception>
+    /// <exception cref="OpenDALException">Native read fails.</exception>
+    public T Read<T>(
+        string path,
+        Func<ReadOnlySequence<byte>, T> consume,
+        ReadOptions? options = null,
+        Executor? executor = null)
+    {
+        ArgumentNullException.ThrowIfNull(consume);
+
+        using var buffer = ReadBuffer(path, options, executor);
+        return consume(buffer.Sequence);
+    }
+
+    /// <inheritdoc cref="Read{T}(string, Func{ReadOnlySequence{byte}, T}, ReadOptions?, Executor?)" />
+    /// <summary>
+    /// Reads a path asynchronously and consumes the payload in place as a
+    /// <see cref="ReadOnlySequence{T}"/> over native memory, without copying
+    /// into a managed array.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> is already canceled.</exception>
+    public async Task<T> ReadAsync<T>(
+        string path,
+        Func<ReadOnlySequence<byte>, T> consume,
+        ReadOptions? options = null,
+        Executor? executor = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(consume);
+
+        using var buffer = await ReadBufferAsync(path, options, executor, cancellationToken).ConfigureAwait(false);
+        return consume(buffer.Sequence);
+    }
+
+    /// <summary>
+    /// Native read callback that keeps ownership of a successful payload with
+    /// the awaiter instead of materializing it. Without an awaiter, for
+    /// example after cancellation, the payload is released here.
+    /// </summary>
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    internal static void OnReadResultRetained(long context, OpenDALReadResult result)
+    {
+        if (!AsyncStateRegistry.TryTake<AsyncState<OpenDALReadResult>>(context, out var state))
+        {
+            result.Release();
+            return;
+        }
+
+        state.CancellationRegistration.Dispose();
+        if (!state.Completion.TrySetResult(result))
+        {
+            // Cancellation won the completion race, so no awaiter will ever
+            // take ownership of this payload.
+            result.Release();
         }
     }
 
@@ -1529,17 +1897,6 @@ public partial class Operator : SafeHandle
     private static void OnWriteCompleted(long context, OpenDALResult result)
     {
         CompleteAsyncCallback(context, result);
-    }
-
-    /// <summary>
-    /// Native callback invoked when an asynchronous read operation finishes.
-    /// </summary>
-    /// <param name="context">Opaque async state context previously registered by <see cref="AsyncStateRegistry"/>.</param>
-    /// <param name="result">Read completion result returned by the native layer, including byte buffer payload.</param>
-    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
-    private static void OnReadCompleted(long context, OpenDALReadResult result)
-    {
-        CompleteAsyncCallback<byte[], OpenDALReadResult>(context, result);
     }
 
     /// <summary>

--- a/bindings/dotnet/OpenDAL/OperatorInputStream.cs
+++ b/bindings/dotnet/OpenDAL/OperatorInputStream.cs
@@ -28,6 +28,7 @@ public sealed class OperatorInputStream : Stream
 {
     private IntPtr handle;
     private bool disposed;
+    private bool abandoned;
 
     // Current native chunk. Keeping the native handle instead of a managed
     // copy lets Read copy each byte exactly once, straight into the caller's
@@ -45,7 +46,7 @@ public sealed class OperatorInputStream : Stream
         this.handle = handle;
     }
 
-    public override bool CanRead => !disposed;
+    public override bool CanRead => !disposed && !abandoned;
 
     public override bool CanSeek => false;
 
@@ -75,37 +76,136 @@ public sealed class OperatorInputStream : Stream
             if (currentChunk is null || chunkOffset >= currentChunk.Value.Buffer.Len)
             {
                 ReleaseCurrentChunk();
-                var next = NativeMethods.operator_input_stream_read_next(handle);
-                var error = next.GetError();
-                if (error.IsError)
+                if (!AcceptChunk(NativeMethods.operator_input_stream_read_next(handle)))
                 {
-                    var exception = new OpenDALException(error);
-                    next.Release();
-                    throw exception;
-                }
-
-                if (next.Buffer.Handle == IntPtr.Zero || next.Buffer.Len == 0)
-                {
-                    next.Release();
                     break;
                 }
-
-                currentChunk = next;
-                chunkOffset = 0;
             }
 
-            var copied = currentChunk.Value.Buffer.CopyTo(chunkOffset, destination);
+            var copied = CopyFromCurrentChunk(destination);
             if (copied == 0)
             {
                 break;
             }
 
-            chunkOffset += (nuint)copied;
             destination = destination[copied..];
             totalRead += copied;
         }
 
         return totalRead;
+    }
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+        return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var totalRead = 0;
+        while (!destination.IsEmpty)
+        {
+            if (currentChunk is null || chunkOffset >= currentChunk.Value.Buffer.Len)
+            {
+                ReleaseCurrentChunk();
+                if (!AcceptChunk(await FetchNextChunkAsync(cancellationToken).ConfigureAwait(false)))
+                {
+                    break;
+                }
+            }
+
+            var copied = CopyFromCurrentChunk(destination.Span);
+            if (copied == 0)
+            {
+                break;
+            }
+
+            destination = destination[copied..];
+            totalRead += copied;
+        }
+
+        return totalRead;
+    }
+
+    /// <summary>
+    /// Awaits the next chunk from the native async read path.
+    /// </summary>
+    /// <remarks>
+    /// On success the returned result still owns its native buffer; the caller
+    /// takes that ownership through <see cref="AcceptChunk"/>. When the token
+    /// fires first, the late native callback finds no awaiter and releases the
+    /// chunk itself, and the stream is poisoned because its position no
+    /// longer matches what the caller consumed.
+    /// </remarks>
+    private async ValueTask<OpenDALReadResult> FetchNextChunkAsync(CancellationToken cancellationToken)
+    {
+        var context = AsyncStateRegistry.Register<OpenDALReadResult>(out var state);
+        OpenDALResult submit;
+        unsafe
+        {
+            submit = NativeMethods.operator_input_stream_read_next_async(
+                handle, &Operator.OnReadResultRetained, context);
+        }
+
+        try
+        {
+            Operator.ThrowIfErrorAndRelease(submit);
+        }
+        catch
+        {
+            AsyncStateRegistry.Unregister(context);
+            throw;
+        }
+
+        state.BindCancellation(cancellationToken);
+        try
+        {
+            return await state.Completion.Task.ConfigureAwait(false);
+        }
+        catch
+        {
+            // The native position may already sit past a chunk this caller
+            // never received. Poison the stream instead of silently skipping
+            // those bytes on the next read.
+            abandoned = true;
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Takes ownership of a fetched chunk, releasing empty results.
+    /// </summary>
+    /// <returns><see langword="false"/> on EOF.</returns>
+    private bool AcceptChunk(OpenDALReadResult next)
+    {
+        var error = next.GetError();
+        if (error.IsError)
+        {
+            var exception = new OpenDALException(error);
+            next.Release();
+            throw exception;
+        }
+
+        if (next.Buffer.Handle == IntPtr.Zero || next.Buffer.Len == 0)
+        {
+            next.Release();
+            return false;
+        }
+
+        currentChunk = next;
+        chunkOffset = 0;
+        return true;
+    }
+
+    private int CopyFromCurrentChunk(Span<byte> destination)
+    {
+        var copied = currentChunk!.Value.Buffer.CopyTo(chunkOffset, destination);
+        chunkOffset += (nuint)copied;
+        return copied;
     }
 
     private void ReleaseCurrentChunk()
@@ -116,18 +216,6 @@ public sealed class OperatorInputStream : Stream
             currentChunk = null;
             chunkOffset = 0;
         }
-    }
-
-    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        return Task.FromResult(Read(buffer, offset, count));
-    }
-
-    public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        return ValueTask.FromResult(Read(buffer.Span));
     }
 
     public override void Flush()
@@ -158,6 +246,11 @@ public sealed class OperatorInputStream : Stream
     private void ThrowIfDisposed()
     {
         ObjectDisposedException.ThrowIf(disposed || handle == IntPtr.Zero, this);
+        if (abandoned)
+        {
+            throw new InvalidOperationException(
+                "An abandoned read left the native stream position unknown; dispose this stream and open a new one.");
+        }
     }
 
     protected override void Dispose(bool disposing)

--- a/bindings/dotnet/OpenDAL/OperatorInputStream.cs
+++ b/bindings/dotnet/OpenDAL/OperatorInputStream.cs
@@ -28,8 +28,12 @@ public sealed class OperatorInputStream : Stream
 {
     private IntPtr handle;
     private bool disposed;
-    private byte[]? chunk;
-    private int chunkOffset;
+
+    // Current native chunk. Keeping the native handle instead of a managed
+    // copy lets Read copy each byte exactly once, straight into the caller's
+    // destination. Released once fully consumed, on EOF, or on dispose.
+    private OpenDALReadResult? currentChunk;
+    private nuint chunkOffset;
 
     internal OperatorInputStream(IntPtr handle)
     {
@@ -64,34 +68,54 @@ public sealed class OperatorInputStream : Stream
     public override int Read(Span<byte> destination)
     {
         ThrowIfDisposed();
-        if (destination.Length == 0)
-        {
-            return 0;
-        }
 
         var totalRead = 0;
         while (destination.Length > 0)
         {
-            if (chunk is null || chunkOffset >= chunk.Length)
+            if (currentChunk is null || chunkOffset >= currentChunk.Value.Buffer.Len)
             {
+                ReleaseCurrentChunk();
                 var next = NativeMethods.operator_input_stream_read_next(handle);
-                chunk = Operator.ToValueOrThrowAndRelease<byte[], OpenDALReadResult>(next);
-                chunkOffset = 0;
-                if (chunk.Length == 0)
+                var error = next.GetError();
+                if (error.IsError)
                 {
-                    return totalRead;
+                    var exception = new OpenDALException(error);
+                    next.Release();
+                    throw exception;
                 }
+
+                if (next.Buffer.Handle == IntPtr.Zero || next.Buffer.Len == 0)
+                {
+                    next.Release();
+                    break;
+                }
+
+                currentChunk = next;
+                chunkOffset = 0;
             }
 
-            var available = chunk.Length - chunkOffset;
-            var toCopy = Math.Min(available, destination.Length);
-            chunk.AsSpan(chunkOffset, toCopy).CopyTo(destination);
-            chunkOffset += toCopy;
-            destination = destination[toCopy..];
-            totalRead += toCopy;
+            var copied = currentChunk.Value.Buffer.CopyTo(chunkOffset, destination);
+            if (copied == 0)
+            {
+                break;
+            }
+
+            chunkOffset += (nuint)copied;
+            destination = destination[copied..];
+            totalRead += copied;
         }
 
         return totalRead;
+    }
+
+    private void ReleaseCurrentChunk()
+    {
+        if (currentChunk is { } chunk)
+        {
+            chunk.Release();
+            currentChunk = null;
+            chunkOffset = 0;
+        }
     }
 
     public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -140,10 +164,9 @@ public sealed class OperatorInputStream : Stream
     {
         if (!disposed)
         {
+            ReleaseCurrentChunk();
             NativeMethods.operator_input_stream_free(handle);
             handle = IntPtr.Zero;
-            chunk = null;
-            chunkOffset = 0;
             disposed = true;
         }
 

--- a/bindings/dotnet/OpenDAL/OperatorOutputStream.cs
+++ b/bindings/dotnet/OpenDAL/OperatorOutputStream.cs
@@ -28,7 +28,7 @@ namespace OpenDAL;
 /// </summary>
 public sealed class OperatorOutputStream : Stream
 {
-    internal const int DefaultBufferSize = 16 * 1024;
+    internal const int DefaultBufferSize = 16 * 1024; // 16 KiB
 
     private IntPtr handle;
     private bool disposed;

--- a/bindings/dotnet/OpenDAL/OperatorOutputStream.cs
+++ b/bindings/dotnet/OpenDAL/OperatorOutputStream.cs
@@ -17,6 +17,10 @@
  * under the License.
  */
 
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using OpenDAL.Interop.Result;
+
 namespace OpenDAL;
 
 /// <summary>
@@ -28,6 +32,8 @@ public sealed class OperatorOutputStream : Stream
 
     private IntPtr handle;
     private bool disposed;
+    private bool completed;
+    private bool abandoned;
     private readonly byte[] buffer;
     private int buffered;
 
@@ -51,7 +57,7 @@ public sealed class OperatorOutputStream : Stream
 
     public override bool CanSeek => false;
 
-    public override bool CanWrite => !disposed;
+    public override bool CanWrite => !disposed && !completed && !abandoned;
 
     public override long Length => throw new NotSupportedException();
 
@@ -88,18 +94,39 @@ public sealed class OperatorOutputStream : Stream
 
     public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-        Write(buffer, offset, count);
-        return Task.CompletedTask;
+        ArgumentNullException.ThrowIfNull(buffer);
+        return WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
     }
 
-    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
     {
+        ThrowIfDisposed();
         cancellationToken.ThrowIfCancellationRequested();
-        Write(buffer.Span);
-        return ValueTask.CompletedTask;
+
+        while (!source.IsEmpty)
+        {
+            var writable = buffer.Length - buffered;
+            if (writable == 0)
+            {
+                await FlushBufferedAsync(cancellationToken).ConfigureAwait(false);
+                writable = buffer.Length;
+            }
+
+            var take = Math.Min(writable, source.Length);
+            source.Span[..take].CopyTo(buffer.AsSpan(buffered));
+            buffered += take;
+            source = source[take..];
+        }
     }
 
+    /// <summary>
+    /// Pushes buffered bytes to the native writer.
+    /// </summary>
+    /// <remarks>
+    /// This does not persist the content: the backend finalizes the write
+    /// only when the stream completes, through <see cref="Complete"/>,
+    /// <see cref="CompleteAsync"/>, or disposal.
+    /// </remarks>
     public override void Flush()
     {
         ThrowIfDisposed();
@@ -108,11 +135,122 @@ public sealed class OperatorOutputStream : Stream
         Operator.ThrowIfErrorAndRelease(result);
     }
 
-    public override Task FlushAsync(CancellationToken cancellationToken)
+    /// <inheritdoc cref="Flush" />
+    public override async Task FlushAsync(CancellationToken cancellationToken)
     {
+        ThrowIfDisposed();
         cancellationToken.ThrowIfCancellationRequested();
-        Flush();
-        return Task.CompletedTask;
+        await FlushBufferedAsync(cancellationToken).ConfigureAwait(false);
+        var result = NativeMethods.operator_output_stream_flush(handle);
+        Operator.ThrowIfErrorAndRelease(result);
+    }
+
+    /// <summary>
+    /// Flushes buffered bytes and finalizes the write, persisting the
+    /// content.
+    /// </summary>
+    /// <remarks>
+    /// Errors surface here, so prefer completing explicitly over relying on
+    /// disposal, which can only close best-effort. After completion the
+    /// stream rejects further writes and disposal just releases native
+    /// resources.
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">The stream has been disposed.</exception>
+    /// <exception cref="InvalidOperationException">The stream was already completed.</exception>
+    /// <exception cref="OpenDALException">Native close fails.</exception>
+    public void Complete()
+    {
+        ThrowIfDisposed();
+        FlushBuffered();
+        var result = NativeMethods.operator_output_stream_close(handle);
+        Operator.ThrowIfErrorAndRelease(result);
+        completed = true;
+    }
+
+    /// <inheritdoc cref="Complete" />
+    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
+    public async Task CompleteAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        cancellationToken.ThrowIfCancellationRequested();
+        await FlushBufferedAsync(cancellationToken).ConfigureAwait(false);
+
+        var context = AsyncStateRegistry.Register<bool>(out var state);
+        OpenDALResult submit;
+        unsafe
+        {
+            submit = NativeMethods.operator_output_stream_close_async(
+                handle, &OnStreamWriteCompleted, context);
+        }
+
+        try
+        {
+            Operator.ThrowIfErrorAndRelease(submit);
+        }
+        catch
+        {
+            AsyncStateRegistry.Unregister(context);
+            throw;
+        }
+
+        state.BindCancellation(cancellationToken);
+        await state.Completion.Task.ConfigureAwait(false);
+        completed = true;
+    }
+
+    /// <summary>
+    /// Pushes the managed buffer to the native writer without blocking the
+    /// calling thread.
+    /// </summary>
+    private async ValueTask FlushBufferedAsync(CancellationToken cancellationToken)
+    {
+        if (buffered == 0)
+        {
+            return;
+        }
+
+        var context = AsyncStateRegistry.Register<bool>(out var state);
+        OpenDALResult submit;
+        unsafe
+        {
+            submit = NativeMethods.operator_output_stream_write_async(
+                handle, buffer, (nuint)buffered, &OnStreamWriteCompleted, context);
+        }
+
+        try
+        {
+            Operator.ThrowIfErrorAndRelease(submit);
+        }
+        catch
+        {
+            AsyncStateRegistry.Unregister(context);
+            throw;
+        }
+
+        state.BindCancellation(cancellationToken);
+        try
+        {
+            await state.Completion.Task.ConfigureAwait(false);
+        }
+        catch
+        {
+            // The submitted bytes already belong to the native writer, so the
+            // stream cannot tell what landed. Poison it rather than risk
+            // flushing the same bytes twice.
+            abandoned = true;
+            throw;
+        }
+
+        buffered = 0;
+    }
+
+    /// <summary>
+    /// Native callback invoked when an asynchronous stream write finishes.
+    /// </summary>
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static void OnStreamWriteCompleted(long context, OpenDALResult result)
+    {
+        Operator.CompleteAsyncCallback(context, result);
     }
 
     public override int Read(byte[] buffer, int offset, int count)
@@ -145,25 +283,42 @@ public sealed class OperatorOutputStream : Stream
     private void ThrowIfDisposed()
     {
         ObjectDisposedException.ThrowIf(disposed || handle == IntPtr.Zero, this);
+        if (completed)
+        {
+            throw new InvalidOperationException(
+                "The stream was already completed; open a new write stream for further writes.");
+        }
+
+        if (abandoned)
+        {
+            throw new InvalidOperationException(
+                "An abandoned flush left the native writer in an unknown state; dispose this stream and open a new one.");
+        }
     }
 
+    /// <summary>
+    /// Releases the stream. When the stream has not been completed, the
+    /// remaining bytes are closed out best-effort and errors are swallowed;
+    /// call <see cref="Complete"/> or <see cref="CompleteAsync"/> first when
+    /// close errors must surface. A stream poisoned by an abandoned flush is
+    /// released without closing.
+    /// </summary>
     protected override void Dispose(bool disposing)
     {
         if (!disposed)
         {
-            OpenDALException? pending = null;
             try
             {
-                Flush();
-                var close = NativeMethods.operator_output_stream_close(handle);
-                try
+                if (!completed && !abandoned)
                 {
+                    FlushBuffered();
+                    var close = NativeMethods.operator_output_stream_close(handle);
                     Operator.ThrowIfErrorAndRelease(close);
                 }
-                catch (OpenDALException ex)
-                {
-                    pending = ex;
-                }
+            }
+            catch
+            {
+                // Best-effort close only; Complete() is the throwing path.
             }
             finally
             {
@@ -172,13 +327,27 @@ public sealed class OperatorOutputStream : Stream
                 buffered = 0;
                 disposed = true;
             }
-
-            if (pending is not null)
-            {
-                throw pending;
-            }
         }
 
         base.Dispose(disposing);
+    }
+
+    /// <inheritdoc cref="Dispose(bool)" />
+    public override async ValueTask DisposeAsync()
+    {
+        if (!disposed && !completed && !abandoned)
+        {
+            try
+            {
+                await CompleteAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort close only; CompleteAsync() is the throwing path.
+            }
+        }
+
+        Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/bindings/dotnet/OpenDAL/Options/NativeOptionsBuilder.cs
+++ b/bindings/dotnet/OpenDAL/Options/NativeOptionsBuilder.cs
@@ -17,7 +17,6 @@
  * under the License.
  */
 
-using System.Runtime.InteropServices;
 using OpenDAL.Interop.Result;
 
 namespace OpenDAL.Options;

--- a/bindings/dotnet/src/buffer.rs
+++ b/bindings/dotnet/src/buffer.rs
@@ -159,7 +159,7 @@ pub unsafe extern "C" fn read_buffer_chunks(
 /// - `handle` must be null or come from `OpendalReadBuffer::from_buffer`.
 /// - This function must be called at most once for the same handle.
 /// - Callers must not use `handle` after this function returns.
-pub unsafe fn read_buffer_free(handle: *mut c_void) {
+pub(crate) unsafe fn read_buffer_free(handle: *mut c_void) {
     if handle.is_null() {
         return;
     }

--- a/bindings/dotnet/src/buffer.rs
+++ b/bindings/dotnet/src/buffer.rs
@@ -194,7 +194,7 @@ impl OpendalWriteBuffer {
 
 /// Sealed segments with their committed lengths, plus the segment currently
 /// exposed to the caller.
-struct FillingState {
+pub(crate) struct FillingState {
     sealed: Vec<(Vec<MaybeUninit<u8>>, usize)>,
     current: Vec<MaybeUninit<u8>>,
 }

--- a/bindings/dotnet/src/buffer.rs
+++ b/bindings/dotnet/src/buffer.rs
@@ -15,13 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Read payloads travelling from this crate to the caller.
+//! Native payload buffers crossing the FFI boundary in both directions.
 //!
-//! Bytes going the other way, such as write payloads, are passed as a plain
-//! pointer and length, because the caller already owns that memory.
+//! Read payloads keep the [`opendal::Buffer`] behind a handle so the caller
+//! copies (or views) chunks straight from native memory. Write buffers grow
+//! segment by segment — segments never move, so handed-out pointers stay
+//! valid — and a write consumes them, frozen into one
+//! non-contiguous buffer without copying.
 
 use std::ffi::c_void;
+use std::mem::MaybeUninit;
 use std::ptr;
+
+use crate::chunk::OpendalChunk;
+use crate::error::OpenDALError;
+use crate::result::OpendalWriteBufferResult;
+use crate::utils::config_invalid_error;
 
 #[repr(C)]
 /// Read payload owned by this crate.
@@ -29,14 +38,14 @@ use std::ptr;
 /// Holds the [`opendal::Buffer`] itself rather than a flattened copy, so the
 /// caller can copy straight into its final destination. `handle` must be
 /// released with `opendal_read_result_release` exactly once.
-pub struct OpendalBuffer {
+pub struct OpendalReadBuffer {
     /// Leaked `Box<opendal::Buffer>`, or null when there is no payload.
     pub handle: *mut c_void,
     /// Total readable bytes across every chunk.
     pub len: usize,
 }
 
-impl OpendalBuffer {
+impl OpendalReadBuffer {
     /// Create an empty payload that does not own anything.
     pub fn empty() -> Self {
         Self {
@@ -59,18 +68,21 @@ impl OpendalBuffer {
     }
 }
 
-/// Copy the whole payload into `dest`, returning the number of bytes written.
+/// Copy the payload from `src_offset` onwards into `dest`, returning the
+/// number of bytes written.
 ///
 /// Copies at most `dest_len` bytes. An `opendal::Buffer` may be split across
 /// several chunks, so this walks them and writes each one directly into the
-/// destination; that is the only copy a read performs.
+/// destination; that is the only copy a read performs. An offset at or past
+/// the end of the payload writes nothing.
 /// # Safety
 ///
-/// - `handle` must be null or come from `OpendalBuffer::from_buffer`.
+/// - `handle` must be null or come from `OpendalReadBuffer::from_buffer`.
 /// - `dest` must be valid for writes of `dest_len` bytes.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn buffer_copy_to(
+pub unsafe extern "C" fn read_buffer_copy_to(
     handle: *const c_void,
+    src_offset: usize,
     dest: *mut u8,
     dest_len: usize,
 ) -> usize {
@@ -78,9 +90,14 @@ pub unsafe extern "C" fn buffer_copy_to(
         return 0;
     }
 
-    // Iterating consumes the buffer, so work on a clone. `Buffer` is backed by
-    // `Bytes`, meaning this only bumps reference counts.
-    let chunks = unsafe { &*(handle as *const opendal::Buffer) }.clone();
+    let buffer = unsafe { &*(handle as *const opendal::Buffer) };
+    if src_offset >= buffer.len() {
+        return 0;
+    }
+
+    // Slicing bumps reference counts on the backing `Bytes` instead of
+    // copying; iterating then consumes the sliced view, not the original.
+    let chunks = buffer.slice(src_offset..);
 
     let mut written = 0usize;
     for chunk in chunks {
@@ -98,17 +115,274 @@ pub unsafe extern "C" fn buffer_copy_to(
     written
 }
 
+/// Enumerate the chunks of a read payload without copying.
+///
+/// Fills `out` with up to `cap` descriptors and returns the total number of
+/// chunks; call with `cap` 0 first to size the array. Descriptor pointers
+/// stay valid until the owning handle is released.
 /// # Safety
 ///
-/// - `handle` must be null or come from `OpendalBuffer::from_buffer`.
+/// - `handle` must be null or come from `OpendalReadBuffer::from_buffer`.
+/// - When `cap > 0`, `out` must be valid for writes of `cap` descriptors.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn read_buffer_chunks(
+    handle: *const c_void,
+    out: *mut OpendalChunk,
+    cap: usize,
+) -> usize {
+    if handle.is_null() {
+        return 0;
+    }
+
+    let buffer = unsafe { &*(handle as *const opendal::Buffer) };
+
+    // Iterated chunks are `Bytes` clones sharing storage with the handle's
+    // buffer, so the recorded pointers outlive this call.
+    let mut count = 0usize;
+    for chunk in buffer.clone() {
+        if count < cap && !out.is_null() {
+            unsafe {
+                *out.add(count) = OpendalChunk {
+                    data: chunk.as_ptr(),
+                    len: chunk.len(),
+                };
+            }
+        }
+        count += 1;
+    }
+
+    count
+}
+
+/// # Safety
+///
+/// - `handle` must be null or come from `OpendalReadBuffer::from_buffer`.
 /// - This function must be called at most once for the same handle.
 /// - Callers must not use `handle` after this function returns.
-pub unsafe fn buffer_free(handle: *mut c_void) {
+pub unsafe fn read_buffer_free(handle: *mut c_void) {
     if handle.is_null() {
         return;
     }
 
     drop(unsafe { Box::from_raw(handle as *mut opendal::Buffer) });
+}
+
+#[repr(C)]
+/// Writable segment handed to the caller.
+///
+/// `data` points at `capacity` writable bytes owned by `handle`. The handle
+/// must be released exactly once with `write_buffer_free`, whether or not its
+/// contents were consumed.
+pub struct OpendalWriteBuffer {
+    /// Leaked `Box<WriteBufferSlot>` owning every segment.
+    pub handle: *mut c_void,
+    /// Raw pointer to the newest segment, valid until the handle is freed.
+    pub data: *mut u8,
+    /// Writable bytes behind `data`.
+    pub capacity: usize,
+}
+
+impl OpendalWriteBuffer {
+    pub fn empty() -> Self {
+        Self {
+            handle: std::ptr::null_mut(),
+            data: std::ptr::null_mut(),
+            capacity: 0,
+        }
+    }
+}
+
+/// Sealed segments with their committed lengths, plus the segment currently
+/// exposed to the caller.
+struct FillingState {
+    sealed: Vec<(Vec<MaybeUninit<u8>>, usize)>,
+    current: Vec<MaybeUninit<u8>>,
+}
+
+/// Allocate a segment without initializing it, like a pooled array: contents
+/// are unspecified until the caller writes them.
+fn uninit_segment(capacity: usize) -> Vec<MaybeUninit<u8>> {
+    let mut segment = Vec::with_capacity(capacity);
+    // SAFETY: `MaybeUninit<u8>` requires no initialization.
+    unsafe { segment.set_len(capacity) };
+    segment
+}
+
+/// Freeze the committed prefix of a segment into `Bytes`.
+///
+/// The caller wrote the first `committed` bytes through the segment's raw
+/// pointer, so that prefix is initialized. The tail past it is freed without
+/// ever being read.
+fn freeze_committed(segment: Vec<MaybeUninit<u8>>, committed: usize) -> bytes::Bytes {
+    debug_assert!(committed <= segment.len());
+    let mut segment = std::mem::ManuallyDrop::new(segment);
+    let (ptr, capacity) = (segment.as_mut_ptr(), segment.capacity());
+    // SAFETY: same allocation and layout (`MaybeUninit<u8>` mirrors `u8`),
+    // length capped to the initialized prefix, capacity preserved for the
+    // eventual free.
+    let vec = unsafe { Vec::from_raw_parts(ptr.cast::<u8>(), committed, capacity) };
+    bytes::Bytes::from(vec)
+}
+
+/// Lifecycle of an allocated write buffer.
+///
+/// Consumption keeps a guard clone of the assembled buffer until
+/// `write_buffer_free`, so a stale caller-side view can never dangle.
+pub(crate) enum WriteBufferSlot {
+    Filling(FillingState),
+    Consumed { _guard: opendal::Buffer },
+}
+
+/// Seal the current segment and expose a fresh one of `min_capacity` bytes.
+fn grow(
+    slot: &mut WriteBufferSlot,
+    committed_in_current: usize,
+    min_capacity: usize,
+) -> Result<(*mut u8, usize), OpenDALError> {
+    if min_capacity == 0 {
+        return Err(config_invalid_error(
+            "write buffer segment capacity must be greater than 0",
+        ));
+    }
+
+    match slot {
+        WriteBufferSlot::Filling(state) => {
+            if committed_in_current > state.current.len() {
+                return Err(config_invalid_error(
+                    "committed length exceeds the current segment capacity",
+                ));
+            }
+
+            let mut next = uninit_segment(min_capacity);
+            let data = next.as_mut_ptr().cast::<u8>();
+            let sealed = std::mem::replace(&mut state.current, next);
+            state.sealed.push((sealed, committed_in_current));
+            Ok((data, min_capacity))
+        }
+        WriteBufferSlot::Consumed { .. } => Err(config_invalid_error(
+            "write buffer contents were already consumed",
+        )),
+    }
+}
+
+/// Assemble the committed bytes of every segment into one buffer.
+///
+/// On success the slot moves to `Consumed`; errors leave it untouched, so
+/// the caller keeps full ownership.
+pub(crate) fn take_payload(
+    slot: &mut WriteBufferSlot,
+    committed_in_current: usize,
+) -> Result<opendal::Buffer, OpenDALError> {
+    match slot {
+        WriteBufferSlot::Filling(state) => {
+            if committed_in_current > state.current.len() {
+                return Err(config_invalid_error(
+                    "committed length exceeds the current segment capacity",
+                ));
+            }
+
+            let mut parts: Vec<bytes::Bytes> = Vec::with_capacity(state.sealed.len() + 1);
+            for (segment, committed) in state.sealed.drain(..) {
+                if committed == 0 {
+                    continue;
+                }
+
+                parts.push(freeze_committed(segment, committed));
+            }
+
+            if committed_in_current > 0 {
+                let current = std::mem::take(&mut state.current);
+                parts.push(freeze_committed(current, committed_in_current));
+            }
+
+            let buffer = if parts.is_empty() {
+                opendal::Buffer::new()
+            } else {
+                opendal::Buffer::from(parts)
+            };
+
+            *slot = WriteBufferSlot::Consumed {
+                _guard: buffer.clone(),
+            };
+            Ok(buffer)
+        }
+        WriteBufferSlot::Consumed { .. } => Err(config_invalid_error(
+            "write buffer contents were already consumed",
+        )),
+    }
+}
+
+/// Allocate a buffer exposing `capacity` writable bytes. The memory is not
+/// initialized: contents are unspecified until the caller writes them.
+///
+/// The returned handle must eventually be released with `write_buffer_free`.
+#[unsafe(no_mangle)]
+pub extern "C" fn write_buffer_create(capacity: usize) -> OpendalWriteBufferResult {
+    if capacity == 0 {
+        return OpendalWriteBufferResult::from_error(config_invalid_error(
+            "write buffer capacity must be greater than 0",
+        ));
+    }
+
+    let mut current = uninit_segment(capacity);
+    let data = current.as_mut_ptr().cast::<u8>();
+    let slot = WriteBufferSlot::Filling(FillingState {
+        sealed: Vec::new(),
+        current,
+    });
+    let handle = Box::into_raw(Box::new(slot)) as *mut c_void;
+
+    OpendalWriteBufferResult::ok(OpendalWriteBuffer {
+        handle,
+        data,
+        capacity,
+    })
+}
+
+/// Seal the current segment at `committed_in_current` bytes and expose a new
+/// segment of at least `min_capacity` bytes. Earlier segments keep their
+/// addresses.
+/// # Safety
+///
+/// - `handle` must come from `write_buffer_create` and not have been freed.
+/// - Calls for the same handle must not run concurrently.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn write_buffer_add_segment(
+    handle: *mut c_void,
+    committed_in_current: usize,
+    min_capacity: usize,
+) -> OpendalWriteBufferResult {
+    if handle.is_null() {
+        return OpendalWriteBufferResult::from_error(config_invalid_error(
+            "write buffer handle is null",
+        ));
+    }
+
+    let slot = unsafe { &mut *(handle as *mut WriteBufferSlot) };
+    match grow(slot, committed_in_current, min_capacity) {
+        Ok((data, capacity)) => OpendalWriteBufferResult::ok(OpendalWriteBuffer {
+            handle,
+            data,
+            capacity,
+        }),
+        Err(error) => OpendalWriteBufferResult::from_error(error),
+    }
+}
+
+/// Release an allocated write buffer handle. After the contents are consumed this only
+/// drops the guard clone; the backend keeps the payload alive for as long as it needs.
+/// # Safety
+///
+/// - `handle` must be null or come from `write_buffer_create`.
+/// - Must be called at most once for the same handle.
+/// - Segment pointers must not be used after this call.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn write_buffer_free(handle: *mut c_void) {
+    if handle.is_null() {
+        return;
+    }
+
+    drop(unsafe { Box::from_raw(handle as *mut WriteBufferSlot) });
 }
 
 #[cfg(test)]
@@ -125,11 +399,16 @@ mod tests {
         ])
     }
 
-    fn copy(buffer: &opendal::Buffer, dest: &mut [u8]) -> usize {
-        let owned = OpendalBuffer::from_buffer(buffer.clone());
-        let written = unsafe { buffer_copy_to(owned.handle, dest.as_mut_ptr(), dest.len()) };
-        unsafe { buffer_free(owned.handle) };
+    fn copy_at(buffer: &opendal::Buffer, src_offset: usize, dest: &mut [u8]) -> usize {
+        let owned = OpendalReadBuffer::from_buffer(buffer.clone());
+        let written =
+            unsafe { read_buffer_copy_to(owned.handle, src_offset, dest.as_mut_ptr(), dest.len()) };
+        unsafe { read_buffer_free(owned.handle) };
         written
+    }
+
+    fn copy(buffer: &opendal::Buffer, dest: &mut [u8]) -> usize {
+        copy_at(buffer, 0, dest)
     }
 
     #[test]
@@ -161,11 +440,175 @@ mod tests {
     }
 
     #[test]
+    fn resumes_from_an_offset_inside_a_chunk() {
+        // Streaming reads drain one chunk across several calls, so the copy
+        // must be able to start mid-chunk and keep walking the later parts.
+        let buffer = split_buffer();
+        let mut dest = vec![0u8; 4];
+
+        assert_eq!(copy_at(&buffer, 4, &mut dest), 4);
+        assert_eq!(&dest, b"efgh");
+    }
+
+    #[test]
+    fn writes_nothing_at_or_past_the_end() {
+        let buffer = split_buffer();
+        let mut dest = vec![0u8; 4];
+
+        assert_eq!(copy_at(&buffer, buffer.len(), &mut dest), 0);
+        assert_eq!(copy_at(&buffer, buffer.len() + 1, &mut dest), 0);
+        assert_eq!(&dest, &[0u8; 4]);
+    }
+
+    #[test]
+    fn chunks_reports_every_part_and_respects_capacity() {
+        let owned = OpendalReadBuffer::from_buffer(split_buffer());
+
+        // Sizing call: no output array, just the count.
+        let count = unsafe { read_buffer_chunks(owned.handle, std::ptr::null_mut(), 0) };
+        assert_eq!(count, 3);
+
+        let mut chunks = vec![
+            OpendalChunk {
+                data: std::ptr::null(),
+                len: 0,
+            },
+            OpendalChunk {
+                data: std::ptr::null(),
+                len: 0,
+            },
+            OpendalChunk {
+                data: std::ptr::null(),
+                len: 0,
+            },
+        ];
+        let filled = unsafe { read_buffer_chunks(owned.handle, chunks.as_mut_ptr(), chunks.len()) };
+        assert_eq!(filled, 3);
+
+        let collected: Vec<u8> = chunks
+            .iter()
+            .flat_map(|chunk| unsafe { std::slice::from_raw_parts(chunk.data, chunk.len) })
+            .copied()
+            .collect();
+        assert_eq!(&collected, b"abcdefgh");
+
+        unsafe { read_buffer_free(owned.handle) };
+    }
+
+    #[test]
     fn empty_payload_owns_nothing() {
-        let owned = OpendalBuffer::from_buffer(opendal::Buffer::new());
+        let owned = OpendalReadBuffer::from_buffer(opendal::Buffer::new());
 
         assert!(owned.handle.is_null());
         assert_eq!(owned.len, 0);
-        unsafe { buffer_free(owned.handle) };
+        unsafe { read_buffer_free(owned.handle) };
+    }
+
+    fn as_uninit(bytes: Vec<u8>) -> Vec<MaybeUninit<u8>> {
+        bytes.into_iter().map(MaybeUninit::new).collect()
+    }
+
+    fn filling(segments: Vec<(Vec<u8>, usize)>, current: Vec<u8>) -> WriteBufferSlot {
+        WriteBufferSlot::Filling(FillingState {
+            sealed: segments
+                .into_iter()
+                .map(|(segment, committed)| (as_uninit(segment), committed))
+                .collect(),
+            current: as_uninit(current),
+        })
+    }
+
+    #[test]
+    fn take_assembles_committed_bytes_across_segments_in_order() {
+        // Sealed segments carry their own committed lengths; the tail commit
+        // arrives as an argument. Uncommitted capacity must never leak.
+        let mut slot = filling(
+            vec![(b"abcX".to_vec(), 3), (b"deXX".to_vec(), 2)],
+            b"fghXX".to_vec(),
+        );
+
+        let payload = take_payload(&mut slot, 3).unwrap();
+
+        assert_eq!(payload.to_vec(), b"abcdefgh");
+        match &slot {
+            WriteBufferSlot::Consumed { _guard } => assert_eq!(_guard.len(), 8),
+            WriteBufferSlot::Filling(_) => panic!("slot must move to Consumed"),
+        }
+    }
+
+    #[test]
+    fn take_skips_segments_with_nothing_committed() {
+        let mut slot = filling(vec![(b"XXXX".to_vec(), 0)], b"ab".to_vec());
+
+        let payload = take_payload(&mut slot, 2).unwrap();
+
+        assert_eq!(payload.to_vec(), b"ab");
+    }
+
+    #[test]
+    fn take_rejects_a_second_take() {
+        let mut slot = filling(Vec::new(), b"abc".to_vec());
+        take_payload(&mut slot, 3).unwrap();
+
+        assert!(take_payload(&mut slot, 0).is_err());
+    }
+
+    #[test]
+    fn take_rejects_commits_beyond_capacity_and_keeps_the_slot_usable() {
+        let mut slot = filling(Vec::new(), b"abc".to_vec());
+
+        assert!(take_payload(&mut slot, 4).is_err());
+
+        // The failed call must not consume the buffer.
+        let payload = take_payload(&mut slot, 2).unwrap();
+        assert_eq!(payload.to_vec(), b"ab");
+    }
+
+    #[test]
+    fn grow_seals_the_current_segment_and_keeps_earlier_pointers_stable() {
+        let mut slot = filling(Vec::new(), b"abc".to_vec());
+        let first_ptr = match &slot {
+            WriteBufferSlot::Filling(state) => state.current.as_ptr(),
+            WriteBufferSlot::Consumed { .. } => unreachable!(),
+        };
+
+        let (data, capacity) = grow(&mut slot, 2, 8).unwrap();
+
+        assert_eq!(capacity, 8);
+        assert!(!data.is_null());
+        match &slot {
+            WriteBufferSlot::Filling(state) => {
+                assert_eq!(state.sealed.len(), 1);
+                assert_eq!(state.sealed[0].1, 2);
+                // The sealed segment must not have moved when it changed hands.
+                assert_eq!(state.sealed[0].0.as_ptr(), first_ptr);
+            }
+            WriteBufferSlot::Consumed { .. } => panic!("slot must stay Filling"),
+        }
+    }
+
+    #[test]
+    fn create_hands_out_writable_memory_and_free_releases_it() {
+        let result = write_buffer_create(8);
+        assert_eq!(result.error.has_error, 0);
+
+        let buffer = result.buffer;
+        assert_eq!(buffer.capacity, 8);
+        unsafe {
+            *buffer.data = 7;
+            assert_eq!(*buffer.data, 7);
+            write_buffer_free(buffer.handle);
+        }
+    }
+
+    #[test]
+    fn create_rejects_zero_capacity() {
+        let mut result = write_buffer_create(0);
+        assert_eq!(result.error.has_error, 1);
+        assert!(result.buffer.handle.is_null());
+        crate::result::opendal_error_release(std::mem::replace(
+            &mut result.error,
+            OpenDALError::ok(),
+        ));
     }
 }

--- a/bindings/dotnet/src/chunk.rs
+++ b/bindings/dotnet/src/chunk.rs
@@ -15,22 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Rust FFI layer backing the OpenDAL .NET binding.
-//!
-//! This crate exposes `extern "C"` APIs consumed by C# via P/Invoke and keeps
-//! interop memory ownership explicit through dedicated release functions.
-
-mod buffer;
-mod capability;
-mod chunk;
-mod entry;
-mod error;
-mod executor;
-mod metadata;
-mod operator;
-mod operator_info;
-mod options;
-mod presign;
-mod result;
-mod utils;
-mod validators;
+#[repr(C)]
+/// Descriptor of one contiguous chunk inside a read payload.
+pub struct OpendalChunk {
+    pub data: *const u8,
+    pub len: usize,
+}

--- a/bindings/dotnet/src/entry.rs
+++ b/bindings/dotnet/src/entry.rs
@@ -17,34 +17,37 @@
 
 use std::ffi::{c_char, c_void};
 
-use crate::metadata::{OpendalMetadata, metadata_free};
+use crate::metadata::{OpendalMetadata, metadata_release_fields};
 use crate::utils::into_string_ptr;
 
 #[repr(C)]
 /// FFI representation of an OpenDAL entry.
 ///
-/// String and metadata fields are heap-allocated and owned by Rust until
-/// released via `entry_list_free`.
+/// The path string and metadata string fields are heap-allocated and owned by
+/// Rust until released via `entry_list_free`. Metadata is stored inline so a
+/// list is one contiguous array instead of a pointer per entry.
 pub struct OpendalEntry {
     pub path: *mut c_char,
-    pub metadata: *mut OpendalMetadata,
+    pub metadata: OpendalMetadata,
 }
 
 #[repr(C)]
 /// FFI representation of a list of entries.
+///
+/// `entries` points at a contiguous array of `len` entries stored by value.
 pub struct OpendalEntryList {
-    pub entries: *mut *mut OpendalEntry,
+    pub entries: *mut OpendalEntry,
     pub len: usize,
 }
 
 impl OpendalEntry {
     pub fn from_entry(entry: opendal::Entry) -> Self {
-        let path = into_string_ptr(entry.path().to_string());
-        let metadata = Box::into_raw(Box::new(OpendalMetadata::from_metadata(
-            entry.metadata().clone(),
-        )));
+        let (path, metadata) = entry.into_parts();
 
-        Self { path, metadata }
+        Self {
+            path: into_string_ptr(path),
+            metadata: OpendalMetadata::from_metadata(metadata),
+        }
     }
 }
 
@@ -52,41 +55,17 @@ impl OpendalEntry {
 ///
 /// The returned pointer must be released by `entry_list_free`.
 pub fn into_entry_list_ptr(entries: Vec<opendal::Entry>) -> *mut c_void {
-    let mut entry_ptrs: Vec<*mut OpendalEntry> = entries
-        .into_iter()
-        .map(|entry| Box::into_raw(Box::new(OpendalEntry::from_entry(entry))))
-        .collect();
+    // A boxed slice always allocates exactly `len` elements, so
+    // `entry_list_free` can rebuild it from the raw parts alone.
+    let entries: Box<[OpendalEntry]> = entries.into_iter().map(OpendalEntry::from_entry).collect();
 
-    let len = entry_ptrs.len();
-    let entries_ptr = entry_ptrs.as_mut_ptr();
-    std::mem::forget(entry_ptrs);
+    let len = entries.len();
+    let entries_ptr = Box::into_raw(entries) as *mut OpendalEntry;
 
     Box::into_raw(Box::new(OpendalEntryList {
         entries: entries_ptr,
         len,
     })) as *mut c_void
-}
-
-/// Release one FFI entry payload.
-///
-/// # Safety
-///
-/// - `entry` must be null or a pointer previously produced by this crate.
-/// - This function must be called at most once per non-null pointer.
-unsafe fn free_entry(entry: *mut OpendalEntry) {
-    if entry.is_null() {
-        return;
-    }
-
-    unsafe {
-        let entry = Box::from_raw(entry);
-        if !entry.path.is_null() {
-            drop(std::ffi::CString::from_raw(entry.path));
-        }
-        if !entry.metadata.is_null() {
-            metadata_free(entry.metadata);
-        }
-    }
 }
 
 /// # Safety
@@ -101,11 +80,16 @@ pub unsafe extern "C" fn entry_list_free(list: *mut OpendalEntryList) {
 
     unsafe {
         let list = Box::from_raw(list);
-        if !list.entries.is_null() {
-            let entries = Vec::from_raw_parts(list.entries, list.len, list.len);
-            for entry in entries {
-                free_entry(entry);
+        if list.entries.is_null() {
+            return;
+        }
+
+        let mut entries = Box::from_raw(std::ptr::slice_from_raw_parts_mut(list.entries, list.len));
+        for entry in entries.iter_mut() {
+            if !entry.path.is_null() {
+                drop(std::ffi::CString::from_raw(entry.path));
             }
+            metadata_release_fields(&mut entry.metadata);
         }
     }
 }

--- a/bindings/dotnet/src/entry.rs
+++ b/bindings/dotnet/src/entry.rs
@@ -72,8 +72,7 @@ pub fn into_entry_list_ptr(entries: Vec<opendal::Entry>) -> *mut c_void {
 ///
 /// - `list` must be null or a pointer returned by Rust as `OpendalEntryList`.
 /// - Must be called at most once for the same pointer.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn entry_list_free(list: *mut OpendalEntryList) {
+pub(crate) unsafe fn entry_list_free(list: *mut OpendalEntryList) {
     if list.is_null() {
         return;
     }

--- a/bindings/dotnet/src/error.rs
+++ b/bindings/dotnet/src/error.rs
@@ -21,6 +21,7 @@ use std::os::raw::c_char;
 use crate::utils::into_string_ptr;
 
 #[repr(C)]
+#[derive(Debug)]
 /// Error payload returned by exported FFI functions.
 pub struct OpenDALError {
     /// `1` when an error is present, otherwise `0`.

--- a/bindings/dotnet/src/executor.rs
+++ b/bindings/dotnet/src/executor.rs
@@ -20,7 +20,7 @@ use std::ffi::c_void;
 use std::future::Future;
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, LazyLock, Mutex, OnceLock};
+use std::sync::{Arc, LazyLock, OnceLock, RwLock};
 use std::thread::available_parallelism;
 
 use crate::error::OpenDALError;
@@ -29,8 +29,8 @@ use crate::utils::config_invalid_error;
 
 static DEFAULT_EXECUTOR: OnceLock<Arc<Executor>> = OnceLock::new();
 
-static EXECUTOR_REGISTRY: LazyLock<Mutex<HashMap<usize, Arc<Executor>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static EXECUTOR_REGISTRY: LazyLock<RwLock<HashMap<usize, Arc<Executor>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 static NEXT_EXECUTOR_ID: AtomicUsize = AtomicUsize::new(1);
 
 pub struct Executor {
@@ -109,7 +109,7 @@ pub fn executor_or_default(executor: *const c_void) -> Result<Arc<Executor>, Ope
 
     let id = executor as usize;
     let registry = EXECUTOR_REGISTRY
-        .lock()
+        .read()
         .map_err(|_| config_invalid_error("executor registry is poisoned"))?;
 
     registry
@@ -123,7 +123,7 @@ pub extern "C" fn executor_create(threads: usize) -> OpendalExecutorResult {
     match Executor::new(threads) {
         Ok(executor) => {
             let id = NEXT_EXECUTOR_ID.fetch_add(1, Ordering::Relaxed);
-            match EXECUTOR_REGISTRY.lock() {
+            match EXECUTOR_REGISTRY.write() {
                 Ok(mut registry) => {
                     registry.insert(id, Arc::new(executor));
                     OpendalExecutorResult::ok(id as *mut c_void)
@@ -148,7 +148,7 @@ pub unsafe extern "C" fn executor_free(executor: *mut c_void) {
         return;
     }
 
-    if let Ok(mut registry) = EXECUTOR_REGISTRY.lock() {
+    if let Ok(mut registry) = EXECUTOR_REGISTRY.write() {
         registry.remove(&(executor as usize));
     }
 }

--- a/bindings/dotnet/src/executor.rs
+++ b/bindings/dotnet/src/executor.rs
@@ -73,10 +73,6 @@ impl Executor {
     {
         self.runtime.spawn(future)
     }
-
-    pub fn enter(&self) -> tokio::runtime::EnterGuard<'_> {
-        self.runtime.enter()
-    }
 }
 
 fn default_executor() -> Result<Arc<Executor>, OpenDALError> {

--- a/bindings/dotnet/src/metadata.rs
+++ b/bindings/dotnet/src/metadata.rs
@@ -114,8 +114,7 @@ pub(crate) unsafe fn metadata_release_fields(metadata: &mut OpendalMetadata) {
 ///
 /// - `metadata` must be null or a pointer returned by Rust for `OpendalMetadata`.
 /// - Must be called at most once for the same pointer.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn metadata_free(metadata: *mut OpendalMetadata) {
+pub(crate) unsafe fn metadata_free(metadata: *mut OpendalMetadata) {
     if metadata.is_null() {
         return;
     }

--- a/bindings/dotnet/src/metadata.rs
+++ b/bindings/dotnet/src/metadata.rs
@@ -81,6 +81,35 @@ fn optional_string_to_ptr(value: Option<&str>) -> *mut c_char {
         .unwrap_or(std::ptr::null_mut())
 }
 
+/// Release the heap-allocated string fields of a metadata value in place.
+///
+/// Entries store metadata inline, so their release path frees the strings
+/// without also freeing a containing box.
+/// # Safety
+///
+/// - Every string field must be null or produced by `into_string_ptr`.
+/// - Must be called at most once for the same value.
+pub(crate) unsafe fn metadata_release_fields(metadata: &mut OpendalMetadata) {
+    unsafe fn release(field: &mut *mut c_char) {
+        if field.is_null() {
+            return;
+        }
+
+        drop(unsafe { std::ffi::CString::from_raw(*field) });
+        *field = std::ptr::null_mut();
+    }
+
+    unsafe {
+        release(&mut metadata.content_disposition);
+        release(&mut metadata.content_md5);
+        release(&mut metadata.content_type);
+        release(&mut metadata.content_encoding);
+        release(&mut metadata.cache_control);
+        release(&mut metadata.etag);
+        release(&mut metadata.version);
+    }
+}
+
 /// # Safety
 ///
 /// - `metadata` must be null or a pointer returned by Rust for `OpendalMetadata`.
@@ -92,27 +121,7 @@ pub unsafe extern "C" fn metadata_free(metadata: *mut OpendalMetadata) {
     }
 
     unsafe {
-        let metadata = Box::from_raw(metadata);
-        if !metadata.content_disposition.is_null() {
-            drop(std::ffi::CString::from_raw(metadata.content_disposition));
-        }
-        if !metadata.content_md5.is_null() {
-            drop(std::ffi::CString::from_raw(metadata.content_md5));
-        }
-        if !metadata.content_type.is_null() {
-            drop(std::ffi::CString::from_raw(metadata.content_type));
-        }
-        if !metadata.content_encoding.is_null() {
-            drop(std::ffi::CString::from_raw(metadata.content_encoding));
-        }
-        if !metadata.cache_control.is_null() {
-            drop(std::ffi::CString::from_raw(metadata.cache_control));
-        }
-        if !metadata.etag.is_null() {
-            drop(std::ffi::CString::from_raw(metadata.etag));
-        }
-        if !metadata.version.is_null() {
-            drop(std::ffi::CString::from_raw(metadata.version));
-        }
+        let mut metadata = Box::from_raw(metadata);
+        metadata_release_fields(&mut metadata);
     }
 }

--- a/bindings/dotnet/src/operator.rs
+++ b/bindings/dotnet/src/operator.rs
@@ -315,8 +315,7 @@ fn operator_info_get_inner(op: *const opendal::Operator) -> Result<*mut c_void, 
 /// - `info` must be either null or a pointer returned by `operator_info_get`.
 /// - The pointer must not be used after this call.
 /// - This function must be called at most once for the same pointer.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn operator_info_free(info: *mut OpendalOperatorInfo) {
+pub(crate) unsafe fn operator_info_free(info: *mut OpendalOperatorInfo) {
     if info.is_null() {
         return;
     }

--- a/bindings/dotnet/src/operator.rs
+++ b/bindings/dotnet/src/operator.rs
@@ -39,7 +39,12 @@ use crate::{
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::os::raw::c_char;
+use std::sync::Arc;
 use std::time::Duration;
+
+use futures::StreamExt;
+
+use crate::executor::Executor;
 
 /// Callback signature for async write completion.
 ///
@@ -1258,6 +1263,38 @@ pub extern "C" fn operator_input_stream_create(
     }
 }
 
+/// Streaming reader backing `OperatorInputStream`.
+///
+/// The underlying byte stream is async; the sync FFI path blocks on it
+/// through the owning executor while the async path spawns onto it. The
+/// mutex is defensive — the C# stream contract already forbids concurrent
+/// reads — and the `Arc` lets in-flight tasks outlive an early free safely.
+struct InputStream {
+    executor: Arc<Executor>,
+    inner: Arc<tokio::sync::Mutex<opendal::FuturesBytesStream>>,
+}
+
+/// Convert one polled chunk into an FFI read payload.
+///
+/// EOF becomes an empty buffer, matching the one-shot read contract.
+fn next_chunk_to_buffer(
+    value: Option<std::io::Result<bytes::Bytes>>,
+) -> Result<OpendalReadBuffer, OpenDALError> {
+    value
+        .transpose()
+        .map_err(|err| {
+            OpenDALError::from_opendal_error(opendal::Error::new(
+                opendal::ErrorKind::Unexpected,
+                err.to_string(),
+            ))
+        })
+        .map(|chunk| {
+            chunk
+                .map(|bytes| OpendalReadBuffer::from_buffer(bytes.into()))
+                .unwrap_or_else(OpendalReadBuffer::empty)
+        })
+}
+
 fn operator_input_stream_create_inner(
     op: *const opendal::Operator,
     executor: *const c_void,
@@ -1273,9 +1310,7 @@ fn operator_input_stream_create_inner(
         unsafe { (&*options).clone() }
     };
 
-    let _guard = executor.enter();
-
-    let range = options.range.to_range();
+    let range = options.range;
     let reader_options = opendal::options::ReaderOptions {
         version: options.version,
         if_match: options.if_match,
@@ -1289,16 +1324,18 @@ fn operator_input_stream_create_inner(
         ..Default::default()
     };
 
-    let blocking_op =
-        opendal::blocking::Operator::new(op.clone()).map_err(OpenDALError::from_opendal_error)?;
-    let reader = blocking_op
-        .reader_options(&path, reader_options)
-        .map_err(OpenDALError::from_opendal_error)?;
-    let stream = reader
-        .into_bytes_iterator(range)
+    let stream_op = op.clone();
+    let stream = executor
+        .block_on(async move {
+            let reader = stream_op.reader_options(&path, reader_options).await?;
+            reader.into_bytes_stream(range).await
+        })
         .map_err(OpenDALError::from_opendal_error)?;
 
-    Ok(Box::into_raw(Box::new(stream)) as *mut c_void)
+    Ok(Box::into_raw(Box::new(InputStream {
+        executor,
+        inner: Arc::new(tokio::sync::Mutex::new(stream)),
+    })) as *mut c_void)
 }
 
 /// Read next bytes chunk from input stream.
@@ -1308,9 +1345,7 @@ fn operator_input_stream_create_inner(
 ///
 /// - `stream` must be a valid pointer returned by `operator_input_stream_create`.
 #[unsafe(no_mangle)]
-pub extern "C" fn operator_input_stream_read_next(
-    stream: *mut opendal::blocking::StdBytesIterator,
-) -> OpendalReadResult {
+pub extern "C" fn operator_input_stream_read_next(stream: *mut c_void) -> OpendalReadResult {
     match operator_input_stream_read_next_inner(stream) {
         Ok(buffer) => OpendalReadResult::ok(buffer),
         Err(error) => OpendalReadResult::from_error(error),
@@ -1318,7 +1353,7 @@ pub extern "C" fn operator_input_stream_read_next(
 }
 
 fn operator_input_stream_read_next_inner(
-    stream: *mut opendal::blocking::StdBytesIterator,
+    stream: *mut c_void,
 ) -> Result<OpendalReadBuffer, OpenDALError> {
     if stream.is_null() {
         return Err(crate::utils::config_invalid_error(
@@ -1326,21 +1361,64 @@ fn operator_input_stream_read_next_inner(
         ));
     }
 
-    let stream = unsafe { &mut *stream };
-
+    let stream = unsafe { &*(stream as *const InputStream) };
+    let inner = stream.inner.clone();
     let value = stream
-        .next()
-        .transpose()
-        .map_err(|err| {
-            OpenDALError::from_opendal_error(opendal::Error::new(
-                opendal::ErrorKind::Unexpected,
-                err.to_string(),
-            ))
-        })?
-        .map(|v| OpendalReadBuffer::from_buffer(v.into()))
-        .unwrap_or_else(OpendalReadBuffer::empty);
+        .executor
+        .block_on(async move { inner.lock().await.next().await });
 
-    Ok(value)
+    next_chunk_to_buffer(value)
+}
+
+/// Read next bytes chunk from input stream asynchronously.
+///
+/// The callback is invoked exactly once; EOF is reported as an empty buffer.
+/// On successful reads, the callback result must be released with
+/// `opendal_read_result_release`. The stream must not be read again, on
+/// either path, until the callback fires.
+/// # Safety
+///
+/// - `stream` must be a valid pointer returned by `operator_input_stream_create`.
+/// - `callback` must be a valid function pointer and remain callable until invoked.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn operator_input_stream_read_next_async(
+    stream: *mut c_void,
+    callback: Option<ReadCallback>,
+    context: i64,
+) -> OpendalResult {
+    match operator_input_stream_read_next_async_inner(stream, callback, context) {
+        Ok(()) => OpendalResult::ok(),
+        Err(error) => OpendalResult::from_error(error),
+    }
+}
+
+fn operator_input_stream_read_next_async_inner(
+    stream: *mut c_void,
+    callback: Option<ReadCallback>,
+    context: i64,
+) -> Result<(), OpenDALError> {
+    if stream.is_null() {
+        return Err(crate::utils::config_invalid_error(
+            "input stream pointer is null",
+        ));
+    }
+    let callback = require_callback(callback)?;
+
+    let stream = unsafe { &*(stream as *const InputStream) };
+    let inner = stream.inner.clone();
+    stream.executor.spawn(async move {
+        let value = inner.lock().await.next().await;
+
+        callback(
+            context,
+            match next_chunk_to_buffer(value) {
+                Ok(buffer) => OpendalReadResult::ok(buffer),
+                Err(error) => OpendalReadResult::from_error(error),
+            },
+        );
+    });
+
+    Ok(())
 }
 
 /// # Safety
@@ -1348,15 +1426,13 @@ fn operator_input_stream_read_next_inner(
 /// - `stream` must be null or a pointer returned by `operator_input_stream_create`.
 /// - Must be called at most once for the same pointer.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn operator_input_stream_free(
-    stream: *mut opendal::blocking::StdBytesIterator,
-) {
+pub unsafe extern "C" fn operator_input_stream_free(stream: *mut c_void) {
     if stream.is_null() {
         return;
     }
 
     unsafe {
-        drop(Box::from_raw(stream));
+        drop(Box::from_raw(stream as *mut InputStream));
     }
 }
 
@@ -1380,6 +1456,17 @@ pub extern "C" fn operator_output_stream_create(
     }
 }
 
+/// Streaming writer backing `OperatorOutputStream`.
+///
+/// Same split as [`InputStream`]: async writer underneath, sync FFI blocks on
+/// it, async FFI spawns onto it. The C# stream contract forbids concurrent
+/// writes; the mutex is defensive and the `Arc` keeps in-flight tasks safe
+/// against an early free.
+struct OutputStream {
+    executor: Arc<Executor>,
+    inner: Arc<tokio::sync::Mutex<opendal::Writer>>,
+}
+
 fn operator_output_stream_create_inner(
     op: *const opendal::Operator,
     executor: *const c_void,
@@ -1395,15 +1482,15 @@ fn operator_output_stream_create_inner(
         unsafe { (&*options).clone() }
     };
 
-    let _guard = executor.enter();
-
-    let blocking_op =
-        opendal::blocking::Operator::new(op.clone()).map_err(OpenDALError::from_opendal_error)?;
-    let stream = blocking_op
-        .writer_options(&path, options)
+    let writer_op = op.clone();
+    let writer = executor
+        .block_on(async move { writer_op.writer_options(&path, options).await })
         .map_err(OpenDALError::from_opendal_error)?;
 
-    Ok(Box::into_raw(Box::new(stream)) as *mut c_void)
+    Ok(Box::into_raw(Box::new(OutputStream {
+        executor,
+        inner: Arc::new(tokio::sync::Mutex::new(writer)),
+    })) as *mut c_void)
 }
 
 /// Write bytes to output stream.
@@ -1413,7 +1500,7 @@ fn operator_output_stream_create_inner(
 /// - When `len > 0`, `data` must be non-null and readable for `len` bytes.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_output_stream_write(
-    stream: *mut opendal::blocking::Writer,
+    stream: *mut c_void,
     data: *const u8,
     len: usize,
 ) -> OpendalResult {
@@ -1424,7 +1511,7 @@ pub extern "C" fn operator_output_stream_write(
 }
 
 fn operator_output_stream_write_inner(
-    stream: *mut opendal::blocking::Writer,
+    stream: *mut c_void,
     data: *const u8,
     len: usize,
 ) -> Result<(), OpenDALError> {
@@ -1435,36 +1522,106 @@ fn operator_output_stream_write_inner(
     }
     require_data_ptr(data, len)?;
 
-    let stream = unsafe { &mut *stream };
+    let stream = unsafe { &*(stream as *const OutputStream) };
     let payload = if len == 0 {
-        &[][..]
+        bytes::Bytes::new()
     } else {
-        unsafe { std::slice::from_raw_parts(data, len) }
+        bytes::Bytes::copy_from_slice(unsafe { std::slice::from_raw_parts(data, len) })
     };
 
+    let inner = stream.inner.clone();
     stream
-        .write(payload)
+        .executor
+        .block_on(async move { inner.lock().await.write(payload).await })
         .map(|_| ())
         .map_err(OpenDALError::from_opendal_error)
 }
 
+/// Write bytes to output stream asynchronously.
+///
+/// The payload is copied before this function returns, so the caller only has
+/// to keep `data` alive for the duration of this call. The callback is
+/// invoked exactly once. The stream must not be written to again, on either
+/// path, until the callback fires.
+/// # Safety
+///
+/// - `stream` must be a valid pointer returned by `operator_output_stream_create`.
+/// - When `len > 0`, `data` must be non-null and readable for `len` bytes.
+/// - `callback` must be a valid function pointer and remain callable until invoked.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn operator_output_stream_write_async(
+    stream: *mut c_void,
+    data: *const u8,
+    len: usize,
+    callback: Option<WriteCallback>,
+    context: i64,
+) -> OpendalResult {
+    match operator_output_stream_write_async_inner(stream, data, len, callback, context) {
+        Ok(()) => OpendalResult::ok(),
+        Err(error) => OpendalResult::from_error(error),
+    }
+}
+
+fn operator_output_stream_write_async_inner(
+    stream: *mut c_void,
+    data: *const u8,
+    len: usize,
+    callback: Option<WriteCallback>,
+    context: i64,
+) -> Result<(), OpenDALError> {
+    if stream.is_null() {
+        return Err(crate::utils::config_invalid_error(
+            "output stream pointer is null",
+        ));
+    }
+    require_data_ptr(data, len)?;
+    let callback = require_callback(callback)?;
+
+    let stream = unsafe { &*(stream as *const OutputStream) };
+    let payload = if len == 0 {
+        bytes::Bytes::new()
+    } else {
+        bytes::Bytes::copy_from_slice(unsafe { std::slice::from_raw_parts(data, len) })
+    };
+
+    let inner = stream.inner.clone();
+    stream.executor.spawn(async move {
+        let result = inner
+            .lock()
+            .await
+            .write(payload)
+            .await
+            .map(|_| ())
+            .map_err(OpenDALError::from_opendal_error);
+
+        callback(
+            context,
+            match result {
+                Ok(()) => OpendalResult::ok(),
+                Err(error) => OpendalResult::from_error(error),
+            },
+        );
+    });
+
+    Ok(())
+}
+
 /// Flush output stream.
+///
+/// The underlying writer only persists data on close, so this is a no-op that
+/// exists to keep the FFI surface symmetric.
 /// # Safety
 ///
 /// - `stream` must be a valid pointer returned by `operator_output_stream_create`.
 #[unsafe(no_mangle)]
-pub extern "C" fn operator_output_stream_flush(
-    stream: *mut opendal::blocking::Writer,
-) -> OpendalResult {
+pub extern "C" fn operator_output_stream_flush(stream: *mut c_void) -> OpendalResult {
     match operator_output_stream_flush_inner(stream) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
-fn operator_output_stream_flush_inner(
-    stream: *mut opendal::blocking::Writer,
-) -> Result<(), OpenDALError> {
+fn operator_output_stream_flush_inner(stream: *mut c_void) -> Result<(), OpenDALError> {
     if stream.is_null() {
         return Err(crate::utils::config_invalid_error(
             "output stream pointer is null",
@@ -1479,29 +1636,82 @@ fn operator_output_stream_flush_inner(
 ///
 /// - `stream` must be a valid pointer returned by `operator_output_stream_create`.
 #[unsafe(no_mangle)]
-pub extern "C" fn operator_output_stream_close(
-    stream: *mut opendal::blocking::Writer,
-) -> OpendalResult {
+pub extern "C" fn operator_output_stream_close(stream: *mut c_void) -> OpendalResult {
     match operator_output_stream_close_inner(stream) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
-fn operator_output_stream_close_inner(
-    stream: *mut opendal::blocking::Writer,
-) -> Result<(), OpenDALError> {
+fn operator_output_stream_close_inner(stream: *mut c_void) -> Result<(), OpenDALError> {
     if stream.is_null() {
         return Err(crate::utils::config_invalid_error(
             "output stream pointer is null",
         ));
     }
 
-    let stream = unsafe { &mut *stream };
+    let stream = unsafe { &*(stream as *const OutputStream) };
+    let inner = stream.inner.clone();
     stream
-        .close()
+        .executor
+        .block_on(async move { inner.lock().await.close().await })
         .map(|_| ())
         .map_err(OpenDALError::from_opendal_error)
+}
+
+/// Close output stream asynchronously.
+///
+/// The callback is invoked exactly once. After a successful close the handle
+/// only needs `operator_output_stream_free`.
+/// # Safety
+///
+/// - `stream` must be a valid pointer returned by `operator_output_stream_create`.
+/// - `callback` must be a valid function pointer and remain callable until invoked.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn operator_output_stream_close_async(
+    stream: *mut c_void,
+    callback: Option<WriteCallback>,
+    context: i64,
+) -> OpendalResult {
+    match operator_output_stream_close_async_inner(stream, callback, context) {
+        Ok(()) => OpendalResult::ok(),
+        Err(error) => OpendalResult::from_error(error),
+    }
+}
+
+fn operator_output_stream_close_async_inner(
+    stream: *mut c_void,
+    callback: Option<WriteCallback>,
+    context: i64,
+) -> Result<(), OpenDALError> {
+    if stream.is_null() {
+        return Err(crate::utils::config_invalid_error(
+            "output stream pointer is null",
+        ));
+    }
+    let callback = require_callback(callback)?;
+
+    let stream = unsafe { &*(stream as *const OutputStream) };
+    let inner = stream.inner.clone();
+    stream.executor.spawn(async move {
+        let result = inner
+            .lock()
+            .await
+            .close()
+            .await
+            .map(|_| ())
+            .map_err(OpenDALError::from_opendal_error);
+
+        callback(
+            context,
+            match result {
+                Ok(()) => OpendalResult::ok(),
+                Err(error) => OpendalResult::from_error(error),
+            },
+        );
+    });
+
+    Ok(())
 }
 
 /// # Safety
@@ -1509,13 +1719,13 @@ fn operator_output_stream_close_inner(
 /// - `stream` must be null or a pointer returned by `operator_output_stream_create`.
 /// - Must be called at most once for the same pointer.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn operator_output_stream_free(stream: *mut opendal::blocking::Writer) {
+pub unsafe extern "C" fn operator_output_stream_free(stream: *mut c_void) {
     if stream.is_null() {
         return;
     }
 
     unsafe {
-        drop(Box::from_raw(stream));
+        drop(Box::from_raw(stream as *mut OutputStream));
     }
 }
 

--- a/bindings/dotnet/src/operator.rs
+++ b/bindings/dotnet/src/operator.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::{
-    buffer::OpendalBuffer,
+    buffer::{OpendalReadBuffer, WriteBufferSlot, take_payload},
     entry::into_entry_list_ptr,
     error::OpenDALError,
     executor::executor_or_default,
@@ -1319,7 +1319,7 @@ pub extern "C" fn operator_input_stream_read_next(
 
 fn operator_input_stream_read_next_inner(
     stream: *mut opendal::blocking::StdBytesIterator,
-) -> Result<OpendalBuffer, OpenDALError> {
+) -> Result<OpendalReadBuffer, OpenDALError> {
     if stream.is_null() {
         return Err(crate::utils::config_invalid_error(
             "input stream pointer is null",
@@ -1337,8 +1337,8 @@ fn operator_input_stream_read_next_inner(
                 err.to_string(),
             ))
         })?
-        .map(|v| OpendalBuffer::from_buffer(v.into()))
-        .unwrap_or_else(OpendalBuffer::empty);
+        .map(|v| OpendalReadBuffer::from_buffer(v.into()))
+        .unwrap_or_else(OpendalReadBuffer::empty);
 
     Ok(value)
 }
@@ -1519,15 +1519,178 @@ pub unsafe extern "C" fn operator_output_stream_free(stream: *mut opendal::block
     }
 }
 
-/// Write bytes to `path` synchronously with options.
+/// Write the committed bytes of a write buffer to `path` synchronously.
+///
+/// On a non-error return the contents belong to the write and the caller
+/// must not write through the buffer's pointers again; the handle itself
+/// still needs `write_buffer_free`. An error raised before the payload is
+/// taken leaves the slot untouched, while a backend failure after it has
+/// already consumed the contents.
+/// # Safety
+///
+/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `path` must be a valid null-terminated UTF-8 string.
+/// - `buffer` must be a handle from `write_buffer_create` whose contents
+///   have not been consumed, and must not have been freed.
+/// - Calls taking the same buffer handle must not run concurrently.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn operator_write_with_options(
+    op: *const opendal::Operator,
+    executor: *const c_void,
+    path: *const c_char,
+    buffer: *mut c_void,
+    committed_in_current: usize,
+    options: *const opendal::options::WriteOptions,
+) -> OpendalResult {
+    match operator_write_with_options_inner(
+        op,
+        executor,
+        path,
+        buffer,
+        committed_in_current,
+        options,
+    ) {
+        Ok(()) => OpendalResult::ok(),
+        Err(error) => OpendalResult::from_error(error),
+    }
+}
+
+fn operator_write_with_options_inner(
+    op: *const opendal::Operator,
+    executor: *const c_void,
+    path: *const c_char,
+    buffer: *mut c_void,
+    committed_in_current: usize,
+    options: *const opendal::options::WriteOptions,
+) -> Result<(), OpenDALError> {
+    let op = require_operator(op)?;
+    let executor = executor_or_default(executor)?;
+    let path = require_cstr(path, "path")?;
+    if buffer.is_null() {
+        return Err(crate::utils::config_invalid_error(
+            "write buffer handle is null",
+        ));
+    }
+    let options = if options.is_null() {
+        opendal::options::WriteOptions::default()
+    } else {
+        unsafe { (&*options).clone() }
+    };
+
+    // Taken only after every fallible check above, so an error result means
+    // ownership never transferred and the buffer stays usable.
+    let slot = unsafe { &mut *(buffer as *mut WriteBufferSlot) };
+    let payload = take_payload(slot, committed_in_current)?;
+
+    executor
+        .block_on(op.write_options(path, payload, options))
+        .map(|_| ())
+        .map_err(OpenDALError::from_opendal_error)
+}
+
+/// Write the committed bytes of a write buffer to `path` asynchronously.
+///
+/// The callback is invoked exactly once. Ownership behaves as in the sync
+/// variant: consumed on a non-error return, untouched on error.
+/// # Safety
+///
+/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `path` must be a valid null-terminated UTF-8 string.
+/// - `buffer` must be a handle from `write_buffer_create` whose contents
+///   have not been consumed, and must not have been freed.
+/// - Calls taking the same buffer handle must not run concurrently.
+/// - `callback` must be a valid function pointer and remain callable until invoked.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn operator_write_with_options_async(
+    op: *const opendal::Operator,
+    executor: *const c_void,
+    path: *const c_char,
+    buffer: *mut c_void,
+    committed_in_current: usize,
+    options: *const opendal::options::WriteOptions,
+    callback: Option<WriteCallback>,
+    context: i64,
+) -> OpendalResult {
+    match operator_write_with_options_async_inner(
+        op,
+        executor,
+        path,
+        buffer,
+        committed_in_current,
+        options,
+        callback,
+        context,
+    ) {
+        Ok(()) => OpendalResult::ok(),
+        Err(error) => OpendalResult::from_error(error),
+    }
+}
+
+// Mirrors the `extern "C"` signature above, which clippy exempts because a C ABI
+// is not a design choice. This helper exists only to give that function a body it
+// can write with `?`.
+#[allow(clippy::too_many_arguments)]
+fn operator_write_with_options_async_inner(
+    op: *const opendal::Operator,
+    executor: *const c_void,
+    path: *const c_char,
+    buffer: *mut c_void,
+    committed_in_current: usize,
+    options: *const opendal::options::WriteOptions,
+    callback: Option<WriteCallback>,
+    context: i64,
+) -> Result<(), OpenDALError> {
+    let op = require_operator(op)?;
+    let executor = executor_or_default(executor)?;
+    let path = require_cstr(path, "path")?.to_string();
+    let callback = require_callback(callback)?;
+    if buffer.is_null() {
+        return Err(crate::utils::config_invalid_error(
+            "write buffer handle is null",
+        ));
+    }
+    let options = if options.is_null() {
+        opendal::options::WriteOptions::default()
+    } else {
+        unsafe { (&*options).clone() }
+    };
+
+    // Taken only after every fallible check above, so an error result means
+    // ownership never transferred and the buffer stays usable.
+    let slot = unsafe { &mut *(buffer as *mut WriteBufferSlot) };
+    let payload = take_payload(slot, committed_in_current)?;
+
+    let op = op.clone();
+    executor.spawn(async move {
+        let result = op
+            .write_options(&path, payload, options)
+            .await
+            .map(|_| ())
+            .map_err(OpenDALError::from_opendal_error);
+
+        callback(
+            context,
+            match result {
+                Ok(()) => OpendalResult::ok(),
+                Err(error) => OpendalResult::from_error(error),
+            },
+        );
+    });
+
+    Ok(())
+}
+
+/// Write a caller-owned byte range to `path` synchronously.
+///
+/// The bytes are copied before the write, so `data` only has to stay valid
+/// for the duration of this call.
 /// # Safety
 ///
 /// - `op` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - When `len > 0`, `data` must be non-null and readable for `len` bytes.
-/// - When `option_len > 0`, `option_keys` and `option_values` must be valid arrays.
 #[unsafe(no_mangle)]
-pub extern "C" fn operator_write_with_options(
+pub unsafe extern "C" fn operator_write_bytes_with_options(
     op: *const opendal::Operator,
     executor: *const c_void,
     path: *const c_char,
@@ -1535,13 +1698,13 @@ pub extern "C" fn operator_write_with_options(
     len: usize,
     options: *const opendal::options::WriteOptions,
 ) -> OpendalResult {
-    match operator_write_with_options_inner(op, executor, path, data, len, options) {
+    match operator_write_bytes_with_options_inner(op, executor, path, data, len, options) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
-fn operator_write_with_options_inner(
+fn operator_write_bytes_with_options_inner(
     op: *const opendal::Operator,
     executor: *const c_void,
     path: *const c_char,
@@ -1559,10 +1722,14 @@ fn operator_write_with_options_inner(
         unsafe { (&*options).clone() }
     };
 
+    // Copied explicitly: the only `Into<Buffer>` impl for slices is
+    // `From<&'static [u8]>`, which is zero-copy, so passing the raw slice
+    // would launder the caller's pointer into `'static` and let backends
+    // retain memory that is only pinned for the duration of this call.
     let payload = if len == 0 {
-        &[][..]
+        bytes::Bytes::new()
     } else {
-        unsafe { std::slice::from_raw_parts(data, len) }
+        bytes::Bytes::copy_from_slice(unsafe { std::slice::from_raw_parts(data, len) })
     };
 
     executor
@@ -1571,17 +1738,19 @@ fn operator_write_with_options_inner(
         .map_err(OpenDALError::from_opendal_error)
 }
 
-/// Write bytes to `path` asynchronously with options.
+/// Write a caller-owned byte range to `path` asynchronously.
 ///
-/// The callback is invoked exactly once with the final result.
+/// The bytes are copied before the task is spawned, so `data` only has to
+/// stay valid for the duration of this call. The callback is invoked exactly
+/// once with the final result.
 /// # Safety
 ///
 /// - `op` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
-/// - `data` must be non-null and readable for `len` bytes when `len > 0`.
+/// - When `len > 0`, `data` must be non-null and readable for `len` bytes.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn operator_write_with_options_async(
+pub unsafe extern "C" fn operator_write_bytes_with_options_async(
     op: *const opendal::Operator,
     executor: *const c_void,
     path: *const c_char,
@@ -1591,7 +1760,7 @@ pub unsafe extern "C" fn operator_write_with_options_async(
     callback: Option<WriteCallback>,
     context: i64,
 ) -> OpendalResult {
-    match operator_write_with_options_async_inner(
+    match operator_write_bytes_with_options_async_inner(
         op, executor, path, data, len, options, callback, context,
     ) {
         Ok(()) => OpendalResult::ok(),
@@ -1603,7 +1772,7 @@ pub unsafe extern "C" fn operator_write_with_options_async(
 // is not a design choice. This helper exists only to give that function a body it
 // can write with `?`.
 #[allow(clippy::too_many_arguments)]
-fn operator_write_with_options_async_inner(
+fn operator_write_bytes_with_options_async_inner(
     op: *const opendal::Operator,
     executor: *const c_void,
     path: *const c_char,
@@ -1627,9 +1796,9 @@ fn operator_write_with_options_async_inner(
     // Copied before the task is spawned, so the caller only has to keep its
     // array alive for the duration of this call.
     let payload = if len == 0 {
-        Vec::new()
+        bytes::Bytes::new()
     } else {
-        unsafe { std::slice::from_raw_parts(data, len) }.to_vec()
+        bytes::Bytes::copy_from_slice(unsafe { std::slice::from_raw_parts(data, len) })
     };
 
     let op = op.clone();
@@ -1678,7 +1847,7 @@ fn operator_read_with_options_inner(
     executor: *const c_void,
     path: *const c_char,
     options: *const opendal::options::ReadOptions,
-) -> Result<OpendalBuffer, OpenDALError> {
+) -> Result<OpendalReadBuffer, OpenDALError> {
     let op = require_operator(op)?;
     let executor = executor_or_default(executor)?;
     let path = require_cstr(path, "path")?;
@@ -1692,7 +1861,7 @@ fn operator_read_with_options_inner(
         .block_on(op.read_options(path, options))
         .map_err(OpenDALError::from_opendal_error)?;
 
-    Ok(OpendalBuffer::from_buffer(value))
+    Ok(OpendalReadBuffer::from_buffer(value))
 }
 
 /// Read bytes from `path` asynchronously with options.
@@ -1743,7 +1912,7 @@ fn operator_read_with_options_async_inner(
         let result = op
             .read_options(&path, options)
             .await
-            .map(OpendalBuffer::from_buffer)
+            .map(OpendalReadBuffer::from_buffer)
             .map_err(OpenDALError::from_opendal_error);
 
         callback(

--- a/bindings/dotnet/src/presign.rs
+++ b/bindings/dotnet/src/presign.rs
@@ -82,8 +82,7 @@ pub fn into_presigned_request_ptr(
 ///
 /// - `request` must be null or a pointer produced by `into_presigned_request_ptr`.
 /// - This function must be called at most once per non-null pointer.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn presigned_request_free(request: *mut OpendalPresignedRequest) {
+pub(crate) unsafe fn presigned_request_free(request: *mut OpendalPresignedRequest) {
     if request.is_null() {
         return;
     }

--- a/bindings/dotnet/src/result.rs
+++ b/bindings/dotnet/src/result.rs
@@ -17,7 +17,7 @@
 
 use std::ffi::c_void;
 
-use crate::buffer::{OpendalBuffer, buffer_free};
+use crate::buffer::{OpendalReadBuffer, OpendalWriteBuffer, read_buffer_free};
 use crate::entry::entry_list_free;
 use crate::error::OpenDALError;
 use crate::metadata::metadata_free;
@@ -75,7 +75,7 @@ pub struct OpendalEntryListResult {
 #[repr(C)]
 /// Result for operations returning a byte buffer payload.
 pub struct OpendalReadResult {
-    pub buffer: OpendalBuffer,
+    pub buffer: OpendalReadBuffer,
     pub error: OpenDALError,
 }
 
@@ -83,6 +83,17 @@ pub struct OpendalReadResult {
 /// Result for operations returning a presigned request payload pointer.
 pub struct OpendalPresignedRequestResult {
     pub ptr: *mut c_void,
+    pub error: OpenDALError,
+}
+
+#[repr(C)]
+/// Result for operations returning an allocated write buffer.
+///
+/// On success the caller owns the buffer handle; there is no dedicated
+/// release API for this result because the handle's lifecycle is managed by
+/// `write_buffer_free`, and the error message by `opendal_error_release`.
+pub struct OpendalWriteBufferResult {
+    pub buffer: OpendalWriteBuffer,
     pub error: OpenDALError,
 }
 
@@ -164,14 +175,20 @@ define_result!(
 
 define_result!(
     OpendalReadResult,
-    field = buffer: OpendalBuffer,
-    error_value = OpendalBuffer::empty()
+    field = buffer: OpendalReadBuffer,
+    error_value = OpendalReadBuffer::empty()
 );
 
 define_result!(
     OpendalPresignedRequestResult,
     field = ptr: *mut c_void,
     error_value = std::ptr::null_mut()
+);
+
+define_result!(
+    OpendalWriteBufferResult,
+    field = buffer: OpendalWriteBuffer,
+    error_value = OpendalWriteBuffer::empty()
 );
 
 fn release_error_message(error: &mut OpenDALError) {
@@ -255,12 +272,12 @@ pub extern "C" fn opendal_entry_list_result_release(mut result: OpendalEntryList
 /// This function is idempotent for empty/null buffers.
 /// # Safety
 ///
-/// - `result.buffer` must originate from `OpendalBuffer::from_buffer` in this crate.
+/// - `result.buffer` must originate from `OpendalReadBuffer::from_buffer` in this crate.
 /// - The buffer must not be accessed after this call.
 #[unsafe(no_mangle)]
 pub extern "C" fn opendal_read_result_release(mut result: OpendalReadResult) {
     unsafe {
-        buffer_free(result.buffer.handle);
+        read_buffer_free(result.buffer.handle);
     }
 
     release_error_message(&mut result.error);


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

This PR removes the redundant copies from every read and write path, makes the stream async methods truly async, and fixes a silent memory-corruption hazard in the sync write path. It started as performance tuning, but the tuning kept exposing rough spots in the earlier implementation, so the boundary cleanup rides along:

- The sync write hands backends the caller's array without a copy. An in-process backend keeps reading that memory after the call returns, so later changes to the array silently corrupt what the backend stored.
- Every payload is copied more often than it needs to be.
- The stream async methods block on the sync natives.
- The read FFI names its buffers just `buffer_*`. This PR moves buffers across the boundary in both directions, and a name that omits the direction also hides the contract: which side fills the memory and which side frees it.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The bullets follow the commit order — the zero-copy commit gets two.

- **List entries marshal in one pass.** Store them by value in one contiguous array instead of a pointer chase per entry.
- **Executor registry lookups stop serializing.** Swap the registry `Mutex` for an `RwLock`.
- **Zero-copy callback paths in both directions.** A write callback fills native memory through `IBufferWriter<byte>` (the .NET counterpart of `bytes::BufMut`), and the write consumes those segments without copying. A read callback parses the native chunks in place through `ReadOnlySequence<byte>` (the .NET counterpart of `opendal::Buffer`). Stream reads become single-copy: each native chunk goes straight into the caller's buffer. The buffers behind all of this stay internal to the binding.
- **The `byte[]` overloads keep their signatures and copy once at the boundary.** A write copies the array into native memory during the call, so the native side no longer keeps a pointer into the caller's array after the call returns. A read assembles the returned array from the native chunks. The write-side copy is what fixes the corruption described in the rationale, and a regression test proves it by mutating the source array right after a write.
- **Streams are truly async and explicitly completable.** The async methods drive the native async reader and writer instead of blocking, and `Complete`/`CompleteAsync` let callers finalize a write and see its errors instead of relying on disposal (the .NET destructor path).
- **The interop boundary tightens.** `Operator.Op` and `AsyncState<T>` leave the public surface, internal-only helpers stop being exported symbols, a dead import goes away, and the read FFI family is renamed `read_buffer_*` to mirror the new `write_buffer_*` one.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

### API changes

| change | API | notes |
| --- | --- | --- |
| Added | `Write` / `WriteAsync(path, Action<IBufferWriter<byte>>, int sizeHint = 0)` | The producer fills a native-backed writer. `sizeHint` pre-sizes the first native segment. The memory the writer hands out is uninitialized, as pooled buffers usually are, so write before you read. |
| Added | `Read<T>` / `ReadAsync<T>(path, Func<ReadOnlySequence<byte>, T>)` | The consumer parses the payload in place over native memory. |
| Added | `OperatorOutputStream.Complete` / `CompleteAsync` | Flush, close the native writer, and seal the stream, so write errors surface instead of being lost in disposal. |
| Removed | `Operator.Op` | It duplicated the raw-handle accessor (`SafeHandle.DangerousGetHandle`) that is already public. |
| Removed | `AsyncState<T>` | Now internal. Nothing outside the library has a use for the callback plumbing. |

The new surface speaks only standard-library buffer types (`System.Buffers`), no binding-invented ones, so standard producers and parsers work over native memory directly, and that memory never outlives the callback scope.

### Compatibility

Existing `byte[]` code keeps working as before. Measured against main on the same rig and methodology as the benchmarks below, `byte[]` read and write throughput is unchanged within noise on every service, small writes included.

Cancellation semantics on streams got stricter: a canceled in-flight stream read or flush poisons the stream, and later use throws instead of silently skipping or duplicating bytes. Disposing a poisoned stream still releases its native resources but skips the final flush and close. One-shot reads and writes stay safe to cancel — an abandoned native result is released by the completion callback.

### Benchmarks

AMD Ryzen 5 9600X (6C/12T), 32 GB DDR5-4800, Windows 11, release builds on both sides, Stopwatch medians. Services are the in-process memory service, local fs, and webdav backed by dufs, all over loopback. Only the stream table is a before/after against main. The other tables compare the two APIs this PR ships — the `byte[]` overloads against the callback forms, measured back to back within every iteration so service drift hits both equally — and read as a guide to choosing between them, not as a regression check.

One caveat: a real .NET application would reach for `MemoryCache` (an in-process cache) rather than the memory service, so the memory rows mostly isolate what the FFI boundary costs, while the storage-backed services are the realistic scenarios.

**Stream read** — 16 MiB payload, MiB/s. In-process throughput nearly quintuples, fs more than doubles, the HTTP-bound webdav holds steady (medians of five interleaved before/after rounds, to keep HTTP drift out of the comparison), and GC allocations per pass drop from the payload size to 128 B on every service:

| service | before | after |
| --- | --- | --- |
| memory | 14,401 | 66,170 |
| fs | 3,263 | 7,651 |
| webdav (dufs) | 634 | 637 |

**Read and consume** — 16 MiB payload, MiB/s. The `byte[]` overload materializes a managed array, the sequence callback parses in place:

| service | Read (byte[]) | Read (sequence callback) | allocations per read, byte[] -> callback |
| --- | --- | --- | --- |
| memory | 3,441 | 4,879 | 16.8 MB -> 956 B |
| fs | 1,503 | 1,794 | 16.8 MB -> 1.7 KB |
| webdav (dufs) | 476 | 522 | 16.8 MB -> 46 KB |

**Fill and write** — 16 MiB payload, MiB/s, each column timing the full fill plus the write. The `byte[]` overload fills a managed array first, the fill callback writes straight into native memory:

| service | Write (byte[]) | Write (fill callback) |
| --- | --- | --- |
| memory | 4,950 | 6,927 |
| fs | 702 | 747 |
| webdav (dufs) | 92 | 91 |

**Payload size scaling** — MiB/s medians of the same two-API comparison, the 16 MiB rows repeating the tables above. The step to 128 MiB changes nothing about the picture: the callback read keeps its lead on memory and fs while the `byte[]` overload pays the GC for a payload-sized array on every call, webdav stays wire-bound with the write columns converged, and the allocation profiles hold (callback reads well under the payload size, stream reads at 128 B per pass):

| service | payload | Read (byte[]) | Read (callback) | Write (byte[]) | Write (callback) |
| --- | --- | --- | --- | --- | --- |
| memory | 16 MiB | 3,441 | 4,879 | 4,950 | 6,927 |
| memory | 128 MiB | 3,068 | 4,706 | 3,490 | 5,289 |
| fs | 16 MiB | 1,503 | 1,794 | 702 | 747 |
| fs | 128 MiB | 1,363 | 1,648 | 686 | 712 |
| webdav (dufs) | 16 MiB | 476 | 522 | 92 | 91 |
| webdav (dufs) | 128 MiB | 457 | 502 | 86 | 88 |

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->

This PR was developed with Claude Code (model: Claude Fable 5).
