### PR TITLE
feat(parquet): expose writer abort

### DIFF
--- a/integrations/parquet/src/async_writer.rs
+++ b/integrations/parquet/src/async_writer.rs
@@ -80,6 +80,11 @@ impl AsyncWriter {
     pub fn new(writer: Writer) -> Self {
         Self { inner: writer }
     }
+
+    /// Aborts the write and cleans up data written by the underlying [`Writer`].
+    pub async fn abort(&mut self) -> opendal::Result<()> {
+        self.inner.abort().await
+    }
 }
 
 impl AsyncFileWriter for AsyncWriter {
@@ -136,7 +141,7 @@ mod tests {
         writer.write(bytes).await.unwrap();
         let bytes = Bytes::from_static(b"hello, OpenDAL!");
         writer.write(bytes).await.unwrap();
-        drop(writer);
+        writer.abort().await.unwrap();
 
         let exist = op.exists(path).await.unwrap();
         assert!(!exist);


### PR DESCRIPTION
# Which issue does this PR close?

Closes #8101.

# Rationale for this change

`parquet_opendal::AsyncWriter` does not expose OpenDAL's explicit abort operation. Applications currently need a custom `AsyncFileWriter` adapter to clean up failed writes, including multipart uploads.

# What changes are included in this PR?

- Add `AsyncWriter::abort`, preserving the underlying `opendal::Error` for this OpenDAL-specific lifecycle operation.
- Update the abort test to terminate the writer explicitly instead of dropping it.

# Are there any user-facing changes?

Yes. Applications can retrieve `AsyncWriter` through `AsyncArrowWriter::into_inner()` and explicitly abort the underlying OpenDAL write.

# AI Usage Statement

Pi with the OpenAI GPT-5.6 model was used to inspect the implementation, make the focused change, and draft tests and documentation.
