### PR TITLE
fix(services/d1): repair the upsert statement that breaks every write

### DIFF
--- a/core/services/d1/src/core.rs
+++ b/core/services/d1/src/core.rs
@@ -49,23 +49,6 @@ impl Debug for D1Core {
 
 const CLOUDFLARE_API_BASE_URL: &str = "https://api.cloudflare.com/client/v4";
 
-/// Build the upsert issued by [`D1Core::set`].
-///
-/// Two things this statement has to get right, both of which it got wrong before:
-///
-/// - it is a raw string, so a trailing `\` is a literal backslash rather than a line
-///   continuation, and SQLite rejects the statement outright at that token;
-/// - the key placeholder must be a bare `?`. Quoting it makes `'?'` a string literal, which
-///   leaves one bind marker for the two parameters that are always sent.
-fn build_set_query(table: &str, key_field: &str, value_field: &str) -> String {
-    format!(
-        r#"INSERT INTO "{table}" ("{key_field}", "{value_field}")
-            VALUES (?, ?)
-            ON CONFLICT ("{key_field}")
-                DO UPDATE SET "{value_field}" = EXCLUDED."{value_field}""#
-    )
-}
-
 impl D1Core {
     fn create_d1_query_request(
         &self,
@@ -146,7 +129,15 @@ impl D1Core {
     }
 
     pub async fn set(&self, ctx: &OperationContext, path: &str, value: Buffer) -> Result<()> {
-        let query = build_set_query(&self.table, &self.key_field, &self.value_field);
+        let table = &self.table;
+        let key_field = &self.key_field;
+        let value_field = &self.value_field;
+        let query = format!(
+            r#"INSERT INTO "{table}" ("{key_field}", "{value_field}")
+                VALUES (?, ?)
+                ON CONFLICT ("{key_field}")
+                    DO UPDATE SET "{value_field}" = EXCLUDED."{value_field}""#,
+        );
 
         let params = vec![path.into(), value.to_vec().into()];
         let req = self.create_d1_query_request(&query, params, Operation::Write, "Set")?;
@@ -241,46 +232,3 @@ mod error {
 }
 
 pub(super) use error::*;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn set_query_binds_both_parameters() {
-        let query = build_set_query("data", "key", "value");
-
-        // In a raw string a trailing `\` is a literal backslash, and SQLite stops at that
-        // token: `unrecognized token: "\"`.
-        assert!(
-            !query.contains('\\'),
-            "statement must not carry a literal backslash: {query}"
-        );
-        // `set` always sends two params, so the statement needs two bare placeholders. `'?'`
-        // is a string literal, not a bind marker.
-        assert!(
-            !query.contains("'?'"),
-            "the key placeholder must not be quoted: {query}"
-        );
-        assert_eq!(
-            query.matches('?').count(),
-            2,
-            "expected one bind marker per parameter: {query}"
-        );
-    }
-
-    #[test]
-    fn set_query_keeps_the_configured_identifiers_quoted() {
-        let query = build_set_query("my table", "my key", "my value");
-
-        assert!(
-            query.contains(r#"INSERT INTO "my table" ("my key", "my value")"#),
-            "{query}"
-        );
-        assert!(query.contains(r#"ON CONFLICT ("my key")"#), "{query}");
-        assert!(
-            query.contains(r#"DO UPDATE SET "my value" = EXCLUDED."my value""#),
-            "{query}"
-        );
-    }
-}

--- a/core/services/d1/src/core.rs
+++ b/core/services/d1/src/core.rs
@@ -49,6 +49,23 @@ impl Debug for D1Core {
 
 const CLOUDFLARE_API_BASE_URL: &str = "https://api.cloudflare.com/client/v4";
 
+/// Build the upsert issued by [`D1Core::set`].
+///
+/// Two things this statement has to get right, both of which it got wrong before:
+///
+/// - it is a raw string, so a trailing `\` is a literal backslash rather than a line
+///   continuation, and SQLite rejects the statement outright at that token;
+/// - the key placeholder must be a bare `?`. Quoting it makes `'?'` a string literal, which
+///   leaves one bind marker for the two parameters that are always sent.
+fn build_set_query(table: &str, key_field: &str, value_field: &str) -> String {
+    format!(
+        r#"INSERT INTO "{table}" ("{key_field}", "{value_field}")
+            VALUES (?, ?)
+            ON CONFLICT ("{key_field}")
+                DO UPDATE SET "{value_field}" = EXCLUDED."{value_field}""#
+    )
+}
+
 impl D1Core {
     fn create_d1_query_request(
         &self,
@@ -129,15 +146,7 @@ impl D1Core {
     }
 
     pub async fn set(&self, ctx: &OperationContext, path: &str, value: Buffer) -> Result<()> {
-        let table = &self.table;
-        let key_field = &self.key_field;
-        let value_field = &self.value_field;
-        let query = format!(
-            r#"INSERT INTO "{table}" ("{key_field}", "{value_field}") \
-                VALUES ('?', ?) \
-                ON CONFLICT ("{key_field}") \
-                    DO UPDATE SET "{value_field}" = EXCLUDED."{value_field}""#,
-        );
+        let query = build_set_query(&self.table, &self.key_field, &self.value_field);
 
         let params = vec![path.into(), value.to_vec().into()];
         let req = self.create_d1_query_request(&query, params, Operation::Write, "Set")?;
@@ -232,3 +241,46 @@ mod error {
 }
 
 pub(super) use error::*;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_query_binds_both_parameters() {
+        let query = build_set_query("data", "key", "value");
+
+        // In a raw string a trailing `\` is a literal backslash, and SQLite stops at that
+        // token: `unrecognized token: "\"`.
+        assert!(
+            !query.contains('\\'),
+            "statement must not carry a literal backslash: {query}"
+        );
+        // `set` always sends two params, so the statement needs two bare placeholders. `'?'`
+        // is a string literal, not a bind marker.
+        assert!(
+            !query.contains("'?'"),
+            "the key placeholder must not be quoted: {query}"
+        );
+        assert_eq!(
+            query.matches('?').count(),
+            2,
+            "expected one bind marker per parameter: {query}"
+        );
+    }
+
+    #[test]
+    fn set_query_keeps_the_configured_identifiers_quoted() {
+        let query = build_set_query("my table", "my key", "my value");
+
+        assert!(
+            query.contains(r#"INSERT INTO "my table" ("my key", "my value")"#),
+            "{query}"
+        );
+        assert!(query.contains(r#"ON CONFLICT ("my key")"#), "{query}");
+        assert!(
+            query.contains(r#"DO UPDATE SET "my value" = EXCLUDED."my value""#),
+            "{query}"
+        );
+    }
+}


### PR DESCRIPTION
### Which issue does this PR close?

None — found while reading the service.

### Rationale for this change

`D1Core::set` builds this statement:

```rust
let query = format!(
    r#"INSERT INTO "{table}" ("{key_field}", "{value_field}") \
        VALUES ('?', ?) \
        ON CONFLICT ("{key_field}") \
            DO UPDATE SET "{value_field}" = EXCLUDED."{value_field}""#,
);
```

Two defects, either of which alone stops a write from landing.

**1. The backslashes are literal.** It is a raw string, so a trailing `\` is a backslash character, not a line continuation. SQLite stops at the first one:

```
sqlite> INSERT INTO "data" ("key", "value") \
Parse error near line 1: unrecognized token: "\"
                        error here ---^
```

**2. The key placeholder is quoted.** `'?'` is the one-character string literal `?`, not a bind marker — so there is one placeholder for the two parameters `set` always sends, and rows land under the literal key `?`:

```
sqlite> INSERT INTO "data" ("key","value") VALUES ('?','hello')
   ...>   ON CONFLICT ("key") DO UPDATE SET "value" = EXCLUDED."value";
sqlite> SELECT '['||key||'] -> '||value FROM data;
[?] -> hello
```

Both arrived together in 311f324cc (#7857), which rewrote the literal as a raw string to quote the table and column identifiers:

```diff
-  "INSERT INTO {table} ({key_field}, {value_field}) \
-      VALUES (?, ?) \
+  r#"INSERT INTO "{table}" ("{key_field}", "{value_field}") \
+      VALUES ('?', ?) \
```

Switching to a raw string is what turned the existing line continuations into literal backslashes.

### What changes are included in this PR?

The escaping and the placeholder are corrected; the identifier quoting #7857 was after is kept exactly as it is. The statement moves into a `build_set_query` helper so it can be asserted on directly.

The rest of the crate is unaffected — `delete` and the two `SELECT`s are single-line raw strings with a bare `?` — and a sweep for the shape (a raw string containing a line-ending backslash) finds no other occurrence anywhere in the repository.

### Left out deliberately, for you to judge separately

`set` matches on the HTTP status alone:

```rust
match status {
    StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok(()),
    _ => Err(parse_error(resp)),
}
```

while `get` and `get_length` both run `D1Response::parse`. D1 answers a rejected statement with `200` and `success: false`, so the parse error above was reported to callers as a **successful** write — which is presumably why a service whose every write fails has no bug report against it. Happy to add the `D1Response::parse` call here in this PR if you would like it; I left it out to keep the change to the statement itself.

### Tests

Two unit tests. Restoring either defect on its own fails `set_query_binds_both_parameters`:

| mutation | `set_query_binds_both_parameters` | `set_query_keeps_the_configured_identifiers_quoted` |
|---|---|---|
| backslashes restored, placeholders bare | **FAILED** | ok |
| `'?'` restored, no backslashes | **FAILED** | ok |
| neither (this PR) | ok | ok |

The second test pins the identifier quoting and passes against both the old and the new statement, so it holds the #7857 intent in place and keeps the first test from being trivially red.

`cargo test -p opendal-service-d1 --lib` → 5 passed. `cargo fmt --all -- --check` and `cargo clippy -p opendal-service-d1 --all-targets` both clean.

### Are there any user-facing changes?

Yes — `services-d1` writes now reach the database. Previously every `write` was rejected by SQLite and the failure was reported as success.
