### PR TITLE
feat(services/azblob): support if_match writes and honor preconditions on block commit

### DIFF
--- a/core/services/azblob/src/backend.rs
+++ b/core/services/azblob/src/backend.rs
@@ -407,6 +407,7 @@ impl Builder for AzblobBuilder {
             write_can_multi: true,
             write_with_cache_control: true,
             write_with_content_type: true,
+            write_with_if_match: true,
             write_with_if_not_exists: true,
             write_with_if_none_match: true,
             write_with_user_metadata: true,

--- a/core/services/azblob/src/core.rs
+++ b/core/services/azblob/src/core.rs
@@ -306,6 +306,10 @@ impl AzblobCore {
             req = req.header(IF_NONE_MATCH, v);
         }
 
+        if let Some(v) = args.if_match() {
+            req = req.header(IF_MATCH, v);
+        }
+
         if let Some(cache_control) = args.cache_control() {
             req = req.header(constants::X_MS_BLOB_CACHE_CONTROL, cache_control);
         }
@@ -584,6 +588,20 @@ impl AzblobCore {
         let mut req = self.insert_sse_headers(req);
         if let Some(cache_control) = args.cache_control() {
             req = req.header(constants::X_MS_BLOB_CACHE_CONTROL, cache_control);
+        }
+
+        // Put Block List is the request that actually commits a blocked write, so the
+        // write's preconditions have to be evaluated here rather than on Put Block.
+        if args.if_not_exists() {
+            req = req.header(IF_NONE_MATCH, "*");
+        }
+
+        if let Some(v) = args.if_none_match() {
+            req = req.header(IF_NONE_MATCH, v);
+        }
+
+        if let Some(v) = args.if_match() {
+            req = req.header(IF_MATCH, v);
         }
 
         let content = quick_xml::se::to_string(&PutBlockListRequest {

--- a/core/tests/behavior/async_write.rs
+++ b/core/tests/behavior/async_write.rs
@@ -813,22 +813,6 @@ pub async fn test_write_with_if_match(op: Operator) -> Result<()> {
     Ok(())
 }
 
-/// Writing more than once before `close()` commits through the service's multi-part
-/// completion request instead of a single-shot upload. Preconditions must still be honored
-/// on that path, otherwise a conditional write silently degrades to an unconditional
-/// overwrite.
-///
-/// Services normally evaluate the precondition at commit time, but some may reject earlier,
-/// so an error from either `write()` or `close()` is accepted.
-async fn write_conditionally_in_chunks(
-    w: &mut Writer,
-    content: &[u8],
-) -> opendal::Result<Metadata> {
-    w.write(content.to_vec()).await?;
-    w.write(content.to_vec()).await?;
-    w.close().await
-}
-
 /// Write an existing file through a chunked writer with if_not_exists should get a
 /// ConditionNotMatch error.
 pub async fn test_writer_write_with_if_not_exists(op: Operator) -> Result<()> {
@@ -837,15 +821,23 @@ pub async fn test_writer_write_with_if_not_exists(op: Operator) -> Result<()> {
         return Ok(());
     }
 
-    let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
+    let path = TEST_FIXTURE.new_file_path();
+    let content = gen_fixed_bytes(cap.write_multi_min_size.unwrap_or(1));
 
     op.write(&path, content.clone())
         .await
         .expect("write must succeed");
 
-    let mut w = op.writer_with(&path).if_not_exists(true).await?;
-    let res = write_conditionally_in_chunks(&mut w, &content).await;
-    assert!(res.is_err());
+    // Some services reject the precondition when the writer is created or on an early
+    // write rather than at commit time
+    let res: opendal::Result<()> = async {
+        let mut w = op.writer_with(&path).if_not_exists(true).await?;
+        w.write(content.clone()).await?;
+        w.write(content.clone()).await?;
+        w.close().await?;
+        Ok(())
+    }
+    .await;
     assert_eq!(res.unwrap_err().kind(), ErrorKind::ConditionNotMatch);
 
     Ok(())
@@ -859,7 +851,8 @@ pub async fn test_writer_write_with_if_none_match(op: Operator) -> Result<()> {
         return Ok(());
     }
 
-    let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
+    let path = TEST_FIXTURE.new_file_path();
+    let content = gen_fixed_bytes(cap.write_multi_min_size.unwrap_or(1));
 
     op.write(&path, content.clone())
         .await
@@ -868,9 +861,14 @@ pub async fn test_writer_write_with_if_none_match(op: Operator) -> Result<()> {
     let meta = op.stat(&path).await?;
     let etag = meta.etag().expect("etag must exist");
 
-    let mut w = op.writer_with(&path).if_none_match(etag).await?;
-    let res = write_conditionally_in_chunks(&mut w, &content).await;
-    assert!(res.is_err());
+    let res: opendal::Result<()> = async {
+        let mut w = op.writer_with(&path).if_none_match(etag).await?;
+        w.write(content.clone()).await?;
+        w.write(content.clone()).await?;
+        w.close().await?;
+        Ok(())
+    }
+    .await;
     assert_eq!(res.unwrap_err().kind(), ErrorKind::ConditionNotMatch);
 
     Ok(())
@@ -884,7 +882,8 @@ pub async fn test_writer_write_with_if_match(op: Operator) -> Result<()> {
         return Ok(());
     }
 
-    let (path_a, content_a, _) = TEST_FIXTURE.new_file(op.clone());
+    let path_a = TEST_FIXTURE.new_file_path();
+    let content_a = gen_fixed_bytes(cap.write_multi_min_size.unwrap_or(1));
     let (path_b, content_b, _) = TEST_FIXTURE.new_file(op.clone());
 
     op.write(&path_a, content_a.clone()).await?;
@@ -903,15 +902,20 @@ pub async fn test_writer_write_with_if_match(op: Operator) -> Result<()> {
         .expect("etag must exist")
         .to_string();
 
-    // Should succeed: writing to path_a with its own etag.
     let mut w = op.writer_with(&path_a).if_match(&etag_a).await?;
-    let res = write_conditionally_in_chunks(&mut w, &content_a).await;
-    assert!(res.is_ok());
+    w.write(content_a.clone()).await?;
+    w.write(content_a.clone()).await?;
+    w.close().await.expect("close with own etag must succeed");
 
     // Should fail: writing to path_a with path_b's etag.
-    let mut w = op.writer_with(&path_a).if_match(&etag_b).await?;
-    let res = write_conditionally_in_chunks(&mut w, &content_a).await;
-    assert!(res.is_err());
+    let res: opendal::Result<()> = async {
+        let mut w = op.writer_with(&path_a).if_match(&etag_b).await?;
+        w.write(content_a.clone()).await?;
+        w.write(content_a.clone()).await?;
+        w.close().await?;
+        Ok(())
+    }
+    .await;
     assert_eq!(res.unwrap_err().kind(), ErrorKind::ConditionNotMatch);
 
     Ok(())

--- a/core/tests/behavior/async_write.rs
+++ b/core/tests/behavior/async_write.rs
@@ -57,7 +57,10 @@ pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
             test_writer_futures_copy,
             test_writer_futures_copy_with_concurrent,
             test_writer_return_metadata,
-            test_writer_write_non_contiguous_data
+            test_writer_write_non_contiguous_data,
+            test_writer_write_with_if_not_exists,
+            test_writer_write_with_if_none_match,
+            test_writer_write_with_if_match
         ))
     }
 
@@ -804,6 +807,110 @@ pub async fn test_write_with_if_match(op: Operator) -> Result<()> {
         .write_with(&path_a, content_a.clone())
         .if_match(etag_b)
         .await;
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::ConditionNotMatch);
+
+    Ok(())
+}
+
+/// Writing more than once before `close()` commits through the service's multi-part
+/// completion request instead of a single-shot upload. Preconditions must still be honored
+/// on that path, otherwise a conditional write silently degrades to an unconditional
+/// overwrite.
+///
+/// Services normally evaluate the precondition at commit time, but some may reject earlier,
+/// so an error from either `write()` or `close()` is accepted.
+async fn write_conditionally_in_chunks(
+    w: &mut Writer,
+    content: &[u8],
+) -> opendal::Result<Metadata> {
+    w.write(content.to_vec()).await?;
+    w.write(content.to_vec()).await?;
+    w.close().await
+}
+
+/// Write an existing file through a chunked writer with if_not_exists should get a
+/// ConditionNotMatch error.
+pub async fn test_writer_write_with_if_not_exists(op: Operator) -> Result<()> {
+    let cap = op.info().capability();
+    if !cap.write_with_if_not_exists || !cap.write_can_multi {
+        return Ok(());
+    }
+
+    let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
+
+    op.write(&path, content.clone())
+        .await
+        .expect("write must succeed");
+
+    let mut w = op.writer_with(&path).if_not_exists(true).await?;
+    let res = write_conditionally_in_chunks(&mut w, &content).await;
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::ConditionNotMatch);
+
+    Ok(())
+}
+
+/// Write an existing file through a chunked writer with its own etag as if_none_match
+/// should get a ConditionNotMatch error.
+pub async fn test_writer_write_with_if_none_match(op: Operator) -> Result<()> {
+    let cap = op.info().capability();
+    if !cap.write_with_if_none_match || !cap.write_can_multi {
+        return Ok(());
+    }
+
+    let (path, content, _) = TEST_FIXTURE.new_file(op.clone());
+
+    op.write(&path, content.clone())
+        .await
+        .expect("write must succeed");
+
+    let meta = op.stat(&path).await?;
+    let etag = meta.etag().expect("etag must exist");
+
+    let mut w = op.writer_with(&path).if_none_match(etag).await?;
+    let res = write_conditionally_in_chunks(&mut w, &content).await;
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err().kind(), ErrorKind::ConditionNotMatch);
+
+    Ok(())
+}
+
+/// Write a file through a chunked writer with if_match should succeed with the file's own
+/// etag and get a ConditionNotMatch error with a stale one.
+pub async fn test_writer_write_with_if_match(op: Operator) -> Result<()> {
+    let cap = op.info().capability();
+    if !cap.write_with_if_match || !cap.write_can_multi {
+        return Ok(());
+    }
+
+    let (path_a, content_a, _) = TEST_FIXTURE.new_file(op.clone());
+    let (path_b, content_b, _) = TEST_FIXTURE.new_file(op.clone());
+
+    op.write(&path_a, content_a.clone()).await?;
+    op.write(&path_b, content_b.clone()).await?;
+
+    let etag_a = op
+        .stat(&path_a)
+        .await?
+        .etag()
+        .expect("etag must exist")
+        .to_string();
+    let etag_b = op
+        .stat(&path_b)
+        .await?
+        .etag()
+        .expect("etag must exist")
+        .to_string();
+
+    // Should succeed: writing to path_a with its own etag.
+    let mut w = op.writer_with(&path_a).if_match(&etag_a).await?;
+    let res = write_conditionally_in_chunks(&mut w, &content_a).await;
+    assert!(res.is_ok());
+
+    // Should fail: writing to path_a with path_b's etag.
+    let mut w = op.writer_with(&path_a).if_match(&etag_b).await?;
+    let res = write_conditionally_in_chunks(&mut w, &content_a).await;
     assert!(res.is_err());
     assert_eq!(res.unwrap_err().kind(), ErrorKind::ConditionNotMatch);
 


### PR DESCRIPTION
Supersedes https://github.com/apache/opendal/pull/7990

# Which issue does this PR close?

Part of #7889.

This is the Azure Blob half of #7890, split out so it can land independently. The GCS half of #7890 is heading for an RFC discussion and is not included here; #7889 stays open for it.

# Rationale for this change

Azure Blob's Put Blob API supports `If-Match` with an arbitrary ETag, but OpenDAL only wired up `If-None-Match`, so `write_with_if_match` was reported as unsupported even though the underlying API can do it. This blocks optimistic-concurrency writes ("only overwrite if the object hasn't changed since I read it") on azblob.

While wiring that up, a related gap surfaced on the chunked write path. Conditional args were only applied to the single-shot Put Blob request. A caller that writes more than once before `close()` — via `writer_with(..)`, `chunk(..)`, or just two `write()` calls — commits through Put Block + Put Block List instead, and `azblob_complete_put_block_list_request` carried no conditional headers at all. `if_match`, `if_none_match` and `if_not_exists` were silently dropped there, so a conditional write degraded to an unconditional overwrite with no error to signal that the precondition had been discarded.

The `if_none_match` / `if_not_exists` part of that is a pre-existing bug independent of `if_match`: both capabilities are already declared for azblob and both work single-shot, so `if_not_exists(true)` through a chunked writer overwrote rather than failing. It is fixed here rather than separately because it is the same dropped-precondition bug in the same function, and fixing only `if_match` would leave the identical hole open two lines away. Happy to split it out if reviewers prefer.

# What changes are included in this PR?

- **`if_match` on Put Blob**: wire the `If-Match` header into `azblob_put_blob_request` mirroring the existing `if_none_match` handling, and declare `write_with_if_match`.
- **Preconditions on block commit**: apply `if_not_exists`, `if_none_match` and `if_match` to `azblob_complete_put_block_list_request`. Put Block does not evaluate preconditions, so they belong on Put Block List, which does. This matches `azblob_complete_copy_block_list_request`, which already honors `if_not_exists`.
- **Behavior tests**: three new shared tests (`test_writer_write_with_if_not_exists`, `test_writer_write_with_if_none_match`, `test_writer_write_with_if_match`) that force the multi-part commit path by writing twice before `close()`. They are gated on `write_can_multi` plus the relevant conditional capability, so they exercise any service declaring those.
- No error-mapping changes: azblob's `parse_error` already maps 412/409/304 to `ErrorKind::ConditionNotMatch`.
- No changes to S3, GCS, or `Capability` docs.

Verified against Azurite:

- On the pre-change code, `test_writer_write_with_if_none_match` and `test_writer_write_with_if_not_exists` fail (`assertion failed: res.is_err()` — the conditional write succeeded where it should have returned `ConditionNotMatch`). `test_writer_write_with_if_match` early-returns there since the capability isn't declared yet.
- With this change, the full azblob behavior suite passes: 122 passed, 0 failed. That also covers the existing `test_write_with_if_match`, which now runs on azblob for the first time.

Also run: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, and `cargo test -p opendal-service-azblob`.

# Are there any user-facing changes?

Yes, both additive:

- Azure Blob users can now pass `if_match` to `write_with` / `writer_with`, matching what was already available for `if_none_match`.
- Conditional writes now behave consistently between single-shot and chunked writes on azblob. Code that previously passed `if_not_exists(true)` or `if_none_match(..)` through a chunked writer and saw the write succeed will now correctly get `ErrorKind::ConditionNotMatch` when the precondition does not hold. This is a bug fix, but it is a behavior change for anyone who was unknowingly relying on the precondition being dropped.

No breaking changes to public APIs.

# AI Usage Statement

This PR was developed with Claude Code (Anthropic), model Claude Opus 5: codebase investigation, implementation, and verification. Behavior tests were run against a local Azurite instance in Docker, both before and after the change; no live Azure account was used.