### PR TITLE
fix(services/onedrive): disable write_total_max_size on smaller machine

### DIFF
--- a/core/services/onedrive/src/backend.rs
+++ b/core/services/onedrive/src/backend.rs
@@ -134,6 +134,8 @@ impl Builder for OnedriveBuilder {
 
             write: true,
             write_with_if_match: true,
+            // disable because usize is too small on armhf and other arch to represent more than 4GB
+            #[cfg(target_pointer_width = "64")]
             // Read more at https://support.microsoft.com/en-us/office/restrictions-and-limitations-in-onedrive-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa#individualfilesize
             write_total_max_size: Some(250 * 1024 * 1024 * 1024), // 250GB
             copy: true,


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Allow release.

# What changes are included in this PR?

- Fix OneDrive service capability write_total_max_size overflow.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

# AI Usage Statement

<!--
If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
-->
