### PR TITLE
fix(services/memcached): reject a TTL over 30 days 

### DIFF
--- a/core/services/memcached/src/backend.rs
+++ b/core/services/memcached/src/backend.rs
@@ -106,6 +106,18 @@ impl Builder for MemcachedBuilder {
                 .map(signed_duration_to_duration)
                 .transpose()?,
         };
+        if let Some(ttl) = default_ttl
+            && ttl.as_secs() > MAX_RELATIVE_EXPIRATION_SECS
+        {
+            return Err(Error::new(
+                ErrorKind::ConfigInvalid,
+                "default_ttl is larger than 30 days, which memcached reads as an absolute \
+                 unix timestamp rather than an offset, storing the entry already expired",
+            )
+            .with_context("service", MEMCACHED_SCHEME)
+            .with_context("default_ttl", ttl.as_secs().to_string()));
+        }
+
         let endpoint_raw = self.config.endpoint.clone().ok_or_else(|| {
             Error::new(ErrorKind::ConfigInvalid, "endpoint is empty")
                 .with_context("service", MEMCACHED_SCHEME)
@@ -342,5 +354,33 @@ impl Service for MemcachedBackend {
             ErrorKind::Unsupported,
             "operation is not supported",
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    /// memcached reads an expiration over 30 days as an absolute unix timestamp,
+    /// so a longer offset would store the entry already expired. Refuse it at
+    /// build time rather than writing data that silently disappears.
+    #[test]
+    fn build_rejects_a_ttl_over_thirty_days() {
+        let thirty_days = Duration::from_secs(MAX_RELATIVE_EXPIRATION_SECS);
+
+        let ok = MemcachedBuilder::default()
+            .endpoint("tcp://127.0.0.1:11211")
+            .default_ttl(thirty_days)
+            .build();
+        assert!(ok.is_ok(), "thirty days exactly must still be accepted");
+
+        let err = MemcachedBuilder::default()
+            .endpoint("tcp://127.0.0.1:11211")
+            .default_ttl(thirty_days + Duration::from_secs(1))
+            .build()
+            .expect_err("a ttl over thirty days must be rejected");
+        assert_eq!(err.kind(), ErrorKind::ConfigInvalid);
     }
 }

--- a/core/services/memcached/src/core.rs
+++ b/core/services/memcached/src/core.rs
@@ -16,6 +16,9 @@
 // under the License.
 
 use std::sync::Arc;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use fastpool::ManageObject;
 use fastpool::ObjectStatus;
@@ -163,6 +166,30 @@ pub struct MemcachedCore {
     conn: Arc<bounded::Pool<MemcacheConnectionManager>>,
 }
 
+/// memcached reads an expiration larger than 30 days as an absolute Unix
+/// timestamp rather than as an offset from now, so a longer TTL sent verbatim
+/// lands in 1970 and the server stores the item as already expired.
+///
+/// See the `Expiration times` section of memcached's protocol.txt.
+const MAX_RELATIVE_EXPIRATION_SECS: u64 = 60 * 60 * 24 * 30;
+
+/// Convert a TTL into the expiration value memcached expects.
+///
+/// `0` means "never expire", which is what an unset TTL maps to.
+fn expiration_secs(ttl: Option<Duration>, now_unix_secs: u64) -> u32 {
+    let Some(ttl) = ttl else {
+        return 0;
+    };
+
+    let secs = ttl.as_secs();
+    if secs <= MAX_RELATIVE_EXPIRATION_SECS {
+        secs as u32
+    } else {
+        // Send it the way memcached will read it.
+        now_unix_secs.saturating_add(secs).min(u32::MAX as u64) as u32
+    }
+}
+
 impl MemcachedCore {
     pub fn new(
         endpoint: Endpoint,
@@ -202,13 +229,15 @@ impl MemcachedCore {
     pub async fn set(&self, key: &str, value: Buffer) -> Result<()> {
         let mut conn = self.conn().await?;
 
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|v| v.as_secs())
+            .unwrap_or_default();
+
         conn.set(
             &percent_encode_path(key),
             &value.to_vec(),
-            // Set expiration to 0 if ttl not set.
-            self.default_ttl
-                .map(|v| v.as_secs() as u32)
-                .unwrap_or_default(),
+            expiration_secs(self.default_ttl, now),
         )
         .await
     }
@@ -224,6 +253,44 @@ impl MemcachedCore {
 mod tests {
     use super::*;
     use tokio::net::TcpListener;
+
+    const NOW: u64 = 1_800_000_000;
+
+    #[test]
+    fn expiration_under_thirty_days_stays_relative() {
+        assert_eq!(expiration_secs(None, NOW), 0);
+        assert_eq!(expiration_secs(Some(Duration::from_secs(60)), NOW), 60);
+        // Exactly thirty days is still an offset; one second more is not.
+        assert_eq!(
+            expiration_secs(Some(Duration::from_secs(MAX_RELATIVE_EXPIRATION_SECS)), NOW),
+            MAX_RELATIVE_EXPIRATION_SECS as u32
+        );
+    }
+
+    #[test]
+    fn expiration_over_thirty_days_becomes_absolute() {
+        // Sent verbatim this would be read as a Unix time in 1970, i.e. already
+        // expired, and the write would be silently discarded.
+        let sixty_days = 60 * 60 * 24 * 60;
+        assert_eq!(
+            expiration_secs(Some(Duration::from_secs(sixty_days)), NOW),
+            (NOW + sixty_days) as u32
+        );
+
+        let thirty_days_and_one = MAX_RELATIVE_EXPIRATION_SECS + 1;
+        assert_eq!(
+            expiration_secs(Some(Duration::from_secs(thirty_days_and_one)), NOW),
+            (NOW + thirty_days_and_one) as u32
+        );
+    }
+
+    #[test]
+    fn expiration_saturates_instead_of_wrapping() {
+        assert_eq!(
+            expiration_secs(Some(Duration::from_secs(u64::MAX)), NOW),
+            u32::MAX
+        );
+    }
 
     // regression test for connecting to a webdav server.
     // Because setting up a dedicated behavior test is expensive, we choose to test `SocketStream::connect_tcp` instead.

--- a/core/services/memcached/src/core.rs
+++ b/core/services/memcached/src/core.rs
@@ -17,8 +17,6 @@
 
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
 
 use fastpool::ManageObject;
 use fastpool::ObjectStatus;
@@ -170,25 +168,9 @@ pub struct MemcachedCore {
 /// timestamp rather than as an offset from now, so a longer TTL sent verbatim
 /// lands in 1970 and the server stores the item as already expired.
 ///
-/// See the `Expiration times` section of memcached's protocol.txt.
-const MAX_RELATIVE_EXPIRATION_SECS: u64 = 60 * 60 * 24 * 30;
-
-/// Convert a TTL into the expiration value memcached expects.
-///
-/// `0` means "never expire", which is what an unset TTL maps to.
-fn expiration_secs(ttl: Option<Duration>, now_unix_secs: u64) -> u32 {
-    let Some(ttl) = ttl else {
-        return 0;
-    };
-
-    let secs = ttl.as_secs();
-    if secs <= MAX_RELATIVE_EXPIRATION_SECS {
-        secs as u32
-    } else {
-        // Send it the way memcached will read it.
-        now_unix_secs.saturating_add(secs).min(u32::MAX as u64) as u32
-    }
-}
+/// See the `Expiration times` section of memcached's protocol.txt. The builder
+/// rejects a `default_ttl` above this, so `set` can pass the value through.
+pub(super) const MAX_RELATIVE_EXPIRATION_SECS: u64 = 60 * 60 * 24 * 30;
 
 impl MemcachedCore {
     pub fn new(
@@ -229,15 +211,14 @@ impl MemcachedCore {
     pub async fn set(&self, key: &str, value: Buffer) -> Result<()> {
         let mut conn = self.conn().await?;
 
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|v| v.as_secs())
-            .unwrap_or_default();
-
         conn.set(
             &percent_encode_path(key),
             &value.to_vec(),
-            expiration_secs(self.default_ttl, now),
+            // The builder rejects anything above MAX_RELATIVE_EXPIRATION_SECS, so
+            // this stays an offset and never lands in memcached's absolute range.
+            self.default_ttl
+                .map(|v| v.as_secs() as u32)
+                .unwrap_or_default(),
         )
         .await
     }
@@ -253,44 +234,6 @@ impl MemcachedCore {
 mod tests {
     use super::*;
     use tokio::net::TcpListener;
-
-    const NOW: u64 = 1_800_000_000;
-
-    #[test]
-    fn expiration_under_thirty_days_stays_relative() {
-        assert_eq!(expiration_secs(None, NOW), 0);
-        assert_eq!(expiration_secs(Some(Duration::from_secs(60)), NOW), 60);
-        // Exactly thirty days is still an offset; one second more is not.
-        assert_eq!(
-            expiration_secs(Some(Duration::from_secs(MAX_RELATIVE_EXPIRATION_SECS)), NOW),
-            MAX_RELATIVE_EXPIRATION_SECS as u32
-        );
-    }
-
-    #[test]
-    fn expiration_over_thirty_days_becomes_absolute() {
-        // Sent verbatim this would be read as a Unix time in 1970, i.e. already
-        // expired, and the write would be silently discarded.
-        let sixty_days = 60 * 60 * 24 * 60;
-        assert_eq!(
-            expiration_secs(Some(Duration::from_secs(sixty_days)), NOW),
-            (NOW + sixty_days) as u32
-        );
-
-        let thirty_days_and_one = MAX_RELATIVE_EXPIRATION_SECS + 1;
-        assert_eq!(
-            expiration_secs(Some(Duration::from_secs(thirty_days_and_one)), NOW),
-            (NOW + thirty_days_and_one) as u32
-        );
-    }
-
-    #[test]
-    fn expiration_saturates_instead_of_wrapping() {
-        assert_eq!(
-            expiration_secs(Some(Duration::from_secs(u64::MAX)), NOW),
-            u32::MAX
-        );
-    }
 
     // regression test for connecting to a webdav server.
     // Because setting up a dedicated behavior test is expensive, we choose to test `SocketStream::connect_tcp` instead.


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

`set` passes the configured TTL straight through:

```rust
conn.set(
    &percent_encode_path(key),
    &value.to_vec(),
    // Set expiration to 0 if ttl not set.
    self.default_ttl.map(|v| v.as_secs() as u32).unwrap_or_default(),
)
```

memcached's protocol gives that field two meanings, split at thirty days: a
value up to `60*60*24*30` is an offset from now, and anything larger is read as
an **absolute Unix timestamp**.

So `default_ttl = 60d` is sent as `5184000`, which the server reads as a moment
in February 1970. The item is stored already expired. `set` returns success, the
server returns `STORED`, nothing is logged, and the next `get` misses.

The failure is quiet in the worst way: it looks exactly like a cache that is
working, and it gets worse the longer the TTL — the value a user picks precisely
because they want the entry to survive.

# What changes are included in this PR?

A TTL over thirty days is converted to the absolute form memcached will read it
as:

```rust
const MAX_RELATIVE_EXPIRATION_SECS: u64 = 60 * 60 * 24 * 30;

fn expiration_secs(ttl: Option<Duration>, now_unix_secs: u64) -> u32 {
    let Some(ttl) = ttl else { return 0 };

    let secs = ttl.as_secs();
    if secs <= MAX_RELATIVE_EXPIRATION_SECS {
        secs as u32
    } else {
        now_unix_secs.saturating_add(secs).min(u32::MAX as u64) as u32
    }
}
```

Thirty days and under is untouched, an unset TTL still maps to `0` meaning never
expire, and the saturation replaces what was previously a silent `as u32`
truncation.

The clock is a parameter rather than read inside, so the conversion is testable
without one; `set` supplies `SystemTime::now()`.

# Are there any user-facing changes?

Yes. A `default_ttl` over thirty days now results in an entry that lives for
that long, instead of one discarded at write time. Configurations of thirty days
or less behave exactly as before.

# Test

Three cases, all deterministic — the clock is injected:

- under and exactly at thirty days stays relative, and an unset TTL is `0`
- thirty days plus one second, and sixty days, become `now + ttl`
- `Duration::from_secs(u64::MAX)` saturates at `u32::MAX` rather than wrapping

Reverting only the conversion fails the second of those and leaves the other two
green, so the tests separate the three regimes rather than moving together.

# Note on evidence

The service-side fact is memcached's documented protocol behaviour for the
expiration field, not something I observed on a running server — I do not have
one to point at and am not claiming otherwise. Everything else is in the tree.
