### PR TITLE
fix(core): Return Ok(0) instead of panicking on zero-length write

### DIFF
--- a/core/core/src/types/write/futures_async_writer.rs
+++ b/core/core/src/types/write/futures_async_writer.rs
@@ -56,6 +56,10 @@ impl AsyncWrite for FuturesAsyncWriter {
     ) -> Poll<io::Result<usize>> {
         let this = self.get_mut();
 
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
         loop {
             let n = this.buf.put(buf);
             if n > 0 {
@@ -113,6 +117,8 @@ impl AsyncWrite for FuturesAsyncWriter {
 mod tests {
     use std::sync::Arc;
 
+    use futures::AsyncWriteExt;
+
     use super::*;
     use crate::raw::MaybeSend;
 
@@ -134,5 +140,26 @@ mod tests {
         let v = FuturesAsyncWriter::new(write_gen);
 
         let _: Box<dyn Unpin + MaybeSend + Sync + 'static> = Box::new(v);
+    }
+
+    #[tokio::test]
+    async fn test_empty_write() {
+        let op = Operator::via_iter(services::MEMORY_SCHEME, []).unwrap();
+
+        let mut w = op
+            .writer("test_empty_write")
+            .await
+            .unwrap()
+            .into_futures_async_write();
+
+        assert_eq!(w.write(b"").await.unwrap(), 0);
+        w.write_all(b"hello").await.unwrap();
+        assert_eq!(w.write(b"").await.unwrap(), 0);
+        w.close().await.unwrap();
+
+        assert_eq!(
+            op.read("test_empty_write").await.unwrap().to_vec(),
+            b"hello"
+        );
     }
 }


### PR DESCRIPTION
`FuturesAsyncWriter::poll_write` panicked with `frozen buffer must be valid` when called with an empty buffer, even though both `std::io::Write::write` and `futures::AsyncWrite::poll_write` allow a zero-length input and specify `Ok(0)` as the result.

`FlexBuf::put` returns 0 both when the buffer is already frozen and when the input slice is empty. The loop in `poll_write` assumed only the first case, so on an empty input it called `get()` on a buffer that was never frozen and hit the `expect`. `BufferSink` already guards this case, so add the same guard to the adapter.

The blocking `StdWriter` path is fixed transitively, since it forwards to `FuturesAsyncWriter::write`.

Closes #8161

# Which issue does this PR close?

Closes #8161

# What changes are included in this PR?

- `core/core/src/types/write/futures_async_writer.rs`: return `Poll::Ready(Ok(0))` from
`poll_write` when the input buffer is empty, before entering the drain loop.
- A unit test in the same file’s existing mod tests, covering an empty write before and
after a non-empty one, and asserting the surrounding payload still commits and reads back
intact.


# Are there any user-facing changes?

Yes but nothing breaking. The zero length previously panicked and now returns `Ok(0)`. No API signature
changes, and no behavior change for any non-empty write.


# AI Usage Statement
AI identified this bug when using opendal in my project and identified this as a potential fix.
The fix is pretty simple though!

