### PR TITLE
docs: add AI-assisted contribution policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -22,13 +22,13 @@ labels: ["bug"]
 body:
   - type: markdown
     attributes:
-      value: "Thank you for taking the time to report a bug. Bug reports must describe behavior reproduced against the affected component. For service-specific bugs, reproduce against the actual service rather than relying only on a mock, emulator, or source-code analysis."
+      value: "Thank you for taking your time to report a bug. Bug reports must describe steps and behavior reproducable against an affected component. For service-specific bugs, reproduce against an actual service rather than relying only on a mock, emulator, or source-code analysis."
 
   - type: input
     id: opendal-version
     attributes:
       label: OpenDAL version or commit
-      description: "Specify the released version or commit where you reproduced the bug."
+      description: "Specify a release or commit where you reproduced the bug."
       placeholder: "For example: v0.58.1 or commit abc1234"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -22,7 +22,25 @@ labels: ["bug"]
 body:
   - type: markdown
     attributes:
-      value: "Thank you for taking the time to report a bug. Please provide as much information as possible to help us understand and resolve the issue."
+      value: "Thank you for taking the time to report a bug. Bug reports must describe behavior reproduced against the affected component. For service-specific bugs, reproduce against the actual service rather than relying only on a mock, emulator, or source-code analysis."
+
+  - type: input
+    id: opendal-version
+    attributes:
+      label: OpenDAL version or commit
+      description: "Specify the released version or commit where you reproduced the bug."
+      placeholder: "For example: v0.58.1 or commit abc1234"
+    validations:
+      required: true
+
+  - type: input
+    id: affected-component
+    attributes:
+      label: Affected service or component
+      description: "Name the service, core component, layer, integration, or binding where you reproduced the bug."
+      placeholder: "For example: services/s3 against AWS S3"
+    validations:
+      required: true
 
   - type: textarea
     id: describe-bug
@@ -37,7 +55,17 @@ body:
     id: steps-to-reproduce
     attributes:
       label: Steps to Reproduce
-      description: "Steps to reproduce the behavior:"
+      description: "Provide minimal code or commands, relevant sanitized configuration, and the actual service or environment used."
+      placeholder: "Provide a minimal, self-contained reproduction."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: "Include the actual output, error, or other observable behavior."
+      placeholder: "Explain what happened and include relevant sanitized logs."
     validations:
       required: true
 
@@ -61,7 +89,15 @@ body:
 
   - type: markdown
     attributes:
-      value: "Please make sure to include any relevant information such as screenshots, logs, or code snippets that may help in diagnosing the issue."
+      value: "Do not publish credentials or other sensitive data. Report security concerns privately by following the [OpenDAL security process](https://opendal.apache.org/community/security). If you found a possible bug through source analysis but cannot reproduce it, start a [Discussion](https://github.com/apache/opendal/discussions) instead."
+
+  - type: checkboxes
+    id: reproduction-confirmation
+    attributes:
+      label: Reproduction confirmation
+      options:
+        - label: "I reproduced this issue against the affected component. For a service-specific report, I used the actual service rather than only a mock, emulator, or source-code analysis."
+          required: true
 
   - type: checkboxes
     id: willing-to-submit-pr

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,5 +33,10 @@ If there are any breaking changes to public APIs, please add the `breaking-chang
 # AI Usage Statement
 
 <!--
-If you are using AI tools to build this PR, please include a statement specifying the tool and models you are using.
+If you used AI tools to build this PR, name the tools and models, briefly
+describe how you verified their output, and disclose important assumptions or
+unknowns. Do not paste raw AI output. You must understand every submitted claim
+and change well enough to explain and defend it during review.
+
+If you did not use AI tools, write "None".
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,10 +33,10 @@ If there are any breaking changes to public APIs, please add the `breaking-chang
 # AI Usage Statement
 
 <!--
-If you used AI tools to build this PR, name the tools and models, briefly
-describe how you verified their output, and disclose important assumptions or
-unknowns. Do not paste raw AI output. You must understand every submitted claim
-and change well enough to explain and defend it during review.
+If AI materially assisted this PR, briefly describe its role and disclose any
+assumptions or unknowns that affect review. Do not include routine command output
+or repeat information provided elsewhere.
 
-If you did not use AI tools, write "None".
+The author remains responsible for every submitted claim and change. If AI did
+not materially assist this PR, write "None".
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Guidance for AI coding agents working in this repository.
 
 ## AI-Assisted Contributions
 
-Follow the [AI-Assisted Contributions](CONTRIBUTING.md#ai-assisted-contributions)
+Follow [AI-Assisted Contributions](CONTRIBUTING.md#ai-assisted-contributions)
 policy.
 
 - Do not publish an Issue, Pull Request, Discussion, or review comment unless a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,21 @@ Guidance for AI coding agents working in this repository.
 - Add tests when they verify real behavior or guard a regression; do not add placeholder tests.
 - Do not change public APIs or behavior tests unless the task explicitly requires it.
 
+## AI-Assisted Contributions
+
+Follow the [AI-Assisted Contributions](CONTRIBUTING.md#ai-assisted-contributions)
+policy.
+
+- Do not publish an Issue, Pull Request, Discussion, or review comment unless a
+  human has meaningfully reviewed the content and explicitly asked you to submit
+  it.
+- Treat source-code findings as hypotheses until they are reproduced. Reproduce
+  service-specific bugs against the actual service.
+- In a Pull Request, briefly disclose AI's material role and any assumptions or
+  unknowns that affect review. Do not repeat routine validation output.
+
+The human contributor remains responsible for every submitted claim and change.
+
 ## Documentation Style
 
 - Prefer active voice. Name the type or component that performs an action, for example, “`RetryLayer` retries failed operations.”

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,8 @@ guides the work and remains accountable for it.
   verify AI-assisted analysis before sharing it with the community.
 - Understand every submitted claim and change well enough to explain and defend
   it during review.
-- Disclose important assumptions, unknowns, and the AI tools and models used.
+- Disclose material AI involvement and any assumptions or unknowns that affect
+  review.
 
 The contributor, not the AI tool, is responsible for the accuracy, relevance,
 and quality of every submission.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@ First, thank you for contributing to OpenDAL! The goal of this document is to pr
 
 - [Contributing](#contributing)
   - [Your First Contribution](#your-first-contribution)
+  - [AI-Assisted Contributions](#ai-assisted-contributions)
+    - [Human Involvement](#human-involvement)
+    - [Bug Reports](#bug-reports)
+    - [Code Changes](#code-changes)
   - [Workflow](#workflow)
     - [Git Branches](#git-branches)
     - [GitHub Pull Requests](#github-pull-requests)
@@ -23,6 +27,64 @@ First, thank you for contributing to OpenDAL! The goal of this document is to pr
 1. [Create a new Git branch](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-and-deleting-branches-within-your-repository).
 1. Make your changes.
 1. [Submit the branch as a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork) to the main OpenDAL repo. An OpenDAL team member should comment and/or review your pull request within a few days. Although, depending on the circumstances, it may take longer.
+
+## AI-Assisted Contributions
+
+Attention is the scarcest resource in an open source community. We appreciate
+everyone who gives their attention to OpenDAL, and we ask contributors to
+protect the attention of others. These standards apply to every contribution;
+AI assistance does not lower them.
+
+### Human Involvement
+
+OpenDAL welcomes and encourages AI-assisted contributions when a human actively
+guides the work and remains accountable for it.
+
+- Every Issue, Pull Request, Discussion, and review conversation must involve
+  meaningful human participation. Do not delegate project communication entirely
+  to an AI agent.
+- Do not copy and paste LLM output into project conversations. Review, edit, and
+  verify AI-assisted analysis before sharing it with the community.
+- Understand every submitted claim and change well enough to explain and defend
+  it during review.
+- Disclose important assumptions, unknowns, and the AI tools and models used.
+
+The contributor, not the AI tool, is responsible for the accuracy, relevance,
+and quality of every submission.
+
+### Bug Reports
+
+OpenDAL welcomes the use of AI tools to analyze source code and find bugs. A
+source-code hypothesis is not sufficient evidence for a bug report.
+
+- Reproduce the reported behavior against the affected component. For a
+  service-specific bug, reproduce it against the actual service being reported.
+  A mock server, emulator, or source-code analysis alone does not establish a
+  bug in the service.
+- Provide the OpenDAL version or commit, the service or component, relevant
+  sanitized configuration, minimal reproduction steps, the actual result, and
+  the expected result.
+- Submit an unverified hypothesis as a
+  [Discussion](https://github.com/apache/opendal/discussions) or question, not as
+  a confirmed bug.
+
+Do not publish credentials or other sensitive data. Report security concerns
+through the process described in [Security](website/community/security.md).
+
+### Code Changes
+
+OpenDAL welcomes AI-assisted bug fixes and feature implementations that solve a
+demonstrated problem or meet a concrete use case.
+
+- Link the change to an Issue that establishes the problem or requirement.
+- Verify a bug before fixing it, and add tests that demonstrate the failure and
+  protect the intended behavior when practical.
+- Explain the user-facing, correctness, or maintenance value of the change.
+
+OpenDAL does not accept speculative fixes for unverified bugs or mechanical
+refactors without an agreed technical goal. Maintainers may close submissions
+that lack meaningful human participation or are unverified, speculative, or
+otherwise incomplete without performing a detailed technical review.
 
 ## Workflow
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6795.

# Rationale for this change

Community attention is limited. AI-assisted contributions are welcome, but contributors must not transfer the cost of understanding, verification, or communication to maintainers.

# What changes are included in this PR?

This PR defines the human ownership, reproduction evidence, and demonstrated-value requirements for AI-assisted contributions. It adds a concise agent-facing entry and updates the bug report and pull request templates so contributors provide the information needed to apply the policy.

# Are there any user-facing changes?

Contributors reporting bugs must identify the affected version and component, provide the actual observed behavior, and confirm reproduction against the affected component. Service-specific reports must use the actual service rather than relying only on a mock, emulator, or source-code analysis.

# AI Usage Statement

AI assisted with drafting and editing this policy. I reviewed and take responsibility for the final text. There are no known assumptions or unknowns that affect review.
