### PR TITLE
fix(services/gcs): make conditional uploads retry-safe

### DIFF
--- a/core/services/gcs/src/core.rs
+++ b/core/services/gcs/src/core.rs
@@ -29,6 +29,7 @@ use http::header::CACHE_CONTROL;
 use http::header::CONTENT_DISPOSITION;
 use http::header::CONTENT_ENCODING;
 use http::header::CONTENT_LENGTH;
+use http::header::CONTENT_RANGE;
 use http::header::CONTENT_TYPE;
 use http::header::HOST;
 use http::header::IF_MATCH;
@@ -421,22 +422,36 @@ impl GcsCore {
         total: Option<u64>,
     ) -> Result<Response<Buffer>> {
         let end = offset + body.len() as u64;
-        let content_range = if body.is_empty() {
-            format!("bytes */{}", total.unwrap_or_default())
-        } else {
-            format!(
-                "bytes {}-{}/{}",
-                offset,
-                end - 1,
-                total.map_or_else(|| "*".to_string(), |v| v.to_string())
-            )
-        };
+        let mut content_range = BytesContentRange::default();
+        if !body.is_empty() {
+            content_range = content_range.with_range(offset, end - 1);
+        }
+        if let Some(total) = total {
+            content_range = content_range.with_size(total);
+        }
         let req = Request::put(session_uri)
             .header(CONTENT_LENGTH, body.len())
-            .header("content-range", content_range)
+            .header(CONTENT_RANGE, content_range.to_header())
             .extension(Operation::Write)
             .extension(ServiceOperation("UploadResumableChunk"))
             .body(body)
+            .map_err(new_request_build_error)?;
+        self.send(ctx, req).await
+    }
+
+    pub async fn gcs_query_resumable_upload(
+        &self,
+        ctx: &OperationContext,
+        session_uri: &str,
+        total: u64,
+    ) -> Result<Response<Buffer>> {
+        let content_range = BytesContentRange::default().with_size(total);
+        let req = Request::put(session_uri)
+            .header(CONTENT_LENGTH, 0)
+            .header(CONTENT_RANGE, content_range.to_header())
+            .extension(Operation::Write)
+            .extension(ServiceOperation("QueryResumableUpload"))
+            .body(Buffer::new())
             .map_err(new_request_build_error)?;
         self.send(ctx, req).await
     }

--- a/core/services/gcs/src/writer.rs
+++ b/core/services/gcs/src/writer.rs
@@ -201,6 +201,18 @@ pub struct GcsConditionalWriter {
     session_uri: Option<String>,
     offset: u64,
     pending: oio::QueueBuf,
+    finalize_state: FinalizeState,
+}
+
+enum ResumableUploadStatus {
+    Incomplete(u64),
+    Complete(Box<Metadata>),
+}
+
+#[derive(Eq, PartialEq)]
+enum FinalizeState {
+    Ready,
+    CheckStatus,
 }
 
 impl GcsConditionalWriter {
@@ -213,6 +225,7 @@ impl GcsConditionalWriter {
             session_uri: None,
             offset: 0,
             pending: oio::QueueBuf::new(),
+            finalize_state: FinalizeState::Ready,
         }
     }
 
@@ -271,136 +284,201 @@ impl GcsConditionalWriter {
         })
     }
 
-    async fn upload(&mut self, mut body: Buffer, total: Option<u64>) -> Result<Option<Metadata>> {
-        loop {
-            let session_uri = self.ensure_session().await?.to_string();
-            let sent_offset = self.offset;
-            let sent_end = sent_offset + body.len() as u64;
-            let resp = self
-                .core
-                .gcs_upload_resumable_chunk(
-                    &self.ctx,
-                    &session_uri,
-                    sent_offset,
-                    body.clone(),
-                    total,
-                )
-                .await?;
+    async fn query_status(&mut self, total: u64) -> Result<ResumableUploadStatus> {
+        let session_uri = self.ensure_session().await?.to_string();
+        let resp = self
+            .core
+            .gcs_query_resumable_upload(&self.ctx, &session_uri, total)
+            .await?;
 
-            if resp.status() == StatusCode::PERMANENT_REDIRECT {
-                let persisted = Self::persisted_offset(&resp)?;
-                if persisted <= sent_offset || persisted > sent_end {
-                    return Err(Error::new(
-                        ErrorKind::Unexpected,
-                        "GCS resumable upload reported invalid persisted range",
-                    )
-                    .with_context("offset", sent_offset)
-                    .with_context("persisted", persisted)
-                    .set_temporary());
-                }
-                body.advance((persisted - sent_offset) as usize);
-                self.offset = persisted;
-                if body.is_empty() {
-                    if total.is_some() {
-                        return Err(Error::new(
-                            ErrorKind::Unexpected,
-                            "GCS did not finalize the last resumable upload chunk",
-                        )
-                        .set_temporary());
-                    }
-                    return Ok(None);
-                }
-                continue;
-            }
-
-            if resp.status() == StatusCode::OK || resp.status() == StatusCode::CREATED {
-                if total.is_none() {
-                    return Err(Error::new(
-                        ErrorKind::Unexpected,
-                        "GCS finalized a resumable upload before the last chunk",
-                    ));
-                }
-                self.offset = sent_end;
-                return GcsCore::build_metadata_from_object_response(&self.path, resp.into_body())
-                    .map(Some);
-            }
-
-            return Err(parse_error(
-                ErrorContext::new(ServiceOperation("UploadResumableChunk"))
-                    .with_if_not_exists(self.op.if_not_exists())
-                    .with_if_match(self.op.if_match().is_some())
-                    .with_if_none_match(self.op.if_none_match().is_some())
-                    .with_if_version_match(self.op.if_version_match().is_some())
-                    .with_if_version_not_match(self.op.if_version_not_match().is_some()),
-                resp,
-            ));
-        }
-    }
-
-    async fn write_once(&self, body: Buffer) -> Result<Metadata> {
-        let req = self.core.gcs_insert_object_request(
-            &self.path,
-            Some(body.len() as u64),
-            &self.op,
-            body,
-        )?;
-        let req = self.core.sign(&self.ctx, req).await?;
-        let resp = self.core.send(&self.ctx, req).await?;
         match resp.status() {
+            StatusCode::PERMANENT_REDIRECT => {
+                let persisted = Self::persisted_offset(&resp)?;
+                Ok(ResumableUploadStatus::Incomplete(persisted))
+            }
             StatusCode::OK | StatusCode::CREATED => {
-                GcsCore::build_metadata_from_object_response(&self.path, resp.into_body())
+                let metadata =
+                    GcsCore::build_metadata_from_object_response(&self.path, resp.into_body())?;
+                Ok(ResumableUploadStatus::Complete(Box::new(metadata)))
             }
             _ => Err(parse_error(
-                ErrorContext::new(ServiceOperation("InsertObject"))
-                    .with_if_not_exists(self.op.if_not_exists())
-                    .with_if_match(self.op.if_match().is_some())
-                    .with_if_none_match(self.op.if_none_match().is_some())
-                    .with_if_version_match(self.op.if_version_match().is_some())
-                    .with_if_version_not_match(self.op.if_version_not_match().is_some()),
+                ErrorContext::new(ServiceOperation("QueryResumableUpload")),
                 resp,
             )),
         }
+    }
+
+    async fn upload_chunk(&mut self, body: Buffer) -> Result<()> {
+        let start = self.offset;
+        let end = start + body.len() as u64;
+        let session_uri = self.ensure_session().await?.to_string();
+        let resp = self
+            .core
+            .gcs_upload_resumable_chunk(&self.ctx, &session_uri, start, body, None)
+            .await?;
+
+        if resp.status() == StatusCode::PERMANENT_REDIRECT {
+            let persisted = Self::persisted_offset(&resp)?;
+            if persisted < start || persisted > end {
+                return Err(Error::new(
+                    ErrorKind::Unexpected,
+                    "GCS resumable upload reported invalid persisted range",
+                )
+                .with_context("start", start)
+                .with_context("end", end)
+                .with_context("persisted", persisted)
+                .set_temporary());
+            }
+            if persisted < end {
+                // GCS ignores an already persisted prefix when the same chunk
+                // is retried, so advance only after the full chunk is acknowledged.
+                return Err(Error::new(
+                    ErrorKind::Unexpected,
+                    "GCS resumable upload persisted only part of a chunk",
+                )
+                .with_context("start", start)
+                .with_context("end", end)
+                .with_context("persisted", persisted)
+                .set_temporary());
+            }
+            self.offset = end;
+            return Ok(());
+        }
+
+        if resp.status() == StatusCode::OK || resp.status() == StatusCode::CREATED {
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "GCS finalized a resumable upload before the last chunk",
+            ));
+        }
+
+        Err(parse_error(
+            ErrorContext::new(ServiceOperation("UploadResumableChunk"))
+                .with_if_not_exists(self.op.if_not_exists())
+                .with_if_match(self.op.if_match().is_some())
+                .with_if_none_match(self.op.if_none_match().is_some())
+                .with_if_version_match(self.op.if_version_match().is_some())
+                .with_if_version_not_match(self.op.if_version_not_match().is_some()),
+            resp,
+        ))
+    }
+
+    async fn flush_pending(&mut self) -> Result<()> {
+        while self.pending.len() > RESUMABLE_CHUNK_SIZE {
+            let mut chunk = self.pending.clone().collect();
+            chunk.truncate(RESUMABLE_CHUNK_SIZE);
+            self.upload_chunk(chunk).await?;
+            self.pending.advance(RESUMABLE_CHUNK_SIZE);
+        }
+        Ok(())
     }
 }
 
 impl oio::Write for GcsConditionalWriter {
     async fn write(&mut self, body: Buffer) -> Result<()> {
+        self.flush_pending().await?;
         self.pending.push(body);
-        while self.pending.len() > RESUMABLE_CHUNK_SIZE {
-            let mut buffered = self.pending.take().collect();
-            let chunk = buffered.split_to(RESUMABLE_CHUNK_SIZE);
-            self.pending.push(buffered);
-            self.upload(chunk, None).await?;
-        }
         Ok(())
     }
 
     async fn close(&mut self) -> Result<Metadata> {
-        let body = self.pending.take().collect();
-        if self.session_uri.is_none() {
-            return self.write_once(body).await;
+        self.flush_pending().await?;
+        let body = self.pending.clone().collect();
+        let start = self.offset;
+        let total = start + body.len() as u64;
+
+        if self.finalize_state == FinalizeState::CheckStatus {
+            match self.query_status(total).await? {
+                ResumableUploadStatus::Incomplete(persisted) => {
+                    if persisted < start || persisted > total {
+                        return Err(Error::new(
+                            ErrorKind::Unexpected,
+                            "GCS resumable upload reported invalid persisted range",
+                        )
+                        .with_context("start", start)
+                        .with_context("end", total)
+                        .with_context("persisted", persisted)
+                        .set_temporary());
+                    }
+                    self.finalize_state = FinalizeState::Ready;
+                }
+                ResumableUploadStatus::Complete(metadata) => {
+                    self.finalize_state = FinalizeState::Ready;
+                    self.offset = total;
+                    self.pending.advance(body.len());
+                    return Ok(*metadata);
+                }
+            }
         }
 
-        let total = self.offset + body.len() as u64;
-        self.upload(body, Some(total))
-            .await?
-            .ok_or_else(|| Error::new(ErrorKind::Unexpected, "GCS upload returned no metadata"))
+        let session_uri = self.ensure_session().await?.to_string();
+        self.finalize_state = FinalizeState::CheckStatus;
+        let resp = self
+            .core
+            .gcs_upload_resumable_chunk(&self.ctx, &session_uri, start, body.clone(), Some(total))
+            .await?;
+
+        if resp.status() == StatusCode::PERMANENT_REDIRECT {
+            let persisted = Self::persisted_offset(&resp)?;
+            if persisted < start || persisted > total {
+                return Err(Error::new(
+                    ErrorKind::Unexpected,
+                    "GCS resumable upload reported invalid persisted range",
+                )
+                .with_context("start", start)
+                .with_context("end", total)
+                .with_context("persisted", persisted)
+                .set_temporary());
+            }
+            self.finalize_state = FinalizeState::Ready;
+            return Err(Error::new(
+                ErrorKind::Unexpected,
+                "GCS did not finalize the last resumable upload chunk",
+            )
+            .with_context("persisted", persisted)
+            .set_temporary());
+        }
+
+        if resp.status() == StatusCode::OK || resp.status() == StatusCode::CREATED {
+            let metadata =
+                GcsCore::build_metadata_from_object_response(&self.path, resp.into_body())?;
+            self.finalize_state = FinalizeState::Ready;
+            self.offset = total;
+            self.pending.advance(body.len());
+            return Ok(metadata);
+        }
+
+        let err = parse_error(
+            ErrorContext::new(ServiceOperation("UploadResumableChunk"))
+                .with_if_not_exists(self.op.if_not_exists())
+                .with_if_match(self.op.if_match().is_some())
+                .with_if_none_match(self.op.if_none_match().is_some())
+                .with_if_version_match(self.op.if_version_match().is_some())
+                .with_if_version_not_match(self.op.if_version_not_match().is_some()),
+            resp,
+        );
+        if !err.is_temporary() {
+            self.finalize_state = FinalizeState::Ready;
+        }
+        Err(err)
     }
 
     async fn abort(&mut self) -> Result<()> {
-        self.pending.clear();
-        let Some(session_uri) = self.session_uri.take() else {
+        let Some(session_uri) = self.session_uri.as_deref() else {
+            self.pending.clear();
             return Ok(());
         };
         let resp = self
             .core
-            .gcs_cancel_resumable_upload(&self.ctx, &session_uri)
+            .gcs_cancel_resumable_upload(&self.ctx, session_uri)
             .await?;
         if resp.status().is_success()
             || resp.status().as_u16() == 499
             || resp.status() == StatusCode::NOT_FOUND
             || resp.status() == StatusCode::GONE
         {
+            self.session_uri = None;
+            self.pending.clear();
             Ok(())
         } else {
             Err(parse_error(
@@ -408,5 +486,313 @@ impl oio::Write for GcsConditionalWriter {
                 resp,
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use bytes::Bytes;
+    use futures::stream;
+    use http::Request;
+    use http::Response;
+    use http::header::CONTENT_LENGTH;
+    use opendal_core::raw::oio::Write as _;
+    use reqsign_core::Context;
+    use reqsign_core::ProvideCredentialChain;
+    use reqsign_core::Signer;
+    use reqsign_google::RequestSigner;
+    use reqsign_google::TokenCredentialProvider;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MockState {
+        uploaded: Vec<u8>,
+        ranges: Vec<String>,
+        fail_chunk_response: bool,
+        fail_final_response: bool,
+        fail_final_response_partially: bool,
+        completed: bool,
+    }
+
+    #[derive(Clone, Default)]
+    struct MockResumableTransport {
+        state: Arc<Mutex<MockState>>,
+    }
+
+    impl MockResumableTransport {
+        fn fail_chunk_response(&self) {
+            self.state.lock().unwrap().fail_chunk_response = true;
+        }
+
+        fn fail_final_response(&self) {
+            self.state.lock().unwrap().fail_final_response = true;
+        }
+
+        fn fail_final_response_partially(&self) {
+            self.state.lock().unwrap().fail_final_response_partially = true;
+        }
+
+        fn uploaded(&self) -> Vec<u8> {
+            self.state.lock().unwrap().uploaded.clone()
+        }
+
+        fn ranges(&self) -> Vec<String> {
+            self.state.lock().unwrap().ranges.clone()
+        }
+
+        fn response(
+            status: StatusCode,
+            range: Option<String>,
+            body: Option<String>,
+        ) -> Result<Response<HttpBody>> {
+            let body = body.unwrap_or_default();
+            let size = body.len() as u64;
+            let mut response = Response::builder()
+                .status(status)
+                .header(CONTENT_LENGTH, size);
+            if let Some(range) = range {
+                response = response.header(RANGE, range);
+            }
+            let stream = if body.is_empty() {
+                stream::iter(Vec::<Result<Buffer>>::new())
+            } else {
+                stream::iter(vec![Ok(Buffer::from(Bytes::from(body)))])
+            };
+            Ok(response
+                .body(HttpBody::new(stream, Some(size)))
+                .expect("mock response must build"))
+        }
+
+        fn completed_response(size: usize) -> Result<Response<HttpBody>> {
+            Self::response(
+                StatusCode::OK,
+                None,
+                Some(format!(r#"{{"size":"{size}","generation":"1"}}"#)),
+            )
+        }
+    }
+
+    impl HttpTransport for MockResumableTransport {
+        async fn fetch(&self, req: Request<Buffer>) -> Result<Response<HttpBody>> {
+            if req.method() == http::Method::POST {
+                return Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .header(LOCATION, "https://upload.example/session")
+                    .header(CONTENT_LENGTH, 0)
+                    .body(HttpBody::new(
+                        stream::iter(Vec::<Result<Buffer>>::new()),
+                        Some(0),
+                    ))
+                    .expect("mock response must build"));
+            }
+
+            assert_eq!(req.method(), http::Method::PUT);
+            assert_eq!(req.uri(), "https://upload.example/session");
+
+            let content_range = req
+                .headers()
+                .get("content-range")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string();
+            let body = req.body().to_bytes();
+            let mut state = self.state.lock().unwrap();
+            state.ranges.push(content_range.clone());
+
+            if body.is_empty() {
+                if content_range == "bytes */0" && state.uploaded.is_empty() {
+                    state.completed = true;
+                    return Self::completed_response(0);
+                }
+                if state.completed {
+                    return Self::completed_response(state.uploaded.len());
+                }
+                let range = (!state.uploaded.is_empty())
+                    .then(|| format!("bytes=0-{}", state.uploaded.len() - 1));
+                return Self::response(StatusCode::PERMANENT_REDIRECT, range, None);
+            }
+
+            let value = content_range.strip_prefix("bytes ").unwrap();
+            let (range, total) = value.split_once('/').unwrap();
+            let (start, end) = range.split_once('-').unwrap();
+            let start = start.parse::<usize>().unwrap();
+            let end = end.parse::<usize>().unwrap();
+            assert_eq!(end + 1 - start, body.len());
+            assert!(start <= state.uploaded.len());
+            let persisted = state.uploaded.len() - start;
+            assert!(persisted <= body.len());
+            assert_eq!(&state.uploaded[start..], &body[..persisted]);
+            let remaining = &body[persisted..];
+
+            if total == "*" {
+                if state.fail_chunk_response {
+                    state.fail_chunk_response = false;
+                    state
+                        .uploaded
+                        .extend_from_slice(&remaining[..remaining.len() / 2]);
+                    return Err(
+                        Error::new(ErrorKind::Unexpected, "mock lost chunk response")
+                            .set_temporary(),
+                    );
+                }
+                state.uploaded.extend_from_slice(remaining);
+                let range = Some(format!("bytes=0-{}", state.uploaded.len() - 1));
+                return Self::response(StatusCode::PERMANENT_REDIRECT, range, None);
+            }
+
+            if state.fail_final_response_partially {
+                state.fail_final_response_partially = false;
+                state
+                    .uploaded
+                    .extend_from_slice(&remaining[..remaining.len() / 2]);
+                return Err(
+                    Error::new(ErrorKind::Unexpected, "mock lost partial final response")
+                        .set_temporary(),
+                );
+            }
+            state.uploaded.extend_from_slice(remaining);
+            assert_eq!(total.parse::<usize>().unwrap(), state.uploaded.len());
+            state.completed = true;
+            if state.fail_final_response {
+                state.fail_final_response = false;
+                return Err(
+                    Error::new(ErrorKind::Unexpected, "mock lost final response").set_temporary(),
+                );
+            }
+            Self::completed_response(state.uploaded.len())
+        }
+    }
+
+    fn test_writer(transport: MockResumableTransport) -> GcsConditionalWriter {
+        let sign_ctx = Context::new();
+        let signer = Signer::new(
+            sign_ctx.clone(),
+            ProvideCredentialChain::new().push(TokenCredentialProvider::new("test-token")),
+            RequestSigner::new("storage"),
+        );
+        let core = Arc::new(GcsCore {
+            info: ServiceInfo::new("gcs", "/", "test-bucket"),
+            capability: Capability::default(),
+            endpoint: "https://storage.googleapis.com".to_string(),
+            bucket: "test-bucket".to_string(),
+            root: "/".to_string(),
+            signer,
+            sign_ctx,
+            predefined_acl: None,
+            default_storage_class: None,
+            skip_signature: true,
+        });
+        let ctx = OperationContext::new().with_http_transport(HttpTransporter::new(transport));
+        let (op, _) = OpWrite::from_options(
+            &Capability::default(),
+            options::WriteOptions {
+                if_not_exists: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        GcsConditionalWriter::new(core, ctx, "object", op)
+    }
+
+    #[tokio::test]
+    async fn retry_write_resends_interrupted_chunk_before_accepting_input() {
+        let transport = MockResumableTransport::default();
+        transport.fail_chunk_response();
+        let mut writer = test_writer(transport.clone());
+        let mut expected = vec![7; RESUMABLE_CHUNK_SIZE + 3];
+        let body = Buffer::from(Bytes::copy_from_slice(&expected));
+        let next = Bytes::from_static(b"next");
+
+        writer.write(body).await.unwrap();
+        let err = writer.write(Buffer::from(next.clone())).await.unwrap_err();
+        assert!(err.is_temporary());
+        writer.write(Buffer::from(next.clone())).await.unwrap();
+        let metadata = writer.close().await.unwrap();
+
+        expected.extend_from_slice(&next);
+        assert_eq!(transport.uploaded(), expected);
+        assert_eq!(
+            metadata.content_length(),
+            (RESUMABLE_CHUNK_SIZE + 3 + next.len()) as u64
+        );
+        assert_eq!(
+            transport.ranges(),
+            vec![
+                format!("bytes 0-{}/*", RESUMABLE_CHUNK_SIZE - 1),
+                format!("bytes 0-{}/*", RESUMABLE_CHUNK_SIZE - 1),
+                format!(
+                    "bytes {}-{}/{}",
+                    RESUMABLE_CHUNK_SIZE,
+                    RESUMABLE_CHUNK_SIZE + 2 + next.len(),
+                    RESUMABLE_CHUNK_SIZE + 3 + next.len()
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_close_reconciles_lost_final_response() {
+        let transport = MockResumableTransport::default();
+        transport.fail_final_response();
+        let mut writer = test_writer(transport.clone());
+        let expected = b"hello".to_vec();
+        writer
+            .write(Buffer::from(Bytes::copy_from_slice(&expected)))
+            .await
+            .unwrap();
+
+        let err = writer.close().await.unwrap_err();
+        assert!(err.is_temporary());
+        let metadata = writer.close().await.unwrap();
+
+        assert_eq!(transport.uploaded(), expected);
+        assert_eq!(metadata.content_length(), 5);
+        assert_eq!(
+            transport.ranges(),
+            vec!["bytes 0-4/5".to_string(), "bytes */5".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_close_resends_after_incomplete_status() {
+        let transport = MockResumableTransport::default();
+        transport.fail_final_response_partially();
+        let mut writer = test_writer(transport.clone());
+        let expected = b"hello".to_vec();
+        writer
+            .write(Buffer::from(Bytes::copy_from_slice(&expected)))
+            .await
+            .unwrap();
+
+        let err = writer.close().await.unwrap_err();
+        assert!(err.is_temporary());
+        let metadata = writer.close().await.unwrap();
+
+        assert_eq!(transport.uploaded(), expected);
+        assert_eq!(metadata.content_length(), 5);
+        assert_eq!(
+            transport.ranges(),
+            vec![
+                "bytes 0-4/5".to_string(),
+                "bytes */5".to_string(),
+                "bytes 0-4/5".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn close_empty_object_uses_resumable_upload() {
+        let transport = MockResumableTransport::default();
+        let mut writer = test_writer(transport.clone());
+
+        let metadata = writer.close().await.unwrap();
+
+        assert_eq!(metadata.content_length(), 0);
+        assert_eq!(transport.uploaded(), Vec::<u8>::new());
+        assert_eq!(transport.ranges(), vec!["bytes */0".to_string()]);
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #8198.

# Rationale for this change

GCS generation preconditions require the JSON resumable upload path. If a request fails after GCS persists part or all of its body, the writer must retain the accepted input and reconcile an ambiguous final response before retrying.

Google Cloud documents that an interrupted chunk can be resent in its entirety and that bytes at already persisted offsets are ignored: https://docs.cloud.google.com/storage/docs/performing-resumable-uploads

# What changes are included in this PR?

The conditional writer now flushes previously accepted data before accepting new input, retains a complete chunk until GCS acknowledges its full range, and advances its offset only after that acknowledgement. It queries the resumable session only when the final response is ambiguous, and it builds `Content-Range` through `BytesContentRange`.

Regression tests cover an interrupted intermediate chunk, lost and partially persisted final responses, and an empty upload.

# Are there any user-facing changes?

Yes. Conditional GCS writes now preserve staged input across retries and reconcile ambiguous final responses. There are no public API changes.

# AI Usage Statement

AI materially assisted the implementation and regression tests under maintainer direction. The design relies on the documented GCS resumable-upload retry semantics linked above. No credential-backed GCS test was available; validation used the service unit tests with a mock HTTP transport.
