### PR TITLE
fix(services/gcs): percent-encode object path in presign requests

### DIFF
--- a/core/services/gcs/src/core.rs
+++ b/core/services/gcs/src/core.rs
@@ -198,7 +198,12 @@ impl GcsCore {
     ) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
-        let url = format!("{}/{}/{}", self.endpoint, self.bucket, p);
+        let url = format!(
+            "{}/{}/{}",
+            self.endpoint,
+            self.bucket,
+            percent_encode_path(&p)
+        );
 
         let mut req = Request::get(&url);
 
@@ -338,7 +343,12 @@ impl GcsCore {
     ) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
-        let url = format!("{}/{}/{}", self.endpoint, self.bucket, p);
+        let url = format!(
+            "{}/{}/{}",
+            self.endpoint,
+            self.bucket,
+            percent_encode_path(&p)
+        );
 
         let mut req = Request::put(&url);
 
@@ -414,7 +424,12 @@ impl GcsCore {
     ) -> Result<Request<Buffer>> {
         let p = build_abs_path(&self.root, path);
 
-        let url = format!("{}/{}/{}", self.endpoint, self.bucket, p);
+        let url = format!(
+            "{}/{}/{}",
+            self.endpoint,
+            self.bucket,
+            percent_encode_path(&p)
+        );
 
         let mut req = Request::head(&url);
 
@@ -1004,6 +1019,50 @@ mod tests {
             .expect("request must sign");
 
         assert_eq!(signed.uri(), &original_uri);
+    }
+
+    #[test]
+    fn test_xml_requests_percent_encode_object_path() {
+        let sign_ctx = Context::new();
+        let signer = Signer::new(
+            sign_ctx.clone(),
+            ProvideCredentialChain::new().push(TokenCredentialProvider::new("test-token")),
+            RequestSigner::new("storage"),
+        );
+
+        let core = GcsCore {
+            info: ServiceInfo::new("gcs", "/", "test-bucket"),
+            capability: Capability::default(),
+            endpoint: "https://storage.googleapis.com".to_string(),
+            bucket: "test-bucket".to_string(),
+            root: "/".to_string(),
+            signer,
+            sign_ctx,
+            predefined_acl: None,
+            default_storage_class: None,
+            skip_signature: false,
+        };
+
+        let path = "nested/object #1?v=2 .txt";
+        let expected = "/test-bucket/nested/object%20%231%3Fv%3D2%20.txt";
+
+        let get = core
+            .gcs_get_object_xml_request(path, BytesRange::default(), &OpRead::default())
+            .expect("request must build");
+        assert_eq!(get.uri().path(), expected);
+        assert_eq!(get.uri().query(), None);
+
+        let put = core
+            .gcs_insert_object_xml_request(path, &OpWrite::default(), Buffer::new())
+            .expect("request must build");
+        assert_eq!(put.uri().path(), expected);
+        assert_eq!(put.uri().query(), None);
+
+        let head = core
+            .gcs_head_object_xml_request(path, &OpStat::default())
+            .expect("request must build");
+        assert_eq!(head.uri().path(), expected);
+        assert_eq!(head.uri().query(), None);
     }
 
     #[test]


### PR DESCRIPTION
# Which issue does this PR close?

None

# Rationale for this change

`presign` on GCS goes through the XML API request builders `gcs_get_object_xml_request`, `gcs_insert_object_xml_request` and `gcs_head_object_xml_request`, and those three build the URL from the raw object key while every other URL builder in `gcs/core.rs` (and the equivalent S3, COS, OBS, OSS and TOS XML builders) percent-encodes it. The key is whatever the caller passes to `presign_read`, `presign_write` or `presign_stat`, so anything outside the unreserved set reaches `http::Uri` unescaped. A key with a space fails request construction with `invalid uri character`, which makes `presign_read("reports/Q3 summary.pdf")` return an error today. A key containing `?` or `#` is worse because the URI parser quietly splits on it: `dir/a?b.txt` becomes path `/bucket/dir/a` plus query `b.txt`, and `dir/a#b.txt` becomes `/bucket/dir/a` with the fragment dropped, so the signed GET, PUT or HEAD URL is for a different object than the one the caller asked to authorize. I noticed it while comparing the presign builders against `gcs_get_object_request`, which does encode. The encoding was removed on purpose in #2132 because the reqsign of that time percent-encoded the path itself during signing and produced a double-encoded URL, but `reqsign_google` 3 builds the canonical URI by decoding each wire path segment and re-encoding it, and it appends the `X-Goog-*` parameters to the original URI without touching the path, so the reason for the workaround is gone. Restoring `percent_encode_path` at the three sites, the same helper S3 uses for its XML URLs, keeps `/` intact and fixes both failure modes in the place that constructs the request.

# What changes are included in this PR?

- `percent_encode_path` on the object path in the three `*_xml_request` builders in `core/services/gcs/src/core.rs`.
- A unit test that builds all three requests for a key containing a space, `#`, `?` and `=` and checks the URI path is the encoded key with no query. It fails on the current tree.

The four multipart XML builders (`gcs_initiate_multipart_upload`, `gcs_upload_part`, `gcs_complete_multipart_upload`, `gcs_abort_multipart_upload`) stay on `gcs_percent_encode_path`, which encodes `/` as `%2F`. That is deliberate: they go out as signed-header requests where GCS decodes the path and treats `%2F` and `/` in object names as the same object, so they address the right object today, and switching their encoder would change the bytes of live requests, which deserves its own verification against a real bucket. This PR only touches the presign builders, which fail outright.

Verification was local: the new test, the existing `test_insert_object_signing_preserves_wire_uri`, and a throwaway service-account key run through `sign_query`, which produced a path of `/test-bucket/dir/a%20b%3Fx%23y.txt` with only the `X-Goog-*` query parameters attached. I did not have a GCS bucket to round-trip the signed URL against, so a run of the gcs presign behavior tests would be a good extra check.

# Are there any user-facing changes?

`presign_read`, `presign_write` and `presign_stat` on `services::Gcs` now succeed for keys with spaces and other reserved characters, and produce a URL for the requested object when the key contains `?` or `#`. Keys made only of unreserved characters produce the same URL as before.

# AI Usage Statement

<!--
If AI materially assisted this PR, briefly describe its role and disclose any
assumptions or unknowns that affect review. Do not include routine command output
or repeat information provided elsewhere.

The author remains responsible for every submitted claim and change. If AI did
not materially assist this PR, write "None".
-->

