### PR TITLE
fix(services): escape filename in koofr and seafile multipart disposition

### DIFF
--- a/core/core/src/raw/http_util/mod.rs
+++ b/core/core/src/raw/http_util/mod.rs
@@ -63,3 +63,4 @@ pub use multipart::MixedPart;
 pub use multipart::Multipart;
 pub use multipart::Part;
 pub use multipart::RelatedPart;
+pub use multipart::escape_multipart_filename;

--- a/core/core/src/raw/http_util/multipart.rs
+++ b/core/core/src/raw/http_util/multipart.rs
@@ -164,6 +164,19 @@ pub trait Part: Sized + 'static {
     fn parse(s: &str) -> Result<Self>;
 }
 
+/// Escape a value for the quoted-string form of a multipart
+/// `Content-Disposition` parameter such as `filename`.
+///
+/// The quoted-string grammar only gives special meaning to `\` (the escape
+/// character) and `"` (the closing delimiter), so both are backslash-escaped
+/// and every other byte is left untouched. Services that build the header from
+/// an untrusted object key must run the value through this first: a key
+/// containing `"` otherwise closes the quoted string early and injects extra
+/// parameters into the part header.
+pub fn escape_multipart_filename(filename: &str) -> String {
+    filename.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 /// FormDataPart is a builder for multipart/form-data part.
 pub struct FormDataPart {
     headers: HeaderMap,
@@ -634,6 +647,18 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    #[test]
+    fn test_escape_multipart_filename() {
+        assert_eq!(escape_multipart_filename("plain.txt"), "plain.txt");
+        // A bare quote must not close the quoted string early.
+        assert_eq!(
+            escape_multipart_filename("evil\"; name=\"replace"),
+            "evil\\\"; name=\\\"replace"
+        );
+        // Backslash is escaped before quotes so it round-trips.
+        assert_eq!(escape_multipart_filename("a\\b\"c"), "a\\\\b\\\"c");
+    }
 
     #[test]
     fn test_multipart_formdata_basic() -> Result<()> {

--- a/core/services/koofr/src/core.rs
+++ b/core/services/koofr/src/core.rs
@@ -316,9 +316,12 @@ impl KoofrCore {
         let file_part = FormDataPart::new("file")
             .header(
                 header::CONTENT_DISPOSITION,
-                format!("form-data; name=\"file\"; filename=\"{filename}\"")
-                    .parse()
-                    .unwrap(),
+                format!(
+                    "form-data; name=\"file\"; filename=\"{}\"",
+                    escape_multipart_filename(filename)
+                )
+                .parse()
+                .unwrap(),
             )
             .content(bs);
 

--- a/core/services/seafile/src/core.rs
+++ b/core/services/seafile/src/core.rs
@@ -220,9 +220,12 @@ impl SeafileCore {
         let file_part = FormDataPart::new("file")
             .header(
                 header::CONTENT_DISPOSITION,
-                format!("form-data; name=\"file\"; filename=\"{filename}\"")
-                    .parse()
-                    .unwrap(),
+                format!(
+                    "form-data; name=\"file\"; filename=\"{}\"",
+                    escape_multipart_filename(filename)
+                )
+                .parse()
+                .unwrap(),
             )
             .content(body);
 


### PR DESCRIPTION
# Which issue does this PR close?

No existing issue; details below.

# Rationale for this change

The Koofr and Seafile write paths build the multipart/form-data `Content-Disposition` header for the uploaded part by dropping the object key basename straight into `filename="{filename}"`. That basename comes from the caller-supplied key, and `normalize_path` leaves quotes and backslashes intact, so nothing escapes the value before it reaches the header. A key whose basename contains a double quote closes the quoted string early: writing `dir/evil"; name="x` yields `filename="evil"; name="x"`, which a receiving parser reads as an extra `name` parameter on the part. On Seafile that part sits beside real control fields (`parent_dir`, `relative_path`, `replace`), so an injected `name=` can shadow one of them and change how the upload is interpreted. I noticed it while auditing these multipart writers against the URL builders in the same files, which already run every key through `percent_encode_path`. Escaping the quoted-string metacharacters at the point the header is built keeps the fix in the layer that owns the encoding, and valid filenames stay byte-for-byte the same.

# What changes are included in this PR?

- Add `escape_multipart_filename` in `core/core/src/raw/http_util/multipart.rs` (backslash-escapes `\` first, then `"`, the two quoted-string metacharacters) and export it from `raw::http_util`.
- Apply it when building the `file` part disposition in the Koofr and Seafile write paths.
- Unit test for plain, embedded-quote, and backslash inputs.

# Are there any user-facing changes?

No public API changes. Uploads whose key basename contains a `"` or `\` now send a correctly quoted `Content-Disposition` filename instead of a malformed one.

# AI Usage Statement

<!--
If AI materially assisted this PR, briefly describe its role and disclose any
assumptions or unknowns that affect review. Do not include routine command output
or repeat information provided elsewhere.

The author remains responsible for every submitted claim and change. If AI did
not materially assist this PR, write "None".
-->
