### PR TITLE
fix(services/hdfs): normalize atomic_write_dir the way root already is

### DIFF
--- a/core/services/hdfs/src/backend.rs
+++ b/core/services/hdfs/src/backend.rs
@@ -142,7 +142,7 @@ impl Builder for HdfsBuilder {
             client.create_dir(&root).map_err(new_std_io_error)?
         }
 
-        let atomic_write_dir = self.config.atomic_write_dir;
+        let atomic_write_dir = self.config.atomic_write_dir.as_deref().map(normalize_root);
 
         // If atomic write dir is not exist, we must create it.
         if let Some(d) = &atomic_write_dir


### PR DESCRIPTION
### Which issue does this PR close?

None — found while reading the service.

### Rationale for this change

`root` goes through `normalize_root`; `atomic_write_dir` is stored verbatim two dozen lines later:

```rust
let root = normalize_root(&self.config.root.unwrap_or_default());   // :123
...
let atomic_write_dir = self.config.atomic_write_dir;                // :145
```

It is then handed to `build_rooted_abs_path` (`core.rs:115`), which is pure concatenation and whose contract — stated as `debug_assert`s — requires a value that both starts and ends with `/`.

So the value from the builder's own rustdoc, written without a trailing slash, does not land where it says:

```
atomic_write_dir("/tmp/opendal"), write("a.txt")
    tmp path = "/tmp/opendal" + "a.txt.AbCdEfGh"
             = /tmp/opendala.txt.AbCdEfGh
```

a **sibling** of the configured directory rather than a file inside it. A relative value is worse — `"tmp"` yields `tmpa.txt.XXXX`, resolved against the HDFS home directory. In a debug build the `debug_assert` fires first and it panics instead.

There is a second consequence: the build step immediately above **pre-creates** the configured directory, so it is not the one written to. A user with write permission only on the directory they configured gets a failure, and any leftover temp file lands somewhere they never named.

Neither the rustdoc nor `docs.md` mentions a trailing-slash requirement:

```rust
/// Set temp dir for atomic write.
///
/// # Notes
///
/// - When append is enabled, we will not use atomic write
///   to avoid data loss and performance issue.
pub fn atomic_write_dir(mut self, dir: &str) -> Self {
```

CI passes because both action files happen to set one:

```
.github/services/hdfs/hdfs_cluster_with_atomic_write_dir/action.yml:37
.github/services/hdfs/hdfs_default_with_atomic_write_dir/action.yml:32
    OPENDAL_HDFS_ATOMIC_WRITE_DIR=/tmp/atomic_write_dir/opendal/
```

So the invariant is required, undocumented, and unenforced.

### What changes are included in this PR?

One line — normalize it at build time, the same as `root`.

**Blast radius**: `normalize_root` is the identity on `/tmp/atomic_write_dir/opendal/`, so the configuration CI uses is byte-identical. Only a value missing the leading or trailing slash changes, and it changes to what `build_rooted_abs_path` already requires.

### Tests

None — the change makes one config value go through the same normalizer as the one beside it, and the existing atomic-write CI jobs exercise the path with a value the change does not alter.

`cargo build -p opendal-service-hdfs`, `cargo clippy -p opendal-service-hdfs --all-targets` (zero warnings) and `cargo fmt --all -- --check` are clean.

### Are there any user-facing changes?

Yes: `atomic_write_dir` written without a trailing slash now writes inside that directory rather than alongside it, and a relative value is resolved as an absolute path rather than against the HDFS home directory.

### Note

The sibling `fs` service sidesteps this entirely by using `PathBuf::join` instead of string concatenation. Making hdfs do the same would be a larger change; this one keeps to the existing shape.
