### PR TITLE
refactor(services/monoiofs): use asyncband channels

### DIFF
--- a/bindings/python/src/file.rs
+++ b/bindings/python/src/file.rs
@@ -31,7 +31,6 @@ use pyo3::IntoPyObjectExt;
 use pyo3::buffer::PyBuffer;
 use pyo3::exceptions::PyIOError;
 use pyo3::exceptions::PyValueError;
-use pyo3::prelude::*;
 use pyo3_async_runtimes::tokio::future_into_py;
 
 use crate::*;

--- a/bindings/python/src/lister.rs
+++ b/bindings/python/src/lister.rs
@@ -21,7 +21,6 @@ use asyncband::mutex::Mutex;
 use futures::TryStreamExt;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyStopAsyncIteration;
-use pyo3::prelude::*;
 use pyo3_async_runtimes::tokio::future_into_py;
 
 use crate::*;

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -20,7 +20,6 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use pyo3::IntoPyObjectExt;
-use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::types::PyDict;
 use pyo3::types::PyTuple;

--- a/bindings/ruby/src/capability.rs
+++ b/bindings/ruby/src/capability.rs
@@ -18,7 +18,6 @@
 use magnus::Error;
 use magnus::RModule;
 use magnus::method;
-use magnus::prelude::*;
 
 use crate::*;
 

--- a/bindings/ruby/src/io.rs
+++ b/bindings/ruby/src/io.rs
@@ -36,7 +36,6 @@ use magnus::RString;
 use magnus::Value;
 use magnus::io::FMode;
 use magnus::method;
-use magnus::prelude::*;
 use magnus::scan_args::scan_args;
 
 use crate::*;

--- a/bindings/ruby/src/lister.rs
+++ b/bindings/ruby/src/lister.rs
@@ -31,7 +31,6 @@ use magnus::Error;
 use magnus::RModule;
 use magnus::Ruby;
 use magnus::method;
-use magnus::prelude::*;
 
 use crate::metadata::Metadata;
 use crate::*;

--- a/bindings/ruby/src/metadata.rs
+++ b/bindings/ruby/src/metadata.rs
@@ -25,7 +25,6 @@
 use magnus::Error;
 use magnus::RModule;
 use magnus::method;
-use magnus::prelude::*;
 
 use crate::*;
 

--- a/bindings/ruby/src/operator_info.rs
+++ b/bindings/ruby/src/operator_info.rs
@@ -23,7 +23,6 @@
 use magnus::Error;
 use magnus::RModule;
 use magnus::method;
-use magnus::prelude::*;
 
 use crate::capability::Capability;
 use crate::*;

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -7314,9 +7314,9 @@ dependencies = [
 name = "opendal-service-monoiofs"
 version = "0.58.2"
 dependencies = [
+ "asyncband",
  "bytes",
  "flume 0.12.0",
- "futures",
  "monoio",
  "opendal-core",
  "serde",

--- a/core/layers/foyer/src/lib.rs
+++ b/core/layers/foyer/src/lib.rs
@@ -361,7 +361,6 @@ mod tests {
         BlockEngineConfig, DeviceBuilder, Error as FoyerError, ErrorKind as FoyerErrorKind,
         FsDeviceBuilder, HybridCache, HybridCacheBuilder, RecoverMode,
     };
-    use opendal_core::raw::Layer as _;
     use opendal_core::raw::oio::Read as _;
     use opendal_core::raw::oio::ReadStream as _;
     use opendal_core::{Buffer, Operator, services::Memory};

--- a/core/services/monoiofs/Cargo.toml
+++ b/core/services/monoiofs/Cargo.toml
@@ -32,9 +32,9 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
+asyncband = { workspace = true }
 bytes = { workspace = true }
 flume = "0.12"
-futures = { workspace = true, features = ["std", "async-await"] }
 monoio = { version = "0.2.4", features = [
   "sync",
   "mkdirat",

--- a/core/services/monoiofs/src/core.rs
+++ b/core/services/monoiofs/src/core.rs
@@ -15,15 +15,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::future::Future;
 use std::mem;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
+use asyncband::oneshot;
 use flume::Receiver;
 use flume::Sender;
-use futures::Future;
-use futures::channel::oneshot;
 use monoio::FusionDriver;
 use monoio::RuntimeBuilder;
 use opendal_core::raw::*;
@@ -230,9 +230,8 @@ impl MonoiofsCore {
 mod tests {
     use std::sync::Arc;
 
-    use futures::StreamExt;
-    use futures::channel::mpsc::UnboundedSender;
-    use futures::channel::mpsc::{self};
+    use asyncband::mpsc;
+    use asyncband::mpsc::UnboundedSender;
 
     use super::*;
 
@@ -261,16 +260,16 @@ mod tests {
                     })
                     .await;
                 assert_eq!(result, sleep_millis);
-                tx.unbounded_send(result).unwrap();
+                tx.send(result).unwrap();
             });
         }
 
         spawn_task(core.clone(), tx.clone(), 200);
         spawn_task(core.clone(), tx.clone(), 20);
         drop(tx);
-        let first = rx.next().await;
-        let second = rx.next().await;
-        let third = rx.next().await;
+        let first = rx.recv().await.ok();
+        let second = rx.recv().await.ok();
+        let third = rx.recv().await.ok();
         assert_eq!(first, Some(20));
         assert_eq!(second, Some(200));
         assert_eq!(third, None);

--- a/core/services/monoiofs/src/reader.rs
+++ b/core/services/monoiofs/src/reader.rs
@@ -17,9 +17,8 @@
 
 use super::core::MonoiofsCore;
 use super::writer::MonoiofsWriter;
-use futures::StreamExt;
-use futures::channel::mpsc;
-use futures::channel::oneshot;
+use asyncband::mpsc;
+use asyncband::oneshot;
 use monoio::fs::OpenOptions;
 use opendal_core::raw::*;
 use opendal_core::*;
@@ -76,7 +75,7 @@ impl MonoiofsReader {
         };
         // wait for read request and send back result to main thread
         loop {
-            let Some(req) = rx.next().await else {
+            let Ok(req) = rx.recv().await else {
                 // MonoiofsReader is dropped, exit worker task
                 break;
             };
@@ -104,12 +103,11 @@ impl MonoiofsReader {
 
         // send read request to worker thread and wait for result
         let (tx, rx) = oneshot::channel();
-        self.core
-            .unwrap(self.tx.unbounded_send(ReaderRequest::Read {
-                offset,
-                buf: vec![0; size].into_boxed_slice(),
-                tx,
-            }));
+        self.core.unwrap(self.tx.send(ReaderRequest::Read {
+            offset,
+            buf: vec![0; size].into_boxed_slice(),
+            tx,
+        }));
         let (n, buf) = self.core.unwrap(rx.await)?;
 
         let mut buf = Vec::from(buf);

--- a/core/services/monoiofs/src/writer.rs
+++ b/core/services/monoiofs/src/writer.rs
@@ -18,12 +18,10 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use asyncband::mpsc;
+use asyncband::oneshot;
 use bytes::Buf;
 use bytes::Bytes;
-use futures::SinkExt;
-use futures::StreamExt;
-use futures::channel::mpsc;
-use futures::channel::oneshot;
 use monoio::fs::OpenOptions;
 use opendal_core::raw::*;
 use opendal_core::*;
@@ -93,7 +91,7 @@ impl MonoiofsWriter {
         };
         // wait for write or close request and send back result to main thread
         loop {
-            let Some(req) = rx.next().await else {
+            let Ok(req) = rx.recv().await else {
                 // MonoiofsWriter is dropped, exit worker task
                 break;
             };
@@ -131,15 +129,11 @@ impl oio::Write for MonoiofsWriter {
             let buf = bs.current();
             let n = buf.len();
             let (tx, rx) = oneshot::channel();
-            self.core.unwrap(
-                self.tx
-                    .send(WriterRequest::Write {
-                        pos: self.pos,
-                        buf,
-                        tx,
-                    })
-                    .await,
-            );
+            self.core.unwrap(self.tx.send(WriterRequest::Write {
+                pos: self.pos,
+                buf,
+                tx,
+            }));
             self.core.unwrap(rx.await)?;
             self.pos += n as u64;
             bs.advance(n);
@@ -152,13 +146,11 @@ impl oio::Write for MonoiofsWriter {
     /// on worker thread.
     async fn close(&mut self) -> Result<Metadata> {
         let (tx, rx) = oneshot::channel();
-        self.core
-            .unwrap(self.tx.send(WriterRequest::Stat { tx }).await);
+        self.core.unwrap(self.tx.send(WriterRequest::Stat { tx }));
         let file_meta = self.core.unwrap(rx.await)?;
 
         let (tx, rx) = oneshot::channel();
-        self.core
-            .unwrap(self.tx.send(WriterRequest::Close { tx }).await);
+        self.core.unwrap(self.tx.send(WriterRequest::Close { tx }));
         self.core.unwrap(rx.await)?;
 
         let mode = if file_meta.is_dir() {


### PR DESCRIPTION
# Which issue does this PR close?

N/A. This is a maintenance-only refactor requested by a maintainer.

# Rationale for this change

The Monoiofs service still uses `futures` channels while the workspace already uses `asyncband` for runtime-agnostic synchronization primitives. Using the shared channel implementation removes the service direct dependency on `futures` and keeps its cross-runtime communication consistent with the rest of the workspace.

# What changes are included in this PR?

- Replace the Monoiofs unbounded MPSC channels with `asyncband::mpsc`.
- Replace all Monoiofs oneshot channels with `asyncband::oneshot`.
- Use `std::future::Future` and remove the service direct `futures` dependency.

# Are there any user-facing changes?

No.

# AI Usage Statement

Codex materially assisted with the implementation and validation under maintainer direction. The focused checks pass. The full Monoiofs behavior suite retains a pre-existing `test_write_with_append` failure that was reproduced on the unmodified base commit.