### PR TITLE
feat(bindings/dotnet): support conditional delete with if-match

### DIFF
--- a/bindings/dotnet/OpenDAL.Tests/Behavior/DeleteBehaviorTest.cs
+++ b/bindings/dotnet/OpenDAL.Tests/Behavior/DeleteBehaviorTest.cs
@@ -150,4 +150,46 @@ public sealed class DeleteBehaviorTest : BehaviorTestBase
 
         Op.Delete(target, new DeleteOptions { Version = foreignVersion });
     }
+
+    [Fact]
+    public async Task DeleteBehavior_WithIfMatch_RemovesObjectIfMatchedAsync()
+    {
+        if (!Supports(c => c.DeleteWithIfMatch && c.Write && c.Stat))
+        {
+            return;
+        }
+
+        var path = NewPath("delete-if-match");
+        await Op.WriteAsync(path, RandomBytes(16), CT);
+
+        var etag = (await Op.StatAsync(path, CT)).ETag;
+        Assert.NotNull(etag);
+
+        await Op.DeleteAsync(path, new DeleteOptions { IfMatch = etag }, CT);
+
+        var ex = await Assert.ThrowsAsync<OpenDALException>(() => Op.StatAsync(path, CT));
+        Assert.True(IsMissingError(ex));
+    }
+
+    [Fact]
+    public async Task DeleteBehavior_WithIfMatch_DoesNotRemoveObjectIfNotMatchedAsync()
+    {
+        if (!Supports(c => c.DeleteWithIfMatch && c.Write && c.Stat))
+        {
+            return;
+        }
+
+        var path = NewPath("delete-if-match-not-matched");
+        await Op.WriteAsync(path, RandomBytes(16), CT);
+
+        var etag = (await Op.StatAsync(path, CT)).ETag;
+        Assert.NotNull(etag);
+
+        var ex = await Assert.ThrowsAsync<OpenDALException>(
+            () => Op.DeleteAsync(path, new DeleteOptions { IfMatch = "\"this-etag-does-not-match\"" }, CT));
+        Assert.Equal(ErrorCode.ConditionNotMatch, ex.Code);
+
+        var stat = await Op.StatAsync(path, CT);
+        Assert.Equal(etag, stat.ETag);
+    }
 }

--- a/bindings/dotnet/OpenDAL/Capability.cs
+++ b/bindings/dotnet/OpenDAL/Capability.cs
@@ -73,6 +73,7 @@ public struct Capability
         Delete = native.delete != 0;
         DeleteWithVersion = native.deleteWithVersion != 0;
         DeleteWithRecursive = native.deleteWithRecursive != 0;
+        DeleteWithIfMatch = native.deleteWithIfMatch != 0;
         DeleteMaxSize = native.deleteMaxSize == nuint.MaxValue ? null : native.deleteMaxSize;
 
         Copy = native.copy != 0;
@@ -275,6 +276,11 @@ public struct Capability
     /// If operator supports delete with version.
     /// </summary>
     public bool DeleteWithVersion { get; private set; }
+
+    /// <summary>
+    /// If operator supports delete with if match.
+    /// </summary>
+    public bool DeleteWithIfMatch { get; private set; }
 
     /// <summary>
     /// If operator supports delete with recursive.

--- a/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALCapability.cs
+++ b/bindings/dotnet/OpenDAL/Interop/NativeObject/OpenDALCapability.cs
@@ -65,6 +65,7 @@ internal struct OpenDALCapability
     [MarshalAs(UnmanagedType.U1)] internal byte delete;
     [MarshalAs(UnmanagedType.U1)] internal byte deleteWithVersion;
     [MarshalAs(UnmanagedType.U1)] internal byte deleteWithRecursive;
+    [MarshalAs(UnmanagedType.U1)] internal byte deleteWithIfMatch;
     internal nuint deleteMaxSize;
 
     [MarshalAs(UnmanagedType.U1)] internal byte copy;

--- a/bindings/dotnet/OpenDAL/Options/DeleteOptions.cs
+++ b/bindings/dotnet/OpenDAL/Options/DeleteOptions.cs
@@ -40,11 +40,23 @@ public sealed class DeleteOptions : IOptions
     /// </remarks>
     public bool Recursive { get; init; }
 
+    /// <summary>
+    /// Sets the condition that the delete operation will succeed only if the
+    /// existing object's ETag matches the given value.
+    /// </summary>
+    /// <remarks>
+    /// Check <see cref="Capability.DeleteWithIfMatch"/> before using this feature.
+    /// If supported, the delete operation will only succeed when the existing
+    /// object's ETag matches the given value.
+    /// </remarks>
+    public string? IfMatch { get; init; }
+
     public NativeOptionsHandle BuildNativeOptionsHandle()
     {
         var nativeOptions = new NativeOptionsBuilder()
             .AddString("version", Version)
             .AddBoolTrue("recursive", Recursive)
+            .AddString("if_match", IfMatch)
             .Build();
 
         return NativeOptionsBuilder.BuildNativeOptionsHandle(

--- a/bindings/dotnet/src/capability.rs
+++ b/bindings/dotnet/src/capability.rs
@@ -66,6 +66,7 @@ pub struct Capability {
     pub delete: bool,
     pub delete_with_version: bool,
     pub delete_with_recursive: bool,
+    pub delete_with_if_match: bool,
     pub delete_max_size: usize,
 
     pub copy: bool,
@@ -130,6 +131,7 @@ impl Capability {
             delete: cap.delete,
             delete_with_version: cap.delete_with_version,
             delete_with_recursive: cap.delete_with_recursive,
+            delete_with_if_match: cap.delete_with_if_match,
             delete_max_size: cap.delete_max_size.unwrap_or(usize::MIN),
             copy: cap.copy,
             copy_with_if_not_exists: cap.copy_with_if_not_exists,

--- a/bindings/dotnet/src/options.rs
+++ b/bindings/dotnet/src/options.rs
@@ -217,6 +217,6 @@ pub fn parse_delete_options(
     Ok(opendal::options::DeleteOptions {
         version: parse_string(values, "version"),
         recursive: parse_bool(values, "recursive")?.unwrap_or(false),
-        if_match: None,
+        if_match: parse_string(values, "if_match"),
     })
 }


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

N/A

# Rationale for this change

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

[#7607](https://github.com/Fatorin/opendal/issues/7607) added conditional delete with If-Match to core and services/s3, but the .NET binding was left with if_match hardcoded to None in parse_delete_options, so the option was unreachable from C#.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

Parse `if_match` from the native options map, expose it as `DeleteOptions.IfMatch`, and add the corresponding `delete_with_if_match` field to the FFI capability struct and `Capability.DeleteWithIfMatch`.

Two behavior tests cover the matching and the mismatching case, verified against AWS S3.

# Are there any user-facing changes?


<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking-changes` label.
-->

`DeleteOptions.IfMatch` and `Capability.DeleteWithIfMatch` are new.
Nothing is removed or renamed, so there are no breaking changes.

# AI Usage Statement

<!--
If AI materially assisted this PR, briefly describe its role and disclose any
assumptions or unknowns that affect review. Do not include routine command output
or repeat information provided elsewhere.

The author remains responsible for every submitted claim and change. If AI did
not materially assist this PR, write "None".
-->
AI reviewed the diff and the new tests, and helped confirm which S3 implementations actually honour If-Match on DeleteObject. All code was written by hand.