### PR TITLE
perf(bindings/python): avoid an extra copy when reading bytes

### DIFF
--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -472,10 +472,9 @@ impl Operator {
         let buffer = self
             .core
             .read_options(&path, opts.into())
-            .map_err(format_pyerr)?
-            .to_vec();
+            .map_err(format_pyerr)?;
 
-        Buffer::new(buffer).into_bytes_ref(py)
+        Ok(buffer_into_py_bytes(py, buffer)?.into_any())
     }
 
     /// Write bytes to a file at the given path.
@@ -1219,9 +1218,8 @@ impl AsyncOperator {
                 .map_err(format_pyerr)?
                 .read(range.to_range())
                 .await
-                .map_err(format_pyerr)?
-                .to_vec();
-            Python::attach(|py| Buffer::new(res).into_bytes(py))
+                .map_err(format_pyerr)?;
+            Python::attach(|py| buffer_into_py_bytes(py, res).map(Bound::unbind))
         })
     }
 

--- a/bindings/python/src/utils.rs
+++ b/bindings/python/src/utils.rs
@@ -17,9 +17,65 @@
 
 use std::os::raw::c_int;
 
+use bytes::Buf;
 use pyo3::IntoPyObjectExt;
+use pyo3::exceptions::PyOverflowError;
 use pyo3::ffi;
 use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+use crate::ocore;
+
+/// Copy an OpenDAL buffer directly into a new Python `bytes` object.
+pub fn buffer_into_py_bytes<'py>(
+    py: Python<'py>,
+    mut buffer: ocore::Buffer,
+) -> PyResult<Bound<'py, PyBytes>> {
+    let len = buffer.remaining();
+    let py_len = len
+        .try_into()
+        .map_err(|_| PyOverflowError::new_err("buffer is too large for Python bytes"))?;
+
+    unsafe {
+        let bytes = Bound::from_owned_ptr_or_err(
+            py,
+            ffi::PyBytes_FromStringAndSize(std::ptr::null(), py_len),
+        )?
+        .cast_into_unchecked::<PyBytes>();
+
+        // PyBytes_FromStringAndSize with a null source allocates an uninitialized
+        // buffer. `buffer` has exactly `len` remaining bytes, so copy_to_slice
+        // initializes the entire Python object before it becomes observable.
+        let dst =
+            std::slice::from_raw_parts_mut(ffi::PyBytes_AsString(bytes.as_ptr()).cast::<u8>(), len);
+        buffer.copy_to_slice(dst);
+
+        Ok(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use pyo3::types::PyBytesMethods;
+
+    use super::*;
+
+    #[test]
+    fn test_buffer_into_py_bytes() {
+        Python::initialize();
+        Python::attach(|py| {
+            let buffer = [Bytes::from_static(b"hello, "), Bytes::from_static(b"world")]
+                .into_iter()
+                .collect();
+            let result = buffer_into_py_bytes(py, buffer).unwrap();
+            assert_eq!(result.as_bytes(), b"hello, world");
+
+            let result = buffer_into_py_bytes(py, ocore::Buffer::new()).unwrap();
+            assert!(result.as_bytes().is_empty());
+        });
+    }
+}
 
 /// A bytes-like object that implements buffer protocol.
 #[pyclass(module = "opendal")]


### PR DESCRIPTION
# Which issue does this PR close?

Part of #8159.

# Rationale for this change

`Operator.read` and `AsyncOperator.read` currently copy the returned OpenDAL buffer into an intermediate `Vec<u8>`, then copy it again into Python `bytes`. The intermediate copy adds a payload-sized allocation and memory copy to every whole-object read.

This change allocates the final Python `bytes` object once and copies the OpenDAL buffer chunks directly into it. The Python API continues to return `bytes`.

## Benchmark

The comparison used otherwise identical release builds on base commit `7ca2c0261`, CPython 3.14.5 with the GIL enabled, the memory backend, and an Apple M4 Max. Each value is the median after warmup.

| Workload | Before | After | Change |
| --- | ---: | ---: | ---: |
| Sync read, 1 MiB | 34.7 us | 26.1 us | 24.8% faster |
| Sync read, 8 MiB | 210.6 us | 123.2 us | 41.5% faster |
| Sync read, 32 MiB | 901.5 us | 494.9 us | 45.1% faster |
| Async read, 1 MiB | 63.8 us | 57.3 us | 10.1% faster |
| Async read, 8 MiB | 241.3 us | 151.8 us | 37.1% faster |
| Async read, 32 MiB | 948.2 us | 536.1 us | 43.5% faster |
| Sync read, 128 MiB peak RSS | 405.6 MiB | 278.0 MiB | 31.5% lower |

The memory backend isolates binding conversion overhead. End-to-end gains can be smaller when network or storage latency dominates. A 4 KiB read showed no measurable benefit because fixed Python and call overhead dominates at that size.

# What changes are included in this PR?

- Add a conversion helper that allocates Python `bytes` once and fills it from contiguous or segmented OpenDAL buffers.
- Use the helper in synchronous and asynchronous whole-object reads.
- Cover segmented and empty buffers with a focused unit test.

# Are there any user-facing changes?

There is no API or return-type change. Whole-object reads use less CPU and peak memory, especially for larger payloads.

# AI Usage Statement

AI materially assisted source analysis, implementation, focused test preparation, and local performance measurement. The contributor reviewed the resulting change and claims before submission.
