### PR TITLE
fix(services/ghac): propagate v2 finalize errors

### DIFF
--- a/core/services/ghac/src/writer.rs
+++ b/core/services/ghac/src/writer.rs
@@ -270,10 +270,9 @@ impl oio::Write for GhacWriterV2 {
 
     async fn close(&mut self) -> Result<Metadata> {
         self.writer.close().await?;
-        let _ = self
-            .core
+        self.core
             .ghac_finalize_upload(&self.ctx, &self.path, &self.url, self.size)
-            .await;
+            .await?;
         Ok(Metadata::default().with_content_length(self.size))
     }
 


### PR DESCRIPTION
# Which issue does this PR close?

Closes #8127

# Rationale for this change

`GhacWriterV2::close()` uploads the cache data and then calls GitHub Actions Cache V2's `FinalizeCacheEntryUpload` operation. The current implementation discards that operation's result, so a finalization failure can still be reported as a successful write. The issue discussion confirmed that this asymmetry came from a mechanical rewrite; `GhacWriterV1::close()` already propagates the same error.

This matters because callers can treat the cache entry as durable even though GitHub did not finalize it. Returning the finalization error lets callers observe the failed write and keeps V2 consistent with V1.

# What changes are included in this PR?

- Propagate the result of `ghac_finalize_upload` from `GhacWriterV2::close()` with `?`.
- Preserve the existing successful return value and metadata.
- Do not change upload, retry, or public API behavior.

# Are there any user-facing changes?

When GitHub Actions Cache V2 finalization fails, `close()` now returns that error instead of returning successful metadata. Successful finalization behaves exactly as before.

# Verification

- `RUSTUP_TOOLCHAIN=1.98.0-aarch64-apple-darwin cargo test --manifest-path core/Cargo.toml -p opendal-service-ghac` (4 unit tests and 2 doc tests passed)
- `RUSTUP_TOOLCHAIN=1.98.0-aarch64-apple-darwin cargo fmt --manifest-path core/Cargo.toml --all -- --check`
- `git diff --check`

# AI Usage Statement

OpenAI Codex materially assisted with source inspection, implementation, local verification, commit signing, and PR preparation. The issue discussion, surrounding V1 implementation, and final diff were reviewed for accuracy. The live GitHub Cache service failure was not reproduced end to end; this patch is limited to propagating the already-returned finalization error, matching V1 semantics.
