### PR TITLE
fix(services/cos): keep the port and stop doubling the bucket label

### DIFF
--- a/core/services/cos/src/backend.rs
+++ b/core/services/cos/src/backend.rs
@@ -192,13 +192,7 @@ impl Builder for CosBuilder {
                 .with_context("service", COS_SCHEME)),
         }?;
 
-        let scheme = match uri.scheme_str() {
-            Some(scheme) => scheme.to_string(),
-            None => "https".to_string(),
-        };
-
-        // If endpoint contains bucket name, we should trim them.
-        let endpoint = uri.host().unwrap().replace(&format!("//{bucket}."), "//");
+        let endpoint = build_endpoint(&uri, &bucket)?;
         debug!("backend use endpoint {}", endpoint);
 
         let os_env = OsEnv;
@@ -294,7 +288,7 @@ impl Builder for CosBuilder {
                 capability,
                 bucket: bucket.clone(),
                 root,
-                endpoint: format!("{}://{}.{}", scheme, bucket, endpoint),
+                endpoint,
                 signer,
             }),
         })
@@ -499,5 +493,94 @@ impl Service for CosBackend {
             parts.uri,
             parts.headers,
         )))
+    }
+}
+
+/// Compose the request endpoint for a bucket, as `scheme://bucket.host[:port]`.
+///
+/// Extracted so it can be unit tested, mirroring `S3Builder::build_endpoint`.
+fn build_endpoint(uri: &Uri, bucket: &str) -> Result<String> {
+    let scheme = uri.scheme_str().unwrap_or("https");
+
+    let host = uri.host().ok_or_else(|| {
+        Error::new(ErrorKind::ConfigInvalid, "endpoint host is empty")
+            .with_context("service", COS_SCHEME)
+            .with_context("endpoint", uri.to_string())
+    })?;
+
+    // If the endpoint already carries the bucket as its leftmost label, don't add it twice.
+    let host = host.strip_prefix(&format!("{bucket}.")).unwrap_or(host);
+
+    // Keep the port. `Uri::host` omits it, so composing from the host alone silently sent every
+    // request to the scheme default.
+    Ok(match uri.port_u16() {
+        Some(port) => format!("{scheme}://{bucket}.{host}:{port}"),
+        None => format!("{scheme}://{bucket}.{host}"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn endpoint_of(raw: &str, bucket: &str) -> String {
+        build_endpoint(&raw.parse::<Uri>().unwrap(), bucket).unwrap()
+    }
+
+    #[test]
+    fn build_endpoint_keeps_a_custom_port() {
+        assert_eq!(
+            endpoint_of(
+                "https://cos.internal.example.com:8443",
+                "examplebucket-1250000000"
+            ),
+            "https://examplebucket-1250000000.cos.internal.example.com:8443"
+        );
+    }
+
+    #[test]
+    fn build_endpoint_prefixes_the_bucket() {
+        assert_eq!(
+            endpoint_of(
+                "https://cos.ap-guangzhou.myqcloud.com",
+                "examplebucket-1250000000"
+            ),
+            "https://examplebucket-1250000000.cos.ap-guangzhou.myqcloud.com"
+        );
+    }
+
+    #[test]
+    fn build_endpoint_does_not_repeat_a_bucket_already_in_the_host() {
+        // The previous `replace("//{bucket}.", "//")` could never match, because Uri::host never
+        // contains "//", so this doubled the bucket label.
+        assert_eq!(
+            endpoint_of(
+                "https://examplebucket-1250000000.cos.ap-guangzhou.myqcloud.com",
+                "examplebucket-1250000000"
+            ),
+            "https://examplebucket-1250000000.cos.ap-guangzhou.myqcloud.com"
+        );
+    }
+
+    #[test]
+    fn build_endpoint_defaults_the_scheme_to_https() {
+        // A bare host parses with no scheme; "//host" parses with no host at all, which is why
+        // the missing-host case below is a real input rather than a contrived one.
+        assert_eq!(
+            endpoint_of("cos.ap-guangzhou.myqcloud.com", "b"),
+            "https://b.cos.ap-guangzhou.myqcloud.com"
+        );
+    }
+
+    #[test]
+    fn build_endpoint_reports_a_missing_host_instead_of_panicking() {
+        // Both of these parse to host = None. The previous code called .unwrap() on that.
+        for raw in ["/just/a/path", "//cos.ap-guangzhou.myqcloud.com"] {
+            let uri = raw.parse::<Uri>().unwrap();
+            assert!(
+                build_endpoint(&uri, "b").is_err(),
+                "expected an error for {raw}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Which issue does this PR close?

None filed — reporting and fixing together.

## Rationale of this change

`CosBuilder::build` composed the request endpoint from `Uri::host`, which omits the port:

```rust
let endpoint = uri.host().unwrap().replace(&format!("//{bucket}."), "//");
...
endpoint: format!("{}://{}.{}", scheme, bucket, endpoint),
```

Three problems on that one line.

**1. The port is dropped.** `https://cos.internal.example.com:8443` becomes `https://bucket.cos.internal.example.com` and every request goes to 443. This is the same defect #4899 fixed for OSS ("fix: oss will not use the port"), and this follows that shape — `uri.port_u16()`.

**2. The bucket-trim can never fire.** `Uri::host` never contains `//`, so `replace("//{bucket}.", "//")` has no match by construction. An endpoint that already carries the bucket came out with the label twice:

| endpoint in | before | after |
|---|---|---|
| `https://b.cos.example.com` | `https://b.b.cos.example.com` | `https://b.cos.example.com` |

**3. `.unwrap()` panics on a host-less endpoint.** Both `/just/a/path` and `//cos.example.com` parse to `host = None` — I checked rather than assumed:

```
//cos.example.com     host=None  scheme=None  port=None
cos.example.com       host=Some  scheme=None  port=None
/just/a/path          host=None  scheme=None  port=None
```

so a misconfiguration panicked instead of returning `ConfigInvalid`, which is what the same function already does for an unparseable or empty endpoint.

The composition is extracted into `build_endpoint` so it can be asserted on directly, mirroring `S3Builder::build_endpoint`.

### Known limitation, unchanged here

COS always composes `{bucket}.{host}`, so an IP-based endpoint remains unusable — `http://127.0.0.1:9000` becomes `http://bucket.127.0.0.1:9000`. Fixing that needs an addressing-style option like OSS and S3 have, which is a larger change than this. Worth saying plainly rather than implying "custom endpoints now work".

## Are there any user-facing changes?

Yes, and all three are corrections: a custom port is honoured, an endpoint that already names the bucket is no longer doubled, and a host-less endpoint returns a config error instead of panicking.

## Tests

Five, in a new `mod tests` in `backend.rs`. Three fail against the previous expression:

```
build_endpoint_keeps_a_custom_port ... FAILED
build_endpoint_does_not_repeat_a_bucket_already_in_the_host ... FAILED
build_endpoint_reports_a_missing_host_instead_of_panicking ... FAILED
test result: FAILED. 8 passed; 3 failed
```

The other two — plain bucket prefixing and the `https` default — pass **both** before and after, so they are controls showing the first three are not trivially red.

11/11 with the fix. `cargo fmt --check` exits 0 and `cargo clippy --all-targets` is clean.
