### PR TITLE
refactor!: merge OpCopier into OpCopy

### DIFF
--- a/bindings/cpp/src/test_support.rs
+++ b/bindings/cpp/src/test_support.rs
@@ -130,14 +130,7 @@ impl Service for HangingService {
         ))
     }
 
-    fn copy(
-        &self,
-        _: &OperationContext,
-        _: &str,
-        _: &str,
-        _: OpCopy,
-        _: OpCopier,
-    ) -> Result<Self::Copier> {
+    fn copy(&self, _: &OperationContext, _: &str, _: &str, _: OpCopy) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",
@@ -244,14 +237,7 @@ impl Service for RetryableService {
         ))
     }
 
-    fn copy(
-        &self,
-        _: &OperationContext,
-        _: &str,
-        _: &str,
-        _: OpCopy,
-        _: OpCopier,
-    ) -> Result<Self::Copier> {
+    fn copy(&self, _: &OperationContext, _: &str, _: &str, _: OpCopy) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/core/src/layers/capability_override.rs
+++ b/core/core/src/layers/capability_override.rs
@@ -163,9 +163,8 @@ impl Service for CapabilityOverrideService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
-        self.inner.copy(ctx, from, to, args, opts)
+        self.inner.copy(ctx, from, to, args)
     }
 
     async fn rename(

--- a/core/core/src/layers/complete.rs
+++ b/core/core/src/layers/complete.rs
@@ -96,9 +96,8 @@ impl Service for CompleteService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
-        self.inner.copy(ctx, from, to, args, opts)
+        self.inner.copy(ctx, from, to, args)
     }
 
     async fn rename(

--- a/core/core/src/layers/correctness_check.rs
+++ b/core/core/src/layers/correctness_check.rs
@@ -245,7 +245,6 @@ impl Service for CorrectnessService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         let capability = self.capability();
         let scheme = self.info().scheme();
@@ -288,7 +287,7 @@ impl Service for CorrectnessService {
             ));
         }
 
-        self.inner.copy(ctx, from, to, args, opts)
+        self.inner.copy(ctx, from, to, args)
     }
 
     fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
@@ -508,14 +507,7 @@ mod tests {
             Ok(MockDeleter)
         }
 
-        fn copy(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: &str,
-            _: OpCopy,
-            _: OpCopier,
-        ) -> Result<Self::Copier> {
+        fn copy(&self, _: &OperationContext, _: &str, _: &str, _: OpCopy) -> Result<Self::Copier> {
             Ok(())
         }
 

--- a/core/core/src/layers/error_context.rs
+++ b/core/core/src/layers/error_context.rs
@@ -126,10 +126,9 @@ impl Service for ErrorContextService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         self.inner
-            .copy(ctx, from, to, args, opts)
+            .copy(ctx, from, to, args)
             .map(|p| ErrorContextWrapper::new(self.info().scheme(), to, p))
             .map_err(|err| {
                 err.with_operation(Operation::Copy)

--- a/core/core/src/layers/simulate.rs
+++ b/core/core/src/layers/simulate.rs
@@ -330,9 +330,8 @@ impl Service for SimulateService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
-        self.srv.copy(ctx, from, to, args, opts)
+        self.srv.copy(ctx, from, to, args)
     }
 
     async fn rename(
@@ -713,14 +712,7 @@ mod tests {
             Err(Error::new(ErrorKind::Unsupported, "list is not supported"))
         }
 
-        fn copy(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: &str,
-            _: OpCopy,
-            _: OpCopier,
-        ) -> Result<Self::Copier> {
+        fn copy(&self, _: &OperationContext, _: &str, _: &str, _: OpCopy) -> Result<Self::Copier> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",

--- a/core/core/src/raw/accessor.rs
+++ b/core/core/src/raw/accessor.rs
@@ -212,7 +212,6 @@ pub trait Service: Send + Sync + Debug + Unpin + 'static {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier>;
 
     /// Invoke the `rename` operation on the specified `from` path and `to` path.
@@ -321,7 +320,6 @@ pub trait ServiceDyn: Send + Sync + Debug + Unpin + 'static {
         from: &'a str,
         to: &'a str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<oio::Copier>;
 
     /// Dyn version of [`Service::rename`].
@@ -417,9 +415,8 @@ impl<S: Service + ?Sized> ServiceDyn for S {
         from: &'a str,
         to: &'a str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<oio::Copier> {
-        Ok(Box::new(self.copy(ctx, from, to, args, opts)?) as oio::Copier)
+        Ok(Box::new(self.copy(ctx, from, to, args)?) as oio::Copier)
     }
 
     fn rename_dyn<'a>(
@@ -502,9 +499,8 @@ impl<T: ServiceDyn + ?Sized> Service for Arc<T> {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<oio::Copier> {
-        self.as_ref().copy_dyn(ctx, from, to, args, opts)
+        self.as_ref().copy_dyn(ctx, from, to, args)
     }
 
     async fn rename(
@@ -599,14 +595,7 @@ impl Service for () {
         ))
     }
 
-    fn copy(
-        &self,
-        _: &OperationContext,
-        _: &str,
-        _: &str,
-        _: OpCopy,
-        _: OpCopier,
-    ) -> Result<Self::Copier> {
+    fn copy(&self, _: &OperationContext, _: &str, _: &str, _: OpCopy) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/core/src/raw/oio/copy/multipart_copy.rs
+++ b/core/core/src/raw/oio/copy/multipart_copy.rs
@@ -226,7 +226,7 @@ impl<C: MultipartCopy> MultipartCopier<C> {
         if part_count > max_parts {
             return Err(Error::new(
                 ErrorKind::Unsupported,
-                "multipart copy part count exceeds service limit, please increase `OpCopier::chunk`"
+                "multipart copy part count exceeds service limit, please increase `OpCopy::chunk`",
             )
             .with_context("source_size", source_size)
             .with_context("part_size", self.part_size)

--- a/core/core/src/raw/ops.rs
+++ b/core/core/src/raw/ops.rs
@@ -1027,6 +1027,9 @@ pub struct OpCopy {
     if_version_match: Option<String>,
     if_version_not_match: Option<String>,
     source_version: Option<String>,
+    concurrent: usize,
+    chunk: Option<usize>,
+    source_content_length_hint: Option<u64>,
 }
 
 impl OpCopy {
@@ -1108,73 +1111,54 @@ impl OpCopy {
     pub fn source_version(&self) -> Option<&str> {
         self.source_version.as_deref()
     }
-}
 
-/// Arguments for `copier` operation.
-#[derive(Debug, Clone, Default)]
-pub struct OpCopier {
-    concurrent: usize,
-    chunk: Option<usize>,
-    source_content_length_hint: Option<u64>,
-}
-
-impl OpCopier {
-    /// Create a new `OpCopier`.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Set the concurrent tasks for the copier.
+    /// Set the concurrent tasks for the copy operation.
     pub fn with_concurrent(mut self, concurrent: usize) -> Self {
         self.concurrent = concurrent.max(1);
         self
     }
 
-    /// Get the concurrent tasks for the copier.
+    /// Get the concurrent tasks for the copy operation.
     pub fn concurrent(&self) -> usize {
         self.concurrent.max(1)
     }
 
-    /// Set the chunk size for the copier.
+    /// Set the chunk size for the copy operation.
     pub fn with_chunk(mut self, chunk: usize) -> Self {
         self.chunk = Some(chunk);
         self
     }
 
-    /// Get the chunk size for the copier.
+    /// Get the chunk size for the copy operation.
     pub fn chunk(&self) -> Option<usize> {
         self.chunk
     }
 
-    /// Set source content length hint for the copier.
+    /// Set source content length hint for the copy operation.
     pub fn with_source_content_length_hint(mut self, content_length: u64) -> Self {
         self.source_content_length_hint = Some(content_length);
         self
     }
 
-    /// Get source content length hint from the copier.
+    /// Get source content length hint from the copy operation.
     pub fn source_content_length_hint(&self) -> Option<u64> {
         self.source_content_length_hint
     }
 }
 
-impl From<options::CopyOptions> for (OpCopy, OpCopier) {
+impl From<options::CopyOptions> for OpCopy {
     fn from(value: options::CopyOptions) -> Self {
-        (
-            OpCopy {
-                if_not_exists: value.if_not_exists,
-                if_match: value.if_match,
-                if_none_match: value.if_none_match,
-                if_version_match: value.if_version_match,
-                if_version_not_match: value.if_version_not_match,
-                source_version: value.source_version,
-            },
-            OpCopier {
-                concurrent: value.concurrent.max(1),
-                chunk: value.chunk,
-                source_content_length_hint: value.source_content_length_hint,
-            },
-        )
+        OpCopy {
+            if_not_exists: value.if_not_exists,
+            if_match: value.if_match,
+            if_none_match: value.if_none_match,
+            if_version_match: value.if_version_match,
+            if_version_not_match: value.if_version_not_match,
+            source_version: value.source_version,
+            concurrent: value.concurrent.max(1),
+            chunk: value.chunk,
+            source_content_length_hint: value.source_content_length_hint,
+        }
     }
 }
 

--- a/core/core/src/services/memory/backend.rs
+++ b/core/core/src/services/memory/backend.rs
@@ -169,14 +169,7 @@ impl Service for MemoryBackend {
         Ok(lister)
     }
 
-    fn copy(
-        &self,
-        _: &OperationContext,
-        _: &str,
-        _: &str,
-        _: OpCopy,
-        _: OpCopier,
-    ) -> Result<Self::Copier> {
+    fn copy(&self, _: &OperationContext, _: &str, _: &str, _: OpCopy) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/core/src/types/copy.rs
+++ b/core/core/src/types/copy.rs
@@ -61,9 +61,8 @@ impl Copier {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self> {
-        let copier = srv.copy(&ctx, from, to, args, opts)?;
+        let copier = srv.copy(&ctx, from, to, args)?;
 
         Ok(Self {
             copier: Some(copier),

--- a/core/core/src/types/operator/operator.rs
+++ b/core/core/src/types/operator/operator.rs
@@ -1492,8 +1492,8 @@ impl Operator {
                 .with_operation(Operation::Copy.into_static()));
             }
         }
-        let (args, opts) = opts.into();
-        std::future::ready(Copier::create(ctx, srv, &from, &to, args, opts)).await
+        let args = opts.into();
+        std::future::ready(Copier::create(ctx, srv, &from, &to, args)).await
     }
 
     /// Rename a file from `from` to `to`.

--- a/core/layers/async-backtrace/src/lib.rs
+++ b/core/layers/async-backtrace/src/lib.rs
@@ -118,9 +118,8 @@ impl Service for AsyncBacktraceAccessor {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
-        self.inner.copy(ctx, from, to, args, opts)
+        self.inner.copy(ctx, from, to, args)
     }
 
     #[async_backtrace::framed]

--- a/core/layers/await-tree/src/lib.rs
+++ b/core/layers/await-tree/src/lib.rs
@@ -117,10 +117,9 @@ impl Service for AwaitTreeAccessor {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         self.inner
-            .copy(ctx, from, to, args, opts)
+            .copy(ctx, from, to, args)
             .map(AwaitTreeWrapper::new)
     }
 

--- a/core/layers/capability-check/src/lib.rs
+++ b/core/layers/capability-check/src/lib.rs
@@ -160,7 +160,6 @@ impl Service for CapabilityCheckService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         let capability = self.capability();
         let info = self.info();
@@ -182,7 +181,7 @@ impl Service for CapabilityCheckService {
             ));
         }
 
-        self.inner.copy(ctx, from, to, args, opts)
+        self.inner.copy(ctx, from, to, args)
     }
 
     fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {
@@ -309,14 +308,7 @@ mod tests {
             ))
         }
 
-        fn copy(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: &str,
-            _: OpCopy,
-            _: OpCopier,
-        ) -> Result<Self::Copier> {
+        fn copy(&self, _: &OperationContext, _: &str, _: &str, _: OpCopy) -> Result<Self::Copier> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",

--- a/core/layers/chaos/src/lib.rs
+++ b/core/layers/chaos/src/lib.rs
@@ -152,9 +152,8 @@ impl Service for ChaosService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
-        self.inner.copy(ctx, from, to, args, opts)
+        self.inner.copy(ctx, from, to, args)
     }
 
     fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {

--- a/core/layers/concurrent-limit/src/lib.rs
+++ b/core/layers/concurrent-limit/src/lib.rs
@@ -292,10 +292,9 @@ where
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         self.inner
-            .copy(ctx, from, to, args, opts)
+            .copy(ctx, from, to, args)
             .map(|c| ConcurrentLimitWrapper::new(c, self.semaphore.clone()))
     }
 
@@ -624,7 +623,6 @@ mod tests {
                 _: &str,
                 _: &str,
                 _: OpCopy,
-                _: OpCopier,
             ) -> Result<Self::Copier> {
                 Ok(())
             }
@@ -777,7 +775,6 @@ mod tests {
                 _: &str,
                 _: &str,
                 _: OpCopy,
-                _: OpCopier,
             ) -> Result<Self::Copier> {
                 Ok(PendingCopier)
             }
@@ -984,7 +981,6 @@ mod tests {
                 _: &str,
                 _: &str,
                 _: OpCopy,
-                _: OpCopier,
             ) -> Result<Self::Copier> {
                 Err(Error::new(
                     ErrorKind::Unsupported,

--- a/core/layers/dtrace/src/lib.rs
+++ b/core/layers/dtrace/src/lib.rs
@@ -210,11 +210,10 @@ impl Service for DTraceService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         let c_from = CString::new(from).unwrap();
         probe_lazy!(opendal, copy_start, c_from.as_ptr());
-        let result = self.inner.copy(ctx, from, to, args, opts);
+        let result = self.inner.copy(ctx, from, to, args);
         probe_lazy!(opendal, copy_end, c_from.as_ptr());
         result
     }

--- a/core/layers/fastrace/src/lib.rs
+++ b/core/layers/fastrace/src/lib.rs
@@ -186,10 +186,9 @@ impl Service for FastraceAccessor {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         let _guard = Span::enter_with_local_parent(Operation::Copy.into_static());
-        self.inner.copy(ctx, from, to, args, opts).map(|c| {
+        self.inner.copy(ctx, from, to, args).map(|c| {
             FastraceWrapper::new(
                 Span::enter_with_local_parent(Operation::Copy.into_static()),
                 c,

--- a/core/layers/foyer/src/lib.rs
+++ b/core/layers/foyer/src/lib.rs
@@ -316,9 +316,8 @@ impl Service for FoyerService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
-        self.inner.copy(ctx, from, to, args, opts)
+        self.inner.copy(ctx, from, to, args)
     }
 
     fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
@@ -553,14 +552,7 @@ mod tests {
             ))
         }
 
-        fn copy(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: &str,
-            _: OpCopy,
-            _: OpCopier,
-        ) -> Result<Self::Copier> {
+        fn copy(&self, _: &OperationContext, _: &str, _: &str, _: OpCopy) -> Result<Self::Copier> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",

--- a/core/layers/hotpath/src/lib.rs
+++ b/core/layers/hotpath/src/lib.rs
@@ -149,10 +149,9 @@ impl Service for HotpathAccessor {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         self.inner
-            .copy(ctx, from, to, args, opts)
+            .copy(ctx, from, to, args)
             .map(HotpathWrapper::new)
     }
 

--- a/core/layers/immutable-index/src/lib.rs
+++ b/core/layers/immutable-index/src/lib.rs
@@ -194,9 +194,8 @@ impl Service for ImmutableIndexService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
-        self.inner.copy(ctx, from, to, args, opts)
+        self.inner.copy(ctx, from, to, args)
     }
 
     fn list(&self, _ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
@@ -359,14 +358,7 @@ mod tests {
             ))
         }
 
-        fn copy(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: &str,
-            _: OpCopy,
-            _: OpCopier,
-        ) -> Result<Self::Copier> {
+        fn copy(&self, _: &OperationContext, _: &str, _: &str, _: OpCopy) -> Result<Self::Copier> {
             Err(Error::new(
                 ErrorKind::Unsupported,
                 "operation is not supported",

--- a/core/layers/logging/src/lib.rs
+++ b/core/layers/logging/src/lib.rs
@@ -370,11 +370,10 @@ impl<I: LoggingInterceptor> Service for LoggingService<I> {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         self.log_start(Operation::Copy, &[("from", from), ("to", to)]);
         self.inner
-            .copy(ctx, from, to, args, opts)
+            .copy(ctx, from, to, args)
             .map(|c| {
                 self.logger.log(
                     &self.info,

--- a/core/layers/mime-guess/src/lib.rs
+++ b/core/layers/mime-guess/src/lib.rs
@@ -154,9 +154,8 @@ impl Service for MimeGuessAccessor {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
-        self.0.copy(ctx, from, to, args, opts)
+        self.0.copy(ctx, from, to, args)
     }
 
     async fn stat(&self, ctx: &OperationContext, path: &str, args: OpStat) -> Result<RpStat> {

--- a/core/layers/observe-metrics-common/src/lib.rs
+++ b/core/layers/observe-metrics-common/src/lib.rs
@@ -842,7 +842,6 @@ impl<I: MetricsIntercept> Service for MetricsAccessor<I> {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         let labels = MetricLabels::new(self.info.clone(), Operation::Copy.into_static());
 
@@ -853,7 +852,7 @@ impl<I: MetricsIntercept> Service for MetricsAccessor<I> {
         let mut guard =
             ExecutingGuard::new_operation(self.interceptor.clone(), labels.clone(), start);
 
-        match self.inner.copy(ctx, from, to, args, opts.clone()) {
+        match self.inner.copy(ctx, from, to, args) {
             Ok(copier) => {
                 guard.defuse();
                 Ok(MetricsWrapper::new(

--- a/core/layers/oteltrace/src/lib.rs
+++ b/core/layers/oteltrace/src/lib.rs
@@ -149,7 +149,6 @@ impl Service for OtelTraceService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         let tracer = global::tracer("opendal");
         let mut span = tracer.start("copy");
@@ -158,7 +157,7 @@ impl Service for OtelTraceService {
         span.set_attribute(KeyValue::new("args", format!("{args:?}")));
         let cx = TraceContext::current_with_span(span);
         let _guard = cx.attach();
-        self.inner.copy(ctx, from, to, args, opts)
+        self.inner.copy(ctx, from, to, args)
     }
 
     async fn rename(

--- a/core/layers/retry/src/lib.rs
+++ b/core/layers/retry/src/lib.rs
@@ -418,10 +418,9 @@ impl<I: RetryInterceptor> Service for RetryService<I> {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         let mut attempt: u32 = 0;
-        let copier = { || self.inner.copy(ctx, from, to, args.clone(), opts.clone()) }
+        let copier = { || self.inner.copy(ctx, from, to, args.clone()) }
             .retry(self.builder)
             .when(|e| e.is_temporary())
             .notify(|err, dur| {
@@ -1207,14 +1206,7 @@ mod tests {
             Ok(lister)
         }
 
-        fn copy(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: &str,
-            _: OpCopy,
-            _: OpCopier,
-        ) -> Result<Self::Copier> {
+        fn copy(&self, _: &OperationContext, _: &str, _: &str, _: OpCopy) -> Result<Self::Copier> {
             Ok(MockCopier {
                 attempt: self.attempt.clone(),
             })

--- a/core/layers/route/src/lib.rs
+++ b/core/layers/route/src/lib.rs
@@ -239,11 +239,10 @@ impl Service for RouteAccessor {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<oio::Copier> {
         match self.select(from) {
-            RouteSelected::Default(srv) => srv.copy(ctx, from, to, args, opts),
-            RouteSelected::Target(target) => target.srv.copy(&target.ctx, from, to, args, opts),
+            RouteSelected::Default(srv) => srv.copy(ctx, from, to, args),
+            RouteSelected::Target(target) => target.srv.copy(&target.ctx, from, to, args),
         }
     }
 
@@ -550,7 +549,6 @@ mod tests {
             from: &str,
             to: &str,
             _: OpCopy,
-            _: OpCopier,
         ) -> Result<Self::Copier> {
             if !self.paths.lock().unwrap().contains(from) {
                 return Err(Error::new(ErrorKind::NotFound, "source not found"));

--- a/core/layers/tail-cut/src/lib.rs
+++ b/core/layers/tail-cut/src/lib.rs
@@ -412,10 +412,9 @@ impl Service for TailCutService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         self.inner
-            .copy(ctx, from, to, args, opts)
+            .copy(ctx, from, to, args)
             .map(|c| TailCutWrapper::new(c, None, self.config.clone(), self.stats.clone()))
     }
 

--- a/core/layers/throttle/src/lib.rs
+++ b/core/layers/throttle/src/lib.rs
@@ -162,9 +162,8 @@ impl Service for ThrottleAccessor {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
-        self.inner.copy(ctx, from, to, args, opts)
+        self.inner.copy(ctx, from, to, args)
     }
 
     fn delete(&self, ctx: &OperationContext) -> Result<Self::Deleter> {

--- a/core/layers/timeout/src/lib.rs
+++ b/core/layers/timeout/src/lib.rs
@@ -243,10 +243,9 @@ impl Service for TimeoutService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         self.inner
-            .copy(ctx, from, to, args, opts)
+            .copy(ctx, from, to, args)
             .map(|c| TimeoutWrapper::new(c, self.io_timeout))
     }
 
@@ -509,14 +508,7 @@ mod tests {
             Ok(MockLister)
         }
 
-        fn copy(
-            &self,
-            _: &OperationContext,
-            _: &str,
-            _: &str,
-            _: OpCopy,
-            _: OpCopier,
-        ) -> Result<Self::Copier> {
+        fn copy(&self, _: &OperationContext, _: &str, _: &str, _: OpCopy) -> Result<Self::Copier> {
             Ok(MockCopier)
         }
 
@@ -666,9 +658,7 @@ mod tests {
             .with_io_timeout(Duration::from_millis(100))
             .apply_service(Arc::new(MockService));
         let ctx = OperationContext::new();
-        let mut copier = service
-            .copy(&ctx, "f", "t", OpCopy::default(), OpCopier::default())
-            .unwrap();
+        let mut copier = service.copy(&ctx, "f", "t", OpCopy::default()).unwrap();
 
         let err = copier.next().await.unwrap_err();
         assert!(err.to_string().contains("timeout"));

--- a/core/layers/tracing/src/lib.rs
+++ b/core/layers/tracing/src/lib.rs
@@ -266,11 +266,10 @@ impl Service for TracingService {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
-        let span = span!(Level::DEBUG, "copy", from, to, ?args, ?opts);
+        let span = span!(Level::DEBUG, "copy", from, to, ?args);
         let _guard = span.enter();
-        self.inner.copy(ctx, from, to, args, opts)
+        self.inner.copy(ctx, from, to, args)
     }
 
     async fn rename(

--- a/core/services/aliyun-drive/src/backend.rs
+++ b/core/services/aliyun-drive/src/backend.rs
@@ -254,7 +254,6 @@ impl Service for AliyunDriveBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/alluxio/src/backend.rs
+++ b/core/services/alluxio/src/backend.rs
@@ -211,7 +211,6 @@ impl Service for AlluxioBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/azblob/src/backend.rs
+++ b/core/services/azblob/src/backend.rs
@@ -588,10 +588,9 @@ impl Service for AzblobBackend {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         let output: AzblobCopiers = {
-            let copier = new_azblob_copier(self.core.clone(), ctx, from, to, args, opts)?;
+            let copier = new_azblob_copier(self.core.clone(), ctx, from, to, args)?;
             Ok(copier)
         }?;
 

--- a/core/services/azblob/src/copier.rs
+++ b/core/services/azblob/src/copier.rs
@@ -39,8 +39,10 @@ pub fn new_azblob_copier(
     from: &str,
     to: &str,
     args: OpCopy,
-    opts: OpCopier,
 ) -> Result<AzblobCopiers> {
+    let chunk = args.chunk();
+    let source_content_length_hint = args.source_content_length_hint();
+    let concurrent = args.concurrent();
     let copier = AzblobCopier {
         core,
         ctx: ctx.clone(),
@@ -49,7 +51,7 @@ pub fn new_azblob_copier(
         args,
     };
 
-    let Some(chunk) = opts.chunk() else {
+    let Some(chunk) = chunk else {
         return Ok(TwoWays::One(oio::OneShotCopier::new(async move {
             copier.copy_once().await
         })));
@@ -60,10 +62,10 @@ pub fn new_azblob_copier(
     Ok(TwoWays::Two(oio::BlockCopier::new(
         ctx.executor().clone(),
         copier,
-        opts.source_content_length_hint(),
+        source_content_length_hint,
         block_size.saturating_sub(1),
         block_size,
-        opts.concurrent(),
+        concurrent,
     )))
 }
 

--- a/core/services/azdls/src/backend.rs
+++ b/core/services/azdls/src/backend.rs
@@ -508,7 +508,6 @@ impl Service for AzdlsBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/azfile/src/backend.rs
+++ b/core/services/azfile/src/backend.rs
@@ -415,7 +415,6 @@ impl Service for AzfileBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/b2/src/backend.rs
+++ b/core/services/b2/src/backend.rs
@@ -317,7 +317,6 @@ impl Service for B2Backend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/cacache/src/backend.rs
+++ b/core/services/cacache/src/backend.rs
@@ -167,7 +167,6 @@ impl Service for CacacheBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/cloudflare-kv/src/backend.rs
+++ b/core/services/cloudflare-kv/src/backend.rs
@@ -450,7 +450,6 @@ impl Service for CloudflareKvBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/compfs/src/backend.rs
+++ b/core/services/compfs/src/backend.rs
@@ -182,7 +182,6 @@ impl Service for CompfsBackend {
         from: &str,
         to: &str,
         _: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let from = self.core.prepare_path(from)?;

--- a/core/services/cos/src/backend.rs
+++ b/core/services/cos/src/backend.rs
@@ -432,7 +432,6 @@ impl Service for CosBackend {
         from: &str,
         to: &str,
         args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/d1/src/backend.rs
+++ b/core/services/d1/src/backend.rs
@@ -304,7 +304,6 @@ impl Service for D1Backend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/dashmap/src/backend.rs
+++ b/core/services/dashmap/src/backend.rs
@@ -204,7 +204,6 @@ impl Service for DashmapBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/dbfs/src/backend.rs
+++ b/core/services/dbfs/src/backend.rs
@@ -279,7 +279,6 @@ impl Service for DbfsBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/dropbox/src/backend.rs
+++ b/core/services/dropbox/src/backend.rs
@@ -333,7 +333,6 @@ impl Service for DropboxBackend {
         from: &str,
         to: &str,
         _: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/etcd/src/backend.rs
+++ b/core/services/etcd/src/backend.rs
@@ -324,7 +324,6 @@ impl Service for EtcdBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/foundationdb/src/backend.rs
+++ b/core/services/foundationdb/src/backend.rs
@@ -210,7 +210,6 @@ impl Service for FoundationdbBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/foyer/src/backend.rs
+++ b/core/services/foyer/src/backend.rs
@@ -325,7 +325,6 @@ impl Service for FoyerBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/fs/src/backend.rs
+++ b/core/services/fs/src/backend.rs
@@ -234,7 +234,6 @@ impl Service for FsBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let from = from.to_string();

--- a/core/services/ftp/src/backend.rs
+++ b/core/services/ftp/src/backend.rs
@@ -280,7 +280,6 @@ impl Service for FtpBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/gcs-grpc/src/backend.rs
+++ b/core/services/gcs-grpc/src/backend.rs
@@ -390,7 +390,6 @@ impl Service for GcsGrpcBackend {
         from: &str,
         to: &str,
         args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Ok(Box::new(new_gcs_grpc_copier(
             self.core.clone(),

--- a/core/services/gcs/src/backend.rs
+++ b/core/services/gcs/src/backend.rs
@@ -549,10 +549,9 @@ impl Service for GcsBackend {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         let output: GcsCopier = {
-            let copier = GcsCopier::new(self.core.clone(), ctx.clone(), from, to, args, opts);
+            let copier = GcsCopier::new(self.core.clone(), ctx.clone(), from, to, args);
             Ok(copier)
         }?;
 

--- a/core/services/gcs/src/copier.rs
+++ b/core/services/gcs/src/copier.rs
@@ -49,9 +49,8 @@ impl GcsCopier {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Self {
-        let chunk = opts.chunk().map(|v| {
+        let chunk = args.chunk().map(|v| {
             let v = v.clamp(GCS_REWRITE_MIN_CHUNK_SIZE, GCS_REWRITE_MAX_CHUNK_SIZE);
             v / GCS_REWRITE_MIN_CHUNK_SIZE * GCS_REWRITE_MIN_CHUNK_SIZE
         });

--- a/core/services/gdrive/src/backend.rs
+++ b/core/services/gdrive/src/backend.rs
@@ -376,7 +376,6 @@ impl Service for GdriveBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/ghac/src/backend.rs
+++ b/core/services/ghac/src/backend.rs
@@ -291,7 +291,6 @@ impl Service for GhacBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/github/src/backend.rs
+++ b/core/services/github/src/backend.rs
@@ -272,7 +272,6 @@ impl Service for GithubBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/goosefs/src/backend.rs
+++ b/core/services/goosefs/src/backend.rs
@@ -376,7 +376,6 @@ impl Service for GoosefsBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/gridfs/src/backend.rs
+++ b/core/services/gridfs/src/backend.rs
@@ -279,7 +279,6 @@ impl Service for GridfsBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/hdfs-native/src/backend.rs
+++ b/core/services/hdfs-native/src/backend.rs
@@ -221,7 +221,6 @@ impl Service for HdfsNativeBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/hdfs/src/backend.rs
+++ b/core/services/hdfs/src/backend.rs
@@ -260,7 +260,6 @@ impl Service for HdfsBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/hf/src/backend.rs
+++ b/core/services/hf/src/backend.rs
@@ -372,7 +372,6 @@ impl Service for HfBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/http/src/backend.rs
+++ b/core/services/http/src/backend.rs
@@ -262,7 +262,6 @@ impl Service for HttpBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/ipfs/src/backend.rs
+++ b/core/services/ipfs/src/backend.rs
@@ -216,7 +216,6 @@ impl Service for IpfsBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/ipmfs/src/backend.rs
+++ b/core/services/ipmfs/src/backend.rs
@@ -279,7 +279,6 @@ impl Service for IpmfsBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/koofr/src/backend.rs
+++ b/core/services/koofr/src/backend.rs
@@ -296,7 +296,6 @@ impl Service for KoofrBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/lakefs/src/backend.rs
+++ b/core/services/lakefs/src/backend.rs
@@ -300,7 +300,6 @@ impl Service for LakefsBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/memcached/src/backend.rs
+++ b/core/services/memcached/src/backend.rs
@@ -323,7 +323,6 @@ impl Service for MemcachedBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/mini_moka/src/backend.rs
+++ b/core/services/mini_moka/src/backend.rs
@@ -260,7 +260,6 @@ impl Service for MiniMokaBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/moka/src/backend.rs
+++ b/core/services/moka/src/backend.rs
@@ -336,7 +336,6 @@ impl Service for MokaBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/mongodb/src/backend.rs
+++ b/core/services/mongodb/src/backend.rs
@@ -294,7 +294,6 @@ impl Service for MongodbBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/monoiofs/src/backend.rs
+++ b/core/services/monoiofs/src/backend.rs
@@ -200,7 +200,6 @@ impl Service for MonoiofsBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let from = self.core.prepare_path(from)?;

--- a/core/services/mysql/src/backend.rs
+++ b/core/services/mysql/src/backend.rs
@@ -279,7 +279,6 @@ impl Service for MysqlBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/obs/src/backend.rs
+++ b/core/services/obs/src/backend.rs
@@ -399,7 +399,6 @@ impl Service for ObsBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/onedrive/src/backend.rs
+++ b/core/services/onedrive/src/backend.rs
@@ -301,7 +301,6 @@ impl Service for OnedriveBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/opfs/src/backend.rs
+++ b/core/services/opfs/src/backend.rs
@@ -152,14 +152,7 @@ impl Service for OpfsBackend {
         Ok(output)
     }
 
-    fn copy(
-        &self,
-        _: &OperationContext,
-        _: &str,
-        _: &str,
-        _: OpCopy,
-        _: OpCopier,
-    ) -> Result<Self::Copier> {
+    fn copy(&self, _: &OperationContext, _: &str, _: &str, _: OpCopy) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/core/services/oss/src/backend.rs
+++ b/core/services/oss/src/backend.rs
@@ -762,7 +762,6 @@ impl Service for OssBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/pcloud/src/backend.rs
+++ b/core/services/pcloud/src/backend.rs
@@ -280,7 +280,6 @@ impl Service for PcloudBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/persy/src/backend.rs
+++ b/core/services/persy/src/backend.rs
@@ -235,7 +235,6 @@ impl Service for PersyBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/postgresql/src/backend.rs
+++ b/core/services/postgresql/src/backend.rs
@@ -270,7 +270,6 @@ impl Service for PostgresqlBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/redb/src/backend.rs
+++ b/core/services/redb/src/backend.rs
@@ -253,7 +253,6 @@ impl Service for RedbBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/redis/src/backend.rs
+++ b/core/services/redis/src/backend.rs
@@ -403,7 +403,6 @@ impl Service for RedisBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/rocksdb/src/backend.rs
+++ b/core/services/rocksdb/src/backend.rs
@@ -205,7 +205,6 @@ impl Service for RocksdbBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/s3/src/backend.rs
+++ b/core/services/s3/src/backend.rs
@@ -1296,10 +1296,9 @@ impl Service for S3Backend {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         let output: S3Copiers = {
-            let copier = new_s3_copier(self.core.clone(), ctx, from, to, args, opts)?;
+            let copier = new_s3_copier(self.core.clone(), ctx, from, to, args)?;
             Ok(copier)
         }?;
 
@@ -1329,14 +1328,7 @@ impl Service for S3Backend {
             let copy_args = OpCopy::new()
                 .with_source_version(version)
                 .with_if_not_exists(args.if_not_exists());
-            let mut copier = new_s3_copier(
-                self.core.clone(),
-                ctx,
-                path,
-                path,
-                copy_args,
-                OpCopier::default(),
-            )?;
+            let mut copier = new_s3_copier(self.core.clone(), ctx, path, path, copy_args)?;
 
             return match copier.close().await {
                 Ok(_) => Ok(RpRestore::new()),

--- a/core/services/s3/src/copier.rs
+++ b/core/services/s3/src/copier.rs
@@ -34,7 +34,6 @@ pub fn new_s3_copier(
     from: &str,
     to: &str,
     args: OpCopy,
-    opts: OpCopier,
 ) -> Result<S3Copiers> {
     let capability = core.capability;
     let max_part_size = capability.copy_multi_max_size.ok_or_else(|| {
@@ -44,7 +43,7 @@ pub fn new_s3_copier(
         )
     })?;
 
-    let (copy_once_threshold, part_size) = match opts.chunk() {
+    let (copy_once_threshold, part_size) = match args.chunk() {
         Some(chunk) => {
             let min_part_size = capability.copy_multi_min_size.ok_or_else(|| {
                 Error::new(
@@ -60,6 +59,8 @@ pub fn new_s3_copier(
             (part_size, part_size)
         }
     };
+    let source_content_length_hint = args.source_content_length_hint();
+    let concurrent = args.concurrent();
 
     Ok(oio::MultipartCopier::new(
         (ctx.executor().clone(), capability),
@@ -70,10 +71,10 @@ pub fn new_s3_copier(
             to: to.to_string(),
             args,
         },
-        opts.source_content_length_hint(),
+        source_content_length_hint,
         copy_once_threshold,
         part_size,
-        opts.concurrent(),
+        concurrent,
     ))
 }
 

--- a/core/services/seafile/src/backend.rs
+++ b/core/services/seafile/src/backend.rs
@@ -281,7 +281,6 @@ impl Service for SeafileBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/sftp/src/backend.rs
+++ b/core/services/sftp/src/backend.rs
@@ -290,7 +290,6 @@ impl Service for SftpBackend {
         from: &str,
         to: &str,
         _: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let backend = self.clone();
         let ctx = ctx.clone();

--- a/core/services/sled/src/backend.rs
+++ b/core/services/sled/src/backend.rs
@@ -229,7 +229,6 @@ impl Service for SledBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/sqlite/src/backend.rs
+++ b/core/services/sqlite/src/backend.rs
@@ -317,7 +317,6 @@ impl Service for SqliteBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/surrealdb/src/backend.rs
+++ b/core/services/surrealdb/src/backend.rs
@@ -321,7 +321,6 @@ impl Service for SurrealdbBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/swift/src/backend.rs
+++ b/core/services/swift/src/backend.rs
@@ -376,7 +376,6 @@ impl Service for SwiftBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/tikv/src/backend.rs
+++ b/core/services/tikv/src/backend.rs
@@ -230,7 +230,6 @@ impl Service for TikvBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/tos/src/backend.rs
+++ b/core/services/tos/src/backend.rs
@@ -400,10 +400,9 @@ impl Service for TosBackend {
         from: &str,
         to: &str,
         args: OpCopy,
-        opts: OpCopier,
     ) -> Result<Self::Copier> {
         let output: TosCopiers = {
-            let copier = new_tos_copier(self.core.clone(), ctx, from, to, args, opts)?;
+            let copier = new_tos_copier(self.core.clone(), ctx, from, to, args)?;
             Ok(copier)
         }?;
 

--- a/core/services/tos/src/copier.rs
+++ b/core/services/tos/src/copier.rs
@@ -34,7 +34,6 @@ pub fn new_tos_copier(
     from: &str,
     to: &str,
     args: OpCopy,
-    opts: OpCopier,
 ) -> Result<TosCopiers> {
     let capability = core.capability;
     let max_part_size = capability.copy_multi_max_size.ok_or_else(|| {
@@ -44,7 +43,7 @@ pub fn new_tos_copier(
         )
     })?;
 
-    let (copy_once_threshold, part_size) = match opts.chunk() {
+    let (copy_once_threshold, part_size) = match args.chunk() {
         Some(chunk) => {
             let min_part_size = capability.copy_multi_min_size.ok_or_else(|| {
                 Error::new(
@@ -60,6 +59,8 @@ pub fn new_tos_copier(
             (part_size, part_size)
         }
     };
+    let source_content_length_hint = args.source_content_length_hint();
+    let concurrent = args.concurrent();
 
     Ok(oio::MultipartCopier::new(
         (ctx.executor().clone(), capability),
@@ -70,10 +71,10 @@ pub fn new_tos_copier(
             to: to.to_string(),
             args,
         },
-        opts.source_content_length_hint(),
+        source_content_length_hint,
         copy_once_threshold,
         part_size,
-        opts.concurrent(),
+        concurrent,
     ))
 }
 

--- a/core/services/upyun/src/backend.rs
+++ b/core/services/upyun/src/backend.rs
@@ -282,7 +282,6 @@ impl Service for UpyunBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/vercel-artifacts/src/backend.rs
+++ b/core/services/vercel-artifacts/src/backend.rs
@@ -235,7 +235,6 @@ impl Service for VercelArtifactsBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/vercel-blob/src/backend.rs
+++ b/core/services/vercel-blob/src/backend.rs
@@ -212,7 +212,6 @@ impl Service for VercelBlobBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/webdav/src/backend.rs
+++ b/core/services/webdav/src/backend.rs
@@ -352,7 +352,6 @@ impl Service for WebdavBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/core/services/webhdfs/src/backend.rs
+++ b/core/services/webhdfs/src/backend.rs
@@ -399,7 +399,6 @@ impl Service for WebhdfsBackend {
         _from: &str,
         _to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/core/services/yandex-disk/src/backend.rs
+++ b/core/services/yandex-disk/src/backend.rs
@@ -185,7 +185,6 @@ impl Service for YandexDiskBackend {
         from: &str,
         to: &str,
         _args: OpCopy,
-        _opts: OpCopier,
     ) -> Result<Self::Copier> {
         let core = self.core.clone();
         let ctx = ctx.clone();

--- a/integrations/object_store/src/service/mod.rs
+++ b/integrations/object_store/src/service/mod.rs
@@ -171,14 +171,7 @@ impl Service for ObjectStoreService {
         Ok(lister)
     }
 
-    fn copy(
-        &self,
-        _: &OperationContext,
-        _: &str,
-        _: &str,
-        _: OpCopy,
-        _: OpCopier,
-    ) -> Result<Self::Copier> {
+    fn copy(&self, _: &OperationContext, _: &str, _: &str, _: OpCopy) -> Result<Self::Copier> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "operation is not supported",

--- a/integrations/object_store/src/store.rs
+++ b/integrations/object_store/src/store.rs
@@ -1166,9 +1166,8 @@ mod tests {
                 from: &str,
                 to: &str,
                 args: opendal::raw::OpCopy,
-                opts: opendal::raw::OpCopier,
             ) -> opendal::Result<Self::Copier> {
-                self.srv.copy(ctx, from, to, args, opts)
+                self.srv.copy(ctx, from, to, args)
             }
 
             async fn rename(


### PR DESCRIPTION
# Which issue does this PR close?

N/A. This is a maintainer-directed core API refactor.

# Rationale for this change

`OpCopier` separates execution options from the operation arguments even though `chunk`, `concurrent`, and `source_content_length_hint` are consumed by service implementations. Keeping two argument objects forces every service, layer, and dynamic dispatch boundary to carry an extra parameter without representing a separate responsibility.

# What changes are included in this PR?

Merge the copier execution options into `OpCopy`, remove `OpCopier`, and update `Service::copy`, dynamic dispatch, layers, integrations, and service implementations to pass one complete operation argument. S3, TOS, AzBlob, and GCS now read their copy execution settings directly from `OpCopy`.

# Are there any user-facing changes?

Yes. This is a breaking change to the public raw API:

- `OpCopier` is removed.
- `Service::copy` no longer accepts a separate `OpCopier` parameter.
- Raw service implementations must read copy execution options from `OpCopy`.

The high-level `CopyOptions` API and copy behavior remain unchanged.

# AI Usage Statement

Codex materially assisted with the implementation and validation under maintainer direction. The intentional assumption is that breaking compatibility for the raw `Service` API is acceptable; no high-level copy behavior change is intended.
