### PR TITLE
chore(services/ftp): upgrade suppaftp to 10 and switch to tokio

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -269,17 +269,6 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
@@ -291,59 +280,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if 1.0.4",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.1.4",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -368,32 +310,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1222,7 +1138,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
- "async-channel 2.5.0",
+ "async-channel",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -3058,12 +2974,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -3079,7 +2989,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -3612,10 +3522,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand",
  "futures-core",
- "futures-io",
- "parking",
  "pin-project-lite",
 ]
 
@@ -3628,17 +3535,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "futures-rustls"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
-dependencies = [
- "futures-io",
- "rustls 0.23.40",
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -5205,15 +5101,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy-regex"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5417,9 +5304,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "logforth"
@@ -5894,7 +5778,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-util",
  "parking_lot 0.12.5",
  "portable-atomic",
@@ -7058,8 +6942,6 @@ version = "0.58.2"
 dependencies = [
  "bytes",
  "fastpool",
- "futures",
- "futures-rustls",
  "http 1.4.2",
  "log",
  "opendal-core",
@@ -10520,7 +10402,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -10838,20 +10720,19 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suppaftp"
-version = "8.0.5"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dd9d0f3beeffac0ddc0ccfdb6f29c79d26a9925b4153947a8236abec8d0985"
+checksum = "821001051ea3d12a60fb790b8c7cb9a6f5f8698dcfdca4cd533a025fefb0b5b8"
 dependencies = [
- "async-std",
  "async-trait",
  "chrono",
- "futures-lite",
- "futures-rustls",
  "lazy-regex",
  "log",
  "pin-project",
  "rustls-pki-types",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls 0.26.4",
 ]
 
 [[package]]
@@ -10861,7 +10742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d1d636f9a9104f4446943111e0703e6d6668bfaba6c4415a31d0450dc46630b"
 dependencies = [
  "anyhow",
- "async-channel 2.5.0",
+ "async-channel",
  "boxcar",
  "chrono",
  "futures",
@@ -10913,7 +10794,7 @@ dependencies = [
  "ammonia",
  "anyhow",
  "argon2",
- "async-channel 2.5.0",
+ "async-channel",
  "async-stream",
  "base64 0.22.1",
  "bcrypt",
@@ -11036,7 +10917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac180b3201dbd6f809d3f07fa20ff953a03e06f92e051117e60f326a46160d1"
 dependencies = [
  "anyhow",
- "async-channel 2.5.0",
+ "async-channel",
  "bytes",
  "castaway",
  "chrono",
@@ -11132,7 +11013,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416090a4d8f6358526df5f9f65dfe28750b8b7bfd1fd8a5620f483fc4a75722c"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "futures-util",
  "local-event",
  "loom 0.7.2",
@@ -12181,12 +12062,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "value-bag"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vart"

--- a/core/services/ftp/Cargo.toml
+++ b/core/services/ftp/Cargo.toml
@@ -34,17 +34,15 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 fastpool = "1.0.2"
-futures = { workspace = true, features = ["std", "async-await"] }
-futures-rustls = "0.26.0"
 http = { workspace = true }
 log = { workspace = true }
 opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
 rustls-native-certs = "0.8"
 serde = { workspace = true, features = ["derive"] }
-suppaftp = { version = "8.0.3", default-features = false, features = [
-  "async-std-rustls-ring",
+suppaftp = { version = "10.0.2", default-features = false, features = [
+  "tokio-rustls-ring",
 ] }
-tokio = { workspace = true, features = ["macros", "time"] }
+tokio = { workspace = true, features = ["io-util", "macros", "time"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/ftp/src/backend.rs
+++ b/core/services/ftp/src/backend.rs
@@ -162,6 +162,7 @@ impl Builder for FtpBuilder {
 
         let manager = Manager {
             endpoint: endpoint.clone(),
+            host: host.to_string(),
             root: root.clone(),
             user: user.clone(),
             password: password.clone(),

--- a/core/services/ftp/src/core.rs
+++ b/core/services/ftp/src/core.rs
@@ -16,16 +16,17 @@
 // under the License.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use fastpool::{ManageObject, ObjectStatus, bounded};
-use futures_rustls::TlsConnector;
-use futures_rustls::rustls::ClientConfig;
-use futures_rustls::rustls::RootCertStore;
 use suppaftp::FtpError;
 use suppaftp::Status;
-use suppaftp::async_std::AsyncRustlsConnector;
-use suppaftp::async_std::AsyncRustlsFtpStream;
-use suppaftp::async_std::ImplAsyncFtpStream;
+use suppaftp::tokio::AsyncRustlsConnector;
+use suppaftp::tokio::AsyncRustlsFtpStream;
+use suppaftp::tokio::ImplAsyncFtpStream;
+use suppaftp::tokio_rustls::TlsConnector;
+use suppaftp::tokio_rustls::rustls::ClientConfig;
+use suppaftp::tokio_rustls::rustls::RootCertStore;
 use suppaftp::types::FileType;
 
 use opendal_core::raw::*;
@@ -73,6 +74,7 @@ impl FtpCore {
 #[derive(Clone)]
 pub struct Manager {
     pub endpoint: String,
+    pub host: String,
     pub root: String,
     pub user: String,
     pub password: String,
@@ -100,7 +102,7 @@ impl ManageObject for Manager {
             stream
                 .into_secure(
                     AsyncRustlsConnector::from(TlsConnector::from(Arc::new(cfg))),
-                    &self.endpoint,
+                    &self.host,
                 )
                 .await?
         } else {

--- a/core/services/ftp/src/reader.rs
+++ b/core/services/ftp/src/reader.rs
@@ -23,14 +23,14 @@ use super::lister::FtpLister;
 use super::writer::FtpWriter;
 use bytes::BytesMut;
 use fastpool::bounded;
-use futures::AsyncRead;
-use futures::AsyncReadExt;
 use opendal_core::raw::*;
 use opendal_core::*;
 use std::sync::Arc;
 use suppaftp::FtpError;
 use suppaftp::Status;
 use suppaftp::types::Response;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncReadExt;
 
 pub struct FtpReadStream {
     /// Keep the connection alive while data stream is alive.

--- a/core/services/ftp/src/writer.rs
+++ b/core/services/ftp/src/writer.rs
@@ -17,8 +17,8 @@
 
 use bytes::Buf;
 use fastpool::bounded;
-use futures::AsyncWrite;
-use futures::AsyncWriteExt;
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
 
 use super::core::Manager;
 use super::core::format_ftp_error;


### PR DESCRIPTION
# Which issue does this PR close?

None.

# Rationale for this change

The FTP service was the last OpenDAL core path that still pulled `async-std`, via `suppaftp` 8's `async-std-rustls-ring` feature. OpenDAL already runs this service on tokio, and `suppaftp` 10 dropped async-std in favor of tokio/smol.

# What changes are included in this PR?

Upgrade `suppaftp` to 10.0.2 and switch the FTP client to `tokio-rustls-ring`. Data streams now use tokio's `AsyncRead`/`AsyncWrite`. FTPS SNI uses the endpoint host instead of `host:port`.

# Are there any user-facing changes?

FTP object keys that contain CR or LF now fail in the FTP client instead of being written onto the control channel. The `services-ftp` feature no longer depends on `async-std`.

# AI Usage Statement

AI implemented the tokio runtime switch by reading the `suppaftp` 10 tokio API and adapting the FTP service. Local verification covered `opendal-service-ftp` clippy/unit tests and `cargo check -p opendal --features services-ftp`. Behavior tests against a live FTP server were not run.
