### PR TITLE
fix(services/b2): percent-encode the object path in presigned requests

### DIFF
--- a/core/services/b2/src/backend.rs
+++ b/core/services/b2/src/backend.rs
@@ -374,7 +374,10 @@ impl Service for B2Backend {
 
                 let url = format!(
                     "{}/file/{}/{}?Authorization={}",
-                    auth_info.download_url, self.core.bucket, path, resp.authorization_token
+                    auth_info.download_url,
+                    self.core.bucket,
+                    percent_encode_path(&path),
+                    resp.authorization_token
                 );
 
                 let req = Request::get(url);
@@ -401,7 +404,10 @@ impl Service for B2Backend {
 
                 let url = format!(
                     "{}/file/{}/{}?Authorization={}",
-                    auth_info.download_url, self.core.bucket, path, resp.authorization_token
+                    auth_info.download_url,
+                    self.core.bucket,
+                    percent_encode_path(&path),
+                    resp.authorization_token
                 );
 
                 let req = Request::get(url);
@@ -423,7 +429,10 @@ impl Service for B2Backend {
                 let mut req = Request::post(&resp.upload_url);
 
                 req = req.header(http::header::AUTHORIZATION, resp.authorization_token);
-                req = req.header("X-Bz-File-Name", build_abs_path(&self.core.root, path));
+                req = req.header(
+                    "X-Bz-File-Name",
+                    percent_encode_path(&build_abs_path(&self.core.root, path)),
+                );
                 req = req.header(http::header::CONTENT_TYPE, "b2/x-auto");
                 req = req.header(constants::X_BZ_CONTENT_SHA1, "do_not_verify");
 


### PR DESCRIPTION
### Which issue does this PR close?

None — found while reading the service.

### Rationale for this change

The three presign arms interpolate the object path raw, while the ordinary read and write paths **in the same crate** encode it.

Presign (`backend.rs`), Stat and Read:

```rust
let url = format!(
    "{}/file/{}/{}?Authorization={}",
    auth_info.download_url, self.core.bucket, path, resp.authorization_token
);
```

Presign Write:

```rust
req = req.header("X-Bz-File-Name", build_abs_path(&self.core.root, path));
```

The reference, `core.rs`:

```rust
// :144-149  download_file_by_name
let url = format!("{}/file/{}/{}",
    auth_info.download_url, self.bucket, percent_encode_path(&path));

// :262  upload_file
req = req.header(X_BZ_FILE_NAME, percent_encode_path(&p));
```

Handing the formatted strings to `http::Request::get` shows what a presigned URL actually becomes:

| path | resulting URI |
|---|---|
| `dir/file.txt` | `path=/file/bkt/dir/file.txt`, `query=Authorization=TOK` ✅ |
| `a#b.txt` | `path=/file/bkt/a`, **`query=None`** |
| `a?b.txt` | `path=/file/bkt/a`, `query=b.txt?Authorization=TOK` |
| `a b.txt` | **`BUILD ERROR: invalid uri character`** |
| `a%20b.txt` | sends `a%20b.txt`, which B2 decodes to `a b.txt` |

The `#` row is the worst: the URL is truncated to a **different object** *and* the entire `?Authorization=` is swallowed as a fragment, so the presigned URL carries no token at all. `a b.txt` cannot be presigned even though `op.read("a b.txt")` on the same object works — that call goes through the encoding path. And the write header sends `a%20b.txt` where `op.write("a%20b.txt")` sends `a%2520b.txt`, so a presigned upload lands on a **different key** than an ordinary write for the same OpenDAL path.

**Blast radius** — the first row is the one that matters: a path with no reserved characters encodes to itself, because `percent_encode_path` leaves `/` alone. Presigned URLs for ordinary object names are byte-identical to what they are today; only names that are currently broken change.

### What changes are included in this PR?

One call to `percent_encode_path` at each of the three sites, making presign agree with `download_file_by_name` and `upload_file`.

### Tests

No new tests, deliberately: these are `format!` arguments and a header value inside an async method whose only seam is a live B2 authorization call, and asserting on them would mean restructuring the presign arms — which I would rather not fold into a fix. The 3 existing unit tests pass; `cargo fmt --all -- --check` and `cargo clippy -p opendal-service-b2 --all-targets` are clean with zero warnings.

### Note for rebasing

#7801 renames `build_abs_path` at these same three sites. If it lands first, the `X-Bz-File-Name` line needs a one-word rebase.

### Are there any user-facing changes?

Yes, for `services-b2`: `presign_read` / `presign_stat` / `presign_write` on an object whose name contains a character that is reserved in a URL now address that object, keep their authorization token, and agree with what a non-presigned read or write would do. Presigned URLs for names without reserved characters are unchanged.
