### PR TITLE
Revert "fix(core): deserialize duration config values from strings"

### DIFF
--- a/core/core/src/raw/time.rs
+++ b/core/core/src/raw/time.rs
@@ -18,12 +18,11 @@
 //! Time related utils.
 
 use crate::*;
-
+use jiff::SignedDuration;
 use std::fmt;
 use std::ops::{Add, AddAssign, Sub, SubAssign};
 use std::str::FromStr;
 
-pub use jiff::SignedDuration;
 pub use std::time::{Duration, UNIX_EPOCH};
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub use std::time::{Instant, SystemTime};
@@ -255,6 +254,7 @@ impl SubAssign<Duration> for Timestamp {
     }
 }
 
+/// Convert an unsigned [`Duration`] into a jiff [`SignedDuration`].
 /// Parse a duration encoded either as ISO-8601 (e.g. `PT5M`) or friendly (e.g. `5m`).
 #[inline]
 pub fn signed_to_duration(value: &str) -> Result<Duration> {
@@ -262,13 +262,7 @@ pub fn signed_to_duration(value: &str) -> Result<Duration> {
         Error::new(ErrorKind::ConfigInvalid, "failed to parse duration").set_source(err)
     })?;
 
-    signed_duration_to_duration(signed)
-}
-
-/// Convert a jiff [`SignedDuration`] into an unsigned [`Duration`].
-#[inline]
-pub fn signed_duration_to_duration(value: SignedDuration) -> Result<Duration> {
-    Duration::try_from(value).map_err(|err| {
+    Duration::try_from(signed).map_err(|err| {
         Error::new(
             ErrorKind::ConfigInvalid,
             "duration must not be negative or overflow",
@@ -309,10 +303,5 @@ mod tests {
         let s = "Sat, 29 Oct 1994 19:43:31 +0000";
         let v = Timestamp::parse_rfc2822(s).unwrap();
         assert_eq!("Sat, 29 Oct 1994 19:43:31 GMT", v.format_http_date());
-    }
-
-    #[test]
-    fn test_signed_duration_to_duration_rejects_negative_values() {
-        assert!(signed_duration_to_duration(SignedDuration::from_secs(-1)).is_err());
     }
 }

--- a/core/services/cloudflare-kv/src/backend.rs
+++ b/core/services/cloudflare-kv/src/backend.rs
@@ -37,7 +37,6 @@ use super::writer::CloudflareWriter;
 #[derive(Default)]
 pub struct CloudflareKvBuilder {
     pub(super) config: CloudflareKvConfig,
-    pub(super) default_ttl: Option<Duration>,
 }
 
 impl Debug for CloudflareKvBuilder {
@@ -77,7 +76,7 @@ impl CloudflareKvBuilder {
     ///
     /// If set, we will specify `EX` for write operations.
     pub fn default_ttl(mut self, ttl: Duration) -> Self {
-        self.default_ttl = Some(ttl);
+        self.config.default_ttl = Some(ttl);
         self
     }
 
@@ -97,14 +96,6 @@ impl Builder for CloudflareKvBuilder {
     type Config = CloudflareKvConfig;
 
     fn build(self) -> Result<impl Service> {
-        let default_ttl = match self.default_ttl {
-            Some(ttl) => Some(ttl),
-            None => self
-                .config
-                .default_ttl
-                .map(signed_duration_to_duration)
-                .transpose()?,
-        };
         let api_token = match &self.config.api_token {
             Some(api_token) => format_authorization_by_bearer(api_token)?,
             None => {
@@ -130,7 +121,7 @@ impl Builder for CloudflareKvBuilder {
         };
 
         // Validate default TTL is at least 60 seconds if specified
-        if let Some(ttl) = default_ttl
+        if let Some(ttl) = self.config.default_ttl
             && ttl < Duration::from_secs(60)
         {
             return Err(Error::new(
@@ -152,7 +143,7 @@ impl Builder for CloudflareKvBuilder {
                 api_token,
                 account_id,
                 namespace_id,
-                expiration_ttl: default_ttl,
+                expiration_ttl: self.config.default_ttl,
                 info: ServiceInfo::new(CLOUDFLARE_KV_SCHEME, &root, ""),
                 capability: Capability {
                     create_dir: true,

--- a/core/services/cloudflare-kv/src/config.rs
+++ b/core/services/cloudflare-kv/src/config.rs
@@ -34,7 +34,7 @@ pub struct CloudflareKvConfig {
     /// The namespace ID. Used as URI path parameter.
     pub namespace_id: Option<String>,
     /// The default ttl for write operations.
-    pub default_ttl: Option<SignedDuration>,
+    pub default_ttl: Option<Duration>,
 
     /// Root within this backend.
     pub root: Option<String>,
@@ -94,10 +94,7 @@ impl opendal_core::Configurator for CloudflareKvConfig {
     }
 
     fn into_builder(self) -> Self::Builder {
-        CloudflareKvBuilder {
-            config: self,
-            default_ttl: None,
-        }
+        CloudflareKvBuilder { config: self }
     }
 }
 
@@ -127,13 +124,5 @@ mod tests {
             OperatorUri::new("cloudflare-kv://acc123", Vec::<(String, String)>::new()).unwrap();
 
         assert!(CloudflareKvConfig::from_uri(&uri).is_err());
-    }
-
-    #[test]
-    fn from_iter_parses_default_ttl() {
-        let cfg = CloudflareKvConfig::from_iter([("default_ttl".to_string(), "PT1M".to_string())])
-            .unwrap();
-
-        assert_eq!(cfg.default_ttl, Some(SignedDuration::from_mins(1)));
     }
 }

--- a/core/services/memcached/src/backend.rs
+++ b/core/services/memcached/src/backend.rs
@@ -34,7 +34,6 @@ use super::writer::MemcachedWriter;
 #[derive(Debug, Default)]
 pub struct MemcachedBuilder {
     pub(super) config: MemcachedConfig,
-    pub(super) default_ttl: Option<Duration>,
 }
 
 impl MemcachedBuilder {
@@ -75,7 +74,7 @@ impl MemcachedBuilder {
 
     /// Set the default ttl for memcached services.
     pub fn default_ttl(mut self, ttl: Duration) -> Self {
-        self.default_ttl = Some(ttl);
+        self.config.default_ttl = Some(ttl);
         self
     }
 
@@ -98,14 +97,6 @@ impl Builder for MemcachedBuilder {
     type Config = MemcachedConfig;
 
     fn build(self) -> Result<impl Service> {
-        let default_ttl = match self.default_ttl {
-            Some(ttl) => Some(ttl),
-            None => self
-                .config
-                .default_ttl
-                .map(signed_duration_to_duration)
-                .transpose()?,
-        };
         let endpoint_raw = self.config.endpoint.clone().ok_or_else(|| {
             Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
                 .with_context("service", MEMCACHED_SCHEME)
@@ -180,7 +171,7 @@ impl Builder for MemcachedBuilder {
             endpoint,
             self.config.username,
             self.config.password,
-            default_ttl,
+            self.config.default_ttl,
             self.config.connection_pool_max_size,
         ))
         .with_normalized_root(root))

--- a/core/services/memcached/src/config.rs
+++ b/core/services/memcached/src/config.rs
@@ -44,7 +44,7 @@ pub struct MemcachedConfig {
     /// Memcached password, optional.
     pub password: Option<String>,
     /// The default ttl for put operations.
-    pub default_ttl: Option<SignedDuration>,
+    pub default_ttl: Option<Duration>,
     /// The maximum number of connections allowed.
     ///
     /// default is 10
@@ -81,10 +81,7 @@ impl Configurator for MemcachedConfig {
     }
 
     fn into_builder(self) -> Self::Builder {
-        MemcachedBuilder {
-            config: self,
-            default_ttl: None,
-        }
+        MemcachedBuilder { config: self }
     }
 }
 
@@ -102,14 +99,6 @@ mod tests {
         let cfg = MemcachedConfig::from_uri(&uri)?;
         assert_eq!(cfg.endpoint.as_deref(), Some("tcp://cache.local:11211"));
         assert_eq!(cfg.root.as_deref(), Some("app/session"));
-        Ok(())
-    }
-
-    #[test]
-    fn from_iter_parses_default_ttl() -> Result<()> {
-        let cfg = MemcachedConfig::from_iter([("default_ttl".to_string(), "1500ms".to_string())])?;
-
-        assert_eq!(cfg.default_ttl, Some(SignedDuration::from_millis(1500)));
         Ok(())
     }
 }

--- a/core/services/redis/src/backend.rs
+++ b/core/services/redis/src/backend.rs
@@ -44,7 +44,6 @@ const DEFAULT_REDIS_PORT: u16 = 6379;
 #[derive(Debug, Default)]
 pub struct RedisBuilder {
     pub(super) config: RedisConfig,
-    pub(super) default_ttl: Option<Duration>,
 }
 
 impl RedisBuilder {
@@ -109,7 +108,7 @@ impl RedisBuilder {
     ///
     /// If set, we will specify `EX` for write operations.
     pub fn default_ttl(mut self, ttl: Duration) -> Self {
-        self.default_ttl = Some(ttl);
+        self.config.default_ttl = Some(ttl);
         self
     }
 
@@ -145,14 +144,6 @@ impl Builder for RedisBuilder {
     type Config = RedisConfig;
 
     fn build(self) -> Result<impl Service> {
-        let default_ttl = match self.default_ttl {
-            Some(ttl) => Some(ttl),
-            None => self
-                .config
-                .default_ttl
-                .map(signed_duration_to_duration)
-                .transpose()?,
-        };
         let root = normalize_root(
             self.config
                 .root
@@ -179,7 +170,7 @@ impl Builder for RedisBuilder {
                 endpoints,
                 None,
                 Some(client),
-                default_ttl,
+                self.config.default_ttl,
                 self.config.connection_pool_max_size,
             ))
             .with_normalized_root(root))
@@ -203,7 +194,7 @@ impl Builder for RedisBuilder {
                 endpoint,
                 Some(client),
                 None,
-                default_ttl,
+                self.config.default_ttl,
                 self.config.connection_pool_max_size,
             ))
             .with_normalized_root(root))

--- a/core/services/redis/src/config.rs
+++ b/core/services/redis/src/config.rs
@@ -59,7 +59,7 @@ pub struct RedisConfig {
     /// default is db 0
     pub db: i64,
     /// The default ttl for put operations.
-    pub default_ttl: Option<SignedDuration>,
+    pub default_ttl: Option<Duration>,
 }
 
 impl Debug for RedisConfig {
@@ -120,10 +120,7 @@ impl Configurator for RedisConfig {
     }
 
     fn into_builder(self) -> Self::Builder {
-        RedisBuilder {
-            config: self,
-            default_ttl: None,
-        }
+        RedisBuilder { config: self }
     }
 }
 
@@ -156,14 +153,6 @@ mod tests {
         assert_eq!(cfg.endpoint.as_deref(), Some("redis://localhost:6379"));
         assert_eq!(cfg.db, 0);
         assert_eq!(cfg.root.as_deref(), Some("app/data"));
-        Ok(())
-    }
-
-    #[test]
-    fn from_iter_parses_default_ttl() -> Result<()> {
-        let cfg = RedisConfig::from_iter([("default_ttl".to_string(), "5s".to_string())])?;
-
-        assert_eq!(cfg.default_ttl, Some(SignedDuration::from_secs(5)));
         Ok(())
     }
 

--- a/dev/src/generate/parser.rs
+++ b/dev/src/generate/parser.rs
@@ -83,7 +83,7 @@ pub enum ConfigType {
     Bool,
     /// Mapping to rust's `String`
     String,
-    /// Mapping to rust's `Duration` and `SignedDuration`
+    /// Mapping to rust's `Duration`
     Duration,
 
     /// Mapping to rust's `usize`
@@ -113,7 +113,7 @@ impl FromStr for ConfigType {
         Ok(match s {
             "bool" => ConfigType::Bool,
             "String" => ConfigType::String,
-            "Duration" | "SignedDuration" => ConfigType::Duration,
+            "Duration" => ConfigType::Duration,
 
             "usize" => ConfigType::Usize,
             "u64" => ConfigType::U64,
@@ -507,19 +507,6 @@ mod tests {
                     name: "root".to_string(),
                     value: ConfigType::String,
                     optional: false,
-                    deprecated: None,
-                    comments: "".to_string(),
-                    group: None,
-                    default_value: None,
-                    example: None,
-                },
-            ),
-            (
-                "default_ttl: Option<SignedDuration>",
-                Config {
-                    name: "default_ttl".to_string(),
-                    value: ConfigType::Duration,
-                    optional: true,
                     deprecated: None,
                     comments: "".to_string(),
                     group: None,

--- a/dev/src/generate/python.rs
+++ b/dev/src/generate/python.rs
@@ -264,7 +264,8 @@ fn is_path_like_field(name: &str) -> bool {
 fn make_config_field_type(field: ViaDeserialize<Config>) -> Result<String, minijinja::Error> {
     Ok(match field.value {
         ConfigType::Bool => "bool".to_string(),
-        // Duration values cross the Python binding as strings, e.g. "5s".
+        // Duration is typed `str` (a humantime string, e.g. "5s"). See #7887:
+        // core cannot yet deserialize Duration config fields from strings.
         ConfigType::Duration => "str".to_string(),
         ConfigType::Usize
         | ConfigType::U64


### PR DESCRIPTION
This reverts commit 188f0c0744991f8fb2dc703ade6fd272832743c4. Exclusion for 0.58.2 release.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Part of #8026.

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
