### PR TITLE
feat(services): retry HTTP 429 responses

### DIFF
--- a/core/services/azblob/src/core.rs
+++ b/core/services/azblob/src/core.rs
@@ -1155,6 +1155,7 @@ mod error {
             StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED | StatusCode::CONFLICT => {
                 (ErrorKind::ConditionNotMatch, false)
             }
+            StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
             StatusCode::INTERNAL_SERVER_ERROR
             | StatusCode::BAD_GATEWAY
             | StatusCode::SERVICE_UNAVAILABLE

--- a/core/services/azdls/src/core.rs
+++ b/core/services/azdls/src/core.rs
@@ -683,6 +683,7 @@ mod error {
             StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED | StatusCode::CONFLICT => {
                 (ErrorKind::ConditionNotMatch, false)
             }
+            StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
             StatusCode::INTERNAL_SERVER_ERROR
             | StatusCode::BAD_GATEWAY
             | StatusCode::SERVICE_UNAVAILABLE

--- a/core/services/hf/src/core.rs
+++ b/core/services/hf/src/core.rs
@@ -806,6 +806,7 @@ mod error {
             StatusCode::PRECONDITION_FAILED => {
                 (ErrorKind::ConditionNotMatch, branch_updated_conflict)
             }
+            StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
             StatusCode::INTERNAL_SERVER_ERROR
             | StatusCode::BAD_GATEWAY
             | StatusCode::SERVICE_UNAVAILABLE

--- a/core/services/oss/src/core.rs
+++ b/core/services/oss/src/core.rs
@@ -1166,6 +1166,7 @@ mod error {
             StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED | StatusCode::CONFLICT => {
                 (ErrorKind::ConditionNotMatch, false)
             }
+            StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
             StatusCode::INTERNAL_SERVER_ERROR
             | StatusCode::BAD_GATEWAY
             | StatusCode::SERVICE_UNAVAILABLE


### PR DESCRIPTION
# Which issue does this PR close?

N/A. This is a small consistency improvement across service error parsers.

# Rationale for this change

`RetryLayer` retries only errors marked as temporary. Azure Blob, Azure Data Lake Storage, OSS, and Hugging Face currently classify HTTP 429 responses as persistent `Unexpected` errors, so `RetryLayer` does not retry them.

The retry behavior is supported by the providers' official SDKs or documentation:

- Azure SDK lists HTTP 429 among the default retryable status codes and demonstrates the retry policy with `BlobClientOptions`. Azure Data Lake clients inherit the Azure Core retry options: [Azure SDK retry policy](https://learn.microsoft.com/en-us/azure/developer/cpp/sdk/fundamentals/http-pipelines-and-retries) and [DataLakeClientOptions](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.files.datalake.datalakeclientoptions).
- Alibaba Cloud OSS Go SDK v2 explicitly includes `429 // Rate exceeded` in its retryable error codes: [retryable_error.go](https://github.com/aliyun/alibabacloud-oss-go-sdk-v2/blob/master/oss/retry/retryable_error.go).
- Hugging Face Hub documents that rate limit violations return HTTP 429 and that official clients handle retries using the reset value: [Hub rate limits](https://huggingface.co/docs/hub/en/rate-limits).

This PR intentionally leaves Tencent COS unchanged. The official COS documentation describes QPS limits and flow control but does not document that they return HTTP 429, and the official Go SDK retry tests cover 500, 503, and 504 but not 429: [COS request rate limits](https://cloud.tencent.com/document/product/436/14518) and [COS Go SDK retry tests](https://github.com/tencentyun/cos-go-sdk-v5/blob/master/retry_test.go).

# What changes are included in this PR?

- Classify HTTP 429 as temporary `ErrorKind::RateLimited` in the Azure Blob, Azure Data Lake Storage, OSS, and Hugging Face error parsers.
- Keep retry policy, backoff, and `Retry-After` handling unchanged.

Validation:

- `cargo fmt --all -- --check`
- Focused clippy for the four service packages with `-D warnings`
- Existing unit tests for the four service packages: 82 passed, 4 ignored

# Are there any user-facing changes?

Yes. When users wrap these services with `RetryLayer`, HTTP 429 responses now enter the configured retry flow. There are no public API changes.

# AI Usage Statement

OpenAI Codex (GPT-5) was used to investigate provider retry behavior, implement the change, and run validation.
