### PR TITLE
perf(bindings/python): avoid intermediate buffers in file reads

### DIFF
--- a/bindings/python/src/file.rs
+++ b/bindings/python/src/file.rs
@@ -24,7 +24,6 @@ use std::ops::DerefMut;
 use std::sync::Arc;
 
 use asyncband::mutex::Mutex;
-use futures::AsyncReadExt;
 use futures::AsyncSeekExt;
 use futures::AsyncWriteExt;
 use pyo3::IntoPyObjectExt;
@@ -99,24 +98,12 @@ impl File {
         };
 
         let buffer = match size {
-            Some(size) => {
-                let mut bs = vec![0; size];
-                let n = reader
-                    .read(&mut bs)
-                    .map_err(|err| PyIOError::new_err(err.to_string()))?;
-                bs.truncate(n);
-                bs
-            }
-            None => {
-                let mut buffer = Vec::new();
-                reader
-                    .read_to_end(&mut buffer)
-                    .map_err(|err| PyIOError::new_err(err.to_string()))?;
-                buffer
-            }
-        };
+            Some(size) => reader.read_buffer(size),
+            None => reader.read_to_end_buffer(),
+        }
+        .map_err(|err| PyIOError::new_err(err.to_string()))?;
 
-        Buffer::new(buffer).into_bytes_ref(py)
+        buffer_into_py_bytes(py, buffer).map(Bound::into_any)
     }
 
     /// Read one line from this file.
@@ -175,7 +162,7 @@ impl File {
             }
         };
 
-        Buffer::new(buffer).into_bytes_ref(py)
+        buffer_into_py_bytes(py, buffer.into()).map(Bound::into_any)
     }
 
     /// Read bytes into a pre-allocated buffer.
@@ -492,27 +479,12 @@ impl AsyncFile {
             };
 
             let buffer = match size {
-                Some(size) => {
-                    // TODO: optimize here by using uninit slice.
-                    let mut bs = vec![0; size];
-                    let n = reader
-                        .read(&mut bs)
-                        .await
-                        .map_err(|err| PyIOError::new_err(err.to_string()))?;
-                    bs.truncate(n);
-                    bs
-                }
-                None => {
-                    let mut buffer = Vec::new();
-                    reader
-                        .read_to_end(&mut buffer)
-                        .await
-                        .map_err(|err| PyIOError::new_err(err.to_string()))?;
-                    buffer
-                }
-            };
+                Some(size) => reader.read_buffer(size).await,
+                None => reader.read_to_end_buffer().await,
+            }
+            .map_err(|err| PyIOError::new_err(err.to_string()))?;
 
-            Python::attach(|py| Buffer::new(buffer).into_bytes(py))
+            Python::attach(|py| buffer_into_py_bytes(py, buffer).map(Bound::unbind))
         })
     }
 

--- a/bindings/python/src/utils.rs
+++ b/bindings/python/src/utils.rs
@@ -15,11 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::os::raw::c_int;
-
 use bytes::Buf;
 use bytes::Bytes;
-use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyOverflowError;
 use pyo3::ffi;
 use pyo3::prelude::*;
@@ -109,62 +106,6 @@ mod tests {
             buffer
         });
         assert_eq!(buffer.to_vec(), b"mutable");
-    }
-}
-
-/// A bytes-like object that implements buffer protocol.
-#[pyclass(module = "opendal")]
-pub struct Buffer {
-    inner: Vec<u8>,
-}
-
-impl Buffer {
-    pub fn new(inner: Vec<u8>) -> Self {
-        Buffer { inner }
-    }
-
-    /// Consume self to build a bytes
-    pub fn into_bytes(self, py: Python) -> PyResult<Py<PyAny>> {
-        let buffer = self.into_py_any(py)?;
-
-        unsafe {
-            Bound::from_owned_ptr_or_err(py, ffi::PyBytes_FromObject(buffer.as_ptr()))
-                .map(Bound::unbind)
-        }
-    }
-
-    /// Consume self to build a bytes
-    pub fn into_bytes_ref(self, py: Python) -> PyResult<Bound<PyAny>> {
-        let buffer = self.into_py_any(py)?;
-        let view =
-            unsafe { Bound::from_owned_ptr_or_err(py, ffi::PyBytes_FromObject(buffer.as_ptr()))? };
-
-        Ok(view)
-    }
-}
-
-#[pymethods]
-impl Buffer {
-    unsafe fn __getbuffer__(
-        slf: PyRefMut<Self>,
-        view: *mut ffi::Py_buffer,
-        flags: c_int,
-    ) -> PyResult<()> {
-        let bytes = slf.inner.as_slice();
-        let ret = unsafe {
-            ffi::PyBuffer_FillInfo(
-                view,
-                slf.as_ptr() as *mut _,
-                bytes.as_ptr() as *mut _,
-                bytes.len().try_into().unwrap(),
-                1, // read only
-                flags,
-            )
-        };
-        if ret == -1 {
-            return Err(PyErr::fetch(slf.py()));
-        }
-        Ok(())
     }
 }
 

--- a/bindings/python/tests/test_read.py
+++ b/bindings/python/tests/test_read.py
@@ -92,6 +92,25 @@ def test_sync_reader(service_name, operator, async_operator):
 
 
 @pytest.mark.need_capability("read", "write", "delete")
+def test_sync_reader_read_sizes(operator):
+    filename = f"random_file_{str(uuid4())}"
+    content = b"hello, world"
+    operator.write(filename, content)
+
+    with operator.open(filename, "rb") as reader:
+        assert reader.read(0) == b""
+        assert reader.tell() == 0
+        assert reader.read(5) == b"hello"
+        assert reader.tell() == 5
+        assert reader.read(1024) == b", world"
+        assert reader.read(1) == b""
+        reader.seek(2)
+        assert reader.read() == b"llo, world"
+
+    operator.delete(filename)
+
+
+@pytest.mark.need_capability("read", "write", "delete")
 def test_sync_reader_readline(service_name, operator, async_operator):
     size = randint(1, 1024)
     lines = randint(1, min(100, size))
@@ -204,6 +223,26 @@ async def test_async_reader(service_name, operator, async_operator):
         read_content = await reader.read()
         assert read_content is not None
         assert read_content == content[range_start:range_end]
+
+    await async_operator.delete(filename)
+
+
+@pytest.mark.asyncio
+@pytest.mark.need_capability("read", "write", "delete")
+async def test_async_reader_read_sizes(async_operator):
+    filename = f"random_file_{str(uuid4())}"
+    content = b"hello, world"
+    await async_operator.write(filename, content)
+
+    async with await async_operator.open(filename, "rb") as reader:
+        assert await reader.read(0) == b""
+        assert await reader.tell() == 0
+        assert await reader.read(5) == b"hello"
+        assert await reader.tell() == 5
+        assert await reader.read(1024) == b", world"
+        assert await reader.read(1) == b""
+        await reader.seek(2)
+        assert await reader.read() == b"llo, world"
 
     await async_operator.delete(filename)
 

--- a/core/core/src/blocking/read/std_reader.rs
+++ b/core/core/src/blocking/read/std_reader.rs
@@ -44,6 +44,31 @@ impl StdReader {
     pub(super) fn new(handle: tokio::runtime::Handle, r: FuturesAsyncReader) -> Self {
         Self { handle, r: Some(r) }
     }
+
+    /// Read at most `size` bytes and return them as an OpenDAL [`Buffer`].
+    ///
+    /// This method preserves the underlying buffer storage and does not copy
+    /// the payload. It can return fewer bytes than requested, including an
+    /// empty buffer at EOF.
+    pub fn read_buffer(&mut self, size: usize) -> io::Result<Buffer> {
+        let Some(r) = self.r.as_mut() else {
+            return Err(Error::new(ErrorKind::Unexpected, "reader has been dropped").into());
+        };
+
+        self.handle.block_on(r.read_buffer(size))
+    }
+
+    /// Read all remaining bytes and return them as an OpenDAL [`Buffer`].
+    ///
+    /// This method preserves the underlying buffer storage and only allocates
+    /// metadata when multiple buffers must be combined.
+    pub fn read_to_end_buffer(&mut self) -> io::Result<Buffer> {
+        let Some(r) = self.r.as_mut() else {
+            return Err(Error::new(ErrorKind::Unexpected, "reader has been dropped").into());
+        };
+
+        self.handle.block_on(r.read_to_end_buffer())
+    }
 }
 
 impl BufRead for StdReader {

--- a/core/core/src/types/read/futures_async_reader.rs
+++ b/core/core/src/types/read/futures_async_reader.rs
@@ -74,6 +74,69 @@ impl FuturesAsyncReader {
             pos: 0,
         }
     }
+
+    /// Read at most `size` bytes and return them as an OpenDAL [`Buffer`].
+    ///
+    /// This method preserves the underlying buffer storage and does not copy
+    /// the payload. It can return fewer bytes than requested, including an
+    /// empty buffer at EOF.
+    pub async fn read_buffer(&mut self, size: usize) -> io::Result<Buffer> {
+        if size == 0 {
+            return Ok(Buffer::new());
+        }
+
+        while self.buf.is_empty() {
+            self.buf = match self.stream.next().await {
+                Some(Ok(buf)) => buf,
+                Some(Err(err)) => return Err(format_std_io_error(err)),
+                None => return Ok(Buffer::new()),
+            };
+        }
+
+        let size = self.buf.len().min(size);
+        let buffer = self.buf.split_to(size);
+        if self.buf.is_empty() {
+            self.buf = Buffer::new();
+        }
+        self.pos += size as u64;
+        Ok(buffer)
+    }
+
+    /// Read all remaining bytes and return them as an OpenDAL [`Buffer`].
+    ///
+    /// This method preserves the underlying buffer storage and only allocates
+    /// metadata when multiple buffers must be combined.
+    pub async fn read_to_end_buffer(&mut self) -> io::Result<Buffer> {
+        let mut buffer = std::mem::take(&mut self.buf);
+        let current_size = buffer.len();
+        self.pos += current_size as u64;
+        let mut parts = None;
+
+        while let Some(result) = self.stream.next().await {
+            let next = result.map_err(format_std_io_error)?;
+            self.pos += next.len() as u64;
+            if next.is_empty() {
+                continue;
+            }
+
+            if buffer.is_empty() && parts.is_none() {
+                buffer = next;
+                continue;
+            }
+
+            if parts.is_none() {
+                let mut combined = Vec::new();
+                combined.extend(std::mem::take(&mut buffer));
+                parts = Some(combined);
+            }
+            parts
+                .as_mut()
+                .expect("buffer parts must exist")
+                .extend(next);
+        }
+
+        Ok(parts.map(Buffer::from).unwrap_or(buffer))
+    }
 }
 
 impl AsyncBufRead for FuturesAsyncReader {
@@ -244,6 +307,59 @@ mod tests {
         let mut bs = vec![];
         fr.read_to_end(&mut bs).await.unwrap();
         assert_eq!(&bs, "or".as_bytes());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_read_buffer() -> Result<()> {
+        let op = Operator::via_iter(services::MEMORY_SCHEME, [])?;
+        let content = Bytes::from_static(b"HelloWorld");
+        op.write("test", Buffer::from(content.clone())).await?;
+
+        let ctx = op.context().clone();
+        let srv = op.service().clone();
+        let ctx = Arc::new(new_read_context(ctx, srv, "test", OpReader::new())?);
+
+        let mut fr = FuturesAsyncReader::new(ctx, 0..10);
+        let buffer = fr.read_buffer(0).await.unwrap();
+        assert!(buffer.is_empty());
+        assert_eq!(fr.seek(SeekFrom::Current(0)).await.unwrap(), 0);
+
+        let buffer = fr.read_buffer(5).await.unwrap();
+        assert_eq!(buffer.to_vec(), b"Hello");
+        assert_eq!(buffer.current().as_ptr(), content.as_ptr());
+        assert_eq!(fr.seek(SeekFrom::Current(0)).await.unwrap(), 5);
+
+        let buffer = fr.read_to_end_buffer().await.unwrap();
+        assert_eq!(buffer.to_vec(), b"World");
+        assert_eq!(fr.seek(SeekFrom::Current(0)).await.unwrap(), 10);
+        assert!(fr.read_buffer(1).await.unwrap().is_empty());
+
+        fr.seek(SeekFrom::Start(2)).await.unwrap();
+        assert_eq!(fr.read_to_end_buffer().await.unwrap().to_vec(), b"lloWorld");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_read_to_end_buffer_with_concurrent() -> Result<()> {
+        let op = Operator::via_iter(services::MEMORY_SCHEME, [])?;
+        op.write("test", Buffer::from("HelloWorld")).await?;
+
+        let ctx = op.context().clone();
+        let srv = op.service().clone();
+        let ctx = Arc::new(new_read_context(
+            ctx,
+            srv,
+            "test",
+            OpReader::new().with_concurrent(3).with_chunk(1),
+        )?);
+
+        let mut fr = FuturesAsyncReader::new(ctx, 0..10);
+        let buffer = fr.read_to_end_buffer().await.unwrap();
+        assert_eq!(buffer.to_vec(), b"HelloWorld");
+        assert_eq!(fr.seek(SeekFrom::Current(0)).await.unwrap(), 10);
 
         Ok(())
     }


### PR DESCRIPTION
# Which issue does this PR close?

Part of #8159.

# Rationale for this change

`File.read` and `AsyncFile.read` currently materialize reader output in an intermediate `Vec<u8>` before copying it into the returned Python `bytes`. Sized reads also allocate and zero-initialize the complete requested size, while full reads can grow the vector beyond the logical payload size.

# What changes are included in this PR?

This PR adds buffer-returning methods to `FuturesAsyncReader` and `StdReader`, then lets the Python file APIs copy OpenDAL `Buffer` contents directly into the final Python `bytes`. It also removes the obsolete private Python buffer wrapper and adds coverage for zero-sized reads, partial reads, EOF, cursor position, and seek behavior.

# Are there any user-facing changes?

The Python API and return type remain unchanged. `File.read` and `AsyncFile.read` still return `bytes` and preserve partial-read, EOF, and cursor behavior.

## Benchmark

Release builds on CPython 3.14.5 used the memory backend to isolate reader-adapter, allocation, and Python conversion costs. Fixture writes, `open`, and `close` were outside the timed region. Results are medians from ten alternating paired rounds.

Baseline: `e6ac14c937b8bf519a1d85cdaef6ea7a8525ec4a`  
Optimized: `468cf55ce49b1b3d4ff34b372b0022202840b27e`

| API | Workload | Baseline | Optimized | Improvement |
| --- | --- | ---: | ---: | ---: |
| sync | Full read, 1 MiB | 0.054 ms | 0.014 ms | 3.99x faster |
| sync | Full read, 8 MiB | 0.979 ms | 0.105 ms | 9.44x faster |
| sync | Full read, 64 MiB | 7.985 ms | 0.955 ms | 8.29x faster |
| async | Full read, 1 MiB | 0.094 ms | 0.053 ms | 1.77x faster |
| async | Full read, 8 MiB | 1.027 ms | 0.146 ms | 6.93x faster |
| async | Full read, 64 MiB | 14.476 ms | 1.001 ms | 14.21x faster |
| sync | 64 MiB in 1 MiB reads | 2.545 ms | 0.915 ms | 2.74x faster |
| async | 64 MiB in 1 MiB reads | 4.724 ms | 3.472 ms | 1.35x faster |

A 128 MiB full read reduced median peak RSS from 544.30 MiB to 286.56 MiB for sync and from 545.09 MiB to 287.16 MiB for async. Remote-storage latency will reduce the end-to-end speedup ratio, while the removed payload-sized allocation and copy apply to every backend.

The current PR head also merges the latest `origin/main`; those upstream changes do not touch this read path or its build configuration, so the benchmarked implementation is unchanged.

# AI Usage Statement

AI materially assisted the implementation, regression tests, and benchmark harness. The author reviewed and authorized the final change and reported claims. The benchmark uses the memory backend to isolate binding overhead; remote end-to-end speedups depend on storage latency.
