### PR TITLE
fix(services/dbfs): build stat metadata from the body, not the API response headers

### DIFF
--- a/core/services/dbfs/src/backend.rs
+++ b/core/services/dbfs/src/backend.rs
@@ -181,20 +181,22 @@ impl Service for DbfsBackend {
 
         match status {
             StatusCode::OK => {
-                let mut meta = parse_into_metadata(path, resp.headers())?;
                 let bs = resp.into_body();
                 let decoded_response: DbfsStatus =
                     serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
+
+                // The response headers describe the get-status API response, not the
+                // file, so the metadata is built from the decoded body alone.
+                let mut meta = if decoded_response.is_dir {
+                    Metadata::new(EntryMode::DIR)
+                } else {
+                    let mut m = Metadata::new(EntryMode::FILE);
+                    m.set_content_length(decoded_response.file_size as u64);
+                    m
+                };
                 meta.set_last_modified(Timestamp::from_millisecond(
                     decoded_response.modification_time,
                 )?);
-                match decoded_response.is_dir {
-                    true => meta.set_mode(EntryMode::DIR),
-                    false => {
-                        meta.set_mode(EntryMode::FILE);
-                        meta.set_content_length(decoded_response.file_size as u64)
-                    }
-                };
                 Ok(RpStat::new(meta))
             }
             StatusCode::NOT_FOUND if path.ends_with('/') => {


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

`stat` fetches `GET /api/2.0/dbfs/get-status` and then hands that response's
headers to `parse_into_metadata`:

```rust
let mut meta = parse_into_metadata(path, resp.headers())?;
let bs = resp.into_body();
let decoded_response: DbfsStatus = serde_json::from_reader(bs.reader())?;
```

`parse_into_metadata` (`core/raw/http_util/header.rs`) reads `cache-control`,
`content-length`, `content-type`, `content-encoding`, `content-range`, `etag`,
`content-md5`, `last-modified` and `content-disposition` off those headers. On
this request they describe the **JSON envelope the API returned**, not the file
being described.

The body then corrects some of it and not the rest:

| field | source today | correct? |
|---|---|---|
| `last_modified` | overwritten from `modification_time` | yes |
| `mode` | overwritten from `is_dir` | yes |
| `content_length` (file) | overwritten from `file_size` | yes |
| `content_length` (directory) | **left as the envelope's byte count** | no |
| `content_type` | **the API response's, i.e. `application/json`** | no |
| `etag` | **the API response's, if it sent one** | no |
| `cache_control` | **the API response's** | no |

So `op.stat(path).content_type()` reports `application/json` for every object in
DBFS regardless of what it holds, and a directory reports a content length that
is the size of the JSON reply.

**dbfs is the only service that does this.** Ten services call
`parse_into_metadata` inside `stat` — azblob, azfile, cos, dbfs, ghac, http,
obs, swift, tos, vercel-artifacts — and in every one except dbfs the request is
a HEAD against the object itself, so the response headers *are* the object's
metadata. The services shaped like dbfs, where `stat` is a JSON API call, all
build metadata from the decoded body and never touch the response headers:
`koofr`, `gdrive` and `dropbox`.

# What changes are included in this PR?

The metadata is built from `DbfsStatus` alone. `is_dir` picks the mode,
`file_size` sets the content length for files, `modification_time` sets the last
modified. Nothing is read off the envelope.

# Are there any user-facing changes?

Yes, and they are all corrections: `stat` no longer reports `application/json`
as the content type, no longer reports the envelope's etag or cache control, and
a directory no longer carries the JSON reply's byte count as its content length.
Callers that were reading `content_type` from a DBFS stat were receiving a
constant, so nothing that depended on a real value can regress.

# Note on testing

No test added. `dbfs` has no `#[cfg(test)]` module outside `config.rs`, `stat` is
an `async fn` on the backend with no pure function to exercise, and building a
mock around the whole backend to assert an absence of headers would be a larger
change than the fix with no precedent in this repository.

I do not have a Databricks workspace and have not run this against one. The
claim rests on what `parse_into_metadata` reads, what request `stat` makes, and
the nine sibling services that use the helper the way it was meant — all of which
are decidable from the tree.
