### PR TITLE
fix(services/cloudflare-kv): strip only the root prefix from listed keys

### DIFF
--- a/core/services/cloudflare-kv/src/lister.rs
+++ b/core/services/cloudflare-kv/src/lister.rs
@@ -34,6 +34,22 @@ pub struct CloudflareKvLister {
     recursive: bool,
 }
 
+/// Strip the service root from a root-prefixed key.
+///
+/// The keys returned by the KV API carry the service root as a prefix, so only that prefix may be
+/// removed. `str::replace` removes *every* occurrence anywhere in the key, which silently mangles
+/// any key that repeats the root as an inner path segment.
+///
+/// The sibling object-store listers reach for `build_rel_path` here, but that helper
+/// `debug_assert!`s that the path really does start with the root -- a guarantee this service does
+/// not enforce on the values the API hands back -- so this stays total and leaves a
+/// non-root-prefixed key untouched.
+fn relative_to_root(root: &str, name: &str) -> String {
+    name.strip_prefix(root.trim_start_matches('/'))
+        .unwrap_or(name)
+        .to_string()
+}
+
 impl CloudflareKvLister {
     pub fn new(
         core: Arc<CloudflareKvCore>,
@@ -60,7 +76,7 @@ impl CloudflareKvLister {
             name += "/";
         }
 
-        let mut name = name.replace(root.trim_start_matches('/'), "");
+        let mut name = relative_to_root(root, &name);
 
         // If it is the root directory, it needs to be processed as /
         if name.is_empty() {
@@ -91,7 +107,7 @@ impl CloudflareKvLister {
             let entry = self.build_entry_for_item(item, root)?;
             ctx.entries.push_back(entry);
         } else if !result.is_empty() {
-            let path_name = self.path.replace(root.trim_start_matches('/'), "");
+            let path_name = relative_to_root(root, &self.path);
             let entry = oio::Entry::new(
                 &format!("{path_name}/"),
                 Metadata::new(EntryMode::DIR)
@@ -169,5 +185,35 @@ impl oio::PageList for CloudflareKvLister {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relative_to_root_strips_only_the_prefix() {
+        // The root repeated as an inner segment must survive; only the leading copy goes.
+        assert_eq!(
+            relative_to_root("/data/", "data/backup/data/file.txt"),
+            "backup/data/file.txt"
+        );
+        assert_eq!(relative_to_root("/data/", "data/file.txt"), "file.txt");
+    }
+
+    #[test]
+    fn relative_to_root_does_not_match_mid_key() {
+        // "replace" would turn this into "xfile.txt" by deleting a substring that is not a prefix.
+        assert_eq!(
+            relative_to_root("/data/", "xdata/file.txt"),
+            "xdata/file.txt"
+        );
+    }
+
+    #[test]
+    fn relative_to_root_handles_the_root_itself_and_a_bare_root() {
+        assert_eq!(relative_to_root("/data/", "data/"), "");
+        assert_eq!(relative_to_root("/", "file.txt"), "file.txt");
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

None filed — reporting and fixing together.

## Rationale of this change

`CloudflareKvLister` removed the service root from listed keys with `str::replace`:

```rust
let mut name = name.replace(root.trim_start_matches('/'), "");
```

`str::replace` removes **every** occurrence anywhere in the string, not the leading one. So any key that repeats the root as an inner path segment comes back mangled:

| root | stored key | listed as | should be |
|---|---|---|---|
| `/data/` | `data/backup/data/file.txt` | `backup/file.txt` | `backup/data/file.txt` |
| `/data/` | `xdata/file.txt` | `xfile.txt` | `xdata/file.txt` |

The second row shows it is not even anchored — a key merely *containing* the root loses that substring.

The same expression appeared at both call sites (`build_entry_for_item` for the key, and the non-recursive branch for `self.path`), so both now go through one `relative_to_root` helper.

**On `build_rel_path`:** that is what the s3/oss/cos/obs listers use here, and it was my first choice. It `debug_assert!`s that the path really does start with the root — a guarantee this service does not enforce on what the API returns — so a key that is not root-prefixed would panic in debug builds where `replace` previously left it alone. The helper therefore stays total and preserves that behaviour. Happy to switch to `build_rel_path` if you would rather have the assertion.

## Are there any user-facing changes?

Yes: listed entry names are now correct for keys that repeat the root as an inner segment. Keys that do not are unaffected.

## Tests

Three unit tests in `lister.rs`. Two fail against the previous expression:

```
test lister::tests::relative_to_root_does_not_match_mid_key ... FAILED
test lister::tests::relative_to_root_strips_only_the_prefix ... FAILED
test result: FAILED. 3 passed; 2 failed
```

The third covers the root itself and a bare `/` root and passes **both** before and after, which is what shows the other two are not trivially red.

With the fix: 5/5 pass (including the two pre-existing config tests). `cargo fmt --check` exits 0 and `cargo clippy --all-targets` is clean.
