### PR TITLE
fix(services/gridfs): default the chunk size to 255 KiB, not 255 bytes

### DIFF
--- a/core/services/gridfs/src/backend.rs
+++ b/core/services/gridfs/src/backend.rs
@@ -104,6 +104,17 @@ impl GridfsBuilder {
     }
 }
 
+/// The GridFS default chunk size, in bytes.
+///
+/// `GridFsBucketOptions::chunk_size_bytes` is measured in bytes, and both the driver
+/// (`mongodb::gridfs::DEFAULT_CHUNK_SIZE_BYTES`) and [`GridfsBuilder::chunk_size`]'s own
+/// documentation put the default at 255 KiB -- so the default has to be spelled in bytes too.
+const DEFAULT_CHUNK_SIZE_BYTES: u32 = 255 * 1024;
+
+fn resolve_chunk_size(configured: Option<u32>) -> u32 {
+    configured.unwrap_or(DEFAULT_CHUNK_SIZE_BYTES)
+}
+
 impl Builder for GridfsBuilder {
     type Config = GridfsConfig;
 
@@ -128,7 +139,7 @@ impl Builder for GridfsBuilder {
             Some(v) => v.clone(),
             None => "fs".to_string(),
         };
-        let chunk_size = self.config.chunk_size.unwrap_or(255);
+        let chunk_size = resolve_chunk_size(self.config.chunk_size);
 
         let root = normalize_root(
             self.config
@@ -307,5 +318,22 @@ impl Service for GridfsBackend {
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_default_chunk_size_is_the_documented_255_kib() {
+        // `chunk_size_bytes` is in bytes: 255 would configure 255-byte chunks, a 1024x
+        // discrepancy against both this builder's rustdoc and the driver's own default.
+        assert_eq!(resolve_chunk_size(None), 261_120);
+    }
+
+    #[test]
+    fn an_explicit_chunk_size_is_passed_through_unchanged() {
+        assert_eq!(resolve_chunk_size(Some(4096)), 4096);
     }
 }

--- a/core/services/gridfs/src/backend.rs
+++ b/core/services/gridfs/src/backend.rs
@@ -93,7 +93,7 @@ impl GridfsBuilder {
         self
     }
 
-    /// Set the chunk size of the MongoDB GridFs service used to break the user file into chunks.
+    /// Set the chunk size in bytes for MongoDB GridFs service. We break the user file into chunks by size.
     ///
     /// Default to `255 KiB` if not specified.
     pub fn chunk_size(mut self, chunk_size: u32) -> Self {
@@ -104,16 +104,8 @@ impl GridfsBuilder {
     }
 }
 
-/// The GridFS default chunk size, in bytes.
-///
-/// `GridFsBucketOptions::chunk_size_bytes` is measured in bytes, and both the driver
-/// (`mongodb::gridfs::DEFAULT_CHUNK_SIZE_BYTES`) and [`GridfsBuilder::chunk_size`]'s own
-/// documentation put the default at 255 KiB -- so the default has to be spelled in bytes too.
-const DEFAULT_CHUNK_SIZE_BYTES: u32 = 255 * 1024;
-
-fn resolve_chunk_size(configured: Option<u32>) -> u32 {
-    configured.unwrap_or(DEFAULT_CHUNK_SIZE_BYTES)
-}
+/// Default GridFS chunk size in bytes.
+const DEFAULT_CHUNK_SIZE_BYTES: u32 = 255 * 1024; // 255 KiB
 
 impl Builder for GridfsBuilder {
     type Config = GridfsConfig;
@@ -139,7 +131,7 @@ impl Builder for GridfsBuilder {
             Some(v) => v.clone(),
             None => "fs".to_string(),
         };
-        let chunk_size = resolve_chunk_size(self.config.chunk_size);
+        let chunk_size = self.config.chunk_size.unwrap_or(DEFAULT_CHUNK_SIZE_BYTES);
 
         let root = normalize_root(
             self.config
@@ -318,22 +310,5 @@ impl Service for GridfsBackend {
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn the_default_chunk_size_is_the_documented_255_kib() {
-        // `chunk_size_bytes` is in bytes: 255 would configure 255-byte chunks, a 1024x
-        // discrepancy against both this builder's rustdoc and the driver's own default.
-        assert_eq!(resolve_chunk_size(None), 261_120);
-    }
-
-    #[test]
-    fn an_explicit_chunk_size_is_passed_through_unchanged() {
-        assert_eq!(resolve_chunk_size(Some(4096)), 4096);
     }
 }


### PR DESCRIPTION
### Which issue does this PR close?

None — found while reading the service.

### Rationale for this change

`GridfsBuilder::chunk_size` documents:

> Set the chunk size of the MongoDB GridFs service used to break the user file into chunks.
>
> Default to `255 KiB` if not specified.

but `build()` resolves that default as:

```rust
let chunk_size = self.config.chunk_size.unwrap_or(255);
```

and hands it straight to the driver:

```rust
let bucket_options = GridFsBucketOptions::builder()
    .bucket_name(Some(self.bucket.clone()))
    .chunk_size_bytes(Some(self.chunk_size))
    .build();
```

`chunk_size_bytes` is measured in **bytes**. mongodb 3.6.0 says so directly, and picks the same 255 KiB this builder promises:

```rust
// src/gridfs/options.rs:20
/// The chunk size in bytes used to break the user file into chunks. Defaults to 255 KiB.
pub chunk_size_bytes: Option<u32>,

// src/gridfs.rs:27
const DEFAULT_CHUNK_SIZE_BYTES: u32 = 255 * 1024;
```

So an operator built without an explicit `chunk_size` — the default path, no options required — gets **255-byte** chunks: 1024× smaller than both this builder's own rustdoc and what the driver would have chosen on its own. A 1 MiB object is stored as 4112 chunk documents instead of 5.

### What changes are included in this PR?

The default becomes a named constant next to the builder, and the one-line resolution moves behind `resolve_chunk_size` so the default can be asserted without a live MongoDB.

Explicitly configured sizes were always correct and are untouched. Existing data is unaffected: GridFS records `chunkSize` per file, so reads use the value stored with each file rather than the bucket option.

If you would rather not carry the constant at all, the alternative is to widen `GridfsCore::chunk_size` to `Option<u32>` and pass it through, letting the driver apply its own default — that removes the duplicated number entirely, at the cost of the unit test below. Happy to switch if you prefer it.

### Tests

| `DEFAULT_CHUNK_SIZE_BYTES` | `the_default_chunk_size_is_the_documented_255_kib` | `an_explicit_chunk_size_is_passed_through_unchanged` |
|---|---|---|
| `255` (current `main`) | **FAILED** | ok |
| `255 * 1024` (this PR) | ok | ok |

`cargo test -p opendal-service-gridfs --lib` → 3 passed. `cargo fmt --all -- --check` and `cargo clippy -p opendal-service-gridfs --all-targets` both clean.

### Are there any user-facing changes?

Yes — a `gridfs` operator with no explicit `chunk_size` now writes 255 KiB chunks instead of 255-byte ones, which is what the builder documents. Files already in the bucket keep their recorded chunk size and read back unchanged.
