### PR TITLE
perf(bindings/python): avoid copying bytes in async file writes

### DIFF
--- a/bindings/python/src/file.rs
+++ b/bindings/python/src/file.rs
@@ -31,6 +31,8 @@ use pyo3::IntoPyObjectExt;
 use pyo3::buffer::PyBuffer;
 use pyo3::exceptions::PyIOError;
 use pyo3::exceptions::PyValueError;
+use pyo3::pybacked::PyBackedBytes;
+use pyo3::types::PyBytes;
 use pyo3_async_runtimes::tokio::future_into_py;
 
 use crate::*;
@@ -527,11 +529,13 @@ impl AsyncFile {
     /// coroutine
     ///     An awaitable that returns the number of bytes written.
     #[pyo3(signature = (bs: "bytes") -> "collections.abc.Awaitable[int]")]
-    pub fn write<'p>(&'p mut self, py: Python<'p>, bs: &'p [u8]) -> PyResult<Bound<'p, PyAny>> {
+    pub fn write<'p>(
+        &'p mut self,
+        py: Python<'p>,
+        bs: &Bound<PyBytes>,
+    ) -> PyResult<Bound<'p, PyAny>> {
         let state = self.0.clone();
-
-        // FIXME: can we avoid this clone?
-        let bs = bs.to_vec();
+        let bs = PyBackedBytes::from(bs.clone());
 
         future_into_py(py, async move {
             let mut guard = state.lock().await;

--- a/bindings/python/tests/test_write.py
+++ b/bindings/python/tests/test_write.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import gc
 import os
 from pathlib import Path
 from random import randint
@@ -148,6 +149,25 @@ async def test_async_writer(service_name, operator, async_operator):
     await async_operator.delete(filename)
     with pytest.raises(NotFound):
         await async_operator.stat(filename)
+
+
+@pytest.mark.asyncio
+@pytest.mark.need_capability("write", "read", "delete")
+async def test_async_writer_keeps_bytes_alive(service_name, operator, async_operator):
+    filename = f"test_file_{str(uuid4())}.txt"
+    expected = bytes(range(256)) * 4
+    content = bytes(bytearray(expected))
+    f = await async_operator.open(filename, "wb")
+
+    write = f.write(content)
+    del content
+    gc.collect()
+
+    written_bytes = await write
+    assert written_bytes == len(expected)
+    await f.close()
+    assert await async_operator.read(filename) == expected
+    await async_operator.delete(filename)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Which issue does this PR close?

Part of #8159.

# Rationale for this change

`AsyncFile.write` currently copies every Python `bytes` payload into a new Rust `Vec<u8>` before the asynchronous write starts. The copy adds a payload-sized allocation, memory bandwidth cost, and peak memory usage.

Python `bytes` is immutable, so the write future can safely retain the Python-owned storage for the complete operation.

# What changes are included in this PR?

This PR converts the `bytes` argument into `PyBackedBytes`, which keeps the Python object alive while exposing its storage directly to the asynchronous writer. The public method continues to accept only immutable `bytes`.

A focused regression test drops the caller's reference before awaiting the write and verifies that the complete payload remains valid. The writer adapter's existing 256 KiB coalescing buffer remains unchanged.

# Are there any user-facing changes?

The Python API and accepted inputs remain unchanged. `AsyncFile.write` no longer requires a binding-owned payload copy, reducing write latency and peak memory usage for large payloads.

## Benchmark

The paired release benchmark compares base commit `fffd329db` with this PR at `4e8e0938c` on an Apple M4 Max using CPython 3.14.5 and the memory service. File creation, close, and cleanup stay outside the measured `await AsyncFile.write(payload)` operation. Results use 10 alternating paired rounds; Improvement is the median paired speedup.

| Payload | Before | After | Improvement |
| ---: | ---: | ---: | ---: |
| 64 KiB | 45.95 us | 44.23 us | 1.07x faster |
| 1 MiB | 73.00 us | 56.40 us | 1.30x faster |
| 8 MiB | 298.27 us | 173.29 us | 1.75x faster |
| 64 MiB | 2.362 ms | 1.255 ms | 1.86x faster |

A 128 MiB write reduced median peak RSS from 414.8 MiB to 287.0 MiB, removing 127.7 MiB.

The memory service isolates binding and writer-adapter overhead. Network and service latency will reduce the proportional end-to-end latency improvement for remote storage, while the binding-owned allocation and copy remain eliminated.

# AI Usage Statement

AI materially assisted with source analysis, implementation, lifecycle regression coverage, and paired performance measurement. The author reviewed the resulting code and claims. The benchmark measures binding and writer-adapter overhead with the memory service; remote-service end-to-end latency remains unmeasured.
