### PR TITLE
docs: forbid speculative service changes in agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,15 @@ policy.
 - Do not publish an Issue, Pull Request, Discussion, or review comment unless a
   human has meaningfully reviewed the content and explicitly asked you to submit
   it.
-- Treat source-code findings as hypotheses until they are reproduced. Reproduce
-  service-specific bugs against the actual service.
+- Do not implement or submit a service-specific change based only on source-code
+  analysis, a mock or emulator, a synthetic malformed response, or another
+  service's implementation. Reproduce the problem against the actual service
+  first.
+- If actual-service reproduction is unavailable, stop before changing code or
+  opening a Pull Request. Raise the hypothesis in a Discussion unless a
+  maintainer has explicitly accepted it as a hardening or maintenance goal.
+- A test against a fabricated response can verify implementation behavior, but
+  it does not establish that the change solves a real-world problem.
 - In a Pull Request, briefly disclose AI's material role and any assumptions or
   unknowns that affect review. Do not repeat routine validation output.
 


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up to #6795.

# Rationale for this change

The existing agent guidance requires reproduction but does not explicitly tell an agent to stop before implementation. This leaves room to present an unverified service-specific hypothesis as defensive hardening.

# What changes are included in this PR?

This PR prohibits implementing or submitting service-specific changes based only on source analysis, mocks, synthetic malformed responses, or comparisons with another service. When actual-service reproduction is unavailable, the agent must stop before changing code or opening a Pull Request unless a maintainer has explicitly accepted the work as a hardening or maintenance goal.

The guidance also clarifies that a test against a fabricated response verifies implementation behavior but does not establish a real-world problem.

# Are there any user-facing changes?

No. This change clarifies the contribution policy for coding agents.

# AI Usage Statement

AI materially assisted with drafting this clarification. I reviewed and take responsibility for the final text. There are no known assumptions or unknowns that affect review.
