### PR TITLE
refactor(services): standardize error normalization

### DIFF
--- a/core/services/aliyun-drive/src/core.rs
+++ b/core/services/aliyun-drive/src/core.rs
@@ -85,7 +85,7 @@ impl AliyunDriveCore {
         ctx: &OperationContext,
         mut req: Request<Buffer>,
         token: Option<&str>,
-    ) -> Result<Buffer> {
+    ) -> Result<Response<Buffer>> {
         // AliyunDrive raise NullPointerException if you haven't set a user-agent.
         req.headers_mut().insert(
             header::USER_AGENT,
@@ -105,11 +105,7 @@ impl AliyunDriveCore {
                     .expect("access token must be valid header value"),
             );
         }
-        let res = ctx.http_transport().send(req).await?;
-        if !res.status().is_success() {
-            return Err(parse_error(res));
-        }
-        Ok(res.into_body())
+        ctx.http_transport().send(req).await
     }
 
     async fn get_access_token(
@@ -129,14 +125,28 @@ impl AliyunDriveCore {
         let req = Request::post(format!("{}/oauth/access_token", self.endpoint))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
-        self.send(ctx, req, None).await
+        let res = self.send(ctx, req, None).await?;
+        if !res.status().is_success() {
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetAccessToken")),
+                res,
+            ));
+        }
+        Ok(res.into_body())
     }
 
     async fn get_drive_id(&self, ctx: &OperationContext, token: Option<&str>) -> Result<Buffer> {
         let req = Request::post(format!("{}/adrive/v1.0/user/getDriveInfo", self.endpoint))
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
-        self.send(ctx, req, token).await
+        let res = self.send(ctx, req, token).await?;
+        if !res.status().is_success() {
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetDriveInfo")),
+                res,
+            ));
+        }
+        Ok(res.into_body())
     }
 
     pub async fn get_token_and_drive(
@@ -212,7 +222,14 @@ impl AliyunDriveCore {
             .extension(ServiceOperation("GetFileByPath"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
-        self.send(ctx, req, token.as_deref()).await
+        let res = self.send(ctx, req, token.as_deref()).await?;
+        if !res.status().is_success() {
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetFileByPath")),
+                res,
+            ));
+        }
+        Ok(res.into_body())
     }
 
     pub async fn ensure_dir_exists(&self, ctx: &OperationContext, path: &str) -> Result<String> {
@@ -281,7 +298,14 @@ impl AliyunDriveCore {
             .extension(ServiceOperation("CreateFile"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
-        self.send(ctx, req, token.as_deref()).await
+        let res = self.send(ctx, req, token.as_deref()).await?;
+        if !res.status().is_success() {
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateFile")),
+                res,
+            ));
+        }
+        Ok(res.into_body())
     }
 
     pub async fn create(
@@ -314,6 +338,13 @@ impl AliyunDriveCore {
         .map_err(new_request_build_error)?;
 
         let res = self.send(ctx, req, token.as_deref()).await?;
+        if !res.status().is_success() {
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetDownloadUrl")),
+                res,
+            ));
+        }
+        let res = res.into_body();
 
         let output: GetDownloadUrlResponse =
             serde_json::from_reader(res.reader()).map_err(new_json_serialize_error)?;
@@ -356,7 +387,13 @@ impl AliyunDriveCore {
             .extension(ServiceOperation("MoveFile"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
-        self.send(ctx, req, token.as_deref()).await?;
+        let res = self.send(ctx, req, token.as_deref()).await?;
+        if !res.status().is_success() {
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("MoveFile")),
+                res,
+            ));
+        }
         Ok(())
     }
 
@@ -379,7 +416,13 @@ impl AliyunDriveCore {
             .extension(ServiceOperation("UpdateFile"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
-        self.send(ctx, req, token.as_deref()).await?;
+        let res = self.send(ctx, req, token.as_deref()).await?;
+        if !res.status().is_success() {
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("UpdateFile")),
+                res,
+            ));
+        }
         Ok(())
     }
 
@@ -403,7 +446,14 @@ impl AliyunDriveCore {
             .extension(ServiceOperation("CopyFile"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
-        self.send(ctx, req, token.as_deref()).await
+        let res = self.send(ctx, req, token.as_deref()).await?;
+        if !res.status().is_success() {
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("CopyFile")),
+                res,
+            ));
+        }
+        Ok(res.into_body())
     }
 
     pub async fn delete_path(&self, ctx: &OperationContext, file_id: &str) -> Result<()> {
@@ -418,7 +468,13 @@ impl AliyunDriveCore {
             .extension(ServiceOperation("DeleteFile"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
-        self.send(ctx, req, token.as_deref()).await?;
+        let res = self.send(ctx, req, token.as_deref()).await?;
+        if !res.status().is_success() {
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("DeleteFile")),
+                res,
+            ));
+        }
         Ok(())
     }
 
@@ -442,7 +498,14 @@ impl AliyunDriveCore {
             .extension(ServiceOperation("ListFiles"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
-        self.send(ctx, req, token.as_deref()).await
+        let res = self.send(ctx, req, token.as_deref()).await?;
+        if !res.status().is_success() {
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListFiles")),
+                res,
+            ));
+        }
+        Ok(res.into_body())
     }
 
     pub async fn complete(
@@ -463,7 +526,14 @@ impl AliyunDriveCore {
             .extension(ServiceOperation("CompleteUpload"))
             .body(Buffer::from(body))
             .map_err(new_request_build_error)?;
-        self.send(ctx, req, token.as_deref()).await
+        let res = self.send(ctx, req, token.as_deref()).await?;
+        if !res.status().is_success() {
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("CompleteUpload")),
+                res,
+            ));
+        }
+        Ok(res.into_body())
     }
 
     async fn get_upload_url(
@@ -495,6 +565,13 @@ impl AliyunDriveCore {
         .map_err(new_request_build_error)?;
 
         let res = self.send(ctx, req, token.as_deref()).await?;
+        if !res.status().is_success() {
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetUploadUrl")),
+                res,
+            ));
+        }
+        let res = res.into_body();
 
         let mut output: UploadUrlResponse =
             serde_json::from_reader(res.reader()).map_err(new_json_deserialize_error)?;
@@ -526,7 +603,14 @@ impl AliyunDriveCore {
             .extension(ServiceOperation("UploadPart"))
             .body(body)
             .map_err(new_request_build_error)?;
-        self.send(ctx, req, None).await
+        let res = self.send(ctx, req, None).await?;
+        if !res.status().is_success() {
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadPart")),
+                res,
+            ));
+        }
+        Ok(res.into_body())
     }
 }
 
@@ -701,46 +785,51 @@ pub struct PartInfoItem {
     part_number: Option<usize>,
 }
 
-mod error {
-    use bytes::Buf;
-    use http::Response;
-    use serde::Deserialize;
+#[derive(Default, Debug, Deserialize)]
+struct AliyunDriveError {
+    code: String,
+    message: String,
+}
 
-    use opendal_core::*;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    #[derive(Default, Debug, Deserialize)]
-    struct AliyunDriveError {
-        code: String,
-        message: String,
-    }
-
-    pub(crate) fn parse_error(res: Response<Buffer>) -> Error {
-        let (parts, body) = res.into_parts();
-        let bs = body.to_bytes();
-        let (code, message) = serde_json::from_reader::<_, AliyunDriveError>(bs.clone().reader())
-            .map(|err| (Some(err.code), err.message))
-            .unwrap_or((None, String::from_utf8_lossy(&bs).into_owned()));
-        let (kind, retryable) = match parts.status.as_u16() {
-            403 => (ErrorKind::PermissionDenied, false),
-            400 => match code {
-                Some(code) if code == "NotFound.File" => (ErrorKind::NotFound, false),
-                Some(code) if code == "AlreadyExist.File" => (ErrorKind::AlreadyExists, false),
-                Some(code) if code == "PreHashMatched" => (ErrorKind::IsSameFile, false),
-                _ => (ErrorKind::Unexpected, false),
-            },
-            409 => (ErrorKind::AlreadyExists, false),
-            429 => match code {
-                Some(code) if code == "TooManyRequests" => (ErrorKind::RateLimited, true),
-                _ => (ErrorKind::Unexpected, false),
-            },
-            _ => (ErrorKind::Unexpected, false),
-        };
-        let mut err = Error::new(kind, message);
-        if retryable {
-            err = err.set_temporary();
-        }
-        err
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, res: Response<Buffer>) -> Error {
+    let (parts, body) = res.into_parts();
+    let bs = body.to_bytes();
+    let (code, message) = serde_json::from_reader::<_, AliyunDriveError>(bs.clone().reader())
+        .map(|err| (Some(err.code), err.message))
+        .unwrap_or((None, String::from_utf8_lossy(&bs).into_owned()));
+    let (kind, retryable) = match parts.status.as_u16() {
+        403 => (ErrorKind::PermissionDenied, false),
+        400 => match code {
+            Some(code) if code == "NotFound.File" => (ErrorKind::NotFound, false),
+            Some(code) if code == "AlreadyExist.File" => (ErrorKind::AlreadyExists, false),
+            Some(code) if code == "PreHashMatched" => (ErrorKind::IsSameFile, false),
+            _ => (ErrorKind::Unexpected, false),
+        },
+        409 => (ErrorKind::AlreadyExists, false),
+        429 => match code {
+            Some(code) if code == "TooManyRequests" => (ErrorKind::RateLimited, true),
+            _ => (ErrorKind::Unexpected, false),
+        },
+        _ => (ErrorKind::Unexpected, false),
+    };
+    let mut err =
+        Error::new(kind, message).with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+    if retryable {
+        err = err.set_temporary();
+    }
+    err
+}

--- a/core/services/aliyun-drive/src/reader.rs
+++ b/core/services/aliyun-drive/src/reader.rs
@@ -67,7 +67,10 @@ impl oio::StreamRead for AliyunDriveReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("DownloadFile")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/alluxio/src/core.rs
+++ b/core/services/alluxio/src/core.rs
@@ -80,7 +80,10 @@ impl AlluxioCore {
         let status = resp.status();
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateDirectory")),
+                resp,
+            )),
         }
     }
 
@@ -119,7 +122,10 @@ impl AlluxioCore {
                     serde_json::from_reader(body.reader()).map_err(new_json_serialize_error)?;
                 Ok(steam_id)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateFile")),
+                resp,
+            )),
         }
     }
 
@@ -148,7 +154,10 @@ impl AlluxioCore {
                     serde_json::from_reader(body.reader()).map_err(new_json_serialize_error)?;
                 Ok(steam_id)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("OpenFile")),
+                resp,
+            )),
         }
     }
 
@@ -173,7 +182,7 @@ impl AlluxioCore {
         match status {
             StatusCode::OK => Ok(()),
             _ => {
-                let err = parse_error(resp);
+                let err = parse_error(ErrorContext::new(ServiceOperation("Delete")), resp);
                 if err.kind() == ErrorKind::NotFound {
                     return Ok(());
                 }
@@ -205,7 +214,10 @@ impl AlluxioCore {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Rename")),
+                resp,
+            )),
         }
     }
 
@@ -235,7 +247,10 @@ impl AlluxioCore {
                     serde_json::from_reader(body.reader()).map_err(new_json_serialize_error)?;
                 Ok(file_info)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetStatus")),
+                resp,
+            )),
         }
     }
 
@@ -269,7 +284,10 @@ impl AlluxioCore {
                     serde_json::from_reader(body.reader()).map_err(new_json_deserialize_error)?;
                 Ok(file_infos)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListStatus")),
+                resp,
+            )),
         }
     }
 
@@ -329,7 +347,10 @@ impl AlluxioCore {
                     serde_json::from_reader(body.reader()).map_err(new_json_serialize_error)?;
                 Ok(size)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("WriteStream")),
+                resp,
+            )),
         }
     }
 
@@ -351,13 +372,18 @@ impl AlluxioCore {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CloseStream")),
+                resp,
+            )),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use http::StatusCode;
+
     use super::*;
 
     #[tokio::test]
@@ -376,6 +402,38 @@ mod tests {
         };
 
         assert_eq!(err.kind(), ErrorKind::Unsupported);
+    }
+
+    /// Error response example is from https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+    #[test]
+    fn test_parse_error() {
+        let err_res = vec![
+            (
+                r#"{"statusCode":"ALREADY_EXISTS","message":"The resource you requested already exist"}"#,
+                ErrorKind::AlreadyExists,
+            ),
+            (
+                r#"{"statusCode":"NOT_FOUND","message":"The resource you requested does not exist"}"#,
+                ErrorKind::NotFound,
+            ),
+            (
+                r#"{"statusCode":"INTERNAL_SERVER_ERROR","message":"Internal server error"}"#,
+                ErrorKind::Unexpected,
+            ),
+        ];
+
+        for res in err_res {
+            let bs = bytes::Bytes::from(res.0);
+            let body = Buffer::from(bs);
+            let resp = Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(body)
+                .unwrap();
+
+            let err = parse_error(ErrorContext::new(ServiceOperation("Test")), resp);
+
+            assert_eq!(err.kind(), res.1);
+        }
     }
 }
 
@@ -426,90 +484,53 @@ impl TryFrom<FileInfo> for Metadata {
     }
 }
 
-mod error {
-    use bytes::Buf;
-    use http::Response;
-    use serde::Deserialize;
+/// the error response of alluxio
+#[derive(Default, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct AlluxioError {
+    status_code: String,
+    message: String,
+}
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    /// the error response of alluxio
-    #[derive(Default, Debug, Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    #[allow(dead_code)]
-    struct AlluxioError {
-        status_code: String,
-        message: String,
-    }
-
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let mut kind = match parts.status.as_u16() {
-            500 => ErrorKind::Unexpected,
-            _ => ErrorKind::Unexpected,
-        };
-
-        let (message, alluxio_err) =
-            serde_json::from_reader::<_, AlluxioError>(bs.clone().reader())
-                .map(|alluxio_err| (format!("{alluxio_err:?}"), Some(alluxio_err)))
-                .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
-
-        if let Some(alluxio_err) = alluxio_err {
-            kind = match alluxio_err.status_code.as_str() {
-                "ALREADY_EXISTS" => ErrorKind::AlreadyExists,
-                "NOT_FOUND" => ErrorKind::NotFound,
-                _ => ErrorKind::Unexpected,
-            }
-        }
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        err
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use http::StatusCode;
-
-        use super::*;
-
-        /// Error response example is from https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
-        #[test]
-        fn test_parse_error() {
-            let err_res = vec![
-                (
-                    r#"{"statusCode":"ALREADY_EXISTS","message":"The resource you requested already exist"}"#,
-                    ErrorKind::AlreadyExists,
-                ),
-                (
-                    r#"{"statusCode":"NOT_FOUND","message":"The resource you requested does not exist"}"#,
-                    ErrorKind::NotFound,
-                ),
-                (
-                    r#"{"statusCode":"INTERNAL_SERVER_ERROR","message":"Internal server error"}"#,
-                    ErrorKind::Unexpected,
-                ),
-            ];
-
-            for res in err_res {
-                let bs = bytes::Bytes::from(res.0);
-                let body = Buffer::from(bs);
-                let resp = Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(body)
-                    .unwrap();
-
-                let err = parse_error(resp);
-
-                assert_eq!(err.kind(), res.1);
-            }
-        }
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let mut kind = match parts.status.as_u16() {
+        500 => ErrorKind::Unexpected,
+        _ => ErrorKind::Unexpected,
+    };
+
+    let (message, alluxio_err) = serde_json::from_reader::<_, AlluxioError>(bs.clone().reader())
+        .map(|alluxio_err| (format!("{alluxio_err:?}"), Some(alluxio_err)))
+        .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
+
+    if let Some(alluxio_err) = alluxio_err {
+        kind = match alluxio_err.status_code.as_str() {
+            "ALREADY_EXISTS" => ErrorKind::AlreadyExists,
+            "NOT_FOUND" => ErrorKind::NotFound,
+            _ => ErrorKind::Unexpected,
+        }
+    }
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    err
+}

--- a/core/services/alluxio/src/reader.rs
+++ b/core/services/alluxio/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use opendal_core::raw::*;
 use opendal_core::*;
@@ -53,7 +53,10 @@ impl oio::StreamRead for AlluxioReader {
         if !resp.status().is_success() {
             let (part, mut body) = resp.into_parts();
             let buf = body.to_buffer().await?;
-            return Err(parse_error(Response::from_parts(part, buf)));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ReadStream")),
+                Response::from_parts(part, buf),
+            ));
         }
 
         let rp = RpRead::new(parse_into_metadata(path, resp.headers())?);

--- a/core/services/azdls/src/backend.rs
+++ b/core/services/azdls/src/backend.rs
@@ -34,9 +34,9 @@ use reqsign_file_read_tokio::TokioFileRead;
 
 use super::AZDLS_SCHEME;
 use super::config::AzdlsConfig;
-use super::core::AzdlsCore;
 use super::core::DIRECTORY;
 use super::core::parse_error;
+use super::core::{AzdlsCore, ErrorContext};
 use super::deleter::AzdlsDeleter;
 use super::lister::AzdlsLister;
 use super::reader::*;
@@ -413,7 +413,10 @@ impl Service for AzdlsBackend {
         let status = resp.status();
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(RpCreateDir::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateDirectory")),
+                resp,
+            )),
         }
     }
 
@@ -520,7 +523,12 @@ impl Service for AzdlsBackend {
             let status = resp.status();
             match status {
                 StatusCode::CREATED | StatusCode::CONFLICT => {}
-                _ => return Err(parse_error(resp)),
+                _ => {
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("CreateDirectory")),
+                        resp,
+                    ));
+                }
             }
         }
 
@@ -530,7 +538,10 @@ impl Service for AzdlsBackend {
 
         match status {
             StatusCode::CREATED => Ok(RpRename::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("RenamePath")),
+                resp,
+            )),
         }
     }
 

--- a/core/services/azdls/src/core.rs
+++ b/core/services/azdls/src/core.rs
@@ -371,7 +371,10 @@ impl AzdlsCore {
         let resp = self.azdls_get_properties(ctx, path).await?;
 
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetPathProperties")),
+                resp,
+            ));
         }
 
         let headers = resp.headers();
@@ -498,7 +501,12 @@ impl AzdlsCore {
             let status = resp.status();
             match status {
                 StatusCode::OK | StatusCode::ACCEPTED | StatusCode::NOT_FOUND => {}
-                _ => return Err(parse_error(resp)),
+                _ => {
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("RecursiveDeletePath")),
+                        resp,
+                    ));
+                }
             }
 
             let next = resp
@@ -643,96 +651,101 @@ mod tests {
     }
 }
 
-mod error {
-    use std::fmt::Debug;
+use bytes::Buf;
+use opendal_core::raw::ServiceOperation;
+use opendal_service_azure_common::with_azure_error_response_context;
+use quick_xml::de;
+use serde::Deserialize;
 
-    use bytes::Buf;
-    use http::Response;
-    use http::StatusCode;
-    use opendal_core::*;
-    use opendal_service_azure_common::with_azure_error_response_context;
-    use quick_xml::de;
-    use serde::Deserialize;
+/// AzdlsError is the error returned by azure dfs service.
+#[derive(Default, Deserialize)]
+#[serde(default, rename_all = "PascalCase")]
+struct AzdlsError {
+    code: String,
+    message: String,
+    query_parameter_name: String,
+    query_parameter_value: String,
+    reason: String,
+}
 
-    /// AzdlsError is the error returned by azure dfs service.
-    #[derive(Default, Deserialize)]
-    #[serde(default, rename_all = "PascalCase")]
-    struct AzdlsError {
-        code: String,
-        message: String,
-        query_parameter_name: String,
-        query_parameter_value: String,
-        reason: String,
-    }
+impl Debug for AzdlsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut de = f.debug_struct("AzdlsError");
+        de.field("code", &self.code);
+        // replace `\n` to ` ` for better reading.
+        de.field("message", &self.message.replace('\n', " "));
 
-    impl Debug for AzdlsError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            let mut de = f.debug_struct("AzdlsError");
-            de.field("code", &self.code);
-            // replace `\n` to ` ` for better reading.
-            de.field("message", &self.message.replace('\n', " "));
-
-            if !self.query_parameter_name.is_empty() {
-                de.field("query_parameter_name", &self.query_parameter_name);
-            }
-            if !self.query_parameter_value.is_empty() {
-                de.field("query_parameter_value", &self.query_parameter_value);
-            }
-            if !self.reason.is_empty() {
-                de.field("reason", &self.reason);
-            }
-
-            de.finish()
+        if !self.query_parameter_name.is_empty() {
+            de.field("query_parameter_name", &self.query_parameter_name);
         }
-    }
-
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
-            StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED | StatusCode::CONFLICT => {
-                (ErrorKind::ConditionNotMatch, false)
-            }
-            StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let mut message = match de::from_reader::<_, AzdlsError>(bs.clone().reader()) {
-            Ok(azdls_err) => format!("{azdls_err:?}"),
-            Err(_) => String::from_utf8_lossy(&bs).into_owned(),
-        };
-        // If there is no body here, fill with error code.
-        if message.is_empty()
-            && let Some(v) = parts.headers.get("x-ms-error-code")
-            && let Ok(code) = v.to_str()
-        {
-            message = format!(
-                "{:?}",
-                AzdlsError {
-                    code: code.to_string(),
-                    ..Default::default()
-                }
-            )
+        if !self.query_parameter_value.is_empty() {
+            de.field("query_parameter_value", &self.query_parameter_value);
+        }
+        if !self.reason.is_empty() {
+            de.field("reason", &self.reason);
         }
 
-        let mut err = Error::new(kind, &message);
-
-        err = with_azure_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
+        de.finish()
     }
 }
 
-pub(super) use error::*;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
+
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED | StatusCode::CONFLICT => {
+            (ErrorKind::ConditionNotMatch, false)
+        }
+        StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let mut message = match de::from_reader::<_, AzdlsError>(bs.clone().reader()) {
+        Ok(azdls_err) => format!("{azdls_err:?}"),
+        Err(_) => String::from_utf8_lossy(&bs).into_owned(),
+    };
+    // If there is no body here, fill with error code.
+    if message.is_empty()
+        && let Some(v) = parts.headers.get("x-ms-error-code")
+        && let Ok(code) = v.to_str()
+    {
+        message = format!(
+            "{:?}",
+            AzdlsError {
+                code: code.to_string(),
+                ..Default::default()
+            }
+        )
+    }
+
+    let mut err = Error::new(kind, &message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_azure_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}

--- a/core/services/azdls/src/deleter.rs
+++ b/core/services/azdls/src/deleter.rs
@@ -49,7 +49,14 @@ impl oio::OneShotDelete for AzdlsDeleter {
 
         match status {
             StatusCode::OK | StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(if args.recursive() {
+                    ServiceOperation("RecursiveDeletePath")
+                } else {
+                    ServiceOperation("DeletePath")
+                }),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/azdls/src/lister.rs
+++ b/core/services/azdls/src/lister.rs
@@ -21,8 +21,8 @@ use bytes::Buf;
 use serde::Deserialize;
 use serde_json::de;
 
-use super::core::AzdlsCore;
 use super::core::parse_error;
+use super::core::{AzdlsCore, ErrorContext};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -64,7 +64,10 @@ impl oio::PageList for AzdlsLister {
         }
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListPaths")),
+                resp,
+            ));
         }
 
         // Return self at the first page.

--- a/core/services/azdls/src/reader.rs
+++ b/core/services/azdls/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -65,7 +65,10 @@ impl oio::StreamRead for AzdlsReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("ReadFile")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/azdls/src/writer.rs
+++ b/core/services/azdls/src/writer.rs
@@ -20,10 +20,10 @@ use std::sync::Arc;
 use asyncband::once::OnceCell;
 use http::StatusCode;
 
-use super::core::AzdlsCore;
 use super::core::FILE;
 use super::core::X_MS_VERSION_ID;
 use super::core::parse_error;
+use super::core::{AzdlsCore, ErrorContext};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -77,11 +77,16 @@ impl AzdlsWriter {
             .await?;
         match resp.status() {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            StatusCode::CONFLICT if self.op.if_not_exists() => {
-                Err(parse_error(resp).with_operation("Backend::azdls_create_request"))
-            }
+            StatusCode::CONFLICT if self.op.if_not_exists() => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateFile")),
+                resp,
+            )
+            .with_operation("Backend::azdls_create_request")),
             StatusCode::CONFLICT => Ok(()),
-            _ => Err(parse_error(resp).with_operation("Backend::azdls_create_request")),
+            _ => Err(
+                parse_error(ErrorContext::new(ServiceOperation("CreateFile")), resp)
+                    .with_operation("Backend::azdls_create_request"),
+            ),
         }
     }
 
@@ -114,7 +119,10 @@ impl oio::PositionWrite for AzdlsWriter {
 
         match resp.status() {
             StatusCode::OK | StatusCode::ACCEPTED => Ok(()),
-            _ => Err(parse_error(resp).with_operation("Backend::azdls_append_request")),
+            _ => Err(
+                parse_error(ErrorContext::new(ServiceOperation("AppendData")), resp)
+                    .with_operation("Backend::azdls_append_request"),
+            ),
         }
     }
 
@@ -130,7 +138,10 @@ impl oio::PositionWrite for AzdlsWriter {
 
         match resp.status() {
             StatusCode::OK | StatusCode::ACCEPTED => Ok(meta),
-            _ => Err(parse_error(resp).with_operation("Backend::azdls_flush_request")),
+            _ => Err(
+                parse_error(ErrorContext::new(ServiceOperation("FlushData")), resp)
+                    .with_operation("Backend::azdls_flush_request"),
+            ),
         }
     }
 
@@ -171,7 +182,10 @@ impl oio::AppendWrite for AzdlsWriter {
         match status {
             StatusCode::OK => Ok(parse_content_length(headers)?.unwrap_or_default()),
             StatusCode::NOT_FOUND => Ok(0),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetPathProperties")),
+                resp,
+            )),
         }
     }
 
@@ -196,7 +210,10 @@ impl oio::AppendWrite for AzdlsWriter {
 
         match resp.status() {
             StatusCode::OK | StatusCode::ACCEPTED => Ok(meta),
-            _ => Err(parse_error(resp).with_operation("Backend::azdls_append_request")),
+            _ => Err(
+                parse_error(ErrorContext::new(ServiceOperation("AppendData")), resp)
+                    .with_operation("Backend::azdls_append_request"),
+            ),
         }
     }
 }

--- a/core/services/azfile/src/backend.rs
+++ b/core/services/azfile/src/backend.rs
@@ -32,9 +32,9 @@ use reqsign_file_read_tokio::TokioFileRead;
 
 use super::AZFILE_SCHEME;
 use super::config::AzfileConfig;
-use super::core::AzfileCore;
 use super::core::X_MS_META_PREFIX;
 use super::core::parse_error;
+use super::core::{AzfileCore, ErrorContext};
 use super::deleter::AzfileDeleter;
 use super::lister::AzfileLister;
 use super::reader::*;
@@ -311,7 +311,10 @@ impl Service for AzfileBackend {
                 {
                     Ok(RpCreateDir::default())
                 } else {
-                    Err(parse_error(resp))
+                    Err(parse_error(
+                        ErrorContext::new(ServiceOperation("CreateDirectory")),
+                        resp,
+                    ))
                 }
             }
         }
@@ -335,7 +338,14 @@ impl Service for AzfileBackend {
                 }
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(if path.ends_with('/') {
+                    ServiceOperation("GetDirectoryProperties")
+                } else {
+                    ServiceOperation("GetFileProperties")
+                }),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
@@ -422,7 +432,10 @@ impl Service for AzfileBackend {
         let status = resp.status();
         match status {
             StatusCode::OK => Ok(RpRename::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Rename")),
+                resp,
+            )),
         }
     }
 

--- a/core/services/azfile/src/core.rs
+++ b/core/services/azfile/src/core.rs
@@ -487,103 +487,111 @@ impl AzfileCore {
                 continue;
             }
 
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateDirectory")),
+                resp,
+            ));
         }
 
         Ok(())
     }
 }
 
-mod error {
-    use std::fmt::Debug;
+use bytes::Buf;
+use opendal_core::raw::ServiceOperation;
+use opendal_service_azure_common::with_azure_error_response_context;
+use quick_xml::de;
+use serde::Deserialize;
 
-    use bytes::Buf;
-    use http::Response;
-    use http::StatusCode;
-    use opendal_core::*;
-    use opendal_service_azure_common::with_azure_error_response_context;
-    use quick_xml::de;
-    use serde::Deserialize;
+/// AzfileError is the error returned by azure file service.
+#[derive(Default, Deserialize)]
+#[serde(default, rename_all = "PascalCase")]
+struct AzfileError {
+    code: String,
+    message: String,
+    query_parameter_name: String,
+    query_parameter_value: String,
+    reason: String,
+}
 
-    /// AzfileError is the error returned by azure file service.
-    #[derive(Default, Deserialize)]
-    #[serde(default, rename_all = "PascalCase")]
-    struct AzfileError {
-        code: String,
-        message: String,
-        query_parameter_name: String,
-        query_parameter_value: String,
-        reason: String,
-    }
+impl Debug for AzfileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut de = f.debug_struct("AzfileError");
+        de.field("code", &self.code);
+        // replace `\n` to ` ` for better reading.
+        de.field("message", &self.message.replace('\n', " "));
 
-    impl Debug for AzfileError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            let mut de = f.debug_struct("AzfileError");
-            de.field("code", &self.code);
-            // replace `\n` to ` ` for better reading.
-            de.field("message", &self.message.replace('\n', " "));
-
-            if !self.query_parameter_name.is_empty() {
-                de.field("query_parameter_name", &self.query_parameter_name);
-            }
-            if !self.query_parameter_value.is_empty() {
-                de.field("query_parameter_value", &self.query_parameter_value);
-            }
-            if !self.reason.is_empty() {
-                de.field("reason", &self.reason);
-            }
-
-            de.finish()
+        if !self.query_parameter_name.is_empty() {
+            de.field("query_parameter_name", &self.query_parameter_name);
         }
-    }
-
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
-            StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED => {
-                (ErrorKind::ConditionNotMatch, false)
-            }
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let mut message = match de::from_reader::<_, AzfileError>(bs.clone().reader()) {
-            Ok(azfile_err) => format!("{azfile_err:?}"),
-            Err(_) => String::from_utf8_lossy(&bs).into_owned(),
-        };
-
-        // If there is no body here, fill with error code.
-        if message.is_empty()
-            && let Some(v) = parts.headers.get("x-ms-error-code")
-            && let Ok(code) = v.to_str()
-        {
-            message = format!(
-                "{:?}",
-                AzfileError {
-                    code: code.to_string(),
-                    ..Default::default()
-                }
-            )
+        if !self.query_parameter_value.is_empty() {
+            de.field("query_parameter_value", &self.query_parameter_value);
+        }
+        if !self.reason.is_empty() {
+            de.field("reason", &self.reason);
         }
 
-        let mut err = Error::new(kind, &message);
-
-        err = with_azure_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
+        de.finish()
     }
 }
 
-pub(super) use error::*;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
+
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED => {
+            (ErrorKind::ConditionNotMatch, false)
+        }
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let mut message = match de::from_reader::<_, AzfileError>(bs.clone().reader()) {
+        Ok(azfile_err) => format!("{azfile_err:?}"),
+        Err(_) => String::from_utf8_lossy(&bs).into_owned(),
+    };
+
+    // If there is no body here, fill with error code.
+    if message.is_empty()
+        && let Some(v) = parts.headers.get("x-ms-error-code")
+        && let Ok(code) = v.to_str()
+    {
+        message = format!(
+            "{:?}",
+            AzfileError {
+                code: code.to_string(),
+                ..Default::default()
+            }
+        )
+    }
+
+    let mut err = Error::new(kind, &message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_azure_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}

--- a/core/services/azfile/src/deleter.rs
+++ b/core/services/azfile/src/deleter.rs
@@ -46,7 +46,14 @@ impl oio::OneShotDelete for AzfileDeleter {
         let status = resp.status();
         match status {
             StatusCode::ACCEPTED | StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(if path.ends_with('/') {
+                    ServiceOperation("DeleteDirectory")
+                } else {
+                    ServiceOperation("DeleteFile")
+                }),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/azfile/src/lister.rs
+++ b/core/services/azfile/src/lister.rs
@@ -22,8 +22,8 @@ use http::StatusCode;
 use quick_xml::de;
 use serde::Deserialize;
 
-use super::core::AzfileCore;
 use super::core::parse_error;
+use super::core::{AzfileCore, ErrorContext};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -64,7 +64,10 @@ impl oio::PageList for AzfileLister {
                 ctx.done = true;
                 return Ok(());
             }
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListDirectoriesAndFiles")),
+                resp,
+            ));
         }
 
         // Return self at the first page.

--- a/core/services/azfile/src/reader.rs
+++ b/core/services/azfile/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -59,7 +59,10 @@ impl oio::StreamRead for AzfileReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetFile")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/azfile/src/writer.rs
+++ b/core/services/azfile/src/writer.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use http::StatusCode;
 
-use super::core::AzfileCore;
 use super::core::parse_error;
+use super::core::{AzfileCore, ErrorContext};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -78,7 +78,10 @@ impl oio::OneShotWrite for AzfileWriter {
         match status {
             StatusCode::OK | StatusCode::CREATED => {}
             _ => {
-                return Err(parse_error(resp).with_operation("Backend::azfile_create_file"));
+                return Err(
+                    parse_error(ErrorContext::new(ServiceOperation("CreateFile")), resp)
+                        .with_operation("Backend::azfile_create_file"),
+                );
             }
         }
 
@@ -91,7 +94,10 @@ impl oio::OneShotWrite for AzfileWriter {
         meta.set_content_length(size as u64);
         match status {
             StatusCode::OK | StatusCode::CREATED => Ok(meta),
-            _ => Err(parse_error(resp).with_operation("Backend::azfile_update")),
+            _ => Err(
+                parse_error(ErrorContext::new(ServiceOperation("PutRange")), resp)
+                    .with_operation("Backend::azfile_update"),
+            ),
         }
     }
 }
@@ -109,7 +115,10 @@ impl oio::AppendWrite for AzfileWriter {
 
         match status {
             StatusCode::OK => Ok(parse_content_length(resp.headers())?.unwrap_or_default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetFileProperties")),
+                resp,
+            )),
         }
     }
 
@@ -124,7 +133,10 @@ impl oio::AppendWrite for AzfileWriter {
         meta.set_content_length(offset + size);
         match status {
             StatusCode::OK | StatusCode::CREATED => Ok(meta),
-            _ => Err(parse_error(resp).with_operation("Backend::azfile_update")),
+            _ => Err(
+                parse_error(ErrorContext::new(ServiceOperation("PutRange")), resp)
+                    .with_operation("Backend::azfile_update"),
+            ),
         }
     }
 }

--- a/core/services/b2/src/backend.rs
+++ b/core/services/b2/src/backend.rs
@@ -25,11 +25,11 @@ use log::debug;
 
 use super::B2_SCHEME;
 use super::config::B2Config;
-use super::core::B2Core;
 use super::core::B2Signer;
 use super::core::constants;
 use super::core::parse_error;
 use super::core::parse_file_info;
+use super::core::{B2Core, ErrorContext};
 use super::deleter::B2Deleter;
 use super::lister::B2Lister;
 use super::reader::*;
@@ -338,7 +338,10 @@ impl Service for B2Backend {
 
             match status {
                 StatusCode::OK => Ok(Metadata::default()),
-                _ => Err(parse_error(resp)),
+                _ => Err(parse_error(
+                    ErrorContext::new(ServiceOperation("CopyFile")),
+                    resp,
+                )),
             }
         }))
     }

--- a/core/services/b2/src/core.rs
+++ b/core/services/b2/src/core.rs
@@ -120,7 +120,10 @@ impl B2Core {
                     };
                 }
                 _ => {
-                    return Err(parse_error(resp));
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("AuthorizeAccount")),
+                        resp,
+                    ));
                 }
             }
             Ok(signer.auth_info.clone())
@@ -196,7 +199,10 @@ impl B2Core {
                     .map_err(new_json_deserialize_error)?;
                 Ok(resp)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetUploadUrl")),
+                resp,
+            )),
         }
     }
 
@@ -241,7 +247,10 @@ impl B2Core {
                     .map_err(new_json_deserialize_error)?;
                 Ok(resp)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetDownloadAuthorization")),
+                resp,
+            )),
         }
     }
 
@@ -385,7 +394,10 @@ impl B2Core {
                     .map_err(new_json_deserialize_error)?;
                 Ok(resp)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetUploadPartUrl")),
+                resp,
+            )),
         }
     }
 
@@ -505,7 +517,10 @@ impl B2Core {
                 }
                 Ok(resp.files.swap_remove(0))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListFileNames")),
+                resp,
+            )),
         }
     }
 
@@ -843,123 +858,124 @@ pub struct GetDownloadAuthorizationResponse {
     pub authorization_token: String,
 }
 
-mod error {
-    use bytes::Buf;
-    use http::Response;
-    use serde::Deserialize;
+/// the error response of b2
+#[derive(Default, Debug, Deserialize)]
+#[allow(dead_code)]
+struct B2Error {
+    status: u32,
+    code: String,
+    message: String,
+}
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    /// the error response of b2
-    #[derive(Default, Debug, Deserialize)]
-    #[allow(dead_code)]
-    struct B2Error {
-        status: u32,
-        code: String,
-        message: String,
-    }
-
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (mut kind, mut retryable) = match parts.status.as_u16() {
-            403 => (ErrorKind::PermissionDenied, false),
-            404 => (ErrorKind::NotFound, false),
-            304 | 412 => (ErrorKind::ConditionNotMatch, false),
-            // Service b2 could return 403, show the authorization error
-            401 => (ErrorKind::PermissionDenied, true),
-            429 => (ErrorKind::RateLimited, true),
-            500 | 502 | 503 | 504 => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let (message, b2_err) = serde_json::from_reader::<_, B2Error>(bs.clone().reader())
-            .map(|b2_err| (format!("{b2_err:?}"), Some(b2_err)))
-            .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
-
-        if let Some(b2_err) = b2_err {
-            (kind, retryable) =
-                parse_b2_error_code(b2_err.code.as_str()).unwrap_or((kind, retryable));
-        };
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    /// Returns the `Error kind` of this code and whether the error is retryable.
-    pub(crate) fn parse_b2_error_code(code: &str) -> Option<(ErrorKind, bool)> {
-        match code {
-            "already_hidden" => Some((ErrorKind::AlreadyExists, false)),
-            "no_such_file" => Some((ErrorKind::NotFound, false)),
-            _ => None,
-        }
-    }
-
-    #[cfg(test)]
-    mod test {
-        use http::StatusCode;
-
-        use super::*;
-
-        #[test]
-        fn test_parse_b2_error_code() {
-            let code = "already_hidden";
-            assert_eq!(
-                parse_b2_error_code(code),
-                Some((opendal_core::ErrorKind::AlreadyExists, false))
-            );
-
-            let code = "no_such_file";
-            assert_eq!(
-                parse_b2_error_code(code),
-                Some((opendal_core::ErrorKind::NotFound, false))
-            );
-
-            let code = "not_found";
-            assert_eq!(parse_b2_error_code(code), None);
-        }
-
-        #[tokio::test]
-        async fn test_parse_error() {
-            let err_res = vec![
-                (
-                    r#"{"status": 403, "code": "access_denied", "message":"The provided customer-managed encryption key is wrong."}"#,
-                    ErrorKind::PermissionDenied,
-                    StatusCode::FORBIDDEN,
-                ),
-                (
-                    r#"{"status": 404, "code": "not_found", "message":"File is not in B2 Cloud Storage."}"#,
-                    ErrorKind::NotFound,
-                    StatusCode::NOT_FOUND,
-                ),
-                (
-                    r#"{"status": 401, "code": "bad_auth_token", "message":"The auth token used is not valid. Call b2_authorize_account again to either get a new one, or an error message describing the problem."}"#,
-                    ErrorKind::PermissionDenied,
-                    StatusCode::UNAUTHORIZED,
-                ),
-            ];
-
-            for res in err_res {
-                let bs = bytes::Bytes::from(res.0);
-                let body = Buffer::from(bs);
-                let resp = Response::builder().status(res.2).body(body).unwrap();
-
-                let err = parse_error(resp);
-
-                assert_eq!(err.kind(), res.1);
-            }
-        }
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (mut kind, mut retryable) = match parts.status.as_u16() {
+        403 => (ErrorKind::PermissionDenied, false),
+        404 => (ErrorKind::NotFound, false),
+        304 | 412 => (ErrorKind::ConditionNotMatch, false),
+        // Service b2 could return 403, show the authorization error
+        401 => (ErrorKind::PermissionDenied, true),
+        429 => (ErrorKind::RateLimited, true),
+        500 | 502 | 503 | 504 => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let (message, b2_err) = serde_json::from_reader::<_, B2Error>(bs.clone().reader())
+        .map(|b2_err| (format!("{b2_err:?}"), Some(b2_err)))
+        .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
+
+    if let Some(b2_err) = b2_err {
+        (kind, retryable) = parse_b2_error_code(b2_err.code.as_str()).unwrap_or((kind, retryable));
+    };
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}
+
+/// Returns the `Error kind` of this code and whether the error is retryable.
+pub(crate) fn parse_b2_error_code(code: &str) -> Option<(ErrorKind, bool)> {
+    match code {
+        "already_hidden" => Some((ErrorKind::AlreadyExists, false)),
+        "no_such_file" => Some((ErrorKind::NotFound, false)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http::StatusCode;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_b2_error_code() {
+        let code = "already_hidden";
+        assert_eq!(
+            parse_b2_error_code(code),
+            Some((opendal_core::ErrorKind::AlreadyExists, false))
+        );
+
+        let code = "no_such_file";
+        assert_eq!(
+            parse_b2_error_code(code),
+            Some((opendal_core::ErrorKind::NotFound, false))
+        );
+
+        let code = "not_found";
+        assert_eq!(parse_b2_error_code(code), None);
+    }
+
+    #[tokio::test]
+    async fn test_parse_error() {
+        let err_res = vec![
+            (
+                r#"{"status": 403, "code": "access_denied", "message":"The provided customer-managed encryption key is wrong."}"#,
+                ErrorKind::PermissionDenied,
+                StatusCode::FORBIDDEN,
+            ),
+            (
+                r#"{"status": 404, "code": "not_found", "message":"File is not in B2 Cloud Storage."}"#,
+                ErrorKind::NotFound,
+                StatusCode::NOT_FOUND,
+            ),
+            (
+                r#"{"status": 401, "code": "bad_auth_token", "message":"The auth token used is not valid. Call b2_authorize_account again to either get a new one, or an error message describing the problem."}"#,
+                ErrorKind::PermissionDenied,
+                StatusCode::UNAUTHORIZED,
+            ),
+        ];
+
+        for res in err_res {
+            let bs = bytes::Bytes::from(res.0);
+            let body = Buffer::from(bs);
+            let resp = Response::builder().status(res.2).body(body).unwrap();
+
+            let err = parse_error(ErrorContext::new(ServiceOperation("Test")), resp);
+
+            assert_eq!(err.kind(), res.1);
+        }
+    }
+}

--- a/core/services/b2/src/deleter.rs
+++ b/core/services/b2/src/deleter.rs
@@ -44,7 +44,7 @@ impl oio::OneShotDelete for B2Deleter {
         match status {
             StatusCode::OK => Ok(()),
             _ => {
-                let err = parse_error(resp);
+                let err = parse_error(ErrorContext::new(ServiceOperation("HideFile")), resp);
                 match err.kind() {
                     ErrorKind::NotFound => Ok(()),
                     // Representative deleted

--- a/core/services/b2/src/lister.rs
+++ b/core/services/b2/src/lister.rs
@@ -19,10 +19,10 @@ use std::sync::Arc;
 
 use bytes::Buf;
 
-use super::core::B2Core;
 use super::core::ListFileNamesResponse;
 use super::core::parse_error;
 use super::core::parse_file_info;
+use super::core::{B2Core, ErrorContext};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -80,7 +80,10 @@ impl oio::PageList for B2Lister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListFileNames")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();

--- a/core/services/b2/src/reader.rs
+++ b/core/services/b2/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -60,7 +60,10 @@ impl oio::StreamRead for B2Reader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("DownloadFileByName")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/b2/src/writer.rs
+++ b/core/services/b2/src/writer.rs
@@ -20,11 +20,11 @@ use std::sync::Arc;
 use bytes::Buf;
 use http::StatusCode;
 
-use super::core::B2Core;
 use super::core::StartLargeFileResponse;
 use super::core::UploadPartResponse;
 use super::core::UploadResponse;
 use super::core::parse_error;
+use super::core::{B2Core, ErrorContext};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -85,7 +85,10 @@ impl oio::MultipartWrite for B2Writer {
 
                 Ok(meta)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadFile")),
+                resp,
+            )),
         }
     }
 
@@ -106,7 +109,10 @@ impl oio::MultipartWrite for B2Writer {
 
                 Ok(result.file_id)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("StartLargeFile")),
+                resp,
+            )),
         }
     }
 
@@ -141,7 +147,10 @@ impl oio::MultipartWrite for B2Writer {
                     size: None,
                 })
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadPart")),
+                resp,
+            )),
         }
     }
 
@@ -180,7 +189,10 @@ impl oio::MultipartWrite for B2Writer {
 
                 Ok(meta)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("FinishLargeFile")),
+                resp,
+            )),
         }
     }
 
@@ -189,7 +201,10 @@ impl oio::MultipartWrite for B2Writer {
         match resp.status() {
             // b2 returns code 200 if abort succeeds.
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CancelLargeFile")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/cloudflare-kv/src/backend.rs
+++ b/core/services/cloudflare-kv/src/backend.rs
@@ -25,8 +25,8 @@ use opendal_core::*;
 
 use super::CLOUDFLARE_KV_SCHEME;
 use super::config::CloudflareKvConfig;
-use super::core::CloudflareKvCore;
 use super::core::parse_error;
+use super::core::{CloudflareKvCore, ErrorContext};
 use super::deleter::CloudflareKvDeleter;
 use super::lister::CloudflareKvLister;
 use super::model::*;
@@ -287,7 +287,10 @@ impl Service for CloudflareKvBackend {
             }
 
             // For all other error cases, parse the error response
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetMetadata")),
+                resp,
+            ));
         }
 
         let resp_body = resp.into_body();

--- a/core/services/cloudflare-kv/src/core.rs
+++ b/core/services/cloudflare-kv/src/core.rs
@@ -174,69 +174,75 @@ impl CloudflareKvCore {
     }
 }
 
-mod error {
-    use bytes::Buf;
-    use http::Response;
-    use http::StatusCode;
-    use opendal_core::raw::*;
-    use opendal_core::*;
-    use serde_json::de;
+use bytes::Buf;
+use http::StatusCode;
+use serde_json::de;
 
-    use crate::model::CfKvError;
-    use crate::model::CfKvResponse;
+use crate::model::CfKvError;
+use crate::model::CfKvResponse;
 
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-        let (mut kind, mut retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            // Some services (like owncloud) return 403 while file locked.
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, true),
-            // Allowing retry for resource locked.
-            StatusCode::LOCKED => (ErrorKind::Unexpected, true),
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let (message, err) = de::from_reader::<_, CfKvResponse>(bs.clone().reader())
-            .map(|err| (format!("{err:?}"), Some(err)))
-            .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
-
-        if let Some(err) = err {
-            (kind, retryable) = parse_cfkv_error_code(err.errors).unwrap_or((kind, retryable));
-        }
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    pub(crate) fn parse_cfkv_error_code(errors: Vec<CfKvError>) -> Option<(ErrorKind, bool)> {
-        if errors.is_empty() {
-            return None;
-        }
-
-        match errors[0].code {
-            // The request is malformed: failed to decode id.
-            7400 => Some((ErrorKind::Unexpected, false)),
-            // no such column: Xxxx.
-            7500 => Some((ErrorKind::NotFound, false)),
-            // Authentication error.
-            10000 => Some((ErrorKind::PermissionDenied, false)),
-            _ => None,
-        }
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (mut kind, mut retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        // Some services (like owncloud) return 403 while file locked.
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, true),
+        // Allowing retry for resource locked.
+        StatusCode::LOCKED => (ErrorKind::Unexpected, true),
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let (message, err) = de::from_reader::<_, CfKvResponse>(bs.clone().reader())
+        .map(|err| (format!("{err:?}"), Some(err)))
+        .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
+
+    if let Some(err) = err {
+        (kind, retryable) = parse_cfkv_error_code(err.errors).unwrap_or((kind, retryable));
+    }
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}
+
+pub(crate) fn parse_cfkv_error_code(errors: Vec<CfKvError>) -> Option<(ErrorKind, bool)> {
+    if errors.is_empty() {
+        return None;
+    }
+
+    match errors[0].code {
+        // The request is malformed: failed to decode id.
+        7400 => Some((ErrorKind::Unexpected, false)),
+        // no such column: Xxxx.
+        7500 => Some((ErrorKind::NotFound, false)),
+        // Authentication error.
+        10000 => Some((ErrorKind::PermissionDenied, false)),
+        _ => None,
+    }
+}

--- a/core/services/cloudflare-kv/src/deleter.rs
+++ b/core/services/cloudflare-kv/src/deleter.rs
@@ -49,7 +49,10 @@ impl oio::BatchDelete for CloudflareKvDeleter {
         let status = resp.status();
 
         if status != StatusCode::OK {
-            return Err(parse_error(resp.clone()));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("BulkDelete")),
+                resp.clone(),
+            ));
         }
 
         let bs = resp.clone().into_body();
@@ -57,7 +60,10 @@ impl oio::BatchDelete for CloudflareKvDeleter {
             serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
 
         if !res.success {
-            return Err(parse_error(resp.clone()));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("BulkDelete")),
+                resp.clone(),
+            ));
         }
 
         Ok(())
@@ -77,7 +83,10 @@ impl oio::BatchDelete for CloudflareKvDeleter {
         let status = resp.status();
 
         if status != StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("BulkDelete")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();

--- a/core/services/cloudflare-kv/src/lister.rs
+++ b/core/services/cloudflare-kv/src/lister.rs
@@ -21,8 +21,8 @@ use bytes::Buf;
 use opendal_core::raw::*;
 use opendal_core::*;
 
-use super::core::CloudflareKvCore;
 use super::core::parse_error;
+use super::core::{CloudflareKvCore, ErrorContext};
 use super::model::{CfKvListKey, CfKvListResponse};
 
 pub struct CloudflareKvLister {
@@ -130,7 +130,10 @@ impl oio::PageList for CloudflareKvLister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListKeys")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();

--- a/core/services/cloudflare-kv/src/reader.rs
+++ b/core/services/cloudflare-kv/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use super::model::*;
 use bytes::Buf;
 use http::StatusCode;
@@ -58,7 +58,10 @@ impl oio::StreamRead for CloudflareKvReader {
         let status = resp.status();
 
         if status != StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetValue")),
+                resp,
+            ));
         }
 
         let resp_body = resp.into_body();
@@ -71,7 +74,10 @@ impl oio::StreamRead for CloudflareKvReader {
             let meta_resp = backend.core.metadata(&self.ctx, &path).await?;
 
             if meta_resp.status() != StatusCode::OK {
-                return Err(parse_error(meta_resp));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetMetadata")),
+                    meta_resp,
+                ));
             }
 
             let cf_response: CfKvStatResponse =

--- a/core/services/cloudflare-kv/src/writer.rs
+++ b/core/services/cloudflare-kv/src/writer.rs
@@ -21,8 +21,8 @@ use http::StatusCode;
 use opendal_core::raw::*;
 use opendal_core::*;
 
-use super::core::CloudflareKvCore;
 use super::core::parse_error;
+use super::core::{CloudflareKvCore, ErrorContext};
 use super::model::CfKvMetadata;
 
 pub struct CloudflareWriter {
@@ -62,7 +62,10 @@ impl oio::OneShotWrite for CloudflareWriter {
 
                 Ok(metadata)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("WriteValue")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/cos/src/backend.rs
+++ b/core/services/cos/src/backend.rs
@@ -351,7 +351,10 @@ impl Service for CosBackend {
 
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("HeadObject")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
@@ -442,7 +445,10 @@ impl Service for CosBackend {
 
             match status {
                 StatusCode::OK => Ok(Metadata::default()),
-                _ => Err(parse_error(resp)),
+                _ => Err(parse_error(
+                    ErrorContext::new(ServiceOperation("CopyObject")),
+                    resp,
+                )),
             }
         }))
     }

--- a/core/services/cos/src/core.rs
+++ b/core/services/cos/src/core.rs
@@ -836,75 +836,11 @@ mod tests {
             ["hello", "world"],
         )
     }
-}
 
-mod error {
-    use bytes::Buf;
-    use http::Response;
-    use http::StatusCode;
-    use quick_xml::de;
-    use serde::Deserialize;
-
-    use opendal_core::Buffer;
-    use opendal_core::Error;
-    use opendal_core::ErrorKind;
-    use opendal_core::raw::*;
-
-    /// CosError is the error returned by cos service.
-    #[derive(Default, Debug, Deserialize)]
-    #[serde(default, rename_all = "PascalCase")]
-    struct CosError {
-        code: String,
-        message: String,
-        resource: String,
-        request_id: String,
-        host_id: String,
-    }
-
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
-            StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED | StatusCode::CONFLICT => {
-                (ErrorKind::ConditionNotMatch, false)
-            }
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            // COS could return `520 Origin Error` errors which should be retried.
-            v if v.as_u16() == 520 => (ErrorKind::Unexpected, true),
-
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let message = match de::from_reader::<_, CosError>(bs.clone().reader()) {
-            Ok(cos_error) => format!("{cos_error:?}"),
-            Err(_) => String::from_utf8_lossy(&bs).into_owned(),
-        };
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-        err
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn test_parse_error() {
-            let bs = bytes::Bytes::from(
-                r#"
+    #[test]
+    fn test_parse_error() {
+        let bs = bytes::Bytes::from(
+            r#"
 <?xml version="1.0" encoding="UTF-8"?>
 <Error>
 <Code>NoSuchKey</Code>
@@ -914,21 +850,85 @@ mod error {
 <HostId>RkRCRDJENDc5MzdGQkQ4OUY3MTI4NTQ3NDk2Mjg0M0FBQUFBQUFBYmJiYmJiYmJD</HostId>
 </Error>
 "#,
-            );
+        );
 
-            let out: CosError = de::from_reader(bs.reader()).expect("must success");
-            println!("{out:?}");
+        let out: CosError = de::from_reader(bs.reader()).expect("must success");
+        println!("{out:?}");
 
-            assert_eq!(out.code, "NoSuchKey");
-            assert_eq!(out.message, "The resource you requested does not exist");
-            assert_eq!(out.resource, "/example-bucket/object");
-            assert_eq!(out.request_id, "001B21A61C6C0000013402C4616D5285");
-            assert_eq!(
-                out.host_id,
-                "RkRCRDJENDc5MzdGQkQ4OUY3MTI4NTQ3NDk2Mjg0M0FBQUFBQUFBYmJiYmJiYmJD"
-            );
-        }
+        assert_eq!(out.code, "NoSuchKey");
+        assert_eq!(out.message, "The resource you requested does not exist");
+        assert_eq!(out.resource, "/example-bucket/object");
+        assert_eq!(out.request_id, "001B21A61C6C0000013402C4616D5285");
+        assert_eq!(
+            out.host_id,
+            "RkRCRDJENDc5MzdGQkQ4OUY3MTI4NTQ3NDk2Mjg0M0FBQUFBQUFBYmJiYmJiYmJD"
+        );
     }
 }
 
-pub(super) use error::*;
+use bytes::Buf;
+use http::StatusCode;
+use quick_xml::de;
+
+use opendal_core::Error;
+use opendal_core::ErrorKind;
+
+/// CosError is the error returned by cos service.
+#[derive(Default, Debug, Deserialize)]
+#[serde(default, rename_all = "PascalCase")]
+struct CosError {
+    code: String,
+    message: String,
+    resource: String,
+    request_id: String,
+    host_id: String,
+}
+
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
+
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED | StatusCode::CONFLICT => {
+            (ErrorKind::ConditionNotMatch, false)
+        }
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        // COS could return `520 Origin Error` errors which should be retried.
+        v if v.as_u16() == 520 => (ErrorKind::Unexpected, true),
+
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let message = match de::from_reader::<_, CosError>(bs.clone().reader()) {
+        Ok(cos_error) => format!("{cos_error:?}"),
+        Err(_) => String::from_utf8_lossy(&bs).into_owned(),
+    };
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+    err
+}

--- a/core/services/cos/src/deleter.rs
+++ b/core/services/cos/src/deleter.rs
@@ -44,7 +44,10 @@ impl oio::OneShotDelete for CosDeleter {
 
         match status {
             StatusCode::NO_CONTENT | StatusCode::ACCEPTED | StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("DeleteObject")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/cos/src/lister.rs
+++ b/core/services/cos/src/lister.rs
@@ -73,7 +73,10 @@ impl oio::PageList for CosLister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListObjects")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();
@@ -174,7 +177,10 @@ impl oio::PageList for CosObjectVersionsLister {
             )
             .await?;
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListObjectVersions")),
+                resp,
+            ));
         }
 
         let body = resp.into_body();

--- a/core/services/cos/src/reader.rs
+++ b/core/services/cos/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -66,7 +66,10 @@ impl oio::StreamRead for CosReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetObject")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/cos/src/writer.rs
+++ b/core/services/cos/src/writer.rs
@@ -86,7 +86,10 @@ impl oio::MultipartWrite for CosWriter {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(meta),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("PutObject")),
+                resp,
+            )),
         }
     }
 
@@ -108,7 +111,10 @@ impl oio::MultipartWrite for CosWriter {
 
                 Ok(result.upload_id)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("InitiateMultipartUpload")),
+                resp,
+            )),
         }
     }
 
@@ -147,7 +153,10 @@ impl oio::MultipartWrite for CosWriter {
                     size: None,
                 })
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadPart")),
+                resp,
+            )),
         }
     }
 
@@ -180,7 +189,10 @@ impl oio::MultipartWrite for CosWriter {
 
         match status {
             StatusCode::OK => Ok(meta),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CompleteMultipartUpload")),
+                resp,
+            )),
         }
     }
 
@@ -193,7 +205,10 @@ impl oio::MultipartWrite for CosWriter {
             // cos returns code 204 if abort succeeds.
             // Reference: https://www.tencentcloud.com/document/product/436/7740
             StatusCode::NO_CONTENT => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("AbortMultipartUpload")),
+                resp,
+            )),
         }
     }
 }
@@ -217,7 +232,10 @@ impl oio::AppendWrite for CosWriter {
                 Ok(content_length)
             }
             StatusCode::NOT_FOUND => Ok(0),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("HeadObject")),
+                resp,
+            )),
         }
     }
 
@@ -236,7 +254,10 @@ impl oio::AppendWrite for CosWriter {
 
         match status {
             StatusCode::OK => Ok(meta),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("AppendObject")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/d1/src/core.rs
+++ b/core/services/d1/src/core.rs
@@ -103,7 +103,10 @@ impl D1Core {
                 let d1_response = D1Response::parse(&bs)?;
                 Ok(d1_response.get_result(&self.value_field))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Query")),
+                resp,
+            )),
         }
     }
 
@@ -124,7 +127,10 @@ impl D1Core {
                 let d1_response = D1Response::parse(&bs)?;
                 d1_response.get_usize_result("content_length")
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Query")),
+                resp,
+            )),
         }
     }
 
@@ -146,7 +152,10 @@ impl D1Core {
         let status = resp.status();
         match status {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Query")),
+                resp,
+            )),
         }
     }
 
@@ -162,73 +171,80 @@ impl D1Core {
         let status = resp.status();
         match status {
             StatusCode::OK | StatusCode::PARTIAL_CONTENT => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Query")),
+                resp,
+            )),
         }
     }
 }
 
-mod error {
-    use bytes::Buf;
-    use http::Response;
-    use http::StatusCode;
-    use serde_json::de;
+use bytes::Buf;
+use http::Response;
+use serde_json::de;
 
-    use crate::model::*;
-    use opendal_core::raw::*;
-    use opendal_core::*;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (mut kind, mut retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            // Some services (like owncloud) return 403 while file locked.
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, true),
-            // Allowing retry for resource locked.
-            StatusCode::LOCKED => (ErrorKind::Unexpected, true),
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let (message, d1_err) = de::from_reader::<_, D1Response>(bs.clone().reader())
-            .map(|d1_err| (format!("{d1_err:?}"), Some(d1_err)))
-            .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
-
-        if let Some(d1_err) = d1_err {
-            (kind, retryable) = parse_d1_error_code(d1_err.errors).unwrap_or((kind, retryable));
-        }
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    pub fn parse_d1_error_code(errors: Vec<D1Error>) -> Option<(ErrorKind, bool)> {
-        if errors.is_empty() {
-            return None;
-        }
-
-        match errors[0].code {
-            // The request is malformed: failed to decode id.
-            7400 => Some((ErrorKind::Unexpected, false)),
-            // no such column: Xxxx.
-            7500 => Some((ErrorKind::NotFound, false)),
-            // Authentication error.
-            10000 => Some((ErrorKind::PermissionDenied, false)),
-            _ => None,
-        }
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (mut kind, mut retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        // Some services (like owncloud) return 403 while file locked.
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, true),
+        // Allowing retry for resource locked.
+        StatusCode::LOCKED => (ErrorKind::Unexpected, true),
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let (message, d1_err) = de::from_reader::<_, D1Response>(bs.clone().reader())
+        .map(|d1_err| (format!("{d1_err:?}"), Some(d1_err)))
+        .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
+
+    if let Some(d1_err) = d1_err {
+        (kind, retryable) = parse_d1_error_code(d1_err.errors).unwrap_or((kind, retryable));
+    }
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}
+
+pub fn parse_d1_error_code(errors: Vec<D1Error>) -> Option<(ErrorKind, bool)> {
+    if errors.is_empty() {
+        return None;
+    }
+
+    match errors[0].code {
+        // The request is malformed: failed to decode id.
+        7400 => Some((ErrorKind::Unexpected, false)),
+        // no such column: Xxxx.
+        7500 => Some((ErrorKind::NotFound, false)),
+        // Authentication error.
+        10000 => Some((ErrorKind::PermissionDenied, false)),
+        _ => None,
+    }
+}

--- a/core/services/dbfs/src/backend.rs
+++ b/core/services/dbfs/src/backend.rs
@@ -24,8 +24,8 @@ use serde::Deserialize;
 
 use super::DBFS_SCHEME;
 use super::config::DbfsConfig;
-use super::core::DbfsCore;
 use super::core::parse_error;
+use super::core::{DbfsCore, ErrorContext};
 use super::deleter::DbfsDeleter;
 use super::lister::DbfsLister;
 use super::writer::DbfsWriter;
@@ -165,7 +165,10 @@ impl Service for DbfsBackend {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(RpCreateDir::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Mkdirs")),
+                resp,
+            )),
         }
     }
 
@@ -200,7 +203,10 @@ impl Service for DbfsBackend {
             StatusCode::NOT_FOUND if path.ends_with('/') => {
                 Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetStatus")),
+                resp,
+            )),
         }
     }
 
@@ -260,7 +266,10 @@ impl Service for DbfsBackend {
 
         match status {
             StatusCode::OK => Ok(RpRename::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Move")),
+                resp,
+            )),
         }
     }
 

--- a/core/services/dbfs/src/core.rs
+++ b/core/services/dbfs/src/core.rs
@@ -24,6 +24,7 @@ use http::Request;
 use http::Response;
 use http::StatusCode;
 use http::header;
+use serde::Deserialize;
 use serde_json::json;
 
 use opendal_core::raw::*;
@@ -222,71 +223,75 @@ impl DbfsCore {
             StatusCode::NOT_FOUND => {
                 self.dbfs_create_dir(ctx, path).await?;
             }
-            _ => return Err(parse_error(resp)),
+            _ => {
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetStatus")),
+                    resp,
+                ));
+            }
         }
         Ok(())
     }
 }
 
-mod error {
-    use std::fmt::Debug;
+/// DbfsError is the error returned by DBFS service.
+#[derive(Default, Deserialize)]
+struct DbfsError {
+    error_code: String,
+    message: String,
+}
 
-    use http::Response;
-    use http::StatusCode;
-    use serde::Deserialize;
-
-    use opendal_core::raw::*;
-    use opendal_core::*;
-
-    /// DbfsError is the error returned by DBFS service.
-    #[derive(Default, Deserialize)]
-    struct DbfsError {
-        error_code: String,
-        message: String,
-    }
-
-    impl Debug for DbfsError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("DbfsError")
-                .field("error_code", &self.error_code)
-                // replace `\n` to ` ` for better reading.
-                .field("message", &self.message.replace('\n', " "))
-                .finish()
-        }
-    }
-
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
-                (ErrorKind::PermissionDenied, false)
-            }
-            StatusCode::PRECONDITION_FAILED => (ErrorKind::ConditionNotMatch, false),
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let message = match serde_json::from_slice::<DbfsError>(&bs) {
-            Ok(dbfs_error) => format!("{:?}", dbfs_error.message),
-            Err(_) => String::from_utf8_lossy(&bs).into_owned(),
-        };
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
+impl Debug for DbfsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DbfsError")
+            .field("error_code", &self.error_code)
+            // replace `\n` to ` ` for better reading.
+            .field("message", &self.message.replace('\n', " "))
+            .finish()
     }
 }
 
-pub(super) use error::*;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
+
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::PRECONDITION_FAILED => (ErrorKind::ConditionNotMatch, false),
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let message = match serde_json::from_slice::<DbfsError>(&bs) {
+        Ok(dbfs_error) => format!("{:?}", dbfs_error.message),
+        Err(_) => String::from_utf8_lossy(&bs).into_owned(),
+    };
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}

--- a/core/services/dbfs/src/deleter.rs
+++ b/core/services/dbfs/src/deleter.rs
@@ -44,7 +44,10 @@ impl oio::OneShotDelete for DbfsDeleter {
         match status {
             // NOTE: Server will return 200 even if the path doesn't exist.
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Delete")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/dbfs/src/lister.rs
+++ b/core/services/dbfs/src/lister.rs
@@ -21,8 +21,8 @@ use bytes::Buf;
 use http::StatusCode;
 use serde::Deserialize;
 
-use super::core::DbfsCore;
 use super::core::parse_error;
+use super::core::{DbfsCore, ErrorContext};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -48,7 +48,7 @@ impl oio::PageList for DbfsLister {
                 ctx.done = true;
                 return Ok(());
             }
-            let error = parse_error(response);
+            let error = parse_error(ErrorContext::new(ServiceOperation("List")), response);
             return Err(error);
         }
 

--- a/core/services/dbfs/src/writer.rs
+++ b/core/services/dbfs/src/writer.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use http::StatusCode;
 
-use super::core::DbfsCore;
 use super::core::parse_error;
+use super::core::{DbfsCore, ErrorContext};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -59,7 +59,10 @@ impl oio::OneShotWrite for DbfsWriter {
         let status = resp.status();
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(Metadata::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Put")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/dropbox/src/backend.rs
+++ b/core/services/dropbox/src/backend.rs
@@ -270,7 +270,10 @@ impl Service for DropboxBackend {
                 }
                 Ok(RpStat::new(metadata))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetMetadata")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
@@ -344,7 +347,7 @@ impl Service for DropboxBackend {
             match status {
                 StatusCode::OK => Ok(Metadata::default()),
                 _ => {
-                    let err = parse_error(resp);
+                    let err = parse_error(ErrorContext::new(ServiceOperation("CopyFile")), resp);
                     match err.kind() {
                         ErrorKind::NotFound => Ok(Metadata::default()),
                         _ => Err(err),
@@ -368,7 +371,7 @@ impl Service for DropboxBackend {
         match status {
             StatusCode::OK => Ok(RpRename::default()),
             _ => {
-                let err = parse_error(resp);
+                let err = parse_error(ErrorContext::new(ServiceOperation("MoveFile")), resp);
                 match err.kind() {
                     ErrorKind::NotFound => Ok(RpRename::default()),
                     _ => Err(err),

--- a/core/services/dropbox/src/core.rs
+++ b/core/services/dropbox/src/core.rs
@@ -224,7 +224,7 @@ impl DropboxCore {
         match status {
             StatusCode::OK => Ok(RpCreateDir::default()),
             _ => {
-                let err = parse_error(resp);
+                let err = parse_error(ErrorContext::new(ServiceOperation("CreateFolder")), resp);
                 match err.kind() {
                     ErrorKind::AlreadyExists => Ok(RpCreateDir::default()),
                     _ => Err(err),
@@ -529,75 +529,77 @@ pub struct DropboxListResponse {
     pub has_more: bool,
 }
 
-mod error {
-    use http::Response;
-    use http::StatusCode;
-    use serde::Deserialize;
+#[derive(Default, Debug, Deserialize)]
+#[serde(default)]
+pub struct DropboxErrorResponse {
+    pub error_summary: String,
+}
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    #[derive(Default, Debug, Deserialize)]
-    #[serde(default)]
-    pub struct DropboxErrorResponse {
-        pub error_summary: String,
-    }
-
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (mut kind, mut retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
-            StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let (message, dropbox_err) = serde_json::from_slice::<DropboxErrorResponse>(&bs)
-            .map(|dropbox_err| (format!("{dropbox_err:?}"), Some(dropbox_err)))
-            .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
-
-        if let Some(dropbox_err) = dropbox_err {
-            (kind, retryable) = parse_dropbox_error_summary(&dropbox_err.error_summary)
-                .unwrap_or((kind, retryable));
-        }
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    /// We cannot get the error type from the response header when the status code is 409.
-    /// Because Dropbox API v2 will put error summary in the response body,
-    /// we need to parse it to get the correct error type and then error kind.
-    ///
-    /// See <https://www.dropbox.com/developers/documentation/http/documentation#error-handling>
-    pub fn parse_dropbox_error_summary(summary: &str) -> Option<(ErrorKind, bool)> {
-        if summary.starts_with("path/not_found")
-            || summary.starts_with("path_lookup/not_found")
-            || summary.starts_with("from_lookup/not_found")
-        {
-            Some((ErrorKind::NotFound, false))
-        } else if summary.starts_with("path/conflict") {
-            Some((ErrorKind::AlreadyExists, false))
-        } else if summary.starts_with("too_many_write_operations") {
-            Some((ErrorKind::RateLimited, true))
-        } else {
-            None
-        }
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (mut kind, mut retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let (message, dropbox_err) = serde_json::from_slice::<DropboxErrorResponse>(&bs)
+        .map(|dropbox_err| (format!("{dropbox_err:?}"), Some(dropbox_err)))
+        .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
+
+    if let Some(dropbox_err) = dropbox_err {
+        (kind, retryable) =
+            parse_dropbox_error_summary(&dropbox_err.error_summary).unwrap_or((kind, retryable));
+    }
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}
+
+/// We cannot get the error type from the response header when the status code is 409.
+/// Because Dropbox API v2 will put error summary in the response body,
+/// we need to parse it to get the correct error type and then error kind.
+///
+/// See <https://www.dropbox.com/developers/documentation/http/documentation#error-handling>
+pub fn parse_dropbox_error_summary(summary: &str) -> Option<(ErrorKind, bool)> {
+    if summary.starts_with("path/not_found")
+        || summary.starts_with("path_lookup/not_found")
+        || summary.starts_with("from_lookup/not_found")
+    {
+        Some((ErrorKind::NotFound, false))
+    } else if summary.starts_with("path/conflict") {
+        Some((ErrorKind::AlreadyExists, false))
+    } else if summary.starts_with("too_many_write_operations") {
+        Some((ErrorKind::RateLimited, true))
+    } else {
+        None
+    }
+}

--- a/core/services/dropbox/src/deleter.rs
+++ b/core/services/dropbox/src/deleter.rs
@@ -44,7 +44,7 @@ impl oio::OneShotDelete for DropboxDeleter {
         match status {
             StatusCode::OK => Ok(()),
             _ => {
-                let err = parse_error(resp);
+                let err = parse_error(ErrorContext::new(ServiceOperation("DeleteFile")), resp);
                 match err.kind() {
                     ErrorKind::NotFound => Ok(()),
                     _ => Err(err),

--- a/core/services/dropbox/src/lister.rs
+++ b/core/services/dropbox/src/lister.rs
@@ -68,7 +68,14 @@ impl oio::PageList for DropboxLister {
         let status_code = response.status();
 
         if !status_code.is_success() {
-            let error = parse_error(response);
+            let error = parse_error(
+                ErrorContext::new(if ctx.token.is_empty() {
+                    ServiceOperation("ListFolder")
+                } else {
+                    ServiceOperation("ListFolderContinue")
+                }),
+                response,
+            );
 
             let result = match error.kind() {
                 ErrorKind::NotFound => Ok(()),

--- a/core/services/dropbox/src/reader.rs
+++ b/core/services/dropbox/src/reader.rs
@@ -65,7 +65,10 @@ impl oio::StreamRead for DropboxReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("DownloadFile")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/dropbox/src/writer.rs
+++ b/core/services/dropbox/src/writer.rs
@@ -21,7 +21,7 @@ use bytes::Buf;
 use http::StatusCode;
 
 use super::core::parse_error;
-use super::core::{DropboxCore, DropboxMetadataResponse};
+use super::core::{DropboxCore, DropboxMetadataResponse, ErrorContext};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -84,7 +84,10 @@ impl oio::OneShotWrite for DropboxWriter {
                 let metadata = DropboxWriter::parse_metadata(decoded_response)?;
                 Ok(metadata)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadFile")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/etcd/src/core.rs
+++ b/core/services/etcd/src/core.rs
@@ -148,16 +148,10 @@ impl EtcdCore {
     }
 }
 
-mod error {
-    use etcd_client::Error as EtcdError;
+use etcd_client::Error as EtcdError;
 
-    use opendal_core::{Error, ErrorKind};
-
-    pub fn format_etcd_error(e: EtcdError) -> Error {
-        Error::new(ErrorKind::Unexpected, e.to_string().as_str())
-            .set_source(e)
-            .set_temporary()
-    }
+pub fn format_etcd_error(e: EtcdError) -> Error {
+    Error::new(ErrorKind::Unexpected, e.to_string().as_str())
+        .set_source(e)
+        .set_temporary()
 }
-
-pub(super) use error::*;

--- a/core/services/fs/src/core.rs
+++ b/core/services/fs/src/core.rs
@@ -158,7 +158,10 @@ impl FsCore {
             open_options.truncate(true);
         }
 
-        let f = open_options.open(path).await.map_err(parse_error)?;
+        let f = open_options
+            .open(path)
+            .await
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("OpenForWrite")), err))?;
 
         Ok(f)
     }
@@ -188,7 +191,12 @@ impl FsCore {
         open_options.write(true);
         open_options.truncate(true);
 
-        let f = open_options.open(&tmp_path).await.map_err(parse_error)?;
+        let f = open_options.open(&tmp_path).await.map_err(|err| {
+            parse_error(
+                ErrorContext::new(ServiceOperation("OpenTemporaryFile")),
+                err,
+            )
+        })?;
 
         Ok((f, Some(tmp_path)))
     }
@@ -315,24 +323,31 @@ impl FsCore {
 #[cfg(unix)]
 const XATTR_USER_PREFIX: &str = "user.";
 
-mod error {
-    use opendal_core::raw::*;
-    use opendal_core::*;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(e: std::io::Error) -> Error {
-        match e.kind() {
-            std::io::ErrorKind::AlreadyExists => Error::new(
-                ErrorKind::ConditionNotMatch,
-                "The file already exists in the filesystem",
-            )
-            .set_source(e),
-            _ => new_std_io_error(e),
-        }
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error using its service operation context.
+pub(crate) fn parse_error(ctx: ErrorContext, err: std::io::Error) -> Error {
+    let err = match err.kind() {
+        std::io::ErrorKind::AlreadyExists => Error::new(
+            ErrorKind::ConditionNotMatch,
+            "The file already exists in the filesystem",
+        )
+        .set_source(err),
+        _ => new_std_io_error(err),
+    };
+
+    err.with_context("service_operation", ctx.service_operation.0)
+}
 
 #[cfg(test)]
 mod tests {

--- a/core/services/gcs/src/deleter.rs
+++ b/core/services/gcs/src/deleter.rs
@@ -46,11 +46,10 @@ impl oio::BatchDelete for GcsDeleter {
             .with_if_version_not_match(args.if_version_not_match().is_some())
             .with_delete();
 
-        if resp.status().is_success() {
-            Ok(())
-        } else if resp.status() == StatusCode::NOT_FOUND
-            && args.if_match().is_none()
-            && args.if_version_match().is_none()
+        if resp.status().is_success()
+            || (resp.status() == StatusCode::NOT_FOUND
+                && args.if_match().is_none()
+                && args.if_version_match().is_none())
         {
             Ok(())
         } else {
@@ -96,11 +95,10 @@ impl oio::BatchDelete for GcsDeleter {
                 .with_if_version_not_match(op.if_version_not_match().is_some())
                 .with_delete();
 
-            if resp.status().is_success() {
-                batched_result.succeeded.push((path, op));
-            } else if resp.status() == StatusCode::NOT_FOUND
-                && op.if_match().is_none()
-                && op.if_version_match().is_none()
+            if resp.status().is_success()
+                || (resp.status() == StatusCode::NOT_FOUND
+                    && op.if_match().is_none()
+                    && op.if_version_match().is_none())
             {
                 batched_result.succeeded.push((path, op));
             } else {

--- a/core/services/gdrive/src/backend.rs
+++ b/core/services/gdrive/src/backend.rs
@@ -21,11 +21,11 @@ use std::sync::Arc;
 use bytes::Buf;
 use http::StatusCode;
 
-use super::core::GdriveCore;
 use super::core::GdriveFile;
 use super::core::GdriveRecentPathState;
 use super::core::normalize_dir_path;
 use super::core::parse_error;
+use super::core::{ErrorContext, GdriveCore};
 use super::deleter::GdriveDeleter;
 use super::lister::GdriveFlatLister;
 use super::lister::GdriveLister;
@@ -285,7 +285,10 @@ impl Service for GdriveBackend {
         }
 
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetFile")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();
@@ -449,10 +452,16 @@ impl Service for GdriveBackend {
 
                             Ok(Metadata::default())
                         }
-                        _ => Err(parse_error(resp)),
+                        _ => Err(parse_error(
+                            ErrorContext::new(ServiceOperation("CopyFile")),
+                            resp,
+                        )),
                     }
                 }
-                _ => Err(parse_error(resp)),
+                _ => Err(parse_error(
+                    ErrorContext::new(ServiceOperation("CopyFile")),
+                    resp,
+                )),
             }
         }))
     }
@@ -528,7 +537,10 @@ impl Service for GdriveBackend {
                     .await?;
 
                 if resp.status() != StatusCode::OK {
-                    return Err(parse_error(resp));
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("MoveFile")),
+                        resp,
+                    ));
                 }
 
                 let body = resp.into_body();
@@ -570,7 +582,10 @@ impl Service for GdriveBackend {
 
                 Ok(RpRename::default())
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("MoveFile")),
+                resp,
+            )),
         }
     }
 

--- a/core/services/gdrive/src/core.rs
+++ b/core/services/gdrive/src/core.rs
@@ -123,7 +123,10 @@ impl GdriveCore {
                 return Ok(());
             }
             if resp.status() != StatusCode::OK {
-                return Err(parse_error(resp));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("TrashFile")),
+                    resp,
+                ));
             }
 
             self.invalidate_file_id(path).await;
@@ -763,7 +766,10 @@ impl GdriveSigner {
                         - Duration::from_secs(120);
                 }
                 _ => {
-                    return Err(parse_error(resp));
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("RefreshAccessToken")),
+                        resp,
+                    ));
                 }
             }
         }
@@ -843,7 +849,10 @@ impl crate::path_index::GdrivePathQueryer for GdrivePathQuery {
                     Ok(None)
                 }
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListFiles")),
+                resp,
+            )),
         }
     }
 
@@ -874,7 +883,10 @@ impl crate::path_index::GdrivePathQueryer for GdrivePathQuery {
 
         let resp = ctx.http_transport().send(req).await?;
         if !resp.status().is_success() {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateFolder")),
+                resp,
+            ));
         }
 
         let body = resp.into_body();
@@ -1077,30 +1089,34 @@ mod tests {
     }
 }
 
-mod error {
-    use http::Response;
-    use http::StatusCode;
-    use serde::Deserialize;
+#[derive(Default, Debug, Deserialize)]
+struct GdriveError {
+    error: GdriveInnerError,
+}
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+#[derive(Default, Debug, Deserialize)]
+struct GdriveInnerError {
+    message: String,
+}
 
-    #[derive(Default, Debug, Deserialize)]
-    struct GdriveError {
-        error: GdriveInnerError,
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
+}
 
-    #[derive(Default, Debug, Deserialize)]
-    struct GdriveInnerError {
-        message: String,
-    }
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
 
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (mut kind, mut retryable) = match parts.status {
+    let (mut kind, mut retryable) = match parts.status {
         StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
         StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
         StatusCode::INTERNAL_SERVER_ERROR
@@ -1112,35 +1128,33 @@ mod error {
         _ => (ErrorKind::Unexpected, false),
     };
 
-        let (message, gdrive_err) = serde_json::from_slice::<GdriveError>(bs.as_ref())
-            .map(|gdrive_err| (format!("{gdrive_err:?}"), Some(gdrive_err)))
-            .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
+    let (message, gdrive_err) = serde_json::from_slice::<GdriveError>(bs.as_ref())
+        .map(|gdrive_err| (format!("{gdrive_err:?}"), Some(gdrive_err)))
+        .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
 
-        if let Some(gdrive_err) = gdrive_err {
-            (kind, retryable) = parse_gdrive_error_code(gdrive_err.error.message.as_str())
-                .unwrap_or((kind, retryable));
-        }
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
+    if let Some(gdrive_err) = gdrive_err {
+        (kind, retryable) =
+            parse_gdrive_error_code(gdrive_err.error.message.as_str()).unwrap_or((kind, retryable));
     }
 
-    pub fn parse_gdrive_error_code(message: &str) -> Option<(ErrorKind, bool)> {
-        match message {
-            // > Please reduce your request rate.
-            //
-            // It's Ok to retry since later on the request rate may get reduced.
-            "User rate limit exceeded." => Some((ErrorKind::RateLimited, true)),
-            _ => None,
-        }
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
     }
+
+    err
 }
 
-pub(super) use error::*;
+pub fn parse_gdrive_error_code(message: &str) -> Option<(ErrorKind, bool)> {
+    match message {
+        // > Please reduce your request rate.
+        //
+        // It's Ok to retry since later on the request rate may get reduced.
+        "User rate limit exceeded." => Some((ErrorKind::RateLimited, true)),
+        _ => None,
+    }
+}

--- a/core/services/gdrive/src/deleter.rs
+++ b/core/services/gdrive/src/deleter.rs
@@ -70,7 +70,10 @@ impl oio::OneShotDelete for GdriveDeleter {
                 return Ok(());
             }
             if resp.status() != StatusCode::OK {
-                return Err(parse_error(resp));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetFile")),
+                    resp,
+                ));
             }
 
             let bs = resp.into_body().to_bytes();
@@ -99,7 +102,10 @@ impl oio::OneShotDelete for GdriveDeleter {
             return Ok(());
         }
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("TrashFile")),
+                resp,
+            ));
         }
 
         if is_dir {

--- a/core/services/gdrive/src/lister.rs
+++ b/core/services/gdrive/src/lister.rs
@@ -23,11 +23,11 @@ use std::sync::Arc;
 use asyncband::mutex::Mutex;
 use http::StatusCode;
 
-use super::core::GdriveCore;
 use super::core::GdriveFile;
 use super::core::GdriveFileList;
 use super::core::GdriveRecentPathState;
 use super::core::parse_error;
+use super::core::{ErrorContext, GdriveCore};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -173,7 +173,10 @@ impl oio::PageList for GdriveLister {
                 resp = self.core.gdrive_stat_by_id(&self.ctx, &file_id).await?;
             }
             if resp.status() != StatusCode::OK {
-                return Err(parse_error(resp));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetFile")),
+                    resp,
+                ));
             }
 
             let bytes = resp.into_body().to_bytes();
@@ -215,7 +218,12 @@ impl oio::PageList for GdriveLister {
 
         let bytes = match resp.status() {
             StatusCode::OK => resp.into_body().to_bytes(),
-            _ => return Err(parse_error(resp)),
+            _ => {
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("ListFiles")),
+                    resp,
+                ));
+            }
         };
 
         // Google Drive returns an empty response when attempting to list a non-existent directory.
@@ -524,7 +532,10 @@ impl GdriveFlatLister {
             resp = self.core.gdrive_stat_by_id(&self.ctx, &root_id).await?;
         }
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetFile")),
+                resp,
+            ));
         }
 
         let bytes = resp.into_body().to_bytes();
@@ -645,7 +656,12 @@ impl GdriveFlatLister {
 
         let bytes = match resp.status() {
             StatusCode::OK => resp.into_body().to_bytes(),
-            _ => return Err(parse_error(resp)),
+            _ => {
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("ListFiles")),
+                    resp,
+                ));
+            }
         };
 
         log::debug!("GdriveFlatLister: response size: {} bytes", bytes.len());

--- a/core/services/gdrive/src/reader.rs
+++ b/core/services/gdrive/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -76,14 +76,20 @@ impl oio::StreamRead for GdriveReader {
                     _ => {
                         let (part, mut body) = resp.into_parts();
                         let buf = body.to_buffer().await?;
-                        return Err(parse_error(Response::from_parts(part, buf)));
+                        return Err(parse_error(
+                            ErrorContext::new(ServiceOperation("DownloadFile")),
+                            Response::from_parts(part, buf),
+                        ));
                     }
                 }
             }
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("DownloadFile")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/gdrive/src/writer.rs
+++ b/core/services/gdrive/src/writer.rs
@@ -20,9 +20,9 @@ use std::sync::Arc;
 use bytes::Buf;
 use http::StatusCode;
 
-use super::core::GdriveCore;
 use super::core::GdriveFile;
 use super::core::parse_error;
+use super::core::{ErrorContext, GdriveCore};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -106,7 +106,12 @@ impl oio::OneShotWrite for GdriveWriter {
                     current_file_id = self.core.resolve_path(&self.ctx, &self.path).await?;
                     continue;
                 }
-                _ => return Err(parse_error(resp)),
+                _ => {
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("UploadFile")),
+                        resp,
+                    ));
+                }
             }
         }
     }

--- a/core/services/ghac/src/backend.rs
+++ b/core/services/ghac/src/backend.rs
@@ -243,7 +243,10 @@ impl Service for GhacBackend {
                 let meta = parse_into_metadata(path, resp.headers())?;
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetCacheEntry")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {

--- a/core/services/ghac/src/core.rs
+++ b/core/services/ghac/src/core.rs
@@ -128,7 +128,10 @@ impl GhacCore {
                         .map_err(new_json_deserialize_error)?;
                     query_resp.archive_location
                 } else {
-                    return Err(parse_error(resp));
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("GetCacheEntry")),
+                        resp,
+                    ));
                 };
                 Ok(location)
             }
@@ -180,7 +183,10 @@ impl GhacCore {
                     }
                     query_resp.signed_download_url
                 } else {
-                    return Err(parse_error(resp));
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("GetCacheEntryDownloadUrl")),
+                        resp,
+                    ));
                 };
 
                 Ok(location)
@@ -254,7 +260,11 @@ impl GhacCore {
                         .map_err(new_json_deserialize_error)?;
                     reserve_resp.cache_id
                 } else {
-                    return Err(parse_error(resp).with_operation("Backend::ghac_reserve"));
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("ReserveCache")),
+                        resp,
+                    )
+                    .with_operation("Backend::ghac_reserve"));
                 };
 
                 let url = build_cache_url(
@@ -299,7 +309,10 @@ impl GhacCore {
                     }
                     query_resp.signed_upload_url
                 } else {
-                    return Err(parse_error(resp));
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("CreateCacheEntry")),
+                        resp,
+                    ));
                 };
                 Ok(location)
             }
@@ -361,7 +374,10 @@ impl GhacCore {
                 if resp.status().is_success() {
                     Ok(())
                 } else {
-                    Err(parse_error(resp))
+                    Err(parse_error(
+                        ErrorContext::new(ServiceOperation("CommitCache")),
+                        resp,
+                    ))
                 }
             }
             GhacVersion::V2 => {
@@ -389,7 +405,10 @@ impl GhacCore {
                     .map_err(new_request_build_error)?;
                 let resp = ctx.http_transport().send(req).await?;
                 if resp.status() != StatusCode::OK {
-                    return Err(parse_error(resp));
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("FinalizeCacheEntryUpload")),
+                        resp,
+                    ));
                 };
                 Ok(())
             }
@@ -525,42 +544,45 @@ mod tests {
     }
 }
 
-mod error {
-    use http::Response;
-    use http::StatusCode;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
-
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND | StatusCode::NO_CONTENT => (ErrorKind::NotFound, false),
-            StatusCode::CONFLICT => (ErrorKind::AlreadyExists, false),
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
-            StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let bs = body.to_bytes();
-        let message = String::from_utf8_lossy(&bs);
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND | StatusCode::NO_CONTENT => (ErrorKind::NotFound, false),
+        StatusCode::CONFLICT => (ErrorKind::AlreadyExists, false),
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let bs = body.to_bytes();
+    let message = String::from_utf8_lossy(&bs);
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}

--- a/core/services/ghac/src/reader.rs
+++ b/core/services/ghac/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -54,7 +54,10 @@ impl oio::StreamRead for GhacReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("Download")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/ghac/src/writer.rs
+++ b/core/services/ghac/src/writer.rs
@@ -231,7 +231,10 @@ impl oio::Write for GhacWriterV1 {
             .ghac_v1_write(&self.ctx, &self.url, size, offset, bs)
             .await?;
         if !resp.status().is_success() {
-            return Err(parse_error(resp).with_operation("Backend::ghac_upload"));
+            return Err(
+                parse_error(ErrorContext::new(ServiceOperation("UploadChunk")), resp)
+                    .with_operation("Backend::ghac_upload"),
+            );
         }
         self.size += size;
         Ok(())

--- a/core/services/github/src/backend.rs
+++ b/core/services/github/src/backend.rs
@@ -25,8 +25,8 @@ use log::debug;
 use super::GITHUB_SCHEME;
 use super::config::GithubConfig;
 use super::core::Entry;
-use super::core::GithubCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, GithubCore};
 use super::deleter::GithubDeleter;
 use super::lister::GithubLister;
 use super::reader::*;
@@ -187,7 +187,10 @@ impl Service for GithubBackend {
 
         match status {
             StatusCode::OK | StatusCode::CREATED => Ok(RpCreateDir::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateOrUpdateFileContents")),
+                resp,
+            )),
         }
     }
 
@@ -212,7 +215,10 @@ impl Service for GithubBackend {
 
                 Ok(RpStat::new(m))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetRepositoryContent")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {

--- a/core/services/github/src/core.rs
+++ b/core/services/github/src/core.rs
@@ -104,7 +104,10 @@ impl GithubCore {
                 Ok(Some(resp.sha))
             }
             StatusCode::NOT_FOUND => Ok(None),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetRepositoryContent")),
+                resp,
+            )),
         }
     }
 
@@ -258,7 +261,10 @@ impl GithubCore {
         match resp.status() {
             StatusCode::OK => Ok(()),
             StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("DeleteFile")),
+                resp,
+            )),
         }
     }
 
@@ -296,7 +302,10 @@ impl GithubCore {
                 Ok(resp)
             }
             StatusCode::NOT_FOUND => Ok(ListResponse::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetRepositoryContent")),
+                resp,
+            )),
         }
     }
 
@@ -331,7 +340,10 @@ impl GithubCore {
 
                 Ok(resp.tree)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetTree")),
+                resp,
+            )),
         }
     }
 }
@@ -383,93 +395,93 @@ pub struct ContentResponse {
     pub content: Entry,
 }
 
-mod error {
-    use bytes::Buf;
-    use http::Response;
-    use serde::Deserialize;
+#[derive(Default, Debug, Deserialize)]
+#[allow(dead_code)]
+struct GithubError {
+    error: GithubSubError,
+}
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+#[derive(Default, Debug, Deserialize)]
+#[allow(dead_code)]
+struct GithubSubError {
+    message: String,
+    documentation_url: String,
+}
 
-    #[derive(Default, Debug, Deserialize)]
-    #[allow(dead_code)]
-    struct GithubError {
-        error: GithubSubError,
-    }
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    #[derive(Default, Debug, Deserialize)]
-    #[allow(dead_code)]
-    struct GithubSubError {
-        message: String,
-        documentation_url: String,
-    }
-
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (kind, retryable) = match parts.status.as_u16() {
-            401 | 403 => (ErrorKind::PermissionDenied, false),
-            404 => (ErrorKind::NotFound, false),
-            304 | 412 => (ErrorKind::ConditionNotMatch, false),
-            // https://github.com/apache/opendal/issues/4146
-            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/423
-            // We should retry it when we get 423 error.
-            423 => (ErrorKind::RateLimited, true),
-            // Service like Upyun could return 499 error with a message like:
-            // Client Disconnect, we should retry it.
-            499 => (ErrorKind::Unexpected, true),
-            500 | 502 | 503 | 504 => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let (message, _github_content_err) =
-            serde_json::from_reader::<_, GithubError>(bs.clone().reader())
-                .map(|github_content_err| {
-                    (format!("{github_content_err:?}"), Some(github_content_err))
-                })
-                .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    #[cfg(test)]
-    mod test {
-        use http::StatusCode;
-
-        use super::*;
-
-        #[tokio::test]
-        async fn test_parse_error() {
-            let err_res = vec![(
-                r#"{
-                "message": "Not Found",
-                "documentation_url": "https://docs.github.com/rest/repos/contents#get-repository-content"
-            }"#,
-                ErrorKind::NotFound,
-                StatusCode::NOT_FOUND,
-            )];
-
-            for res in err_res {
-                let bs = bytes::Bytes::from(res.0);
-                let body = Buffer::from(bs);
-                let resp = Response::builder().status(res.2).body(body).unwrap();
-
-                let err = parse_error(resp);
-
-                assert_eq!(err.kind(), res.1);
-            }
-        }
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status.as_u16() {
+        401 | 403 => (ErrorKind::PermissionDenied, false),
+        404 => (ErrorKind::NotFound, false),
+        304 | 412 => (ErrorKind::ConditionNotMatch, false),
+        // https://github.com/apache/opendal/issues/4146
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/423
+        // We should retry it when we get 423 error.
+        423 => (ErrorKind::RateLimited, true),
+        // Service like Upyun could return 499 error with a message like:
+        // Client Disconnect, we should retry it.
+        499 => (ErrorKind::Unexpected, true),
+        500 | 502 | 503 | 504 => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let (message, _github_content_err) =
+        serde_json::from_reader::<_, GithubError>(bs.clone().reader())
+            .map(|github_content_err| (format!("{github_content_err:?}"), Some(github_content_err)))
+            .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}
+
+#[cfg(test)]
+mod tests {
+    use http::StatusCode;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_parse_error() {
+        let err_res = vec![(
+            r#"{
+                "message": "Not Found",
+                "documentation_url": "https://docs.github.com/rest/repos/contents#get-repository-content"
+            }"#,
+            ErrorKind::NotFound,
+            StatusCode::NOT_FOUND,
+        )];
+
+        for res in err_res {
+            let bs = bytes::Bytes::from(res.0);
+            let body = Buffer::from(bs);
+            let resp = Response::builder().status(res.2).body(body).unwrap();
+
+            let err = parse_error(ErrorContext::new(ServiceOperation("Test")), resp);
+
+            assert_eq!(err.kind(), res.1);
+        }
+    }
+}

--- a/core/services/github/src/reader.rs
+++ b/core/services/github/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -60,7 +60,10 @@ impl oio::StreamRead for GithubReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetRawContent")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/github/src/writer.rs
+++ b/core/services/github/src/writer.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 use bytes::Buf;
 use http::StatusCode;
 
-use super::core::GithubCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, GithubCore};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -69,7 +69,10 @@ impl oio::OneShotWrite for GithubWriter {
                 let metadata = GithubWriter::parse_metadata(&content_resp.content)?;
                 Ok(metadata)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateOrUpdateFileContents")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/goosefs/src/core.rs
+++ b/core/services/goosefs/src/core.rs
@@ -173,7 +173,7 @@ impl GoosefsCore {
         // `FileSystemContext::connect` already returns `Arc<FileSystemContext>`.
         let ctx = FileSystemContext::connect(self.config.clone())
             .await
-            .map_err(parse_error)?;
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("Connect")), err))?;
         *guard = Some(Arc::clone(&ctx));
         self.ctx_pid.store(current_pid, Ordering::Relaxed);
 
@@ -214,19 +214,25 @@ impl GoosefsCore {
         master
             .create_directory(&full, true)
             .await
-            .map_err(parse_error)
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("CreateDirectory")), err))
     }
 
     pub async fn get_status(&self, path: &str) -> Result<FileInfo> {
         let full = self.full_path(path);
         let master = self.master().await?;
-        master.get_status(&full).await.map_err(parse_error)
+        master
+            .get_status(&full)
+            .await
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("GetStatus")), err))
     }
 
     pub async fn list_status(&self, path: &str) -> Result<Vec<FileInfo>> {
         let full = self.full_path(path);
         let master = self.master().await?;
-        master.list_status(&full, false).await.map_err(parse_error)
+        master
+            .list_status(&full, false)
+            .await
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("ListStatus")), err))
     }
 
     pub async fn delete(&self, path: &str) -> Result<()> {
@@ -241,7 +247,10 @@ impl GoosefsCore {
                 if matches!(e, goosefs_sdk::error::Error::NotFound { .. }) {
                     Ok(())
                 } else {
-                    Err(parse_error(e))
+                    Err(parse_error(
+                        ErrorContext::new(ServiceOperation("Delete")),
+                        e,
+                    ))
                 }
             }
         }
@@ -307,12 +316,19 @@ impl GoosefsCore {
                 }
                 // Overwrite path ONLY. Master rename rejects existing dst;
                 // delete first so overwrite can proceed.
-                master.delete(&dst, false).await.map_err(parse_error)?;
+                master.delete(&dst, false).await.map_err(|err| {
+                    parse_error(ErrorContext::new(ServiceOperation("Delete")), err)
+                })?;
             }
             // Parent may already exist (write-via-temp always does). Create it
             // only if the subsequent rename reports it missing.
             Err(goosefs_sdk::error::Error::NotFound { .. }) => {}
-            Err(e) => return Err(parse_error(e)),
+            Err(e) => {
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetStatus")),
+                    e,
+                ));
+            }
         }
 
         match rename_creating_parent_if_missing(&master, &src, &dst).await {
@@ -336,7 +352,10 @@ impl GoosefsCore {
                 .with_context("from", from)
                 .with_context("to", to))
             }
-            Err(e) => Err(parse_error(e)),
+            Err(e) => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Rename")),
+                e,
+            )),
         }
     }
 
@@ -405,14 +424,25 @@ impl GoosefsCore {
                     (Some(off), Some(len)) => {
                         GoosefsFileReader::read_range_with_context(fresh_ctx, &full, off, len)
                             .await
-                            .map_err(parse_error)
+                            .map_err(|err| {
+                                parse_error(ErrorContext::new(ServiceOperation("ReadRange")), err)
+                            })
                     }
                     _ => GoosefsFileReader::read_file_with_context(fresh_ctx, &full)
                         .await
-                        .map_err(parse_error),
+                        .map_err(|err| {
+                            parse_error(ErrorContext::new(ServiceOperation("ReadFile")), err)
+                        }),
                 }
             }
-            Err(e) => Err(parse_error(e)),
+            Err(e) => Err(parse_error(
+                ErrorContext::new(if offset.is_some() && length.is_some() {
+                    ServiceOperation("ReadRange")
+                } else {
+                    ServiceOperation("ReadFile")
+                }),
+                e,
+            )),
         }
     }
 
@@ -423,9 +453,15 @@ impl GoosefsCore {
         let ctx = self.ctx().await?;
         let mut writer = GoosefsFileWriter::create_with_context(ctx, &full, None)
             .await
-            .map_err(parse_error)?;
-        writer.write(data).await.map_err(parse_error)?;
-        writer.close().await.map_err(parse_error)?;
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("CreateFile")), err))?;
+        writer
+            .write(data)
+            .await
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("Write")), err))?;
+        writer
+            .close()
+            .await
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("Close")), err))?;
         Ok(())
     }
 
@@ -435,7 +471,7 @@ impl GoosefsCore {
         let ctx = self.ctx().await?;
         GoosefsFileWriter::create_with_context(ctx, &full, None)
             .await
-            .map_err(parse_error)
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("CreateFile")), err))
     }
 
     /// Create a streaming file reader (full-file) via the shared context.
@@ -460,9 +496,14 @@ impl GoosefsCore {
                 let fresh_ctx = self.ctx().await?;
                 GoosefsFileReader::open_with_context(fresh_ctx, &full)
                     .await
-                    .map_err(parse_error)
+                    .map_err(|err| {
+                        parse_error(ErrorContext::new(ServiceOperation("OpenFile")), err)
+                    })
             }
-            Err(e) => Err(parse_error(e)),
+            Err(e) => Err(parse_error(
+                ErrorContext::new(ServiceOperation("OpenFile")),
+                e,
+            )),
         }
     }
 
@@ -491,9 +532,14 @@ impl GoosefsCore {
                 let fresh_ctx = self.ctx().await?;
                 GoosefsFileReader::open_range_with_context(fresh_ctx, &full, offset, length)
                     .await
-                    .map_err(parse_error)
+                    .map_err(|err| {
+                        parse_error(ErrorContext::new(ServiceOperation("OpenRange")), err)
+                    })
             }
-            Err(e) => Err(parse_error(e)),
+            Err(e) => Err(parse_error(
+                ErrorContext::new(ServiceOperation("OpenRange")),
+                e,
+            )),
         }
     }
 
@@ -598,7 +644,15 @@ fn parent_of(path: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
-    use super::parent_of;
+    use goosefs_sdk::error::Error as GfsError;
+
+    use super::*;
+
+    /// Build SDK errors whose variants expose public fields. The remaining variants require
+    /// integration tests against GooseFS because their inner fields are private.
+    fn run(err: GfsError) -> Error {
+        parse_error(ErrorContext::new(ServiceOperation("Test")), err)
+    }
 
     #[test]
     fn parent_of_root_returns_none() {
@@ -634,187 +688,175 @@ mod tests {
         assert_eq!(parent_of("foo"), None);
         assert_eq!(parent_of(""), None);
     }
-}
 
-mod error {
-    use opendal_core::*;
-
-    /// Map goosefs-sdk Error to OpenDAL Error.
-    ///
-    /// This is the bridge between Layer 3 (goosefs-sdk) error types
-    /// and Layer 2 (OpenDAL) error types.
-    pub(crate) fn parse_error(err: goosefs_sdk::error::Error) -> Error {
-        use goosefs_sdk::error::Error as GfsError;
-
-        let (kind, message, temporary) = match &err {
-            GfsError::NotFound { path } => {
-                (ErrorKind::NotFound, format!("not found: {}", path), false)
-            }
-
-            GfsError::AlreadyExists { path } => (
-                ErrorKind::AlreadyExists,
-                format!("already exists: {}", path),
-                false,
-            ),
-
-            GfsError::PermissionDenied { message } => {
-                (ErrorKind::PermissionDenied, message.clone(), false)
-            }
-
-            GfsError::InvalidArgument { message } => {
-                (ErrorKind::ConfigInvalid, message.clone(), false)
-            }
-
-            GfsError::ConfigError { message } => (ErrorKind::ConfigInvalid, message.clone(), false),
-
-            GfsError::NoWorkerAvailable { message } => {
-                // No worker available is a transient error
-                (
-                    ErrorKind::Unexpected,
-                    format!("no worker available: {}", message),
-                    true,
-                )
-            }
-
-            GfsError::MasterUnavailable { message } => (
-                ErrorKind::Unexpected,
-                format!("master unavailable: {}", message),
-                true,
-            ),
-
-            // Authentication failures are transient — the SASL stream expired
-            // (e.g. after process fork or long idle). The goosefs-sdk layer
-            // should have already attempted reconnection, but if the error
-            // propagates up to OpenDAL, mark it as temporary so upper layers
-            // (e.g. RetryLayer) can retry the entire operation.
-            GfsError::AuthenticationFailed { message } => (
-                ErrorKind::Unexpected,
-                format!("authentication failed (retriable): {}", message),
-                true,
-            ),
-
-            // For GrpcError, the goosefs_sdk::error::Error::From<tonic::Status>
-            // already maps NotFound/AlreadyExists/PermissionDenied/InvalidArgument
-            // to specific error variants above. GrpcError only contains codes that
-            // were NOT mapped (Unavailable, DeadlineExceeded, Internal, etc.)
-            GfsError::GrpcError { message, .. } => (ErrorKind::Unexpected, message.clone(), false),
-
-            GfsError::TransportError { message, .. } => {
-                (ErrorKind::Unexpected, message.clone(), true)
-            }
-
-            _ => (ErrorKind::Unexpected, format!("{}", err), false),
-        };
-
-        let mut error = Error::new(kind, message).set_source(err);
-        if temporary {
-            error = error.set_temporary();
-        }
-        error
+    #[test]
+    fn not_found_maps_to_not_found_and_is_permanent() {
+        let e = run(GfsError::NotFound {
+            path: "/missing".into(),
+        });
+        assert_eq!(e.kind(), ErrorKind::NotFound);
+        assert!(
+            !e.is_temporary(),
+            "NotFound must not be flagged temporary (callers rely on fast-fail)"
+        );
+        assert!(
+            e.to_string().contains("/missing"),
+            "error message should include the offending path, got: {e}"
+        );
     }
 
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use goosefs_sdk::error::Error as GfsError;
+    #[test]
+    fn already_exists_maps_to_already_exists() {
+        let e = run(GfsError::AlreadyExists {
+            path: "/dup".into(),
+        });
+        assert_eq!(e.kind(), ErrorKind::AlreadyExists);
+        assert!(!e.is_temporary());
+        assert!(e.to_string().contains("/dup"));
+    }
 
-        /// Helper: build a fresh SDK error of each "leaf" variant. We
-        /// deliberately skip `GrpcError` / `TransportError` here — they carry
-        /// non-public inner fields that cannot be constructed from a unit test
-        /// without touching the SDK's internals; their handling is covered by
-        /// integration tests against a real GooseFS cluster.
-        fn run(err: GfsError) -> Error {
-            parse_error(err)
-        }
+    #[test]
+    fn permission_denied_maps_and_is_permanent() {
+        let e = run(GfsError::PermissionDenied {
+            message: "nope".into(),
+        });
+        assert_eq!(e.kind(), ErrorKind::PermissionDenied);
+        assert!(!e.is_temporary());
+    }
 
-        #[test]
-        fn not_found_maps_to_not_found_and_is_permanent() {
-            let e = run(GfsError::NotFound {
-                path: "/missing".into(),
-            });
-            assert_eq!(e.kind(), ErrorKind::NotFound);
-            assert!(
-                !e.is_temporary(),
-                "NotFound must not be flagged temporary (callers rely on fast-fail)"
+    #[test]
+    fn invalid_argument_and_config_error_both_map_to_config_invalid() {
+        let ia = run(GfsError::InvalidArgument {
+            message: "bad arg".into(),
+        });
+        assert_eq!(ia.kind(), ErrorKind::ConfigInvalid);
+        assert!(!ia.is_temporary());
+
+        let ce = run(GfsError::ConfigError {
+            message: "bad cfg".into(),
+        });
+        assert_eq!(ce.kind(), ErrorKind::ConfigInvalid);
+        assert!(!ce.is_temporary());
+    }
+
+    /// Transient server-side errors must be temporary so `RetryLayer` retries the operation.
+    #[test]
+    fn transient_errors_are_marked_temporary() {
+        for (err, label) in [
+            (
+                GfsError::NoWorkerAvailable {
+                    message: "no worker".into(),
+                },
+                "NoWorkerAvailable",
+            ),
+            (
+                GfsError::MasterUnavailable {
+                    message: "master down".into(),
+                },
+                "MasterUnavailable",
+            ),
+            (
+                GfsError::AuthenticationFailed {
+                    message: "sasl expired".into(),
+                },
+                "AuthenticationFailed",
+            ),
+        ] {
+            let e = run(err);
+            assert_eq!(
+                e.kind(),
+                ErrorKind::Unexpected,
+                "{label} should map to Unexpected (transient), got {:?}",
+                e.kind()
             );
             assert!(
-                e.to_string().contains("/missing"),
-                "error message should include the offending path, got: {e}"
+                e.is_temporary(),
+                "{label} must be flagged temporary so RetryLayer retries"
             );
-        }
-
-        #[test]
-        fn already_exists_maps_to_already_exists() {
-            let e = run(GfsError::AlreadyExists {
-                path: "/dup".into(),
-            });
-            assert_eq!(e.kind(), ErrorKind::AlreadyExists);
-            assert!(!e.is_temporary());
-            assert!(e.to_string().contains("/dup"));
-        }
-
-        #[test]
-        fn permission_denied_maps_and_is_permanent() {
-            let e = run(GfsError::PermissionDenied {
-                message: "nope".into(),
-            });
-            assert_eq!(e.kind(), ErrorKind::PermissionDenied);
-            assert!(!e.is_temporary());
-        }
-
-        #[test]
-        fn invalid_argument_and_config_error_both_map_to_config_invalid() {
-            let ia = run(GfsError::InvalidArgument {
-                message: "bad arg".into(),
-            });
-            assert_eq!(ia.kind(), ErrorKind::ConfigInvalid);
-            assert!(!ia.is_temporary());
-
-            let ce = run(GfsError::ConfigError {
-                message: "bad cfg".into(),
-            });
-            assert_eq!(ce.kind(), ErrorKind::ConfigInvalid);
-            assert!(!ce.is_temporary());
-        }
-
-        /// Transient server-side errors must be flagged `temporary` so OpenDAL's
-        /// `RetryLayer` actually retries the whole operation.
-        #[test]
-        fn transient_errors_are_marked_temporary() {
-            for (err, label) in [
-                (
-                    GfsError::NoWorkerAvailable {
-                        message: "no worker".into(),
-                    },
-                    "NoWorkerAvailable",
-                ),
-                (
-                    GfsError::MasterUnavailable {
-                        message: "master down".into(),
-                    },
-                    "MasterUnavailable",
-                ),
-                (
-                    GfsError::AuthenticationFailed {
-                        message: "sasl expired".into(),
-                    },
-                    "AuthenticationFailed",
-                ),
-            ] {
-                let e = run(err);
-                assert_eq!(
-                    e.kind(),
-                    ErrorKind::Unexpected,
-                    "{label} should map to Unexpected (transient), got {:?}",
-                    e.kind()
-                );
-                assert!(
-                    e.is_temporary(),
-                    "{label} must be flagged temporary so RetryLayer retries"
-                );
-            }
         }
     }
 }
 
-pub(super) use error::*;
+use opendal_core::raw::ServiceOperation;
+
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
+
+/// Map goosefs-sdk Error to OpenDAL Error.
+///
+/// This is the bridge between Layer 3 (goosefs-sdk) error types
+/// and Layer 2 (OpenDAL) error types.
+pub(crate) fn parse_error(ctx: ErrorContext, err: goosefs_sdk::error::Error) -> Error {
+    use goosefs_sdk::error::Error as GfsError;
+
+    let (kind, message, temporary) = match &err {
+        GfsError::NotFound { path } => (ErrorKind::NotFound, format!("not found: {}", path), false),
+
+        GfsError::AlreadyExists { path } => (
+            ErrorKind::AlreadyExists,
+            format!("already exists: {}", path),
+            false,
+        ),
+
+        GfsError::PermissionDenied { message } => {
+            (ErrorKind::PermissionDenied, message.clone(), false)
+        }
+
+        GfsError::InvalidArgument { message } => (ErrorKind::ConfigInvalid, message.clone(), false),
+
+        GfsError::ConfigError { message } => (ErrorKind::ConfigInvalid, message.clone(), false),
+
+        GfsError::NoWorkerAvailable { message } => {
+            // No worker available is a transient error
+            (
+                ErrorKind::Unexpected,
+                format!("no worker available: {}", message),
+                true,
+            )
+        }
+
+        GfsError::MasterUnavailable { message } => (
+            ErrorKind::Unexpected,
+            format!("master unavailable: {}", message),
+            true,
+        ),
+
+        // Authentication failures are transient — the SASL stream expired
+        // (e.g. after process fork or long idle). The goosefs-sdk layer
+        // should have already attempted reconnection, but if the error
+        // propagates up to OpenDAL, mark it as temporary so upper layers
+        // (e.g. RetryLayer) can retry the entire operation.
+        GfsError::AuthenticationFailed { message } => (
+            ErrorKind::Unexpected,
+            format!("authentication failed (retriable): {}", message),
+            true,
+        ),
+
+        // For GrpcError, the goosefs_sdk::error::Error::From<tonic::Status>
+        // already maps NotFound/AlreadyExists/PermissionDenied/InvalidArgument
+        // to specific error variants above. GrpcError only contains codes that
+        // were NOT mapped (Unavailable, DeadlineExceeded, Internal, etc.)
+        GfsError::GrpcError { message, .. } => (ErrorKind::Unexpected, message.clone(), false),
+
+        GfsError::TransportError { message, .. } => (ErrorKind::Unexpected, message.clone(), true),
+
+        _ => (ErrorKind::Unexpected, format!("{}", err), false),
+    };
+
+    let mut error = Error::new(kind, message)
+        .with_context("service_operation", ctx.service_operation.0)
+        .set_source(err);
+    if temporary {
+        error = error.set_temporary();
+    }
+    error
+}

--- a/core/services/goosefs/src/reader.rs
+++ b/core/services/goosefs/src/reader.rs
@@ -17,7 +17,7 @@
 
 use super::backend::*;
 use super::core::GoosefsCore;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use goosefs_sdk::io::GoosefsFileReader as SdkReader;
 use opendal_core::raw::*;
 use opendal_core::*;
@@ -103,7 +103,11 @@ impl oio::ReadStream for GoosefsReadStream {
         }
         let reader = self.inner.as_mut().expect("inner was just set");
 
-        match reader.read_next_block().await.map_err(parse_error)? {
+        match reader
+            .read_next_block()
+            .await
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("ReadNextBlock")), err))?
+        {
             Some(block) => Ok(Buffer::from(block)),
             None => {
                 self.done = true;

--- a/core/services/goosefs/src/writer.rs
+++ b/core/services/goosefs/src/writer.rs
@@ -24,7 +24,7 @@ use std::time::UNIX_EPOCH;
 use goosefs_sdk::io::GoosefsFileWriter as ClientWriter;
 
 use super::core::GoosefsCore;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -226,7 +226,10 @@ impl oio::Write for GoosefsWriter {
         // Iterator yields one `Bytes` per segment; the SDK writer
         // takes `&[u8]`, so each chunk flows through without a copy.
         for chunk in bs {
-            writer.write(&chunk).await.map_err(parse_error)?;
+            writer
+                .write(&chunk)
+                .await
+                .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("Write")), err))?;
         }
         Ok(())
     }
@@ -235,7 +238,11 @@ impl oio::Write for GoosefsWriter {
         if let Some(mut writer) = self.writer.take() {
             // Commit the temp inode on the master, then publish it
             // onto the caller's final path via `finalize_rename`.
-            if let Err(e) = writer.close().await.map_err(parse_error) {
+            if let Err(e) = writer
+                .close()
+                .await
+                .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("Close")), err))
+            {
                 // Close failed — the temp is in an indeterminate state
                 // on the master; best-effort sweep to avoid leaks.
                 if let Some(tmp) = self.tmp_path.take() {
@@ -267,7 +274,11 @@ impl oio::Write for GoosefsWriter {
 
         let tmp = Self::make_tmp_path(&self.path);
         let mut w = self.core.create_writer(&tmp).await?;
-        if let Err(e) = w.close().await.map_err(parse_error) {
+        if let Err(e) = w
+            .close()
+            .await
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("Close")), err))
+        {
             let _ = self.core.delete(&tmp).await;
             return Err(e);
         }

--- a/core/services/hdfs-native/src/core.rs
+++ b/core/services/hdfs-native/src/core.rs
@@ -200,49 +200,41 @@ impl HdfsNativeCore {
     }
 }
 
-mod error {
-    use hdfs_native::HdfsError;
-
-    use opendal_core::*;
-
-    /// Parse hdfs-native error into opendal::Error.
-    pub fn parse_hdfs_error(hdfs_error: HdfsError) -> Error {
-        let (kind, retryable, msg) = match &hdfs_error {
-            HdfsError::IOError(err) => (ErrorKind::Unexpected, false, err.to_string()),
-            HdfsError::DataTransferError(msg) => (ErrorKind::Unexpected, false, msg.clone()),
-            HdfsError::ChecksumError => (
-                ErrorKind::Unexpected,
-                false,
-                "checksums didn't match".to_string(),
-            ),
-            HdfsError::UrlParseError(err) => (ErrorKind::Unexpected, false, err.to_string()),
-            HdfsError::AlreadyExists(msg) => (ErrorKind::AlreadyExists, false, msg.clone()),
-            HdfsError::OperationFailed(msg) => (ErrorKind::Unexpected, false, msg.clone()),
-            HdfsError::RPCError(msg0, msg1) => {
-                if msg0.contains("java.io.FileNotFoundException") {
-                    (ErrorKind::NotFound, false, msg1.clone())
-                } else {
-                    (ErrorKind::Unexpected, false, msg1.clone())
-                }
+/// Parse hdfs-native error into opendal::Error.
+pub fn parse_hdfs_error(hdfs_error: HdfsError) -> Error {
+    let (kind, retryable, msg) = match &hdfs_error {
+        HdfsError::IOError(err) => (ErrorKind::Unexpected, false, err.to_string()),
+        HdfsError::DataTransferError(msg) => (ErrorKind::Unexpected, false, msg.clone()),
+        HdfsError::ChecksumError => (
+            ErrorKind::Unexpected,
+            false,
+            "checksums didn't match".to_string(),
+        ),
+        HdfsError::UrlParseError(err) => (ErrorKind::Unexpected, false, err.to_string()),
+        HdfsError::AlreadyExists(msg) => (ErrorKind::AlreadyExists, false, msg.clone()),
+        HdfsError::OperationFailed(msg) => (ErrorKind::Unexpected, false, msg.clone()),
+        HdfsError::RPCError(msg0, msg1) => {
+            if msg0.contains("java.io.FileNotFoundException") {
+                (ErrorKind::NotFound, false, msg1.clone())
+            } else {
+                (ErrorKind::Unexpected, false, msg1.clone())
             }
-            HdfsError::FileNotFound(msg) => (ErrorKind::NotFound, false, msg.clone()),
-            HdfsError::BlocksNotFound(msg) => (ErrorKind::NotFound, false, msg.clone()),
-            HdfsError::IsADirectoryError(msg) => (ErrorKind::IsADirectory, false, msg.clone()),
-            _ => (
-                ErrorKind::Unexpected,
-                false,
-                "unexpected error from hdfs".to_string(),
-            ),
-        };
-
-        let mut err = Error::new(kind, msg).set_source(hdfs_error);
-
-        if retryable {
-            err = err.set_temporary();
         }
+        HdfsError::FileNotFound(msg) => (ErrorKind::NotFound, false, msg.clone()),
+        HdfsError::BlocksNotFound(msg) => (ErrorKind::NotFound, false, msg.clone()),
+        HdfsError::IsADirectoryError(msg) => (ErrorKind::IsADirectory, false, msg.clone()),
+        _ => (
+            ErrorKind::Unexpected,
+            false,
+            "unexpected error from hdfs".to_string(),
+        ),
+    };
 
-        err
+    let mut err = Error::new(kind, msg).set_source(hdfs_error);
+
+    if retryable {
+        err = err.set_temporary();
     }
-}
 
-pub(super) use error::*;
+    err
+}

--- a/core/services/hf/src/core.rs
+++ b/core/services/hf/src/core.rs
@@ -477,7 +477,18 @@ impl HfCore {
             .request(http::Method::GET, &url, scope.operation(), "XetToken")?
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
-        let (_, info): (_, XetTokenResponse) = self.send_parse(ctx, req).await?;
+        let resp = ctx.http_transport().fetch(req).await?;
+        if !resp.status().is_success() {
+            let (parts, _) = resp.into_parts();
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("XetToken")),
+                parts,
+            ));
+        }
+        let (_, mut body) = resp.into_parts();
+        let buffer = body.to_buffer().await?;
+        let info: XetTokenResponse =
+            serde_json::from_reader(buffer.reader()).map_err(new_json_deserialize_error)?;
         let fresh = XetToken {
             cas_url: info.cas_url,
             access_token: info.access_token,
@@ -589,7 +600,18 @@ impl HfCore {
                     .request(http::Method::GET, &url, Operation::Stat, "RepoInfo")?
                     .body(Buffer::new())
                     .map_err(new_request_build_error)?;
-                let (_, info) = self.send_parse::<RepoInfoResponse>(ctx, req).await?;
+                let resp = ctx.http_transport().fetch(req).await?;
+                if !resp.status().is_success() {
+                    let (parts, _) = resp.into_parts();
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("RepoInfo")),
+                        parts,
+                    ));
+                }
+                let (_, mut body) = resp.into_parts();
+                let buffer = body.to_buffer().await?;
+                let info: RepoInfoResponse =
+                    serde_json::from_reader(buffer.reader()).map_err(new_json_deserialize_error)?;
 
                 let mut repo = self.repo.clone();
                 repo.repo_id = info.id;
@@ -613,41 +635,6 @@ impl HfCore {
             .to_string()
     }
 
-    /// Send a request and return the successful streaming response or a parsed error.
-    ///
-    /// Uses `fetch` so error response bodies are never read into memory —
-    /// `parse_error` reads only response headers.
-    async fn send(
-        &self,
-        ctx: &OperationContext,
-        req: Request<Buffer>,
-    ) -> Result<Response<HttpBody>> {
-        let resp = ctx.http_transport().fetch(req).await?;
-        let (parts, body) = resp.into_parts();
-        if parts.status.is_success() {
-            Ok(Response::from_parts(parts, body))
-        } else {
-            // Drop the streaming body without reading it.
-            Err(parse_error(parts))
-        }
-    }
-
-    /// Send a request, check for success, and deserialize the JSON response.
-    ///
-    /// Returns the response parts (status, headers, etc.) alongside the
-    /// deserialized body so callers can inspect headers when needed.
-    pub(super) async fn send_parse<T: serde::de::DeserializeOwned>(
-        &self,
-        ctx: &OperationContext,
-        req: Request<Buffer>,
-    ) -> Result<(http::response::Parts, T)> {
-        let (parts, mut body) = self.send(ctx, req).await?.into_parts();
-        let buffer = body.to_buffer().await?;
-        let parsed =
-            serde_json::from_reader(buffer.reader()).map_err(new_json_deserialize_error)?;
-        Ok((parts, parsed))
-    }
-
     pub(super) async fn path_info(&self, ctx: &OperationContext, path: &str) -> Result<PathInfo> {
         let uri = self.canonical_uri(ctx, path).await?;
         let url = uri.paths_info_url(&self.endpoint);
@@ -658,7 +645,18 @@ impl HfCore {
             .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
             .body(Buffer::from(Bytes::from(form_body)))
             .map_err(new_request_build_error)?;
-        let (_, mut files) = self.send_parse::<Vec<PathInfo>>(ctx, req).await?;
+        let resp = ctx.http_transport().fetch(req).await?;
+        if !resp.status().is_success() {
+            let (parts, _) = resp.into_parts();
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("PathInfo")),
+                parts,
+            ));
+        }
+        let (_, mut body) = resp.into_parts();
+        let buffer = body.to_buffer().await?;
+        let mut files: Vec<PathInfo> =
+            serde_json::from_reader(buffer.reader()).map_err(new_json_deserialize_error)?;
 
         // NOTE: if the file is not found, the server will return 200 with an empty array
         if files.is_empty() {
@@ -704,7 +702,7 @@ impl HfCore {
             // only response headers, so there is no need to buffer the body
             // (which may be a large HTML error page).
             let (parts, _) = resp.into_parts();
-            let mut err = parse_error(parts);
+            let mut err = parse_error(ErrorContext::new(ServiceOperation("Resolve")), parts);
             if status == http::StatusCode::NOT_FOUND && self.path_info(ctx, path).await.is_ok() {
                 err = err.set_temporary();
             }
@@ -747,8 +745,17 @@ impl HfCore {
             .body(Buffer::from(json_body))
             .map_err(new_request_build_error)?;
 
-        let (_, resp) = self.send_parse::<CommitResponse>(ctx, req).await?;
-        Ok(resp)
+        let resp = ctx.http_transport().fetch(req).await?;
+        if !resp.status().is_success() {
+            let (parts, _) = resp.into_parts();
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("CommitGit")),
+                parts,
+            ));
+        }
+        let (_, mut body) = resp.into_parts();
+        let buffer = body.to_buffer().await?;
+        serde_json::from_reader(buffer.reader()).map_err(new_json_deserialize_error)
     }
 
     /// Commit file changes to a bucket repo via the NDJSON batch API.
@@ -782,7 +789,14 @@ impl HfCore {
             .body(Buffer::from(Bytes::from(body)))
             .map_err(new_request_build_error)?;
 
-        self.send(ctx, req).await?;
+        let resp = ctx.http_transport().fetch(req).await?;
+        if !resp.status().is_success() {
+            let (parts, _) = resp.into_parts();
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("CommitBucket")),
+                parts,
+            ));
+        }
         Ok(())
     }
 }
@@ -1018,6 +1032,9 @@ pub(crate) mod test_utils {
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
+
+    use http::Response;
+    use http::StatusCode;
 
     use super::super::core::HfRepoType;
     use super::test_utils::create_test_core;
@@ -1499,70 +1516,10 @@ mod tests {
 
         Ok(())
     }
-}
 
-mod error {
-    use http::StatusCode;
-
-    use opendal_core::raw::*;
-    use opendal_core::*;
-
-    pub(crate) fn parse_error(parts: http::response::Parts) -> Error {
-        // HF sets x-error-message on every error response with a short human-readable
-        // description. Using the header avoids reading the response body, which can be
-        // a large HTML error page (e.g. 52 KB on 404s from the /resolve/ endpoint).
-        let message = parts
-            .headers
-            .get("x-error-message")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("unknown error")
-            .to_string();
-
-        // HF git-style commit APIs reject stale branch snapshots with 412.
-        // Treat this specific conflict as temporary so RetryLayer can replay
-        // the whole write/delete close sequence on a fresh branch head.
-        let branch_updated_conflict = parts.status == StatusCode::PRECONDITION_FAILED
-            && message
-                .to_ascii_lowercase()
-                .contains("branch was updated since you opened this page");
-
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
-                (ErrorKind::PermissionDenied, false)
-            }
-            StatusCode::PRECONDITION_FAILED => {
-                (ErrorKind::ConditionNotMatch, branch_updated_conflict)
-            }
-            StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    #[cfg(test)]
-    mod test {
-        use http::Response;
-        use http::StatusCode;
-
-        use super::*;
-
-        #[test]
-        fn test_parse_error_branch_update_conflict_is_temporary() {
-            let (parts, _) = Response::builder()
+    #[test]
+    fn test_parse_error_branch_update_conflict_is_temporary() {
+        let (parts, _) = Response::builder()
             .status(StatusCode::PRECONDITION_FAILED)
             .header(
                 "x-error-message",
@@ -1572,30 +1529,85 @@ mod error {
             .unwrap()
             .into_parts();
 
-            let err = parse_error(parts);
+        let err = parse_error(ErrorContext::new(ServiceOperation("Test")), parts);
 
-            assert_eq!(err.kind(), ErrorKind::ConditionNotMatch);
-            assert!(err.is_temporary());
-        }
+        assert_eq!(err.kind(), ErrorKind::ConditionNotMatch);
+        assert!(err.is_temporary());
+    }
 
-        #[test]
-        fn test_parse_error_other_precondition_failed_is_not_temporary() {
-            let (parts, _) = Response::builder()
-                .status(StatusCode::PRECONDITION_FAILED)
-                .header("x-error-message", "etag mismatch")
-                .body(())
-                .unwrap()
-                .into_parts();
+    #[test]
+    fn test_parse_error_other_precondition_failed_is_not_temporary() {
+        let (parts, _) = Response::builder()
+            .status(StatusCode::PRECONDITION_FAILED)
+            .header("x-error-message", "etag mismatch")
+            .body(())
+            .unwrap()
+            .into_parts();
 
-            let err = parse_error(parts);
+        let err = parse_error(ErrorContext::new(ServiceOperation("Test")), parts);
 
-            assert_eq!(err.kind(), ErrorKind::ConditionNotMatch);
-            assert!(!err.is_temporary());
-        }
+        assert_eq!(err.kind(), ErrorKind::ConditionNotMatch);
+        assert!(!err.is_temporary());
     }
 }
 
-pub(super) use error::*;
+use http::StatusCode;
+
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
+
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, parts: http::response::Parts) -> Error {
+    // HF sets x-error-message on every error response with a short human-readable
+    // description. Using the header avoids reading the response body, which can be
+    // a large HTML error page (e.g. 52 KB on 404s from the /resolve/ endpoint).
+    let message = parts
+        .headers
+        .get("x-error-message")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown error")
+        .to_string();
+
+    // HF git-style commit APIs reject stale branch snapshots with 412.
+    // Treat this specific conflict as temporary so RetryLayer can replay
+    // the whole write/delete close sequence on a fresh branch head.
+    let branch_updated_conflict = parts.status == StatusCode::PRECONDITION_FAILED
+        && message
+            .to_ascii_lowercase()
+            .contains("branch was updated since you opened this page");
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::PRECONDITION_FAILED => (ErrorKind::ConditionNotMatch, branch_updated_conflict),
+        StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}
 
 mod uri {
     use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};

--- a/core/services/hf/src/lister.rs
+++ b/core/services/hf/src/lister.rs
@@ -17,7 +17,9 @@
 
 use std::sync::Arc;
 
-use super::core::{HfCore, PathInfo};
+use bytes::Buf;
+
+use super::core::{ErrorContext, HfCore, PathInfo, parse_error};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -92,10 +94,18 @@ impl HfLister {
             .request(http::Method::GET, &url, Operation::List, "FileTree")?
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
-        let (parts, files) = self
-            .core
-            .send_parse::<Vec<PathInfo>>(&self.ctx, req)
-            .await?;
+        let resp = self.ctx.http_transport().fetch(req).await?;
+        if !resp.status().is_success() {
+            let (parts, _) = resp.into_parts();
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("FileTree")),
+                parts,
+            ));
+        }
+        let (parts, mut body) = resp.into_parts();
+        let buffer = body.to_buffer().await?;
+        let files: Vec<PathInfo> =
+            serde_json::from_reader(buffer.reader()).map_err(new_json_deserialize_error)?;
 
         let next_cursor = parts
             .headers

--- a/core/services/http/src/backend.rs
+++ b/core/services/http/src/backend.rs
@@ -23,8 +23,7 @@ use log::debug;
 
 use super::HTTP_SCHEME;
 use super::config::HttpConfig;
-use super::core::HttpCore;
-use super::core::parse_error;
+use super::core::{ErrorContext, HttpCore, parse_error};
 use super::reader::*;
 use opendal_core::raw::*;
 use opendal_core::*;
@@ -217,7 +216,10 @@ impl Service for HttpBackend {
             StatusCode::NOT_FOUND | StatusCode::FORBIDDEN if path.ends_with('/') => {
                 Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Head")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {

--- a/core/services/http/src/core.rs
+++ b/core/services/http/src/core.rs
@@ -151,43 +151,48 @@ impl HttpCore {
     }
 }
 
-mod error {
-    use http::Response;
-    use http::StatusCode;
+use http::StatusCode;
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
-            StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED => {
-                (ErrorKind::ConditionNotMatch, false)
-            }
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let message = String::from_utf8_lossy(&bs);
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED => {
+            (ErrorKind::ConditionNotMatch, false)
+        }
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let message = String::from_utf8_lossy(&bs);
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}

--- a/core/services/http/src/reader.rs
+++ b/core/services/http/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -63,7 +63,10 @@ impl oio::StreamRead for HttpReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("Get")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/ipfs/src/backend.rs
+++ b/core/services/ipfs/src/backend.rs
@@ -25,8 +25,8 @@ use prost::Message;
 use super::reader::*;
 use crate::IPFS_SCHEME;
 use crate::config::IpfsConfig;
-use crate::core::IpfsCore;
 use crate::core::parse_error;
+use crate::core::{ErrorContext, IpfsCore};
 use crate::ipld::PBNode;
 use opendal_core::raw::*;
 use opendal_core::*;
@@ -271,7 +271,10 @@ impl oio::PageList for DirStream {
         let resp = self.core.ipfs_list(&self.ctx, &self.path).await?;
 
         if resp.status() != StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("List")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();

--- a/core/services/ipfs/src/core.rs
+++ b/core/services/ipfs/src/core.rs
@@ -246,24 +246,32 @@ impl IpfsCore {
                 Ok(m)
             }
             StatusCode::FOUND | StatusCode::MOVED_PERMANENTLY => Ok(Metadata::new(EntryMode::DIR)),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Resolve")),
+                resp,
+            )),
         }
     }
 }
 
-mod error {
-    use http::Response;
-    use http::StatusCode;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
 
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
 
-        let (kind, retryable) = match parts.status {
+    let (kind, retryable) = match parts.status {
         StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
         StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
         StatusCode::INTERNAL_SERVER_ERROR
@@ -275,18 +283,16 @@ mod error {
         _ => (ErrorKind::Unexpected, false),
     };
 
-        let message = String::from_utf8_lossy(&bs);
+    let message = String::from_utf8_lossy(&bs);
 
-        let mut err = Error::new(kind, message);
+    let mut err = Error::new(kind, message);
 
-        err = with_error_response_context(err, parts);
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
 
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
+    if retryable {
+        err = err.set_temporary();
     }
-}
 
-pub(super) use error::*;
+    err
+}

--- a/core/services/ipfs/src/reader.rs
+++ b/core/services/ipfs/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use crate::core::parse_error;
+use crate::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -55,7 +55,10 @@ impl oio::StreamRead for IpfsReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("Get")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/ipmfs/src/backend.rs
+++ b/core/services/ipmfs/src/backend.rs
@@ -21,8 +21,8 @@ use bytes::Buf;
 use http::StatusCode;
 use serde::Deserialize;
 
-use super::core::IpmfsCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, IpmfsCore};
 use super::deleter::IpmfsDeleter;
 use super::lister::IpmfsLister;
 use super::reader::*;
@@ -187,7 +187,10 @@ impl Service for IpmfsBackend {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(RpCreateDir::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("FilesMkdir")),
+                resp,
+            )),
         }
     }
 
@@ -219,7 +222,10 @@ impl Service for IpmfsBackend {
 
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("FilesStat")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {

--- a/core/services/ipmfs/src/core.rs
+++ b/core/services/ipmfs/src/core.rs
@@ -170,73 +170,79 @@ impl IpmfsCore {
     }
 }
 
-mod error {
-    use http::Response;
-    use http::StatusCode;
-    use serde::Deserialize;
-    use serde_json::de;
+use http::StatusCode;
+use serde::Deserialize;
+use serde_json::de;
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+#[derive(Deserialize, Default, Debug)]
+#[serde(default)]
+struct IpfsError {
+    #[serde(rename = "Message")]
+    message: String,
+    #[serde(rename = "Code")]
+    code: usize,
+    #[serde(rename = "Type")]
+    ty: String,
+}
 
-    #[derive(Deserialize, Default, Debug)]
-    #[serde(default)]
-    struct IpfsError {
-        #[serde(rename = "Message")]
-        message: String,
-        #[serde(rename = "Code")]
-        code: usize,
-        #[serde(rename = "Type")]
-        ty: String,
-    }
+/// Parse error response into io::Error.
+///
+/// > Status code 500 means that the function does exist, but IPFS was not
+/// > able to fulfil the request because of an error.
+/// > To know that reason, you have to look at the error message that is
+/// > usually returned with the body of the response
+/// > (if no error, check the daemon logs).
+///
+/// ref: https://docs.ipfs.tech/reference/kubo/rpc/#http-status-codes
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    /// Parse error response into io::Error.
-    ///
-    /// > Status code 500 means that the function does exist, but IPFS was not
-    /// > able to fulfil the request because of an error.
-    /// > To know that reason, you have to look at the error message that is
-    /// > usually returned with the body of the response
-    /// > (if no error, check the daemon logs).
-    ///
-    /// ref: https://docs.ipfs.tech/reference/kubo/rpc/#http-status-codes
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let ipfs_error = de::from_slice::<IpfsError>(&bs).ok();
-
-        let (kind, retryable) = match parts.status {
-            StatusCode::INTERNAL_SERVER_ERROR => {
-                if let Some(ie) = &ipfs_error {
-                    match ie.message.as_str() {
-                        "file does not exist" => (ErrorKind::NotFound, false),
-                        _ => (ErrorKind::Unexpected, false),
-                    }
-                } else {
-                    (ErrorKind::Unexpected, false)
-                }
-            }
-            StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let message = match ipfs_error {
-            Some(ipfs_error) => format!("{ipfs_error:?}"),
-            None => String::from_utf8_lossy(&bs).into_owned(),
-        };
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let ipfs_error = de::from_slice::<IpfsError>(&bs).ok();
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::INTERNAL_SERVER_ERROR => {
+            if let Some(ie) = &ipfs_error {
+                match ie.message.as_str() {
+                    "file does not exist" => (ErrorKind::NotFound, false),
+                    _ => (ErrorKind::Unexpected, false),
+                }
+            } else {
+                (ErrorKind::Unexpected, false)
+            }
+        }
+        StatusCode::BAD_GATEWAY | StatusCode::SERVICE_UNAVAILABLE | StatusCode::GATEWAY_TIMEOUT => {
+            (ErrorKind::Unexpected, true)
+        }
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let message = match ipfs_error {
+        Some(ipfs_error) => format!("{ipfs_error:?}"),
+        None => String::from_utf8_lossy(&bs).into_owned(),
+    };
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}

--- a/core/services/ipmfs/src/deleter.rs
+++ b/core/services/ipmfs/src/deleter.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use http::StatusCode;
 
-use super::core::IpmfsCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, IpmfsCore};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -43,7 +43,10 @@ impl oio::OneShotDelete for IpmfsDeleter {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("FilesRm")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/ipmfs/src/lister.rs
+++ b/core/services/ipmfs/src/lister.rs
@@ -21,8 +21,8 @@ use bytes::Buf;
 use http::StatusCode;
 use serde::Deserialize;
 
-use super::core::IpmfsCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, IpmfsCore};
 use opendal_core::EntryMode;
 use opendal_core::ErrorKind;
 use opendal_core::Metadata;
@@ -53,7 +53,7 @@ impl oio::PageList for IpmfsLister {
         let resp = self.core.ipmfs_ls(&self.ctx, &self.path).await?;
 
         if resp.status() != StatusCode::OK {
-            let err = parse_error(resp);
+            let err = parse_error(ErrorContext::new(ServiceOperation("FilesLs")), resp);
             if matches!(err.kind(), ErrorKind::NotFound) {
                 // treat as empty listing
                 ctx.done = true;

--- a/core/services/ipmfs/src/reader.rs
+++ b/core/services/ipmfs/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -52,7 +52,10 @@ impl oio::StreamRead for IpmfsReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("Cat")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/ipmfs/src/writer.rs
+++ b/core/services/ipmfs/src/writer.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use http::StatusCode;
 
-use super::core::IpmfsCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, IpmfsCore};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -44,7 +44,10 @@ impl oio::OneShotWrite for IpmfsWriter {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(Metadata::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Add")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/koofr/src/backend.rs
+++ b/core/services/koofr/src/backend.rs
@@ -27,9 +27,9 @@ use log::debug;
 use super::KOOFR_SCHEME;
 use super::config::KoofrConfig;
 use super::core::File;
-use super::core::KoofrCore;
 use super::core::KoofrSigner;
 use super::core::parse_error;
+use super::core::{ErrorContext, KoofrCore};
 use super::deleter::KoofrDeleter;
 use super::lister::KoofrLister;
 use super::reader::*;
@@ -239,7 +239,10 @@ impl Service for KoofrBackend {
 
                 Ok(RpStat::new(md))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("FilesInfo")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
@@ -310,7 +313,10 @@ impl Service for KoofrBackend {
                 let status = resp.status();
 
                 if status != StatusCode::OK && status != StatusCode::NOT_FOUND {
-                    Err(parse_error(resp))
+                    Err(parse_error(
+                        ErrorContext::new(ServiceOperation("FilesRemove")),
+                        resp,
+                    ))
                 } else {
                     let resp = core.copy(&ctx, &from, &to).await?;
 
@@ -318,7 +324,10 @@ impl Service for KoofrBackend {
 
                     match status {
                         StatusCode::OK => Ok(Metadata::default()),
-                        _ => Err(parse_error(resp)),
+                        _ => Err(parse_error(
+                            ErrorContext::new(ServiceOperation("FilesCopy")),
+                            resp,
+                        )),
                     }
                 }
             }
@@ -343,7 +352,10 @@ impl Service for KoofrBackend {
         let status = resp.status();
 
         if status != StatusCode::OK && status != StatusCode::NOT_FOUND {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("FilesRemove")),
+                resp,
+            ));
         }
 
         let resp = self.core.move_object(ctx, from, to).await?;
@@ -352,7 +364,10 @@ impl Service for KoofrBackend {
 
         match status {
             StatusCode::OK => Ok(RpRename::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("FilesMove")),
+                resp,
+            )),
         }
     }
 

--- a/core/services/koofr/src/core.rs
+++ b/core/services/koofr/src/core.rs
@@ -88,7 +88,10 @@ impl KoofrCore {
                 let status = resp.status();
 
                 if status != StatusCode::OK {
-                    return Err(parse_error(resp));
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("ListMounts")),
+                        resp,
+                    ));
                 }
 
                 let bs = resp.into_body();
@@ -139,7 +142,10 @@ impl KoofrCore {
         let status = resp.status();
 
         if status != StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("Authenticate")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();
@@ -219,11 +225,17 @@ impl KoofrCore {
                     // When the directory already exists, Koofr returns 400 Bad Request.
                     // We should treat it as success.
                     StatusCode::OK | StatusCode::CREATED | StatusCode::BAD_REQUEST => Ok(()),
-                    _ => Err(parse_error(resp)),
+                    _ => Err(parse_error(
+                        ErrorContext::new(ServiceOperation("CreateFolder")),
+                        resp,
+                    )),
                 }
             }
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("FilesInfo")),
+                resp,
+            )),
         }
     }
 
@@ -493,62 +505,66 @@ pub struct File {
     pub content_type: String,
 }
 
-mod error {
-    use http::Response;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
-
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (kind, retryable) = match parts.status.as_u16() {
-            403 => (ErrorKind::PermissionDenied, false),
-            404 => (ErrorKind::NotFound, false),
-            304 | 412 => (ErrorKind::ConditionNotMatch, false),
-            // Service like Koofr could return 499 error with a message like:
-            // Client Disconnect, we should retry it.
-            499 => (ErrorKind::Unexpected, true),
-            500 | 502 | 503 | 504 => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let message = String::from_utf8_lossy(&bs).into_owned();
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    #[cfg(test)]
-    mod test {
-        use http::StatusCode;
-
-        use super::*;
-
-        #[tokio::test]
-        async fn test_parse_error() {
-            let err_res = vec![(r#""#, ErrorKind::NotFound, StatusCode::NOT_FOUND)];
-
-            for res in err_res {
-                let bs = bytes::Bytes::from(res.0);
-                let body = Buffer::from(bs);
-                let resp = Response::builder().status(res.2).body(body).unwrap();
-
-                let err = parse_error(resp);
-
-                assert_eq!(err.kind(), res.1);
-            }
-        }
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status.as_u16() {
+        403 => (ErrorKind::PermissionDenied, false),
+        404 => (ErrorKind::NotFound, false),
+        304 | 412 => (ErrorKind::ConditionNotMatch, false),
+        // Service like Koofr could return 499 error with a message like:
+        // Client Disconnect, we should retry it.
+        499 => (ErrorKind::Unexpected, true),
+        500 | 502 | 503 | 504 => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let message = String::from_utf8_lossy(&bs).into_owned();
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}
+
+#[cfg(test)]
+mod tests {
+    use http::StatusCode;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_parse_error() {
+        let err_res = vec![(r#""#, ErrorKind::NotFound, StatusCode::NOT_FOUND)];
+
+        for res in err_res {
+            let bs = bytes::Bytes::from(res.0);
+            let body = Buffer::from(bs);
+            let resp = Response::builder().status(res.2).body(body).unwrap();
+
+            let err = parse_error(ErrorContext::new(ServiceOperation("Test")), resp);
+
+            assert_eq!(err.kind(), res.1);
+        }
+    }
+}

--- a/core/services/koofr/src/deleter.rs
+++ b/core/services/koofr/src/deleter.rs
@@ -45,7 +45,10 @@ impl oio::OneShotDelete for KoofrDeleter {
             StatusCode::OK => Ok(()),
             // Allow 404 when deleting a non-existing object
             StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("FilesRemove")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/koofr/src/lister.rs
+++ b/core/services/koofr/src/lister.rs
@@ -19,9 +19,9 @@ use std::sync::Arc;
 
 use bytes::Buf;
 
-use super::core::KoofrCore;
 use super::core::ListResponse;
 use super::core::parse_error;
+use super::core::{ErrorContext, KoofrCore};
 use opendal_core::EntryMode;
 use opendal_core::Metadata;
 use opendal_core::OperationContext;
@@ -58,7 +58,10 @@ impl oio::PageList for KoofrLister {
         match resp.status() {
             http::StatusCode::OK => {}
             _ => {
-                return Err(parse_error(resp));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("FilesList")),
+                    resp,
+                ));
             }
         }
 

--- a/core/services/koofr/src/reader.rs
+++ b/core/services/koofr/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -54,7 +54,10 @@ impl oio::StreamRead for KoofrReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("FilesGet")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/koofr/src/writer.rs
+++ b/core/services/koofr/src/writer.rs
@@ -21,8 +21,8 @@ use bytes::Buf;
 use http::StatusCode;
 
 use super::core::File;
-use super::core::KoofrCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, KoofrCore};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -71,7 +71,10 @@ impl oio::OneShotWrite for KoofrWriter {
                 let metadata = Self::parse_metadata(&file)?;
                 Ok(metadata)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("FilesPut")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/lakefs/src/backend.rs
+++ b/core/services/lakefs/src/backend.rs
@@ -25,9 +25,9 @@ use opendal_core::*;
 
 use super::LAKEFS_SCHEME;
 use super::config::LakefsConfig;
-use super::core::LakefsCore;
 use super::core::LakefsStatus;
 use super::core::parse_error;
+use super::core::{ErrorContext, LakefsCore};
 use super::deleter::LakefsDeleter;
 use super::lister::LakefsLister;
 use super::reader::*;
@@ -234,7 +234,10 @@ impl Service for LakefsBackend {
 
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("StatObject")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
@@ -310,7 +313,10 @@ impl Service for LakefsBackend {
 
             match status {
                 StatusCode::CREATED => Ok(Metadata::default()),
-                _ => Err(parse_error(resp)),
+                _ => Err(parse_error(
+                    ErrorContext::new(ServiceOperation("CopyObject")),
+                    resp,
+                )),
             }
         }))
     }

--- a/core/services/lakefs/src/core.rs
+++ b/core/services/lakefs/src/core.rs
@@ -322,81 +322,83 @@ pub(super) struct Pagination {
     pub results: u64,
 }
 
-mod error {
-    use std::fmt::Debug;
+use http::StatusCode;
 
-    use http::Response;
-    use http::StatusCode;
-    use opendal_core::raw::*;
-    use opendal_core::*;
-    use serde::Deserialize;
+/// LakefsError is the error returned by Lakefs File System.
+#[derive(Default, Deserialize)]
+struct LakefsError {
+    error: String,
+}
 
-    /// LakefsError is the error returned by Lakefs File System.
-    #[derive(Default, Deserialize)]
-    struct LakefsError {
-        error: String,
+impl Debug for LakefsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LakefsError")
+            .field("message", &self.error.replace('\n', " "))
+            .finish()
+    }
+}
+
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
+
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::PRECONDITION_FAILED => (ErrorKind::ConditionNotMatch, false),
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let message = match serde_json::from_slice::<LakefsError>(&bs) {
+        Ok(hf_error) => format!("{:?}", hf_error.error),
+        Err(_) => String::from_utf8_lossy(&bs).into_owned(),
+    };
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
     }
 
-    impl Debug for LakefsError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("LakefsError")
-                .field("message", &self.error.replace('\n', " "))
-                .finish()
-        }
-    }
+    err
+}
 
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
-                (ErrorKind::PermissionDenied, false)
-            }
-            StatusCode::PRECONDITION_FAILED => (ErrorKind::ConditionNotMatch, false),
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let message = match serde_json::from_slice::<LakefsError>(&bs) {
-            Ok(hf_error) => format!("{:?}", hf_error.error),
-            Err(_) => String::from_utf8_lossy(&bs).into_owned(),
-        };
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    #[cfg(test)]
-    mod test {
-        use super::*;
-
-        #[test]
-        fn test_parse_error() -> Result<()> {
-            let resp = r#"
+    #[test]
+    fn test_parse_error() -> Result<()> {
+        let resp = r#"
             {
                 "error": "Invalid username or password."
             }
             "#;
-            let decoded_response = serde_json::from_slice::<LakefsError>(resp.as_bytes())
-                .map_err(new_json_deserialize_error)?;
+        let decoded_response = serde_json::from_slice::<LakefsError>(resp.as_bytes())
+            .map_err(new_json_deserialize_error)?;
 
-            assert_eq!(decoded_response.error, "Invalid username or password.");
+        assert_eq!(decoded_response.error, "Invalid username or password.");
 
-            Ok(())
-        }
+        Ok(())
     }
 }
-
-pub(super) use error::*;

--- a/core/services/lakefs/src/deleter.rs
+++ b/core/services/lakefs/src/deleter.rs
@@ -49,7 +49,10 @@ impl oio::OneShotDelete for LakefsDeleter {
         match status {
             StatusCode::NO_CONTENT => Ok(()),
             StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("DeleteObject")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/lakefs/src/lister.rs
+++ b/core/services/lakefs/src/lister.rs
@@ -21,9 +21,9 @@ use bytes::Buf;
 use opendal_core::raw::*;
 use opendal_core::*;
 
-use super::core::LakefsCore;
 use super::core::LakefsListResponse;
 use super::core::parse_error;
+use super::core::{ErrorContext, LakefsCore};
 
 pub struct LakefsLister {
     core: Arc<LakefsCore>,
@@ -76,7 +76,7 @@ impl oio::PageList for LakefsLister {
 
         let status_code = response.status();
         if !status_code.is_success() {
-            let error = parse_error(response);
+            let error = parse_error(ErrorContext::new(ServiceOperation("ListObjects")), response);
             return Err(error);
         }
 

--- a/core/services/lakefs/src/reader.rs
+++ b/core/services/lakefs/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -66,7 +66,10 @@ impl oio::StreamRead for LakefsReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetObject")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/lakefs/src/writer.rs
+++ b/core/services/lakefs/src/writer.rs
@@ -22,9 +22,9 @@ use http::StatusCode;
 use opendal_core::raw::*;
 use opendal_core::*;
 
-use super::core::LakefsCore;
 use super::core::LakefsStatus;
 use super::core::parse_error;
+use super::core::{ErrorContext, LakefsCore};
 
 pub struct LakefsWriter {
     core: Arc<LakefsCore>,
@@ -81,12 +81,18 @@ impl oio::OneShotWrite for LakefsWriter {
                                     &lakefs_status,
                                 ))
                             }
-                            _ => Err(parse_error(stat_resp)),
+                            _ => Err(parse_error(
+                                ErrorContext::new(ServiceOperation("StatObject")),
+                                stat_resp,
+                            )),
                         }
                     }
                 }
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadObject")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/obs/src/backend.rs
+++ b/core/services/obs/src/backend.rs
@@ -35,9 +35,9 @@ use reqsign_huaweicloud_obs::StaticCredentialProvider;
 
 use super::OBS_SCHEME;
 use super::config::ObsConfig;
-use super::core::ObsCore;
 use super::core::constants;
 use super::core::parse_error;
+use super::core::{ErrorContext, ObsCore};
 use super::deleter::ObsDeleter;
 use super::lister::ObsLister;
 use super::reader::*;
@@ -328,7 +328,10 @@ impl Service for ObsBackend {
             StatusCode::NOT_FOUND if path.ends_with('/') => {
                 Ok(RpStat::new(Metadata::new(EntryMode::DIR)))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("HeadObject")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
@@ -409,7 +412,10 @@ impl Service for ObsBackend {
 
             match status {
                 StatusCode::OK => Ok(Metadata::default()),
-                _ => Err(parse_error(resp)),
+                _ => Err(parse_error(
+                    ErrorContext::new(ServiceOperation("CopyObject")),
+                    resp,
+                )),
             }
         }))
     }

--- a/core/services/obs/src/core.rs
+++ b/core/services/obs/src/core.rs
@@ -645,74 +645,11 @@ mod tests {
             ["hello", "world"],
         )
     }
-}
 
-mod error {
-    use bytes::Buf;
-    use http::Response;
-    use http::StatusCode;
-    use quick_xml::de;
-    use serde::Deserialize;
-
-    use opendal_core::raw::*;
-    use opendal_core::*;
-
-    /// ObsError is the error returned by obs service.
-    #[derive(Default, Debug, Deserialize)]
-    #[serde(default, rename_all = "PascalCase")]
-    struct ObsError {
-        code: String,
-        message: String,
-        resource: String,
-        request_id: String,
-        host_id: String,
-    }
-
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
-            StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED => {
-                (ErrorKind::ConditionNotMatch, false)
-            }
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            // OBS could return `520 Origin Error` errors which should be retried.
-            v if v.as_u16() == 520 => (ErrorKind::Unexpected, true),
-
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let message = match de::from_reader::<_, ObsError>(bs.clone().reader()) {
-            Ok(obs_error) => format!("{obs_error:?}"),
-            Err(_) => String::from_utf8_lossy(&bs).into_owned(),
-        };
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn test_parse_error() {
-            let bs = bytes::Bytes::from(
-                r#"
+    #[test]
+    fn test_parse_error() {
+        let bs = bytes::Bytes::from(
+            r#"
 <?xml version="1.0" encoding="UTF-8"?>
 <Error>
 <Code>NoSuchKey</Code>
@@ -722,21 +659,83 @@ mod error {
 <HostId>RkRCRDJENDc5MzdGQkQ4OUY3MTI4NTQ3NDk2Mjg0M0FBQUFBQUFBYmJiYmJiYmJD</HostId>
 </Error>
 "#,
-            );
+        );
 
-            let out: ObsError = de::from_reader(bs.reader()).expect("must success");
-            println!("{out:?}");
+        let out: ObsError = de::from_reader(bs.reader()).expect("must success");
+        println!("{out:?}");
 
-            assert_eq!(out.code, "NoSuchKey");
-            assert_eq!(out.message, "The resource you requested does not exist");
-            assert_eq!(out.resource, "/example-bucket/object");
-            assert_eq!(out.request_id, "001B21A61C6C0000013402C4616D5285");
-            assert_eq!(
-                out.host_id,
-                "RkRCRDJENDc5MzdGQkQ4OUY3MTI4NTQ3NDk2Mjg0M0FBQUFBQUFBYmJiYmJiYmJD"
-            );
-        }
+        assert_eq!(out.code, "NoSuchKey");
+        assert_eq!(out.message, "The resource you requested does not exist");
+        assert_eq!(out.resource, "/example-bucket/object");
+        assert_eq!(out.request_id, "001B21A61C6C0000013402C4616D5285");
+        assert_eq!(
+            out.host_id,
+            "RkRCRDJENDc5MzdGQkQ4OUY3MTI4NTQ3NDk2Mjg0M0FBQUFBQUFBYmJiYmJiYmJD"
+        );
     }
 }
 
-pub(super) use error::*;
+use bytes::Buf;
+use http::StatusCode;
+use quick_xml::de;
+
+/// ObsError is the error returned by obs service.
+#[derive(Default, Debug, Deserialize)]
+#[serde(default, rename_all = "PascalCase")]
+struct ObsError {
+    code: String,
+    message: String,
+    resource: String,
+    request_id: String,
+    host_id: String,
+}
+
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
+
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED => {
+            (ErrorKind::ConditionNotMatch, false)
+        }
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        // OBS could return `520 Origin Error` errors which should be retried.
+        v if v.as_u16() == 520 => (ErrorKind::Unexpected, true),
+
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let message = match de::from_reader::<_, ObsError>(bs.clone().reader()) {
+        Ok(obs_error) => format!("{obs_error:?}"),
+        Err(_) => String::from_utf8_lossy(&bs).into_owned(),
+    };
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}

--- a/core/services/obs/src/deleter.rs
+++ b/core/services/obs/src/deleter.rs
@@ -43,7 +43,10 @@ impl oio::OneShotDelete for ObsDeleter {
 
         match status {
             StatusCode::NO_CONTENT | StatusCode::ACCEPTED | StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("DeleteObject")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/obs/src/lister.rs
+++ b/core/services/obs/src/lister.rs
@@ -70,7 +70,10 @@ impl oio::PageList for ObsLister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListObjects")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();

--- a/core/services/obs/src/reader.rs
+++ b/core/services/obs/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -66,7 +66,10 @@ impl oio::StreamRead for ObsReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetObject")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/obs/src/writer.rs
+++ b/core/services/obs/src/writer.rs
@@ -79,7 +79,10 @@ impl oio::MultipartWrite for ObsWriter {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(meta),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("PutObject")),
+                resp,
+            )),
         }
     }
 
@@ -101,7 +104,10 @@ impl oio::MultipartWrite for ObsWriter {
 
                 Ok(result.upload_id)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("InitiateMultipartUpload")),
+                resp,
+            )),
         }
     }
 
@@ -147,7 +153,10 @@ impl oio::MultipartWrite for ObsWriter {
                     size: None,
                 })
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadPart")),
+                resp,
+            )),
         }
     }
 
@@ -180,7 +189,10 @@ impl oio::MultipartWrite for ObsWriter {
 
         match status {
             StatusCode::OK => Ok(meta),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CompleteMultipartUpload")),
+                resp,
+            )),
         }
     }
 
@@ -193,7 +205,10 @@ impl oio::MultipartWrite for ObsWriter {
             // Obs returns code 204 No Content if abort succeeds.
             // Reference: https://support.huaweicloud.com/intl/en-us/api-obs/obs_04_0103.html
             StatusCode::NO_CONTENT => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("AbortMultipartUpload")),
+                resp,
+            )),
         }
     }
 }
@@ -217,7 +232,10 @@ impl oio::AppendWrite for ObsWriter {
                 Ok(content_length)
             }
             StatusCode::NOT_FOUND => Ok(0),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("HeadObject")),
+                resp,
+            )),
         }
     }
 
@@ -242,7 +260,10 @@ impl oio::AppendWrite for ObsWriter {
 
         match status {
             StatusCode::OK => Ok(meta),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("AppendObject")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/onedrive/src/backend.rs
+++ b/core/services/onedrive/src/backend.rs
@@ -22,9 +22,8 @@ use http::StatusCode;
 use opendal_core::raw::*;
 use opendal_core::*;
 
-use super::core::OneDriveCore;
 use super::core::parse_error;
-use super::core::parse_error_with_retry;
+use super::core::{ErrorContext, OneDriveCore};
 use super::deleter::OneDriveDeleter;
 use super::lister::OneDriveLister;
 use super::reader::*;
@@ -247,8 +246,10 @@ impl Service for OnedriveBackend {
         let response = self.core.onedrive_create_dir(ctx, path).await?;
         match response.status() {
             StatusCode::CREATED | StatusCode::OK => Ok(RpCreateDir::default()),
-            StatusCode::BAD_REQUEST => Err(parse_error_with_retry(response)),
-            _ => Err(parse_error(response)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateFolder")),
+                response,
+            )),
         }
     }
 

--- a/core/services/onedrive/src/core.rs
+++ b/core/services/onedrive/src/core.rs
@@ -132,13 +132,20 @@ impl OneDriveCore {
                         serde_json::from_reader(bytes.reader())
                             .map_err(new_json_deserialize_error)?
                     }
-                    StatusCode::BAD_REQUEST => {
-                        return Err(parse_error_with_retry(response));
+                    _ => {
+                        return Err(parse_error(
+                            ErrorContext::new(ServiceOperation("GetItem")),
+                            response,
+                        ));
                     }
-                    _ => return Err(parse_error(response)),
                 }
             }
-            _ => return Err(parse_error(response)),
+            _ => {
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetItem")),
+                    response,
+                ));
+            }
         };
 
         Ok(item)
@@ -191,7 +198,10 @@ impl OneDriveCore {
 
         let response = ctx.http_transport().send(request).await?;
         if !response.status().is_success() {
-            return Err(parse_error(response));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetItem")),
+                response,
+            ));
         }
 
         let bytes = response.into_body();
@@ -241,7 +251,10 @@ impl OneDriveCore {
 
         let response = ctx.http_transport().send(request).await?;
         if !response.status().is_success() {
-            return Err(parse_error(response));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListVersions")),
+                response,
+            ));
         }
         let decoded_response: GraphApiOneDriveVersionsResponse =
             serde_json::from_reader(response.into_body().reader())
@@ -531,7 +544,10 @@ impl OneDriveCore {
         // we must validate if source exist
         let response = self.onedrive_get_stat_plain(ctx, source).await?;
         if !response.status().is_success() {
-            return Err(parse_error(response));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetItem")),
+                response,
+            ));
         }
 
         // We need to stat the destination parent folder to get a parent reference
@@ -559,11 +575,21 @@ impl OneDriveCore {
                 let response = self.onedrive_delete(ctx, destination).await?;
                 match response.status() {
                     StatusCode::NO_CONTENT | StatusCode::NOT_FOUND => {} // expected, intentionally empty
-                    _ => return Err(parse_error(response)),
+                    _ => {
+                        return Err(parse_error(
+                            ErrorContext::new(ServiceOperation("DeleteItem")),
+                            response,
+                        ));
+                    }
                 }
             }
             StatusCode::NOT_FOUND => {} // expected, intentionally empty
-            _ => return Err(parse_error(response)),
+            _ => {
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetItem")),
+                    response,
+                ));
+            }
         }
 
         let url: String = format!("{}:/copy", self.onedrive_item_url(source, true));
@@ -589,8 +615,10 @@ impl OneDriveCore {
                     )
                 })
                 .map(String::from),
-            StatusCode::BAD_REQUEST => Err(parse_error_with_retry(response)),
-            _ => Err(parse_error(response)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CopyItem")),
+                response,
+            )),
         }
     }
 
@@ -672,7 +700,10 @@ impl OneDriveCore {
         match response.status() {
             // can get etag, metadata, etc...
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(response)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("MoveItem")),
+                response,
+            )),
         }
     }
 }
@@ -733,7 +764,10 @@ impl OneDriveSigner {
                     - Duration::from_secs(120); // assumes 2 mins graceful transmission for implementation simplicity
                 Ok(())
             }
-            _ => Err(parse_error(response)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("RefreshAccessToken")),
+                response,
+            )),
         }
     }
 
@@ -889,72 +923,82 @@ mod tests {
         assert_eq!(entries[1].path(), "test.txt");
         assert_eq!(entries[1].mode(), EntryMode::FILE);
     }
+
+    #[test]
+    fn invalid_request_is_temporary() {
+        let response = Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body(Buffer::from(r#"{"error":{"code":"invalidRequest"}}"#))
+            .unwrap();
+
+        let err = parse_error(
+            ErrorContext::new(ServiceOperation("CreateFolder")),
+            response,
+        );
+
+        assert_eq!(err.kind(), ErrorKind::Unexpected);
+        assert!(err.is_temporary());
+    }
 }
 
-mod error {
-    use http::Response;
-    use http::StatusCode;
+use crate::graph_model::GraphErrorResponse;
 
-    use crate::graph_model::GraphErrorResponse;
-    use opendal_core::raw::*;
-    use opendal_core::*;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(response: Response<Buffer>) -> Error {
-        let (parts, body) = response.into_parts();
-        let bs = body.to_bytes();
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
 
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            // The OneDrive service replaces resources.
-            // However, the Onedrive doesn't have Strong Read-After-Write properties,
-            // the concurrent requests to create directories might result in errors.
-            //
-            // Running behavior tests can yield HTTP 409 Conflict because of the consistency guarantee.
-            //
-            // Read more about `REPLACE_EXISTING_ITEM_WHEN_CONFLICT` in `graph_model.rs`.
-            StatusCode::CONFLICT => (ErrorKind::AlreadyExists, true),
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            StatusCode::NOT_MODIFIED | StatusCode::PRECONDITION_FAILED => {
-                (ErrorKind::ConditionNotMatch, false)
-            }
-            _ => (ErrorKind::Unexpected, false),
-        };
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, response: Response<Buffer>) -> Error {
+    let (parts, body) = response.into_parts();
+    let bs = body.to_bytes();
 
-        let message = String::from_utf8_lossy(&bs);
+    let consistency_lag = parts.status == StatusCode::BAD_REQUEST
+        && serde_json::from_slice::<GraphErrorResponse>(&bs)
+            .is_ok_and(|response| response.error.code == "invalidRequest");
 
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
+    let (kind, mut retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        // The OneDrive service replaces resources.
+        // However, the Onedrive doesn't have Strong Read-After-Write properties,
+        // the concurrent requests to create directories might result in errors.
+        //
+        // Running behavior tests can yield HTTP 409 Conflict because of the consistency guarantee.
+        //
+        // Read more about `REPLACE_EXISTING_ITEM_WHEN_CONFLICT` in `graph_model.rs`.
+        StatusCode::CONFLICT => (ErrorKind::AlreadyExists, true),
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        StatusCode::NOT_MODIFIED | StatusCode::PRECONDITION_FAILED => {
+            (ErrorKind::ConditionNotMatch, false)
         }
+        _ => (ErrorKind::Unexpected, false),
+    };
 
-        err
+    if consistency_lag {
+        retryable = true;
     }
 
-    /// Parse a consistency-lag error and mark it temporary.
-    ///
-    /// Other errors retain the classification from [`parse_error`].
-    pub(crate) fn parse_error_with_retry(response: Response<Buffer>) -> Error {
-        let retryable = is_consistency_lag_error(&response.body().to_bytes());
-        let err = parse_error(response);
+    let message = String::from_utf8_lossy(&bs);
 
-        if retryable { err.set_temporary() } else { err }
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
     }
 
-    fn is_consistency_lag_error(body: &[u8]) -> bool {
-        let Ok(response) = serde_json::from_slice::<GraphErrorResponse>(body) else {
-            return false;
-        };
-
-        response.error.code == "invalidRequest"
-    }
+    err
 }
-
-pub(super) use error::*;

--- a/core/services/onedrive/src/deleter.rs
+++ b/core/services/onedrive/src/deleter.rs
@@ -22,8 +22,8 @@ use http::StatusCode;
 use opendal_core::raw::*;
 use opendal_core::*;
 
-use super::core::OneDriveCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, OneDriveCore};
 
 /// Delete operation
 /// Documentation: https://learn.microsoft.com/en-us/onedrive/developer/rest-api/api/driveitem_delete?view=odsp-graph-online
@@ -43,7 +43,10 @@ impl oio::OneShotDelete for OneDriveDeleter {
         let response = self.core.onedrive_delete(&self.ctx, &path).await?;
         match response.status() {
             StatusCode::NO_CONTENT | StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(response)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("DeleteItem")),
+                response,
+            )),
         }
     }
 }

--- a/core/services/onedrive/src/lister.rs
+++ b/core/services/onedrive/src/lister.rs
@@ -23,8 +23,8 @@ use opendal_core::raw::oio;
 use opendal_core::raw::*;
 use opendal_core::*;
 
-use super::core::OneDriveCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, OneDriveCore};
 use super::graph_model::GraphApiOneDriveListResponse;
 use super::graph_model::ItemType;
 
@@ -77,7 +77,10 @@ impl oio::PageList for OneDriveLister {
                 ctx.done = true;
                 return Ok(());
             }
-            return Err(parse_error(response));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListChildren")),
+                response,
+            ));
         }
 
         let bytes = response.into_body();

--- a/core/services/onedrive/src/reader.rs
+++ b/core/services/onedrive/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -74,7 +74,10 @@ impl oio::StreamRead for OnedriveReader {
             _ => {
                 let (part, mut body) = response.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("DownloadContent")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/onedrive/src/writer.rs
+++ b/core/services/onedrive/src/writer.rs
@@ -24,8 +24,8 @@ use http::StatusCode;
 use opendal_core::raw::*;
 use opendal_core::*;
 
-use super::core::OneDriveCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, OneDriveCore};
 use super::graph_model::OneDriveItem;
 use super::graph_model::OneDriveUploadSessionCreationResponseBody;
 
@@ -92,7 +92,10 @@ impl OneDriveWriter {
 
                 Ok(meta)
             }
-            _ => Err(parse_error(response)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadContent")),
+                response,
+            )),
         }
     }
 
@@ -147,7 +150,12 @@ impl OneDriveWriter {
                     meta.set_last_modified(date_utc_last_modified);
                     return Ok(meta);
                 }
-                _ => return Err(parse_error(response)),
+                _ => {
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("UploadFragment")),
+                        response,
+                    ));
+                }
             }
 
             offset += OneDriveWriter::CHUNK_SIZE_FACTOR;
@@ -170,7 +178,10 @@ impl OneDriveWriter {
                     serde_json::from_reader(bs.reader()).map_err(new_json_deserialize_error)?;
                 Ok(result)
             }
-            _ => Err(parse_error(response)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateUploadSession")),
+                response,
+            )),
         }
     }
 }

--- a/core/services/opfs/src/core.rs
+++ b/core/services/opfs/src/core.rs
@@ -57,46 +57,42 @@ impl OpfsCore {
     }
 }
 
-mod error {
-    use wasm_bindgen::JsCast;
-    use wasm_bindgen::JsValue;
-    use web_sys::DomException;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::JsValue;
+use web_sys::DomException;
 
-    use opendal_core::Error;
-    use opendal_core::ErrorKind;
+use opendal_core::Error;
+use opendal_core::ErrorKind;
 
-    pub(crate) fn parse_js_error(value: JsValue) -> Error {
-        if let Some(exc) = value.dyn_ref::<DomException>() {
-            let kind = match exc.name().as_str() {
-                "NotFoundError" => ErrorKind::NotFound,
-                "TypeMismatchError" => ErrorKind::NotFound,
-                "NotAllowedError" => ErrorKind::PermissionDenied,
-                "QuotaExceededError" => ErrorKind::Unexpected,
-                e => {
-                    console_debug!("Got unhandled DOM exception {e:?}");
-                    ErrorKind::Unexpected
-                }
-            };
-            return Error::new(kind, exc.message());
-        }
-
-        // FIXME: how to map `TypeError`` from `getDirectoryHandle`:
-        // "name specified is not a valid string or contains characters that
-        // would interfere with the native file system"
-        if let Some(err) = value.dyn_ref::<js_sys::Error>() {
-            return Error::new(ErrorKind::Unexpected, String::from(err.message()));
-        }
-
-        Error::new(
-            ErrorKind::Unexpected,
-            value
-                .as_string()
-                .unwrap_or_else(|| "unknown JS error".to_string()),
-        )
+pub(crate) fn parse_js_error(value: JsValue) -> Error {
+    if let Some(exc) = value.dyn_ref::<DomException>() {
+        let kind = match exc.name().as_str() {
+            "NotFoundError" => ErrorKind::NotFound,
+            "TypeMismatchError" => ErrorKind::NotFound,
+            "NotAllowedError" => ErrorKind::PermissionDenied,
+            "QuotaExceededError" => ErrorKind::Unexpected,
+            e => {
+                console_debug!("Got unhandled DOM exception {e:?}");
+                ErrorKind::Unexpected
+            }
+        };
+        return Error::new(kind, exc.message());
     }
-}
 
-pub(super) use error::*;
+    // FIXME: how to map `TypeError`` from `getDirectoryHandle`:
+    // "name specified is not a valid string or contains characters that
+    // would interfere with the native file system"
+    if let Some(err) = value.dyn_ref::<js_sys::Error>() {
+        return Error::new(ErrorKind::Unexpected, String::from(err.message()));
+    }
+
+    Error::new(
+        ErrorKind::Unexpected,
+        value
+            .as_string()
+            .unwrap_or_else(|| "unknown JS error".to_string()),
+    )
+}
 
 mod utils {
     use opendal_core::Result;

--- a/core/services/oss/src/backend.rs
+++ b/core/services/oss/src/backend.rs
@@ -680,7 +680,10 @@ impl Service for OssBackend {
 
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("HeadObject")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
@@ -771,7 +774,10 @@ impl Service for OssBackend {
 
             match status {
                 StatusCode::OK => Ok(Metadata::default()),
-                _ => Err(parse_error(resp)),
+                _ => Err(parse_error(
+                    ErrorContext::new(ServiceOperation("CopyObject")),
+                    resp,
+                )),
             }
         }))
     }

--- a/core/services/oss/src/core.rs
+++ b/core/services/oss/src/core.rs
@@ -1144,72 +1144,12 @@ mod tests {
             ]
         )
     }
-}
 
-mod error {
-    use bytes::Buf;
-    use http::Response;
-    use http::StatusCode;
-    use quick_xml::de;
-    use serde::Deserialize;
-
-    use opendal_core::raw::*;
-    use opendal_core::*;
-
-    /// OssError is the error returned by oss service.
-    #[derive(Default, Debug, Deserialize)]
-    #[serde(default, rename_all = "PascalCase")]
-    struct OssError {
-        code: String,
-        message: String,
-        request_id: String,
-        host_id: String,
-    }
-
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
-            StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED | StatusCode::CONFLICT => {
-                (ErrorKind::ConditionNotMatch, false)
-            }
-            StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let message = match de::from_reader::<_, OssError>(bs.clone().reader()) {
-            Ok(oss_err) => format!("{oss_err:?}"),
-            Err(_) => String::from_utf8_lossy(&bs).into_owned(),
-        };
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        /// Error response example is from https://www.alibabacloud.com/help/en/object-storage-service/latest/error-responses
-        #[test]
-        fn test_parse_error() {
-            let bs = bytes::Bytes::from(
-                r#"
+    /// Error response example is from https://www.alibabacloud.com/help/en/object-storage-service/latest/error-responses
+    #[test]
+    fn test_parse_error() {
+        let bs = bytes::Bytes::from(
+            r#"
 <?xml version="1.0" ?>
 <Error xmlns="http://doc.oss-cn-hangzhou.aliyuncs.com">
     <Code>
@@ -1226,20 +1166,79 @@ mod error {
     </HostId>
 </Error>
 "#,
-            );
+        );
 
-            let out: OssError = de::from_reader(bs.reader()).expect("must success");
-            println!("{out:?}");
+        let out: OssError = de::from_reader(bs.reader()).expect("must success");
+        println!("{out:?}");
 
-            assert_eq!(out.code.trim(), "AccessDenied");
-            assert_eq!(
-                out.message.trim(),
-                "Query-string authentication requires the Signature, Expires and OSSAccessKeyId parameters"
-            );
-            assert_eq!(out.request_id.trim(), "1D842BC54255****");
-            assert_eq!(out.host_id.trim(), "oss-cn-hangzhou.aliyuncs.com");
-        }
+        assert_eq!(out.code.trim(), "AccessDenied");
+        assert_eq!(
+            out.message.trim(),
+            "Query-string authentication requires the Signature, Expires and OSSAccessKeyId parameters"
+        );
+        assert_eq!(out.request_id.trim(), "1D842BC54255****");
+        assert_eq!(out.host_id.trim(), "oss-cn-hangzhou.aliyuncs.com");
     }
 }
 
-pub(super) use error::*;
+use bytes::Buf;
+use http::StatusCode;
+use quick_xml::de;
+
+/// OssError is the error returned by oss service.
+#[derive(Default, Debug, Deserialize)]
+#[serde(default, rename_all = "PascalCase")]
+struct OssError {
+    code: String,
+    message: String,
+    request_id: String,
+    host_id: String,
+}
+
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
+
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED | StatusCode::CONFLICT => {
+            (ErrorKind::ConditionNotMatch, false)
+        }
+        StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let message = match de::from_reader::<_, OssError>(bs.clone().reader()) {
+        Ok(oss_err) => format!("{oss_err:?}"),
+        Err(_) => String::from_utf8_lossy(&bs).into_owned(),
+    };
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}

--- a/core/services/oss/src/deleter.rs
+++ b/core/services/oss/src/deleter.rs
@@ -46,7 +46,10 @@ impl oio::BatchDelete for OssDeleter {
 
         match status {
             StatusCode::NO_CONTENT | StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("DeleteObject")),
+                resp,
+            )),
         }
     }
 
@@ -63,7 +66,10 @@ impl oio::BatchDelete for OssDeleter {
         let status = resp.status();
 
         if status != StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("DeleteMultipleObjects")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();

--- a/core/services/oss/src/lister.rs
+++ b/core/services/oss/src/lister.rs
@@ -80,7 +80,10 @@ impl oio::PageList for OssLister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListObjectsV2")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();
@@ -176,7 +179,10 @@ impl oio::PageList for OssObjectVersionsLister {
             )
             .await?;
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListObjectVersions")),
+                resp,
+            ));
         }
 
         let body = resp.into_body();

--- a/core/services/oss/src/reader.rs
+++ b/core/services/oss/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -66,7 +66,10 @@ impl oio::StreamRead for OssReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetObject")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/oss/src/writer.rs
+++ b/core/services/oss/src/writer.rs
@@ -76,7 +76,10 @@ impl oio::MultipartWrite for OssWriter {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(meta),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("PutObject")),
+                resp,
+            )),
         }
     }
 
@@ -98,7 +101,10 @@ impl oio::MultipartWrite for OssWriter {
 
                 Ok(result.upload_id)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("InitiateMultipartUpload")),
+                resp,
+            )),
         }
     }
 
@@ -145,7 +151,10 @@ impl oio::MultipartWrite for OssWriter {
                     size: None,
                 })
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadPart")),
+                resp,
+            )),
         }
     }
 
@@ -174,7 +183,10 @@ impl oio::MultipartWrite for OssWriter {
 
         match status {
             StatusCode::OK => Ok(meta),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CompleteMultipartUpload")),
+                resp,
+            )),
         }
     }
 
@@ -186,7 +198,10 @@ impl oio::MultipartWrite for OssWriter {
         match resp.status() {
             // OSS returns code 204 if abort succeeds.
             StatusCode::NO_CONTENT => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("AbortMultipartUpload")),
+                resp,
+            )),
         }
     }
 }
@@ -210,7 +225,10 @@ impl oio::AppendWrite for OssWriter {
                 Ok(content_length)
             }
             StatusCode::NOT_FOUND => Ok(0),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("HeadObject")),
+                resp,
+            )),
         }
     }
 
@@ -227,7 +245,10 @@ impl oio::AppendWrite for OssWriter {
 
         match status {
             StatusCode::OK => Ok(meta),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("AppendObject")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/pcloud/src/backend.rs
+++ b/core/services/pcloud/src/backend.rs
@@ -223,7 +223,10 @@ impl Service for PcloudBackend {
 
                 Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Stat")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
@@ -309,7 +312,14 @@ impl Service for PcloudBackend {
                         Ok(Metadata::default())
                     }
                 }
-                _ => Err(parse_error(resp)),
+                _ => Err(parse_error(
+                    ErrorContext::new(if from.ends_with('/') {
+                        ServiceOperation("CopyFolder")
+                    } else {
+                        ServiceOperation("CopyFile")
+                    }),
+                    resp,
+                )),
             }
         }))
     }
@@ -346,7 +356,14 @@ impl Service for PcloudBackend {
 
                 Ok(RpRename::default())
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(if from.ends_with('/') {
+                    ServiceOperation("RenameFolder")
+                } else {
+                    ServiceOperation("RenameFile")
+                }),
+                resp,
+            )),
         }
     }
 

--- a/core/services/pcloud/src/core.rs
+++ b/core/services/pcloud/src/core.rs
@@ -107,7 +107,10 @@ impl PcloudCore {
                 }
                 Err(Error::new(ErrorKind::Unexpected, "hosts is empty"))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetFileLink")),
+                resp,
+            )),
         }
     }
 
@@ -158,7 +161,12 @@ impl PcloudCore {
                         return Err(Error::new(ErrorKind::Unexpected, format!("{resp:?}")));
                     }
                 }
-                _ => return Err(parse_error(resp)),
+                _ => {
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("CreateFolderIfNotExists")),
+                        resp,
+                    ));
+                }
             }
         }
         Ok(())
@@ -519,53 +527,58 @@ pub struct ListMetadata {
     pub contents: Option<Vec<ListMetadata>>,
 }
 
-mod error {
-    use std::fmt::Debug;
+/// PcloudError is the error returned by Pcloud service.
+#[derive(Default, Deserialize)]
+pub(crate) struct PcloudError {
+    pub result: u32,
+    pub error: Option<String>,
+}
 
-    use http::Response;
-    use opendal_core::raw::*;
-    use opendal_core::*;
-    use serde::Deserialize;
-
-    /// PcloudError is the error returned by Pcloud service.
-    #[derive(Default, Deserialize)]
-    pub(crate) struct PcloudError {
-        pub result: u32,
-        pub error: Option<String>,
+impl Debug for PcloudError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PcloudError")
+            .field("result", &self.result)
+            .field("error", &self.error)
+            .finish_non_exhaustive()
     }
+}
 
-    impl Debug for PcloudError {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("PcloudError")
-                .field("result", &self.result)
-                .field("error", &self.error)
-                .finish_non_exhaustive()
-        }
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
+}
 
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-        let message = String::from_utf8_lossy(&bs).into_owned();
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+    let message = String::from_utf8_lossy(&bs).into_owned();
 
-        let mut err = Error::new(ErrorKind::Unexpected, message);
+    let mut err = Error::new(ErrorKind::Unexpected, message);
 
-        err = with_error_response_context(err, parts);
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
 
-        err
-    }
+    err
+}
 
-    #[cfg(test)]
-    mod test {
-        use http::StatusCode;
+#[cfg(test)]
+mod tests {
+    use http::StatusCode;
 
-        use super::*;
+    use super::*;
 
-        #[tokio::test]
-        async fn test_parse_error() {
-            let err_res = vec![(
-                r#"<html>
+    #[tokio::test]
+    async fn test_parse_error() {
+        let err_res = vec![(
+            r#"<html>
 
                 <head>
                     <title>Invalid link</title>
@@ -574,21 +587,18 @@ mod error {
                 <body>This link was generated for another IP address. Try previous step again.</body>
 
                 </html> "#,
-                ErrorKind::Unexpected,
-                StatusCode::GONE,
-            )];
+            ErrorKind::Unexpected,
+            StatusCode::GONE,
+        )];
 
-            for res in err_res {
-                let bs = bytes::Bytes::from(res.0);
-                let body = Buffer::from(bs);
-                let resp = Response::builder().status(res.2).body(body).unwrap();
+        for res in err_res {
+            let bs = bytes::Bytes::from(res.0);
+            let body = Buffer::from(bs);
+            let resp = Response::builder().status(res.2).body(body).unwrap();
 
-                let err = parse_error(resp);
+            let err = parse_error(ErrorContext::new(ServiceOperation("Test")), resp);
 
-                assert_eq!(err.kind(), res.1);
-            }
+            assert_eq!(err.kind(), res.1);
         }
     }
 }
-
-pub(super) use error::*;

--- a/core/services/pcloud/src/deleter.rs
+++ b/core/services/pcloud/src/deleter.rs
@@ -61,7 +61,14 @@ impl oio::OneShotDelete for PcloudDeleter {
 
                 Ok(())
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(if path.ends_with('/') {
+                    ServiceOperation("DeleteFolder")
+                } else {
+                    ServiceOperation("DeleteFile")
+                }),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/pcloud/src/lister.rs
+++ b/core/services/pcloud/src/lister.rs
@@ -90,7 +90,10 @@ impl oio::PageList for PcloudLister {
                     String::from_utf8_lossy(&bs.to_bytes()),
                 ))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListFolder")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/pcloud/src/reader.rs
+++ b/core/services/pcloud/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -62,7 +62,10 @@ impl oio::StreamRead for PcloudReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("DownloadFile")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/pcloud/src/writer.rs
+++ b/core/services/pcloud/src/writer.rs
@@ -22,9 +22,9 @@ use http::StatusCode;
 use opendal_core::raw::*;
 use opendal_core::*;
 
-use super::core::PcloudCore;
 use super::core::PcloudError;
 use super::core::parse_error;
+use super::core::{ErrorContext, PcloudCore};
 
 pub type PcloudWriters = oio::OneShotWriter<PcloudWriter>;
 
@@ -61,7 +61,10 @@ impl oio::OneShotWrite for PcloudWriter {
 
                 Ok(Metadata::default())
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadFile")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/persy/src/core.rs
+++ b/core/services/persy/src/core.rs
@@ -17,7 +17,20 @@
 
 use std::fmt::Debug;
 
+use opendal_core::raw::ServiceOperation;
 use opendal_core::*;
+
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
 
 #[derive(Clone)]
 pub struct PersyCore {
@@ -42,9 +55,11 @@ impl PersyCore {
         let mut read_id = self
             .persy
             .get::<String, persy::PersyId>(&self.index, &path.to_string())
-            .map_err(parse_error)?;
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("GetIndex")), err))?;
         if let Some(id) = read_id.next() {
-            let value = self.persy.read(&self.segment, &id).map_err(parse_error)?;
+            let value = self.persy.read(&self.segment, &id).map_err(|err| {
+                parse_error(ErrorContext::new(ServiceOperation("ReadRecord")), err)
+            })?;
             return Ok(value.map(Buffer::from));
         }
 
@@ -52,15 +67,27 @@ impl PersyCore {
     }
 
     pub fn set(&self, path: &str, value: Buffer) -> Result<()> {
-        let mut tx = self.persy.begin().map_err(parse_error)?;
+        let mut tx = self.persy.begin().map_err(|err| {
+            parse_error(ErrorContext::new(ServiceOperation("BeginTransaction")), err)
+        })?;
         let id = tx
             .insert(&self.segment, &value.to_vec())
-            .map_err(parse_error)?;
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("InsertRecord")), err))?;
 
         tx.put::<String, persy::PersyId>(&self.index, path.to_string(), id)
-            .map_err(parse_error)?;
-        let prepared = tx.prepare().map_err(parse_error)?;
-        prepared.commit().map_err(parse_error)?;
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("PutIndex")), err))?;
+        let prepared = tx.prepare().map_err(|err| {
+            parse_error(
+                ErrorContext::new(ServiceOperation("PrepareTransaction")),
+                err,
+            )
+        })?;
+        prepared.commit().map_err(|err| {
+            parse_error(
+                ErrorContext::new(ServiceOperation("CommitTransaction")),
+                err,
+            )
+        })?;
 
         Ok(())
     }
@@ -69,30 +96,48 @@ impl PersyCore {
         let mut delete_id = self
             .persy
             .get::<String, persy::PersyId>(&self.index, &path.to_string())
-            .map_err(parse_error)?;
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("GetIndex")), err))?;
         if let Some(id) = delete_id.next() {
             // Begin a transaction.
-            let mut tx = self.persy.begin().map_err(parse_error)?;
+            let mut tx = self.persy.begin().map_err(|err| {
+                parse_error(ErrorContext::new(ServiceOperation("BeginTransaction")), err)
+            })?;
             // Delete the record.
-            tx.delete(&self.segment, &id).map_err(parse_error)?;
+            tx.delete(&self.segment, &id).map_err(|err| {
+                parse_error(ErrorContext::new(ServiceOperation("DeleteRecord")), err)
+            })?;
             // Remove the index.
             tx.remove::<String, persy::PersyId>(&self.index, path.to_string(), Some(id))
-                .map_err(parse_error)?;
+                .map_err(|err| {
+                    parse_error(ErrorContext::new(ServiceOperation("RemoveIndex")), err)
+                })?;
             // Commit the tx.
-            let prepared = tx.prepare().map_err(parse_error)?;
-            prepared.commit().map_err(parse_error)?;
+            let prepared = tx.prepare().map_err(|err| {
+                parse_error(
+                    ErrorContext::new(ServiceOperation("PrepareTransaction")),
+                    err,
+                )
+            })?;
+            prepared.commit().map_err(|err| {
+                parse_error(
+                    ErrorContext::new(ServiceOperation("CommitTransaction")),
+                    err,
+                )
+            })?;
         }
 
         Ok(())
     }
 }
 
-fn parse_error<T: Into<persy::PersyError>>(err: persy::PE<T>) -> Error {
+fn parse_error<T: Into<persy::PersyError>>(ctx: ErrorContext, err: persy::PE<T>) -> Error {
     let err: persy::PersyError = err.persy_error();
     let kind = match err {
         persy::PersyError::RecordNotFound(_) => ErrorKind::NotFound,
         _ => ErrorKind::Unexpected,
     };
 
-    Error::new(kind, "error from persy").set_source(err)
+    Error::new(kind, "error from persy")
+        .with_context("service_operation", ctx.service_operation.0)
+        .set_source(err)
 }

--- a/core/services/seafile/src/core.rs
+++ b/core/services/seafile/src/core.rs
@@ -109,7 +109,10 @@ impl SeafileCore {
                     };
                 }
                 _ => {
-                    return Err(parse_error(resp));
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("AuthToken")),
+                        resp,
+                    ));
                 }
             }
 
@@ -150,7 +153,10 @@ impl SeafileCore {
                     }
                 }
                 _ => {
-                    return Err(parse_error(resp));
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("ListRepositories")),
+                        resp,
+                    ));
                 }
             }
             Ok(signer.auth_info.clone())
@@ -185,7 +191,10 @@ impl SeafileCore {
                     .map_err(new_json_deserialize_error)?;
                 Ok(upload_url)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetUploadLink")),
+                resp,
+            )),
         }
     }
 
@@ -256,7 +265,10 @@ impl SeafileCore {
 
         match resp.status() {
             StatusCode::OK | StatusCode::CREATED => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Mkdir")),
+                resp,
+            )),
         }
     }
 
@@ -290,7 +302,10 @@ impl SeafileCore {
 
                 Ok(download_url)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetDownloadLink")),
+                resp,
+            )),
         }
     }
 
@@ -344,7 +359,10 @@ impl SeafileCore {
                     .map_err(new_json_deserialize_error)?;
                 Ok(file_detail)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetFileDetail")),
+                resp,
+            )),
         }
     }
 
@@ -377,7 +395,10 @@ impl SeafileCore {
                     .map_err(new_json_deserialize_error)?;
                 Ok(dir_detail)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetDirDetail")),
+                resp,
+            )),
         }
     }
 
@@ -415,7 +436,10 @@ impl SeafileCore {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Delete")),
+                resp,
+            )),
         }
     }
 
@@ -457,7 +481,10 @@ impl SeafileCore {
                 infos: None,
                 rooted_abs_path,
             }),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListDir")),
+                resp,
+            )),
         }
     }
 }
@@ -528,77 +555,78 @@ pub struct ListResponse {
     pub rooted_abs_path: String,
 }
 
-mod error {
-    use bytes::Buf;
-    use http::Response;
-    use serde::Deserialize;
+/// the error response of seafile
+#[derive(Default, Debug, Deserialize)]
+#[allow(dead_code)]
+struct SeafileError {
+    error_msg: String,
+}
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    /// the error response of seafile
-    #[derive(Default, Debug, Deserialize)]
-    #[allow(dead_code)]
-    struct SeafileError {
-        error_msg: String,
-    }
-
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (kind, _retryable) = match parts.status.as_u16() {
-            403 => (ErrorKind::PermissionDenied, false),
-            404 => (ErrorKind::NotFound, false),
-            520 => (ErrorKind::Unexpected, false),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let (message, _seafile_err) =
-            serde_json::from_reader::<_, SeafileError>(bs.clone().reader())
-                .map(|seafile_err| (format!("{seafile_err:?}"), Some(seafile_err)))
-                .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        err
-    }
-
-    #[cfg(test)]
-    mod test {
-        use http::StatusCode;
-
-        use super::*;
-
-        #[tokio::test]
-        async fn test_parse_error() {
-            let err_res = vec![
-                (
-                    r#"{"error_msg": "Permission denied"}"#,
-                    ErrorKind::PermissionDenied,
-                    StatusCode::FORBIDDEN,
-                ),
-                (
-                    r#"{"error_msg": "Folder /e982e75a-fead-487c-9f41-63094d9bf0de/a9d867b9-778d-4612-b674-47e674c14c28/ not found."}"#,
-                    ErrorKind::NotFound,
-                    StatusCode::NOT_FOUND,
-                ),
-            ];
-
-            for res in err_res {
-                let bs = bytes::Bytes::from(res.0);
-                let body = Buffer::from(bs);
-                let resp = Response::builder().status(res.2).body(body).unwrap();
-
-                let err = parse_error(resp);
-
-                assert_eq!(err.kind(), res.1);
-            }
-        }
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, _retryable) = match parts.status.as_u16() {
+        403 => (ErrorKind::PermissionDenied, false),
+        404 => (ErrorKind::NotFound, false),
+        520 => (ErrorKind::Unexpected, false),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let (message, _seafile_err) = serde_json::from_reader::<_, SeafileError>(bs.clone().reader())
+        .map(|seafile_err| (format!("{seafile_err:?}"), Some(seafile_err)))
+        .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    err
+}
+
+#[cfg(test)]
+mod tests {
+    use http::StatusCode;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_parse_error() {
+        let err_res = vec![
+            (
+                r#"{"error_msg": "Permission denied"}"#,
+                ErrorKind::PermissionDenied,
+                StatusCode::FORBIDDEN,
+            ),
+            (
+                r#"{"error_msg": "Folder /e982e75a-fead-487c-9f41-63094d9bf0de/a9d867b9-778d-4612-b674-47e674c14c28/ not found."}"#,
+                ErrorKind::NotFound,
+                StatusCode::NOT_FOUND,
+            ),
+        ];
+
+        for res in err_res {
+            let bs = bytes::Bytes::from(res.0);
+            let body = Buffer::from(bs);
+            let resp = Response::builder().status(res.2).body(body).unwrap();
+
+            let err = parse_error(ErrorContext::new(ServiceOperation("Test")), resp);
+
+            assert_eq!(err.kind(), res.1);
+        }
+    }
+}

--- a/core/services/seafile/src/reader.rs
+++ b/core/services/seafile/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -60,7 +60,10 @@ impl oio::StreamRead for SeafileReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("DownloadFile")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/seafile/src/writer.rs
+++ b/core/services/seafile/src/writer.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use http::StatusCode;
 
-use super::core::SeafileCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, SeafileCore};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -51,7 +51,10 @@ impl oio::OneShotWrite for SeafileWriter {
         let status = resp.status();
         match status {
             StatusCode::OK => Ok(Metadata::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadFile")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/sftp/src/core.rs
+++ b/core/services/sftp/src/core.rs
@@ -160,54 +160,50 @@ impl ManageObject for Manager {
     }
 }
 
-mod error {
-    use openssh::Error as SshError;
-    use openssh_sftp_client::Error as SftpClientError;
-    use openssh_sftp_client::error::SftpErrorKind;
+use openssh::Error as SshError;
+use openssh_sftp_client::Error as SftpClientError;
+use openssh_sftp_client::error::SftpErrorKind;
 
-    use opendal_core::Error;
-    use opendal_core::ErrorKind;
+use opendal_core::Error;
+use opendal_core::ErrorKind;
 
-    pub fn parse_sftp_error(e: SftpClientError) -> Error {
-        let kind = match &e {
-            SftpClientError::UnsupportedSftpProtocol { version: _ } => ErrorKind::Unsupported,
-            SftpClientError::SftpError(kind, _msg) => match kind {
-                SftpErrorKind::NoSuchFile => ErrorKind::NotFound,
-                SftpErrorKind::PermDenied => ErrorKind::PermissionDenied,
-                SftpErrorKind::OpUnsupported => ErrorKind::Unsupported,
-                _ => ErrorKind::Unexpected,
-            },
+pub fn parse_sftp_error(e: SftpClientError) -> Error {
+    let kind = match &e {
+        SftpClientError::UnsupportedSftpProtocol { version: _ } => ErrorKind::Unsupported,
+        SftpClientError::SftpError(kind, _msg) => match kind {
+            SftpErrorKind::NoSuchFile => ErrorKind::NotFound,
+            SftpErrorKind::PermDenied => ErrorKind::PermissionDenied,
+            SftpErrorKind::OpUnsupported => ErrorKind::Unsupported,
             _ => ErrorKind::Unexpected,
-        };
+        },
+        _ => ErrorKind::Unexpected,
+    };
 
-        let mut err = Error::new(kind, "sftp error").set_source(e);
+    let mut err = Error::new(kind, "sftp error").set_source(e);
 
-        // Mark error as temporary if it's unexpected.
-        if kind == ErrorKind::Unexpected {
-            err = err.set_temporary();
-        }
-
-        err
+    // Mark error as temporary if it's unexpected.
+    if kind == ErrorKind::Unexpected {
+        err = err.set_temporary();
     }
 
-    pub fn parse_ssh_error(e: SshError) -> Error {
-        Error::new(ErrorKind::Unexpected, "ssh error").set_source(e)
-    }
-
-    pub(crate) fn is_not_found(e: &SftpClientError) -> bool {
-        matches!(e, SftpClientError::SftpError(SftpErrorKind::NoSuchFile, _))
-    }
-
-    pub(crate) fn is_sftp_protocol_error(e: &SftpClientError) -> bool {
-        matches!(e, SftpClientError::SftpError(_, _))
-    }
-
-    pub(crate) fn is_sftp_failure(e: &SftpClientError) -> bool {
-        matches!(e, SftpClientError::SftpError(SftpErrorKind::Failure, _))
-    }
+    err
 }
 
-pub(super) use error::*;
+pub fn parse_ssh_error(e: SshError) -> Error {
+    Error::new(ErrorKind::Unexpected, "ssh error").set_source(e)
+}
+
+pub(crate) fn is_not_found(e: &SftpClientError) -> bool {
+    matches!(e, SftpClientError::SftpError(SftpErrorKind::NoSuchFile, _))
+}
+
+pub(crate) fn is_sftp_protocol_error(e: &SftpClientError) -> bool {
+    matches!(e, SftpClientError::SftpError(_, _))
+}
+
+pub(crate) fn is_sftp_failure(e: &SftpClientError) -> bool {
+    matches!(e, SftpClientError::SftpError(SftpErrorKind::Failure, _))
+}
 
 mod utils {
     use openssh_sftp_client::metadata::MetaData as SftpMeta;

--- a/core/services/sled/src/core.rs
+++ b/core/services/sled/src/core.rs
@@ -17,7 +17,20 @@
 
 use std::fmt::Debug;
 
+use opendal_core::raw::ServiceOperation;
 use opendal_core::*;
+
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
 
 #[derive(Clone)]
 pub struct SledCore {
@@ -35,19 +48,24 @@ impl Debug for SledCore {
 
 impl SledCore {
     pub fn get(&self, path: &str) -> Result<Option<Buffer>> {
-        let res = self.tree.get(path).map_err(parse_error)?;
+        let res = self
+            .tree
+            .get(path)
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("Get")), err))?;
         Ok(res.map(|v| Buffer::from(v.to_vec())))
     }
 
     pub fn set(&self, path: &str, value: Buffer) -> Result<()> {
         self.tree
             .insert(path, value.to_vec())
-            .map_err(parse_error)?;
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("Insert")), err))?;
         Ok(())
     }
 
     pub fn delete(&self, path: &str) -> Result<()> {
-        self.tree.remove(path).map_err(parse_error)?;
+        self.tree
+            .remove(path)
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("Remove")), err))?;
         Ok(())
     }
 
@@ -56,7 +74,9 @@ impl SledCore {
         let mut res = Vec::default();
 
         for i in it {
-            let (key, value) = i.map_err(parse_error)?;
+            let (key, value) = i.map_err(|err| {
+                parse_error(ErrorContext::new(ServiceOperation("ScanPrefix")), err)
+            })?;
             let bs = key.to_vec();
             let v = String::from_utf8(bs).map_err(|err| {
                 Error::new(ErrorKind::Unexpected, "store key is not valid utf-8 string")
@@ -70,6 +90,8 @@ impl SledCore {
     }
 }
 
-fn parse_error(err: sled::Error) -> Error {
-    Error::new(ErrorKind::Unexpected, "error from sled").set_source(err)
+fn parse_error(ctx: ErrorContext, err: sled::Error) -> Error {
+    Error::new(ErrorKind::Unexpected, "error from sled")
+        .with_context("service_operation", ctx.service_operation.0)
+        .set_source(err)
 }

--- a/core/services/swift/src/backend.rs
+++ b/core/services/swift/src/backend.rs
@@ -274,7 +274,10 @@ impl Service for SwiftBackend {
 
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("ShowObjectMetadata")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
@@ -389,7 +392,10 @@ impl Service for SwiftBackend {
 
             match status {
                 StatusCode::CREATED | StatusCode::OK => Ok(Metadata::default()),
-                _ => Err(parse_error(resp)),
+                _ => Err(parse_error(
+                    ErrorContext::new(ServiceOperation("CopyObject")),
+                    resp,
+                )),
             }
         }))
     }

--- a/core/services/swift/src/core.rs
+++ b/core/services/swift/src/core.rs
@@ -851,72 +851,12 @@ mod tests {
         );
         assert!(TempUrlHashAlgorithm::from_str_opt("md5").is_err());
     }
-}
 
-mod error {
-    use bytes::Buf;
-    use bytes::Bytes;
-    use http::Response;
-    use http::StatusCode;
-    use quick_xml::de;
-    use serde::Deserialize;
-
-    use opendal_core::raw::*;
-    use opendal_core::*;
-
-    #[allow(dead_code)]
-    #[derive(Debug, Deserialize)]
-    struct ErrorResponse {
-        h1: String,
-        p: String,
-    }
-
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
-                (ErrorKind::PermissionDenied, false)
-            }
-            StatusCode::NOT_MODIFIED | StatusCode::PRECONDITION_FAILED => {
-                (ErrorKind::ConditionNotMatch, false)
-            }
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let message = parse_error_response(&bs);
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    fn parse_error_response(resp: &Bytes) -> String {
-        match de::from_reader::<_, ErrorResponse>(resp.clone().reader()) {
-            Ok(swift_err) => swift_err.p,
-            Err(_) => String::from_utf8_lossy(resp).into_owned(),
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn parse_error_response_test() -> Result<()> {
-            let resp = Bytes::from(
+    #[test]
+    fn html_body_is_used_as_message() {
+        let resp = Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Buffer::from(
                 r#"
 <html>
 <h1>Not Found</h1>
@@ -924,13 +864,69 @@ mod error {
 
 </html>
             "#,
-            );
+            ))
+            .unwrap();
 
-            let msg = parse_error_response(&resp);
-            assert_eq!(msg, "The resource could not be found.".to_string(),);
-            Ok(())
-        }
+        let err = parse_error(ErrorContext::new(ServiceOperation("Test")), resp);
+
+        assert_eq!(err.kind(), ErrorKind::NotFound);
+        assert!(err.to_string().contains("The resource could not be found."));
     }
 }
 
-pub(super) use error::*;
+use bytes::Buf;
+use http::StatusCode;
+use quick_xml::de;
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct ErrorResponse {
+    h1: String,
+    p: String,
+}
+
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
+
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::NOT_MODIFIED | StatusCode::PRECONDITION_FAILED => {
+            (ErrorKind::ConditionNotMatch, false)
+        }
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let message = de::from_reader::<_, ErrorResponse>(bs.clone().reader())
+        .map(|swift_err| swift_err.p)
+        .unwrap_or_else(|_| String::from_utf8_lossy(&bs).into_owned());
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}

--- a/core/services/swift/src/deleter.rs
+++ b/core/services/swift/src/deleter.rs
@@ -44,7 +44,10 @@ impl oio::BatchDelete for SwiftDeleter {
         match status {
             StatusCode::NO_CONTENT | StatusCode::OK => Ok(()),
             StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("DeleteObject")),
+                resp,
+            )),
         }
     }
 
@@ -53,7 +56,10 @@ impl oio::BatchDelete for SwiftDeleter {
 
         let status = resp.status();
         if status != StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("BulkDelete")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body().to_bytes();

--- a/core/services/swift/src/lister.rs
+++ b/core/services/swift/src/lister.rs
@@ -75,7 +75,7 @@ impl oio::PageList for SwiftLister {
         let status_code = response.status();
 
         if !status_code.is_success() {
-            let error = parse_error(response);
+            let error = parse_error(ErrorContext::new(ServiceOperation("ListObjects")), response);
             return Err(error);
         }
 

--- a/core/services/swift/src/reader.rs
+++ b/core/services/swift/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -66,7 +66,10 @@ impl oio::StreamRead for SwiftReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetObject")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/swift/src/writer.rs
+++ b/core/services/swift/src/writer.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 use http::StatusCode;
 
 use super::core::SloManifestEntry;
-use super::core::SwiftCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, SwiftCore};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -71,7 +71,10 @@ impl oio::MultipartWrite for SwiftWriter {
                 let metadata = SwiftWriter::parse_metadata(resp.headers())?;
                 Ok(metadata)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateObject")),
+                resp,
+            )),
         }
     }
 
@@ -113,7 +116,10 @@ impl oio::MultipartWrite for SwiftWriter {
                     size: Some(size),
                 })
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadSegment")),
+                resp,
+            )),
         }
     }
 
@@ -148,7 +154,10 @@ impl oio::MultipartWrite for SwiftWriter {
                 let metadata = SwiftWriter::parse_metadata(resp.headers())?;
                 Ok(metadata)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadManifest")),
+                resp,
+            )),
         }
     }
 

--- a/core/services/tikv/src/core.rs
+++ b/core/services/tikv/src/core.rs
@@ -22,7 +22,19 @@ use tikv_client::Config;
 use tikv_client::RawClient;
 
 use super::TIKV_SCHEME;
+use opendal_core::raw::ServiceOperation;
 use opendal_core::*;
+
+#[derive(Clone, Copy, Debug)]
+struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
 
 /// TikvCore holds the configuration and client for interacting with TiKV.
 #[derive(Clone)]
@@ -49,9 +61,9 @@ impl TikvCore {
         self.client
             .get_or_try_init(|| async {
                 if self.insecure {
-                    return RawClient::new(self.endpoints.clone())
-                        .await
-                        .map_err(parse_tikv_config_error);
+                    return RawClient::new(self.endpoints.clone()).await.map_err(|err| {
+                        parse_error(ErrorContext::new(ServiceOperation("Connect")), err)
+                    });
                 }
 
                 if let Some(ca_path) = self.ca_path.as_ref()
@@ -61,7 +73,9 @@ impl TikvCore {
                     let config = Config::default().with_security(ca_path, cert_path, key_path);
                     return RawClient::new_with_config(self.endpoints.clone(), config)
                         .await
-                        .map_err(parse_tikv_config_error);
+                        .map_err(|err| {
+                            parse_error(ErrorContext::new(ServiceOperation("Connect")), err)
+                        });
                 }
 
                 Err(
@@ -79,7 +93,7 @@ impl TikvCore {
             .await?
             .get(path.to_owned())
             .await
-            .map_err(parse_tikv_error)?;
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("Get")), err))?;
         Ok(result.map(Buffer::from))
     }
 
@@ -88,7 +102,7 @@ impl TikvCore {
             .await?
             .put(path.to_owned(), value.to_vec())
             .await
-            .map_err(parse_tikv_error)
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("Put")), err))
     }
 
     pub async fn delete(&self, path: &str) -> Result<()> {
@@ -96,16 +110,19 @@ impl TikvCore {
             .await?
             .delete(path.to_owned())
             .await
-            .map_err(parse_tikv_error)
+            .map_err(|err| parse_error(ErrorContext::new(ServiceOperation("Delete")), err))
     }
 }
 
-fn parse_tikv_error(e: tikv_client::Error) -> Error {
-    Error::new(ErrorKind::Unexpected, "error from tikv").set_source(e)
-}
+fn parse_error(ctx: ErrorContext, err: tikv_client::Error) -> Error {
+    let (kind, message) = if ctx.service_operation.0 == "Connect" {
+        (ErrorKind::ConfigInvalid, "invalid configuration")
+    } else {
+        (ErrorKind::Unexpected, "error from tikv")
+    };
 
-fn parse_tikv_config_error(e: tikv_client::Error) -> Error {
-    Error::new(ErrorKind::ConfigInvalid, "invalid configuration")
+    Error::new(kind, message)
         .with_context("service", TIKV_SCHEME)
-        .set_source(e)
+        .with_context("service_operation", ctx.service_operation.0)
+        .set_source(err)
 }

--- a/core/services/tos/src/backend.rs
+++ b/core/services/tos/src/backend.rs
@@ -328,7 +328,10 @@ impl Service for TosBackend {
 
                 Ok(RpStat::new(meta))
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("HeadObject")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {

--- a/core/services/tos/src/copier.rs
+++ b/core/services/tos/src/copier.rs
@@ -97,7 +97,10 @@ impl oio::MultipartCopy for TosCopier {
                 let headers = resp.headers();
                 tos_parse_into_metadata(&self.from, headers)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("HeadObject")),
+                resp,
+            )),
         }
     }
 
@@ -123,7 +126,10 @@ impl oio::MultipartCopy for TosCopier {
                 meta.set_etag(result.etag.trim_matches('"'));
                 Ok(meta)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CopyObject")),
+                resp,
+            )),
         }
     }
 
@@ -141,7 +147,10 @@ impl oio::MultipartCopy for TosCopier {
 
                 Ok(result.upload_id)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateMultipartUpload")),
+                resp,
+            )),
         }
     }
 
@@ -185,7 +194,10 @@ impl oio::MultipartCopy for TosCopier {
                     size: Some(size),
                 })
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadPartCopy")),
+                resp,
+            )),
         }
     }
 
@@ -226,7 +238,10 @@ impl oio::MultipartCopy for TosCopier {
 
                 Ok(meta)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CompleteMultipartUpload")),
+                resp,
+            )),
         }
     }
 
@@ -237,7 +252,10 @@ impl oio::MultipartCopy for TosCopier {
             .await?;
         match resp.status() {
             StatusCode::NO_CONTENT => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("AbortMultipartUpload")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/tos/src/core.rs
+++ b/core/services/tos/src/core.rs
@@ -1081,99 +1081,103 @@ pub struct CopyObjectOutput {
     pub etag: String,
 }
 
-mod error {
-    use bytes::Buf;
-    use http::{Response, StatusCode};
-    use quick_xml::de;
-    use serde::Deserialize;
+use bytes::Buf;
+use http::StatusCode;
+use quick_xml::de;
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+/// TosError is the error returned by TOS service.
+#[derive(Default, Debug, Deserialize, PartialEq, Eq)]
+#[serde(default, rename_all = "PascalCase")]
+pub(crate) struct TosError {
+    pub code: String,
+    pub message: String,
+    pub resource: String,
+    pub request_id: String,
+}
 
-    /// TosError is the error returned by TOS service.
-    #[derive(Default, Debug, Deserialize, PartialEq, Eq)]
-    #[serde(default, rename_all = "PascalCase")]
-    pub(crate) struct TosError {
-        pub code: String,
-        pub message: String,
-        pub resource: String,
-        pub request_id: String,
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
+}
 
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
 
-        let (mut kind, mut retryable) = match parts.status {
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::NOT_MODIFIED | StatusCode::PRECONDITION_FAILED => {
-                (ErrorKind::ConditionNotMatch, false)
-            }
-            StatusCode::CONFLICT => (ErrorKind::ConditionNotMatch, true),
-            StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
-            code if code.is_server_error() => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let (message, tos_err) = parse_tos_error(&bs)
-            .map(|tos_err| (format!("{tos_err:?}"), Some(tos_err)))
-            .unwrap_or_else(|| (String::from_utf8_lossy(&bs).into_owned(), None));
-
-        if let Some(tos_err) = tos_err {
-            (kind, retryable) =
-                parse_tos_error_code(tos_err.code.as_str()).unwrap_or((kind, retryable));
+    let (mut kind, mut retryable) = match parts.status {
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::NOT_MODIFIED | StatusCode::PRECONDITION_FAILED => {
+            (ErrorKind::ConditionNotMatch, false)
         }
+        StatusCode::CONFLICT => (ErrorKind::ConditionNotMatch, true),
+        StatusCode::TOO_MANY_REQUESTS => (ErrorKind::RateLimited, true),
+        code if code.is_server_error() => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
 
-        let mut err = Error::new(kind, message);
+    let (message, tos_err) = parse_tos_error(&bs)
+        .map(|tos_err| (format!("{tos_err:?}"), Some(tos_err)))
+        .unwrap_or_else(|| (String::from_utf8_lossy(&bs).into_owned(), None));
 
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
+    if let Some(tos_err) = tos_err {
+        (kind, retryable) =
+            parse_tos_error_code(tos_err.code.as_str()).unwrap_or((kind, retryable));
     }
 
-    fn parse_tos_error(bs: &bytes::Bytes) -> Option<TosError> {
-        de::from_reader::<_, TosError>(bs.chunk().reader())
-            .or_else(|_| serde_json::from_slice::<TosError>(bs))
-            .ok()
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
     }
 
-    /// Returns the `Error kind` of this code and whether the error is retryable.
-    /// TOS error codes: https://www.volcengine.com/docs/6349/74874
-    pub fn parse_tos_error_code(code: &str) -> Option<(ErrorKind, bool)> {
-        match code {
-            "NoSuchBucket" => Some((ErrorKind::ConfigInvalid, false)),
-            "NoSuchKey" => Some((ErrorKind::NotFound, false)),
-            "DuplicateObject" => Some((ErrorKind::ConditionNotMatch, false)),
-            "RequestTimeout" => Some((ErrorKind::Unexpected, true)),
-            "InternalError" => Some((ErrorKind::Unexpected, true)),
-            "OperationAborted" => Some((ErrorKind::Unexpected, true)),
-            "SlowDown" => Some((ErrorKind::RateLimited, true)),
-            "ServiceUnavailable" => Some((ErrorKind::Unexpected, true)),
-            "TooManyRequests" => Some((ErrorKind::RateLimited, true)),
-            "ExceedAccountQPSLimit" | "ExceedAccountRateLimit" => {
-                Some((ErrorKind::RateLimited, true))
-            }
-            "ExceedBucketQPSLimit" | "ExceedBucketRateLimit" => {
-                Some((ErrorKind::RateLimited, true))
-            }
-            _ => None,
-        }
+    err
+}
+
+fn parse_tos_error(bs: &bytes::Bytes) -> Option<TosError> {
+    de::from_reader::<_, TosError>(bs.chunk().reader())
+        .or_else(|_| serde_json::from_slice::<TosError>(bs))
+        .ok()
+}
+
+/// Returns the `Error kind` of this code and whether the error is retryable.
+/// TOS error codes: https://www.volcengine.com/docs/6349/74874
+pub fn parse_tos_error_code(code: &str) -> Option<(ErrorKind, bool)> {
+    match code {
+        "NoSuchBucket" => Some((ErrorKind::ConfigInvalid, false)),
+        "NoSuchKey" => Some((ErrorKind::NotFound, false)),
+        "DuplicateObject" => Some((ErrorKind::ConditionNotMatch, false)),
+        "RequestTimeout" => Some((ErrorKind::Unexpected, true)),
+        "InternalError" => Some((ErrorKind::Unexpected, true)),
+        "OperationAborted" => Some((ErrorKind::Unexpected, true)),
+        "SlowDown" => Some((ErrorKind::RateLimited, true)),
+        "ServiceUnavailable" => Some((ErrorKind::Unexpected, true)),
+        "TooManyRequests" => Some((ErrorKind::RateLimited, true)),
+        "ExceedAccountQPSLimit" | "ExceedAccountRateLimit" => Some((ErrorKind::RateLimited, true)),
+        "ExceedBucketQPSLimit" | "ExceedBucketRateLimit" => Some((ErrorKind::RateLimited, true)),
+        _ => None,
     }
+}
 
-    #[cfg(test)]
-    mod tests {
-        use super::*;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-        #[test]
-        fn test_parse_error() {
-            let bs = bytes::Bytes::from(
-                r#"
+    #[test]
+    fn test_parse_error() {
+        let bs = bytes::Bytes::from(
+            r#"
 <?xml version="1.0" encoding="UTF-8"?>
 <Error>
   <Code>NoSuchKey</Code>
@@ -1182,34 +1186,34 @@ mod error {
   <RequestId>4442587FB7D0A2F9</RequestId>
 </Error>
 "#,
-            );
+        );
 
-            let out: TosError = de::from_reader(bs.reader()).expect("must success");
-            println!("{out:?}");
+        let out: TosError = de::from_reader(bs.reader()).expect("must success");
+        println!("{out:?}");
 
-            assert_eq!(out.code, "NoSuchKey");
-            assert_eq!(out.message, "The resource you requested does not exist");
-            assert_eq!(out.resource, "/mybucket/myfoto.jpg");
-            assert_eq!(out.request_id, "4442587FB7D0A2F9");
-        }
+        assert_eq!(out.code, "NoSuchKey");
+        assert_eq!(out.message, "The resource you requested does not exist");
+        assert_eq!(out.resource, "/mybucket/myfoto.jpg");
+        assert_eq!(out.request_id, "4442587FB7D0A2F9");
+    }
 
-        #[test]
-        fn test_parse_json_error() {
-            let bs = bytes::Bytes::from(
-                r#"{"Code":"DuplicateObject","RequestId":"request-id","Message":"The object already exists."}"#,
-            );
+    #[test]
+    fn test_parse_json_error() {
+        let bs = bytes::Bytes::from(
+            r#"{"Code":"DuplicateObject","RequestId":"request-id","Message":"The object already exists."}"#,
+        );
 
-            let out = parse_tos_error(&bs).expect("must success");
+        let out = parse_tos_error(&bs).expect("must success");
 
-            assert_eq!(out.code, "DuplicateObject");
-            assert_eq!(out.message, "The object already exists.");
-            assert_eq!(out.request_id, "request-id");
-        }
+        assert_eq!(out.code, "DuplicateObject");
+        assert_eq!(out.message, "The object already exists.");
+        assert_eq!(out.request_id, "request-id");
+    }
 
-        #[test]
-        fn test_parse_error_from_unrelated_input() {
-            let bs = bytes::Bytes::from(
-                r#"
+    #[test]
+    fn test_parse_error_from_unrelated_input() {
+        let bs = bytes::Bytes::from(
+            r#"
 <?xml version="1.0" encoding="UTF-8"?>
 <CompleteMultipartUploadResult xmlns="http://tos.apache.org/doc/2024-01-01/">
   <Bucket>example-bucket</Bucket>
@@ -1217,15 +1221,12 @@ mod error {
   <UploadId>VXBsb2FkIElEIGZvciA2aWWpbmcncyBteS1tb3ZpZS5tMnRzIHVwbG9hZA</UploadId>
 </CompleteMultipartUploadResult>
 "#,
-            );
+        );
 
-            let out: TosError = de::from_reader(bs.reader()).expect("must success");
-            assert_eq!(out, TosError::default());
-        }
+        let out: TosError = de::from_reader(bs.reader()).expect("must success");
+        assert_eq!(out, TosError::default());
     }
 }
-
-pub(super) use error::*;
 
 mod utils {
     use http::HeaderMap;

--- a/core/services/tos/src/deleter.rs
+++ b/core/services/tos/src/deleter.rs
@@ -50,7 +50,10 @@ impl oio::BatchDelete for TosDeleter {
         match status {
             StatusCode::NO_CONTENT => Ok(()),
             StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(crate::core::parse_error(resp)),
+            _ => Err(crate::core::parse_error(
+                crate::core::ErrorContext::new(ServiceOperation("DeleteObject")),
+                resp,
+            )),
         }
     }
 
@@ -59,7 +62,10 @@ impl oio::BatchDelete for TosDeleter {
 
         let status = resp.status();
         if status != StatusCode::OK {
-            return Err(crate::core::parse_error(resp));
+            return Err(crate::core::parse_error(
+                crate::core::ErrorContext::new(ServiceOperation("DeleteMultipleObjects")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();

--- a/core/services/tos/src/lister.rs
+++ b/core/services/tos/src/lister.rs
@@ -77,7 +77,10 @@ impl oio::PageList for TosLister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListObjectsV2")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();
@@ -172,7 +175,10 @@ impl oio::PageList for TosObjectVersionsLister {
             .await?;
 
         if resp.status() != http::StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListObjectVersions")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();

--- a/core/services/tos/src/reader.rs
+++ b/core/services/tos/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use crate::core::parse_error;
+use crate::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::BytesRange;
@@ -67,7 +67,10 @@ impl oio::StreamRead for TosReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetObject")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/tos/src/writer.rs
+++ b/core/services/tos/src/writer.rs
@@ -77,7 +77,10 @@ impl oio::MultipartWrite for TosWriter {
 
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(meta),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("PutObject")),
+                resp,
+            )),
         }
     }
 
@@ -97,7 +100,10 @@ impl oio::MultipartWrite for TosWriter {
 
                 Ok(result.upload_id)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateMultipartUpload")),
+                resp,
+            )),
         }
     }
 
@@ -135,7 +141,10 @@ impl oio::MultipartWrite for TosWriter {
                     size: None,
                 })
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadPart")),
+                resp,
+            )),
         }
     }
 
@@ -179,7 +188,10 @@ impl oio::MultipartWrite for TosWriter {
 
                 Ok(meta)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CompleteMultipartUpload")),
+                resp,
+            )),
         }
     }
 
@@ -191,7 +203,10 @@ impl oio::MultipartWrite for TosWriter {
 
         match resp.status() {
             StatusCode::NO_CONTENT => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("AbortMultipartUpload")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/upyun/src/backend.rs
+++ b/core/services/upyun/src/backend.rs
@@ -210,7 +210,10 @@ impl Service for UpyunBackend {
 
         match status {
             StatusCode::OK => Ok(RpCreateDir::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateFolder")),
+                resp,
+            )),
         }
     }
 
@@ -221,7 +224,10 @@ impl Service for UpyunBackend {
 
         match status {
             StatusCode::OK => parse_info(resp.headers()).map(RpStat::new),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetFileInfo")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
@@ -289,7 +295,10 @@ impl Service for UpyunBackend {
 
             match status {
                 StatusCode::OK => Ok(Metadata::default()),
-                _ => Err(parse_error(resp)),
+                _ => Err(parse_error(
+                    ErrorContext::new(ServiceOperation("CopyFile")),
+                    resp,
+                )),
             }
         }))
     }
@@ -307,7 +316,10 @@ impl Service for UpyunBackend {
 
         match status {
             StatusCode::OK => Ok(RpRename::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("MoveFile")),
+                resp,
+            )),
         }
     }
 

--- a/core/services/upyun/src/core.rs
+++ b/core/services/upyun/src/core.rs
@@ -580,93 +580,93 @@ pub(super) struct ListObjectsResponse {
     pub files: Vec<File>,
 }
 
-mod error {
-    use bytes::Buf;
-    use http::Response;
-    use opendal_core::raw::*;
-    use opendal_core::*;
-    use quick_xml::de;
-    use serde::Deserialize;
+use bytes::Buf;
+use quick_xml::de;
 
-    /// UpyunError is the error returned by upyun service.
-    #[derive(Default, Debug, Deserialize)]
-    #[serde(default, rename_all = "PascalCase")]
-    struct UpyunError {
-        code: i64,
-        msg: String,
-        id: String,
-    }
+/// UpyunError is the error returned by upyun service.
+#[derive(Default, Debug, Deserialize)]
+#[serde(default, rename_all = "PascalCase")]
+struct UpyunError {
+    code: i64,
+    msg: String,
+    id: String,
+}
 
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-        let (kind, retryable) = match parts.status.as_u16() {
-            403 => (ErrorKind::PermissionDenied, false),
-            404 => (ErrorKind::NotFound, false),
-            304 | 412 => (ErrorKind::ConditionNotMatch, false),
-            // Service like Upyun could return 499 error with a message like:
-            // Client Disconnect, we should retry it.
-            499 => (ErrorKind::Unexpected, true),
-            500 | 502 | 503 | 504 => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let (message, _upyun_err) = de::from_reader::<_, UpyunError>(bs.clone().reader())
-            .map(|upyun_err| (format!("{upyun_err:?}"), Some(upyun_err)))
-            .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    #[cfg(test)]
-    mod test {
-        use http::StatusCode;
-
-        use super::*;
-
-        #[tokio::test]
-        async fn test_parse_error() {
-            let err_res = vec![
-                (
-                    r#"{"code": 40100016, "msg": "invalid date value in header", "id": "f5b30c720ddcecc70abd2f5c1c64bde8"}"#,
-                    ErrorKind::Unexpected,
-                    StatusCode::UNAUTHORIZED,
-                ),
-                (
-                    r#"{"code": 40300010, "msg": "file type error", "id": "f5b30c720ddcecc70abd2f5c1c64bde7"}"#,
-                    ErrorKind::PermissionDenied,
-                    StatusCode::FORBIDDEN,
-                ),
-            ];
-
-            for res in err_res {
-                let bs = bytes::Bytes::from(res.0);
-                let body = Buffer::from(bs);
-                let resp = Response::builder().status(res.2).body(body).unwrap();
-
-                let err = parse_error(resp);
-
-                assert_eq!(err.kind(), res.1);
-            }
-        }
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status.as_u16() {
+        403 => (ErrorKind::PermissionDenied, false),
+        404 => (ErrorKind::NotFound, false),
+        304 | 412 => (ErrorKind::ConditionNotMatch, false),
+        // Service like Upyun could return 499 error with a message like:
+        // Client Disconnect, we should retry it.
+        499 => (ErrorKind::Unexpected, true),
+        500 | 502 | 503 | 504 => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let (message, _upyun_err) = de::from_reader::<_, UpyunError>(bs.clone().reader())
+        .map(|upyun_err| (format!("{upyun_err:?}"), Some(upyun_err)))
+        .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}
 
 #[cfg(test)]
 mod tests {
+    use http::StatusCode;
+
     use super::*;
+
+    #[tokio::test]
+    async fn test_parse_error() {
+        let err_res = vec![
+            (
+                r#"{"code": 40100016, "msg": "invalid date value in header", "id": "f5b30c720ddcecc70abd2f5c1c64bde8"}"#,
+                ErrorKind::Unexpected,
+                StatusCode::UNAUTHORIZED,
+            ),
+            (
+                r#"{"code": 40300010, "msg": "file type error", "id": "f5b30c720ddcecc70abd2f5c1c64bde7"}"#,
+                ErrorKind::PermissionDenied,
+                StatusCode::FORBIDDEN,
+            ),
+        ];
+
+        for res in err_res {
+            let bs = bytes::Bytes::from(res.0);
+            let body = Buffer::from(bs);
+            let resp = Response::builder().status(res.2).body(body).unwrap();
+
+            let err = parse_error(ErrorContext::new(ServiceOperation("Test")), resp);
+
+            assert_eq!(err.kind(), res.1);
+        }
+    }
 
     #[test]
     fn folder_path_handles_the_service_root() {

--- a/core/services/upyun/src/deleter.rs
+++ b/core/services/upyun/src/deleter.rs
@@ -45,7 +45,10 @@ impl oio::OneShotDelete for UpyunDeleter {
             StatusCode::OK => Ok(()),
             // Allow 404 when deleting a non-existing object
             StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("DeleteFile")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/upyun/src/lister.rs
+++ b/core/services/upyun/src/lister.rs
@@ -21,9 +21,7 @@ use bytes::Buf;
 use opendal_core::raw::*;
 use opendal_core::*;
 
-use super::core::ListObjectsResponse;
-use super::core::UpyunCore;
-use super::core::parse_error;
+use super::core::{ErrorContext, ListObjectsResponse, UpyunCore, parse_error};
 
 pub struct UpyunLister {
     core: Arc<UpyunCore>,
@@ -68,7 +66,10 @@ impl oio::PageList for UpyunLister {
                 return Ok(());
             }
             _ => {
-                return Err(parse_error(resp));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("ListObjects")),
+                    resp,
+                ));
             }
         }
 

--- a/core/services/upyun/src/reader.rs
+++ b/core/services/upyun/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -55,7 +55,10 @@ impl oio::StreamRead for UpyunReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("DownloadFile")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/upyun/src/writer.rs
+++ b/core/services/upyun/src/writer.rs
@@ -21,9 +21,9 @@ use http::StatusCode;
 use opendal_core::raw::*;
 use opendal_core::*;
 
-use super::core::UpyunCore;
 use super::core::constants::X_UPYUN_MULTI_UUID;
 use super::core::parse_error;
+use super::core::{ErrorContext, UpyunCore};
 
 pub type UpyunWriters = oio::MultipartWriter<UpyunWriter>;
 
@@ -55,7 +55,10 @@ impl oio::MultipartWrite for UpyunWriter {
 
         match status {
             StatusCode::OK => Ok(Metadata::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadFile")),
+                resp,
+            )),
         }
     }
 
@@ -77,7 +80,10 @@ impl oio::MultipartWrite for UpyunWriter {
 
                 Ok(id.to_string())
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("InitiateMultipartUpload")),
+                resp,
+            )),
         }
     }
 
@@ -103,7 +109,10 @@ impl oio::MultipartWrite for UpyunWriter {
                 checksum: None,
                 size: None,
             }),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadPart")),
+                resp,
+            )),
         }
     }
 
@@ -121,7 +130,10 @@ impl oio::MultipartWrite for UpyunWriter {
 
         match status {
             StatusCode::NO_CONTENT => Ok(Metadata::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CompleteMultipartUpload")),
+                resp,
+            )),
         }
     }
 

--- a/core/services/vercel-artifacts/src/backend.rs
+++ b/core/services/vercel-artifacts/src/backend.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use http::StatusCode;
 
-use super::core::VercelArtifactsCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, VercelArtifactsCore};
 use super::reader::*;
 use super::writer::VercelArtifactsWriter;
 use opendal_core::raw::*;
@@ -183,7 +183,10 @@ impl Service for VercelArtifactsBackend {
                 Ok(RpStat::new(meta))
             }
 
-            _ => Err(parse_error(response)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("HeadArtifact")),
+                response,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {

--- a/core/services/vercel-artifacts/src/core.rs
+++ b/core/services/vercel-artifacts/src/core.rs
@@ -130,40 +130,45 @@ impl VercelArtifactsCore {
     }
 }
 
-mod error {
-    use http::Response;
-    use http::StatusCode;
+use http::StatusCode;
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(response: Response<Buffer>) -> Error {
-        let (parts, body) = response.into_parts();
-        let bs = body.to_bytes();
-
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let message = String::from_utf8_lossy(&bs);
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, response: Response<Buffer>) -> Error {
+    let (parts, body) = response.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let message = String::from_utf8_lossy(&bs);
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}

--- a/core/services/vercel-artifacts/src/reader.rs
+++ b/core/services/vercel-artifacts/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -66,7 +66,10 @@ impl oio::StreamRead for VercelArtifactsReader {
             _ => {
                 let (part, mut body) = response.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetArtifact")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/vercel-artifacts/src/writer.rs
+++ b/core/services/vercel-artifacts/src/writer.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use http::StatusCode;
 
-use super::core::VercelArtifactsCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, VercelArtifactsCore};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -59,7 +59,10 @@ impl oio::OneShotWrite for VercelArtifactsWriter {
 
         match status {
             StatusCode::OK | StatusCode::ACCEPTED => Ok(Metadata::default()),
-            _ => Err(parse_error(response)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("PutArtifact")),
+                response,
+            )),
         }
     }
 }

--- a/core/services/vercel-blob/src/backend.rs
+++ b/core/services/vercel-blob/src/backend.rs
@@ -25,9 +25,9 @@ use log::debug;
 use super::VERCEL_BLOB_SCHEME;
 use super::config::VercelBlobConfig;
 use super::core::Blob;
-use super::core::VercelBlobCore;
 use super::core::parse_blob;
 use super::core::parse_error;
+use super::core::{ErrorContext, VercelBlobCore};
 use super::deleter::VercelBlobDeleter;
 use super::lister::VercelBlobLister;
 use super::reader::*;
@@ -173,7 +173,10 @@ impl Service for VercelBlobBackend {
 
                 parse_blob(&resp).map(RpStat::new)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("HeadBlob")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {
@@ -222,7 +225,10 @@ impl Service for VercelBlobBackend {
 
             match status {
                 StatusCode::OK => Ok(Metadata::default()),
-                _ => Err(parse_error(resp)),
+                _ => Err(parse_error(
+                    ErrorContext::new(ServiceOperation("CopyBlob")),
+                    resp,
+                )),
             }
         }))
     }

--- a/core/services/vercel-blob/src/core.rs
+++ b/core/services/vercel-blob/src/core.rs
@@ -262,7 +262,10 @@ impl VercelBlobCore {
         let status = resp.status();
 
         if status != StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("ListBlobs")),
+                resp,
+            ));
         }
 
         let body = resp.into_body();
@@ -306,7 +309,10 @@ impl VercelBlobCore {
 
         match status {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("DeleteBlob")),
+                resp,
+            )),
         }
     }
 
@@ -479,101 +485,103 @@ pub struct UploadPartResponse {
     pub etag: String,
 }
 
-mod error {
-    use bytes::Buf;
-    use http::Response;
-    use quick_xml::de;
-    use serde::Deserialize;
+use quick_xml::de;
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+/// VercelBlobError is the error returned by VercelBlob service.
+#[derive(Default, Debug, Deserialize)]
+#[serde(default)]
+struct VercelBlobError {
+    error: VercelBlobErrorDetail,
+}
 
-    /// VercelBlobError is the error returned by VercelBlob service.
-    #[derive(Default, Debug, Deserialize)]
-    #[serde(default)]
-    struct VercelBlobError {
-        error: VercelBlobErrorDetail,
+#[derive(Default, Debug, Deserialize)]
+#[serde(default)]
+struct VercelBlobErrorDetail {
+    code: String,
+    message: Option<String>,
+}
+
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
+
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status.as_u16() {
+        403 => (ErrorKind::PermissionDenied, false),
+        404 => (ErrorKind::NotFound, false),
+        500 | 502 | 503 | 504 => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let (message, _vercel_blob_err) = de::from_reader::<_, VercelBlobError>(bs.clone().reader())
+        .map(|vercel_blob_err| (format!("{vercel_blob_err:?}"), Some(vercel_blob_err)))
+        .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
     }
 
-    #[derive(Default, Debug, Deserialize)]
-    #[serde(default)]
-    struct VercelBlobErrorDetail {
-        code: String,
-        message: Option<String>,
-    }
+    err
+}
 
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
+#[cfg(test)]
+mod tests {
+    use http::StatusCode;
 
-        let (kind, retryable) = match parts.status.as_u16() {
-            403 => (ErrorKind::PermissionDenied, false),
-            404 => (ErrorKind::NotFound, false),
-            500 | 502 | 503 | 504 => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
+    use super::*;
 
-        let (message, _vercel_blob_err) =
-            de::from_reader::<_, VercelBlobError>(bs.clone().reader())
-                .map(|vercel_blob_err| (format!("{vercel_blob_err:?}"), Some(vercel_blob_err)))
-                .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    #[cfg(test)]
-    mod test {
-        use http::StatusCode;
-
-        use super::*;
-
-        #[tokio::test]
-        async fn test_parse_error() {
-            let err_res = vec![(
-                r#"{
+    #[tokio::test]
+    async fn test_parse_error() {
+        let err_res = vec![(
+            r#"{
                     "error": {
                         "code": "forbidden",
                         "message": "Invalid token"
                     }
                 }"#,
-                ErrorKind::PermissionDenied,
-                StatusCode::FORBIDDEN,
-            )];
+            ErrorKind::PermissionDenied,
+            StatusCode::FORBIDDEN,
+        )];
 
-            for res in err_res {
-                let body = Buffer::from(res.0.as_bytes().to_vec());
-                let resp = Response::builder().status(res.2).body(body).unwrap();
+        for res in err_res {
+            let body = Buffer::from(res.0.as_bytes().to_vec());
+            let resp = Response::builder().status(res.2).body(body).unwrap();
 
-                let err = parse_error(resp);
+            let err = parse_error(ErrorContext::new(ServiceOperation("Test")), resp);
 
-                assert_eq!(err.kind(), res.1);
-            }
+            assert_eq!(err.kind(), res.1);
+        }
 
-            let bs = bytes::Bytes::from(
-                r#"{
+        let bs = bytes::Bytes::from(
+            r#"{
                 "error": {
                     "code": "forbidden",
                     "message": "Invalid token"
                 }
             }"#,
-            );
+        );
 
-            let out: VercelBlobError = serde_json::from_reader(bs.reader()).expect("must success");
-            println!("{out:?}");
+        let out: VercelBlobError = serde_json::from_reader(bs.reader()).expect("must success");
+        println!("{out:?}");
 
-            assert_eq!(out.error.code, "forbidden");
-            assert_eq!(out.error.message, Some("Invalid token".to_string()));
-        }
+        assert_eq!(out.error.code, "forbidden");
+        assert_eq!(out.error.message, Some("Invalid token".to_string()));
     }
 }
-
-pub(super) use error::*;

--- a/core/services/vercel-blob/src/reader.rs
+++ b/core/services/vercel-blob/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -63,7 +63,10 @@ impl oio::StreamRead for VercelBlobReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("DownloadBlob")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/vercel-blob/src/writer.rs
+++ b/core/services/vercel-blob/src/writer.rs
@@ -23,8 +23,8 @@ use http::StatusCode;
 use super::core::InitiateMultipartUploadResponse;
 use super::core::Part;
 use super::core::UploadPartResponse;
-use super::core::VercelBlobCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, VercelBlobCore};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -64,7 +64,10 @@ impl oio::MultipartWrite for VercelBlobWriter {
 
         match status {
             StatusCode::OK => Ok(Metadata::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("PutBlob")),
+                resp,
+            )),
         }
     }
 
@@ -85,7 +88,10 @@ impl oio::MultipartWrite for VercelBlobWriter {
 
                 Ok(resp.upload_id)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CreateMultipartUpload")),
+                resp,
+            )),
         }
     }
 
@@ -119,7 +125,10 @@ impl oio::MultipartWrite for VercelBlobWriter {
                     size: None,
                 })
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("UploadPart")),
+                resp,
+            )),
         }
     }
 
@@ -145,7 +154,10 @@ impl oio::MultipartWrite for VercelBlobWriter {
 
         match status {
             StatusCode::OK => Ok(Metadata::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("CompleteMultipartUpload")),
+                resp,
+            )),
         }
     }
 

--- a/core/services/webdav/src/backend.rs
+++ b/core/services/webdav/src/backend.rs
@@ -371,7 +371,10 @@ impl Service for WebdavBackend {
 
                 match status {
                     StatusCode::CREATED | StatusCode::NO_CONTENT => Ok(Metadata::default()),
-                    _ => Err(parse_error(resp)),
+                    _ => Err(parse_error(
+                        ErrorContext::new(ServiceOperation("Copy")),
+                        resp,
+                    )),
                 }
             }
         }))
@@ -391,7 +394,10 @@ impl Service for WebdavBackend {
             StatusCode::CREATED | StatusCode::NO_CONTENT | StatusCode::OK => {
                 Ok(RpRename::default())
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Move")),
+                resp,
+            )),
         }
     }
 

--- a/core/services/webdav/src/core.rs
+++ b/core/services/webdav/src/core.rs
@@ -140,7 +140,10 @@ impl WebdavCore {
 
         let resp = ctx.http_transport().send(req).await?;
         if !resp.status().is_success() {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("Propfind")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();
@@ -495,7 +498,10 @@ impl WebdavCore {
 
                 Ok(())
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Mkcol")),
+                resp,
+            )),
         }
     }
 }
@@ -1624,50 +1630,53 @@ mod tests {
     }
 }
 
-mod error {
-    use http::Response;
-    use http::StatusCode;
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
-
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            // Some services (like owncloud) return 403 while file locked.
-            StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, true),
-            // RFC 7232: 412 means an If-Match / If-Unmodified-Since
-            // precondition failed; 304 means an If-None-Match /
-            // If-Modified-Since precondition matched. Surface both as
-            // ConditionNotMatch so callers can branch on it.
-            StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED => {
-                (ErrorKind::ConditionNotMatch, false)
-            }
-            // Allowing retry for resource locked.
-            StatusCode::LOCKED => (ErrorKind::Unexpected, true),
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
-
-        let message = String::from_utf8_lossy(&bs);
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
     }
 }
 
-pub(super) use error::*;
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        // Some services (like owncloud) return 403 while file locked.
+        StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, true),
+        // RFC 7232: 412 means an If-Match / If-Unmodified-Since
+        // precondition failed; 304 means an If-None-Match /
+        // If-Modified-Since precondition matched. Surface both as
+        // ConditionNotMatch so callers can branch on it.
+        StatusCode::PRECONDITION_FAILED | StatusCode::NOT_MODIFIED => {
+            (ErrorKind::ConditionNotMatch, false)
+        }
+        // Allowing retry for resource locked.
+        StatusCode::LOCKED => (ErrorKind::Unexpected, true),
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let message = String::from_utf8_lossy(&bs);
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
+    }
+
+    err
+}

--- a/core/services/webdav/src/deleter.rs
+++ b/core/services/webdav/src/deleter.rs
@@ -43,7 +43,10 @@ impl oio::OneShotDelete for WebdavDeleter {
         let status = resp.status();
         match status {
             StatusCode::NO_CONTENT | StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Delete")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/webdav/src/lister.rs
+++ b/core/services/webdav/src/lister.rs
@@ -66,7 +66,10 @@ impl oio::PageList for WebdavLister {
             ctx.done = true;
             return Ok(());
         } else {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("Propfind")),
+                resp,
+            ));
         };
 
         let result: Multistatus = deserialize_multistatus(&bs.to_bytes())?;

--- a/core/services/webdav/src/reader.rs
+++ b/core/services/webdav/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::oio;
@@ -67,7 +67,10 @@ impl oio::StreamRead for WebdavReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("Get")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/webdav/src/writer.rs
+++ b/core/services/webdav/src/writer.rs
@@ -92,13 +92,19 @@ impl oio::OneShotWrite for WebdavWriter {
                         let xml = String::from_utf8_lossy(&body);
                         check_proppatch_response(&xml)?;
                     } else if !proppatch_status.is_success() {
-                        return Err(parse_error(proppatch_resp));
+                        return Err(parse_error(
+                            ErrorContext::new(ServiceOperation("Proppatch")),
+                            proppatch_resp,
+                        ));
                     }
                 }
 
                 Ok(metadata)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Put")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/webhdfs/src/backend.rs
+++ b/core/services/webhdfs/src/backend.rs
@@ -25,8 +25,8 @@ use log::debug;
 
 use super::WEBHDFS_SCHEME;
 use super::config::WebhdfsConfig;
-use super::core::WebhdfsCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, WebhdfsCore};
 use super::deleter::WebhdfsDeleter;
 use super::lister::WebhdfsLister;
 use super::message::BooleanResp;
@@ -229,7 +229,12 @@ impl WebhdfsBackend {
             StatusCode::NOT_FOUND => {
                 self.create_dir(ctx, "/", OpCreateDir::new()).await?;
             }
-            _ => return Err(parse_error(resp)),
+            _ => {
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("GetFileStatus")),
+                    resp,
+                ));
+            }
         }
         Ok(())
     }
@@ -280,7 +285,10 @@ impl Service for WebhdfsBackend {
                     ))
                 }
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Mkdirs")),
+                resp,
+            )),
         }
     }
 
@@ -313,7 +321,10 @@ impl Service for WebhdfsBackend {
                 Ok(RpStat::new(meta))
             }
 
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetFileStatus")),
+                resp,
+            )),
         }
     }
     fn read(&self, ctx: &OperationContext, path: &str, args: OpRead) -> Result<Self::Reader> {

--- a/core/services/webhdfs/src/core.rs
+++ b/core/services/webhdfs/src/core.rs
@@ -118,7 +118,10 @@ impl WebhdfsCore {
         let status = resp.status();
 
         if status != StatusCode::CREATED && status != StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("Create")),
+                resp,
+            ));
         }
 
         let bs = resp.into_body();
@@ -205,7 +208,10 @@ impl WebhdfsCore {
 
                 Ok(resp.location)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Append")),
+                resp,
+            )),
         }
     }
 
@@ -430,82 +436,80 @@ pub(super) struct LocationResponse {
     pub location: String,
 }
 
-mod error {
-    use http::Response;
-    use http::StatusCode;
-    use http::response::Parts;
-    use serde::Deserialize;
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct WebHdfsErrorWrapper {
+    pub remote_exception: WebHdfsError,
+}
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+/// WebHdfsError is the error message returned by WebHdfs service
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct WebHdfsError {
+    exception: String,
+    message: String,
+    java_class_name: String,
+}
 
-    #[derive(Debug, Deserialize)]
-    #[serde(rename_all = "PascalCase")]
-    struct WebHdfsErrorWrapper {
-        pub remote_exception: WebHdfsError,
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
+
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+    let (kind, retryable) = match parts.status {
+        StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => (ErrorKind::PermissionDenied, false),
+        // passing invalid arguments will return BAD_REQUEST
+        // should be un-retryable
+        StatusCode::BAD_REQUEST => (ErrorKind::Unexpected, false),
+        StatusCode::INTERNAL_SERVER_ERROR
+        | StatusCode::BAD_GATEWAY
+        | StatusCode::SERVICE_UNAVAILABLE
+        | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let message = match serde_json::from_slice::<WebHdfsErrorWrapper>(&bs) {
+        Ok(wh_error) => format!("{:?}", wh_error.remote_exception),
+        Err(_) => String::from_utf8_lossy(&bs).into_owned(),
+    };
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
     }
 
-    /// WebHdfsError is the error message returned by WebHdfs service
-    #[derive(Debug, Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    #[allow(dead_code)]
-    struct WebHdfsError {
-        exception: String,
-        message: String,
-        java_class_name: String,
-    }
+    err
+}
 
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
-        let s = String::from_utf8_lossy(&bs);
-        parse_error_msg(parts, &s)
-    }
+#[cfg(test)]
+mod tests {
+    use bytes::Buf;
+    use serde_json::from_reader;
 
-    pub(crate) fn parse_error_msg(parts: Parts, body: &str) -> Error {
-        let (kind, retryable) = match parts.status {
-            StatusCode::NOT_FOUND => (ErrorKind::NotFound, false),
-            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
-                (ErrorKind::PermissionDenied, false)
-            }
-            // passing invalid arguments will return BAD_REQUEST
-            // should be un-retryable
-            StatusCode::BAD_REQUEST => (ErrorKind::Unexpected, false),
-            StatusCode::INTERNAL_SERVER_ERROR
-            | StatusCode::BAD_GATEWAY
-            | StatusCode::SERVICE_UNAVAILABLE
-            | StatusCode::GATEWAY_TIMEOUT => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
+    use super::*;
 
-        let message = match serde_json::from_str::<WebHdfsErrorWrapper>(body) {
-            Ok(wh_error) => format!("{:?}", wh_error.remote_exception),
-            Err(_) => body.to_owned(),
-        };
-
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use bytes::Buf;
-        use serde_json::from_reader;
-
-        use super::*;
-
-        /// Error response example from https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Error%20Responses
-        #[tokio::test]
-        async fn test_parse_error() -> Result<()> {
-            let ill_args = bytes::Bytes::from(
-                r#"
+    /// Error response example from https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Error%20Responses
+    #[tokio::test]
+    async fn test_parse_error() -> Result<()> {
+        let ill_args = bytes::Bytes::from(
+            r#"
 {
   "RemoteException":
   {
@@ -515,33 +519,30 @@ mod error {
   }
 }
     "#,
-            );
-            let body = Buffer::from(ill_args.clone());
-            let resp = Response::builder()
-                .status(StatusCode::BAD_REQUEST)
-                .body(body)
-                .unwrap();
+        );
+        let body = Buffer::from(ill_args.clone());
+        let resp = Response::builder()
+            .status(StatusCode::BAD_REQUEST)
+            .body(body)
+            .unwrap();
 
-            let err = parse_error(resp);
-            assert_eq!(err.kind(), ErrorKind::Unexpected);
-            assert!(!err.is_temporary());
+        let err = parse_error(ErrorContext::new(ServiceOperation("Test")), resp);
+        assert_eq!(err.kind(), ErrorKind::Unexpected);
+        assert!(!err.is_temporary());
 
-            let err_msg: WebHdfsError = from_reader::<_, WebHdfsErrorWrapper>(ill_args.reader())
-                .expect("must success")
-                .remote_exception;
-            assert_eq!(err_msg.exception, "IllegalArgumentException");
-            assert_eq!(
-                err_msg.java_class_name,
-                "java.lang.IllegalArgumentException"
-            );
-            assert_eq!(
-                err_msg.message,
-                "Invalid value for webhdfs parameter \"permission\": ..."
-            );
+        let err_msg: WebHdfsError = from_reader::<_, WebHdfsErrorWrapper>(ill_args.reader())
+            .expect("must success")
+            .remote_exception;
+        assert_eq!(err_msg.exception, "IllegalArgumentException");
+        assert_eq!(
+            err_msg.java_class_name,
+            "java.lang.IllegalArgumentException"
+        );
+        assert_eq!(
+            err_msg.message,
+            "Invalid value for webhdfs parameter \"permission\": ..."
+        );
 
-            Ok(())
-        }
+        Ok(())
     }
 }
-
-pub(super) use error::*;

--- a/core/services/webhdfs/src/deleter.rs
+++ b/core/services/webhdfs/src/deleter.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use http::StatusCode;
 
-use super::core::WebhdfsCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, WebhdfsCore};
 use opendal_core::raw::oio;
 use opendal_core::raw::*;
 use opendal_core::*;
@@ -42,7 +42,10 @@ impl oio::OneShotDelete for WebhdfsDeleter {
 
         match resp.status() {
             StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Delete")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/webhdfs/src/lister.rs
+++ b/core/services/webhdfs/src/lister.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 use bytes::Buf;
 use http::StatusCode;
 
-use super::core::WebhdfsCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, WebhdfsCore};
 use super::message::*;
 use opendal_core::raw::oio;
 use opendal_core::raw::*;
@@ -65,7 +65,12 @@ impl oio::PageList for WebhdfsLister {
                     ctx.done = true;
                     return Ok(());
                 }
-                _ => return Err(parse_error(resp)),
+                _ => {
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("ListStatus")),
+                        resp,
+                    ));
+                }
             }
         } else {
             let resp = self
@@ -98,7 +103,12 @@ impl oio::PageList for WebhdfsLister {
                     ctx.done = true;
                     return Ok(());
                 }
-                _ => return Err(parse_error(resp)),
+                _ => {
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("ListStatusBatch")),
+                        resp,
+                    ));
+                }
             }
         };
 

--- a/core/services/webhdfs/src/reader.rs
+++ b/core/services/webhdfs/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::oio;
@@ -60,7 +60,10 @@ impl oio::StreamRead for WebhdfsReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("Open")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/webhdfs/src/writer.rs
+++ b/core/services/webhdfs/src/writer.rs
@@ -21,8 +21,8 @@ use bytes::Buf;
 use http::StatusCode;
 use uuid::Uuid;
 
-use super::core::WebhdfsCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, WebhdfsCore};
 use crate::message::FileStatusWrapper;
 use opendal_core::raw::oio;
 use opendal_core::raw::*;
@@ -60,7 +60,10 @@ impl oio::BlockWrite for WebhdfsWriter {
         let status = resp.status();
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(Metadata::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Create")),
+                resp,
+            )),
         }
     }
 
@@ -85,7 +88,10 @@ impl oio::BlockWrite for WebhdfsWriter {
         let status = resp.status();
         match status {
             StatusCode::CREATED | StatusCode::OK => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Create")),
+                resp,
+            )),
         }
     }
 
@@ -110,7 +116,10 @@ impl oio::BlockWrite for WebhdfsWriter {
 
             let status = resp.status();
             if status != StatusCode::OK {
-                return Err(parse_error(resp));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("Concat")),
+                    resp,
+                ));
             }
         }
         // delete the path file
@@ -118,7 +127,10 @@ impl oio::BlockWrite for WebhdfsWriter {
 
         let status = resp.status();
         if status != StatusCode::OK {
-            return Err(parse_error(resp));
+            return Err(parse_error(
+                ErrorContext::new(ServiceOperation("Delete")),
+                resp,
+            ));
         }
 
         // rename concat file to path
@@ -130,7 +142,10 @@ impl oio::BlockWrite for WebhdfsWriter {
         let status = resp.status();
         match status {
             StatusCode::OK => Ok(Metadata::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Rename")),
+                resp,
+            )),
         }
     }
 
@@ -148,7 +163,12 @@ impl oio::BlockWrite for WebhdfsWriter {
                 .await?;
             match resp.status() {
                 StatusCode::OK => {}
-                _ => return Err(parse_error(resp)),
+                _ => {
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("Delete")),
+                        resp,
+                    ));
+                }
             }
         }
         Ok(())
@@ -181,10 +201,16 @@ impl oio::AppendWrite for WebhdfsWriter {
                 let status = resp.status();
                 match status {
                     StatusCode::CREATED | StatusCode::OK => Ok(0),
-                    _ => Err(parse_error(resp)),
+                    _ => Err(parse_error(
+                        ErrorContext::new(ServiceOperation("Create")),
+                        resp,
+                    )),
                 }
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetFileStatus")),
+                resp,
+            )),
         }
     }
 
@@ -197,7 +223,10 @@ impl oio::AppendWrite for WebhdfsWriter {
         let status = resp.status();
         match status {
             StatusCode::OK => Ok(Metadata::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Append")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/yandex-disk/src/backend.rs
+++ b/core/services/yandex-disk/src/backend.rs
@@ -172,7 +172,10 @@ impl Service for YandexDiskBackend {
 
         match status {
             StatusCode::OK | StatusCode::CREATED => Ok(RpRename::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("MoveResource")),
+                resp,
+            )),
         }
     }
 
@@ -198,7 +201,10 @@ impl Service for YandexDiskBackend {
 
             match status {
                 StatusCode::OK | StatusCode::CREATED => Ok(Metadata::default()),
-                _ => Err(parse_error(resp)),
+                _ => Err(parse_error(
+                    ErrorContext::new(ServiceOperation("CopyResource")),
+                    resp,
+                )),
             }
         }))
     }
@@ -229,7 +235,10 @@ impl Service for YandexDiskBackend {
 
                 parse_info(mf).map(RpStat::new)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetMetainformation")),
+                resp,
+            )),
         }
     }
 

--- a/core/services/yandex-disk/src/core.rs
+++ b/core/services/yandex-disk/src/core.rs
@@ -99,7 +99,10 @@ impl YandexDiskCore {
 
                 Ok(resp.href)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetUploadUrl")),
+                resp,
+            )),
         }
     }
 
@@ -151,7 +154,10 @@ impl YandexDiskCore {
 
                 Ok(resp.href)
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetDownloadUrl")),
+                resp,
+            )),
         }
     }
 
@@ -185,7 +191,12 @@ impl YandexDiskCore {
 
             match status {
                 StatusCode::CREATED | StatusCode::CONFLICT => {}
-                _ => return Err(parse_error(resp)),
+                _ => {
+                    return Err(parse_error(
+                        ErrorContext::new(ServiceOperation("CreateResource")),
+                        resp,
+                    ));
+                }
             }
         }
         Ok(())
@@ -378,95 +389,97 @@ pub struct Embedded {
     pub items: Vec<MetainformationResponse>,
 }
 
-mod error {
-    use bytes::Buf;
-    use http::Response;
-    use quick_xml::de;
-    use serde::Deserialize;
+use quick_xml::de;
 
-    use opendal_core::raw::*;
-    use opendal_core::*;
+/// YandexDiskError is the error returned by YandexDisk service.
+#[derive(Default, Debug, Deserialize)]
+#[allow(unused)]
+struct YandexDiskError {
+    message: String,
+    description: String,
+    error: String,
+}
 
-    /// YandexDiskError is the error returned by YandexDisk service.
-    #[derive(Default, Debug, Deserialize)]
-    #[allow(unused)]
-    struct YandexDiskError {
-        message: String,
-        description: String,
-        error: String,
+/// Context needed to classify an error from this service.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ErrorContext {
+    service_operation: ServiceOperation,
+}
+
+impl ErrorContext {
+    pub(crate) const fn new(service_operation: ServiceOperation) -> Self {
+        Self { service_operation }
+    }
+}
+
+/// Parse an error response using its service request context.
+pub(crate) fn parse_error(ctx: ErrorContext, resp: Response<Buffer>) -> Error {
+    let (parts, body) = resp.into_parts();
+    let bs = body.to_bytes();
+
+    let (kind, retryable) = match parts.status.as_u16() {
+        410 | 403 => (ErrorKind::PermissionDenied, false),
+        404 => (ErrorKind::NotFound, false),
+        // We should retry it when we get 423 error.
+        423 => (ErrorKind::RateLimited, true),
+        499 => (ErrorKind::Unexpected, true),
+        503 | 507 => (ErrorKind::Unexpected, true),
+        _ => (ErrorKind::Unexpected, false),
+    };
+
+    let (message, _yandex_disk_err) = de::from_reader::<_, YandexDiskError>(bs.clone().reader())
+        .map(|yandex_disk_err| (format!("{yandex_disk_err:?}"), Some(yandex_disk_err)))
+        .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
+
+    let mut err = Error::new(kind, message);
+
+    err = err.with_context("service_operation", ctx.service_operation.0);
+    err = with_error_response_context(err, parts);
+
+    if retryable {
+        err = err.set_temporary();
     }
 
-    /// Parse error response into Error.
-    pub(crate) fn parse_error(resp: Response<Buffer>) -> Error {
-        let (parts, body) = resp.into_parts();
-        let bs = body.to_bytes();
+    err
+}
 
-        let (kind, retryable) = match parts.status.as_u16() {
-            410 | 403 => (ErrorKind::PermissionDenied, false),
-            404 => (ErrorKind::NotFound, false),
-            // We should retry it when we get 423 error.
-            423 => (ErrorKind::RateLimited, true),
-            499 => (ErrorKind::Unexpected, true),
-            503 | 507 => (ErrorKind::Unexpected, true),
-            _ => (ErrorKind::Unexpected, false),
-        };
+#[cfg(test)]
+mod tests {
+    use http::StatusCode;
 
-        let (message, _yandex_disk_err) =
-            de::from_reader::<_, YandexDiskError>(bs.clone().reader())
-                .map(|yandex_disk_err| (format!("{yandex_disk_err:?}"), Some(yandex_disk_err)))
-                .unwrap_or_else(|_| (String::from_utf8_lossy(&bs).into_owned(), None));
+    use super::*;
 
-        let mut err = Error::new(kind, message);
-
-        err = with_error_response_context(err, parts);
-
-        if retryable {
-            err = err.set_temporary();
-        }
-
-        err
-    }
-
-    #[cfg(test)]
-    mod test {
-        use http::StatusCode;
-
-        use super::*;
-
-        #[tokio::test]
-        async fn test_parse_error() {
-            let err_res = vec![
-                (
-                    r#"{
+    #[tokio::test]
+    async fn test_parse_error() {
+        let err_res = vec![
+            (
+                r#"{
                     "message": "Не удалось найти запрошенный ресурс.",
                     "description": "Resource not found.",
                     "error": "DiskNotFoundError"
                 }"#,
-                    ErrorKind::NotFound,
-                    StatusCode::NOT_FOUND,
-                ),
-                (
-                    r#"{
+                ErrorKind::NotFound,
+                StatusCode::NOT_FOUND,
+            ),
+            (
+                r#"{
                     "message": "Не авторизован.",
                     "description": "Unauthorized",
                     "error": "UnauthorizedError"
                 }"#,
-                    ErrorKind::PermissionDenied,
-                    StatusCode::FORBIDDEN,
-                ),
-            ];
+                ErrorKind::PermissionDenied,
+                StatusCode::FORBIDDEN,
+            ),
+        ];
 
-            for res in err_res {
-                let bs = bytes::Bytes::from(res.0);
-                let body = Buffer::from(bs);
-                let resp = Response::builder().status(res.2).body(body).unwrap();
+        for res in err_res {
+            let bs = bytes::Bytes::from(res.0);
+            let body = Buffer::from(bs);
+            let resp = Response::builder().status(res.2).body(body).unwrap();
 
-                let err = parse_error(resp);
+            let err = parse_error(ErrorContext::new(ServiceOperation("Test")), resp);
 
-                assert_eq!(err.kind(), res.1);
-            }
+            assert_eq!(err.kind(), res.1);
         }
     }
 }
-
-pub(super) use error::*;

--- a/core/services/yandex-disk/src/deleter.rs
+++ b/core/services/yandex-disk/src/deleter.rs
@@ -49,7 +49,10 @@ impl oio::OneShotDelete for YandexDiskDeleter {
             StatusCode::ACCEPTED => Ok(()),
             // Allow 404 when deleting a non-existing object
             StatusCode::NOT_FOUND => Ok(()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("DeleteResource")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/yandex-disk/src/lister.rs
+++ b/core/services/yandex-disk/src/lister.rs
@@ -20,9 +20,9 @@ use std::sync::Arc;
 use bytes::Buf;
 
 use super::core::MetainformationResponse;
-use super::core::YandexDiskCore;
 use super::core::parse_error;
 use super::core::parse_info;
+use super::core::{ErrorContext, YandexDiskCore};
 use opendal_core::OperationContext;
 use opendal_core::Result;
 use opendal_core::raw::oio::Entry;
@@ -128,7 +128,10 @@ impl oio::PageList for YandexDiskLister {
                 ctx.done = true;
                 Ok(())
             }
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("GetMetainformation")),
+                resp,
+            )),
         }
     }
 }

--- a/core/services/yandex-disk/src/reader.rs
+++ b/core/services/yandex-disk/src/reader.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use super::backend::*;
-use super::core::parse_error;
+use super::core::{ErrorContext, parse_error};
 use http::Response;
 use http::StatusCode;
 use opendal_core::raw::*;
@@ -59,7 +59,10 @@ impl oio::StreamRead for YandexDiskReader {
             _ => {
                 let (part, mut body) = resp.into_parts();
                 let buf = body.to_buffer().await?;
-                return Err(parse_error(Response::from_parts(part, buf)));
+                return Err(parse_error(
+                    ErrorContext::new(ServiceOperation("Download")),
+                    Response::from_parts(part, buf),
+                ));
             }
         };
 

--- a/core/services/yandex-disk/src/writer.rs
+++ b/core/services/yandex-disk/src/writer.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use http::StatusCode;
 
-use super::core::YandexDiskCore;
 use super::core::parse_error;
+use super::core::{ErrorContext, YandexDiskCore};
 use opendal_core::raw::*;
 use opendal_core::*;
 
@@ -47,7 +47,10 @@ impl oio::OneShotWrite for YandexDiskWriter {
         let status = resp.status();
         match status {
             StatusCode::CREATED => Ok(Metadata::default()),
-            _ => Err(parse_error(resp)),
+            _ => Err(parse_error(
+                ErrorContext::new(ServiceOperation("Upload")),
+                resp,
+            )),
         }
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #8173.

# Rationale for this change

Service error normalization needs the actual operation context to distinguish provider semantics and safe retries. The existing implementations use inconsistent parser signatures and ownership boundaries, which makes `ErrorKind`, retryability, and preserved diagnostic context difficult to audit across services.

This change establishes one explicit, service-owned normalization boundary. Provider-specific payloads, status fallbacks, native error codes, operation conditions, and retry decisions remain local to the service that owns them.

# What changes are included in this PR?

Service implementations now use `parse_error(ErrorContext, native_error)` at the operation response boundary. Request construction and transport helpers return raw responses, while the operation handler supplies the actual service operation before normalization.

The refactor also consolidates alternate parser entry points, keeps unknown errors conservative and diagnosable, separates error classification from temporary retry marking, and places each parser and its tests directly in the owning service core module.

# Are there any user-facing changes?

There is no public API change. Some service failures can now report a more precise `ErrorKind`, operation context, or temporary retry classification because normalization consistently considers provider and operation semantics.

# AI Usage Statement

AI materially assisted the repository-wide audit, implementation, and validation under maintainer direction. This is an explicitly accepted maintenance and hardening goal; no live credentialed reproduction was performed for every provider, so the PR does not claim to fix a demonstrated service-specific bug.
