### PR TITLE
feat(services/hdfs-native): support rename with if_not_exists

### DIFF
--- a/core/services/hdfs-native/src/backend.rs
+++ b/core/services/hdfs-native/src/backend.rs
@@ -135,6 +135,7 @@ impl Builder for HdfsNativeBuilder {
                     list: true,
 
                     rename: true,
+                    rename_with_if_not_exists: true,
 
                     shared: true,
 
@@ -234,9 +235,9 @@ impl Service for HdfsNativeBackend {
         _ctx: &OperationContext,
         from: &str,
         to: &str,
-        _args: OpRename,
+        args: OpRename,
     ) -> Result<RpRename> {
-        self.core.hdfs_rename(from, to).await?;
+        self.core.hdfs_rename(from, to, &args).await?;
         Ok(RpRename::default())
     }
 

--- a/core/services/hdfs-native/src/core.rs
+++ b/core/services/hdfs-native/src/core.rs
@@ -24,19 +24,6 @@ use hdfs_native::WriteOptions;
 use opendal_core::raw::*;
 use opendal_core::*;
 
-fn map_hdfs_rename_error(err: HdfsError, if_not_exists: bool, to_path: &str) -> Error {
-    if if_not_exists && matches!(err, HdfsError::AlreadyExists(_)) {
-        return Error::new(
-            ErrorKind::ConditionNotMatch,
-            "target path already exists while if_not_exists is set",
-        )
-        .with_context("input", to_path)
-        .set_source(err);
-    }
-
-    parse_hdfs_error(err)
-}
-
 /// HdfsNativeCore contains code that directly interacts with HDFS Native client.
 #[derive(Clone)]
 pub struct HdfsNativeCore {
@@ -201,14 +188,10 @@ impl HdfsNativeCore {
             }
             Err(err) => match &err {
                 HdfsError::FileNotFound(_) => {
-                    // `WriteOptions::default()` does not overwrite, so this also fails when
-                    // another writer took the target between the stat above and here.
                     self.client
                         .create(&to_path, WriteOptions::default().create_parent(true))
                         .await
-                        .map_err(|err| {
-                            map_hdfs_rename_error(err, args.if_not_exists(), &to_path)
-                        })?;
+                        .map_err(parse_hdfs_error)?;
                 }
                 _ => return Err(parse_hdfs_error(err)),
             },

--- a/core/services/hdfs-native/src/core.rs
+++ b/core/services/hdfs-native/src/core.rs
@@ -24,6 +24,19 @@ use hdfs_native::WriteOptions;
 use opendal_core::raw::*;
 use opendal_core::*;
 
+fn map_hdfs_rename_error(err: HdfsError, if_not_exists: bool, to_path: &str) -> Error {
+    if if_not_exists && matches!(err, HdfsError::AlreadyExists(_)) {
+        return Error::new(
+            ErrorKind::ConditionNotMatch,
+            "target path already exists while if_not_exists is set",
+        )
+        .with_context("input", to_path)
+        .set_source(err);
+    }
+
+    parse_hdfs_error(err)
+}
+
 /// HdfsNativeCore contains code that directly interacts with HDFS Native client.
 #[derive(Clone)]
 pub struct HdfsNativeCore {
@@ -164,7 +177,7 @@ impl HdfsNativeCore {
         Ok(Some((p, current_path)))
     }
 
-    pub async fn hdfs_rename(&self, from: &str, to: &str) -> Result<()> {
+    pub async fn hdfs_rename(&self, from: &str, to: &str, args: &OpRename) -> Result<()> {
         let from_path = build_rooted_abs_path(&self.root, from);
         let to_path = build_rooted_abs_path(&self.root, to);
 
@@ -173,6 +186,12 @@ impl HdfsNativeCore {
                 if status.isdir {
                     return Err(Error::new(ErrorKind::IsADirectory, "path should be a file")
                         .with_context("input", &to_path));
+                } else if args.if_not_exists() {
+                    return Err(Error::new(
+                        ErrorKind::ConditionNotMatch,
+                        "target path already exists while if_not_exists is set",
+                    )
+                    .with_context("input", &to_path));
                 } else {
                     self.client
                         .delete(&to_path, true)
@@ -182,10 +201,14 @@ impl HdfsNativeCore {
             }
             Err(err) => match &err {
                 HdfsError::FileNotFound(_) => {
+                    // `WriteOptions::default()` does not overwrite, so this also fails when
+                    // another writer took the target between the stat above and here.
                     self.client
                         .create(&to_path, WriteOptions::default().create_parent(true))
                         .await
-                        .map_err(parse_hdfs_error)?;
+                        .map_err(|err| {
+                            map_hdfs_rename_error(err, args.if_not_exists(), &to_path)
+                        })?;
                 }
                 _ => return Err(parse_hdfs_error(err)),
             },

--- a/core/services/hdfs-native/src/docs.md
+++ b/core/services/hdfs-native/src/docs.md
@@ -13,6 +13,7 @@ Depending on its configuration and the backing system, this service can expose:
 - [x] list
 - [ ] copy
 - [x] rename
+- [x] rename (if_not_exists)
 - [ ] ~~presign~~
 
 Inspect the effective capability set with [`opendal_core::Operator::info`] and


### PR DESCRIPTION
### Which issue does this PR close?

Part of #7828 — RFC-7818. Said on #8089 that `hdfs_native` would follow webdav; this is that.

### Rationale for this change

`hdfs_native` took `_args: OpRename` and ignored it, so `if_not_exists` was rejected by the correctness-check layer. The sibling `hdfs` service already implements this; the two now behave the same way.

Two places needed the flag.

**1. The destination is stat'd before the rename, and an existing file is deleted.**

```rust
Ok(status) => {
    if status.isdir { return Err(IsADirectory) }
    else { self.client.delete(&to_path, true).await? }   // <- destroys the target
}
```

`test_rename_with_if_not_exists_returns_condition_not_match` asserts the target still reads back with its original content, so returning `ConditionNotMatch` has to happen *before* the delete. The check is placed after the `isdir` arm, keeping the existing `IsADirectory` answer for a directory destination — same ordering as `hdfs`.

**2. The not-found arm pre-creates the destination, and that create can lose a race.**

```rust
HdfsError::FileNotFound(_) => {
    self.client.create(&to_path, WriteOptions::default().create_parent(true)).await?
}
```

`WriteOptions::default()` is `overwrite: false` (`hdfs-native-0.14.3` `client.rs:53`), so if another writer takes the destination between the stat and this call, the NameNode raises `FileAlreadyExistsException`, which the crate maps to `HdfsError::AlreadyExists` (`hdfs/proxy.rs:347`) and this service maps to `ErrorKind::AlreadyExists`. Under `if_not_exists` the contract calls for `ConditionNotMatch`, so a small mapper translates it — the same shape as `map_hdfs_rename_error` in `services/hdfs`.

The final `rename(..., overwrite = true)` stays as it is: by that point the destination is a file this call just created, so `overwrite = false` would reject our own placeholder.

### Verification

Against a real HDFS cluster, not by reading. The fixture in `fixtures/hdfs/docker-compose-hdfs-cluster.yml` uses `network_mode: host`, which does not reach the host on Docker Desktop for macOS, so I ran the same two images on a bridge network with `dfs.datanode.hostname=localhost` and `dfs.client.use.datanode.hostname=true`. Same Hadoop 3.2.1 images, same `OPENDAL_HDFS_NATIVE_*` variables as the CI action.

Rename suite:

```
running 10 tests
test behavior::test_rename_source_dir                                     ... ok
test behavior::test_rename_non_existing_source                            ... ok
test behavior::test_rename_self                                           ... ok
test behavior::test_rename_target_dir                                     ... ok
test behavior::test_rename_with_if_not_exists_nested                      ... ok
test behavior::test_rename_file                                           ... ok
test behavior::test_rename_with_if_not_exists                             ... ok
test behavior::test_rename_nested                                         ... ok
test behavior::test_rename_with_if_not_exists_returns_condition_not_match ... ok
test behavior::test_rename_overwrite                                      ... ok

test result: ok. 10 passed; 0 failed
```

`test_rename_overwrite` is in that set, so the default path still replaces the destination.

And the control that makes those numbers mean something — dropping the `ConditionNotMatch` return while keeping the capability bit:

```
---- behavior::test_rename_with_if_not_exists_returns_condition_not_match ----
test panicked: rename must fail: ()

test result: FAILED. 9 passed; 1 failed
```

Exactly one test. The check, not the capability bit, is doing the work.

Whole-suite counts, same cluster, `--test-threads 1`, unmodified tree vs this branch:

| | |
|---|---|
| `upstream/main` | `113 passed; 0 failed` |
| this branch | `116 passed; 0 failed` |

The three added tests are exactly the delta in the total, and nothing else moved.

Worth flagging for anyone reproducing this locally: run it single-threaded. With the default thread count a single-DataNode cluster on this machine fails a handful of read-stream tests — a different handful on each run, on the unmodified tree as well — so a parallel run is not a usable control.

`cargo clippy -p opendal-service-hdfs-native --all-features --all-targets -- -D warnings` and `cargo fmt` are clean.

### On not adding a unit test

Setting the capability is what enrolls the service in the three behaviour tests above, and those run against a real NameNode. A unit test over the error mapper would only restate the `if_not_exists &&` guard that is visible in the diff. Happy to add one if you would rather have it.

### Separable

If you would rather land the minimum, the mapper in the not-found arm can be dropped and the stat-path check alone still passes all three behaviour tests — the mapper only changes which error a concurrent writer sees. I have kept it because `AlreadyExists` leaking out of an `if_not_exists` call is the one error kind that operation is defined not to produce.

### Are there any user-facing changes?

Yes — `op.rename_with(from, to).if_not_exists(true)` now works on `hdfs_native`, returning `ErrorKind::ConditionNotMatch` when the destination exists. Ordinary `rename` is unchanged.
