### PR TITLE
fix(services/cos): honor if_not_exists on multipart uploads

### DIFF
--- a/core/services/cos/src/core.rs
+++ b/core/services/cos/src/core.rs
@@ -448,6 +448,16 @@ impl CosCore {
             req = req.header(CACHE_CONTROL, cache_control)
         }
 
+        // COS evaluates x-cos-forbid-overwrite on both InitiateMultipartUpload and
+        // CompleteMultipartUpload, so a multipart if_not_exists write has to carry it
+        // on both requests. Setting it only on the simple PutObject path lets large
+        // uploads silently overwrite an existing object.
+        //
+        // ref: https://www.tencentcloud.com/document/product/436/7746
+        if args.if_not_exists() {
+            req = req.header("x-cos-forbid-overwrite", "true");
+        }
+
         // Set user metadata headers.
         if let Some(user_metadata) = args.user_metadata() {
             for (key, value) in user_metadata {
@@ -504,6 +514,7 @@ impl CosCore {
         path: &str,
         upload_id: &str,
         parts: Vec<CompleteMultipartUploadRequestPart>,
+        args: &OpWrite,
     ) -> Result<Response<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
@@ -514,14 +525,21 @@ impl CosCore {
             percent_encode_path(upload_id)
         );
 
-        let req = Request::post(&url);
+        let mut req = Request::post(&url);
 
         let content = quick_xml::se::to_string(&CompleteMultipartUploadRequest { part: parts })
             .map_err(new_xml_serialize_error)?;
         // Make sure content length has been set to avoid post with chunked encoding.
-        let req = req.header(CONTENT_LENGTH, content.len());
+        req = req.header(CONTENT_LENGTH, content.len());
         // Set content-type to `application/xml` to avoid mixed with form post.
-        let req = req.header(CONTENT_TYPE, "application/xml");
+        req = req.header(CONTENT_TYPE, "application/xml");
+        // CompleteMultipartUpload is the request that commits the object, so the
+        // if_not_exists guard has to be repeated here alongside InitiateMultipartUpload.
+        //
+        // ref: https://www.tencentcloud.com/document/product/436/7742
+        if args.if_not_exists() {
+            req = req.header("x-cos-forbid-overwrite", "true");
+        }
 
         let req = req
             .extension(Operation::Write)

--- a/core/services/cos/src/writer.rs
+++ b/core/services/cos/src/writer.rs
@@ -166,7 +166,7 @@ impl oio::MultipartWrite for CosWriter {
 
         let mut resp = self
             .core
-            .cos_complete_multipart_upload(&self.ctx, &self.path, upload_id, parts)
+            .cos_complete_multipart_upload(&self.ctx, &self.path, upload_id, parts, &self.op)
             .await?;
 
         let mut meta = Self::parse_metadata(resp.headers())?;


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

COS advertises `write_with_if_not_exists`, and any write larger than `write_multi_min_size` (1 MiB) goes through the multipart writer instead of a single PutObject. On the simple path `cos_put_object_request` sets `x-cos-forbid-overwrite` when the caller asks for `if_not_exists`, but the multipart initiate and complete requests never set it, so once a write crosses the multipart threshold the overwrite guard is dropped and an existing object is replaced while the caller still gets `Ok`. I noticed this while reading the recent OSS fix in #8041, which is the same shape: the header has to ride on both InitiateMultipartUpload and CompleteMultipartUpload. Tencent documents `x-cos-forbid-overwrite` as a supported header on InitiateMultipartUpload and lists the `cos:x-cos-forbid-overwrite` condition key against both InitiateMultipartUpload and CompleteMultipartUpload, so setting it on only one of them is not enough. The fix threads `OpWrite` into `cos_complete_multipart_upload` and sets the header on both requests when `if_not_exists()` is true. Small single-shot writes are unaffected since they already carried the header.

# What changes are included in this PR?

- Set `x-cos-forbid-overwrite: true` on `cos_initiate_multipart_upload` and `cos_complete_multipart_upload` when `args.if_not_exists()` is set.
- Pass `OpWrite` through to `cos_complete_multipart_upload` from the writer's `complete_part`.

No new test is added: `test_writer_write_with_if_not_exists` already drives the chunked writer path for any service with `write_with_if_not_exists` and `write_can_multi`, so it covers COS and fails against a real bucket on the current code.

# Are there any user-facing changes?

A large `if_not_exists` write to COS (over `write_multi_min_size`) now returns `ConditionNotMatch` when the object already exists, matching the behavior of small writes. Code that relied on the previous silent overwrite for large objects will now see the precondition enforced.

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
