### PR TITLE
fix(services): percent-encode the pagination marker in list queries

### DIFF
--- a/core/services/azblob/src/core.rs
+++ b/core/services/azblob/src/core.rs
@@ -801,7 +801,7 @@ impl AzblobCore {
             url = url.push("delimiter", delimiter);
         }
         if !next_marker.is_empty() {
-            url = url.push("marker", next_marker);
+            url = url.push("marker", &percent_encode_path(next_marker));
         }
 
         let req = Request::get(url.finish())

--- a/core/services/azfile/src/core.rs
+++ b/core/services/azfile/src/core.rs
@@ -433,7 +433,7 @@ impl AzfileCore {
             .push("include", "Timestamps,ETag");
 
         if !continuation.is_empty() {
-            url = url.push("marker", continuation);
+            url = url.push("marker", &percent_encode_path(continuation));
         }
 
         if let Some(limit) = limit {

--- a/core/services/cos/src/core.rs
+++ b/core/services/cos/src/core.rs
@@ -410,7 +410,7 @@ impl CosCore {
             url = url.push("max-keys", &limit.to_string());
         }
         if !next_marker.is_empty() {
-            url = url.push("marker", next_marker);
+            url = url.push("marker", &percent_encode_path(next_marker));
         }
 
         let req = Request::get(url.finish())

--- a/core/services/obs/src/core.rs
+++ b/core/services/obs/src/core.rs
@@ -351,7 +351,7 @@ impl ObsCore {
             url = url.push("max-keys", &limit.to_string());
         }
         if !next_marker.is_empty() {
-            url = url.push("marker", next_marker);
+            url = url.push("marker", &percent_encode_path(next_marker));
         }
 
         let req = Request::get(url.finish())

--- a/core/services/swift/src/core.rs
+++ b/core/services/swift/src/core.rs
@@ -214,7 +214,7 @@ impl SwiftCore {
             url = url.push("limit", &limit.to_string());
         }
         if !marker.is_empty() {
-            url = url.push("marker", marker);
+            url = url.push("marker", &percent_encode_path(marker));
         }
 
         let mut req = Request::get(url.finish());


### PR DESCRIPTION
### Which issue does this PR close?

None — found while reading the listers.

### Rationale for this change

`QueryPairsWriter::push` does no escaping of its own, and says so:

```rust
/// Push a new pair of key and value to the url.
///
/// The input key and value must already been percent
/// encoded correctly.
pub fn push(mut self, key: &str, value: &str) -> Self {
```

Five list builders hand it a raw marker:

| | |
|---|---|
| `obs/src/core.rs:354` | `url.push("marker", next_marker)` |
| `swift/src/core.rs:217` | `url.push("marker", marker)` |
| `cos/src/core.rs:413` | `url.push("marker", next_marker)` |
| `azblob/src/core.rs:804` | `url.push("marker", next_marker)` |
| `azfile/src/core.rs:436` | `url.push("marker", continuation)` |

The value is whatever the server returned as the resume point — a raw **object key** for obs, cos and swift, an opaque continuation token for azblob and azfile. For swift's *first* page it is the user's own `start_after` argument (`lister.rs:65-69`), so no pagination is needed to reach it at all.

Feeding those exact strings to `http::Request::get` shows what actually goes on the wire:

| marker | what is sent |
|---|---|
| `report 2024.csv` | **`BUILD ERROR: invalid uri character`** — the whole `list` fails |
| `a&b=c` | `marker=a` plus a stray `b=c` parameter |
| `note#1.txt` | `marker=note` — everything from `#` is taken as a fragment |
| `AB+cd==` | `marker=AB+cd==`, whose `+` a server decodes as a space |

The middle two are the dangerous ones: the marker silently **rewinds**, the server resends a page that was already delivered, and because `done` is computed from the marker coming back empty, the listing can repeat that page indefinitely rather than erroring.

### What changes are included in this PR?

One call to `percent_encode_path` at each of the five sites. The repository already does exactly this in three places — one of them **in the same file** as a site being fixed:

```rust
s3/src/core.rs:803    url.push("marker", &percent_encode_path(marker));
cos/src/core.rs:606   url.push("key-marker", &percent_encode_path(key_marker));
oss/src/core.rs:478   url.push("continuation-token", &percent_encode_path(token));
```

`percent_encode_path` is the right helper for a *marker* specifically: it leaves `/` alone, which an object key needs. That is the difference from #7888, which is fixing the same family of defect for cos/tos `versionId` and introduces a stricter set for it — a version id is not a path, a marker is.

### Tests

No new tests, deliberately. Each change is a single call to a helper the file already imports, and asserting on it would mean restructuring five URL builders — which I would rather not fold into a fix. All **39** existing unit tests across the five crates pass, and none of them assert on a marker URL. `cargo fmt --all -- --check` and `cargo clippy --all-targets` on each of the five crates are clean with zero warnings.

Happy to extract a testable URL builder for any of them if you would like the coverage.

### Are there any user-facing changes?

Yes — a truncated listing whose resume marker contains a character that is reserved in a query now resumes at the right place instead of failing to build the request, silently rewinding, or repeating a page. The decoded value the server receives is unchanged for any marker that was already URL-safe.
