### PR TITLE
fix(bindings/dotnet): correct stream error kind and if-modified-since test

### DIFF
--- a/bindings/dotnet/OpenDAL.Tests/Behavior/StatBehaviorTest.cs
+++ b/bindings/dotnet/OpenDAL.Tests/Behavior/StatBehaviorTest.cs
@@ -92,18 +92,33 @@ public sealed class StatBehaviorTest : BehaviorTestBase
     }
 
     [Fact]
-    public void StatBehavior_IfModifiedSince_ReturnsConditionNotMatchWhenUnsupportedByTime()
+    public void StatBehavior_WithIfModifiedSince_AppliesCondition()
     {
         if (!Supports(c => c.Stat && c.Write && c.StatWithIfModifiedSince))
         {
             return;
         }
 
+        var content = RandomBytes(10);
         var path = NewPath("stat-if-modified-since");
-        Op.Write(path, RandomBytes(10));
+        Op.Write(path, content);
 
+        var meta = Op.Stat(path);
+        Assert.True(meta.IsFile);
+        Assert.Equal((ulong)content.LongLength, meta.ContentLength);
+        Assert.NotNull(meta.LastModified);
+
+        var since = meta.LastModified.Value.AddSeconds(-1);
+        var res = Op.Stat(path, new Options.StatOptions { IfModifiedSince = since });
+        Assert.Equal(meta.LastModified, res.LastModified);
+
+        // The next timestamp must not be in the future.
+        // AWS ignores a future If-Modified-Since and returns 200 instead of 304.
+        Thread.Sleep(1000);
+
+        since = meta.LastModified.Value.AddSeconds(1);
         var ex = Assert.Throws<OpenDALException>(() =>
-            Op.Stat(path, new OpenDAL.Options.StatOptions { IfModifiedSince = DateTimeOffset.UtcNow.AddDays(1) }));
+            Op.Stat(path, new Options.StatOptions { IfModifiedSince = since }));
 
         Assert.Equal(ErrorCode.ConditionNotMatch, ex.Code);
     }

--- a/bindings/dotnet/src/operator.rs
+++ b/bindings/dotnet/src/operator.rs
@@ -1272,11 +1272,12 @@ fn next_chunk_to_buffer(
 ) -> Result<OpendalReadBuffer, OpenDALError> {
     value
         .transpose()
-        .map_err(|err| {
-            OpenDALError::from_opendal_error(opendal::Error::new(
+        .map_err(|err| match err.downcast::<opendal::Error>() {
+            Ok(error) => OpenDALError::from_opendal_error(error),
+            Err(err) => OpenDALError::from_opendal_error(opendal::Error::new(
                 opendal::ErrorKind::Unexpected,
                 err.to_string(),
-            ))
+            )),
         })
         .map(|chunk| {
             chunk


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

None

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

The .NET behavior tests had only run against the memory service.

Running them against MinIO and AWS S3 surfaced two problems: 

- Stream reads reported every error as `Unexpected`.
- `If-Modified-Since` test used a client-clock timestamp in the future, which only works on MinIO.

s3 also advertises `write_can_append` on endpoints that answer 501, a core issue related to #8053.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Recover the wrapped `opendal::Error` with `io::Error::downcast` so stream reads report their real
`ErrorCode`.

Derive the `If-Modified-Since` timestamp from the object's `LastModified` and cover both
directions, matching core's `test_stat_with_if_modified_since`.

# Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

Errors from `OpenReadStream` now carry their real `ErrorCode` instead of `Unexpected`.
One-shot `Read` was never affected.

# AI Usage Statement

<!--
If AI materially assisted this PR, briefly describe its role and disclose any
assumptions or unknowns that affect review. Do not include routine command output
or repeat information provided elsewhere.

The author remains responsible for every submitted claim and change. If AI did
not materially assist this PR, write "None".
-->

Claude Code (Claude Opus 5) traced the root cause and reviewed the changes. I wrote the code.

One unknown. The fallback branch in `next_chunk_to_buffer` is unreachable today and kept only
so the FFI boundary cannot panic if core changes, so no test covers it.
