### PR TITLE
fix(bindings/python): fix sized File.readline

### DIFF
--- a/bindings/python/src/file.rs
+++ b/bindings/python/src/file.rs
@@ -164,13 +164,12 @@ impl File {
                 buffer
             }
             Some(size) => {
-                let mut bs = vec![0; size];
+                let mut buffer = Vec::new();
                 let mut reader = reader.take(size as u64);
-                let n = reader
-                    .read_until(b'\n', &mut bs)
+                reader
+                    .read_until(b'\n', &mut buffer)
                     .map_err(|err| PyIOError::new_err(err.to_string()))?;
-                bs.truncate(n);
-                bs
+                buffer
             }
         };
 

--- a/bindings/python/tests/test_read.py
+++ b/bindings/python/tests/test_read.py
@@ -118,6 +118,20 @@ def test_sync_reader_readline(service_name, operator, async_operator):
     operator.delete(filename)
 
 
+@pytest.mark.need_capability("read", "write", "delete")
+def test_sync_reader_readline_with_size(operator):
+    filename = f"random_file_{str(uuid4())}"
+    content = b"alpha\nbeta\ngamma"
+    operator.write(filename, content)
+
+    expected = io.BytesIO(content)
+    with operator.open(filename, "rb") as reader:
+        for size in [3, 10, 0, 5, 2, 10, 10]:
+            assert reader.readline(size) == expected.readline(size)
+
+    operator.delete(filename)
+
+
 @pytest.mark.asyncio
 @pytest.mark.need_capability("read", "write", "delete")
 async def test_async_read(service_name, operator, async_operator):


### PR DESCRIPTION
# Which issue does this PR close?

Part of #8159.

# Rationale for this change

`File.readline(size)` initializes its destination buffer with `size` zero bytes. `BufRead::read_until` appends the line after those bytes, and the implementation then truncates the buffer using only the appended length. As a result, sized reads return zero bytes while advancing the file cursor.

# What changes are included in this PR?

Read sized lines into an empty buffer while retaining the existing `take(size)` limit. Add a synchronous regression test against `io.BytesIO` that covers partial lines, newline boundaries, zero-sized reads, cursor progression, and EOF.

# Are there any user-facing changes?

Yes. `File.readline(size)` now returns the bytes read from the file, up to the requested size, instead of zero-filled data.

# AI Usage Statement

AI materially assisted with root-cause analysis, implementation, regression-test construction, and local validation. Validation used the memory backend through the shared blocking reader path; the full remote-service behavior matrix was not run.
