### PR TITLE
fix(core): Respect logical length in Buffer vectored views

### DIFF
--- a/core/core/src/types/buffer.rs
+++ b/core/core/src/types/buffer.rs
@@ -323,12 +323,21 @@ impl Buffer {
         match &self.0 {
             Inner::Contiguous(bs) => vec![IoSlice::new(bs.chunk())],
             Inner::NonContiguous {
-                parts, idx, offset, ..
+                parts,
+                size,
+                idx,
+                offset,
             } => {
                 let mut ret = Vec::with_capacity(parts.len() - *idx);
                 let mut new_offset = *offset;
+                let mut remaining = *size;
                 for part in parts.iter().skip(*idx) {
-                    ret.push(IoSlice::new(&part[new_offset..]));
+                    if remaining == 0 {
+                        break;
+                    }
+                    let n = (part.len() - new_offset).min(remaining);
+                    ret.push(IoSlice::new(&part[new_offset..new_offset + n]));
+                    remaining -= n;
                     new_offset = 0;
                 }
                 ret
@@ -553,22 +562,29 @@ impl Buf for Buffer {
                 1
             }
             Inner::NonContiguous {
-                parts, idx, offset, ..
+                parts,
+                size,
+                idx,
+                offset,
             } => {
                 if dst.is_empty() {
                     return 0;
                 }
 
                 let mut new_offset = *offset;
-                parts
-                    .iter()
-                    .skip(*idx)
-                    .zip(dst.iter_mut())
-                    .map(|(part, dst)| {
-                        *dst = IoSlice::new(&part[new_offset..]);
-                        new_offset = 0;
-                    })
-                    .count()
+                let mut remaining = *size;
+                let mut count = 0;
+                for (part, dst) in parts.iter().skip(*idx).zip(dst.iter_mut()) {
+                    if remaining == 0 {
+                        break;
+                    }
+                    let n = (part.len() - new_offset).min(remaining);
+                    *dst = IoSlice::new(&part[new_offset..new_offset + n]);
+                    remaining -= n;
+                    new_offset = 0;
+                    count += 1;
+                }
+                count
             }
         }
     }
@@ -1308,5 +1324,79 @@ mod tests {
             end = cur + at;
             // Continue with the head part
         }
+    }
+
+    /// Returns the bytes exposed by `to_io_slice` and by `Buf::chunks_vectored`.
+    fn vectored_bytes(buf: &Buffer) -> (Bytes, Bytes) {
+        let from_io_slice = buf
+            .to_io_slice()
+            .iter()
+            .flat_map(|s| s.iter())
+            .copied()
+            .collect::<Bytes>();
+
+        let mut dst = [IoSlice::new(EMPTY_SLICE); 8];
+        let n = buf.chunks_vectored(&mut dst);
+        let from_chunks_vectored = dst[..n]
+            .iter()
+            .flat_map(|s| s.iter())
+            .copied()
+            .collect::<Bytes>();
+
+        (from_io_slice, from_chunks_vectored)
+    }
+
+    #[test]
+    fn test_vectored_views_after_slice() {
+        let buf = Buffer::from(vec![Bytes::from("abc"), Bytes::from("def")]);
+
+        let view = buf.slice(0..2);
+        assert_eq!(view.remaining(), 2);
+        assert_eq!(view.to_bytes(), Bytes::from("ab"));
+        assert_eq!(
+            vectored_bytes(&view),
+            (Bytes::from("ab"), Bytes::from("ab"))
+        );
+
+        let view = buf.slice(1..4);
+        assert_eq!(view.remaining(), 3);
+        assert_eq!(view.to_bytes(), Bytes::from("bcd"));
+        assert_eq!(
+            vectored_bytes(&view),
+            (Bytes::from("bcd"), Bytes::from("bcd"))
+        );
+    }
+
+    #[test]
+    fn test_vectored_views_after_split_to() {
+        let mut buf = Buffer::from(vec![Bytes::from("abc"), Bytes::from("def")]);
+        let head = buf.split_to(2);
+
+        assert_eq!(head.remaining(), 2);
+        assert_eq!(
+            vectored_bytes(&head),
+            (Bytes::from("ab"), Bytes::from("ab"))
+        );
+
+        assert_eq!(buf.remaining(), 4);
+        assert_eq!(
+            vectored_bytes(&buf),
+            (Bytes::from("cdef"), Bytes::from("cdef"))
+        );
+    }
+
+    #[test]
+    fn test_vectored_views_after_split_off() {
+        let mut buf = Buffer::from(vec![Bytes::from("abc"), Bytes::from("def")]);
+        let tail = buf.split_off(2);
+
+        assert_eq!(buf.remaining(), 2);
+        assert_eq!(vectored_bytes(&buf), (Bytes::from("ab"), Bytes::from("ab")));
+
+        assert_eq!(tail.remaining(), 4);
+        assert_eq!(
+            vectored_bytes(&tail),
+            (Bytes::from("cdef"), Bytes::from("cdef"))
+        );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #8063.

# Rationale for this change

For a non-contiguous `Buffer`, `to_io_slice()` and the `bytes::Buf::chunks_vectored()` impl destructure `Inner::NonContiguous` with `..`, dropping the logical `size` field, and then walk each part to its **physical** end. Because `truncate` / `slice` / `split_to` / `split_off` shrink `size` without dropping `parts`, both methods then hand back more bytes than `remaining()` — for a 2-byte view of `["abc", "def"]` they expose all 6 bytes.

That violates the documented `bytes::Buf::chunks_vectored` contract ("the sum of the lengths of all the buffers written to `dst` will be less than or equal to `Buf::remaining()`"), and it contradicts `chunk()` and `Iterator::next` in the same type, which both clamp with `.min(*size)` to honor the `Inner::NonContiguous` invariant ("the logic view … spans `size` bytes").

#4481 already fixed the `offset` half of this problem in these same two methods; the `size` clamp was not added then.

# What changes are included in this PR?

Both non-contiguous branches now bind `size`, track it as a running `remaining`, clamp each slice with `.min(remaining)`, and stop once it reaches zero — mirroring what `chunk()` already does. Nothing else changes.

Regression tests `test_vectored_views_after_slice`, `test_vectored_views_after_split_to` and `test_vectored_views_after_split_off` assert that both vectored views yield exactly the logical content. They fail on `main` and pass here.

<details>
<summary>Test evidence</summary>

Before the fix (tests applied to unmodified `main`), all three fail — the vectored views expose the whole physical buffer:

```
---- types::buffer::tests::test_vectored_views_after_slice stdout ----
assertion failed: `(left == right)`
 (
<    b"abcdef",
<    b"abcdef",
>    b"ab",
>    b"ab",
 )

failures:
    types::buffer::tests::test_vectored_views_after_slice
    types::buffer::tests::test_vectored_views_after_split_off
    types::buffer::tests::test_vectored_views_after_split_to

test result: FAILED. 0 passed; 3 failed
```

After the fix:

```
$ cargo test -p opendal-core --lib --features "tokio/time"
test result: ok. 182 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo fmt --all -- --check                                              # clean
$ cargo clippy -p opendal-core --all-targets --features "tokio/time" -- -D warnings   # clean
```

`--features "tokio/time"` is only needed to compile `opendal-core`'s `#[cfg(test)]` code when the package is tested in isolation; it is unrelated to this change. The full-workspace `--all-features` clippy/nextest gate and the behavior tests were not run locally.

</details>

# Are there any user-facing changes?

Yes — a bug fix; no signature or API change. A shortened non-contiguous `Buffer` passed to a vectored write now yields only its logical bytes instead of also emitting the truncated tail.

To be precise about the blast radius: there is **no active data corruption in-tree**. The only in-tree vectored write backend, `compfs`, takes its bytes via `Buffer::by_ref().collect()` — the `Iterator` impl, which already respects `size` — so it never reached this path. The defect matters at the public API and trait-contract level: `to_io_slice` is `pub` and documented for vectored writes, and `chunks_vectored` is a `bytes::Buf` impl, so downstream users and any future in-tree consumer doing a vectored write over a shortened view are affected.

# AI Usage Statement

Prepared with AI assistance: Cursor, using Anthropic Claude Opus 5. The AI drafted the patch, the regression tests and this description; I reproduced the defect locally, verified the tests fail before the change and pass after it, and reviewed every line of the diff.
