### PR TITLE
fix(bindings): enable gcs-grpc service

### DIFF
--- a/bindings/dotnet/Cargo.toml
+++ b/bindings/dotnet/Cargo.toml
@@ -53,6 +53,7 @@ opendal = { version = ">=0", path = "../../core", features = [
   "services-cos",
   "services-fs",
   "services-gcs",
+  "services-gcs-grpc",
   "services-ghac",
   "services-http",
   "services-ipmfs",

--- a/bindings/java/Cargo.toml
+++ b/bindings/java/Cargo.toml
@@ -50,6 +50,7 @@ opendal = { version = ">=0", path = "../../core", default-features = false, feat
   "services-cos",
   "services-fs",
   "services-gcs",
+  "services-gcs-grpc",
   "services-ghac",
   "services-http",
   "services-ipmfs",

--- a/bindings/nodejs/Cargo.toml
+++ b/bindings/nodejs/Cargo.toml
@@ -57,6 +57,7 @@ services-all = [
   # FIXME this requires a preinstalled fdb library
   # "services-foundationdb",
   # "services-ftp",
+  "services-gcs-grpc",
   "services-gdrive",
   "services-goosefs",
   # FIXME how to support HDFS services in bindings?
@@ -98,6 +99,7 @@ services-azdls = ["opendal/services-azdls"]
 services-cos = ["opendal/services-cos"]
 services-fs = ["opendal/services-fs"]
 services-gcs = ["opendal/services-gcs"]
+services-gcs-grpc = ["opendal/services-gcs-grpc"]
 services-ghac = ["opendal/services-ghac"]
 services-http = ["opendal/services-http"]
 services-ipmfs = ["opendal/services-ipmfs"]


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up to #8153.

# Rationale for this change

The GCS gRPC behavior setup is exercised across language bindings on `main`, but the Java and .NET native libraries do not enable the service and the Node.js package does not expose its feature. As a result, Java and .NET report that the `gcs-grpc` scheme is not registered, while Node.js fails to build with an unknown `services-gcs-grpc` feature.

# What changes are included in this PR?

Enable `services-gcs-grpc` in the Java and .NET native dependencies. Add the corresponding Node.js forwarding feature and include it in `services-all`.

# Are there any user-facing changes?

Java, .NET, and Node.js builds that include their full service sets can construct the `gcs-grpc` service.

# AI Usage Statement

AI materially assisted with CI log diagnosis, implementation, and local validation. The live GCS behavior tests require repository secrets and were not run locally; the failing jobs did not reach the service because their builds lacked the required feature.
