### PR TITLE
fix(website): update dependency license manifest

### DIFF
--- a/website/DEPENDENCIES.node.csv
+++ b/website/DEPENDENCIES.node.csv
@@ -11,4 +11,7 @@
 "prism-react-renderer@2.4.1","MIT","https://github.com/FormidableLabs/prism-react-renderer"
 "react-dom@19.2.7","MIT","https://github.com/facebook/react"
 "react@19.2.7","MIT","https://github.com/facebook/react"
+"remark-gfm@4.0.1","MIT","https://github.com/remarkjs/remark-gfm"
+"remark-parse@11.0.0","MIT","https://github.com/remarkjs/remark/tree/main/packages/remark-parse"
 "semver@7.8.4","ISC","https://github.com/npm/node-semver"
+"unified@11.0.4","MIT","https://github.com/unifiedjs/unified"


### PR DESCRIPTION
# Which issue does this PR close?

None. This fixes the main-branch CI regression introduced by #8202.

# Rationale for this change

PR #8202 added three direct production dependencies to the website without updating the generated dependency license manifest. The `website-dependencies` CI job regenerates that manifest and fails when the result differs from the repository.

# What changes are included in this PR?

Regenerate `website/DEPENDENCIES.node.csv` so it includes `remark-gfm`, `remark-parse`, and `unified`.

# Are there any user-facing changes?

No.

# AI Usage Statement

AI assisted with diagnosing the CI failure, regenerating the dependency manifest, and validating the generated output. There are no assumptions or unknowns that affect review.
