### PR TITLE
chore(services/hf): bump hf-xet to 1.6.0

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -4315,9 +4315,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hf-xet"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3005542f8cad13a23c2a85674aeeb888e2eb67cc6f413853c8ef169504e284bc"
+checksum = "c237ef4fb0ce1962a5117f8bd8c74454b41629826a9df17d14a1840ca18f0754"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13138,9 +13138,9 @@ dependencies = [
 
 [[package]]
 name = "xet-client"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4ebf97728991933d7bdfbb4118173b773e5423d66433fecb969f1aa7786a70"
+checksum = "c3b8da8cc70aa2e3c500c0400e012df82c656ab9fca47f9f939fffc5afd89aca"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13174,9 +13174,9 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe69515f98acd9e3b357dce5f6ebff234c9626b01aa7dd436593747034fe7fd"
+checksum = "73503c223783dccc864abde22115e09d12f190448a0baf58ab2c54bc709e2f99"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -13207,9 +13207,9 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580ba26ccca44d41f1f7dcec838ffb166f629e9c72fb7172839f6d092439a61c"
+checksum = "c89052ec5dec2187cad30b86af92cc24fd61c4a57a795f1ff7ff5f38d49184eb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13239,9 +13239,9 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca7a88ab94bba9dbf47ca966ca3bb5e6eb1167752a5aff881276bf786cc5d522"
+checksum = "af5c60d5eed38ab4c576f4421bae835e7bd07631fb381705605529d2015c106b"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/core/services/hf/Cargo.toml
+++ b/core/services/hf/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 bytes = { workspace = true }
-hf-xet = "1.5.0"
+hf-xet = "1.6.0"
 http = { workspace = true }
 log = { workspace = true }
 opendal-core = { path = "../../core", version = "0.58.2", default-features = false }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #.

# Rationale for this change

Keep the `hf-xet` dependency current with upstream releases.

# What changes are included in this PR?

Bumps `hf-xet` from 1.5.0 to 1.6.0 in `core/services/hf/Cargo.toml`, and updates
`core/Cargo.lock` accordingly (`hf-xet`, `xet-client`, `xet-core-structures`,
`xet-data`, `xet-runtime` all move from 1.5.4 to 1.6.0). No source changes were
required; the existing `opendal-service-hf` test suite (including the
network-gated tests) passes unchanged against the new version.

# Are there any user-facing changes?

No.

# AI Usage Statement

Claude Code performed the dependency bump, ran the build/test/clippy
verification, and drafted this PR description.