### PR TITLE
refactor(services)!: use typed durations for moka configs

### DIFF
--- a/core/services/mini_moka/src/backend.rs
+++ b/core/services/mini_moka/src/backend.rs
@@ -34,6 +34,8 @@ use super::writer::MiniMokaWriter;
 #[derive(Debug, Default)]
 pub struct MiniMokaBuilder {
     pub(super) config: MiniMokaConfig,
+    pub(super) time_to_live: Option<Duration>,
+    pub(super) time_to_idle: Option<Duration>,
 }
 
 impl MiniMokaBuilder {
@@ -57,7 +59,7 @@ impl MiniMokaBuilder {
     /// Refer to [`mini-moka::sync::CacheBuilder::time_to_live`](https://docs.rs/mini-moka/latest/mini_moka/sync/struct.CacheBuilder.html#method.time_to_live)
     pub fn time_to_live(mut self, v: Duration) -> Self {
         if !v.is_zero() {
-            self.config.time_to_live = Some(format!("{}s", v.as_secs()));
+            self.time_to_live = Some(v);
         }
         self
     }
@@ -67,7 +69,7 @@ impl MiniMokaBuilder {
     /// Refer to [`mini-moka::sync::CacheBuilder::time_to_idle`](https://docs.rs/mini-moka/latest/mini_moka/sync/struct.CacheBuilder.html#method.time_to_idle)
     pub fn time_to_idle(mut self, v: Duration) -> Self {
         if !v.is_zero() {
-            self.config.time_to_idle = Some(format!("{}s", v.as_secs()));
+            self.time_to_idle = Some(v);
         }
         self
     }
@@ -99,12 +101,26 @@ impl Builder for MiniMokaBuilder {
         if let Some(v) = self.config.max_capacity {
             builder = builder.max_capacity(v);
         }
-        if let Some(value) = self.config.time_to_live.as_deref() {
-            let duration = signed_to_duration(value)?;
+        let time_to_live = match self.time_to_live {
+            Some(value) => Some(value),
+            None => self
+                .config
+                .time_to_live
+                .map(signed_duration_to_duration)
+                .transpose()?,
+        };
+        if let Some(duration) = time_to_live {
             builder = builder.time_to_live(duration);
         }
-        if let Some(value) = self.config.time_to_idle.as_deref() {
-            let duration = signed_to_duration(value)?;
+        let time_to_idle = match self.time_to_idle {
+            Some(value) => Some(value),
+            None => self
+                .config
+                .time_to_idle
+                .map(signed_duration_to_duration)
+                .transpose()?,
+        };
+        if let Some(duration) = time_to_idle {
             builder = builder.time_to_idle(duration);
         }
 
@@ -116,6 +132,23 @@ impl Builder for MiniMokaBuilder {
 
         debug!("backend build finished: {root}");
         Ok(MiniMokaBackend::new(core, root))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_preserves_subsecond_durations() {
+        let time_to_live = Duration::new(1, 500_000_001);
+        let time_to_idle = Duration::from_millis(750);
+        let builder = MiniMokaBuilder::default()
+            .time_to_live(time_to_live)
+            .time_to_idle(time_to_idle);
+
+        assert_eq!(builder.time_to_live, Some(time_to_live));
+        assert_eq!(builder.time_to_idle, Some(time_to_idle));
     }
 }
 

--- a/core/services/mini_moka/src/config.rs
+++ b/core/services/mini_moka/src/config.rs
@@ -18,6 +18,7 @@
 use opendal_core::Configurator;
 use opendal_core::OperatorUri;
 use opendal_core::Result;
+use opendal_core::raw::SignedDuration;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -35,11 +36,11 @@ pub struct MiniMokaConfig {
     /// Sets the time to live of the cache.
     ///
     /// Refer to [`mini-moka::sync::CacheBuilder::time_to_live`](https://docs.rs/mini-moka/latest/mini_moka/sync/struct.CacheBuilder.html#method.time_to_live)
-    pub time_to_live: Option<String>,
+    pub time_to_live: Option<SignedDuration>,
     /// Sets the time to idle of the cache.
     ///
     /// Refer to [`mini-moka::sync::CacheBuilder::time_to_idle`](https://docs.rs/mini-moka/latest/mini_moka/sync/struct.CacheBuilder.html#method.time_to_idle)
-    pub time_to_idle: Option<String>,
+    pub time_to_idle: Option<SignedDuration>,
 
     /// root path of this backend
     pub root: Option<String>,
@@ -61,7 +62,10 @@ impl Configurator for MiniMokaConfig {
     }
 
     fn into_builder(self) -> Self::Builder {
-        MiniMokaBuilder { config: self }
+        MiniMokaBuilder {
+            config: self,
+            ..Default::default()
+        }
     }
 }
 
@@ -78,7 +82,19 @@ mod tests {
 
         let cfg = MiniMokaConfig::from_uri(&uri)?;
         assert_eq!(cfg.root.as_deref(), Some("session"));
-        assert!(cfg.time_to_live.is_some());
+        assert_eq!(cfg.time_to_live, Some(SignedDuration::from_secs(300)));
+        Ok(())
+    }
+
+    #[test]
+    fn from_iter_parses_cache_durations() -> Result<()> {
+        let cfg = MiniMokaConfig::from_iter([
+            ("time_to_live".to_string(), "1500ms".to_string()),
+            ("time_to_idle".to_string(), "2s".to_string()),
+        ])?;
+
+        assert_eq!(cfg.time_to_live, Some(SignedDuration::from_millis(1500)));
+        assert_eq!(cfg.time_to_idle, Some(SignedDuration::from_secs(2)));
         Ok(())
     }
 }

--- a/core/services/moka/src/backend.rs
+++ b/core/services/moka/src/backend.rs
@@ -41,6 +41,8 @@ pub type MokaCacheBuilder<K, V> = moka::future::CacheBuilder<K, V, MokaCache<K, 
 pub struct MokaBuilder {
     pub(super) config: MokaConfig,
     pub(super) builder: MokaCacheBuilder<String, MokaValue>,
+    pub(super) time_to_live: Option<Duration>,
+    pub(super) time_to_idle: Option<Duration>,
 }
 
 impl Debug for MokaBuilder {
@@ -113,7 +115,7 @@ impl MokaBuilder {
     /// Refer to [`moka::future::CacheBuilder::time_to_live`](https://docs.rs/moka/latest/moka/future/struct.CacheBuilder.html#method.time_to_live)
     pub fn time_to_live(mut self, v: Duration) -> Self {
         if !v.is_zero() {
-            self.config.time_to_live = Some(format!("{}s", v.as_secs()));
+            self.time_to_live = Some(v);
         }
         self
     }
@@ -123,7 +125,7 @@ impl MokaBuilder {
     /// Refer to [`moka::future::CacheBuilder::time_to_idle`](https://docs.rs/moka/latest/moka/sync/struct.CacheBuilder.html#method.time_to_idle)
     pub fn time_to_idle(mut self, v: Duration) -> Self {
         if !v.is_zero() {
-            self.config.time_to_idle = Some(format!("{}s", v.as_secs()));
+            self.time_to_idle = Some(v);
         }
         self
     }
@@ -161,12 +163,26 @@ impl Builder for MokaBuilder {
         if let Some(v) = self.config.max_capacity {
             builder = builder.max_capacity(v);
         }
-        if let Some(value) = self.config.time_to_live.as_deref() {
-            let duration = signed_to_duration(value)?;
+        let time_to_live = match self.time_to_live {
+            Some(value) => Some(value),
+            None => self
+                .config
+                .time_to_live
+                .map(signed_duration_to_duration)
+                .transpose()?,
+        };
+        if let Some(duration) = time_to_live {
             builder = builder.time_to_live(duration);
         }
-        if let Some(value) = self.config.time_to_idle.as_deref() {
-            let duration = signed_to_duration(value)?;
+        let time_to_idle = match self.time_to_idle {
+            Some(value) => Some(value),
+            None => self
+                .config
+                .time_to_idle
+                .map(signed_duration_to_duration)
+                .transpose()?,
+        };
+        if let Some(duration) = time_to_idle {
             builder = builder.time_to_idle(duration);
         }
 
@@ -367,5 +383,22 @@ impl Service for MokaBackend {
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_preserves_subsecond_durations() {
+        let time_to_live = Duration::new(1, 500_000_001);
+        let time_to_idle = Duration::from_millis(750);
+        let builder = MokaBuilder::default()
+            .time_to_live(time_to_live)
+            .time_to_idle(time_to_idle);
+
+        assert_eq!(builder.time_to_live, Some(time_to_live));
+        assert_eq!(builder.time_to_idle, Some(time_to_idle));
     }
 }

--- a/core/services/moka/src/config.rs
+++ b/core/services/moka/src/config.rs
@@ -19,6 +19,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use super::backend::MokaBuilder;
+use opendal_core::raw::SignedDuration;
 use opendal_core::{Configurator, OperatorUri, Result};
 
 /// Config for Moka services support.
@@ -35,11 +36,11 @@ pub struct MokaConfig {
     /// Sets the time to live of the cache.
     ///
     /// Refer to [`moka::future::CacheBuilder::time_to_live`](https://docs.rs/moka/latest/moka/future/struct.CacheBuilder.html#method.time_to_live)
-    pub time_to_live: Option<String>,
+    pub time_to_live: Option<SignedDuration>,
     /// Sets the time to idle of the cache.
     ///
     /// Refer to [`moka::future::CacheBuilder::time_to_idle`](https://docs.rs/moka/latest/moka/future/struct.CacheBuilder.html#method.time_to_idle)
-    pub time_to_idle: Option<String>,
+    pub time_to_idle: Option<SignedDuration>,
 
     /// root path of this backend
     pub root: Option<String>,
@@ -86,5 +87,17 @@ mod tests {
         let cfg = MokaConfig::from_uri(&uri).unwrap();
         assert_eq!(cfg.name.as_deref(), Some("session"));
         assert_eq!(cfg.root.as_deref(), Some("cache"));
+    }
+
+    #[test]
+    fn from_iter_parses_cache_durations() -> Result<()> {
+        let cfg = MokaConfig::from_iter([
+            ("time_to_live".to_string(), "1500ms".to_string()),
+            ("time_to_idle".to_string(), "2s".to_string()),
+        ])?;
+
+        assert_eq!(cfg.time_to_live, Some(SignedDuration::from_millis(1500)));
+        assert_eq!(cfg.time_to_idle, Some(SignedDuration::from_secs(2)));
+        Ok(())
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

  Closes #8025

  # Rationale for this change

  Moka and MiniMoka are the remaining services that keep cache durations as strings and parse them again during backend construction. Their builders also format `Duration::as_secs()`, which truncates subsecond values
  before parsing.

  # What changes are included in this PR?

  - Store Moka and MiniMoka TTL/TTI config values as `SignedDuration`.
  - Convert configured values with `signed_duration_to_duration`
  - Keep builder-provided `Duration` values as lossless overrides
  - Add config parsing and builder precision regression tests

  # Are there any user-facing changges?

  Yes. `MokaConfig` and `MiniMokaConfig` now expose `Option<SignedDuration>` for `time_to_live` and `time_to_idle` instead of `Option<String>`. String-based configuration continues to accept duration values such as
  `1500ms`