### PR TITLE
fix(services/github): do not double the separator in recursive listings

### DIFF
--- a/core/services/github/src/lister.rs
+++ b/core/services/github/src/lister.rs
@@ -87,7 +87,7 @@ impl oio::PageList for GithubLister {
             let path = if self.path == "/" {
                 t.path
             } else {
-                format!("{}/{}", self.path, t.path)
+                format!("{}/{}", self.path.trim_end_matches('/'), t.path)
             };
             let entry = if t.type_field == "tree" {
                 let path = format!("{path}/");


### PR DESCRIPTION
### Which issue does this PR close?

None — found while reading the service.

### Rationale for this change

The native-recursive branch joins the listed path with each tree entry:

```rust
let path = if self.path == "/" {
    t.path
} else {
    format!("{}/{}", self.path, t.path)
};
```

`self.path` is the path the operator passed in, normalized — so it keeps its trailing slash. github declares `list_with_recursive: true` (`backend.rs:137`), so this is the real recursive path rather than a simulated one.

| call | emitted |
|---|---|
| `op.list_with("src/").recursive(true)` | **`src//services/mod.rs`** |
| `op.list_with("src").recursive(true)` | `src/services/mod.rs` ✅ |

Nothing downstream collapses the doubled separator — `oio::Entry::with` only rewrites the empty string to `"/"` — so it reaches the user. `op.read()` on such a path still works, because `normalize_path` collapses `//` on the way back in; the damage is a wrong path string, and entries that will not compare equal to the ones the *non*-recursive branch produces for the same file.

That non-recursive branch, sixteen lines above, uses `build_rel_path` and gets it right. So the two branches of the same lister disagree.

### What changes are included in this PR?

One line — trim the trailing slash before the join.

**Blast radius**: `list_with("src")` (no trailing slash) is byte-identical before and after, since `trim_end_matches('/')` is a no-op there. The `self.path == "/"` case keeps its own branch untouched, because trimming would turn it into an empty prefix and produce a leading slash.

### Tests

None — the change makes the recursive branch agree with the non-recursive one directly above it, and the effect is visible in the expression itself.

`cargo build`, `cargo clippy -p opendal-service-github --all-targets` (zero warnings) and `cargo fmt --all -- --check` are clean.

### Are there any user-facing changes?

Yes: a recursive listing of a path given with a trailing slash no longer emits paths with a doubled separator.
