### PR TITLE
fix(core): add missing tokio test features so crates build on their own

### DIFF
--- a/core/core/Cargo.toml
+++ b/core/core/Cargo.toml
@@ -96,4 +96,9 @@ logforth = { workspace = true }
 pretty_assertions = "1"
 rand = { workspace = true }
 sha2 = { workspace = true }
-tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = [
+  "fs",
+  "macros",
+  "rt-multi-thread",
+  "time",
+] }

--- a/core/layers/observe-metrics-common/Cargo.toml
+++ b/core/layers/observe-metrics-common/Cargo.toml
@@ -37,4 +37,4 @@ http = { workspace = true }
 opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
# Which issue does this PR close?

None. The `opendal-core` line also exists on #8042, a much larger transport change that is currently conflicting; this splits the build fix out so it can land on its own. The second crate is not covered there.

# Rationale for this change

Two crates cannot have their tests built on their own.

`cargo test -p opendal-core --no-run`, on any non-wasm target:

```
error[E0432]: unresolved import `tokio::time`
   --> core/src/types/execute/executors/tokio_executor.rs:38:16
    |
 38 |     use tokio::time::sleep;
    |                ^^^^ could not find `time` in `tokio`
```

Ten sites across seven files use `tokio::time`, all of them inside `mod tests`, but `time` is only enabled under `[target.'cfg(target_arch = "wasm32")'.dependencies]`.

`cargo check -p opendal-layer-observe-metrics-common --tests`:

```
error: The #[tokio::test] macro requires rt or rt-multi-thread.
    --> layers/observe-metrics-common/src/lib.rs:1538:5
     |
1538 |     #[tokio::test]
     |     ^^^^^^^^^^^^^^
```

Its dev-dependency asks for `["macros"]` alone. The other fifteen layer crates with a tokio dev-dependency all ask for a runtime as well.

Core CI runs `--workspace --all-features`, so feature unification supplies both from sibling crates and neither gap is visible there. They only show up when a crate is built by itself.

# What changes are included in this PR?

`"time"` for `opendal-core`, `"rt-multi-thread"` for `opendal-layer-observe-metrics-common`. `taplo format` expanded the first array, which crossed 80 columns.

I ran `cargo check -p <crate> --tests` over all 105 workspace members. Nothing else fails, apart from `opendal-service-hdfs` and `opendal-service-rocksdb`, which need system libraries I do not have locally.

# Are there any user-facing changes?

No. Dev-dependencies are not part of the published build, and `Cargo.lock` is unchanged. `cargo test -p opendal-core` now runs 183 unit tests and 130 doc tests, and `opendal-layer-observe-metrics-common` runs 18.

# AI Usage Statement

AI assisted with investigating the build failures and drafting this description. I reviewed and take responsibility for the changes. There are no known assumptions or unknowns that affect review.
