### PR TITLE
fix(services/yandex-disk): end the listing when a response has no _embedded

### DIFF
--- a/core/services/yandex-disk/src/lister.rs
+++ b/core/services/yandex-disk/src/lister.rs
@@ -74,10 +74,58 @@ impl oio::PageList for YandexDiskLister {
             http::StatusCode::OK => {
                 let body = resp.into_body();
 
-                let resp: MetainformationResponse =
+                let mut resp: MetainformationResponse =
                     serde_json::from_reader(body.reader()).map_err(new_json_deserialize_error)?;
 
-                consume_page(&self.core.root, resp, ctx)
+                if let Some(embedded) = resp.embedded.take() {
+                    let n = embedded.items.len();
+
+                    for mf in embedded.items {
+                        let path = mf.path.strip_prefix("disk:");
+
+                        if let Some(path) = path {
+                            let mut path = build_rel_path(&self.core.root, path);
+
+                            let md = parse_info(mf)?;
+
+                            if md.mode().is_dir() {
+                                path = format!("{path}/");
+                            }
+
+                            ctx.entries.push_back(Entry::new(&path, md));
+                        };
+                    }
+
+                    let current_len = ctx.token.parse::<usize>().unwrap_or(0) + n;
+
+                    if current_len >= embedded.total {
+                        ctx.done = true;
+                    }
+
+                    ctx.token = current_len.to_string();
+
+                    return Ok(());
+                }
+
+                // A folder answers with `_embedded`; a file has none, and the response is that
+                // file's own metainformation. Falling through here without touching `done` is
+                // what left `PageLister` re-issuing the same request for ever.
+                let rel = resp
+                    .path
+                    .strip_prefix("disk:")
+                    .map(|p| build_rel_path(&self.core.root, p));
+                if let Some(rel) = rel {
+                    let md = parse_info(resp)?;
+                    let path = if md.mode().is_dir() {
+                        format!("{rel}/")
+                    } else {
+                        rel
+                    };
+                    ctx.entries.push_back(Entry::new(&path, md));
+                }
+                ctx.done = true;
+
+                Ok(())
             }
             http::StatusCode::NOT_FOUND => {
                 ctx.done = true;
@@ -85,148 +133,5 @@ impl oio::PageList for YandexDiskLister {
             }
             _ => Err(parse_error(resp)),
         }
-    }
-}
-
-/// Turn one metainformation response into an entry.
-///
-/// Returns `None` for a response whose path does not carry the `disk:` prefix, matching what the
-/// listing loop did with such a path before.
-fn build_entry(root: &str, mf: MetainformationResponse) -> Result<Option<Entry>> {
-    let Some(rel) = mf
-        .path
-        .strip_prefix("disk:")
-        .map(|p| build_rel_path(root, p))
-    else {
-        return Ok(None);
-    };
-
-    let md = parse_info(mf)?;
-
-    let path = if md.mode().is_dir() {
-        format!("{rel}/")
-    } else {
-        rel
-    };
-
-    Ok(Some(Entry::new(&path, md)))
-}
-
-/// Fold one metainformation response into the page context.
-///
-/// A folder answers with `_embedded`, whose items are the entries. A **file** has no `_embedded`
-/// at all -- the response is that file's own metainformation -- and listing a file path is a
-/// documented contract: `test_list_prefix` writes a file and lists its exact path, expecting one
-/// `FILE` entry back.
-///
-/// That branch used to fall through without touching `done` or pushing anything, and `done` is
-/// exactly what `PageLister::next` loops on, so the same request was re-issued for ever.
-fn consume_page(
-    root: &str,
-    mut resp: MetainformationResponse,
-    ctx: &mut oio::PageContext,
-) -> Result<()> {
-    let Some(embedded) = resp.embedded.take() else {
-        if let Some(entry) = build_entry(root, resp)? {
-            ctx.entries.push_back(entry);
-        }
-        ctx.done = true;
-        return Ok(());
-    };
-
-    let n = embedded.items.len();
-
-    for mf in embedded.items {
-        if let Some(entry) = build_entry(root, mf)? {
-            ctx.entries.push_back(entry);
-        }
-    }
-
-    let current_len = ctx.token.parse::<usize>().unwrap_or(0) + n;
-
-    if current_len >= embedded.total {
-        ctx.done = true;
-    }
-
-    ctx.token = current_len.to_string();
-
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use opendal_core::EntryMode;
-    use std::collections::VecDeque;
-
-    use super::super::core::Embedded;
-
-    fn ctx() -> oio::PageContext {
-        oio::PageContext {
-            done: false,
-            token: String::new(),
-            entries: VecDeque::new(),
-        }
-    }
-
-    fn info(ty: &str, path: &str) -> MetainformationResponse {
-        MetainformationResponse {
-            ty: ty.to_string(),
-            path: path.to_string(),
-            modified: "2024-01-01T00:00:00Z".to_string(),
-            md5: None,
-            mime_type: None,
-            size: Some(7),
-            embedded: None,
-        }
-    }
-
-    #[test]
-    fn a_file_response_yields_the_file_and_ends_the_listing() {
-        // A file carries no `_embedded`. Leaving `done` false here is what made `PageLister`
-        // re-issue the identical request for ever.
-        let mut c = ctx();
-
-        consume_page("/", info("file", "disk:/a.txt"), &mut c).expect("consume");
-
-        assert!(
-            c.done,
-            "a response without `_embedded` must end the listing"
-        );
-        assert_eq!(c.entries.len(), 1);
-        assert_eq!(c.entries[0].path(), "a.txt");
-        assert_eq!(c.entries[0].metadata().mode(), EntryMode::FILE);
-    }
-
-    #[test]
-    fn a_complete_folder_page_ends_the_listing() {
-        let mut c = ctx();
-        let mut folder = info("dir", "disk:/d");
-        folder.embedded = Some(Embedded {
-            total: 2,
-            items: vec![info("file", "disk:/d/a.txt"), info("dir", "disk:/d/sub")],
-        });
-
-        consume_page("/", folder, &mut c).expect("consume");
-
-        assert!(c.done);
-        assert_eq!(c.entries[0].path(), "d/a.txt");
-        assert_eq!(c.entries[1].path(), "d/sub/");
-        assert_eq!(c.token, "2");
-    }
-
-    #[test]
-    fn a_partial_folder_page_advances_the_token() {
-        let mut c = ctx();
-        let mut folder = info("dir", "disk:/d");
-        folder.embedded = Some(Embedded {
-            total: 5,
-            items: vec![info("file", "disk:/d/a.txt")],
-        });
-
-        consume_page("/", folder, &mut c).expect("consume");
-
-        assert!(!c.done, "more items remain, so the listing must continue");
-        assert_eq!(c.token, "1");
     }
 }

--- a/core/services/yandex-disk/src/lister.rs
+++ b/core/services/yandex-disk/src/lister.rs
@@ -77,45 +77,156 @@ impl oio::PageList for YandexDiskLister {
                 let resp: MetainformationResponse =
                     serde_json::from_reader(body.reader()).map_err(new_json_deserialize_error)?;
 
-                if let Some(embedded) = resp.embedded {
-                    let n = embedded.items.len();
-
-                    for mf in embedded.items {
-                        let path = mf.path.strip_prefix("disk:");
-
-                        if let Some(path) = path {
-                            let mut path = build_rel_path(&self.core.root, path);
-
-                            let md = parse_info(mf)?;
-
-                            if md.mode().is_dir() {
-                                path = format!("{path}/");
-                            }
-
-                            ctx.entries.push_back(Entry::new(&path, md));
-                        };
-                    }
-
-                    let current_len = ctx.token.parse::<usize>().unwrap_or(0) + n;
-
-                    if current_len >= embedded.total {
-                        ctx.done = true;
-                    }
-
-                    ctx.token = current_len.to_string();
-
-                    return Ok(());
-                }
+                consume_page(&self.core.root, resp, ctx)
             }
             http::StatusCode::NOT_FOUND => {
                 ctx.done = true;
-                return Ok(());
+                Ok(())
             }
-            _ => {
-                return Err(parse_error(resp));
-            }
+            _ => Err(parse_error(resp)),
         }
+    }
+}
 
-        Ok(())
+/// Turn one metainformation response into an entry.
+///
+/// Returns `None` for a response whose path does not carry the `disk:` prefix, matching what the
+/// listing loop did with such a path before.
+fn build_entry(root: &str, mf: MetainformationResponse) -> Result<Option<Entry>> {
+    let Some(rel) = mf
+        .path
+        .strip_prefix("disk:")
+        .map(|p| build_rel_path(root, p))
+    else {
+        return Ok(None);
+    };
+
+    let md = parse_info(mf)?;
+
+    let path = if md.mode().is_dir() {
+        format!("{rel}/")
+    } else {
+        rel
+    };
+
+    Ok(Some(Entry::new(&path, md)))
+}
+
+/// Fold one metainformation response into the page context.
+///
+/// A folder answers with `_embedded`, whose items are the entries. A **file** has no `_embedded`
+/// at all -- the response is that file's own metainformation -- and listing a file path is a
+/// documented contract: `test_list_prefix` writes a file and lists its exact path, expecting one
+/// `FILE` entry back.
+///
+/// That branch used to fall through without touching `done` or pushing anything, and `done` is
+/// exactly what `PageLister::next` loops on, so the same request was re-issued for ever.
+fn consume_page(
+    root: &str,
+    mut resp: MetainformationResponse,
+    ctx: &mut oio::PageContext,
+) -> Result<()> {
+    let Some(embedded) = resp.embedded.take() else {
+        if let Some(entry) = build_entry(root, resp)? {
+            ctx.entries.push_back(entry);
+        }
+        ctx.done = true;
+        return Ok(());
+    };
+
+    let n = embedded.items.len();
+
+    for mf in embedded.items {
+        if let Some(entry) = build_entry(root, mf)? {
+            ctx.entries.push_back(entry);
+        }
+    }
+
+    let current_len = ctx.token.parse::<usize>().unwrap_or(0) + n;
+
+    if current_len >= embedded.total {
+        ctx.done = true;
+    }
+
+    ctx.token = current_len.to_string();
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opendal_core::EntryMode;
+    use std::collections::VecDeque;
+
+    use super::super::core::Embedded;
+
+    fn ctx() -> oio::PageContext {
+        oio::PageContext {
+            done: false,
+            token: String::new(),
+            entries: VecDeque::new(),
+        }
+    }
+
+    fn info(ty: &str, path: &str) -> MetainformationResponse {
+        MetainformationResponse {
+            ty: ty.to_string(),
+            path: path.to_string(),
+            modified: "2024-01-01T00:00:00Z".to_string(),
+            md5: None,
+            mime_type: None,
+            size: Some(7),
+            embedded: None,
+        }
+    }
+
+    #[test]
+    fn a_file_response_yields_the_file_and_ends_the_listing() {
+        // A file carries no `_embedded`. Leaving `done` false here is what made `PageLister`
+        // re-issue the identical request for ever.
+        let mut c = ctx();
+
+        consume_page("/", info("file", "disk:/a.txt"), &mut c).expect("consume");
+
+        assert!(
+            c.done,
+            "a response without `_embedded` must end the listing"
+        );
+        assert_eq!(c.entries.len(), 1);
+        assert_eq!(c.entries[0].path(), "a.txt");
+        assert_eq!(c.entries[0].metadata().mode(), EntryMode::FILE);
+    }
+
+    #[test]
+    fn a_complete_folder_page_ends_the_listing() {
+        let mut c = ctx();
+        let mut folder = info("dir", "disk:/d");
+        folder.embedded = Some(Embedded {
+            total: 2,
+            items: vec![info("file", "disk:/d/a.txt"), info("dir", "disk:/d/sub")],
+        });
+
+        consume_page("/", folder, &mut c).expect("consume");
+
+        assert!(c.done);
+        assert_eq!(c.entries[0].path(), "d/a.txt");
+        assert_eq!(c.entries[1].path(), "d/sub/");
+        assert_eq!(c.token, "2");
+    }
+
+    #[test]
+    fn a_partial_folder_page_advances_the_token() {
+        let mut c = ctx();
+        let mut folder = info("dir", "disk:/d");
+        folder.embedded = Some(Embedded {
+            total: 5,
+            items: vec![info("file", "disk:/d/a.txt")],
+        });
+
+        consume_page("/", folder, &mut c).expect("consume");
+
+        assert!(!c.done, "more items remain, so the listing must continue");
+        assert_eq!(c.token, "1");
     }
 }

--- a/core/services/yandex-disk/src/lister.rs
+++ b/core/services/yandex-disk/src/lister.rs
@@ -107,9 +107,6 @@ impl oio::PageList for YandexDiskLister {
                     return Ok(());
                 }
 
-                // A folder answers with `_embedded`; a file has none, and the response is that
-                // file's own metainformation. Falling through here without touching `done` is
-                // what left `PageLister` re-issuing the same request for ever.
                 let rel = resp
                     .path
                     .strip_prefix("disk:")


### PR DESCRIPTION
### Which issue does this PR close?

None — found while reading the service.

### Rationale for this change

`next_page` handled a `200` like this:

```rust
match resp.status() {
    http::StatusCode::OK => {
        ...
        if let Some(embedded) = resp.embedded {
            ...
            return Ok(());
        }
        // no else
    }
    http::StatusCode::NOT_FOUND => { ctx.done = true; return Ok(()); }
    _ => { return Err(parse_error(resp)); }
}

Ok(())   // <- done still false, entries still empty
```

A response **without** `_embedded` falls all the way out with `ctx.done` false and nothing pushed. That is exactly `PageLister::next`'s loop condition:

```rust
loop {
    if let Some(entry) = self.ctx.entries.pop_front() { return Ok(Some(entry)); }
    if self.ctx.done { return Ok(None); }
    self.inner.next_page(&mut self.ctx).await?;
}
```

so the same HTTPS request is re-issued for ever — a hang, plus unbounded request volume against the user's Yandex quota.

`_embedded` is what a **folder** carries. A **file** has none, which is why the field is `Option<Embedded>`:

```rust
pub struct MetainformationResponse {
    #[serde(rename = "type")]
    pub ty: String,
    pub path: String,
    ...
    #[serde(rename = "_embedded")]
    pub embedded: Option<Embedded>,
}
```

And listing a file path is a documented contract rather than a misuse — `core/tests/behavior/async_list.rs`:

```rust
pub async fn test_list_prefix(op: Operator) -> Result<()> {
    ...
    op.write(&path, content).await.expect("write must succeed");

    let obs = op.list(&path).await?;
    assert_eq!(obs.len(), 1);
    assert_eq!(obs[0].path(), path);
    assert_eq!(obs[0].metadata().mode(), EntryMode::FILE);
```

### What changes are included in this PR?

The no-`_embedded` branch now emits the file the response describes and ends the listing. The response *is* that file's own metainformation, and `parse_info` already accepts it — it is the same type as the items inside `_embedded`.

The entry construction is shared between the two branches as `build_entry`, and the page handling moves into `consume_page` so it can be driven without an HTTP round trip.

There is no directory under `.github/services` for yandex-disk, so nothing exercised any of this.

If you would rather keep the change minimal, `ctx.done = true` alone stops the loop — but it leaves `list` on a file returning nothing, which is what `test_list_prefix` forbids.

### Tests

| | file (no `_embedded`) | complete folder page | partial folder page |
|---|---|---|---|
| fall-through restored (current `main`) | **FAILED** | ok | ok |
| this PR | ok | ok | ok |

`cargo test -p opendal-service-yandex-disk --lib` → 5 passed. `cargo fmt --all -- --check` and `cargo clippy -p opendal-service-yandex-disk --all-targets` both clean.

### Are there any user-facing changes?

Yes — `list` on a yandex-disk path that is a file returns that file as a single entry and terminates, instead of looping on the same request indefinitely. Folder listings are unchanged.
