### PR TITLE
feat(services/webdav): support rename with if_not_exists

### DIFF
--- a/core/services/webdav/src/backend.rs
+++ b/core/services/webdav/src/backend.rs
@@ -235,6 +235,7 @@ impl Builder for WebdavBuilder {
                 copy: true,
 
                 rename: true,
+                rename_with_if_not_exists: true,
 
                 list: true,
 
@@ -382,9 +383,12 @@ impl Service for WebdavBackend {
         ctx: &OperationContext,
         from: &str,
         to: &str,
-        _args: OpRename,
+        args: OpRename,
     ) -> Result<RpRename> {
-        let resp = self.core.webdav_move(ctx, from, to).await?;
+        let resp = self
+            .core
+            .webdav_move(ctx, from, to, args.if_not_exists())
+            .await?;
 
         let status = resp.status();
         match status {

--- a/core/services/webdav/src/core.rs
+++ b/core/services/webdav/src/core.rs
@@ -358,6 +358,7 @@ impl WebdavCore {
         ctx: &OperationContext,
         from: &str,
         to: &str,
+        if_not_exists: bool,
     ) -> Result<Response<Buffer>> {
         // Check if source file exists.
         let _ = self.webdav_stat(ctx, from).await?;
@@ -377,7 +378,7 @@ impl WebdavCore {
         }
 
         req = req.header(HEADER_DESTINATION, target_uri);
-        req = req.header(HEADER_OVERWRITE, "T");
+        req = req.header(HEADER_OVERWRITE, if if_not_exists { "F" } else { "T" });
 
         let req = req
             .extension(Operation::Rename)


### PR DESCRIPTION
### Which issue does this PR close?

Part of #7828 — the `webdav` box of RFC-7818. Announced the intended shape there first; this is that.

### Rationale for this change

The RFC calls webdav a *"Strong candidate: RFC 4918 defines `Overwrite: F` and a failed precondition"*, and §10.6 is explicit — `F` means the server **must not** perform the MOVE if the destination maps to a resource.

`webdav_move` hardcoded the header, so `OpRename` was ignored entirely — the backend took it as `_args`:

```rust
req = req.header(HEADER_OVERWRITE, "T");
```

It now threads the flag through and sends `F` when `if_not_exists` is set.

**Nothing was needed on the error side.** RFC 4918 §9.9.4 has the server answer `412` when the precondition fails, and webdav already maps it:

```rust
// core.rs:1647
StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED => (ErrorKind::ConditionNotMatch, false)
```

which is exactly what `test_rename_with_if_not_exists_returns_condition_not_match` asserts.

### On the capability, since #7828 asks

Plain `rename_with_if_not_exists: true`, no config flag. `Overwrite` is not an optional extension — RFC 4918 §10.6 makes it part of MOVE and a server that ignores it is non-conforming. That is unlike conditional *read*, where servers genuinely differ and `enable_conditional_read` earns its keep. Happy to move it behind a flag if you would rather have consistency with #7637.

### On the mkcol

`webdav_move` creates the destination's parent before issuing the MOVE, and that stays: `test_rename_with_if_not_exists_nested` renames onto a three-level path that does not exist yet, so the parent creation is what makes it pass. The consequence is that a `412` can leave an empty parent behind. The destination itself is untouched, so it does not violate the RFC — flagging it rather than leaving you to find it.

### Verification

Against the `nginx` fixture from `.github/services/webdav`, not by reading:

| | |
|---|---|
| the three `if_not_exists` behaviour tests | **3 passed** |
| all rename behaviour tests | **10 passed** |
| the whole webdav behaviour suite | **124 passed, 0 failed** |

`test_rename_overwrite` is in that set, so the default path still sends `T`.

And the control that makes those numbers mean something — hardcoding `T` back while keeping the capability bit:

```
test behavior::test_rename_with_if_not_exists_returns_condition_not_match ... FAILED
test result: FAILED. 9 passed; 1 failed
```

Exactly one test, the one asserting `ConditionNotMatch`. The header rather than the bit is doing the work.

`cargo clippy -p opendal-service-webdav --all-targets` (zero warnings) and `cargo fmt --all -- --check` are clean.

### Scope

Only webdav. `hdfs_native` can follow — also docker-verifiable, no secrets.

I would leave `azfile` and `azdls` alone for now: their CI fixtures load credentials through `1Password/load-secrets-action`, so a fork PR gets no behaviour coverage on them, and I would rather not advertise an atomicity-gated capability on a code reading alone. Happy to write them if someone who can run that CI wants to take the verification.

### Are there any user-facing changes?

Yes — `op.rename_with(from, to).if_not_exists(true)` now works on webdav, returning `ErrorKind::ConditionNotMatch` when the destination exists. Ordinary `rename` is unchanged.
