### PR TITLE
refactor(bindings/dotnet): bind the executor at operator construction

### DIFF
--- a/bindings/dotnet/OpenDAL.Tests/ExecutorTest.cs
+++ b/bindings/dotnet/OpenDAL.Tests/ExecutorTest.cs
@@ -33,11 +33,11 @@ public class ExecutorTest
     public void ReadWrite_WithDedicatedExecutor_RoundTripsSuccessfully()
     {
         using var executor = new Executor(1);
-        using var op = new Operator("memory");
+        using var op = new Operator("memory", executor: executor);
         var content = System.Text.Encoding.UTF8.GetBytes("executor-content");
 
-        op.Write("executor-sync", content, executor);
-        var read = op.Read("executor-sync", executor);
+        op.Write("executor-sync", content);
+        var read = op.Read("executor-sync");
 
         Assert.Equal(content, read);
     }
@@ -46,27 +46,40 @@ public class ExecutorTest
     public async Task ReadWriteAsync_WithDedicatedExecutor_RoundTripsSuccessfully()
     {
         using var executor = new Executor(1);
-        using var op = new Operator("memory");
+        using var op = new Operator("memory", executor: executor);
         var content = System.Text.Encoding.UTF8.GetBytes("executor-async-content");
 
-        await op.WriteAsync("executor-async", content, executor, CT);
-        var read = await op.ReadAsync("executor-async", executor, CT);
+        await op.WriteAsync("executor-async", content, CT);
+        var read = await op.ReadAsync("executor-async", CT);
 
         Assert.Equal(content, read);
     }
 
     [Fact]
-    public async Task OperatorCalls_WithDisposedExecutor_ThrowObjectDisposedException()
+    public void Construct_WithDisposedExecutor_ThrowsObjectDisposedException()
     {
         var executor = new Executor(1);
-        using var op = new Operator("memory");
-        var content = new byte[] { 1, 2, 3 };
         executor.Dispose();
 
-        Assert.Throws<ObjectDisposedException>(() => op.Write("disposed-executor", content, executor));
-        Assert.Throws<ObjectDisposedException>(() => op.Read("disposed-executor", executor));
-        await Assert.ThrowsAsync<ObjectDisposedException>(() => op.WriteAsync("disposed-executor", content, executor, CT));
-        await Assert.ThrowsAsync<ObjectDisposedException>(() => op.ReadAsync("disposed-executor", executor, CT));
+        Assert.Throws<ObjectDisposedException>(() => new Operator("memory", executor: executor));
+    }
+
+    [Fact]
+    public async Task Operator_OutlivesDisposedExecutor_KeepsWorking()
+    {
+        var executor = new Executor(1);
+        using var op = new Operator("memory", executor: executor);
+        var content = new byte[] { 1, 2, 3 };
+
+        // The operator binds the runtime at construction, so disposing the
+        // executor handle afterwards must not tear the runtime down.
+        executor.Dispose();
+
+        op.Write("outlives-executor-sync", content);
+        Assert.Equal(content, op.Read("outlives-executor-sync"));
+
+        await op.WriteAsync("outlives-executor-async", content, CT);
+        Assert.Equal(content, await op.ReadAsync("outlives-executor-async", CT));
     }
 
     [Fact]
@@ -74,11 +87,11 @@ public class ExecutorTest
     {
         var threads = Math.Max(1, Environment.ProcessorCount);
         using var executor = new Executor(threads);
-        using var op = new Operator("memory");
+        using var op = new Operator("memory", executor: executor);
         var content = System.Text.Encoding.UTF8.GetBytes($"executor-threads-{threads}");
 
-        op.Write("executor-processor-sync", content, executor);
-        var read = op.Read("executor-processor-sync", executor);
+        op.Write("executor-processor-sync", content);
+        var read = op.Read("executor-processor-sync");
 
         Assert.Equal(content, read);
     }
@@ -90,15 +103,15 @@ public class ExecutorTest
         var operationCount = Math.Min(threads * 2, 64);
 
         using var executor = new Executor(threads);
-        using var op = new Operator("memory");
+        using var op = new Operator("memory", executor: executor);
 
         var tasks = Enumerable.Range(0, operationCount).Select(async i =>
         {
             var path = $"executor-processor-async-{i}";
             var content = System.Text.Encoding.UTF8.GetBytes($"executor-content-{i}");
 
-            await op.WriteAsync(path, content, executor, CT);
-            var read = await op.ReadAsync(path, executor, CT);
+            await op.WriteAsync(path, content, CT);
+            var read = await op.ReadAsync(path, CT);
 
             Assert.Equal(content, read);
         });

--- a/bindings/dotnet/OpenDAL/Executor.cs
+++ b/bindings/dotnet/OpenDAL/Executor.cs
@@ -26,9 +26,10 @@ namespace OpenDAL;
 /// Managed wrapper over an OpenDAL native executor handle.
 /// </summary>
 /// <remarks>
-/// Dispose only after every operation submitted with this executor has
-/// completed: disposal tears down the runtime, and tasks it cancels never
-/// complete their awaiters.
+/// An operator binds an executor at construction and owns a reference to its
+/// runtime from then on, so disposing this handle never affects operators
+/// that already use it. Constructing a new operator with a disposed executor
+/// throws <see cref="ObjectDisposedException"/>.
 /// </remarks>
 public sealed class Executor : SafeHandle
 {
@@ -36,7 +37,8 @@ public sealed class Executor : SafeHandle
     /// Creates an executor with the given number of worker threads.
     /// </summary>
     /// <remarks>
-    /// This executor can be passed to operator APIs to control the runtime that executes the underlying native tasks.
+    /// Pass the executor to an <see cref="Operator"/> constructor to control the runtime that
+    /// executes that operator's native tasks.
     /// </remarks>
     /// <param name="threads">Number of Tokio worker threads. Must be greater than zero.</param>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="threads"/> is less than or equal to zero.</exception>

--- a/bindings/dotnet/OpenDAL/NativeMethods.cs
+++ b/bindings/dotnet/OpenDAL/NativeMethods.cs
@@ -34,7 +34,8 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALOperatorResult operator_construct(
         string scheme,
-        IntPtr options
+        IntPtr options,
+        IntPtr executor
     );
 
     [LibraryImport(__DllName, EntryPoint = "constructor_option_build", StringMarshalling = StringMarshalling.Utf8)]
@@ -229,7 +230,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALResult operator_write_bytes_with_options(
         Operator op,
-        IntPtr executor,
         string path,
         [In] byte[] data,
         nuint len,
@@ -240,7 +240,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_write_bytes_with_options_async(
         Operator op,
-        IntPtr executor,
         string path,
         [In] byte[] data,
         nuint len,
@@ -253,7 +252,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALResult operator_write_with_options(
         Operator op,
-        IntPtr executor,
         string path,
         IntPtr buffer,
         nuint committedInCurrent,
@@ -264,7 +262,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_write_with_options_async(
         Operator op,
-        IntPtr executor,
         string path,
         IntPtr buffer,
         nuint committedInCurrent,
@@ -281,7 +278,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALReadResult operator_read_with_options(
         Operator op,
-        IntPtr executor,
         string path,
         IntPtr options
     );
@@ -290,7 +286,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_read_with_options_async(
         Operator op,
-        IntPtr executor,
         string path,
         IntPtr options,
         delegate* unmanaged[Cdecl]<long, OpenDALReadResult, void> callback,
@@ -305,7 +300,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALMetadataResult operator_stat_with_options(
         Operator op,
-        IntPtr executor,
         string path,
         IntPtr options
     );
@@ -314,7 +308,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_stat_with_options_async(
         Operator op,
-        IntPtr executor,
         string path,
         IntPtr options,
         delegate* unmanaged[Cdecl]<long, OpenDALMetadataResult, void> callback,
@@ -329,7 +322,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALEntryListResult operator_list_with_options(
         Operator op,
-        IntPtr executor,
         string path,
         IntPtr options
     );
@@ -338,7 +330,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_list_with_options_async(
         Operator op,
-        IntPtr executor,
         string path,
         IntPtr options,
         delegate* unmanaged[Cdecl]<long, OpenDALEntryListResult, void> callback,
@@ -353,7 +344,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALResult operator_delete(
         Operator op,
-        IntPtr executor,
         string path
     );
 
@@ -361,7 +351,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_delete_async(
         Operator op,
-        IntPtr executor,
         string path,
         delegate* unmanaged[Cdecl]<long, OpenDALResult, void> callback,
         long context
@@ -375,7 +364,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALResult operator_create_dir(
         Operator op,
-        IntPtr executor,
         string path
     );
 
@@ -383,7 +371,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_create_dir_async(
         Operator op,
-        IntPtr executor,
         string path,
         delegate* unmanaged[Cdecl]<long, OpenDALResult, void> callback,
         long context
@@ -397,7 +384,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALResult operator_copy(
         Operator op,
-        IntPtr executor,
         string sourcePath,
         string targetPath
     );
@@ -406,7 +392,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_copy_async(
         Operator op,
-        IntPtr executor,
         string sourcePath,
         string targetPath,
         delegate* unmanaged[Cdecl]<long, OpenDALResult, void> callback,
@@ -421,7 +406,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALResult operator_rename(
         Operator op,
-        IntPtr executor,
         string sourcePath,
         string targetPath
     );
@@ -430,7 +414,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_rename_async(
         Operator op,
-        IntPtr executor,
         string sourcePath,
         string targetPath,
         delegate* unmanaged[Cdecl]<long, OpenDALResult, void> callback,
@@ -445,7 +428,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALResult operator_remove_all(
         Operator op,
-        IntPtr executor,
         string path
     );
 
@@ -453,7 +435,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_remove_all_async(
         Operator op,
-        IntPtr executor,
         string path,
         delegate* unmanaged[Cdecl]<long, OpenDALResult, void> callback,
         long context
@@ -467,7 +448,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_presign_read_async(
         Operator op,
-        IntPtr executor,
         string path,
         ulong expireNanos,
         delegate* unmanaged[Cdecl]<long, OpenDALPresignedRequestResult, void> callback,
@@ -478,7 +458,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_presign_write_async(
         Operator op,
-        IntPtr executor,
         string path,
         ulong expireNanos,
         delegate* unmanaged[Cdecl]<long, OpenDALPresignedRequestResult, void> callback,
@@ -489,7 +468,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_presign_stat_async(
         Operator op,
-        IntPtr executor,
         string path,
         ulong expireNanos,
         delegate* unmanaged[Cdecl]<long, OpenDALPresignedRequestResult, void> callback,
@@ -500,7 +478,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static unsafe partial OpenDALResult operator_presign_delete_async(
         Operator op,
-        IntPtr executor,
         string path,
         ulong expireNanos,
         delegate* unmanaged[Cdecl]<long, OpenDALPresignedRequestResult, void> callback,
@@ -515,7 +492,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALOperatorResult operator_input_stream_create(
         Operator op,
-        IntPtr executor,
         string path,
         IntPtr options
     );
@@ -540,7 +516,6 @@ internal partial class NativeMethods
     [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     internal static partial OpenDALOperatorResult operator_output_stream_create(
         Operator op,
-        IntPtr executor,
         string path,
         IntPtr options
     );

--- a/bindings/dotnet/OpenDAL/Operator.cs
+++ b/bindings/dotnet/OpenDAL/Operator.cs
@@ -84,15 +84,34 @@ public partial class Operator : SafeHandle
     /// <param name="scheme">Name of the backend service, such as <c>fs</c> or <c>memory</c>.</param>
     /// <param name="options">Key/value options used to configure the selected backend service.</param>
     /// <exception cref="ArgumentException"><paramref name="scheme"/> is null, empty, or whitespace.</exception>
+    /// <exception cref="ObjectDisposedException"><paramref name="executor"/> has been disposed.</exception>
     /// <exception cref="OpenDALException">Native operator construction fails.</exception>
-    public Operator(string scheme, IReadOnlyDictionary<string, string>? options = null) : base(IntPtr.Zero, true)
+    public Operator(
+        string scheme,
+        IReadOnlyDictionary<string, string>? options = null,
+        Executor? executor = null) : base(IntPtr.Zero, true)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(scheme);
         info = CreateInfoLazy();
 
         using var nativeOptionsHandle = CreateConstructorOptionsHandle(options);
-        var result = NativeMethods.operator_construct(scheme, GetOptionsHandle(nativeOptionsHandle));
-        SetHandle(ToValueOrThrowAndRelease<IntPtr, OpenDALOperatorResult>(result));
+        var executorAddRefed = false;
+        try
+        {
+            executor?.DangerousAddRef(ref executorAddRefed);
+            var result = NativeMethods.operator_construct(
+                scheme,
+                GetOptionsHandle(nativeOptionsHandle),
+                executor?.DangerousGetHandle() ?? IntPtr.Zero);
+            SetHandle(ToValueOrThrowAndRelease<IntPtr, OpenDALOperatorResult>(result));
+        }
+        finally
+        {
+            if (executorAddRefed)
+            {
+                executor!.DangerousRelease();
+            }
+        }
     }
 
     /// <summary>
@@ -105,9 +124,10 @@ public partial class Operator : SafeHandle
     /// <param name="config">Typed service configuration for the target backend service.</param>
     /// <exception cref="ArgumentNullException"><paramref name="config"/> is null.</exception>
     /// <exception cref="OpenDALException">Native operator construction fails.</exception>
-    public Operator(IServiceConfig config) : this(
+    public Operator(IServiceConfig config, Executor? executor = null) : this(
         config?.Scheme ?? throw new ArgumentNullException(nameof(config)),
-        config.ToOptions())
+        config.ToOptions(),
+        executor)
     {
     }
 
@@ -127,58 +147,19 @@ public partial class Operator : SafeHandle
     }
 
     /// <summary>
-    /// Writes the specified content to a path.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="content">Bytes to write.</param>
-    /// <exception cref="ObjectDisposedException">The operator has been disposed.</exception>
-    /// <exception cref="OpenDALException">Native write fails.</exception>
-    public void Write(string path, byte[] content)
-    {
-        Write(path, content, options: null, executor: null);
-    }
-
-    /// <summary>
     /// Writes the specified content to a path with write options.
     /// </summary>
     /// <param name="path">Target path in the configured backend.</param>
     /// <param name="content">Bytes to write.</param>
     /// <param name="options">Additional write options.</param>
-    public void Write(string path, byte[] content, WriteOptions options)
-    {
-        Write(path, content, (WriteOptions?)options, executor: null);
-    }
-
-    /// <summary>
-    /// Writes the specified content to a path using the provided executor.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="content">Bytes to write.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <exception cref="ObjectDisposedException">The operator or executor has been disposed.</exception>
-    /// <exception cref="OpenDALException">Native write fails.</exception>
-    public void Write(string path, byte[] content, Executor? executor)
-    {
-        Write(path, content, options: null, executor);
-    }
-
-    /// <summary>
-    /// Writes the specified content to a path with write options using the provided executor.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="content">Bytes to write.</param>
-    /// <param name="options">Additional write options.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    public void Write(string path, byte[] content, WriteOptions? options, Executor? executor)
+    public void Write(string path, byte[] content, WriteOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(content);
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         using var nativeOptionsHandle = options?.BuildNativeOptionsHandle();
         var result = NativeMethods.operator_write_bytes_with_options(
             this,
-            executorHandle,
             path,
             content,
             (nuint)content.Length,
@@ -209,7 +190,6 @@ public partial class Operator : SafeHandle
     /// without growing; it is an estimate, not a limit.
     /// </param>
     /// <param name="options">Additional write options, or <see langword="null"/> for default behavior.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
     /// <exception cref="ArgumentNullException"><paramref name="fill"/> is null.</exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="sizeHint"/> is negative.</exception>
     /// <exception cref="ObjectDisposedException">The operator or executor has been disposed.</exception>
@@ -218,8 +198,7 @@ public partial class Operator : SafeHandle
         string path,
         Action<IBufferWriter<byte>> fill,
         int sizeHint = 0,
-        WriteOptions? options = null,
-        Executor? executor = null)
+        WriteOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(fill);
         ArgumentOutOfRangeException.ThrowIfNegative(sizeHint);
@@ -227,7 +206,7 @@ public partial class Operator : SafeHandle
         using var buffer = AllocateWriteBuffer(
             sizeHint > 0 ? sizeHint : WriteBuffer.DefaultInitialCapacity);
         fill(buffer);
-        Write(path, buffer, options, executor);
+        Write(path, buffer, options);
     }
 
     /// <summary>
@@ -246,15 +225,13 @@ public partial class Operator : SafeHandle
     /// <param name="path">Target path in the configured backend.</param>
     /// <param name="content">Allocated buffer holding the bytes to write.</param>
     /// <param name="options">Additional write options, or <see langword="null"/> for default behavior.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
     /// <exception cref="ObjectDisposedException">The operator or buffer has been disposed.</exception>
     /// <exception cref="InvalidOperationException">The buffer contents were already consumed by a write.</exception>
     /// <exception cref="OpenDALException">Native write fails.</exception>
-    internal void Write(string path, WriteBuffer content, WriteOptions? options = null, Executor? executor = null)
+    internal void Write(string path, WriteBuffer content, WriteOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(content);
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         var bufferHandle = content.Handle;
         var committedInTail = content.TailWritten;
@@ -262,7 +239,6 @@ public partial class Operator : SafeHandle
         using var nativeOptionsHandle = options?.BuildNativeOptionsHandle();
         var result = NativeMethods.operator_write_with_options(
             this,
-            executorHandle,
             path,
             bufferHandle,
             (nuint)committedInTail,
@@ -283,50 +259,9 @@ public partial class Operator : SafeHandle
     /// <param name="path">Target path in the configured backend.</param>
     /// <param name="content">Bytes to write.</param>
     /// <param name="cancellationToken">Cancellation token for the managed task.</param>
-    /// <returns>A task that completes when the native callback reports completion.</returns>
-    /// <exception cref="ObjectDisposedException">The operator has been disposed.</exception>
-    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> is already canceled.</exception>
-    /// <exception cref="OpenDALException">Native write submission fails immediately.</exception>
-    public Task WriteAsync(string path, byte[] content, CancellationToken cancellationToken = default)
+    public Task WriteAsync(string path, byte[] content, CancellationToken cancellationToken)
     {
-        return WriteAsync(path, content, options: null, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Writes the specified content to a path asynchronously with write options.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="content">Bytes to write.</param>
-    /// <param name="options">Additional write options.</param>
-    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
-    /// <returns>A task that completes when the native callback reports completion.</returns>
-    public Task WriteAsync(
-        string path,
-        byte[] content,
-        WriteOptions options,
-        CancellationToken cancellationToken = default)
-    {
-        return WriteAsync(path, content, (WriteOptions?)options, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Writes the specified content to a path asynchronously using the provided executor.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="content">Bytes to write.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
-    /// <returns>A task that completes when the native callback reports completion.</returns>
-    /// <exception cref="ObjectDisposedException">The operator or executor has been disposed.</exception>
-    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> is already canceled.</exception>
-    /// <exception cref="OpenDALException">Native write submission fails immediately.</exception>
-    public Task WriteAsync(
-        string path,
-        byte[] content,
-        Executor? executor,
-        CancellationToken cancellationToken = default)
-    {
-        return WriteAsync(path, content, options: null, executor, cancellationToken);
+        return WriteAsync(path, content, options: null, cancellationToken);
     }
 
     /// <summary>
@@ -335,19 +270,16 @@ public partial class Operator : SafeHandle
     /// <param name="path">Target path in the configured backend.</param>
     /// <param name="content">Bytes to write.</param>
     /// <param name="options">Additional write options, or <see langword="null"/> for default behavior.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
     /// <param name="cancellationToken">Cancellation token for the managed task.</param>
     /// <returns>A task that completes when the native callback reports completion.</returns>
     public Task WriteAsync(
         string path,
         byte[] content,
-        WriteOptions? options,
-        Executor? executor,
+        WriteOptions? options = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(content);
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         return SubmitAsyncOperation<bool, WriteOptions>(options, DispatchWriteBytesAsync, cancellationToken);
 
@@ -357,7 +289,6 @@ public partial class Operator : SafeHandle
             {
                 return NativeMethods.operator_write_bytes_with_options_async(
                     this,
-                    executorHandle,
                     path,
                     content,
                     (nuint)content.Length,
@@ -413,7 +344,6 @@ public partial class Operator : SafeHandle
     /// <param name="path">Target path in the configured backend.</param>
     /// <param name="content">Allocated buffer holding the bytes to write.</param>
     /// <param name="options">Additional write options, or <see langword="null"/> for default behavior.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
     /// <param name="cancellationToken">Cancellation token for the managed task.</param>
     /// <returns>A task that completes when the native callback reports completion.</returns>
     /// <exception cref="ObjectDisposedException">The operator or buffer has been disposed.</exception>
@@ -424,12 +354,10 @@ public partial class Operator : SafeHandle
         string path,
         WriteBuffer content,
         WriteOptions? options = null,
-        Executor? executor = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(content);
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         // Surfaces disposed/already-consumed as managed exceptions before the
         // native call; the native slot enforces the same contract again.
@@ -444,7 +372,6 @@ public partial class Operator : SafeHandle
             {
                 var result = NativeMethods.operator_write_with_options_async(
                     this,
-                    executorHandle,
                     path,
                     bufferHandle,
                     (nuint)committedInTail,
@@ -484,7 +411,6 @@ public partial class Operator : SafeHandle
     /// without growing; it is an estimate, not a limit.
     /// </param>
     /// <param name="options">Additional write options, or <see langword="null"/> for default behavior.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
     /// <param name="cancellationToken">Cancellation token for the managed task.</param>
     /// <returns>A task that completes when the native callback reports completion.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="fill"/> is null.</exception>
@@ -497,7 +423,6 @@ public partial class Operator : SafeHandle
         Action<IBufferWriter<byte>> fill,
         int sizeHint = 0,
         WriteOptions? options = null,
-        Executor? executor = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(fill);
@@ -506,19 +431,7 @@ public partial class Operator : SafeHandle
         using var buffer = AllocateWriteBuffer(
             sizeHint > 0 ? sizeHint : WriteBuffer.DefaultInitialCapacity);
         fill(buffer);
-        await WriteAsync(path, buffer, options, executor, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Reads all bytes from a path.
-    /// </summary>
-    /// <param name="path">Source path in the configured backend.</param>
-    /// <returns>The content bytes.</returns>
-    /// <exception cref="ObjectDisposedException">The operator has been disposed.</exception>
-    /// <exception cref="OpenDALException">Native read fails.</exception>
-    public byte[] Read(string path)
-    {
-        return Read(path, options: null, executor: null);
+        await WriteAsync(path, buffer, options, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -527,34 +440,9 @@ public partial class Operator : SafeHandle
     /// <param name="path">Source path in the configured backend.</param>
     /// <param name="options">Additional read options.</param>
     /// <returns>The content bytes.</returns>
-    public byte[] Read(string path, ReadOptions options)
+    public byte[] Read(string path, ReadOptions? options = null)
     {
-        return Read(path, options, executor: null);
-    }
-
-    /// <summary>
-    /// Reads all bytes from a path using the provided executor.
-    /// </summary>
-    /// <param name="path">Source path in the configured backend.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <returns>The content bytes.</returns>
-    /// <exception cref="ObjectDisposedException">The operator or executor has been disposed.</exception>
-    /// <exception cref="OpenDALException">Native read fails.</exception>
-    public byte[] Read(string path, Executor? executor)
-    {
-        return Read(path, options: null, executor);
-    }
-
-    /// <summary>
-    /// Reads bytes from a path with read options using the provided executor.
-    /// </summary>
-    /// <param name="path">Source path in the configured backend.</param>
-    /// <param name="options">Additional read options.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <returns>The content bytes.</returns>
-    public byte[] Read(string path, ReadOptions? options, Executor? executor)
-    {
-        return Read(path, static sequence => sequence.ToArray(), options, executor);
+        return Read(path, static sequence => sequence.ToArray(), options);
     }
 
     /// <summary>
@@ -563,39 +451,9 @@ public partial class Operator : SafeHandle
     /// <param name="path">Source path in the configured backend.</param>
     /// <param name="cancellationToken">Cancellation token for the managed task.</param>
     /// <returns>A task that resolves with the read content.</returns>
-    /// <exception cref="ObjectDisposedException">The operator has been disposed.</exception>
-    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> is already canceled.</exception>
-    /// <exception cref="OpenDALException">Native read submission fails immediately.</exception>
-    public Task<byte[]> ReadAsync(string path, CancellationToken cancellationToken = default)
+    public Task<byte[]> ReadAsync(string path, CancellationToken cancellationToken)
     {
-        return ReadAsync(path, options: null, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Reads bytes from a path asynchronously with read options.
-    /// </summary>
-    /// <param name="path">Source path in the configured backend.</param>
-    /// <param name="options">Additional read options.</param>
-    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
-    /// <returns>A task that resolves with the read content.</returns>
-    public Task<byte[]> ReadAsync(string path, ReadOptions options, CancellationToken cancellationToken = default)
-    {
-        return ReadAsync(path, options, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Reads all bytes from a path asynchronously using the provided executor.
-    /// </summary>
-    /// <param name="path">Source path in the configured backend.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
-    /// <returns>A task that resolves with the read content.</returns>
-    /// <exception cref="ObjectDisposedException">The operator or executor has been disposed.</exception>
-    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> is already canceled.</exception>
-    /// <exception cref="OpenDALException">Native read submission fails immediately.</exception>
-    public Task<byte[]> ReadAsync(string path, Executor? executor, CancellationToken cancellationToken = default)
-    {
-        return ReadAsync(path, options: null, executor, cancellationToken);
+        return ReadAsync(path, options: null, cancellationToken);
     }
 
     /// <summary>
@@ -603,16 +461,14 @@ public partial class Operator : SafeHandle
     /// </summary>
     /// <param name="path">Source path in the configured backend.</param>
     /// <param name="options">Additional read options, or <see langword="null"/> for default behavior.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
     /// <param name="cancellationToken">Cancellation token for the managed task.</param>
     /// <returns>A task that resolves with the read content.</returns>
     public Task<byte[]> ReadAsync(
         string path,
-        ReadOptions? options,
-        Executor? executor,
+        ReadOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        return ReadAsync(path, static sequence => sequence.ToArray(), options, executor, cancellationToken);
+        return ReadAsync(path, static sequence => sequence.ToArray(), options, cancellationToken);
     }
 
     /// <summary>
@@ -626,18 +482,16 @@ public partial class Operator : SafeHandle
     /// </remarks>
     /// <param name="path">Source path in the configured backend.</param>
     /// <param name="options">Additional read options, or <see langword="null"/> for default behavior.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
     /// <returns>The content as a disposable native buffer.</returns>
     /// <exception cref="ObjectDisposedException">The operator or executor has been disposed.</exception>
     /// <exception cref="OpenDALException">Native read fails.</exception>
-    internal ReadBuffer ReadBuffer(string path, ReadOptions? options = null, Executor? executor = null)
+    internal ReadBuffer ReadBuffer(string path, ReadOptions? options = null)
     {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         using var nativeOptionsHandle = options?.BuildNativeOptionsHandle();
         var result = NativeMethods.operator_read_with_options(
-            this, executorHandle, path, GetOptionsHandle(nativeOptionsHandle));
+            this, path, GetOptionsHandle(nativeOptionsHandle));
 
         return Interop.Buffers.ReadBuffer.FromResult(result);
     }
@@ -653,7 +507,6 @@ public partial class Operator : SafeHandle
     /// </remarks>
     /// <param name="path">Source path in the configured backend.</param>
     /// <param name="options">Additional read options, or <see langword="null"/> for default behavior.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
     /// <param name="cancellationToken">Cancellation token for the managed task.</param>
     /// <returns>A task that resolves with the content as a disposable native buffer.</returns>
     /// <exception cref="ObjectDisposedException">The operator or executor has been disposed.</exception>
@@ -662,12 +515,10 @@ public partial class Operator : SafeHandle
     internal async Task<ReadBuffer> ReadBufferAsync(
         string path,
         ReadOptions? options = null,
-        Executor? executor = null,
         CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
         cancellationToken.ThrowIfCancellationRequested();
-        var executorHandle = GetExecutorHandle(executor);
 
         var context = AsyncStateRegistry.Register<OpenDALReadResult>(out var state);
         OpenDALResult submit;
@@ -677,7 +528,6 @@ public partial class Operator : SafeHandle
             {
                 submit = NativeMethods.operator_read_with_options_async(
                     this,
-                    executorHandle,
                     path,
                     GetOptionsHandle(nativeOptionsHandle),
                     &OnReadResultRetained,
@@ -716,7 +566,6 @@ public partial class Operator : SafeHandle
     /// <param name="path">Source path in the configured backend.</param>
     /// <param name="consume">Consumer invoked once with the payload.</param>
     /// <param name="options">Additional read options, or <see langword="null"/> for default behavior.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
     /// <returns>The value returned by <paramref name="consume"/>.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="consume"/> is null.</exception>
     /// <exception cref="ObjectDisposedException">The operator or executor has been disposed.</exception>
@@ -724,12 +573,11 @@ public partial class Operator : SafeHandle
     public T Read<T>(
         string path,
         Func<ReadOnlySequence<byte>, T> consume,
-        ReadOptions? options = null,
-        Executor? executor = null)
+        ReadOptions? options = null)
     {
         ArgumentNullException.ThrowIfNull(consume);
 
-        using var buffer = ReadBuffer(path, options, executor);
+        using var buffer = ReadBuffer(path, options);
         return consume(buffer.Sequence);
     }
 
@@ -745,12 +593,11 @@ public partial class Operator : SafeHandle
         string path,
         Func<ReadOnlySequence<byte>, T> consume,
         ReadOptions? options = null,
-        Executor? executor = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(consume);
 
-        using var buffer = await ReadBufferAsync(path, options, executor, cancellationToken).ConfigureAwait(false);
+        using var buffer = await ReadBufferAsync(path, options, cancellationToken).ConfigureAwait(false);
         return consume(buffer.Sequence);
     }
 
@@ -785,26 +632,24 @@ public partial class Operator : SafeHandle
     /// <returns>Metadata of the target path.</returns>
     public Metadata Stat(string path, StatOptions? options = null)
     {
-        return Stat(path, options, executor: null);
-    }
-
-    /// <summary>
-    /// Gets metadata for the specified path using the provided executor.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="options">Additional stat options.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <returns>Metadata of the target path.</returns>
-    public Metadata Stat(string path, StatOptions? options, Executor? executor)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         OpenDALMetadataResult result;
         using var nativeOptionsHandle = options?.BuildNativeOptionsHandle();
-        result = NativeMethods.operator_stat_with_options(this, executorHandle, path, GetOptionsHandle(nativeOptionsHandle));
+        result = NativeMethods.operator_stat_with_options(this, path, GetOptionsHandle(nativeOptionsHandle));
 
         return ToValueOrThrowAndRelease<Metadata, OpenDALMetadataResult>(result);
+    }
+
+    /// <summary>
+    /// Gets metadata of a path asynchronously.
+    /// </summary>
+    /// <param name="path">Target path in the configured backend.</param>
+    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
+    /// <returns>A task that resolves with the path metadata.</returns>
+    public Task<Metadata> StatAsync(string path, CancellationToken cancellationToken)
+    {
+        return StatAsync(path, options: null, cancellationToken);
     }
 
     /// <summary>
@@ -819,25 +664,7 @@ public partial class Operator : SafeHandle
         StatOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        return StatAsync(path, options, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Gets metadata for the specified path asynchronously using the provided executor.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="options">Additional stat options.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
-    /// <returns>A task that resolves with metadata.</returns>
-    public Task<Metadata> StatAsync(
-        string path,
-        StatOptions? options,
-        Executor? executor,
-        CancellationToken cancellationToken = default)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         return SubmitAsyncOperation<Metadata, StatOptions>(options, SubmitStatAsync, cancellationToken);
 
@@ -847,7 +674,6 @@ public partial class Operator : SafeHandle
             {
                 return NativeMethods.operator_stat_with_options_async(
                     this,
-                    executorHandle,
                     path,
                     optionsHandle,
                     &OnStatCompleted,
@@ -865,26 +691,24 @@ public partial class Operator : SafeHandle
     /// <returns>Listed entries.</returns>
     public IReadOnlyList<Entry> List(string path, ListOptions? options = null)
     {
-        return List(path, options, executor: null);
-    }
-
-    /// <summary>
-    /// Lists entries under the specified path using the provided executor.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="options">Additional list options.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <returns>Listed entries.</returns>
-    public IReadOnlyList<Entry> List(string path, ListOptions? options, Executor? executor)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         OpenDALEntryListResult result;
         using var nativeOptionsHandle = options?.BuildNativeOptionsHandle();
-        result = NativeMethods.operator_list_with_options(this, executorHandle, path, GetOptionsHandle(nativeOptionsHandle));
+        result = NativeMethods.operator_list_with_options(this, path, GetOptionsHandle(nativeOptionsHandle));
 
         return ToValueOrThrowAndRelease<IReadOnlyList<Entry>, OpenDALEntryListResult>(result);
+    }
+
+    /// <summary>
+    /// Lists entries under a path asynchronously.
+    /// </summary>
+    /// <param name="path">Target path in the configured backend.</param>
+    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
+    /// <returns>A task that resolves with the listed entries.</returns>
+    public Task<IReadOnlyList<Entry>> ListAsync(string path, CancellationToken cancellationToken)
+    {
+        return ListAsync(path, options: null, cancellationToken);
     }
 
     /// <summary>
@@ -899,25 +723,7 @@ public partial class Operator : SafeHandle
         ListOptions? options = null,
         CancellationToken cancellationToken = default)
     {
-        return ListAsync(path, options, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Lists entries under the specified path asynchronously using the provided executor.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="options">Additional list options.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
-    /// <returns>A task that resolves with listed entries.</returns>
-    public Task<IReadOnlyList<Entry>> ListAsync(
-        string path,
-        ListOptions? options,
-        Executor? executor,
-        CancellationToken cancellationToken = default)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         return SubmitAsyncOperation<IReadOnlyList<Entry>, ListOptions>(options, SubmitListAsync, cancellationToken);
 
@@ -927,7 +733,6 @@ public partial class Operator : SafeHandle
             {
                 return NativeMethods.operator_list_with_options_async(
                     this,
-                    executorHandle,
                     path,
                     optionsHandle,
                     &OnListCompleted,
@@ -963,19 +768,8 @@ public partial class Operator : SafeHandle
     /// <param name="path">Target path in the configured backend.</param>
     public void Delete(string path)
     {
-        Delete(path, executor: null);
-    }
-
-    /// <summary>
-    /// Deletes the file at the specified path using the provided executor.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    public void Delete(string path, Executor? executor)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
-        var result = NativeMethods.operator_delete(this, executorHandle, path);
+        var result = NativeMethods.operator_delete(this, path);
         ThrowIfErrorAndRelease(result);
     }
 
@@ -987,20 +781,7 @@ public partial class Operator : SafeHandle
     /// <returns>A task that completes when the native callback reports completion.</returns>
     public Task DeleteAsync(string path, CancellationToken cancellationToken = default)
     {
-        return DeleteAsync(path, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Deletes the file at the specified path asynchronously using the provided executor.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
-    /// <returns>A task that completes when the native callback reports completion.</returns>
-    public Task DeleteAsync(string path, Executor? executor, CancellationToken cancellationToken = default)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         return SubmitAsyncOperation(SubmitDeleteAsync, cancellationToken);
 
@@ -1010,7 +791,6 @@ public partial class Operator : SafeHandle
             {
                 return NativeMethods.operator_delete_async(
                     this,
-                    executorHandle,
                     path,
                     &OnDeleteCompleted,
                     context
@@ -1025,19 +805,8 @@ public partial class Operator : SafeHandle
     /// <param name="path">Target path in the configured backend.</param>
     public void CreateDir(string path)
     {
-        CreateDir(path, executor: null);
-    }
-
-    /// <summary>
-    /// Creates a directory at the specified path using the provided executor.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    public void CreateDir(string path, Executor? executor)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
-        var result = NativeMethods.operator_create_dir(this, executorHandle, path);
+        var result = NativeMethods.operator_create_dir(this, path);
         ThrowIfErrorAndRelease(result);
     }
 
@@ -1049,20 +818,7 @@ public partial class Operator : SafeHandle
     /// <returns>A task that completes when the native callback reports completion.</returns>
     public Task CreateDirAsync(string path, CancellationToken cancellationToken = default)
     {
-        return CreateDirAsync(path, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Creates a directory at the specified path asynchronously using the provided executor.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
-    /// <returns>A task that completes when the native callback reports completion.</returns>
-    public Task CreateDirAsync(string path, Executor? executor, CancellationToken cancellationToken = default)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         return SubmitAsyncOperation(SubmitCreateDirAsync, cancellationToken);
 
@@ -1072,7 +828,6 @@ public partial class Operator : SafeHandle
             {
                 return NativeMethods.operator_create_dir_async(
                     this,
-                    executorHandle,
                     path,
                     &OnCreateDirCompleted,
                     context
@@ -1088,20 +843,8 @@ public partial class Operator : SafeHandle
     /// <param name="targetPath">Target path in the configured backend.</param>
     public void Copy(string sourcePath, string targetPath)
     {
-        Copy(sourcePath, targetPath, executor: null);
-    }
-
-    /// <summary>
-    /// Copies a file from source path to target path using the provided executor.
-    /// </summary>
-    /// <param name="sourcePath">Source path in the configured backend.</param>
-    /// <param name="targetPath">Target path in the configured backend.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    public void Copy(string sourcePath, string targetPath, Executor? executor)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
-        var result = NativeMethods.operator_copy(this, executorHandle, sourcePath, targetPath);
+        var result = NativeMethods.operator_copy(this, sourcePath, targetPath);
         ThrowIfErrorAndRelease(result);
     }
 
@@ -1112,27 +855,12 @@ public partial class Operator : SafeHandle
     /// <param name="targetPath">Target path in the configured backend.</param>
     /// <param name="cancellationToken">Cancellation token for the managed task.</param>
     /// <returns>A task that completes when the native callback reports completion.</returns>
-    public Task CopyAsync(string sourcePath, string targetPath, CancellationToken cancellationToken = default)
-    {
-        return CopyAsync(sourcePath, targetPath, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Copies a file from source path to target path asynchronously using the provided executor.
-    /// </summary>
-    /// <param name="sourcePath">Source path in the configured backend.</param>
-    /// <param name="targetPath">Target path in the configured backend.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
-    /// <returns>A task that completes when the native callback reports completion.</returns>
     public Task CopyAsync(
         string sourcePath,
         string targetPath,
-        Executor? executor,
         CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         return SubmitAsyncOperation(SubmitCopyAsync, cancellationToken);
 
@@ -1142,7 +870,6 @@ public partial class Operator : SafeHandle
             {
                 return NativeMethods.operator_copy_async(
                     this,
-                    executorHandle,
                     sourcePath,
                     targetPath,
                     &OnCopyCompleted,
@@ -1159,20 +886,8 @@ public partial class Operator : SafeHandle
     /// <param name="targetPath">Target path in the configured backend.</param>
     public void Rename(string sourcePath, string targetPath)
     {
-        Rename(sourcePath, targetPath, executor: null);
-    }
-
-    /// <summary>
-    /// Renames a file from source path to target path using the provided executor.
-    /// </summary>
-    /// <param name="sourcePath">Source path in the configured backend.</param>
-    /// <param name="targetPath">Target path in the configured backend.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    public void Rename(string sourcePath, string targetPath, Executor? executor)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
-        var result = NativeMethods.operator_rename(this, executorHandle, sourcePath, targetPath);
+        var result = NativeMethods.operator_rename(this, sourcePath, targetPath);
         ThrowIfErrorAndRelease(result);
     }
 
@@ -1183,27 +898,12 @@ public partial class Operator : SafeHandle
     /// <param name="targetPath">Target path in the configured backend.</param>
     /// <param name="cancellationToken">Cancellation token for the managed task.</param>
     /// <returns>A task that completes when the native callback reports completion.</returns>
-    public Task RenameAsync(string sourcePath, string targetPath, CancellationToken cancellationToken = default)
-    {
-        return RenameAsync(sourcePath, targetPath, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Renames a file from source path to target path asynchronously using the provided executor.
-    /// </summary>
-    /// <param name="sourcePath">Source path in the configured backend.</param>
-    /// <param name="targetPath">Target path in the configured backend.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
-    /// <returns>A task that completes when the native callback reports completion.</returns>
     public Task RenameAsync(
         string sourcePath,
         string targetPath,
-        Executor? executor,
         CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         return SubmitAsyncOperation(SubmitRenameAsync, cancellationToken);
 
@@ -1213,7 +913,6 @@ public partial class Operator : SafeHandle
             {
                 return NativeMethods.operator_rename_async(
                     this,
-                    executorHandle,
                     sourcePath,
                     targetPath,
                     &OnRenameCompleted,
@@ -1229,19 +928,8 @@ public partial class Operator : SafeHandle
     /// <param name="path">Target path in the configured backend.</param>
     public void RemoveAll(string path)
     {
-        RemoveAll(path, executor: null);
-    }
-
-    /// <summary>
-    /// Removes all entries under the specified path recursively using the provided executor.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    public void RemoveAll(string path, Executor? executor)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
-        var result = NativeMethods.operator_remove_all(this, executorHandle, path);
+        var result = NativeMethods.operator_remove_all(this, path);
         ThrowIfErrorAndRelease(result);
     }
 
@@ -1253,20 +941,7 @@ public partial class Operator : SafeHandle
     /// <returns>A task that completes when the native callback reports completion.</returns>
     public Task RemoveAllAsync(string path, CancellationToken cancellationToken = default)
     {
-        return RemoveAllAsync(path, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Removes all entries under the specified path recursively asynchronously using the provided executor.
-    /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="executor">Executor used for this operation, or <see langword="null"/> to use default executor.</param>
-    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
-    /// <returns>A task that completes when the native callback reports completion.</returns>
-    public Task RemoveAllAsync(string path, Executor? executor, CancellationToken cancellationToken = default)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         return SubmitAsyncOperation(SubmitRemoveAllAsync, cancellationToken);
 
@@ -1276,7 +951,6 @@ public partial class Operator : SafeHandle
             {
                 return NativeMethods.operator_remove_all_async(
                     this,
-                    executorHandle,
                     path,
                     &OnRemoveAllCompleted,
                     context
@@ -1288,29 +962,12 @@ public partial class Operator : SafeHandle
     /// <summary>
     /// Creates a presigned read request asynchronously.
     /// </summary>
-    /// <param name="path">Target path in the configured backend.</param>
-    /// <param name="expiration">Presigned request expiration duration.</param>
-    /// <param name="cancellationToken">Cancellation token for the managed task.</param>
-    /// <returns>A task that resolves with a presigned request.</returns>
     public Task<PresignedRequest> PresignReadAsync(
         string path,
         TimeSpan expiration,
-        CancellationToken cancellationToken = default)
-    {
-        return PresignReadAsync(path, expiration, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Creates a presigned read request asynchronously using the provided executor.
-    /// </summary>
-    public Task<PresignedRequest> PresignReadAsync(
-        string path,
-        TimeSpan expiration,
-        Executor? executor,
         CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
         var expireNanos = Utilities.ToNanoseconds(expiration, nameof(expiration));
 
         return SubmitAsyncOperation<PresignedRequest>(SubmitPresignReadAsync, cancellationToken);
@@ -1321,7 +978,6 @@ public partial class Operator : SafeHandle
             {
                 return NativeMethods.operator_presign_read_async(
                     this,
-                    executorHandle,
                     path,
                     expireNanos,
                     &OnPresignReadCompleted,
@@ -1339,20 +995,7 @@ public partial class Operator : SafeHandle
         TimeSpan expiration,
         CancellationToken cancellationToken = default)
     {
-        return PresignWriteAsync(path, expiration, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Creates a presigned write request asynchronously using the provided executor.
-    /// </summary>
-    public Task<PresignedRequest> PresignWriteAsync(
-        string path,
-        TimeSpan expiration,
-        Executor? executor,
-        CancellationToken cancellationToken = default)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
         var expireNanos = Utilities.ToNanoseconds(expiration, nameof(expiration));
 
         return SubmitAsyncOperation<PresignedRequest>(SubmitPresignWriteAsync, cancellationToken);
@@ -1363,7 +1006,6 @@ public partial class Operator : SafeHandle
             {
                 return NativeMethods.operator_presign_write_async(
                     this,
-                    executorHandle,
                     path,
                     expireNanos,
                     &OnPresignWriteCompleted,
@@ -1381,20 +1023,7 @@ public partial class Operator : SafeHandle
         TimeSpan expiration,
         CancellationToken cancellationToken = default)
     {
-        return PresignStatAsync(path, expiration, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Creates a presigned stat request asynchronously using the provided executor.
-    /// </summary>
-    public Task<PresignedRequest> PresignStatAsync(
-        string path,
-        TimeSpan expiration,
-        Executor? executor,
-        CancellationToken cancellationToken = default)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
         var expireNanos = Utilities.ToNanoseconds(expiration, nameof(expiration));
 
         return SubmitAsyncOperation<PresignedRequest>(SubmitPresignStatAsync, cancellationToken);
@@ -1405,7 +1034,6 @@ public partial class Operator : SafeHandle
             {
                 return NativeMethods.operator_presign_stat_async(
                     this,
-                    executorHandle,
                     path,
                     expireNanos,
                     &OnPresignStatCompleted,
@@ -1423,20 +1051,7 @@ public partial class Operator : SafeHandle
         TimeSpan expiration,
         CancellationToken cancellationToken = default)
     {
-        return PresignDeleteAsync(path, expiration, executor: null, cancellationToken);
-    }
-
-    /// <summary>
-    /// Creates a presigned delete request asynchronously using the provided executor.
-    /// </summary>
-    public Task<PresignedRequest> PresignDeleteAsync(
-        string path,
-        TimeSpan expiration,
-        Executor? executor,
-        CancellationToken cancellationToken = default)
-    {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
         var expireNanos = Utilities.ToNanoseconds(expiration, nameof(expiration));
 
         return SubmitAsyncOperation<PresignedRequest>(SubmitPresignDeleteAsync, cancellationToken);
@@ -1447,7 +1062,6 @@ public partial class Operator : SafeHandle
             {
                 return NativeMethods.operator_presign_delete_async(
                     this,
-                    executorHandle,
                     path,
                     expireNanos,
                     &OnPresignDeleteCompleted,
@@ -1462,20 +1076,16 @@ public partial class Operator : SafeHandle
     /// </summary>
     /// <param name="path">Target path in the configured backend.</param>
     /// <param name="options">Optional read options.</param>
-    /// <param name="executor">Executor used for stream creation, or <see langword="null"/> to use default executor.</param>
     /// <returns>A readable stream over the given path.</returns>
     public OperatorInputStream OpenReadStream(
         string path,
-        ReadOptions? options = null,
-        Executor? executor = null)
+        ReadOptions? options = null)
     {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         using var nativeOptions = options?.BuildNativeOptionsHandle();
         var result = NativeMethods.operator_input_stream_create(
             this,
-            executorHandle,
             path,
             GetOptionsHandle(nativeOptions)
         );
@@ -1495,21 +1105,17 @@ public partial class Operator : SafeHandle
     /// <param name="path">Target path in the configured backend.</param>
     /// <param name="options">Optional write options.</param>
     /// <param name="bufferSize">Buffer size used by the managed write stream.</param>
-    /// <param name="executor">Executor used for stream creation, or <see langword="null"/> to use default executor.</param>
     /// <returns>A writable stream over the given path.</returns>
     public OperatorOutputStream OpenWriteStream(
         string path,
         WriteOptions? options = null,
-        int bufferSize = OperatorOutputStream.DefaultBufferSize,
-        Executor? executor = null)
+        int bufferSize = OperatorOutputStream.DefaultBufferSize)
     {
         ObjectDisposedException.ThrowIf(IsInvalid, this);
-        var executorHandle = GetExecutorHandle(executor);
 
         using var nativeOptions = options?.BuildNativeOptionsHandle();
         var result = NativeMethods.operator_output_stream_create(
             this,
-            executorHandle,
             path,
             GetOptionsHandle(nativeOptions)
         );
@@ -1549,23 +1155,6 @@ public partial class Operator : SafeHandle
         }
 
         return new Operator(newHandle);
-    }
-
-    /// <summary>
-    /// Gets the native executor handle for operation submission.
-    /// </summary>
-    /// <param name="executor">Executor instance or <see langword="null"/> to use default executor.</param>
-    /// <returns>Native executor pointer, or <see cref="IntPtr.Zero"/> when no executor is specified.</returns>
-    /// <exception cref="ObjectDisposedException">The executor has already been disposed.</exception>
-    private static IntPtr GetExecutorHandle(Executor? executor)
-    {
-        if (executor is null)
-        {
-            return IntPtr.Zero;
-        }
-
-        ObjectDisposedException.ThrowIf(executor.IsClosed || executor.IsInvalid, executor);
-        return executor.DangerousGetHandle();
     }
 
     /// <summary>

--- a/bindings/dotnet/src/executor.rs
+++ b/bindings/dotnet/src/executor.rs
@@ -15,12 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
 use std::ffi::c_void;
 use std::future::Future;
 use std::num::NonZeroUsize;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, LazyLock, OnceLock, RwLock};
+use std::sync::{Arc, OnceLock};
 use std::thread::available_parallelism;
 
 use crate::error::OpenDALError;
@@ -28,10 +26,6 @@ use crate::result::OpendalExecutorResult;
 use crate::utils::config_invalid_error;
 
 static DEFAULT_EXECUTOR: OnceLock<Arc<Executor>> = OnceLock::new();
-
-static EXECUTOR_REGISTRY: LazyLock<RwLock<HashMap<usize, Arc<Executor>>>> =
-    LazyLock::new(|| RwLock::new(HashMap::new()));
-static NEXT_EXECUTOR_ID: AtomicUsize = AtomicUsize::new(1);
 
 pub struct Executor {
     runtime: tokio::runtime::Runtime,
@@ -94,57 +88,52 @@ fn default_executor() -> Result<Arc<Executor>, OpenDALError> {
     Ok(executor)
 }
 
+/// Resolve the executor an operator binds at construction.
+///
 /// # Safety
 ///
-/// `executor` must be either null or a valid handle previously returned by
-/// `executor_create`.
-pub fn executor_or_default(executor: *const c_void) -> Result<Arc<Executor>, OpenDALError> {
+/// `executor` must be either null or a pointer previously returned by
+/// `executor_create` that stays alive for the duration of this call. The
+/// returned clone keeps the runtime alive on its own afterwards.
+pub(crate) unsafe fn executor_or_default(
+    executor: *const c_void,
+) -> Result<Arc<Executor>, OpenDALError> {
     if executor.is_null() {
         return default_executor();
     }
 
-    let id = executor as usize;
-    let registry = EXECUTOR_REGISTRY
-        .read()
-        .map_err(|_| config_invalid_error("executor registry is poisoned"))?;
-
-    registry
-        .get(&id)
-        .cloned()
-        .ok_or_else(|| config_invalid_error("executor handle is invalid or disposed"))
+    // SAFETY: per the contract above the pointer came from `executor_create`'s
+    // `Arc::into_raw` and is still alive, so bumping the strong count and
+    // rebuilding an owned clone is sound.
+    unsafe {
+        let executor = executor as *const Executor;
+        Arc::increment_strong_count(executor);
+        Ok(Arc::from_raw(executor))
+    }
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn executor_create(threads: usize) -> OpendalExecutorResult {
     match Executor::new(threads) {
-        Ok(executor) => {
-            let id = NEXT_EXECUTOR_ID.fetch_add(1, Ordering::Relaxed);
-            match EXECUTOR_REGISTRY.write() {
-                Ok(mut registry) => {
-                    registry.insert(id, Arc::new(executor));
-                    OpendalExecutorResult::ok(id as *mut c_void)
-                }
-                Err(_) => OpendalExecutorResult::from_error(config_invalid_error(
-                    "executor registry is poisoned",
-                )),
-            }
-        }
+        Ok(executor) => OpendalExecutorResult::ok(Arc::into_raw(Arc::new(executor)) as *mut c_void),
         Err(error) => OpendalExecutorResult::from_error(error),
     }
 }
 
 /// # Safety
 ///
-/// `executor` must be either null or a pointer-like handle returned by
-/// `executor_create`.
-/// This function is idempotent for unknown handles and null pointers.
+/// - `executor` must be either null or a pointer returned by `executor_create`.
+/// - The pointer must not be used after this call.
+/// - This function must be called at most once for the same pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn executor_free(executor: *mut c_void) {
     if executor.is_null() {
         return;
     }
 
-    if let Ok(mut registry) = EXECUTOR_REGISTRY.write() {
-        registry.remove(&(executor as usize));
+    // SAFETY: reclaims the reference handed out by `executor_create`.
+    // Operators hold their own clones, so in-flight work keeps its runtime.
+    unsafe {
+        drop(Arc::from_raw(executor as *const Executor));
     }
 }

--- a/bindings/dotnet/src/operator.rs
+++ b/bindings/dotnet/src/operator.rs
@@ -29,7 +29,7 @@ use crate::{
         OpendalOperatorResult, OpendalOptionsResult, OpendalPresignedRequestResult,
         OpendalReadResult, OpendalResult,
     },
-    utils::{collect_options, require_callback, require_cstr, require_data_ptr, require_operator},
+    utils::{collect_options, require_callback, require_cstr, require_data_ptr, require_op_handle},
     validators::prelude::{
         validate_concurrent_limit_options, validate_retry_options, validate_throttle_options,
         validate_timeout_options,
@@ -45,6 +45,37 @@ use std::time::Duration;
 use futures::StreamExt;
 
 use crate::executor::Executor;
+
+/// The operator handle handed to .NET: the opendal operator plus the executor
+/// it was bound to at construction. Every operation runs on that executor, and
+/// the owned `Arc` keeps the runtime alive for as long as the operator lives.
+pub(crate) struct OperatorHandle {
+    op: opendal::Operator,
+    executor: Arc<Executor>,
+}
+
+impl OperatorHandle {
+    /// Build a handle around a derived operator (layered or duplicated), keeping the same executor.
+    fn with_operator(&self, op: opendal::Operator) -> OperatorHandle {
+        OperatorHandle {
+            op,
+            executor: self.executor.clone(),
+        }
+    }
+
+    /// Clone the inner opendal operator into an owned value, e.g. to move it into a spawned task.
+    fn operator(&self) -> opendal::Operator {
+        self.op.clone()
+    }
+}
+
+impl std::ops::Deref for OperatorHandle {
+    type Target = opendal::Operator;
+
+    fn deref(&self) -> &opendal::Operator {
+        &self.op
+    }
+}
 
 /// Callback signature for async write completion.
 ///
@@ -246,12 +277,15 @@ pub unsafe extern "C" fn list_option_free(options: *mut opendal::options::ListOp
 ///   of at least `len` entries.
 /// - Every key/value entry in those arrays must be a valid null-terminated
 ///   UTF-8 string.
+/// - `executor` must be either null or a live pointer returned by
+///   `executor_create`. The operator binds it for its whole lifetime.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn operator_construct(
     scheme: *const c_char,
     options: *const HashMap<String, String>,
+    executor: *const c_void,
 ) -> OpendalOperatorResult {
-    match operator_construct_inner(scheme, options) {
+    match operator_construct_inner(scheme, options, executor) {
         Ok(op) => OpendalOperatorResult::ok(op),
         Err(error) => OpendalOperatorResult::from_error(error),
     }
@@ -260,6 +294,7 @@ pub unsafe extern "C" fn operator_construct(
 fn operator_construct_inner(
     scheme: *const c_char,
     options: *const HashMap<String, String>,
+    executor: *const c_void,
 ) -> Result<*mut c_void, OpenDALError> {
     let scheme = require_cstr(scheme, "scheme")?;
     let options = if options.is_null() {
@@ -267,24 +302,27 @@ fn operator_construct_inner(
     } else {
         unsafe { (&*options).clone() }
     };
+    // SAFETY: the caller keeps the executor handle alive across this call per
+    // `operator_construct`'s contract; the clone owns the runtime afterwards.
+    let executor = unsafe { executor_or_default(executor)? };
     let op =
         opendal::Operator::via_iter(scheme, options).map_err(OpenDALError::from_opendal_error)?;
-    Ok(Box::into_raw(Box::new(op)) as *mut c_void)
+    Ok(Box::into_raw(Box::new(OperatorHandle { op, executor })) as *mut c_void)
 }
 
 /// # Safety
 ///
-/// - `op` must be either null or a pointer returned by `operator_construct`.
+/// - `op_handle` must be either null or a pointer returned by `operator_construct`.
 /// - The pointer must not be used after this call.
 /// - This function must be called at most once for the same pointer.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn operator_free(op: *mut opendal::Operator) {
-    if op.is_null() {
+pub unsafe extern "C" fn operator_free(op_handle: *mut OperatorHandle) {
+    if op_handle.is_null() {
         return;
     }
 
     unsafe {
-        drop(Box::from_raw(op));
+        drop(Box::from_raw(op_handle));
     }
 }
 
@@ -293,20 +331,20 @@ pub unsafe extern "C" fn operator_free(op: *mut opendal::Operator) {
 /// On success, payload must be released by `opendal_operator_info_result_release`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn operator_info_get(
-    op: *const opendal::Operator,
+    op_handle: *const OperatorHandle,
 ) -> OpendalOperatorInfoResult {
-    match operator_info_get_inner(op) {
+    match operator_info_get_inner(op_handle) {
         Ok(value) => OpendalOperatorInfoResult::ok(value),
         Err(error) => OpendalOperatorInfoResult::from_error(error),
     }
 }
 
-fn operator_info_get_inner(op: *const opendal::Operator) -> Result<*mut c_void, OpenDALError> {
-    let op = require_operator(op)?;
-    let info = into_operator_info(op.info());
+fn operator_info_get_inner(op_handle: *const OperatorHandle) -> Result<*mut c_void, OpenDALError> {
+    let handle = require_op_handle(op_handle)?;
+    let info = into_operator_info(handle.info());
     Ok(Box::into_raw(Box::new(info)) as *mut c_void)
 }
 
@@ -340,10 +378,10 @@ pub(crate) unsafe fn operator_info_free(info: *mut OpendalOperatorInfo) {
 /// `operator_free`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_layer_retry(
-    op: *const opendal::Operator,
+    op_handle: *const OperatorHandle,
     jitter: bool,
     factor: f32,
     min_delay_nanos: u64,
@@ -351,7 +389,7 @@ pub extern "C" fn operator_layer_retry(
     max_times: usize,
 ) -> OpendalOperatorResult {
     match operator_layer_retry_inner(
-        op,
+        op_handle,
         jitter,
         factor,
         min_delay_nanos,
@@ -364,14 +402,14 @@ pub extern "C" fn operator_layer_retry(
 }
 
 fn operator_layer_retry_inner(
-    op: *const opendal::Operator,
+    op_handle: *const OperatorHandle,
     jitter: bool,
     factor: f32,
     min_delay_nanos: u64,
     max_delay_nanos: u64,
     max_times: usize,
 ) -> Result<*mut c_void, OpenDALError> {
-    let op = require_operator(op)?;
+    let handle = require_op_handle(op_handle)?;
     validate_retry_options(factor, min_delay_nanos, max_delay_nanos)?;
 
     let mut retry = opendal::layers::RetryLayer::new();
@@ -383,7 +421,9 @@ fn operator_layer_retry_inner(
         retry = retry.with_jitter();
     }
 
-    Ok(Box::into_raw(Box::new(op.clone().layer(retry))) as *mut c_void)
+    Ok(Box::into_raw(Box::new(
+        handle.with_operator(handle.operator().layer(retry)),
+    )) as *mut c_void)
 }
 
 /// Create a new operator layered with concurrent-limit behavior.
@@ -396,27 +436,27 @@ fn operator_layer_retry_inner(
 /// is true; otherwise the HTTP limit is left unset.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_layer_concurrent_limit(
-    op: *const opendal::Operator,
+    op_handle: *const OperatorHandle,
     permits: usize,
     http_permits: usize,
     has_http_permits: bool,
 ) -> OpendalOperatorResult {
     let http_permits = has_http_permits.then_some(http_permits);
-    match operator_layer_concurrent_limit_inner(op, permits, http_permits) {
+    match operator_layer_concurrent_limit_inner(op_handle, permits, http_permits) {
         Ok(value) => OpendalOperatorResult::ok(value),
         Err(error) => OpendalOperatorResult::from_error(error),
     }
 }
 
 fn operator_layer_concurrent_limit_inner(
-    op: *const opendal::Operator,
+    op_handle: *const OperatorHandle,
     permits: usize,
     http_permits: Option<usize>,
 ) -> Result<*mut c_void, OpenDALError> {
-    let op = require_operator(op)?;
+    let handle = require_op_handle(op_handle)?;
     validate_concurrent_limit_options(permits, http_permits)?;
 
     let mut concurrent_limit = opendal::layers::ConcurrentLimitLayer::new(permits);
@@ -424,7 +464,9 @@ fn operator_layer_concurrent_limit_inner(
         concurrent_limit = concurrent_limit.with_http_concurrent_limit(http_permits);
     }
 
-    Ok(Box::into_raw(Box::new(op.clone().layer(concurrent_limit))) as *mut c_void)
+    Ok(Box::into_raw(Box::new(
+        handle.with_operator(handle.operator().layer(concurrent_limit)),
+    )) as *mut c_void)
 }
 
 /// Create a new operator layered with capability override behavior.
@@ -433,29 +475,31 @@ fn operator_layer_concurrent_limit_inner(
 /// `operator_free`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `overrides` must be a valid null-terminated UTF-8 string.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_layer_capability_override(
-    op: *const opendal::Operator,
+    op_handle: *const OperatorHandle,
     overrides: *const c_char,
 ) -> OpendalOperatorResult {
-    match operator_layer_capability_override_inner(op, overrides) {
+    match operator_layer_capability_override_inner(op_handle, overrides) {
         Ok(value) => OpendalOperatorResult::ok(value),
         Err(error) => OpendalOperatorResult::from_error(error),
     }
 }
 
 fn operator_layer_capability_override_inner(
-    op: *const opendal::Operator,
+    op_handle: *const OperatorHandle,
     overrides: *const c_char,
 ) -> Result<*mut c_void, OpenDALError> {
-    let op = require_operator(op)?;
+    let handle = require_op_handle(op_handle)?;
     let overrides = require_cstr(overrides, "capability overrides")?;
     let layer = opendal::layers::CapabilityOverrideLayer::from_overrides(overrides)
         .map_err(OpenDALError::from_opendal_error)?;
 
-    Ok(Box::into_raw(Box::new(op.clone().layer(layer))) as *mut c_void)
+    Ok(Box::into_raw(Box::new(
+        handle.with_operator(handle.operator().layer(layer)),
+    )) as *mut c_void)
 }
 
 /// Create a new operator layered with timeout behavior.
@@ -464,32 +508,34 @@ fn operator_layer_capability_override_inner(
 /// `operator_free`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_layer_timeout(
-    op: *const opendal::Operator,
+    op_handle: *const OperatorHandle,
     timeout_nanos: u64,
     io_timeout_nanos: u64,
 ) -> OpendalOperatorResult {
-    match operator_layer_timeout_inner(op, timeout_nanos, io_timeout_nanos) {
+    match operator_layer_timeout_inner(op_handle, timeout_nanos, io_timeout_nanos) {
         Ok(value) => OpendalOperatorResult::ok(value),
         Err(error) => OpendalOperatorResult::from_error(error),
     }
 }
 
 fn operator_layer_timeout_inner(
-    op: *const opendal::Operator,
+    op_handle: *const OperatorHandle,
     timeout_nanos: u64,
     io_timeout_nanos: u64,
 ) -> Result<*mut c_void, OpenDALError> {
-    let op = require_operator(op)?;
+    let handle = require_op_handle(op_handle)?;
     validate_timeout_options(timeout_nanos, io_timeout_nanos)?;
 
     let timeout = opendal::layers::TimeoutLayer::new()
         .with_timeout(Duration::from_nanos(timeout_nanos))
         .with_io_timeout(Duration::from_nanos(io_timeout_nanos));
 
-    Ok(Box::into_raw(Box::new(op.clone().layer(timeout))) as *mut c_void)
+    Ok(Box::into_raw(Box::new(
+        handle.with_operator(handle.operator().layer(timeout)),
+    )) as *mut c_void)
 }
 
 /// Create a new operator layered with throttle behavior.
@@ -503,29 +549,31 @@ fn operator_layer_timeout_inner(
 /// never acquire enough quota to proceed.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_layer_throttle(
-    op: *const opendal::Operator,
+    op_handle: *const OperatorHandle,
     bandwidth: u32,
     burst: u32,
 ) -> OpendalOperatorResult {
-    match operator_layer_throttle_inner(op, bandwidth, burst) {
+    match operator_layer_throttle_inner(op_handle, bandwidth, burst) {
         Ok(value) => OpendalOperatorResult::ok(value),
         Err(error) => OpendalOperatorResult::from_error(error),
     }
 }
 
 fn operator_layer_throttle_inner(
-    op: *const opendal::Operator,
+    op_handle: *const OperatorHandle,
     bandwidth: u32,
     burst: u32,
 ) -> Result<*mut c_void, OpenDALError> {
-    let op = require_operator(op)?;
+    let handle = require_op_handle(op_handle)?;
     validate_throttle_options(bandwidth, burst)?;
 
     let throttle = opendal::layers::ThrottleLayer::new(bandwidth, burst);
-    Ok(Box::into_raw(Box::new(op.clone().layer(throttle))) as *mut c_void)
+    Ok(Box::into_raw(Box::new(
+        handle.with_operator(handle.operator().layer(throttle)),
+    )) as *mut c_void)
 }
 
 /// Create a new operator layered with MIME-guess behavior.
@@ -534,22 +582,26 @@ fn operator_layer_throttle_inner(
 /// `operator_free`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 #[unsafe(no_mangle)]
-pub extern "C" fn operator_layer_mime_guess(op: *const opendal::Operator) -> OpendalOperatorResult {
-    match operator_layer_mime_guess_inner(op) {
+pub extern "C" fn operator_layer_mime_guess(
+    op_handle: *const OperatorHandle,
+) -> OpendalOperatorResult {
+    match operator_layer_mime_guess_inner(op_handle) {
         Ok(value) => OpendalOperatorResult::ok(value),
         Err(error) => OpendalOperatorResult::from_error(error),
     }
 }
 
 fn operator_layer_mime_guess_inner(
-    op: *const opendal::Operator,
+    op_handle: *const OperatorHandle,
 ) -> Result<*mut c_void, OpenDALError> {
-    let op = require_operator(op)?;
+    let handle = require_op_handle(op_handle)?;
 
     let mime_guess = opendal::layers::MimeGuessLayer::default();
-    Ok(Box::into_raw(Box::new(op.clone().layer(mime_guess))) as *mut c_void)
+    Ok(Box::into_raw(Box::new(
+        handle.with_operator(handle.operator().layer(mime_guess)),
+    )) as *mut c_void)
 }
 
 /// Duplicate an operator instance.
@@ -557,48 +609,46 @@ fn operator_layer_mime_guess_inner(
 /// Returned pointer must be released with `operator_free`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 #[unsafe(no_mangle)]
-pub extern "C" fn operator_duplicate(op: *const opendal::Operator) -> OpendalOperatorResult {
-    match operator_duplicate_inner(op) {
+pub extern "C" fn operator_duplicate(op_handle: *const OperatorHandle) -> OpendalOperatorResult {
+    match operator_duplicate_inner(op_handle) {
         Ok(value) => OpendalOperatorResult::ok(value),
         Err(error) => OpendalOperatorResult::from_error(error),
     }
 }
 
-fn operator_duplicate_inner(op: *const opendal::Operator) -> Result<*mut c_void, OpenDALError> {
-    let op = require_operator(op)?;
-    Ok(Box::into_raw(Box::new(op.clone())) as *mut c_void)
+fn operator_duplicate_inner(op_handle: *const OperatorHandle) -> Result<*mut c_void, OpenDALError> {
+    let handle = require_op_handle(op_handle)?;
+    Ok(Box::into_raw(Box::new(handle.with_operator(handle.operator()))) as *mut c_void)
 }
 
 /// Delete `path` synchronously.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_delete(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
 ) -> OpendalResult {
-    match operator_delete_inner(op, executor, path) {
+    match operator_delete_inner(op_handle, path) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_delete_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?;
 
     executor
-        .block_on(op.delete(path))
+        .block_on(handle.delete(path))
         .map_err(OpenDALError::from_opendal_error)
 }
 
@@ -607,36 +657,34 @@ fn operator_delete_inner(
 /// The callback is invoked exactly once with the final result.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_delete_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     callback: Option<WriteCallback>,
     context: i64,
 ) -> OpendalResult {
-    match operator_delete_async_inner(op, executor, path, callback, context) {
+    match operator_delete_async_inner(op_handle, path, callback, context) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_delete_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     callback: Option<WriteCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     let callback = require_callback(callback)?;
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .delete(&path)
@@ -658,31 +706,29 @@ fn operator_delete_async_inner(
 /// Create directory at `path` synchronously.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_create_dir(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
 ) -> OpendalResult {
-    match operator_create_dir_inner(op, executor, path) {
+    match operator_create_dir_inner(op_handle, path) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_create_dir_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?;
 
     executor
-        .block_on(op.create_dir(path))
+        .block_on(handle.create_dir(path))
         .map_err(OpenDALError::from_opendal_error)
 }
 
@@ -691,36 +737,34 @@ fn operator_create_dir_inner(
 /// The callback is invoked exactly once with the final result.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_create_dir_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     callback: Option<WriteCallback>,
     context: i64,
 ) -> OpendalResult {
-    match operator_create_dir_async_inner(op, executor, path, callback, context) {
+    match operator_create_dir_async_inner(op_handle, path, callback, context) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_create_dir_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     callback: Option<WriteCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     let callback = require_callback(callback)?;
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .create_dir(&path)
@@ -742,34 +786,32 @@ fn operator_create_dir_async_inner(
 /// Copy from `source_path` to `target_path` synchronously.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `source_path` and `target_path` must be valid null-terminated UTF-8 strings.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_copy(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     source_path: *const c_char,
     target_path: *const c_char,
 ) -> OpendalResult {
-    match operator_copy_inner(op, executor, source_path, target_path) {
+    match operator_copy_inner(op_handle, source_path, target_path) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_copy_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     source_path: *const c_char,
     target_path: *const c_char,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let source_path = require_cstr(source_path, "source_path")?;
     let target_path = require_cstr(target_path, "target_path")?;
 
     executor
-        .block_on(op.copy(source_path, target_path))
+        .block_on(handle.copy(source_path, target_path))
         .map(|_| ())
         .map_err(OpenDALError::from_opendal_error)
 }
@@ -779,39 +821,37 @@ fn operator_copy_inner(
 /// The callback is invoked exactly once with the final result.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `source_path` and `target_path` must be valid null-terminated UTF-8 strings.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_copy_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     source_path: *const c_char,
     target_path: *const c_char,
     callback: Option<WriteCallback>,
     context: i64,
 ) -> OpendalResult {
-    match operator_copy_async_inner(op, executor, source_path, target_path, callback, context) {
+    match operator_copy_async_inner(op_handle, source_path, target_path, callback, context) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_copy_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     source_path: *const c_char,
     target_path: *const c_char,
     callback: Option<WriteCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let source_path = require_cstr(source_path, "source_path")?.to_string();
     let target_path = require_cstr(target_path, "target_path")?.to_string();
     let callback = require_callback(callback)?;
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .copy(&source_path, &target_path)
@@ -834,34 +874,32 @@ fn operator_copy_async_inner(
 /// Rename from `source_path` to `target_path` synchronously.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `source_path` and `target_path` must be valid null-terminated UTF-8 strings.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_rename(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     source_path: *const c_char,
     target_path: *const c_char,
 ) -> OpendalResult {
-    match operator_rename_inner(op, executor, source_path, target_path) {
+    match operator_rename_inner(op_handle, source_path, target_path) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_rename_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     source_path: *const c_char,
     target_path: *const c_char,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let source_path = require_cstr(source_path, "source_path")?;
     let target_path = require_cstr(target_path, "target_path")?;
 
     executor
-        .block_on(op.rename(source_path, target_path))
+        .block_on(handle.rename(source_path, target_path))
         .map_err(OpenDALError::from_opendal_error)
 }
 
@@ -870,39 +908,37 @@ fn operator_rename_inner(
 /// The callback is invoked exactly once with the final result.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `source_path` and `target_path` must be valid null-terminated UTF-8 strings.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_rename_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     source_path: *const c_char,
     target_path: *const c_char,
     callback: Option<WriteCallback>,
     context: i64,
 ) -> OpendalResult {
-    match operator_rename_async_inner(op, executor, source_path, target_path, callback, context) {
+    match operator_rename_async_inner(op_handle, source_path, target_path, callback, context) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_rename_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     source_path: *const c_char,
     target_path: *const c_char,
     callback: Option<WriteCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let source_path = require_cstr(source_path, "source_path")?.to_string();
     let target_path = require_cstr(target_path, "target_path")?.to_string();
     let callback = require_callback(callback)?;
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .rename(&source_path, &target_path)
@@ -924,27 +960,25 @@ fn operator_rename_async_inner(
 /// Remove `path` recursively synchronously.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_remove_all(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
 ) -> OpendalResult {
-    match operator_remove_all_inner(op, executor, path) {
+    match operator_remove_all_inner(op_handle, path) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_remove_all_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?;
 
     let options = opendal::options::DeleteOptions {
@@ -953,7 +987,7 @@ fn operator_remove_all_inner(
     };
 
     executor
-        .block_on(op.delete_options(path, options))
+        .block_on(handle.delete_options(path, options))
         .map_err(OpenDALError::from_opendal_error)
 }
 
@@ -962,32 +996,30 @@ fn operator_remove_all_inner(
 /// The callback is invoked exactly once with the final result.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_remove_all_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     callback: Option<WriteCallback>,
     context: i64,
 ) -> OpendalResult {
-    match operator_remove_all_async_inner(op, executor, path, callback, context) {
+    match operator_remove_all_async_inner(op_handle, path, callback, context) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_remove_all_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     callback: Option<WriteCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     let callback = require_callback(callback)?;
     let options = opendal::options::DeleteOptions {
@@ -995,7 +1027,7 @@ fn operator_remove_all_async_inner(
         ..Default::default()
     };
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .delete_options(&path, options)
@@ -1019,39 +1051,37 @@ fn operator_remove_all_async_inner(
 /// The callback is invoked exactly once with the final result.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_presign_read_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     expire_nanos: u64,
     callback: Option<PresignCallback>,
     context: i64,
 ) -> OpendalResult {
-    match operator_presign_read_async_inner(op, executor, path, expire_nanos, callback, context) {
+    match operator_presign_read_async_inner(op_handle, path, expire_nanos, callback, context) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_presign_read_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     expire_nanos: u64,
     callback: Option<PresignCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     let callback = require_callback(callback)?;
     let expire = Duration::from_nanos(expire_nanos);
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .presign_read(&path, expire)
@@ -1076,39 +1106,37 @@ fn operator_presign_read_async_inner(
 /// The callback is invoked exactly once with the final result.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_presign_write_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     expire_nanos: u64,
     callback: Option<PresignCallback>,
     context: i64,
 ) -> OpendalResult {
-    match operator_presign_write_async_inner(op, executor, path, expire_nanos, callback, context) {
+    match operator_presign_write_async_inner(op_handle, path, expire_nanos, callback, context) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_presign_write_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     expire_nanos: u64,
     callback: Option<PresignCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     let callback = require_callback(callback)?;
     let expire = Duration::from_nanos(expire_nanos);
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .presign_write(&path, expire)
@@ -1133,39 +1161,37 @@ fn operator_presign_write_async_inner(
 /// The callback is invoked exactly once with the final result.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_presign_stat_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     expire_nanos: u64,
     callback: Option<PresignCallback>,
     context: i64,
 ) -> OpendalResult {
-    match operator_presign_stat_async_inner(op, executor, path, expire_nanos, callback, context) {
+    match operator_presign_stat_async_inner(op_handle, path, expire_nanos, callback, context) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_presign_stat_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     expire_nanos: u64,
     callback: Option<PresignCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     let callback = require_callback(callback)?;
     let expire = Duration::from_nanos(expire_nanos);
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .presign_stat(&path, expire)
@@ -1190,39 +1216,37 @@ fn operator_presign_stat_async_inner(
 /// The callback is invoked exactly once with the final result.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_presign_delete_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     expire_nanos: u64,
     callback: Option<PresignCallback>,
     context: i64,
 ) -> OpendalResult {
-    match operator_presign_delete_async_inner(op, executor, path, expire_nanos, callback, context) {
+    match operator_presign_delete_async_inner(op_handle, path, expire_nanos, callback, context) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_presign_delete_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     expire_nanos: u64,
     callback: Option<PresignCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     let callback = require_callback(callback)?;
     let expire = Duration::from_nanos(expire_nanos);
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .presign_delete(&path, expire)
@@ -1247,16 +1271,15 @@ fn operator_presign_delete_async_inner(
 /// Returned pointer must be released by `operator_input_stream_free`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_input_stream_create(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::ReadOptions,
 ) -> OpendalOperatorResult {
-    match operator_input_stream_create_inner(op, executor, path, options) {
+    match operator_input_stream_create_inner(op_handle, path, options) {
         Ok(value) => OpendalOperatorResult::ok(value),
         Err(error) => OpendalOperatorResult::from_error(error),
     }
@@ -1295,13 +1318,12 @@ fn next_chunk_to_buffer(
 }
 
 fn operator_input_stream_create_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::ReadOptions,
 ) -> Result<*mut c_void, OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     let options = if options.is_null() {
         opendal::options::ReadOptions::default()
@@ -1323,7 +1345,7 @@ fn operator_input_stream_create_inner(
         ..Default::default()
     };
 
-    let stream_op = op.clone();
+    let stream_op = handle.operator();
     let stream = executor
         .block_on(async move {
             let reader = stream_op.reader_options(&path, reader_options).await?;
@@ -1440,16 +1462,15 @@ pub unsafe extern "C" fn operator_input_stream_free(stream: *mut c_void) {
 /// Returned pointer must be released by `operator_output_stream_free`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_output_stream_create(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::WriteOptions,
 ) -> OpendalOperatorResult {
-    match operator_output_stream_create_inner(op, executor, path, options) {
+    match operator_output_stream_create_inner(op_handle, path, options) {
         Ok(value) => OpendalOperatorResult::ok(value),
         Err(error) => OpendalOperatorResult::from_error(error),
     }
@@ -1467,13 +1488,12 @@ struct OutputStream {
 }
 
 fn operator_output_stream_create_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::WriteOptions,
 ) -> Result<*mut c_void, OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     let options = if options.is_null() {
         opendal::options::WriteOptions::default()
@@ -1481,7 +1501,7 @@ fn operator_output_stream_create_inner(
         unsafe { (&*options).clone() }
     };
 
-    let writer_op = op.clone();
+    let writer_op = handle.operator();
     let writer = executor
         .block_on(async move { writer_op.writer_options(&path, options).await })
         .map_err(OpenDALError::from_opendal_error)?;
@@ -1737,43 +1757,35 @@ pub unsafe extern "C" fn operator_output_stream_free(stream: *mut c_void) {
 /// already consumed the contents.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - `buffer` must be a handle from `write_buffer_create` whose contents
 ///   have not been consumed, and must not have been freed.
 /// - Calls taking the same buffer handle must not run concurrently.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn operator_write_with_options(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     buffer: *mut c_void,
     committed_in_current: usize,
     options: *const opendal::options::WriteOptions,
 ) -> OpendalResult {
-    match operator_write_with_options_inner(
-        op,
-        executor,
-        path,
-        buffer,
-        committed_in_current,
-        options,
-    ) {
+    match operator_write_with_options_inner(op_handle, path, buffer, committed_in_current, options)
+    {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_write_with_options_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     buffer: *mut c_void,
     committed_in_current: usize,
     options: *const opendal::options::WriteOptions,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?;
     if buffer.is_null() {
         return Err(crate::utils::config_invalid_error(
@@ -1792,7 +1804,7 @@ fn operator_write_with_options_inner(
     let payload = take_payload(slot, committed_in_current)?;
 
     executor
-        .block_on(op.write_options(path, payload, options))
+        .block_on(handle.write_options(path, payload, options))
         .map(|_| ())
         .map_err(OpenDALError::from_opendal_error)
 }
@@ -1803,7 +1815,7 @@ fn operator_write_with_options_inner(
 /// variant: consumed on a non-error return, untouched on error.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - `buffer` must be a handle from `write_buffer_create` whose contents
 ///   have not been consumed, and must not have been freed.
@@ -1811,8 +1823,7 @@ fn operator_write_with_options_inner(
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn operator_write_with_options_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     buffer: *mut c_void,
     committed_in_current: usize,
@@ -1821,8 +1832,7 @@ pub unsafe extern "C" fn operator_write_with_options_async(
     context: i64,
 ) -> OpendalResult {
     match operator_write_with_options_async_inner(
-        op,
-        executor,
+        op_handle,
         path,
         buffer,
         committed_in_current,
@@ -1840,8 +1850,7 @@ pub unsafe extern "C" fn operator_write_with_options_async(
 // can write with `?`.
 #[allow(clippy::too_many_arguments)]
 fn operator_write_with_options_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     buffer: *mut c_void,
     committed_in_current: usize,
@@ -1849,8 +1858,8 @@ fn operator_write_with_options_async_inner(
     callback: Option<WriteCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     let callback = require_callback(callback)?;
     if buffer.is_null() {
@@ -1869,7 +1878,7 @@ fn operator_write_with_options_async_inner(
     let slot = unsafe { &mut *(buffer as *mut WriteBufferSlot) };
     let payload = take_payload(slot, committed_in_current)?;
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .write_options(&path, payload, options)
@@ -1895,34 +1904,32 @@ fn operator_write_with_options_async_inner(
 /// for the duration of this call.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - When `len > 0`, `data` must be non-null and readable for `len` bytes.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn operator_write_bytes_with_options(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     data: *const u8,
     len: usize,
     options: *const opendal::options::WriteOptions,
 ) -> OpendalResult {
-    match operator_write_bytes_with_options_inner(op, executor, path, data, len, options) {
+    match operator_write_bytes_with_options_inner(op_handle, path, data, len, options) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_write_bytes_with_options_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     data: *const u8,
     len: usize,
     options: *const opendal::options::WriteOptions,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?;
     require_data_ptr(data, len)?;
     let options = if options.is_null() {
@@ -1942,7 +1949,7 @@ fn operator_write_bytes_with_options_inner(
     };
 
     executor
-        .block_on(op.write_options(path, payload, options))
+        .block_on(handle.write_options(path, payload, options))
         .map(|_| ())
         .map_err(OpenDALError::from_opendal_error)
 }
@@ -1954,14 +1961,13 @@ fn operator_write_bytes_with_options_inner(
 /// once with the final result.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - When `len > 0`, `data` must be non-null and readable for `len` bytes.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn operator_write_bytes_with_options_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     data: *const u8,
     len: usize,
@@ -1970,7 +1976,7 @@ pub unsafe extern "C" fn operator_write_bytes_with_options_async(
     context: i64,
 ) -> OpendalResult {
     match operator_write_bytes_with_options_async_inner(
-        op, executor, path, data, len, options, callback, context,
+        op_handle, path, data, len, options, callback, context,
     ) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
@@ -1982,8 +1988,7 @@ pub unsafe extern "C" fn operator_write_bytes_with_options_async(
 // can write with `?`.
 #[allow(clippy::too_many_arguments)]
 fn operator_write_bytes_with_options_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     data: *const u8,
     len: usize,
@@ -1991,8 +1996,8 @@ fn operator_write_bytes_with_options_async_inner(
     callback: Option<WriteCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     require_data_ptr(data, len)?;
     let callback = require_callback(callback)?;
@@ -2010,7 +2015,7 @@ fn operator_write_bytes_with_options_async_inner(
         bytes::Bytes::copy_from_slice(unsafe { std::slice::from_raw_parts(data, len) })
     };
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .write_options(&path, payload, options)
@@ -2035,30 +2040,28 @@ fn operator_write_bytes_with_options_async_inner(
 /// On success, the returned buffer must be released with `opendal_read_result_release`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - When `option_len > 0`, `option_keys` and `option_values` must be valid arrays.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn operator_read_with_options(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::ReadOptions,
 ) -> OpendalReadResult {
-    match operator_read_with_options_inner(op, executor, path, options) {
+    match operator_read_with_options_inner(op_handle, path, options) {
         Ok(value) => OpendalReadResult::ok(value),
         Err(error) => OpendalReadResult::from_error(error),
     }
 }
 
 fn operator_read_with_options_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::ReadOptions,
 ) -> Result<OpendalReadBuffer, OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?;
     let options = if options.is_null() {
         opendal::options::ReadOptions::default()
@@ -2067,7 +2070,7 @@ fn operator_read_with_options_inner(
     };
 
     let value = executor
-        .block_on(op.read_options(path, options))
+        .block_on(handle.read_options(path, options))
         .map_err(OpenDALError::from_opendal_error)?;
 
     Ok(OpendalReadBuffer::from_buffer(value))
@@ -2079,35 +2082,33 @@ fn operator_read_with_options_inner(
 /// result must be released with `opendal_read_result_release`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - When `option_len > 0`, `option_keys` and `option_values` must be valid arrays.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_read_with_options_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::ReadOptions,
     callback: Option<ReadCallback>,
     context: i64,
 ) -> OpendalResult {
-    match operator_read_with_options_async_inner(op, executor, path, options, callback, context) {
+    match operator_read_with_options_async_inner(op_handle, path, options, callback, context) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_read_with_options_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::ReadOptions,
     callback: Option<ReadCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     let callback = require_callback(callback)?;
     let options = if options.is_null() {
@@ -2116,7 +2117,7 @@ fn operator_read_with_options_async_inner(
         unsafe { (&*options).clone() }
     };
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .read_options(&path, options)
@@ -2141,30 +2142,28 @@ fn operator_read_with_options_async_inner(
 /// On success, returned payload must be released with `opendal_metadata_result_release`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - When `option_len > 0`, `option_keys` and `option_values` must be valid arrays.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_stat_with_options(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::StatOptions,
 ) -> OpendalMetadataResult {
-    match operator_stat_with_options_inner(op, executor, path, options) {
+    match operator_stat_with_options_inner(op_handle, path, options) {
         Ok(value) => OpendalMetadataResult::ok(value as *mut c_void),
         Err(error) => OpendalMetadataResult::from_error(error),
     }
 }
 
 fn operator_stat_with_options_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::StatOptions,
 ) -> Result<*mut OpendalMetadata, OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?;
     let options = if options.is_null() {
         opendal::options::StatOptions::default()
@@ -2173,7 +2172,7 @@ fn operator_stat_with_options_inner(
     };
 
     let metadata = executor
-        .block_on(op.stat_options(path, options))
+        .block_on(handle.stat_options(path, options))
         .map_err(OpenDALError::from_opendal_error)?;
     Ok(Box::into_raw(Box::new(OpendalMetadata::from_metadata(
         metadata,
@@ -2186,35 +2185,33 @@ fn operator_stat_with_options_inner(
 /// released with `opendal_metadata_result_release`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - When `option_len > 0`, `option_keys` and `option_values` must be valid arrays.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_stat_with_options_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::StatOptions,
     callback: Option<StatCallback>,
     context: i64,
 ) -> OpendalResult {
-    match operator_stat_with_options_async_inner(op, executor, path, options, callback, context) {
+    match operator_stat_with_options_async_inner(op_handle, path, options, callback, context) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_stat_with_options_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::StatOptions,
     callback: Option<StatCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     let callback = require_callback(callback)?;
     let options = if options.is_null() {
@@ -2223,7 +2220,7 @@ fn operator_stat_with_options_async_inner(
         unsafe { (&*options).clone() }
     };
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .stat_options(&path, options)
@@ -2249,30 +2246,28 @@ fn operator_stat_with_options_async_inner(
 /// On success, returned payload must be released with `opendal_entry_list_result_release`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - When `option_len > 0`, `option_keys` and `option_values` must be valid arrays.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_list_with_options(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::ListOptions,
 ) -> OpendalEntryListResult {
-    match operator_list_with_options_inner(op, executor, path, options) {
+    match operator_list_with_options_inner(op_handle, path, options) {
         Ok(value) => OpendalEntryListResult::ok(value),
         Err(error) => OpendalEntryListResult::from_error(error),
     }
 }
 
 fn operator_list_with_options_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::ListOptions,
 ) -> Result<*mut c_void, OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?;
     let options = if options.is_null() {
         opendal::options::ListOptions::default()
@@ -2281,7 +2276,7 @@ fn operator_list_with_options_inner(
     };
 
     let entries = executor
-        .block_on(op.list_options(path, options))
+        .block_on(handle.list_options(path, options))
         .map_err(OpenDALError::from_opendal_error)?;
 
     Ok(into_entry_list_ptr(entries))
@@ -2293,35 +2288,33 @@ fn operator_list_with_options_inner(
 /// released with `opendal_entry_list_result_release`.
 /// # Safety
 ///
-/// - `op` must be a valid operator pointer from `operator_construct`.
+/// - `op_handle` must be a valid operator pointer from `operator_construct`.
 /// - `path` must be a valid null-terminated UTF-8 string.
 /// - When `option_len > 0`, `option_keys` and `option_values` must be valid arrays.
 /// - `callback` must be a valid function pointer and remain callable until invoked.
 #[unsafe(no_mangle)]
 pub extern "C" fn operator_list_with_options_async(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::ListOptions,
     callback: Option<ListCallback>,
     context: i64,
 ) -> OpendalResult {
-    match operator_list_with_options_async_inner(op, executor, path, options, callback, context) {
+    match operator_list_with_options_async_inner(op_handle, path, options, callback, context) {
         Ok(()) => OpendalResult::ok(),
         Err(error) => OpendalResult::from_error(error),
     }
 }
 
 fn operator_list_with_options_async_inner(
-    op: *const opendal::Operator,
-    executor: *const c_void,
+    op_handle: *const OperatorHandle,
     path: *const c_char,
     options: *const opendal::options::ListOptions,
     callback: Option<ListCallback>,
     context: i64,
 ) -> Result<(), OpenDALError> {
-    let op = require_operator(op)?;
-    let executor = executor_or_default(executor)?;
+    let handle = require_op_handle(op_handle)?;
+    let executor = handle.executor.clone();
     let path = require_cstr(path, "path")?.to_string();
     let callback = require_callback(callback)?;
     let options = if options.is_null() {
@@ -2330,7 +2323,7 @@ fn operator_list_with_options_async_inner(
         unsafe { (&*options).clone() }
     };
 
-    let op = op.clone();
+    let op = handle.operator();
     executor.spawn(async move {
         let result = op
             .list_options(&path, options)

--- a/bindings/dotnet/src/utils.rs
+++ b/bindings/dotnet/src/utils.rs
@@ -47,14 +47,14 @@ pub fn require_cstr<'a>(value: *const c_char, field: &str) -> Result<&'a str, Op
     })
 }
 
-pub fn require_operator<'a>(
-    op: *const opendal::Operator,
-) -> Result<&'a opendal::Operator, OpenDALError> {
-    if op.is_null() {
-        return Err(config_invalid_error("operator pointer is null"));
+pub fn require_op_handle<'a>(
+    op_handle: *const crate::operator::OperatorHandle,
+) -> Result<&'a crate::operator::OperatorHandle, OpenDALError> {
+    if op_handle.is_null() {
+        return Err(config_invalid_error("operator handle is null"));
     }
 
-    Ok(unsafe { &*op })
+    Ok(unsafe { &*op_handle })
 }
 
 pub fn require_callback<T>(callback: Option<T>) -> Result<T, OpenDALError> {

--- a/website/docs/20-bindings/dotnet/02-getting-started.md
+++ b/website/docs/20-bindings/dotnet/02-getting-started.md
@@ -60,25 +60,27 @@ Console.WriteLine(Encoding.UTF8.GetString(bytes));
 
 ## Executors {#executors}
 
-Async operations run on a native Tokio runtime. By default OpenDAL uses a shared
-executor, so you can call the `…Async` methods without configuring anything. To
-control the worker-thread count, create an [`Executor`] and pass it to each call:
+Every operation runs on a native Tokio runtime. By default OpenDAL uses a shared
+executor, so you can call any method without configuring anything. To control
+the worker-thread count, create an [`Executor`] and bind it when you construct
+the operator:
 
 ```csharp
 using OpenDAL;
 using System.Text;
 
 using var executor = new Executor(2); // two Tokio worker threads
-using var op = new Operator("memory");
+using var op = new Operator("memory", executor: executor);
 
-await op.WriteAsync("hello.txt", Encoding.UTF8.GetBytes("Hello, World!"), executor);
-var bytes = await op.ReadAsync("hello.txt", executor);
+await op.WriteAsync("hello.txt", Encoding.UTF8.GetBytes("Hello, World!"));
+var bytes = await op.ReadAsync("hello.txt");
 ```
 
-Keep an `Executor` alive for the full lifetime of the operations using it.
-Disposing an `Executor` (or `Operator`) while awaited work is still running
-throws `ObjectDisposedException`, so dispose them only after the awaited
-operations complete. See [Going to production](./05-production.md#executor-and-lifetime)
+The operator keeps its runtime alive on the native side, so disposing the
+`Executor` handle never affects operators already bound to it — it only makes
+constructing new operators with it throw `ObjectDisposedException`. One
+operator binds one executor; to spread work across two runtimes, construct two
+operators. See [Going to production](./05-production.md#executor-and-lifetime)
 for the lifetime rules.
 
 [`Executor`]: https://github.com/apache/opendal/blob/main/bindings/dotnet/OpenDAL/Executor.cs

--- a/website/docs/20-bindings/dotnet/03-connecting.md
+++ b/website/docs/20-bindings/dotnet/03-connecting.md
@@ -59,6 +59,19 @@ Available scheme names and their keys are defined by OpenDAL; see the
 [Scheme reference](https://docs.rs/opendal/latest/opendal/enum.Scheme.html) and
 [Services](/services).
 
+### With a dedicated executor
+
+Both constructors accept an optional `Executor` that binds the operator to a
+dedicated Tokio runtime, for example to isolate a heavy workload. Leaving it
+out keeps the shared default:
+
+```csharp
+using var executor = new Executor(4);
+using var op = new Operator("s3", options, executor);
+```
+
+See [Getting started — Executors](./02-getting-started.md#executors).
+
 ## Credentials
 
 Credentials are just more configuration keys. Set them in the dictionary (or on
@@ -83,7 +96,8 @@ manager and pass them in when you build the operator.
 
 ## One operator per service and root
 
-An operator maps to one service and one root path. To work with two buckets or
-two roots, build two operators — they are lightweight handles. Use `Duplicate()`
-to create another handle to the same backend configuration. Always dispose
-operators with `using` or an explicit `Dispose()`.
+An operator maps to one service, one root path, and one executor. To work with
+two buckets, two roots, or two runtimes, build two operators — they are
+lightweight handles. Use `Duplicate()` to create another handle to the same
+backend configuration. Always dispose operators with `using` or an explicit
+`Dispose()`.

--- a/website/docs/20-bindings/dotnet/04-tasks.md
+++ b/website/docs/20-bindings/dotnet/04-tasks.md
@@ -29,6 +29,20 @@ byte[] bytes = op.Read("path/to/file");
 string text = Encoding.UTF8.GetString(bytes);
 ```
 
+When you only consume the payload, `Read<T>` skips the array: your callback
+gets a `ReadOnlySequence<byte>` over native memory and parses in place. The
+memory is only valid inside the callback:
+
+```csharp
+using System.Text;
+
+string text = op.Read("notes.txt", sequence => Encoding.UTF8.GetString(sequence));
+```
+
+Pick `byte[]` when you need to keep the bytes, and the callback form when you
+only parse them — it works with `Utf8JsonReader` and any other
+`ReadOnlySequence`-aware parser. `ReadAsync<T>` is the async counterpart.
+
 ## Read part of a file
 
 Pass a `ReadOptions` with an offset and length:
@@ -46,6 +60,24 @@ using System.Text;
 
 op.Write("path/to/file", Encoding.UTF8.GetBytes("Hello, World!"));
 ```
+
+When you are producing the payload rather than holding it, the fill callback
+serializes straight into native memory with no intermediate `byte[]` — the
+callback receives a native-backed `IBufferWriter<byte>`:
+
+```csharp
+using System.Text.Json;
+
+op.Write("data/config.json", writer =>
+{
+    using var json = new Utf8JsonWriter(writer);
+    JsonSerializer.Serialize(json, config);
+});
+```
+
+Pick `byte[]` when you already hold the bytes, and the fill callback when a
+serializer produces them. An optional `sizeHint` pre-sizes the buffer, and
+`WriteAsync` accepts the same callback.
 
 `WriteOptions` carry content headers, conditions, append mode, and concurrency:
 
@@ -74,7 +106,8 @@ reader.CopyTo(ms);
 ## Stream a large upload
 
 `OpenWriteStream` returns an `OperatorOutputStream`. Write incrementally, then
-dispose to flush and close the native resources deterministically:
+call `CompleteAsync` (or `Complete`) to flush, close the native writer, and
+surface any write error — an error raised during plain disposal is lost:
 
 ```csharp
 using System.Text;
@@ -83,7 +116,7 @@ await using (var writer = op.OpenWriteStream("big.bin"))
 {
     var chunk = Encoding.UTF8.GetBytes("stream-data");
     await writer.WriteAsync(chunk, 0, chunk.Length);
-    await writer.FlushAsync();
+    await writer.CompleteAsync();
 }
 ```
 

--- a/website/docs/20-bindings/dotnet/05-production.md
+++ b/website/docs/20-bindings/dotnet/05-production.md
@@ -46,6 +46,8 @@ The .NET binding exposes these layers in `OpenDAL.Layer`:
 | `RetryLayer` | Retries transient failures with exponential backoff (`MaxTimes`, `MinDelay`, `MaxDelay`, `Factor`, `Jitter`). |
 | `TimeoutLayer` | Bounds slow calls with a total `Timeout` and a per-I/O `IoTimeout`. |
 | `ConcurrentLimitLayer` | Caps the number of concurrent operations (constructor takes the permit count). |
+| `ThrottleLayer` | Rate-limits read and write byte flow (constructor takes bytes per second and the burst size). |
+| `MimeGuessLayer` | Fills in `Content-Type` from the file extension when the caller did not set one. |
 | `CapabilityOverrideLayer` | Overrides reported capabilities. |
 
 See [Concepts](../../03-concepts.mdx#layer) for the model.
@@ -96,14 +98,18 @@ requirement for safety. `Info` also exposes the operator's `Scheme`, `Root`, and
 The binding wraps native handles, so deterministic disposal matters:
 
 - Prefer `using` for `Operator`, `Executor`, and stream instances.
-- Keep an `Executor` alive for the full lifetime of the operations using it.
-- Disposing an `Executor` or `Operator` too early throws
-  `ObjectDisposedException`. For async calls, ensure disposal happens **after**
-  the awaited operations complete.
-- If you do not pass an `Executor`, OpenDAL uses a shared default executor.
+- An operator binds its executor at construction and keeps the runtime alive on
+  the native side. Disposing an `Executor` never affects operators already
+  bound to it — it only makes constructing new operators with it throw
+  `ObjectDisposedException`.
+- Dispose an `Operator` only after its awaited operations complete; disposal
+  while work is in flight is not supported.
+- If you do not bind an `Executor`, OpenDAL uses a shared default executor.
+- Layered operators (`WithLayer`) and `Duplicate()` handles inherit the base
+  operator's executor.
 
 See [Getting started — Executors](./02-getting-started.md#executors) for how to
-create and pass an executor.
+create and bind one.
 
 ## Path conventions
 


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Follow-up to @erickguan's suggestion in https://github.com/apache/opendal/pull/8020#discussion_r3717305249 that the executor registry could live on the .NET side instead of Rust.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The existing registry design turned out to be redundant and made the functions overly complex.

Every operation signature also carried an optional executor, callers had to keep it alive until every call finished, and that one parameter created far too many overloads.

I removed the registry and moved the executor binding to construction, which also makes the lifetime management more robust.

I also updated the docs while I was at it.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- **Executor handles become plain `Arc` pointers.** `executor_create` returns `Arc::into_raw`, `executor_free` reclaims it, and the registry plus its id counter are deleted.
- **The operator binds its executor at construction.** The native handle is now `OperatorHandle { op, executor: Arc<Executor> }`. The per-call executor parameters and the overloads that carried them disappear from both sides of the FFI, the `Operator` constructors gain an optional `executor`, and disposing an `Executor` no longer affects operators bound to it.
- **Internal names follow the new shape.** `OperatorHandle`, `require_op_handle`, and the `handle` locals spell out the handle vs operator distinction. Most of the diff's line count is this mechanical rename.

Benchmarks show almost no change, the contended and default paths both land within noise of the previous commit.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

Breaking:

| change | API | notes |
| --- | --- | --- |
| Removed | every per-call `Executor?` parameter and the overloads that carried it | Operations always run on the operator's bound executor, so wanting two runtimes means constructing two operators. |
| Changed | `Operator(scheme, options, executor)` and `Operator(config, executor)` | The constructors gain an optional `executor` parameter that binds the runtime once at construction. Null keeps the shared default. |
| Behavior | `Executor.Dispose` | Bound operators keep the runtime alive. Disposal only rejects new operator construction. |

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
This PR was developed with Claude Code (model: Fable 5).