### PR TITLE
fix(services/pcloud): send the service root as / rather than empty

### DIFF
--- a/core/services/pcloud/src/core.rs
+++ b/core/services/pcloud/src/core.rs
@@ -425,12 +425,10 @@ impl PcloudCore {
     ) -> Result<Response<Buffer>> {
         let path = build_abs_path(&self.root, path);
 
-        let path = normalize_root(&path);
-
         let path = path.trim_end_matches('/');
 
         let url = format!(
-            "{}/listfolder?path={}&username={}&password={}",
+            "{}/listfolder?path=/{}&username={}&password={}",
             self.endpoint,
             percent_encode_path(path),
             self.username,

--- a/core/services/pcloud/src/core.rs
+++ b/core/services/pcloud/src/core.rs
@@ -425,10 +425,16 @@ impl PcloudCore {
     ) -> Result<Response<Buffer>> {
         let path = build_abs_path(&self.root, path);
 
+        let path = normalize_root(&path);
+
         let path = path.trim_end_matches('/');
 
+        // Trimming leaves nothing when the target is the service root; every other
+        // method here sends `/` for it rather than an empty parameter.
+        let path = if path.is_empty() { "/" } else { path };
+
         let url = format!(
-            "{}/listfolder?path=/{}&username={}&password={}",
+            "{}/listfolder?path={}&username={}&password={}",
             self.endpoint,
             percent_encode_path(path),
             self.username,

--- a/core/services/pcloud/src/core.rs
+++ b/core/services/pcloud/src/core.rs
@@ -429,8 +429,6 @@ impl PcloudCore {
 
         let path = path.trim_end_matches('/');
 
-        // Trimming leaves nothing when the target is the service root; every other
-        // method here sends `/` for it rather than an empty parameter.
         let path = if path.is_empty() { "/" } else { path };
 
         let url = format!(


### PR DESCRIPTION
### Which issue does this PR close?

None — found while reading the service.

### Rationale for this change

`list_folder` is the only method in `pcloud/src/core.rs` that can end up sending an empty `path` parameter.

```rust
let path = build_abs_path(&self.root, path);
let path = normalize_root(&path);
let path = path.trim_end_matches('/');
```

`build_abs_path` returns `root[1..]` when the path is `"/"`, so with the default root that is the empty string; `normalize_root` turns it into `"/"`, and `trim_end_matches('/')` takes it straight back off — leaving the parameter empty.

Compare `stat`, twenty lines above, which sends `/` for the same operator.

| root | call | `list_folder` sends today | `stat` sends |
|---|---|---|---|
| `/` | `list("/")` | **`path=`** | `path=/` |
| `/` | `list("a/")` | `path=/a` | `path=/a` |
| `/data/` | `list("/")` | `path=/data` | `path=/data` |

So listing the root of a default-rooted operator asks pCloud for an empty path. Either the API rejects it — surfaced as `ErrorKind::Unexpected` — or it answers `result: 2005`, which `lister.rs` treats as "done, no entries", i.e. an empty listing reported as success.

### What changes are included in this PR?

Three lines. When trimming leaves nothing, send `/`:

```rust
let path = path.trim_end_matches('/');

// Trimming leaves nothing when the target is the service root; every other
// method here sends `/` for it rather than an empty parameter.
let path = if path.is_empty() { "/" } else { path };
```

**Blast radius**: only the empty-parameter case changes, and it changes to what the sibling methods already send. Every other input reaches `format!` exactly as it does on `main`.

### An earlier revision of this PR was unsound

It removed the `normalize_root` call and hardcoded the leading slash into the format string instead. @erickguan caught that this is not equivalent: `normalize_root` also collapses empty segments —

```rust
v.split('/').filter(|v| !v.is_empty()).collect::<Vec<&str>>().join("/")
```

— so a path with an interior `//` would have produced a different URL, which the description at the time claimed could not happen. Feeding all three variants through the real helpers:

| root | path | main today | earlier revision | this revision |
|---|---|---|---|---|
| `/` | `"/"` | `path=` | `path=/` | `path=/` |
| `/` | `"a/b/"` | `path=/a/b` | `path=/a/b` | `path=/a/b` |
| `/data/` | `"a/"` | `path=/data/a` | `path=/data/a` | `path=/data/a` |
| `/` | `"a//b"` | `path=/a/b` | **`path=/a//b`** | `path=/a/b` |
| `/` | `"a//b/"` | `path=/a/b` | **`path=/a//b`** | `path=/a/b` |
| `/` | `"a b/"` | `path=/a%20b` | `path=/a%20b` | `path=/a%20b` |

### Tests

None — the change is one substitution on a path that is otherwise built exactly as `main` builds it, and the divergence table above is the evidence that nothing else moves.

`cargo clippy -p opendal-service-pcloud --all-features --all-targets -- -D warnings` and `cargo fmt --all -- --check` are clean. There is no directory under `.github/services` for pcloud, so nothing was exercising this.

### Are there any user-facing changes?

Yes: `list("")` / `list("/")` on a pcloud operator with the default root now asks for the root rather than for an empty path.
