### PR TITLE
fix(services/dbfs): make listed entry paths relative to the root

### DIFF
--- a/core/services/dbfs/src/lister.rs
+++ b/core/services/dbfs/src/lister.rs
@@ -59,9 +59,10 @@ impl oio::PageList for DbfsLister {
         ctx.done = true;
 
         for status in decoded_response.files {
+            let path = build_rel_path(&self.core.root, &status.path);
             let entry: oio::Entry = match status.is_dir {
                 true => {
-                    let normalized_path = format!("{}/", status.path);
+                    let normalized_path = format!("{path}/");
                     let mut meta = Metadata::new(EntryMode::DIR);
                     meta.set_last_modified(Timestamp::from_millisecond(status.modification_time)?);
                     oio::Entry::new(&normalized_path, meta)
@@ -70,7 +71,7 @@ impl oio::PageList for DbfsLister {
                     let mut meta = Metadata::new(EntryMode::FILE);
                     meta.set_last_modified(Timestamp::from_millisecond(status.modification_time)?);
                     meta.set_content_length(status.file_size as u64);
-                    oio::Entry::new(&status.path, meta)
+                    oio::Entry::new(&path, meta)
                 }
             };
             ctx.entries.push_back(entry);


### PR DESCRIPTION
### Which issue does this PR close?

None. This is the second half of #8079, kept separate because it changes what users see rather than what goes on the wire.

### Rationale for this change

The lister emits `status.path` straight from the response:

```rust
for status in decoded_response.files {
    let entry: oio::Entry = match status.is_dir {
        true => {
            let normalized_path = format!("{}/", status.path);
            ...
            oio::Entry::new(&normalized_path, meta)
        }
        false => {
            ...
            oio::Entry::new(&status.path, meta)
        }
    };
```

`DbfsCore::list` sends the prefix as `build_rooted_abs_path(&self.root, path)`, and DBFS echoes absolute paths under that prefix. So every entry comes back carrying the root and a leading slash — `/data/dir/f.txt` where the entry contract asks for `dir/f.txt`. Even at the default root the leading slash is wrong.

`alluxio` is the exact analogue in this tree — same API shape, appends `/` for directories, then relativises:

```rust
let path = if file_info.folder { format!("{path}/") } else { path };
ctx.entries.push_back(Entry::new(
    &build_rel_path(&self.core.root, &path),
    file_info.try_into()?,
));
```

Every other HTTP service lister does the same; dbfs is the only one that omits it. Nothing downstream repairs it either — `oio::Entry::with` only rewrites the empty string to `"/"`.

### What changes are included in this PR?

`build_rel_path` applied once per entry, hoisted above the `match` because both arms need it. Three lines.

### Tests

None — the change makes this lister do what `alluxio` and the rest already do, and there is no directory under `.github/services` for dbfs, so nothing exercises the listing path either way.

`cargo build`, `cargo clippy -p opendal-service-dbfs --all-targets` (zero warnings) and `cargo fmt --all -- --check` are clean.

### Are there any user-facing changes?

Yes: listed entries are relative to the operator root, as the entry contract requires, instead of carrying the root and a leading slash.
