### PR TITLE
fix(services/b2): resolve stat and copy by exact name, not by prefix

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -6896,6 +6896,7 @@ version = "0.58.2"
 dependencies = [
  "asyncband",
  "bytes",
+ "futures",
  "http 1.4.2",
  "log",
  "opendal-core",

--- a/core/services/b2/Cargo.toml
+++ b/core/services/b2/Cargo.toml
@@ -41,4 +41,5 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 [dev-dependencies]
+futures = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/b2/src/backend.rs
+++ b/core/services/b2/src/backend.rs
@@ -457,3 +457,105 @@ impl Service for B2Backend {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use bytes::Bytes;
+    use http::Request;
+    use http::Response;
+    use http::StatusCode;
+
+    use super::*;
+
+    /// Answers the two calls a `stat` makes: the account authorization, then the
+    /// prefix listing. The listing body is supplied by the test.
+    #[derive(Clone)]
+    struct B2MockTransport {
+        list_body: &'static str,
+        listed_uris: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl B2MockTransport {
+        fn new(list_body: &'static str) -> Self {
+            Self {
+                list_body,
+                listed_uris: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn response(body: impl Into<Bytes>) -> Response<HttpBody> {
+            let body = Buffer::from(body.into());
+            let size = body.len() as u64;
+            Response::builder()
+                .status(StatusCode::OK)
+                .body(HttpBody::new(
+                    futures::stream::iter(vec![Ok(body)]),
+                    Some(size),
+                ))
+                .expect("mock response must build")
+        }
+    }
+
+    impl HttpTransport for B2MockTransport {
+        async fn fetch(&self, req: Request<Buffer>) -> Result<Response<HttpBody>> {
+            let uri = req.uri().to_string();
+            if uri.contains("b2_authorize_account") {
+                return Ok(Self::response(
+                    r#"{"authorizationToken":"token","apiUrl":"https://api.example.com","downloadUrl":"https://download.example.com"}"#,
+                ));
+            }
+            self.listed_uris.lock().expect("lock poisoned").push(uri);
+            Ok(Self::response(self.list_body))
+        }
+    }
+
+    fn b2_operator(transport: B2MockTransport) -> Operator {
+        Operator::new(
+            B2Builder::default()
+                .application_key_id("key-id")
+                .application_key("key")
+                .bucket("bucket")
+                .bucket_id("bucket-id"),
+        )
+        .expect("b2 operator must build")
+        .with_context(OperationContext::new().with_http_transport(HttpTransporter::new(transport)))
+    }
+
+    /// `b2_list_file_names` filters by prefix, so a listing for "abc" also carries
+    /// "abcd". Resolving a stat to whatever came back first answers for the wrong
+    /// object; the name has to match exactly.
+    #[tokio::test]
+    async fn test_stat_does_not_resolve_a_prefix_match() {
+        let transport = B2MockTransport::new(
+            r#"{"files":[{"fileName":"abcd","contentLength":4,"contentType":"text/plain"}],"nextFileName":null}"#,
+        );
+        let op = b2_operator(transport.clone());
+
+        let err = op
+            .stat("abc")
+            .await
+            .expect_err("abcd must not answer for abc");
+        assert_eq!(err.kind(), ErrorKind::NotFound);
+
+        // the request really did go out as a prefix listing for "abc"
+        let uris = transport.listed_uris.lock().expect("lock poisoned").clone();
+        assert_eq!(uris.len(), 1, "expected one listing, got {uris:?}");
+        assert!(uris[0].contains("prefix=abc"), "unexpected uri {}", uris[0]);
+    }
+
+    /// The exact name still resolves, and it is picked out of a listing that also
+    /// carries longer names sharing the prefix.
+    #[tokio::test]
+    async fn test_stat_resolves_the_exact_name() {
+        let transport = B2MockTransport::new(
+            r#"{"files":[{"fileName":"abc","contentLength":3,"contentType":"text/plain"},{"fileName":"abcd","contentLength":4,"contentType":"text/plain"}],"nextFileName":null}"#,
+        );
+        let op = b2_operator(transport);
+
+        let meta = op.stat("abc").await.expect("abc must resolve");
+        assert_eq!(meta.content_length(), 3);
+    }
+}

--- a/core/services/b2/src/core.rs
+++ b/core/services/b2/src/core.rs
@@ -503,6 +503,24 @@ impl B2Core {
                 if resp.files.is_empty() {
                     return Err(Error::new(ErrorKind::NotFound, "no such file or directory"));
                 }
+
+                // b2_list_file_names filters by prefix, so a lookup for "abc" also
+                // returns "abcd". Take the entry only when the name matches exactly.
+                //
+                // Names come back in alphabetical order and an exact name sorts before
+                // every longer name sharing it, so the match is always the first entry
+                // and is never left on a page this call did not fetch.
+                //
+                // A directory lookup passes a delimiter and lists what is under the
+                // prefix rather than the prefix itself, so it keeps the first entry.
+                if delimiter.is_none() {
+                    let abs_path = build_abs_path(&self.root, path);
+                    return match resp.files.iter().position(|f| f.file_name == abs_path) {
+                        Some(idx) => Ok(resp.files.swap_remove(idx)),
+                        None => Err(Error::new(ErrorKind::NotFound, "no such file or directory")),
+                    };
+                }
+
                 Ok(resp.files.swap_remove(0))
             }
             _ => Err(parse_error(resp)),


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

`stat` and `copy` both resolve a path through `get_file_info`, which asks B2 for
a *prefix* listing and then takes whatever came back first:

```rust
// core.rs:486-510
let resp = self
    .list_file_names_raw(ctx, Some(path), delimiter, None, None, Operation::Stat)
    .await?;
...
if resp.files.is_empty() {
    return Err(Error::new(ErrorKind::NotFound, "no such file or directory"));
}
Ok(resp.files.swap_remove(0))
```

The path goes out as `prefix`:

```rust
// core.rs:541-546
if let Some(prefix) = prefix {
    let prefix = build_abs_path(&self.root, prefix);
    if !prefix.is_empty() {
        url = url.push("prefix", &percent_encode_path(&prefix));
    }
}
```

`b2_list_file_names` returns every file whose name begins with that prefix, so a
lookup for `abc` also returns `abcd`. Nothing then checks that the entry's name
is the name that was asked for. With only `abcd` in the bucket:

| call | today | expected |
|---|---|---|
| `stat("abc")` | a `FILE` carrying `abcd`'s length, mtime and md5 | `NotFound` |
| `exists("abc")` | `true` | `false` |
| `copy("abc", dst)` | **copies `abcd` to `dst`**, returns `Ok` | `NotFound` |

The copy case is the sharp one. `copy` takes the `file_id` off the same
`get_file_info` result and hands it to `b2_copy_file` as the source:

```rust
// backend.rs:328-334
let file_info = core.get_file_info(&ctx, &from, None).await?;
let source_file_id = file_info.file_id;
```

so it silently copies a different object and reports success.

# What changes are included in this PR?

`get_file_info` now takes the entry whose name matches exactly, and reports
`NotFound` when the prefix listing contains no such entry. The comparison is the
one `lister.rs:99` already makes in this crate:

```rust
build_abs_path(&self.core.root, &start_after) == file.file_name
```

Directory lookups are deliberately left alone. A directory `stat` passes a
delimiter and lists what is *under* the prefix rather than the prefix itself, so
requiring an exact match there would change behaviour on a path I cannot test.
The guard is therefore `if delimiter.is_none()`, which covers file `stat` and
`copy` — the two callers that are wrong today.

# Are there any user-facing changes?

Yes. `stat`, `exists`, `read` and `copy` against a B2 path that is a proper
prefix of another object now return `NotFound` instead of silently resolving to
that other object.

# Verification

Executable now, rather than argued. `backend.rs` gains a mock `HttpTransport` — the
same shape as `S3ExpressMockTransport` in `services/s3` — that answers the account
authorization and then returns a listing the test supplies, so the resolution runs
for real:

```
test backend::tests::test_stat_does_not_resolve_a_prefix_match ... ok
test backend::tests::test_stat_resolves_the_exact_name ... ok
test result: ok. 2 passed; 0 failed
```

The first asserts `stat("abc")` is `NotFound` when the listing carries only `abcd`,
and that the request really did go out as `prefix=abc`. The second asserts `abc`
still resolves out of a listing that carries both `abc` and `abcd`.

The control that makes those mean something — reverting to `swap_remove(0)` and
running again:

```
test backend::tests::test_stat_does_not_resolve_a_prefix_match ... FAILED
thread ... panicked at services/b2/src/backend.rs:537:40
test result: FAILED. 4 passed; 1 failed
```

`stat("abc")` succeeds there and hands back `abcd`'s metadata. That is the defect,
run rather than described. `test_stat_resolves_the_exact_name` stays green either
way, so it is the name comparison and not the listing that the first test is
pinning.

`cargo clippy -p opendal-service-b2 --all-targets` is clean and
`cargo fmt --all -- --check` passes. Rebased onto current `main`.

# Note on evidence

What the mock cannot establish is the service-side premise, and I am not claiming
it does. That `prefix` limits `b2_list_file_names` to names starting with it is
B2's documented behaviour, not something I observed on a live account — I do not
have a B2 bucket. The test supplies that response and demonstrates what our
resolution does with it; the defect it shows is ours.

The rest is decidable from the tree: the missing name comparison, the two callers,
and the identical comparison already performed in `lister.rs`. The same class of
bug was fixed for sqlite in #8085, where a path was matched as a `LIKE` pattern
instead of an exact prefix.
