### PR TITLE
fix(core): do not panic when a range has no valid header representation

### DIFF
--- a/core/core/src/types/bytes_range.rs
+++ b/core/core/src/types/bytes_range.rs
@@ -138,8 +138,18 @@ impl BytesRange {
     }
 
     /// Convert bytes range into Range header.
+    ///
+    /// Returns an empty string for a range with no valid HTTP representation -- a zero size, or
+    /// an end that overflows -- which [`Display`] reports by failing. `format!` turns a
+    /// `Display` failure into a panic, and this runs while a request is being built.
     pub fn to_header(&self) -> String {
-        format!("bytes={self}")
+        use std::fmt::Write;
+
+        let mut header = String::from("bytes=");
+        if write!(header, "{self}").is_err() {
+            header.clear();
+        }
+        header
     }
 
     /// Convert bytes range into rust range.
@@ -395,6 +405,15 @@ mod tests {
 
         let h = BytesRange::suffix(1024);
         assert_eq!(h.to_string(), "-1024");
+    }
+
+    #[test]
+    fn test_bytes_range_to_header_is_empty_when_unrepresentable() {
+        // `Display` fails for these, and `format!` turns a `Display` failure into a panic --
+        // `to_header` is called while building a request, at more than forty service call sites.
+        assert_eq!(BytesRange::new(0, Some(0)).to_header(), "");
+        assert_eq!(BytesRange::new(5, Some(0)).to_header(), "");
+        assert_eq!(BytesRange::new(u64::MAX, Some(2)).to_header(), "");
     }
 
     #[test]


### PR DESCRIPTION
### Which issue does this PR close?

None. Following up on #8078, where you said:

> Okay to add a guard for these format calls.

The clamp itself stays closed — this is only the panic.

### Rationale for this change

```rust
pub fn to_header(&self) -> String {
    format!("bytes={self}")
}
```

`Display` deliberately fails for two inputs, and both are pinned by existing tests in the same file:

```rust
// A zero-size range can't be represented as a valid HTTP Range.
BytesRange::Range { size: Some(0), .. } => Err(std::fmt::Error),
BytesRange::Range { offset, size: Some(size) } => write!(
    f, "{offset}-{}", offset.checked_add(size - 1).ok_or(std::fmt::Error)?
),
```

`format!` turns a `Display` failure into a panic. So either input aborts the calling task **while the request is being built**, before any I/O:

```
panicked at library/alloc/src/fmt.rs:655:14:
a formatting trait implementation returned an error when the underlying stream did not: Error
```

`to_header` has 44 call sites across the services, 22 of them behind an `is_full()` check that does not exclude a zero size.

### What changes are included in this PR?

Write through `fmt::Write`, which returns the failure as a value rather than panicking. Representable ranges are byte-identical; the two unrepresentable ones give an empty string.

`Display` is untouched — its failure is intentional and `test_bytes_range_display_zero_size` and `test_bytes_range_display_overflow` exist to hold it in place.

### What this deliberately does not decide

There is no valid HTTP Range for zero bytes, so an empty header is **not** correct either — it is only better than a panic. The honest shape would be `to_header() -> Option<String>` with callers skipping the header, but that is 44 call sites and a much larger change. Say the word if you would rather have that one and I will send it instead.

### Tests

One, next to the two existing `Display` tests. Restoring `format!` fails it and nothing else — 16 passed, 1 failed, with the panic quoted above.

A note on how I ran them: `cargo test -p opendal-core --lib` does not compile on `main` in my environment — eight `unresolved import tokio::time` in `futures_util.rs`, `block_copy.rs`, `block_write.rs` and `multipart_write.rs`. I added `"time"` to the tokio dev-dependency locally to get a signal and then reverted it; that change is **not** in this PR. `cargo build`, `cargo clippy -p opendal-core --lib` (zero warnings) and `cargo fmt --all -- --check` are clean.

### Are there any user-facing changes?

A range with no valid header representation no longer panics the calling task at request-build time. No change for any range that has one.
