### PR TITLE
fix(core): reject unsupported list options instead of ignoring them

### DIFF
--- a/bindings/cpp/tests/basic_test.cpp
+++ b/bindings/cpp/tests/basic_test.cpp
@@ -265,9 +265,6 @@ TEST(OpenDALOptionsTest, ListOptions) {
   opendal::ListOptions options;
   options.recursive = true;
   options.limit = 16;
-  options.start_after = "list_options/";
-  options.versions = true;
-  options.deleted = true;
 
   auto entries = op.List("list_options/", options);
   std::unordered_set<std::string> paths;
@@ -282,6 +279,23 @@ TEST(OpenDALOptionsTest, ListOptions) {
     paths.insert(entry.path);
   }
   EXPECT_TRUE(paths.find("list_options/nested/file") != paths.end());
+}
+
+TEST(OpenDALOptionsTest, ListOptionsUnsupportedByService) {
+  opendal::Operator op("memory");
+  op.Write("list_unsupported/file", "hello");
+
+  opendal::ListOptions start_after;
+  start_after.start_after = "list_unsupported/file";
+  EXPECT_THROW(op.List("list_unsupported/", start_after), std::exception);
+
+  opendal::ListOptions versions;
+  versions.versions = true;
+  EXPECT_THROW(op.List("list_unsupported/", versions), std::exception);
+
+  opendal::ListOptions deleted;
+  deleted.deleted = true;
+  EXPECT_THROW(op.List("list_unsupported/", deleted), std::exception);
 }
 
 TEST(OpenDALOptionsTest, DeleteOptions) {

--- a/bindings/ruby/test/lister_test.rb
+++ b/bindings/ruby/test/lister_test.rb
@@ -67,11 +67,9 @@ class ListerTest < ActiveSupport::TestCase
     assert_equal ["/", "sample", "sub/"], lists
   end
 
-  test "lists the directory with start_after" do
-    lister = @op.list("", start_after: "sub/")
+  test "rejects start_after when the service does not support it" do
+    error = assert_raises(RuntimeError) { @op.list("", start_after: "sub/") }
 
-    lists = lister.map(&:to_h).map { |e| e[:path] }.sort
-
-    assert_equal ["/", "sample", "sub/"], lists # fs backend doesn't support start_after
+    assert_match(/does not support the operation list with the arguments start_after/, error.message)
   end
 end

--- a/core/core/src/layers/correctness_check.rs
+++ b/core/core/src/layers/correctness_check.rs
@@ -160,6 +160,26 @@ impl CorrectnessService {
 
         Ok(())
     }
+
+    fn check_list_args(&self, args: &OpList) -> Result<()> {
+        let capability = self.capability();
+        let scheme = self.info().scheme();
+        if args.start_after().is_some() && !capability.list_with_start_after {
+            return Err(new_unsupported_error(
+                scheme,
+                Operation::List,
+                "start_after",
+            ));
+        }
+        if args.versions() && !capability.list_with_versions {
+            return Err(new_unsupported_error(scheme, Operation::List, "versions"));
+        }
+        if args.deleted() && !capability.list_with_deleted {
+            return Err(new_unsupported_error(scheme, Operation::List, "deleted"));
+        }
+
+        Ok(())
+    }
 }
 
 impl Service for CorrectnessService {
@@ -419,6 +439,7 @@ impl Service for CorrectnessService {
     }
 
     fn list(&self, ctx: &OperationContext, path: &str, args: OpList) -> Result<Self::Lister> {
+        self.check_list_args(&args)?;
         self.inner.list(ctx, path, args)
     }
 
@@ -844,6 +865,43 @@ mod tests {
         });
         let res = op.delete_with("path").version("version").await;
         assert!(res.is_ok())
+    }
+
+    #[tokio::test]
+    async fn test_list() {
+        let op = new_test_operator(Capability {
+            list: true,
+            ..Default::default()
+        });
+        let res = op.list_with("path/").start_after("path/key").await;
+        assert_eq!(res.unwrap_err().kind(), ErrorKind::Unsupported);
+        let res = op.list_with("path/").versions(true).await;
+        assert_eq!(res.unwrap_err().kind(), ErrorKind::Unsupported);
+        let res = op.list_with("path/").deleted(true).await;
+        assert_eq!(res.unwrap_err().kind(), ErrorKind::Unsupported);
+
+        let op = new_test_operator(Capability {
+            list: true,
+            list_with_start_after: true,
+            list_with_versions: true,
+            list_with_deleted: true,
+            ..Default::default()
+        });
+        assert!(op.list_with("path/").start_after("path/key").await.is_ok());
+        assert!(op.list_with("path/").versions(true).await.is_ok());
+        assert!(op.list_with("path/").deleted(true).await.is_ok());
+    }
+
+    /// `limit` is a backend hint and `recursive` is simulated by `SimulateLayer`,
+    /// so neither is gated on a capability.
+    #[tokio::test]
+    async fn test_list_limit_and_recursive_need_no_capability() {
+        let op = new_test_operator(Capability {
+            list: true,
+            ..Default::default()
+        });
+        assert!(op.list_with("path/").limit(1).await.is_ok());
+        assert!(op.list_with("path/").recursive(true).await.is_ok());
     }
 
     #[tokio::test]

--- a/core/core/src/types/operator/operator_futures.rs
+++ b/core/core/src/types/operator/operator_futures.rs
@@ -1416,6 +1416,9 @@ impl<F: Future<Output = Result<Vec<Entry>>>> FutureList<F> {
 
     /// The start_after passes to underlying service to specify the specified key
     /// to start listing from.
+    ///
+    /// Requires [`Capability::list_with_start_after`]; otherwise the operation
+    /// fails with [`ErrorKind::Unsupported`].
     pub fn start_after(mut self, v: &str) -> Self {
         self.args.start_after = Some(v.to_string());
         self
@@ -1441,6 +1444,9 @@ impl<F: Future<Output = Result<Vec<Entry>>>> FutureList<F> {
     /// If `false`, version information will be omitted from the `list` results.
     ///
     /// Default to `false`
+    ///
+    /// Requires [`Capability::list_with_versions`]; otherwise the operation
+    /// fails with [`ErrorKind::Unsupported`].
     pub fn versions(mut self, v: bool) -> Self {
         self.args.versions = v;
         self
@@ -1454,6 +1460,9 @@ impl<F: Future<Output = Result<Vec<Entry>>>> FutureList<F> {
     ///
     /// If `true`, subsequent `list` operations will include deleted files or versions.
     /// If `false`, deleted files or versions will be excluded from the `list` results.
+    ///
+    /// Requires [`Capability::list_with_deleted`]; otherwise the operation
+    /// fails with [`ErrorKind::Unsupported`].
     pub fn deleted(mut self, v: bool) -> Self {
         self.args.deleted = v;
         self
@@ -1477,6 +1486,9 @@ impl<F: Future<Output = Result<Lister>>> FutureLister<F> {
 
     /// The start_after passes to underlying service to specify the specified key
     /// to start listing from.
+    ///
+    /// Requires [`Capability::list_with_start_after`]; otherwise the operation
+    /// fails with [`ErrorKind::Unsupported`].
     pub fn start_after(mut self, v: &str) -> Self {
         self.args.start_after = Some(v.to_string());
         self
@@ -1502,6 +1514,9 @@ impl<F: Future<Output = Result<Lister>>> FutureLister<F> {
     /// If `false`, version information will be omitted from the `list` results.
     ///
     /// Default to `false`
+    ///
+    /// Requires [`Capability::list_with_versions`]; otherwise the operation
+    /// fails with [`ErrorKind::Unsupported`].
     pub fn versions(mut self, v: bool) -> Self {
         self.args.versions = v;
         self
@@ -1515,6 +1530,9 @@ impl<F: Future<Output = Result<Lister>>> FutureLister<F> {
     ///
     /// If `true`, subsequent `list` operations will include deleted files or versions.
     /// If `false`, deleted files or versions will be excluded from the `list` results.
+    ///
+    /// Requires [`Capability::list_with_deleted`]; otherwise the operation
+    /// fails with [`ErrorKind::Unsupported`].
     pub fn deleted(mut self, v: bool) -> Self {
         self.args.deleted = v;
         self

--- a/core/core/src/types/options.rs
+++ b/core/core/src/types/options.rs
@@ -133,12 +133,18 @@ pub struct ListOptions {
     pub limit: Option<usize>,
     /// The start_after passes to underlying service to specify the specified key
     /// to start listing from.
+    ///
+    /// Requires [`Capability::list_with_start_after`](crate::Capability::list_with_start_after).
     pub start_after: Option<String>,
     /// Whether to list recursively under the prefix; default `false`.
     pub recursive: bool,
-    /// Include object versions when supported by the backend; default `false`.
+    /// Include object versions; default `false`.
+    ///
+    /// Requires [`Capability::list_with_versions`](crate::Capability::list_with_versions).
     pub versions: bool,
-    /// Include delete markers when supported by version-aware backends; default `false`.
+    /// Include delete markers; default `false`.
+    ///
+    /// Requires [`Capability::list_with_deleted`](crate::Capability::list_with_deleted).
     pub deleted: bool,
 }
 

--- a/core/tests/behavior/async_list.rs
+++ b/core/tests/behavior/async_list.rs
@@ -42,7 +42,6 @@ pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
             test_list_nested_dir,
             test_list_dir_with_file_path,
             test_list_with_start_after,
-            test_list_with_unsupported_options,
             test_list_non_exist_dir_with_recursive,
             test_list_dir_with_recursive,
             test_list_dir_with_recursive_no_trailing_slash,
@@ -434,41 +433,6 @@ pub async fn test_list_with_start_after(op: Operator) -> Result<()> {
     assert_eq!(expected, actual);
 
     op.delete_with(dir).recursive(true).await?;
-
-    Ok(())
-}
-
-/// List options the service cannot honor must fail instead of being ignored.
-pub async fn test_list_with_unsupported_options(op: Operator) -> Result<()> {
-    let cap = op.info().capability();
-    let dir = &format!("{}/", uuid::Uuid::new_v4());
-
-    if !cap.list_with_start_after {
-        let err = op
-            .list_with(dir)
-            .start_after(&format!("{dir}key"))
-            .await
-            .expect_err("start_after must be rejected when unsupported");
-        assert_eq!(err.kind(), ErrorKind::Unsupported);
-    }
-
-    if !cap.list_with_versions {
-        let err = op
-            .list_with(dir)
-            .versions(true)
-            .await
-            .expect_err("versions must be rejected when unsupported");
-        assert_eq!(err.kind(), ErrorKind::Unsupported);
-    }
-
-    if !cap.list_with_deleted {
-        let err = op
-            .list_with(dir)
-            .deleted(true)
-            .await
-            .expect_err("deleted must be rejected when unsupported");
-        assert_eq!(err.kind(), ErrorKind::Unsupported);
-    }
 
     Ok(())
 }

--- a/core/tests/behavior/async_list.rs
+++ b/core/tests/behavior/async_list.rs
@@ -42,6 +42,7 @@ pub fn tests(op: &Operator, tests: &mut Vec<Trial>) {
             test_list_nested_dir,
             test_list_dir_with_file_path,
             test_list_with_start_after,
+            test_list_with_unsupported_options,
             test_list_non_exist_dir_with_recursive,
             test_list_dir_with_recursive,
             test_list_dir_with_recursive_no_trailing_slash,
@@ -433,6 +434,41 @@ pub async fn test_list_with_start_after(op: Operator) -> Result<()> {
     assert_eq!(expected, actual);
 
     op.delete_with(dir).recursive(true).await?;
+
+    Ok(())
+}
+
+/// List options the service cannot honor must fail instead of being ignored.
+pub async fn test_list_with_unsupported_options(op: Operator) -> Result<()> {
+    let cap = op.info().capability();
+    let dir = &format!("{}/", uuid::Uuid::new_v4());
+
+    if !cap.list_with_start_after {
+        let err = op
+            .list_with(dir)
+            .start_after(&format!("{dir}key"))
+            .await
+            .expect_err("start_after must be rejected when unsupported");
+        assert_eq!(err.kind(), ErrorKind::Unsupported);
+    }
+
+    if !cap.list_with_versions {
+        let err = op
+            .list_with(dir)
+            .versions(true)
+            .await
+            .expect_err("versions must be rejected when unsupported");
+        assert_eq!(err.kind(), ErrorKind::Unsupported);
+    }
+
+    if !cap.list_with_deleted {
+        let err = op
+            .list_with(dir)
+            .deleted(true)
+            .await
+            .expect_err("deleted must be rejected when unsupported");
+        assert_eq!(err.kind(), ErrorKind::Unsupported);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
# Which issue does this PR close?

Closes #6676.

# Rationale for this change

`CorrectnessCheckLayer` validates arguments for read, write, stat, delete, copy and compose, but `list` was forwarded unchecked. So a list option the service cannot honor is dropped silently and the caller gets a full listing back with no signal that anything was ignored.

Reproduced on `fs`, no network needed:

```rust
op.write("d/a", "x").await?;
op.write("d/b", "x").await?;
let got = op.list_with("d/").start_after("d/a").await?;
// expected ["d/b"], got ["d/", "d/a", "d/b"]
```

That is exactly #6676. `versions(true)` and `deleted(true)` fail the same way everywhere: they are only read by the s3, cos, tos, oss and onedrive listers and dropped by every other service. This is not fs-only either, s3-express sets `list_with_start_after: false` and is affected too.

Two existing tests had encoded the old behavior as expected. `bindings/ruby/test/lister_test.rb` asserted the full unfiltered listing with the comment "fs backend doesn't support start_after", and the C++ `OpenDALOptionsTest.ListOptions` set all five options at once against `memory` and passed only because three of them were dropped. Both are updated here.

The `object_store` integration already hand-rolls this guard (`store.rs` checks `list_with_start_after` and falls back to client-side filtering when it is false), which is a fair sign that callers should not have to discover the limitation themselves.

@Xuanwo, on #6676 you said you were open to this if we can inform users about the limitation clearly. An `Unsupported` error is the signal the layer already gives for every other operation, so this reuses it rather than inventing a new mechanism.

# What changes are included in this PR?

`CorrectnessService::list` now rejects `start_after`, `versions` and `deleted` when the matching capability is false.

Two options stay ungated on purpose:

* `limit` is documented as a backend hint.
* `recursive` is emulated by `SimulateLayer` even when `list_with_recursive` is false, which is why `fs` recursion works today. Gating it would break working listings.

Tests: unit tests in `correctness_check.rs` covering all three options in both directions, plus a separate test pinning that `limit` and `recursive` stay ungated. The Ruby test now asserts the error, and the C++ test is split into the two options `memory` supports plus a new `ListOptionsUnsupportedByService` for the three it does not.

There is deliberately no behavior-suite test. I tried one and CI showed why it cannot work: `CapabilityOverrideLayer` is documented to change only the capability reported by `OperatorInfo`, not what the stack enforces, and it is applied above `CorrectnessCheckLayer`. The s3 setups use it (`OPENDAL_TEST_CAPABILITY_OVERRIDES=...,list_with_versions=false,...`) to mask a non-versioned MinIO bucket, so `op.info().capability()` there reports `list_with_versions: false` while the check correctly sees the service's real `true`. A portable test cannot read the capability the check actually uses, so asserting on the advertised one is wrong. Worth knowing separately: that layer can relabel a capability but cannot restrict behavior.

How I found it. My oracle was cross-service agreement: a 71-probe differential harness over list, stat, read, ranges, delete and create_dir, run across every backend I can exercise with no network (fs, memory, dashmap, moka, mini-moka, sled, redb, cacache, persy). `start_after` being silently ignored on `fs` was one of the divergences it turned up.

Verified locally: `cargo test -p opendal-core --lib` (11 correctness_check tests), the behavior suite unchanged at 130 passed on fs and 110 on memory, all 83 C++ tests via cmake/ninja, all 57 Ruby tests via `rake test:base`, `cargo clippy -p opendal-core --all-targets -- -D warnings`, `cargo fmt --all --check`, `cargo test -p opendal-core --doc`, `cargo doc` with no new intra-doc warnings, and the `integrations/object_store` suite including `test_list_with_offset`.

# Are there any user-facing changes?

Yes. Anyone passing one of those three options to a service that does not support it used to get a successful but wrong result and now gets `Unsupported`. No public API signature changes, so I did not add the `breaking-changes` label, happy to add it if you would rather flag it in the changelog.

`ListOptions` and the list futures now document the capability requirement.

# AI Usage Statement

AI-assisted. I used Claude Code to build and run the cross-backend differential harness that surfaced the divergence, and to draft the patch; I reviewed the result, chose the scope, and ran the verification above myself.

Assumptions and unknowns worth your review: every service that supports these three options is network-backed, so I could not exercise the positive path against a real backend. It is covered by the mock unit test and by the existing capability-gated behavior tests in CI. I also assumed `limit` and `recursive` should stay ungated for the reasons above, and that is the judgement call most worth a second opinion.
