### PR TITLE
fix(services/ipmfs): stop stripping the root twice from listed entries

### DIFF
--- a/core/services/ipmfs/src/lister.rs
+++ b/core/services/ipmfs/src/lister.rs
@@ -48,25 +48,6 @@ impl IpmfsLister {
     }
 }
 
-/// Build a listed entry's path from the path being listed and one `files/ls` name.
-///
-/// `list_path` is the path the operator handed to the service, so it is already relative to the
-/// root -- `IpmfsCore::ipmfs_ls` is what turns it into a rooted absolute path for the request.
-/// Concatenating a name onto it therefore yields a root-relative path directly, and stripping the
-/// root off it a second time is what used to truncate the result (or panic outright).
-///
-/// The one thing the concatenation has to handle is that `list_path` is `"/"` when the root
-/// itself is listed, and an entry path carries no leading slash.
-fn build_entry_path(list_path: &str, name: &str, mode: EntryMode) -> String {
-    let prefix = if list_path == "/" { "" } else { list_path };
-
-    match mode {
-        EntryMode::FILE => format!("{prefix}{name}"),
-        EntryMode::DIR => format!("{prefix}{name}/"),
-        EntryMode::Unknown => unreachable!(),
-    }
-}
-
 impl oio::PageList for IpmfsLister {
     async fn next_page(&self, ctx: &mut oio::PageContext) -> Result<()> {
         let resp = self.core.ipmfs_ls(&self.ctx, &self.path).await?;
@@ -98,7 +79,19 @@ impl oio::PageList for IpmfsLister {
         ctx.done = true;
 
         for object in entries_body.entries.unwrap_or_default() {
-            let path = build_entry_path(&self.path, &object.name, object.mode());
+            // `self.path` is "/" when the root itself is listed, and an entry path carries
+            // no leading slash. It is already relative to the root, so it must not be
+            // stripped again.
+            let prefix = if self.path == "/" {
+                ""
+            } else {
+                self.path.as_str()
+            };
+            let path = match object.mode() {
+                EntryMode::FILE => format!("{prefix}{}", object.name),
+                EntryMode::DIR => format!("{prefix}{}/", object.name),
+                EntryMode::Unknown => unreachable!(),
+            };
 
             ctx.entries.push_back(oio::Entry::new(
                 &path,
@@ -148,38 +141,4 @@ impl IpfsLsResponseEntry {
 struct IpfsLsResponse {
     #[serde(rename = "Entries")]
     entries: Option<Vec<IpfsLsResponseEntry>>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn listing_the_root_yields_bare_names() {
-        // `list_path` is "/" here, and an entry path carries no leading slash.
-        assert_eq!(build_entry_path("/", "a.txt", EntryMode::FILE), "a.txt");
-        assert_eq!(build_entry_path("/", "sub", EntryMode::DIR), "sub/");
-    }
-
-    #[test]
-    fn listing_a_directory_keeps_that_directory_in_the_entry_path() {
-        assert_eq!(
-            build_entry_path("dir/", "a.txt", EntryMode::FILE),
-            "dir/a.txt"
-        );
-        assert_eq!(build_entry_path("dir/", "sub", EntryMode::DIR), "dir/sub/");
-    }
-
-    #[test]
-    fn the_entry_path_is_independent_of_the_service_root() {
-        // This is the property the previous expression lacked. It ran the concatenation through
-        // `build_rel_path(root, ..)`, which under the default root "/" is a no-op -- and under
-        // any other root removed a prefix that was never there. `build_entry_path` takes no root
-        // at all, so the same listing produces the same entry paths whatever the root is.
-        assert_eq!(
-            build_entry_path("dir/", "a.txt", EntryMode::FILE),
-            "dir/a.txt"
-        );
-        assert_eq!(build_entry_path("/", "a.txt", EntryMode::FILE), "a.txt");
-    }
 }

--- a/core/services/ipmfs/src/lister.rs
+++ b/core/services/ipmfs/src/lister.rs
@@ -79,9 +79,6 @@ impl oio::PageList for IpmfsLister {
         ctx.done = true;
 
         for object in entries_body.entries.unwrap_or_default() {
-            // `self.path` is "/" when the root itself is listed, and an entry path carries
-            // no leading slash. It is already relative to the root, so it must not be
-            // stripped again.
             let prefix = if self.path == "/" {
                 ""
             } else {

--- a/core/services/ipmfs/src/lister.rs
+++ b/core/services/ipmfs/src/lister.rs
@@ -48,6 +48,25 @@ impl IpmfsLister {
     }
 }
 
+/// Build a listed entry's path from the path being listed and one `files/ls` name.
+///
+/// `list_path` is the path the operator handed to the service, so it is already relative to the
+/// root -- `IpmfsCore::ipmfs_ls` is what turns it into a rooted absolute path for the request.
+/// Concatenating a name onto it therefore yields a root-relative path directly, and stripping the
+/// root off it a second time is what used to truncate the result (or panic outright).
+///
+/// The one thing the concatenation has to handle is that `list_path` is `"/"` when the root
+/// itself is listed, and an entry path carries no leading slash.
+fn build_entry_path(list_path: &str, name: &str, mode: EntryMode) -> String {
+    let prefix = if list_path == "/" { "" } else { list_path };
+
+    match mode {
+        EntryMode::FILE => format!("{prefix}{name}"),
+        EntryMode::DIR => format!("{prefix}{name}/"),
+        EntryMode::Unknown => unreachable!(),
+    }
+}
+
 impl oio::PageList for IpmfsLister {
     async fn next_page(&self, ctx: &mut oio::PageContext) -> Result<()> {
         let resp = self.core.ipmfs_ls(&self.ctx, &self.path).await?;
@@ -79,13 +98,7 @@ impl oio::PageList for IpmfsLister {
         ctx.done = true;
 
         for object in entries_body.entries.unwrap_or_default() {
-            let path = match object.mode() {
-                EntryMode::FILE => format!("{}{}", self.path, object.name),
-                EntryMode::DIR => format!("{}{}/", self.path, object.name),
-                EntryMode::Unknown => unreachable!(),
-            };
-
-            let path = build_rel_path(&self.root, &path);
+            let path = build_entry_path(&self.path, &object.name, object.mode());
 
             ctx.entries.push_back(oio::Entry::new(
                 &path,
@@ -135,4 +148,38 @@ impl IpfsLsResponseEntry {
 struct IpfsLsResponse {
     #[serde(rename = "Entries")]
     entries: Option<Vec<IpfsLsResponseEntry>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn listing_the_root_yields_bare_names() {
+        // `list_path` is "/" here, and an entry path carries no leading slash.
+        assert_eq!(build_entry_path("/", "a.txt", EntryMode::FILE), "a.txt");
+        assert_eq!(build_entry_path("/", "sub", EntryMode::DIR), "sub/");
+    }
+
+    #[test]
+    fn listing_a_directory_keeps_that_directory_in_the_entry_path() {
+        assert_eq!(
+            build_entry_path("dir/", "a.txt", EntryMode::FILE),
+            "dir/a.txt"
+        );
+        assert_eq!(build_entry_path("dir/", "sub", EntryMode::DIR), "dir/sub/");
+    }
+
+    #[test]
+    fn the_entry_path_is_independent_of_the_service_root() {
+        // This is the property the previous expression lacked. It ran the concatenation through
+        // `build_rel_path(root, ..)`, which under the default root "/" is a no-op -- and under
+        // any other root removed a prefix that was never there. `build_entry_path` takes no root
+        // at all, so the same listing produces the same entry paths whatever the root is.
+        assert_eq!(
+            build_entry_path("dir/", "a.txt", EntryMode::FILE),
+            "dir/a.txt"
+        );
+        assert_eq!(build_entry_path("/", "a.txt", EntryMode::FILE), "a.txt");
+    }
 }


### PR DESCRIPTION
### Which issue does this PR close?

None — found while reading the service.

### Rationale for this change

The listing loop concatenates the path being listed with a `files/ls` name, then runs the result through `build_rel_path` a second time:

```rust
for object in entries_body.entries.unwrap_or_default() {
    let path = match object.mode() {
        EntryMode::FILE => format!("{}{}", self.path, object.name),
        EntryMode::DIR => format!("{}{}/", self.path, object.name),
        EntryMode::Unknown => unreachable!(),
    };

    let path = build_rel_path(&self.root, &path);   // <- the root is not in `path`
```

`self.path` is the path the operator handed the service, so it is already relative to the root — `IpmfsCore::ipmfs_ls` is what turns it into a rooted absolute path for the request:

```rust
pub(crate) async fn ipmfs_ls(&self, ctx: &OperationContext, path: &str) -> Result<Response<Buffer>> {
    let p = build_rooted_abs_path(&self.root, path);
```

So the concatenation is root-relative *before* that call, and the call strips a prefix that is not there.

**Under the default root `/` the second strip cancels out**, which is why this has gone unnoticed. Under any other root, measured in release (`cargo test --release`):

| root | listing | name | result |
|---|---|---|---|
| `/` | `dir/` | `a` | `dir/a` ✅ |
| `/abc/` | `dir/` | `a` | `a` — the directory is dropped from every entry path |
| `/abc/` | the root itself, so `self.path` is `/` | `a` | **panic**: `start byte index 5 is out of bounds for string of length 2` |

In a debug build both of the last two trip the `debug_assert!` inside `build_rel_path` instead.

### What changes are included in this PR?

The construction moves into `build_entry_path`, which takes **no root at all** — an entry path does not depend on one. The only thing it has to handle is that `self.path` is `"/"` when the root itself is listed, and an entry path carries no leading slash.

The self-entry twenty lines above is deliberately left alone: it does `build_abs_path` and then `build_rel_path`, a genuine round trip, and is correct.

### Tests

Three unit tests. Restoring the old expression shows the defect and why it survived:

| old expression, service root | result |
|---|---|
| `/` | **4 passed** — the double strip cancels out |
| `/abc/` | **3 failed**, 1 passed |

`cargo test -p opendal-service-ipmfs --lib` → 4 passed. `cargo fmt --all -- --check` and `cargo clippy -p opendal-service-ipmfs --all-targets` both clean.

### Note for rebasing

#7801 renames this very call to `build_relative_path`. If that lands first this needs a one-word rebase — though the call disappears here, which is the point.

### Are there any user-facing changes?

Yes, for `services-ipmfs` with a root other than `/`: listed entry paths keep the directory they are in, and listing the root no longer panics. Behaviour under the default root `/` is unchanged.
