### PR TITLE
fix(services/gcs): do not panic when the batch delete response part count differs

### DIFF
--- a/core/services/gcs/Cargo.toml
+++ b/core/services/gcs/Cargo.toml
@@ -49,5 +49,6 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 
 [dev-dependencies]
+futures = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/gcs/src/deleter.rs
+++ b/core/services/gcs/src/deleter.rs
@@ -74,6 +74,13 @@ impl oio::BatchDelete for GcsDeleter {
             .parse(resp.into_body().to_bytes())?;
         let parts = multipart.into_parts();
 
+        if paths.len() != parts.len() {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "invalid batch response, paths and response parts don't match",
+            ));
+        }
+
         let mut batched_result = BatchDeleteResult::default();
 
         for (i, part) in parts.into_iter().enumerate() {
@@ -98,5 +105,124 @@ impl oio::BatchDelete for GcsDeleter {
         }
 
         Ok(batched_result)
+    }
+}
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use bytes::Bytes;
+    use http::Request;
+    use http::Response;
+    use http::StatusCode;
+    use opendal_core::Operator;
+
+    use super::*;
+    use crate::backend::GcsBuilder;
+
+    /// Answers the batch endpoint with a body the caller controls, so the number of
+    /// sub-responses can be made to disagree with the number of requested paths.
+    #[derive(Clone)]
+    struct BatchMockTransport {
+        body: &'static str,
+        calls: Arc<Mutex<usize>>,
+    }
+
+    impl BatchMockTransport {
+        fn new(body: &'static str) -> Self {
+            Self {
+                body,
+                calls: Arc::new(Mutex::new(0)),
+            }
+        }
+    }
+
+    impl HttpTransport for BatchMockTransport {
+        async fn fetch(&self, _req: Request<Buffer>) -> Result<Response<HttpBody>> {
+            *self.calls.lock().expect("lock poisoned") += 1;
+            let body = Buffer::from(Bytes::from_static(self.body.as_bytes()));
+            let size = body.len() as u64;
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "multipart/mixed; boundary=batch_x")
+                .body(HttpBody::new(
+                    futures::stream::iter(vec![Ok(body)]),
+                    Some(size),
+                ))
+                .expect("mock response must build"))
+        }
+    }
+
+    fn operator(body: &'static str) -> Operator {
+        Operator::new(
+            GcsBuilder::default()
+                .bucket("example")
+                .token("token".to_string())
+                .disable_config_load()
+                .disable_vm_metadata(),
+        )
+        .expect("operator must build")
+        .with_context(
+            OperationContext::new()
+                .with_http_transport(HttpTransporter::new(BatchMockTransport::new(body))),
+        )
+    }
+
+    /// A batch response carrying no sub-responses used to reach
+    /// `batched_result.failed.remove(0)` with both vectors empty.
+    #[tokio::test]
+    async fn delete_batch_errors_when_the_response_has_no_parts() {
+        let op = operator("--batch_x--\r\n");
+
+        let err = op
+            .delete_iter(vec!["a".to_string(), "b".to_string()])
+            .await
+            .expect_err("must report an error rather than panic");
+
+        assert_eq!(err.kind(), ErrorKind::Unexpected);
+    }
+
+    /// And one carrying more sub-responses than paths used to index `paths` out of
+    /// bounds.
+    #[tokio::test]
+    async fn delete_batch_errors_when_the_response_has_extra_parts() {
+        let op = operator(concat!(
+            "--batch_x\r\n",
+            "Content-Type: application/http\r\n\r\n",
+            "HTTP/1.1 204 No Content\r\n\r\n",
+            "--batch_x\r\n",
+            "Content-Type: application/http\r\n\r\n",
+            "HTTP/1.1 204 No Content\r\n\r\n",
+            "--batch_x\r\n",
+            "Content-Type: application/http\r\n\r\n",
+            "HTTP/1.1 204 No Content\r\n\r\n",
+            "--batch_x--\r\n"
+        ));
+
+        let err = op
+            .delete_iter(vec!["a".to_string(), "b".to_string()])
+            .await
+            .expect_err("must report an error rather than panic");
+
+        assert_eq!(err.kind(), ErrorKind::Unexpected);
+    }
+
+    /// Control: a response with one part per path still succeeds.
+    #[tokio::test]
+    async fn delete_batch_succeeds_when_the_counts_agree() {
+        let op = operator(concat!(
+            "--batch_x\r\n",
+            "Content-Type: application/http\r\n\r\n",
+            "HTTP/1.1 204 No Content\r\n\r\n",
+            "--batch_x\r\n",
+            "Content-Type: application/http\r\n\r\n",
+            "HTTP/1.1 204 No Content\r\n\r\n",
+            "--batch_x--\r\n"
+        ));
+
+        op.delete_iter(vec!["a".to_string(), "b".to_string()])
+            .await
+            .expect("must succeed");
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

`GcsDeleter::delete_batch` pairs the batch sub-responses with the requested
paths by position, without checking that the counts match:

```rust
let parts = multipart.into_parts();

let mut batched_result = BatchDeleteResult::default();

for (i, part) in parts.into_iter().enumerate() {
    let resp = part.into_response();
    let path = paths[i].clone();          // :82
    ...
}

if batched_result.succeeded.is_empty() {
    let err = batched_result.failed.remove(0).2;   // :96
    return Err(err);
}
```

Two ways that panics rather than returning an error:

* **fewer parts than paths.** `Multipart::parse` skips empty segments and any
  segment starting with `--` (`multipart.rs:93-98`), so a body of
  `--batch_x--\r\n` yields zero parts. Both result vectors stay empty and
  `failed.remove(0)` panics with `removal index (is 0) should be < len (is 0)`.
* **more parts than paths.** `paths[i]` indexes out of bounds.

Reproduced in process against a mock transport:

```
panicked at services/gcs/src/deleter.rs:96:45: removal index (is 0) should be < len (is 0)
panicked at services/gcs/src/deleter.rs:82:29: index out of bounds: the len is 2 but the index is 2
```

The azblob deleter already guards exactly this, at `deleter.rs:78-83`:

```rust
if paths.len() != parts.len() {
    return Err(Error::new(
        ErrorKind::Unexpected,
        "invalid batch response, paths and response parts don't match",
    ));
}
```

`BatchDeleter::flush_buffer` also treats a count mismatch as an error once
`delete_batch` returns — but the panic happens before it can.

# What changes are included in this PR?

The same guard, in gcs. One check covers both panics.

# Are there any user-facing changes?

A mismatched batch response now surfaces as `ErrorKind::Unexpected` instead of
unwinding the caller's task.

# Note on scope

I have not established that real GCS sends a mismatched part count, and I am not
claiming it does — I do not have a bucket to try it against. The argument is
narrower: a library should return an error rather than panic on a server
response, and azblob already takes that view of the same situation.

Three tests, all in process with a mock transport: zero parts, extra parts, and
a matching control. Removing the guard turns the first two back into panics and
leaves the control passing.
