### PR TITLE
fix(services/sqlite): match the directory prefix exactly instead of with LIKE

### DIFF
--- a/core/services/sqlite/src/core.rs
+++ b/core/services/sqlite/src/core.rs
@@ -95,10 +95,10 @@ impl SqliteCore {
         let pool = self.get_client().await?;
 
         sqlx::query_scalar(&format!(
-            r#"SELECT COUNT(*) FROM "{}" WHERE "{}" LIKE $1 LIMIT 1"#,
+            r#"SELECT COUNT(*) FROM "{}" WHERE instr("{}", $1) = 1 LIMIT 1"#,
             self.table, self.key_field
         ))
-        .bind(format!("{}%", path))
+        .bind(path.to_string())
         .fetch_one(pool)
         .await
         .map_err(parse_sqlite_error)


### PR DESCRIPTION
### Which issue does this PR close?

None — found while reading the service.

### Rationale for this change

`stat` falls back to `count_under` when the exact key is missing, to decide whether the path is a directory (`backend.rs:236-249`). That query interpolates the caller's path into a LIKE **pattern**:

```rust
r#"SELECT COUNT(*) FROM "{}" WHERE "{}" LIKE $1 LIMIT 1"#
    .bind(format!("{}%", path))
```

Two SQLite behaviours leak through: `LIKE` is case-insensitive for ASCII by default, and `_` / `%` inside the pattern are wildcards — and the path is not escaped.

Measured against a table holding `abc/def`, `data-1/f` and `aXb/x`:

| call | `LIKE` (today) | `instr(key, ?) = 1` |
|---|---|---|
| `stat("ABC")` | **1** — reports DIR, only `abc/def` exists | 0 |
| `stat("data_1")` | **1** — the `_` matched `data-1/f` | 0 |
| `stat("a_b")` | **1** — matched `aXb/x` | 0 |
| `stat("abc")` | 1 | 1 ✅ |
| `stat("data-1")` | 1 | 1 ✅ |
| `stat("zzz")` | 0 | 0 |

So `stat` can report `EntryMode::DIR` for a directory that does not exist, on the default configuration, for any key whose siblings differ only in case or in a character `_` happens to cover.

### What changes are included in this PR?

`instr(key, ?) = 1` — an exact, case-sensitive prefix test that takes the needle literally. Two lines.

Escaping would not have been enough on its own: `LIKE ... ESCAPE '\'` fixes the wildcards and leaves the case-insensitivity.

**No query plan is lost.** `EXPLAIN QUERY PLAN` reports `SCAN` for both forms — SQLite cannot use a BINARY-collation index for `LIKE` while `case_sensitive_like` is off, which is the default, so the existing query was already scanning the table.

### Tests

None — the behaviour is SQLite's, and it is reproduced above against a real database rather than argued from documentation.

`cargo build`, `cargo clippy -p opendal-service-sqlite --all-targets` (zero warnings) and `cargo fmt --all -- --check` are clean.

### Are there any user-facing changes?

Yes: `stat` on a path that does not exist no longer reports it as a directory because some other key differs only in letter case, or contains a character the `_` wildcard matched.
