### PR TITLE
fix(services/ipfs): address listed children by their full path

### DIFF
--- a/core/services/ipfs/src/backend.rs
+++ b/core/services/ipfs/src/backend.rs
@@ -285,14 +285,22 @@ impl oio::PageList for DirStream {
             .map(|v| v.name.unwrap())
             .collect::<Vec<String>>();
 
-        for mut name in names {
-            let meta = self.core.ipfs_stat(&self.ctx, &name).await?;
+        for name in names {
+            let child = if self.path == "/" {
+                name
+            } else {
+                format!("{}{}", self.path, name)
+            };
 
-            if meta.mode().is_dir() {
-                name += "/";
-            }
+            let meta = self.core.ipfs_stat(&self.ctx, &child).await?;
 
-            ctx.entries.push_back(oio::Entry::new(&name, meta))
+            let child = if meta.mode().is_dir() {
+                format!("{child}/")
+            } else {
+                child
+            };
+
+            ctx.entries.push_back(oio::Entry::new(&child, meta))
         }
 
         ctx.done = true;


### PR DESCRIPTION
### Which issue does this PR close?

None — found while reading the service.

### Rationale for this change

The links in a dag-pb node are bare names — one path segment each. `DirStream` passed them straight to `ipfs_stat`:

```rust
for mut name in names {
    let meta = self.core.ipfs_stat(&self.ctx, &name).await?;
    ...
    ctx.entries.push_back(oio::Entry::new(&name, meta))
}
```

`ipfs_stat` roots whatever it is given (`core.rs`, `build_rooted_abs_path`), and `self.path` is the operator-relative path — `ipfs_list` is what roots *that* for the request. So for a child of `/ipfs/CID/dir/`, the lister statted `/ipfs/CID/x.txt`: usually a 404 that fails the whole listing, or — if a same-named object happens to exist at the root — silently the wrong metadata. The entry path handed back to the caller lost its directory the same way.

It is correct only when `self.path` is `"/"`.

That is not a corner case: ipfs declares `list: true` but **not** `list_with_recursive`, so `SimulateLayer` drives recursion by re-entering `list` for each directory it finds. A recursive listing from the root hits this on the first subdirectory.

### What changes are included in this PR?

Build the child path once and use it for both the `stat` and the entry. `self.path` already carries its trailing slash.

**Blast radius**: listing the operator root is unchanged — `self.path` is `"/"` there, so the child is the bare name, exactly what was sent before. Only subdirectory listings change, and those are the broken ones.

### Tests

None — the service has no directory under `.github/services`, and reaching the branch needs a live gateway holding a nested UnixFS directory.

`cargo build`, `cargo clippy -p opendal-service-ipfs --all-targets` (zero warnings) and `cargo fmt --all -- --check` are clean.

### Are there any user-facing changes?

Yes: listing a subdirectory returns entries whose paths include that subdirectory, with metadata read from the right object, instead of failing or returning the root's.

### Not in this PR

`.map(|v| v.name.unwrap())` two lines above will panic if a link carries no name — `PBLink.name` is `optional` in the dag-pb spec. I could not establish that any gateway actually omits it rather than sending an empty string, so I have left it alone rather than guess.
