### PR TITLE
fix(services/dropbox): fail copy and rename when the source is missing

### DIFF
--- a/core/services/dropbox/src/backend.rs
+++ b/core/services/dropbox/src/backend.rs
@@ -343,13 +343,7 @@ impl Service for DropboxBackend {
 
             match status {
                 StatusCode::OK => Ok(Metadata::default()),
-                _ => {
-                    let err = parse_error(resp);
-                    match err.kind() {
-                        ErrorKind::NotFound => Ok(Metadata::default()),
-                        _ => Err(err),
-                    }
-                }
+                _ => Err(parse_error(resp)),
             }
         }))
     }
@@ -367,13 +361,7 @@ impl Service for DropboxBackend {
 
         match status {
             StatusCode::OK => Ok(RpRename::default()),
-            _ => {
-                let err = parse_error(resp);
-                match err.kind() {
-                    ErrorKind::NotFound => Ok(RpRename::default()),
-                    _ => Err(err),
-                }
-            }
+            _ => Err(parse_error(resp)),
         }
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

None. The specification this violates is already in the repository — see below —
so there is no service-side behaviour to establish and nothing to reproduce
against Dropbox.

# Rationale for this change

`copy` and `rename` catch `ErrorKind::NotFound` and return success:

```rust
// backend.rs:344-354, copy
match status {
    StatusCode::OK => Ok(Metadata::default()),
    _ => {
        let err = parse_error(resp);
        match err.kind() {
            ErrorKind::NotFound => Ok(Metadata::default()),
            _ => Err(err),
        }
    }
}
```

and the same shape at `:368-378` for `rename`. So `op.copy(src, dst)` and
`op.rename(src, dst)` return `Ok` when `src` does not exist: nothing is created
at `dst`, nothing is raised, and a caller walking a list of paths records every
one of them as copied.

The behavior suite already says this must not happen:

```rust
// core/tests/behavior/async_copy.rs:158-167
pub async fn test_copy_non_existing_source(op: Operator) -> Result<()> {
    let err = op
        .copy(&source_path, &target_path)
        .await
        .expect_err("copy must fail");
    assert_eq!(err.kind(), ErrorKind::NotFound);
    Ok(())
}
```

`test_rename_non_existing_source` asserts the same at `async_rename.rs:78`.

Two things make this worth fixing rather than leaving:

**dropbox is the only service that does it.** Grepping every service for a
`ErrorKind::NotFound => Ok(..)` arm inside `copy` or `rename` returns dropbox
and nothing else.

**Its behavior test cannot catch it.** The service's test action is
`.github/services/dropbox/dropbox/disable_action.yml`, and
`.github/scripts/test_behavior/plan.py:48-53` only picks up files named
`action.yml`, so dropbox is never planned into a behavior run — 7 services are
disabled this way against 83 enabled. The assertion exists; it has simply never
been pointed at this service.

The origin looks like a copy of an idiom that is correct two files away:

| site | `NotFound => Ok` | correct? |
|---|---|---|
| `deleter.rs:49` | yes | yes — deleting a missing path is a no-op |
| `lister.rs:74` | yes | yes — listing a missing directory is empty |
| `backend.rs:349` (copy) | yes | no |
| `backend.rs:373` (rename) | yes | no |

# What changes are included in this PR?

The two special cases are removed, so a non-OK response becomes the error
`parse_error` already built:

```rust
match status {
    StatusCode::OK => Ok(Metadata::default()),
    _ => Err(parse_error(resp)),
}
```

`deleter.rs` and `lister.rs` are left alone.

# Are there any user-facing changes?

Yes. `copy` and `rename` against Dropbox now return `ErrorKind::NotFound` when
the source is missing, instead of a success that copied nothing. Code that
relied on the old behaviour to ignore missing sources needs to handle that error
— which is what it already has to do on every other service.

# Note on testing

I have not added a unit test. The assertion that pins this behaviour already
exists in the behavior suite, quoted above, and the two operations are a status
match inside an async block with no pure function to exercise; adding a mock
around the whole backend would be a bigger change than the fix and has no
precedent in this repository.

I do not have a Dropbox account to run the behavior suite against, and I have
not claimed to. Everything asserted here is decidable from the tree: the two
call sites, the two behavior tests, the absence of the same arm in any other
service, and the disabled test action.
