### PR TITLE
fix(core): clamp a zero chunk when building OpReader from options

### DIFF
--- a/core/core/src/raw/ops.rs
+++ b/core/core/src/raw/ops.rs
@@ -520,9 +520,9 @@ impl From<options::ReadOptions> for (BytesRange, OpRead, OpReader) {
                 content_length_hint: value.content_length_hint,
             },
             OpReader {
-                // Ensure concurrent is at least 1
+                // Ensure concurrent and chunk are at least 1
                 concurrent: value.concurrent.max(1),
-                chunk: value.chunk,
+                chunk: value.chunk.map(|v| v.max(1)),
                 gap: value.gap,
                 prefetch: 0,
             },
@@ -545,9 +545,9 @@ impl From<options::ReaderOptions> for (OpRead, OpReader) {
                 content_length_hint: value.content_length_hint,
             },
             OpReader {
-                // Ensure concurrent is at least 1
+                // Ensure concurrent and chunk are at least 1
                 concurrent: value.concurrent.max(1),
-                chunk: value.chunk,
+                chunk: value.chunk.map(|v| v.max(1)),
                 gap: value.gap,
                 prefetch: value.prefetch,
             },


### PR DESCRIPTION
### Which issue does this PR close?

None — found while reading `raw/ops.rs`.

### Rationale for this change

`OpReader::with_chunk` clamps its argument:

```rust
pub fn with_chunk(mut self, chunk: usize) -> Self {
    self.chunk = Some(chunk.max(1));
    self
}
```

The two `From` impls that build the same struct out of `ReadOptions` / `ReaderOptions` do not — even though the line immediately above clamps `concurrent` for exactly this reason:

```rust
OpReader {
    // Ensure concurrent is at least 1
    concurrent: value.concurrent.max(1),
    chunk: value.chunk,          // <-
```

`chunk` is a `pub` field on both options structs, so `Some(0)` reaches `OpReader` with nothing in between.

Three things follow, all in code that runs **before any service sees the request**:

**1. A read returns nothing.** `ChunkedReader::next_range` (`types/read/buffer_stream.rs`):

```rust
let read_size = self.ctx.options().chunk()
    .map_or(remaining, |chunk| remaining.min(chunk as u64));   // 0
self.offset += read_size;                                      // does not advance
self.remaining = Some(remaining - read_size);                  // does not shrink
```

Every call yields `BytesRange::new(offset, Some(0))`, and `BufferStream::poll_next` ends the stream on the first empty buffer (`Ok(buf) if buf.is_empty() => Poll::Ready(None)`). So a read of a non-empty object returns nothing, with no error.

**2. `Reader::fetch` does not terminate.** `plan_fetch_reads` (`types/read/reader.rs`):

```rust
while offset < range.end {
    let remaining = range.end - offset;
    let size = chunk.map_or(remaining, |v| remaining.min(v));   // 0
    inputs.push(FetchReadInput { .. });
    offset += size;                                             // 0
}
```

Unbounded in time and in memory.

**3. HTTP services panic.** The zero-size range reaches `BytesRange::to_header`, which is `format!("bytes={self}")` over a `Display` that deliberately fails for that case:

```rust
// A zero-size range can't be represented as a valid HTTP Range.
BytesRange::Range { size: Some(0), .. } => Err(std::fmt::Error),
```

`format!` turns a `Display` error into a panic, at request-build time, before any I/O.

### What changes are included in this PR?

`chunk: value.chunk.map(|v| v.max(1))` at both conversion sites, and the neighbouring comment updated to say so. Four lines.

**Blast radius**: `.map(|v| v.max(1))` is the identity on `None` and on every `Some(k >= 1)`, so no existing configuration produces a different `OpReader` than it does today. Only `Some(0)` changes, and only to what `with_chunk` would already have produced.

### Tests

None added — the change is one call on each of two lines, matching what the sibling field on the line above already does.

Worth stating plainly: `cargo test -p opendal-core --lib` **does not compile** on `main` in my environment — eight `unresolved import tokio::time` errors in `futures_util.rs`, `block_copy.rs`, `block_write.rs` and `multipart_write.rs`. I checked that it fails identically on a clean `upstream/main` with this change stashed, so it is not caused by this PR, but it does mean I could not run the suite locally and am leaving it to CI. `cargo build -p opendal-core`, `cargo clippy -p opendal-core --lib` (zero warnings) and `cargo fmt --all -- --check` are clean.

### Are there any user-facing changes?

A `chunk` of `0` passed through `ReadOptions` / `ReaderOptions` now behaves as `1`, the same as `OpReader::with_chunk(0)` already does, instead of returning an empty read, looping forever in `fetch`, or panicking on an HTTP service. Any other value is unaffected.
