### PR TITLE
chore(release): fix jar packaging

### DIFF
--- a/.github/workflows/release_java.yml
+++ b/.github/workflows/release_java.yml
@@ -28,6 +28,8 @@ on:
       - main
     paths:
       - ".github/workflows/release_java.yml"
+      - "bindings/java/pom.xml"
+      - "bindings/java/src/main/resources/META-INF/**"
       - "bindings/java/tools/build.py"
   workflow_dispatch:
 

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -250,15 +250,16 @@
                     <execution>
                         <id>default-jar</id>
                         <configuration>
+                            <!--
+                                Without an includes list, maven-jar-plugin packages every file from
+                                ${project.build.outputDirectory}, including compiled classes and META-INF licensing
+                                files. Adding an <includes> list replaces that all-files default with only the matching
+                                patterns. A licensing-only list would therefore omit compiled classes such as
+                                org/apache/opendal/NativeLibrary.class from the default JAR.
+                            -->
                             <excludes>
                                 <exclude>native/**</exclude>
                             </excludes>
-                            <includes>
-                                <include>META-INF/DEPENDENCIES</include>
-                                <include>META-INF/LICENSE</include>
-                                <include>META-INF/LICENSE-MPL-2.0.txt</include>
-                                <include>META-INF/NOTICE</include>
-                            </includes>
                         </configuration>
                     </execution>
                     <!--  Generate the JAR that contains the native library in it.  -->
@@ -269,6 +270,11 @@
                         </goals>
                         <configuration>
                             <classifier>${jni.classifier}</classifier>
+                            <!--
+                                This <includes> allowlist limits each classified JAR to its native library and the
+                                licensing files required when that JAR is distributed independently. Compiled Java
+                                classes remain in the default JAR.
+                            -->
                             <includes>
                                 <include>native/**</include>
                                 <include>META-INF/DEPENDENCIES</include>


### PR DESCRIPTION
# Which issue does this PR close?

Part of #8026

# Rationale for this change

My previous PR #8061 added <includes> rules for default jar which prevented the build. So fix.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?

None

# AI Usage Statement

No.