### PR TITLE
chore: GitHub action optimization

### DIFF
--- a/.github/workflows/ci_bindings_c.yml
+++ b/.github/workflows/ci_bindings_c.yml
@@ -23,12 +23,18 @@ on:
       - main
     tags:
       - '*'
+    paths:
+      - "bindings/c/**"
+      - "core/**"
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_c.yml"
   pull_request:
     branches:
       - main
     paths:
       - "bindings/c/**"
       - "core/**"
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_c.yml"
   workflow_dispatch:
 

--- a/.github/workflows/ci_bindings_c.yml
+++ b/.github/workflows/ci_bindings_c.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - '*'
-    paths:
+    paths: &paths
       - "bindings/c/**"
       - "core/**"
       - ".github/actions/setup/**"
@@ -31,11 +31,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "bindings/c/**"
-      - "core/**"
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_c.yml"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_cpp.yml
+++ b/.github/workflows/ci_bindings_cpp.yml
@@ -23,12 +23,19 @@ on:
       - main
     tags:
       - '*'
+    paths:
+      - "bindings/cpp/**"
+      - "core/**"
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_cpp.yml"
+      - "examples/cpp/**"
   pull_request:
     branches:
       - main
     paths:
       - "bindings/cpp/**"
       - "core/**"
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_cpp.yml"
       - "examples/cpp/**"
   workflow_dispatch:

--- a/.github/workflows/ci_bindings_cpp.yml
+++ b/.github/workflows/ci_bindings_cpp.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - '*'
-    paths:
+    paths: &paths
       - "bindings/cpp/**"
       - "core/**"
       - ".github/actions/setup/**"
@@ -32,12 +32,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "bindings/cpp/**"
-      - "core/**"
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_cpp.yml"
-      - "examples/cpp/**"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_d.yml
+++ b/.github/workflows/ci_bindings_d.yml
@@ -23,6 +23,12 @@ on:
       - main
     tags:
       - "*"
+    paths:
+      - "core/**"
+      - "bindings/c/**"
+      - "bindings/d/**"
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_d.yml"
   pull_request:
     branches:
       - main
@@ -30,6 +36,7 @@ on:
       - "core/**"
       - "bindings/c/**"
       - "bindings/d/**"
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_d.yml"
   workflow_dispatch:
 

--- a/.github/workflows/ci_bindings_d.yml
+++ b/.github/workflows/ci_bindings_d.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - "*"
-    paths:
+    paths: &paths
       - "core/**"
       - "bindings/c/**"
       - "bindings/d/**"
@@ -32,12 +32,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "core/**"
-      - "bindings/c/**"
-      - "bindings/d/**"
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_d.yml"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_dart.yml
+++ b/.github/workflows/ci_bindings_dart.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - "*"
-    paths:
+    paths: &paths
       - "core/**"
       - "bindings/dart/**"
       - ".github/actions/setup/**"
@@ -31,11 +31,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "core/**"
-      - "bindings/dart/**"
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_dart.yml"
+    paths: *paths
   workflow_dispatch:
 
 env:

--- a/.github/workflows/ci_bindings_dart.yml
+++ b/.github/workflows/ci_bindings_dart.yml
@@ -23,12 +23,18 @@ on:
       - main
     tags:
       - "*"
+    paths:
+      - "core/**"
+      - "bindings/dart/**"
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_dart.yml"
   pull_request:
     branches:
       - main
     paths:
       - "core/**"
       - "bindings/dart/**"
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_dart.yml"
   workflow_dispatch:
 

--- a/.github/workflows/ci_bindings_dotnet.yml
+++ b/.github/workflows/ci_bindings_dotnet.yml
@@ -23,12 +23,18 @@ on:
       - main
     tags:
       - '*'
+    paths:
+      - "bindings/dotnet/**"
+      - "core/**"
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_dotnet.yml"
   pull_request:
     branches:
       - main
     paths:
       - "bindings/dotnet/**"
       - "core/**"
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_dotnet.yml"
   workflow_dispatch:
 

--- a/.github/workflows/ci_bindings_dotnet.yml
+++ b/.github/workflows/ci_bindings_dotnet.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - '*'
-    paths:
+    paths: &paths
       - "bindings/dotnet/**"
       - "core/**"
       - ".github/actions/setup/**"
@@ -31,11 +31,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "bindings/dotnet/**"
-      - "core/**"
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_dotnet.yml"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_go.yml
+++ b/.github/workflows/ci_bindings_go.yml
@@ -23,6 +23,12 @@ on:
       - main
     tags:
       - '*'
+    paths:
+      - "core/**"
+      - "bindings/c/**"
+      - "bindings/go/**"
+      - ".github/workflows/ci_bindings_go.yml"
+      - ".github/scripts/test_go_binding/matrix.yaml"
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci_bindings_go.yml
+++ b/.github/workflows/ci_bindings_go.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - '*'
-    paths:
+    paths: &paths
       - "core/**"
       - "bindings/c/**"
       - "bindings/go/**"
@@ -32,12 +32,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "core/**"
-      - "bindings/c/**"
-      - "bindings/go/**"
-      - ".github/workflows/ci_bindings_go.yml"
-      - ".github/scripts/test_go_binding/matrix.yaml"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_haskell.yml
+++ b/.github/workflows/ci_bindings_haskell.yml
@@ -23,12 +23,18 @@ on:
       - main
     tags:
       - "*"
+    paths:
+      - "bindings/haskell/**"
+      - "core/**"
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_haskell.yml"
   pull_request:
     branches:
       - main
     paths:
       - "bindings/haskell/**"
       - "core/**"
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_haskell.yml"
   workflow_dispatch:
 

--- a/.github/workflows/ci_bindings_haskell.yml
+++ b/.github/workflows/ci_bindings_haskell.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - "*"
-    paths:
+    paths: &paths
       - "bindings/haskell/**"
       - "core/**"
       - ".github/actions/setup/**"
@@ -31,11 +31,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "bindings/haskell/**"
-      - "core/**"
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_haskell.yml"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_java.yml
+++ b/.github/workflows/ci_bindings_java.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - '*'
-    paths:
+    paths: &paths
       - "core/**"
       - "bindings/java/**"
       - ".github/actions/setup/**"
@@ -31,11 +31,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "core/**"
-      - "bindings/java/**"
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_java.yml"
+    paths: *paths
   schedule:
     - cron: '30 1 * * 1'
   workflow_dispatch:

--- a/.github/workflows/ci_bindings_java.yml
+++ b/.github/workflows/ci_bindings_java.yml
@@ -23,12 +23,18 @@ on:
       - main
     tags:
       - '*'
+    paths:
+      - "core/**"
+      - "bindings/java/**"
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_java.yml"
   pull_request:
     branches:
       - main
     paths:
       - "core/**"
       - "bindings/java/**"
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_java.yml"
   schedule:
     - cron: '30 1 * * 1'

--- a/.github/workflows/ci_bindings_lua.yml
+++ b/.github/workflows/ci_bindings_lua.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - '*'
-    paths:
+    paths: &paths
       - "bindings/lua/**"
       - "core/**"
       - ".github/actions/setup/**"
@@ -31,11 +31,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "bindings/lua/**"
-      - "core/**"
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_lua.yml"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_lua.yml
+++ b/.github/workflows/ci_bindings_lua.yml
@@ -23,12 +23,18 @@ on:
       - main
     tags:
       - '*'
+    paths:
+      - "bindings/lua/**"
+      - "core/**"
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_lua.yml"
   pull_request:
     branches:
       - main
     paths:
       - "bindings/lua/**"
       - "core/**"
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_lua.yml"
   workflow_dispatch:
 

--- a/.github/workflows/ci_bindings_nodejs.yml
+++ b/.github/workflows/ci_bindings_nodejs.yml
@@ -31,12 +31,18 @@ on:
       - main
     tags:
       - "*"
+    paths:
+      - "bindings/nodejs/**"
+      - "core/**"
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_nodejs.yml"
   pull_request:
     branches:
       - main
     paths:
       - "bindings/nodejs/**"
       - "core/**"
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_nodejs.yml"
   workflow_dispatch:
 

--- a/.github/workflows/ci_bindings_nodejs.yml
+++ b/.github/workflows/ci_bindings_nodejs.yml
@@ -31,7 +31,7 @@ on:
       - main
     tags:
       - "*"
-    paths:
+    paths: &paths
       - "bindings/nodejs/**"
       - "core/**"
       - ".github/actions/setup/**"
@@ -39,11 +39,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "bindings/nodejs/**"
-      - "core/**"
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_nodejs.yml"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_ocaml.yml
+++ b/.github/workflows/ci_bindings_ocaml.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - "*"
-    paths:
+    paths: &paths
       - "bindings/ocaml/**"
       - "core/**"
       - ".github/actions/setup-ocaml/**"
@@ -31,11 +31,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "bindings/ocaml/**"
-      - "core/**"
-      - ".github/actions/setup-ocaml/**"
-      - ".github/workflows/ci_bindings_ocaml.yml"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_ocaml.yml
+++ b/.github/workflows/ci_bindings_ocaml.yml
@@ -23,6 +23,11 @@ on:
       - main
     tags:
       - "*"
+    paths:
+      - "bindings/ocaml/**"
+      - "core/**"
+      - ".github/actions/setup-ocaml/**"
+      - ".github/workflows/ci_bindings_ocaml.yml"
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci_bindings_php.yml
+++ b/.github/workflows/ci_bindings_php.yml
@@ -23,11 +23,16 @@ on:
       - main
     tags:
       - '*'
+    paths:
+      - "bindings/php/**"
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_php.yml"
   pull_request:
     branches:
       - main
     paths:
       - "bindings/php/**"
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_php.yml"
   workflow_dispatch:
 

--- a/.github/workflows/ci_bindings_php.yml
+++ b/.github/workflows/ci_bindings_php.yml
@@ -23,17 +23,14 @@ on:
       - main
     tags:
       - '*'
-    paths:
+    paths: &paths
       - "bindings/php/**"
       - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_php.yml"
   pull_request:
     branches:
       - main
-    paths:
-      - "bindings/php/**"
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_php.yml"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_python.yml
+++ b/.github/workflows/ci_bindings_python.yml
@@ -21,7 +21,7 @@ on:
   push:
     branches:
       - main
-    paths:
+    paths: &paths
       - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_python.yml"
       - "bindings/python/**"
@@ -29,11 +29,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_python.yml"
-      - "bindings/python/**"
-      - "core/**"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_python.yml
+++ b/.github/workflows/ci_bindings_python.yml
@@ -21,10 +21,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_python.yml"
+      - "bindings/python/**"
+      - "core/**"
   pull_request:
     branches:
       - main
     paths:
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_python.yml"
       - "bindings/python/**"
       - "core/**"

--- a/.github/workflows/ci_bindings_ruby.yml
+++ b/.github/workflows/ci_bindings_ruby.yml
@@ -23,12 +23,18 @@ on:
       - main
     tags:
       - '*'
+    paths:
+      - "bindings/ruby/**"
+      - "core/**"
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_ruby.yml"
   pull_request:
     branches:
       - main
     paths:
       - "bindings/ruby/**"
       - "core/**"
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_ruby.yml"
   workflow_dispatch:
 

--- a/.github/workflows/ci_bindings_ruby.yml
+++ b/.github/workflows/ci_bindings_ruby.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - '*'
-    paths:
+    paths: &paths
       - "bindings/ruby/**"
       - "core/**"
       - ".github/actions/setup/**"
@@ -31,11 +31,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "bindings/ruby/**"
-      - "core/**"
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_ruby.yml"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_swift.yml
+++ b/.github/workflows/ci_bindings_swift.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - '*'
-    paths:
+    paths: &paths
       - "bindings/swift/**"
       - "bindings/c/**"
       - "core/**"
@@ -32,12 +32,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "bindings/swift/**"
-      - "bindings/c/**"
-      - "core/**"
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_swift.yml"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_swift.yml
+++ b/.github/workflows/ci_bindings_swift.yml
@@ -23,6 +23,12 @@ on:
       - main
     tags:
       - '*'
+    paths:
+      - "bindings/swift/**"
+      - "bindings/c/**"
+      - "core/**"
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_swift.yml"
   pull_request:
     branches:
       - main
@@ -30,6 +36,7 @@ on:
       - "bindings/swift/**"
       - "bindings/c/**"
       - "core/**"
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_swift.yml"
   workflow_dispatch:
 

--- a/.github/workflows/ci_bindings_zig.yml
+++ b/.github/workflows/ci_bindings_zig.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - "*"
-    paths:
+    paths: &paths
       - "core/**"
       - "bindings/c/**"
       - "bindings/zig/**"
@@ -32,12 +32,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "core/**"
-      - "bindings/c/**"
-      - "bindings/zig/**"
-      - ".github/actions/setup/**"
-      - ".github/workflows/ci_bindings_zig.yml"
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci_bindings_zig.yml
+++ b/.github/workflows/ci_bindings_zig.yml
@@ -23,6 +23,12 @@ on:
       - main
     tags:
       - "*"
+    paths:
+      - "core/**"
+      - "bindings/c/**"
+      - "bindings/zig/**"
+      - ".github/actions/setup/**"
+      - ".github/workflows/ci_bindings_zig.yml"
   pull_request:
     branches:
       - main
@@ -30,6 +36,7 @@ on:
       - "core/**"
       - "bindings/c/**"
       - "bindings/zig/**"
+      - ".github/actions/setup/**"
       - ".github/workflows/ci_bindings_zig.yml"
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,14 @@ on:
       - main
     tags:
       - "v*"
+    paths:
+      - "core/**"
+      - "bindings/**"
+      - "integrations/**"
+      - "website/**"
+      - ".github/actions/setup/**"
+      - ".github/actions/setup-ocaml/**"
+      - ".github/workflows/docs.yml"
   pull_request:
     branches:
       - main
@@ -31,6 +39,7 @@ on:
       - "bindings/**"
       - "integrations/**"
       - "website/**"
+      - ".github/actions/setup/**"
       - ".github/actions/setup-ocaml/**"
       - ".github/workflows/docs.yml"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ on:
       - main
     tags:
       - "v*"
-    paths:
+    paths: &paths
       - "core/**"
       - "bindings/**"
       - "integrations/**"
@@ -34,14 +34,7 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - "core/**"
-      - "bindings/**"
-      - "integrations/**"
-      - "website/**"
-      - ".github/actions/setup/**"
-      - ".github/actions/setup-ocaml/**"
-      - ".github/workflows/docs.yml"
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}


### PR DESCRIPTION
## Rationale for this change

When I submitted dependency library pr https://github.com/apache/opendal/pull/8074 , I noticed that many unrelated CI jobs were also triggered, such as the website build. Therefore, I took the optimize the CI execution conditions.

After the changes, even if you push directly to the main branch, only the CI for the corresponding bindings will run.

## What changes are included in this PR?

- add `core/**` and `.github/actions/setup/**` triggers where missing
- include workflow file paths so self-changes run the corresponding ci
- align push and pull_request path filters across binding workflows

## AI Usage Statement

Yes, I used Codex for AI assistance, and I also reviewed it.