### PR TITLE
ci: pin pnpm action setup to commit

### DIFF
--- a/.github/workflows/ci_bindings_nodejs.yml
+++ b/.github/workflows/ci_bindings_nodejs.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 8
           run_install: false

--- a/.github/workflows/ci_check.yml
+++ b/.github/workflows/ci_check.yml
@@ -109,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           # Follow website/package.json packageManager field
           version: 11.8.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -120,7 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 8
           run_install: false
@@ -507,7 +507,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           # Follow website/package.json packageManager field
           version: 11.8.0

--- a/.github/workflows/release_nodejs.yml
+++ b/.github/workflows/release_nodejs.yml
@@ -105,7 +105,7 @@ jobs:
             build: pnpm build
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 8
           run_install: false
@@ -178,7 +178,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 8
           run_install: false

--- a/.github/workflows/test_behavior_binding_nodejs.yml
+++ b/.github/workflows/test_behavior_binding_nodejs.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 8
           run_install: false
@@ -82,7 +82,7 @@ jobs:
           echo "OP_CONNECT_HOST=${{ secrets.OP_CONNECT_HOST }}" >> "$GITHUB_ENV"
           echo "OP_CONNECT_TOKEN=${{ secrets.OP_CONNECT_TOKEN }}" >> "$GITHUB_ENV"
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 8
           run_install: false


### PR DESCRIPTION
# Which issue does this PR close?

Closes #8130.

# Rationale for this change

Apache Infrastructure requires third-party GitHub Actions to use immutable commit hashes and remain updateable through automation.

# What changes are included in this PR?

Pin all eight `pnpm/action-setup` uses to the verified commit for v6.0.10. The existing Dependabot `github-actions` configuration includes third-party actions, so it can continue updating the pinned revision and version annotation.

# Are there any user-facing changes?

No.

# AI Usage Statement

AI materially assisted with locating the affected workflow references, verifying the upstream tag and commit, and applying the updates. This change relies on the repository's existing Dependabot `github-actions` configuration to keep the pinned revision current.
