### PR TITLE
perf(bindings/python): avoid copying bytes on write

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -199,7 +199,7 @@ name = "_opendal"
 
 [dependencies]
 asyncband = { version = "0.6" }
-bytes = "1.5.0"
+bytes = "1.10.1"
 futures = "0.3.28"
 jiff = { version = "0.2.15" }
 # this crate won't be published, we always use the local version

--- a/bindings/python/src/operator.rs
+++ b/bindings/python/src/operator.rs
@@ -20,7 +20,6 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use pyo3::IntoPyObjectExt;
-use pyo3::types::PyBytes;
 use pyo3::types::PyDict;
 use pyo3::types::PyTuple;
 use pyo3::types::PyType;
@@ -526,7 +525,7 @@ impl Operator {
     pub fn write(
         &self,
         path: PathBuf,
-        bs: Vec<u8>,
+        bs: &Bound<PyAny>,
         append: Option<bool>,
         chunk: Option<usize>,
         concurrent: Option<usize>,
@@ -540,6 +539,7 @@ impl Operator {
         user_metadata: Option<HashMap<String, String>>,
     ) -> PyResult<()> {
         let path = path.to_string_lossy().to_string();
+        let bs = py_bytes_like_into_buffer(bs)?;
         let opts = WriteOptions {
             append,
             chunk,
@@ -1278,7 +1278,7 @@ impl AsyncOperator {
         &'p self,
         py: Python<'p>,
         path: PathBuf,
-        bs: &Bound<PyBytes>,
+        bs: &Bound<PyAny>,
         append: Option<bool>,
         chunk: Option<usize>,
         concurrent: Option<usize>,
@@ -1305,7 +1305,7 @@ impl AsyncOperator {
             user_metadata,
         };
         let this = self.core.clone();
-        let bs = bs.as_bytes().to_vec();
+        let bs = py_bytes_like_into_buffer(bs)?;
         let path = path.to_string_lossy().to_string();
         future_into_py(py, async move {
             this.write_options(&path, bs, opts.into())

--- a/bindings/python/src/utils.rs
+++ b/bindings/python/src/utils.rs
@@ -18,13 +18,26 @@
 use std::os::raw::c_int;
 
 use bytes::Buf;
+use bytes::Bytes;
 use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyOverflowError;
 use pyo3::ffi;
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedBytes;
+use pyo3::types::PyAny;
 use pyo3::types::PyBytes;
 
 use crate::ocore;
+
+/// Keep immutable Python bytes alive inside an OpenDAL buffer without copying.
+pub fn py_bytes_like_into_buffer(value: &Bound<PyAny>) -> PyResult<ocore::Buffer> {
+    if let Ok(value) = value.cast::<PyBytes>() {
+        let owner = PyBackedBytes::from(value.clone());
+        return Ok(Bytes::from_owner(owner).into());
+    }
+
+    value.extract::<Vec<u8>>().map(Into::into)
+}
 
 /// Copy an OpenDAL buffer directly into a new Python `bytes` object.
 pub fn buffer_into_py_bytes<'py>(
@@ -74,6 +87,28 @@ mod tests {
             let result = buffer_into_py_bytes(py, ocore::Buffer::new()).unwrap();
             assert!(result.as_bytes().is_empty());
         });
+    }
+
+    #[test]
+    fn test_py_bytes_like_into_buffer() {
+        Python::initialize();
+        let (buffer, source_ptr) = Python::attach(|py| {
+            let value = PyBytes::new(py, b"hello, world");
+            let source_ptr = value.as_bytes().as_ptr();
+            let buffer = py_bytes_like_into_buffer(value.as_any()).unwrap();
+            (buffer, source_ptr)
+        });
+
+        assert_eq!(buffer.current().as_ptr(), source_ptr);
+        assert_eq!(buffer.to_vec(), b"hello, world");
+
+        let buffer = Python::attach(|py| {
+            let value = pyo3::types::PyByteArray::new(py, b"mutable");
+            let buffer = py_bytes_like_into_buffer(value.as_any()).unwrap();
+            value.set_item(0, b'M').unwrap();
+            buffer
+        });
+        assert_eq!(buffer.to_vec(), b"mutable");
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of #8159.

# Rationale for this change

`Operator.write` and `AsyncOperator.write` copy every Python `bytes` payload into a new Rust allocation before passing it to OpenDAL. The copy adds payload-sized allocation and memory bandwidth costs to whole-object writes.

Python `bytes` is immutable, so OpenDAL can safely retain its storage when the Rust owner also keeps the Python object alive for the complete operation.

# What changes are included in this PR?

This PR wraps Python `bytes` in `PyBackedBytes` and uses `Bytes::from_owner` to construct the OpenDAL `Buffer` without copying the payload. Both synchronous and asynchronous whole-object writes use this conversion.

Mutable and other bytes-like inputs continue through the existing copying conversion, preserving isolation from later mutation. Focused tests verify that immutable `bytes` shares its allocation and remains valid after leaving the Python attachment scope, while `bytearray` remains isolated.

# Are there any user-facing changes?

The public Python API and accepted inputs remain unchanged. Whole-object writes from immutable `bytes` no longer require a binding-owned payload copy.

## Benchmark

The paired release benchmark compares `10eeb9324` with this PR at `70ecc5bc2` on an Apple M4 Max using CPython 3.14.5 and the memory service. Operator and event-loop setup stay outside the measured operation. Each result is the median of two trial medians.

| Payload | Sync before | Sync after | Speedup | Async before | Async after | Speedup |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 MiB | 22.07 us | 9.30 us | 2.37x | 49.96 us | 40.27 us | 1.24x |
| 8 MiB | 106.66 us | 9.03 us | 11.81x | 138.79 us | 41.09 us | 3.38x |
| 32 MiB | 420.15 us | 8.86 us | 47.40x | 464.15 us | 38.50 us | 12.06x |

A single 128 MiB write reduced peak RSS from 277.48 MiB to 149.53 MiB synchronously and from 284.81 MiB to 156.84 MiB asynchronously, removing approximately one payload-sized allocation.

The memory service isolates binding overhead. Network and service latency will reduce the proportional end-to-end latency improvement for remote storage, while the binding-owned allocation and copy remain eliminated.

# AI Usage Statement

AI materially assisted with implementation, focused test coverage, and benchmark execution. The author reviewed the resulting code and claims. The benchmark measures binding overhead with the memory service; remote-service end-to-end latency remains unmeasured.
