### PR TITLE
chore(release): prepare v0.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- Release notes generated with: gh release create v_draft --generate-notes --draft -->
 
+## [v0.59.0] - 2026-08-31
+
+### Breaking Changes
+* core: `Metadata` and raw operation arguments now use immutable compact representations. Construct metadata with `MetadataBuilder`, use `into_builder()` to modify existing metadata, and convert public options into finalized raw arguments. `DeleteInput` has been removed.
+* core: `OpCopier` has been removed. Raw `Service::copy` implementations now receive copy execution settings through `OpCopy`.
+* integrations/object_store: `object_store_opendal` 0.60 uses `opendal` 0.59. Update direct OpenDAL dependencies together.
+* integrations/parquet: `parquet_opendal` 0.10 uses `opendal` 0.59. Update direct OpenDAL dependencies together.
+* bindings/dotnet: `Operator.DeleteAsync` now accepts `DeleteOptions` before the cancellation token. Pass the token as `cancellationToken: token`, or pass `null` for options before a positional token.
+
+### Added
+* feat(bindings/dotnet): add DeleteOptions with delete functions by @Fatorin in https://github.com/apache/opendal/pull/8098
+* feat(services/s3): add conditional delete with if-match by @YuangGao in https://github.com/apache/opendal/pull/7607
+* feat(bindings/dotnet): support conditional delete with if-match by @Fatorin in https://github.com/apache/opendal/pull/8137
+* feat(services/s3): support S3 Express session authentication by @Xuanwo in https://github.com/apache/opendal/pull/8135
+* feat(services/s3): support object restoration by @Xuanwo in https://github.com/apache/opendal/pull/8143
+* feat(services): support conditional delete for Azure services by @Xuanwo in https://github.com/apache/opendal/pull/8142
+* RFC: Add limited read by @Xuanwo in https://github.com/apache/opendal/pull/7945
+* feat(services/azdls): support custom credential providers by @zakariya-s in https://github.com/apache/opendal/pull/8030
+* feat(core): add conflict error kind by @Xuanwo in https://github.com/apache/opendal/pull/8154
+* feat(parquet): expose writer abort by @starpact in https://github.com/apache/opendal/pull/8102
+* feat: support if_not_changed preconditions by @Xuanwo in https://github.com/apache/opendal/pull/8156
+* feat(services/s3): support Writer::copy_from by @Xuanwo in https://github.com/apache/opendal/pull/8140
+* feat(services/gcs-grpc): add GCS gRPC service by @Xuanwo in https://github.com/apache/opendal/pull/8153
+* feat(services/gcs): support compose by @Xuanwo in https://github.com/apache/opendal/pull/8191
+
+### Changed
+* refactor(services/monoiofs): use asyncband channels by @tisonkun in https://github.com/apache/opendal/pull/8126
+* refactor(bindings/dotnet): generate capability and service configs from core by @Fatorin in https://github.com/apache/opendal/pull/8146
+* refactor(services): standardize error normalization by @Xuanwo in https://github.com/apache/opendal/pull/8174
+* refactor!: merge OpCopier into OpCopy by @Xuanwo in https://github.com/apache/opendal/pull/8190
+* refactor!: compact metadata and operation arguments by @Xuanwo in https://github.com/apache/opendal/pull/8196
+
+### Fixed
+* fix(bindings/dotnet): correct stream error kind and if-modified-since test by @Fatorin in https://github.com/apache/opendal/pull/8121
+* Reapply "fix(core): deserialize duration config values from strings" by @erickguan in https://github.com/apache/opendal/pull/8123
+* fix: Canonicalize HuggingFace IDs to avoid inconsistent API by @mhambre in https://github.com/apache/opendal/pull/8108
+* fix(services/goosefs): skip CreateDirectory when rename parent already exists by @XuQianJin-Stars in https://github.com/apache/opendal/pull/8129
+* fix(services/azblob): carry content type and user metadata on Put Block List by @PDGGK in https://github.com/apache/opendal/pull/8148
+* fix(services/memcached): reject a TTL over 30 days by @PDGGK in https://github.com/apache/opendal/pull/8150
+* fix(dev): validate integration version bumps by @Xuanwo in https://github.com/apache/opendal/pull/8139
+* fix(services/ghac): propagate v2 finalize errors by @fly1d in https://github.com/apache/opendal/pull/8136
+* fix(services/hf): cache XET classification and CAS auth tokens by @kszucs in https://github.com/apache/opendal/pull/8106
+* fix(core): add missing tokio test features so crates build on their own by @Lstarsky0 in https://github.com/apache/opendal/pull/8103
+* fix(ci): use distinct reusable concurrency groups by @jsk1004ha in https://github.com/apache/opendal/pull/8119
+* fix(core): return Ok(0) instead of panicking on zero-length write by @bavardage in https://github.com/apache/opendal/pull/8162
+* fix(bindings/python): fix sized File.readline by @Xuanwo in https://github.com/apache/opendal/pull/8169
+* fix: repair azfile, b2, and conditional read behavior by @Xuanwo in https://github.com/apache/opendal/pull/8175
+* fix(core): align conditional missing-target semantics by @Xuanwo in https://github.com/apache/opendal/pull/8172
+* fix(bindings): enable gcs-grpc service by @Xuanwo in https://github.com/apache/opendal/pull/8185
+* fix: update generated gcs-grpc service docs by @Xuanwo in https://github.com/apache/opendal/pull/8186
+* fix(bindings/python): remove greenlet benchmark dependencies by @Xuanwo in https://github.com/apache/opendal/pull/8189
+* fix(services): return authoritative copy metadata by @Xuanwo in https://github.com/apache/opendal/pull/8197
+* fix(services/gcs): make conditional uploads retry-safe by @Xuanwo in https://github.com/apache/opendal/pull/8199
+* fix: preserve conditional error semantics by @Xuanwo in https://github.com/apache/opendal/pull/8204
+
+### Docs
+* docs: add AI-assisted contribution policy by @Xuanwo in https://github.com/apache/opendal/pull/8099
+* RFC-8147: write_if_not_changed by @Xuanwo in https://github.com/apache/opendal/pull/8147
+* RFC-8145: Distinguish conflicts from unmet conditions by @Xuanwo in https://github.com/apache/opendal/pull/8145
+* docs: forbid speculative service changes in agent guidance by @Xuanwo in https://github.com/apache/opendal/pull/8152
+* docs: clarify helper function guidelines by @Xuanwo in https://github.com/apache/opendal/pull/8155
+* docs: establish OpenDAL specifications by @Xuanwo in https://github.com/apache/opendal/pull/8183
+* docs: add RFC for whole-object composition by @Xuanwo in https://github.com/apache/opendal/pull/8188
+* RFC: Compact metadata and operation arguments by @Xuanwo in https://github.com/apache/opendal/pull/8194
+
+### CI
+* ci: pin pnpm action setup to commit by @Xuanwo in https://github.com/apache/opendal/pull/8131
+
+### Chore
+* chore(services/hf): bump hf-xet to 1.6.0 by @kszucs in https://github.com/apache/opendal/pull/8113
+* chore(services/ftp): upgrade suppaftp to 10 and switch to tokio by @Xuanwo in https://github.com/apache/opendal/pull/8184
+
+## New Contributors
+* @fly1d made their first contribution in https://github.com/apache/opendal/pull/8136
+* @zakariya-s made their first contribution in https://github.com/apache/opendal/pull/8030
+* @Lstarsky0 made their first contribution in https://github.com/apache/opendal/pull/8103
+* @starpact made their first contribution in https://github.com/apache/opendal/pull/8102
+* @bavardage made their first contribution in https://github.com/apache/opendal/pull/8162
+* @jsk1004ha made their first contribution in https://github.com/apache/opendal/pull/8119
+
+**Full Changelog**: https://github.com/apache/opendal/compare/v0.58.2...v0.59.0
+
 ## [v0.58.2] - 2026-08-17
 
 ### Breaking Changes

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -17,14 +17,14 @@ block-buffer@0.12.1	X							X
 bumpalo@3.20.3	X							X				
 bytes@1.12.1								X				
 cbindgen@0.29.4										X		
-cc@1.4.3	X							X				
+cc@1.4.4	X							X				
 cfg-if@1.0.4	X							X				
 clap@4.6.6	X							X				
 clap_builder@4.6.6	X							X				
 clap_lex@1.1.0	X							X				
 cmake@0.1.58	X							X				
 colorchoice@1.0.5	X							X				
-combine@4.6.7								X				
+combine@4.6.8								X				
 const-oid@0.10.2	X							X				
 core-foundation@0.10.1	X							X				
 core-foundation-sys@0.8.7	X							X				
@@ -56,7 +56,7 @@ http-body@1.1.0								X
 http-body-util@0.1.5								X				
 httparse@1.10.1	X							X				
 hybrid-array@0.4.14	X							X				
-hyper@1.11.0								X				
+hyper@1.11.1								X				
 hyper-rustls@0.27.9	X					X		X				
 hyper-util@0.1.20								X				
 icu_collections@2.3.0											X	
@@ -65,10 +65,10 @@ icu_normalizer@2.3.0											X
 icu_normalizer_data@2.3.0											X	
 icu_properties@2.3.0											X	
 icu_properties_data@2.3.0											X	
-icu_provider@2.3.0											X	
+icu_provider@2.3.1											X	
 idna@1.1.0	X							X				
 idna_adapter@1.2.2	X							X				
-indexmap@2.14.0	X							X				
+indexmap@2.14.1	X							X				
 ipnet@2.12.1	X							X				
 is_terminal_polyfill@1.70.2	X							X				
 itoa@1.0.18	X							X				
@@ -87,20 +87,20 @@ link-section@0.19.3	X							X
 linktime-proc-macro@0.2.3	X							X				
 linux-raw-sys@0.12.1	X	X						X				
 litemap@0.8.3											X	
-log@0.4.33	X							X				
+log@0.4.34	X							X				
 md-5@0.11.0	X							X				
 memchr@2.8.3								X				X
 mio@1.2.2								X				
 once_cell@1.21.4	X							X				
 once_cell_polyfill@1.70.2	X							X				
-opendal@0.58.2	X											
+opendal@0.59.0	X											
 opendal-c@0.0.0	X											
-opendal-core@0.58.2	X											
-opendal-http-transport-reqwest@0.58.2	X											
-opendal-layer-concurrent-limit@0.58.2	X											
-opendal-layer-logging@0.58.2	X											
-opendal-layer-retry@0.58.2	X											
-opendal-layer-timeout@0.58.2	X											
+opendal-core@0.59.0	X											
+opendal-http-transport-reqwest@0.59.0	X											
+opendal-layer-concurrent-limit@0.59.0	X											
+opendal-layer-logging@0.59.0	X											
+opendal-layer-retry@0.59.0	X											
+opendal-layer-timeout@0.59.0	X											
 openssl-probe@0.2.1	X							X				
 percent-encoding@2.3.2	X							X				
 pin-project-lite@0.2.17	X							X				
@@ -120,7 +120,7 @@ rustls-native-certs@0.8.4	X					X		X
 rustls-pki-types@1.15.1	X							X				
 rustls-platform-verifier@0.7.0	X							X				
 rustls-platform-verifier-android@0.1.1	X							X				
-rustls-webpki@0.103.14						X						
+rustls-webpki@0.103.15						X						
 rustversion@1.0.23	X							X				
 same-file@1.0.6								X				X
 schannel@0.1.29								X				
@@ -142,7 +142,7 @@ stable_deref_trait@1.2.1	X							X
 strsim@0.11.1								X				
 subtle@2.6.1			X									
 syn@2.0.119	X							X				
-syn@3.0.3	X							X				
+syn@3.0.4	X							X				
 sync_wrapper@1.0.2	X											
 synstructure@0.13.2								X				
 tempfile@3.27.0	X							X				
@@ -169,7 +169,7 @@ untrusted@0.9.0						X
 url@2.5.8	X							X				
 utf8_iter@1.0.4	X							X				
 utf8parse@0.2.2	X							X				
-uuid@1.24.1	X							X				
+uuid@1.26.0	X							X				
 walkdir@2.5.0								X				X
 want@0.3.1								X				
 wasi@0.11.1+wasi-snapshot-preview1	X	X						X				
@@ -194,6 +194,6 @@ zerofrom@0.1.8											X
 zerofrom-derive@0.1.7											X	
 zeroize@1.9.0	X							X				
 zerotrie@0.2.5											X	
-zerovec@0.11.7											X	
-zerovec-derive@0.11.4											X	
+zerovec@0.11.8											X	
+zerovec-derive@0.11.6											X	
 zmij@1.0.23								X				

--- a/bindings/cpp/DEPENDENCIES.rust.tsv
+++ b/bindings/cpp/DEPENDENCIES.rust.tsv
@@ -11,11 +11,11 @@ bitflags@2.13.1	X							X
 block-buffer@0.12.1	X							X				
 bumpalo@3.20.3	X							X				
 bytes@1.12.1								X				
-cc@1.4.3	X							X				
+cc@1.4.4	X							X				
 cfg-if@1.0.4	X							X				
 cmake@0.1.58	X							X				
 codespan-reporting@0.13.1	X											
-combine@4.6.7								X				
+combine@4.6.8								X				
 const-oid@0.10.2	X							X				
 core-foundation@0.10.1	X							X				
 core-foundation-sys@0.8.7	X							X				
@@ -51,7 +51,7 @@ http-body@1.1.0								X
 http-body-util@0.1.5								X				
 httparse@1.10.1	X							X				
 hybrid-array@0.4.14	X							X				
-hyper@1.11.0								X				
+hyper@1.11.1								X				
 hyper-rustls@0.27.9	X					X		X				
 hyper-util@0.1.20								X				
 icu_collections@2.3.0										X		
@@ -60,10 +60,10 @@ icu_normalizer@2.3.0										X
 icu_normalizer_data@2.3.0										X		
 icu_properties@2.3.0										X		
 icu_properties_data@2.3.0										X		
-icu_provider@2.3.0										X		
+icu_provider@2.3.1										X		
 idna@1.1.0	X							X				
 idna_adapter@1.2.2	X							X				
-indexmap@2.14.0	X							X				
+indexmap@2.14.1	X							X				
 ipnet@2.12.1	X							X				
 itoa@1.0.18	X							X				
 jiff@0.2.35								X			X	
@@ -81,19 +81,19 @@ link-cplusplus@1.0.12	X							X
 link-section@0.19.3	X							X				
 linktime-proc-macro@0.2.3	X							X				
 litemap@0.8.3										X		
-log@0.4.33	X							X				
+log@0.4.34	X							X				
 md-5@0.11.0	X							X				
 memchr@2.8.3								X			X	
 mio@1.2.2								X				
 once_cell@1.21.4	X							X				
-opendal@0.58.2	X											
-opendal-core@0.58.2	X											
+opendal@0.59.0	X											
+opendal-core@0.59.0	X											
 opendal-cpp@0.0.0	X											
-opendal-http-transport-reqwest@0.58.2	X											
-opendal-layer-concurrent-limit@0.58.2	X											
-opendal-layer-logging@0.58.2	X											
-opendal-layer-retry@0.58.2	X											
-opendal-layer-timeout@0.58.2	X											
+opendal-http-transport-reqwest@0.59.0	X											
+opendal-layer-concurrent-limit@0.59.0	X											
+opendal-layer-logging@0.59.0	X											
+opendal-layer-retry@0.59.0	X											
+opendal-layer-timeout@0.59.0	X											
 openssl-probe@0.2.1	X							X				
 percent-encoding@2.3.2	X							X				
 pin-project-lite@0.2.17	X							X				
@@ -112,7 +112,7 @@ rustls-native-certs@0.8.4	X					X		X
 rustls-pki-types@1.15.1	X							X				
 rustls-platform-verifier@0.7.0	X							X				
 rustls-platform-verifier-android@0.1.1	X							X				
-rustls-webpki@0.103.14						X						
+rustls-webpki@0.103.15						X						
 rustversion@1.0.23	X							X				
 same-file@1.0.6								X			X	
 schannel@0.1.29								X				
@@ -133,7 +133,7 @@ socket2@0.6.5	X							X
 stable_deref_trait@1.2.1	X							X				
 subtle@2.6.1			X									
 syn@2.0.119	X							X				
-syn@3.0.3	X							X				
+syn@3.0.4	X							X				
 sync_wrapper@1.0.2	X											
 synstructure@0.13.2								X				
 termcolor@1.4.1								X			X	
@@ -157,7 +157,7 @@ unicode-width@0.2.2	X							X
 untrusted@0.9.0						X						
 url@2.5.8	X							X				
 utf8_iter@1.0.4	X							X				
-uuid@1.24.1	X							X				
+uuid@1.26.0	X							X				
 walkdir@2.5.0								X			X	
 want@0.3.1								X				
 wasi@0.11.1+wasi-snapshot-preview1	X	X						X				
@@ -180,6 +180,6 @@ zerofrom@0.1.8										X
 zerofrom-derive@0.1.7										X		
 zeroize@1.9.0	X							X				
 zerotrie@0.2.5										X		
-zerovec@0.11.7										X		
-zerovec-derive@0.11.4										X		
+zerovec@0.11.8										X		
+zerovec-derive@0.11.6										X		
 zmij@1.0.23								X				

--- a/bindings/dotnet/DEPENDENCIES.rust.tsv
+++ b/bindings/dotnet/DEPENDENCIES.rust.tsv
@@ -9,7 +9,6 @@ anyhow@1.0.104		X									X
 approx@0.5.1		X														
 arc-swap@1.9.2		X									X					
 arcstr@1.2.0		X									X					X
-arrayref@0.3.9				X												
 arrayvec@0.7.8		X									X					
 async-lock@3.4.2		X									X					
 async-recursion@0.3.2		X									X					
@@ -37,7 +36,7 @@ base64ct@1.8.3		X									X
 bitflags@1.3.2		X									X					
 bitflags@2.13.1		X									X					
 bitvec@1.1.1											X					
-blake3@1.8.6		X	X				X									
+blake3@1.8.7		X	X				X									
 block-buffer@0.10.4		X									X					
 block-buffer@0.12.1		X									X					
 block-padding@0.3.3		X									X					
@@ -53,27 +52,27 @@ camino@1.2.5		X									X
 cargo-platform@0.1.9		X									X					
 cargo_metadata@0.14.2											X					
 cbc@0.1.2		X									X					
-cc@1.4.3		X									X					
+cc@1.4.4		X									X					
 cfg-if@0.1.10		X									X					
 cfg-if@1.0.4		X									X					
 cfg_aliases@0.2.2											X					
-chacha20@0.10.1		X									X					
+chacha20@0.10.2		X									X					
 chrono@0.4.45		X									X					
 cipher@0.4.4		X									X					
 cmake@0.1.58		X									X					
 cmov@0.5.4		X									X					
 colored@3.1.1													X			
-combine@4.6.7											X					
-compio@0.19.1											X					
+combine@4.6.8											X					
+compio@0.19.2											X					
 compio-buf@0.8.3											X					
-compio-dispatcher@0.11.0											X					
-compio-driver@0.12.4											X					
-compio-executor@0.1.3											X					
-compio-fs@0.12.0											X					
+compio-dispatcher@0.11.1											X					
+compio-driver@0.12.5											X					
+compio-executor@0.1.4											X					
+compio-fs@0.12.1											X					
 compio-io@0.10.1											X					
-compio-log@0.2.0											X					
-compio-net@0.12.4											X					
-compio-runtime@0.12.5											X					
+compio-log@0.2.1											X					
+compio-net@0.12.5											X					
+compio-runtime@0.12.6											X					
 compio-send-wrapper@0.7.2		X									X					
 concurrent-queue@2.5.0		X									X					
 concurrent_arena@0.1.11											X					
@@ -90,12 +89,12 @@ core-foundation@0.9.4		X									X
 core-foundation-sys@0.8.7		X									X					
 countio@0.3.0											X					
 cpufeatures@0.2.17		X									X					
-cpufeatures@0.3.0		X									X					
+cpufeatures@0.3.1		X									X					
 crc@3.4.0		X									X					
 crc-catalog@2.5.0		X									X					
 crc-fast@1.10.0		X									X					
 crc16@0.4.0											X					
-crc32fast@1.5.0		X									X					
+crc32fast@1.5.1		X									X					
 critical-section@1.2.0		X									X					
 crossbeam-channel@0.5.16		X									X					
 crossbeam-epoch@0.9.20		X									X					
@@ -128,7 +127,7 @@ displaydoc@0.2.7		X									X
 dlv-list@0.5.2		X									X					
 dotenvy@0.15.7											X					
 dunce@1.0.5		X					X					X				
-either@1.17.0		X									X					
+either@1.18.0		X									X					
 equivalent@1.0.2		X									X					
 errno@0.3.14		X									X					
 error-chain@0.12.4		X									X					
@@ -137,11 +136,11 @@ etcetera@0.8.0		X									X
 event-listener@5.4.2		X									X					
 event-listener-strategy@0.5.4		X									X					
 fail@0.4.0		X														
-fastpool@1.1.0		X														
+fastpool@1.1.1		X														
 fastrand@2.5.0		X									X					
 find-msvc-tools@0.1.11		X									X					
 fixedbitset@0.5.7		X									X					
-flate2@1.1.9		X									X					
+flate2@1.1.10		X									X					
 flume@0.11.1		X									X					
 flume@0.12.0		X									X					
 fnv@1.0.7		X									X					
@@ -178,7 +177,7 @@ gloo-timers@0.3.0		X									X
 goosefs-sdk@0.1.9		X														
 governor@0.10.4											X					
 h2@0.3.27											X					
-h2@0.4.15											X					
+h2@0.4.19											X					
 hashbrown@0.12.3		X									X					
 hashbrown@0.14.5		X									X					
 hashbrown@0.15.5		X									X					
@@ -187,7 +186,7 @@ hashbrown@0.17.1		X									X
 hashlink@0.10.0		X									X					
 heapify@0.2.0		X									X					
 heck@0.5.0		X									X					
-hermit-abi@0.5.2		X									X					
+hermit-abi@0.5.3		X									X					
 hex@0.4.3		X									X					
 hf-xet@1.6.0		X														
 hickory-net@0.26.1		X									X					
@@ -208,7 +207,7 @@ httpdate@1.0.3		X									X
 humantime@2.4.0		X									X					
 hybrid-array@0.4.14		X									X					
 hyper@0.14.32											X					
-hyper@1.11.0											X					
+hyper@1.11.1											X					
 hyper-rustls@0.27.9		X							X		X					
 hyper-timeout@0.4.1		X									X					
 hyper-timeout@0.5.2		X									X					
@@ -221,12 +220,12 @@ icu_normalizer@2.3.0														X
 icu_normalizer_data@2.3.0														X		
 icu_properties@2.3.0														X		
 icu_properties_data@2.3.0														X		
-icu_provider@2.3.0														X		
+icu_provider@2.3.1														X		
 ident_case@1.0.1		X									X					
 idna@1.1.0		X									X					
 idna_adapter@1.2.2		X									X					
 indexmap@1.9.3		X									X					
-indexmap@2.14.0		X									X					
+indexmap@2.14.1		X									X					
 inout@0.1.4		X									X					
 instant@0.1.13					X											
 io-uring@0.6.4		X									X					
@@ -251,7 +250,7 @@ konst_proc_macros@0.4.1																X
 lazy_static@1.5.0		X									X					
 libc@0.2.189		X									X					
 libm@0.2.16											X					
-libredox@0.1.20											X					
+libredox@0.1.21											X					
 libsqlite3-sys@0.30.1											X					
 link-section@0.19.3		X									X					
 linked-hash-map@0.5.6		X									X					
@@ -260,9 +259,9 @@ linux-raw-sys@0.12.1		X	X								X
 litemap@0.8.3														X		
 local-event@0.1.3											X					
 lock_api@0.4.14		X									X					
-log@0.4.33		X									X					
+log@0.4.34		X									X					
 loom@0.7.2											X					
-lru@0.18.2											X					
+lru@0.18.3											X					
 lz4_flex@0.13.1											X					
 macro_magic@0.5.1											X					
 macro_magic_core@0.5.1											X					
@@ -283,13 +282,13 @@ miette-derive@5.10.0		X
 mime@0.3.17		X									X					
 mime_guess@2.0.5											X					
 mini-moka@0.10.3		X									X					
-miniz_oxide@0.8.9		X									X					X
+miniz_oxide@0.9.1		X									X					X
 mio@0.8.11											X					
 mio@1.2.2											X					
 mod_use@0.2.3											X					
 moka@0.12.16		X									X					
-mongodb@3.8.0		X														
-mongodb-internal-macros@3.8.0		X														
+mongodb@3.8.2		X														
+mongodb-internal-macros@3.8.2		X														
 monoio@0.2.4		X									X					
 monoio-macros@0.1.0		X									X					
 more-asserts@0.3.1		X					X				X				X	
@@ -313,68 +312,69 @@ objc2-io-kit@0.3.2		X									X					X
 objc2-system-configuration@0.3.2		X									X					X
 once_cell@1.21.4		X									X					
 oneshot@0.1.13		X									X					
-opendal@0.58.2		X														
-opendal-core@0.58.2		X														
+opendal@0.59.0		X														
+opendal-core@0.59.0		X														
 opendal-dotnet@0.0.0		X														
-opendal-http-transport-reqwest@0.58.2		X														
-opendal-layer-concurrent-limit@0.58.2		X														
-opendal-layer-logging@0.58.2		X														
-opendal-layer-mime-guess@0.58.2		X														
-opendal-layer-retry@0.58.2		X														
-opendal-layer-throttle@0.58.2		X														
-opendal-layer-timeout@0.58.2		X														
-opendal-service-aliyun-drive@0.58.2		X														
-opendal-service-alluxio@0.58.2		X														
-opendal-service-azblob@0.58.2		X														
-opendal-service-azdls@0.58.2		X														
-opendal-service-azfile@0.58.2		X														
-opendal-service-azure-common@0.58.2		X														
-opendal-service-b2@0.58.2		X														
-opendal-service-cacache@0.58.2		X														
-opendal-service-compfs@0.58.2		X														
-opendal-service-cos@0.58.2		X														
-opendal-service-dashmap@0.58.2		X														
-opendal-service-dropbox@0.58.2		X														
-opendal-service-etcd@0.58.2		X														
-opendal-service-fs@0.58.2		X														
-opendal-service-gcs@0.58.2		X														
-opendal-service-gdrive@0.58.2		X														
-opendal-service-ghac@0.58.2		X														
-opendal-service-goosefs@0.58.2		X														
-opendal-service-gridfs@0.58.2		X														
-opendal-service-hf@0.58.2		X														
-opendal-service-http@0.58.2		X														
-opendal-service-ipfs@0.58.2		X														
-opendal-service-ipmfs@0.58.2		X														
-opendal-service-koofr@0.58.2		X														
-opendal-service-memcached@0.58.2		X														
-opendal-service-mini-moka@0.58.2		X														
-opendal-service-moka@0.58.2		X														
-opendal-service-mongodb@0.58.2		X														
-opendal-service-monoiofs@0.58.2		X														
-opendal-service-mysql@0.58.2		X														
-opendal-service-obs@0.58.2		X														
-opendal-service-onedrive@0.58.2		X														
-opendal-service-oss@0.58.2		X														
-opendal-service-persy@0.58.2		X														
-opendal-service-postgresql@0.58.2		X														
-opendal-service-redb@0.58.2		X														
-opendal-service-redis@0.58.2		X														
-opendal-service-s3@0.58.2		X														
-opendal-service-seafile@0.58.2		X														
-opendal-service-sftp@0.58.2		X														
-opendal-service-sled@0.58.2		X														
-opendal-service-sqlite@0.58.2		X														
-opendal-service-swift@0.58.2		X														
-opendal-service-tikv@0.58.2		X														
-opendal-service-tos@0.58.2		X														
-opendal-service-upyun@0.58.2		X														
-opendal-service-vercel-artifacts@0.58.2		X														
-opendal-service-webdav@0.58.2		X														
-opendal-service-webhdfs@0.58.2		X														
-opendal-service-yandex-disk@0.58.2		X														
+opendal-http-transport-reqwest@0.59.0		X														
+opendal-layer-concurrent-limit@0.59.0		X														
+opendal-layer-logging@0.59.0		X														
+opendal-layer-mime-guess@0.59.0		X														
+opendal-layer-retry@0.59.0		X														
+opendal-layer-throttle@0.59.0		X														
+opendal-layer-timeout@0.59.0		X														
+opendal-service-aliyun-drive@0.59.0		X														
+opendal-service-alluxio@0.59.0		X														
+opendal-service-azblob@0.59.0		X														
+opendal-service-azdls@0.59.0		X														
+opendal-service-azfile@0.59.0		X														
+opendal-service-azure-common@0.59.0		X														
+opendal-service-b2@0.59.0		X														
+opendal-service-cacache@0.59.0		X														
+opendal-service-compfs@0.59.0		X														
+opendal-service-cos@0.59.0		X														
+opendal-service-dashmap@0.59.0		X														
+opendal-service-dropbox@0.59.0		X														
+opendal-service-etcd@0.59.0		X														
+opendal-service-fs@0.59.0		X														
+opendal-service-gcs@0.59.0		X														
+opendal-service-gcs-grpc@0.59.0		X														
+opendal-service-gdrive@0.59.0		X														
+opendal-service-ghac@0.59.0		X														
+opendal-service-goosefs@0.59.0		X														
+opendal-service-gridfs@0.59.0		X														
+opendal-service-hf@0.59.0		X														
+opendal-service-http@0.59.0		X														
+opendal-service-ipfs@0.59.0		X														
+opendal-service-ipmfs@0.59.0		X														
+opendal-service-koofr@0.59.0		X														
+opendal-service-memcached@0.59.0		X														
+opendal-service-mini-moka@0.59.0		X														
+opendal-service-moka@0.59.0		X														
+opendal-service-mongodb@0.59.0		X														
+opendal-service-monoiofs@0.59.0		X														
+opendal-service-mysql@0.59.0		X														
+opendal-service-obs@0.59.0		X														
+opendal-service-onedrive@0.59.0		X														
+opendal-service-oss@0.59.0		X														
+opendal-service-persy@0.59.0		X														
+opendal-service-postgresql@0.59.0		X														
+opendal-service-redb@0.59.0		X														
+opendal-service-redis@0.59.0		X														
+opendal-service-s3@0.59.0		X														
+opendal-service-seafile@0.59.0		X														
+opendal-service-sftp@0.59.0		X														
+opendal-service-sled@0.59.0		X														
+opendal-service-sqlite@0.59.0		X														
+opendal-service-swift@0.59.0		X														
+opendal-service-tikv@0.59.0		X														
+opendal-service-tos@0.59.0		X														
+opendal-service-upyun@0.59.0		X														
+opendal-service-vercel-artifacts@0.59.0		X														
+opendal-service-webdav@0.59.0		X														
+opendal-service-webhdfs@0.59.0		X														
+opendal-service-yandex-disk@0.59.0		X														
 openssh@0.11.6		X									X					
-openssh-sftp-client@0.15.7											X					
+openssh-sftp-client@0.15.8											X					
 openssh-sftp-client-lowlevel@0.7.2											X					
 openssh-sftp-error@0.5.1											X					
 openssh-sftp-protocol@0.24.2											X					
@@ -432,7 +432,7 @@ r-efi@6.0.0		X								X	X
 radium@0.7.0											X					
 rand@0.10.2		X									X					
 rand@0.7.3		X									X					
-rand@0.8.7		X									X					
+rand@0.8.8		X									X					
 rand@0.9.5		X									X					
 rand_chacha@0.2.2		X									X					
 rand_chacha@0.3.1		X									X					
@@ -444,26 +444,25 @@ rand_core@0.9.5		X									X
 rand_hc@0.2.0		X									X					
 raw-cpuid@11.6.0											X					
 redb@3.1.3		X									X					
-redb@4.1.0		X									X					
+redb@4.2.0		X									X					
 redis@1.6.0					X											
 redox_syscall@0.2.16											X					
 redox_syscall@0.5.18											X					
-redox_syscall@0.9.2											X					
 redox_users@0.5.2											X					
 reflink-copy@0.1.30		X									X					
 regex@1.13.1		X									X					
 regex-automata@0.4.18		X									X					
 regex-syntax@0.8.11		X									X					
-reqsign-aliyun-oss@3.1.4		X														
-reqsign-aws-core@3.1.0		X														
-reqsign-aws-v4@3.2.0		X														
-reqsign-azure-storage@3.2.0		X														
-reqsign-core@3.3.0		X														
-reqsign-file-read-tokio@3.0.5		X														
-reqsign-google@3.1.0		X														
-reqsign-huaweicloud-obs@3.0.5		X														
-reqsign-tencent-cos@3.0.5		X														
-reqsign-volcengine-tos@3.1.1		X														
+reqsign-aliyun-oss@3.1.5		X														
+reqsign-aws-core@3.1.1		X														
+reqsign-aws-v4@3.3.0		X														
+reqsign-azure-storage@3.2.1		X														
+reqsign-core@3.3.1		X														
+reqsign-file-read-tokio@3.0.6		X														
+reqsign-google@3.1.1		X														
+reqsign-huaweicloud-obs@3.0.6		X														
+reqsign-tencent-cos@3.0.6		X														
+reqsign-volcengine-tos@3.1.2		X														
 reqwest@0.12.28		X									X					
 reqwest@0.13.4		X									X					
 reqwest-middleware@0.5.2		X									X					
@@ -482,7 +481,7 @@ rustls-pki-types@1.15.1		X									X
 rustls-platform-verifier@0.7.0		X									X					
 rustls-platform-verifier-android@0.1.1		X									X					
 rustls-webpki@0.101.7									X							
-rustls-webpki@0.103.14									X							
+rustls-webpki@0.103.15									X							
 rustversion@1.0.23		X									X					
 ryu@1.0.23		X				X										
 safe-transmute@0.11.3											X					
@@ -550,7 +549,7 @@ subtle@2.6.1					X
 symlink@0.1.0		X									X					
 syn@1.0.109		X									X					
 syn@2.0.119		X									X					
-syn@3.0.3		X									X					
+syn@3.0.4		X									X					
 sync_wrapper@0.1.2		X														
 sync_wrapper@1.0.2		X														
 synchrony@0.1.9											X					
@@ -608,7 +607,7 @@ tracing-serde@0.2.0											X
 tracing-subscriber@0.3.23											X					
 triomphe@0.1.16		X									X					
 try-lock@0.2.5											X					
-twox-hash@2.1.3											X					
+twox-hash@2.1.4											X					
 typed-builder@0.22.0		X									X					
 typed-builder-macro@0.22.0		X									X					
 typenum@1.20.1		X									X					
@@ -626,7 +625,7 @@ untrusted@0.9.0									X
 url@2.5.8		X									X					
 urlencoding@2.1.3											X					
 utf8_iter@1.0.4		X									X					
-uuid@1.24.1		X									X					
+uuid@1.26.0		X									X					
 vcpkg@0.2.15		X									X					
 vec-strings@0.4.8											X					
 version_check@0.9.5		X									X					
@@ -704,7 +703,7 @@ zerofrom@0.1.8														X
 zerofrom-derive@0.1.7														X		
 zeroize@1.9.0		X									X					
 zerotrie@0.2.5														X		
-zerovec@0.11.7														X		
-zerovec-derive@0.11.4														X		
+zerovec@0.11.8														X		
+zerovec-derive@0.11.6														X		
 zigzag@0.1.0											X					
 zmij@1.0.23											X					

--- a/bindings/dotnet/OpenDAL/OpenDAL.csproj
+++ b/bindings/dotnet/OpenDAL/OpenDAL.csproj
@@ -4,7 +4,7 @@
         <Title>Apache OpenDAL .NET</Title>
         <PackageId>Apache.OpenDAL</PackageId>
         <Description>The official .NET binding for Apache OpenDAL™</Description>
-        <VersionPrefix>0.1.2</VersionPrefix>
+        <VersionPrefix>0.2.0</VersionPrefix>
         <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
         <FileVersion>$(VersionPrefix)</FileVersion>
         <Authors>Apache OpenDAL™</Authors>

--- a/bindings/haskell/DEPENDENCIES.rust.tsv
+++ b/bindings/haskell/DEPENDENCIES.rust.tsv
@@ -18,12 +18,12 @@ block-padding@0.3.3	X									X
 bumpalo@3.20.3	X									X			
 bytes@1.12.1										X			
 cbc@0.1.2	X									X			
-cc@1.4.3	X									X			
+cc@1.4.4	X									X			
 cfg-if@1.0.4	X									X			
 cipher@0.4.4	X									X			
 cmake@0.1.58	X									X			
 cmov@0.5.4	X									X			
-combine@4.6.7										X			
+combine@4.6.8										X			
 const-oid@0.10.2	X									X			
 const-oid@0.9.6	X									X			
 const-random@0.1.18	X									X			
@@ -31,7 +31,7 @@ const-random-macro@0.1.16	X									X
 core-foundation@0.10.1	X									X			
 core-foundation-sys@0.8.7	X									X			
 cpufeatures@0.2.17	X									X			
-cpufeatures@0.3.0	X									X			
+cpufeatures@0.3.1	X									X			
 crc-fast@1.10.0	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
@@ -44,7 +44,7 @@ digest@0.11.3	X									X
 displaydoc@0.2.7	X									X			
 dlv-list@0.5.2	X									X			
 dunce@1.0.5	X					X					X		
-either@1.17.0	X									X			
+either@1.18.0	X									X			
 errno@0.3.14	X									X			
 fastrand@2.5.0	X									X			
 find-msvc-tools@0.1.11	X									X			
@@ -74,7 +74,7 @@ http-body@1.1.0										X
 http-body-util@0.1.5										X			
 httparse@1.10.1	X									X			
 hybrid-array@0.4.14	X									X			
-hyper@1.11.0										X			
+hyper@1.11.1										X			
 hyper-rustls@0.27.9	X							X		X			
 hyper-util@0.1.20										X			
 icu_collections@2.3.0												X	
@@ -83,7 +83,7 @@ icu_normalizer@2.3.0												X
 icu_normalizer_data@2.3.0												X	
 icu_properties@2.3.0												X	
 icu_properties_data@2.3.0												X	
-icu_provider@2.3.0												X	
+icu_provider@2.3.1												X	
 idna@1.1.0	X									X			
 idna_adapter@1.2.2	X									X			
 inout@0.1.4	X									X			
@@ -108,8 +108,9 @@ linktime-proc-macro@0.2.3	X									X
 linux-raw-sys@0.12.1	X	X								X			
 litemap@0.8.3												X	
 lock_api@0.4.14	X									X			
-log@0.4.33	X									X			
+log@0.4.34	X									X			
 md-5@0.11.0	X									X			
+mea@0.6.7	X												
 memchr@2.8.3										X			X
 mio@1.2.2										X			
 num-bigint-dig@0.8.6	X									X			
@@ -117,29 +118,29 @@ num-integer@0.1.47	X									X
 num-iter@0.1.46	X									X			
 num-traits@0.2.19	X									X			
 once_cell@1.21.4	X									X			
-opendal@0.58.2	X												
-opendal-core@0.58.2	X												
+opendal@0.59.0	X												
+opendal-core@0.59.0	X												
 opendal-hs@0.0.0	X												
-opendal-http-transport-reqwest@0.58.2	X												
-opendal-layer-concurrent-limit@0.58.2	X												
-opendal-layer-logging@0.58.2	X												
-opendal-layer-retry@0.58.2	X												
-opendal-layer-timeout@0.58.2	X												
-opendal-service-azblob@0.58.2	X												
-opendal-service-azdls@0.58.2	X												
-opendal-service-azfile@0.58.2	X												
-opendal-service-azure-common@0.58.2	X												
-opendal-service-cos@0.58.2	X												
-opendal-service-fs@0.58.2	X												
-opendal-service-gcs@0.58.2	X												
-opendal-service-ghac@0.58.2	X												
-opendal-service-http@0.58.2	X												
-opendal-service-ipmfs@0.58.2	X												
-opendal-service-obs@0.58.2	X												
-opendal-service-oss@0.58.2	X												
-opendal-service-s3@0.58.2	X												
-opendal-service-webdav@0.58.2	X												
-opendal-service-webhdfs@0.58.2	X												
+opendal-http-transport-reqwest@0.59.0	X												
+opendal-layer-concurrent-limit@0.59.0	X												
+opendal-layer-logging@0.59.0	X												
+opendal-layer-retry@0.59.0	X												
+opendal-layer-timeout@0.59.0	X												
+opendal-service-azblob@0.59.0	X												
+opendal-service-azdls@0.59.0	X												
+opendal-service-azfile@0.59.0	X												
+opendal-service-azure-common@0.59.0	X												
+opendal-service-cos@0.59.0	X												
+opendal-service-fs@0.59.0	X												
+opendal-service-gcs@0.59.0	X												
+opendal-service-ghac@0.59.0	X												
+opendal-service-http@0.59.0	X												
+opendal-service-ipmfs@0.59.0	X												
+opendal-service-obs@0.59.0	X												
+opendal-service-oss@0.59.0	X												
+opendal-service-s3@0.59.0	X												
+opendal-service-webdav@0.59.0	X												
+opendal-service-webhdfs@0.59.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-multimap@0.7.3										X			
 parking_lot@0.12.5	X									X			
@@ -163,19 +164,19 @@ prost-derive@0.14.4	X
 quick-xml@0.41.0										X			
 quote@1.0.47	X									X			
 r-efi@6.0.0	X								X	X			
-rand@0.8.7	X									X			
+rand@0.8.8	X									X			
 rand_chacha@0.3.1	X									X			
 rand_core@0.6.4	X									X			
 redox_syscall@0.5.18										X			
-reqsign-aliyun-oss@3.1.4	X												
-reqsign-aws-core@3.1.0	X												
-reqsign-aws-v4@3.2.0	X												
-reqsign-azure-storage@3.2.0	X												
-reqsign-core@3.3.0	X												
-reqsign-file-read-tokio@3.0.5	X												
-reqsign-google@3.1.0	X												
-reqsign-huaweicloud-obs@3.0.5	X												
-reqsign-tencent-cos@3.0.5	X												
+reqsign-aliyun-oss@3.1.5	X												
+reqsign-aws-core@3.1.1	X												
+reqsign-aws-v4@3.3.0	X												
+reqsign-azure-storage@3.2.1	X												
+reqsign-core@3.3.1	X												
+reqsign-file-read-tokio@3.0.6	X												
+reqsign-google@3.1.1	X												
+reqsign-huaweicloud-obs@3.0.6	X												
+reqsign-tencent-cos@3.0.6	X												
 reqwest@0.13.4	X									X			
 rsa@0.9.10	X									X			
 rust-ini@0.21.3										X			
@@ -186,7 +187,7 @@ rustls-native-certs@0.8.4	X							X		X
 rustls-pki-types@1.15.1	X									X			
 rustls-platform-verifier@0.7.0	X									X			
 rustls-platform-verifier-android@0.1.1	X									X			
-rustls-webpki@0.103.14								X					
+rustls-webpki@0.103.15								X					
 rustversion@1.0.23	X									X			
 ryu@1.0.23	X				X								
 salsa20@0.10.2	X									X			
@@ -219,7 +220,7 @@ spki@0.7.3	X									X
 stable_deref_trait@1.2.1	X									X			
 subtle@2.6.1				X									
 syn@2.0.119	X									X			
-syn@3.0.3	X									X			
+syn@3.0.4	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
 thiserror@2.0.20	X									X			
@@ -242,7 +243,7 @@ unicode-ident@1.0.24	X									X		X
 untrusted@0.9.0								X					
 url@2.5.8	X									X			
 utf8_iter@1.0.4	X									X			
-uuid@1.24.1	X									X			
+uuid@1.26.0	X									X			
 version_check@0.9.5	X									X			
 walkdir@2.5.0										X			X
 want@0.3.1										X			
@@ -268,6 +269,6 @@ zerofrom@0.1.8												X
 zerofrom-derive@0.1.7												X	
 zeroize@1.9.0	X									X			
 zerotrie@0.2.5												X	
-zerovec@0.11.7												X	
-zerovec-derive@0.11.4												X	
+zerovec@0.11.8												X	
+zerovec-derive@0.11.6												X	
 zmij@1.0.23										X			

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -9,7 +9,6 @@ anyhow@1.0.104		X									X
 approx@0.5.1		X														
 arc-swap@1.9.2		X									X					
 arcstr@1.2.0		X									X					X
-arrayref@0.3.9				X												
 arrayvec@0.7.8		X									X					
 async-lock@3.4.2		X									X					
 async-recursion@0.3.2		X									X					
@@ -36,7 +35,7 @@ base64ct@1.8.3		X									X
 bitflags@1.3.2		X									X					
 bitflags@2.13.1		X									X					
 bitvec@1.1.1											X					
-blake3@1.8.6		X	X				X									
+blake3@1.8.7		X	X				X									
 block-buffer@0.10.4		X									X					
 block-buffer@0.12.1		X									X					
 block-padding@0.3.3		X									X					
@@ -52,16 +51,16 @@ camino@1.2.5		X									X
 cargo-platform@0.1.9		X									X					
 cargo_metadata@0.14.2											X					
 cbc@0.1.2		X									X					
-cc@1.4.3		X									X					
+cc@1.4.4		X									X					
 cfg-if@0.1.10		X									X					
 cfg-if@1.0.4		X									X					
-chacha20@0.10.1		X									X					
+chacha20@0.10.2		X									X					
 chrono@0.4.45		X									X					
 cipher@0.4.4		X									X					
 cmake@0.1.58		X									X					
 cmov@0.5.4		X									X					
 colored@3.1.1													X			
-combine@4.6.7											X					
+combine@4.6.8											X					
 concurrent_arena@0.1.11											X					
 const-oid@0.10.2		X									X					
 const-oid@0.9.6		X									X					
@@ -76,12 +75,12 @@ core-foundation@0.9.4		X									X
 core-foundation-sys@0.8.7		X									X					
 countio@0.3.0											X					
 cpufeatures@0.2.17		X									X					
-cpufeatures@0.3.0		X									X					
+cpufeatures@0.3.1		X									X					
 crc@3.4.0		X									X					
 crc-catalog@2.5.0		X									X					
 crc-fast@1.10.0		X									X					
 crc16@0.4.0											X					
-crc32fast@1.5.0		X									X					
+crc32fast@1.5.1		X									X					
 critical-section@1.2.0		X									X					
 crossbeam-channel@0.5.16		X									X					
 crossbeam-epoch@0.9.20		X									X					
@@ -114,7 +113,7 @@ displaydoc@0.2.7		X									X
 dlv-list@0.5.2		X									X					
 dotenvy@0.15.7											X					
 dunce@1.0.5		X					X					X				
-either@1.17.0		X									X					
+either@1.18.0		X									X					
 equivalent@1.0.2		X									X					
 errno@0.3.14		X									X					
 error-chain@0.12.4		X									X					
@@ -123,11 +122,11 @@ etcetera@0.8.0		X									X
 event-listener@5.4.2		X									X					
 event-listener-strategy@0.5.4		X									X					
 fail@0.4.0		X														
-fastpool@1.1.0		X														
+fastpool@1.1.1		X														
 fastrand@2.5.0		X									X					
 find-msvc-tools@0.1.11		X									X					
 fixedbitset@0.5.7		X									X					
-flate2@1.1.9		X									X					
+flate2@1.1.10		X									X					
 flume@0.11.1		X									X					
 fnv@1.0.7		X									X					
 foldhash@0.1.5																X
@@ -160,7 +159,7 @@ glob@0.3.4		X									X
 gloo-timers@0.3.0		X									X					
 goosefs-sdk@0.1.9		X														
 h2@0.3.27											X					
-h2@0.4.15											X					
+h2@0.4.19											X					
 hashbrown@0.12.3		X									X					
 hashbrown@0.14.5		X									X					
 hashbrown@0.15.5		X									X					
@@ -188,7 +187,7 @@ httpdate@1.0.3		X									X
 humantime@2.4.0		X									X					
 hybrid-array@0.4.14		X									X					
 hyper@0.14.32											X					
-hyper@1.11.0											X					
+hyper@1.11.1											X					
 hyper-rustls@0.27.9		X							X		X					
 hyper-timeout@0.4.1		X									X					
 hyper-timeout@0.5.2		X									X					
@@ -201,12 +200,12 @@ icu_normalizer@2.3.0														X
 icu_normalizer_data@2.3.0														X		
 icu_properties@2.3.0														X		
 icu_properties_data@2.3.0														X		
-icu_provider@2.3.0														X		
+icu_provider@2.3.1														X		
 ident_case@1.0.1		X									X					
 idna@1.1.0		X									X					
 idna_adapter@1.2.2		X									X					
 indexmap@1.9.3		X									X					
-indexmap@2.14.0		X									X					
+indexmap@2.14.1		X									X					
 inout@0.1.4		X									X					
 instant@0.1.13					X											
 io-uring@0.7.14		X									X					
@@ -230,7 +229,7 @@ konst_proc_macros@0.4.1																X
 lazy_static@1.5.0		X									X					
 libc@0.2.189		X									X					
 libm@0.2.16											X					
-libredox@0.1.20											X					
+libredox@0.1.21											X					
 libsqlite3-sys@0.30.1											X					
 link-section@0.19.3		X									X					
 linked-hash-map@0.5.6		X									X					
@@ -238,8 +237,8 @@ linktime-proc-macro@0.2.3		X									X
 linux-raw-sys@0.12.1		X	X								X					
 litemap@0.8.3														X		
 lock_api@0.4.14		X									X					
-log@0.4.33		X									X					
-lru@0.18.2											X					
+log@0.4.34		X									X					
+lru@0.18.3											X					
 lz4_flex@0.13.1											X					
 macro_magic@0.5.1											X					
 macro_magic_core@0.5.1											X					
@@ -258,11 +257,11 @@ miette@5.10.0		X
 miette-derive@5.10.0		X														
 mime@0.3.17		X									X					
 mini-moka@0.10.3		X									X					
-miniz_oxide@0.8.9		X									X					X
+miniz_oxide@0.9.1		X									X					X
 mio@1.2.2											X					
 moka@0.12.16		X									X					
-mongodb@3.8.0		X														
-mongodb-internal-macros@3.8.0		X														
+mongodb@3.8.2		X														
+mongodb-internal-macros@3.8.2		X														
 more-asserts@0.3.1		X					X				X				X	
 multimap@0.10.1		X									X					
 ndk-context@0.1.1		X									X					
@@ -280,64 +279,65 @@ objc2-io-kit@0.3.2		X									X					X
 objc2-system-configuration@0.3.2		X									X					X
 once_cell@1.21.4		X									X					
 oneshot@0.1.13		X									X					
-opendal@0.58.2		X														
-opendal-core@0.58.2		X														
-opendal-http-transport-reqwest@0.58.2		X														
+opendal@0.59.0		X														
+opendal-core@0.59.0		X														
+opendal-http-transport-reqwest@0.59.0		X														
 opendal-java@0.0.0		X														
-opendal-layer-concurrent-limit@0.58.2		X														
-opendal-layer-logging@0.58.2		X														
-opendal-layer-retry@0.58.2		X														
-opendal-layer-timeout@0.58.2		X														
-opendal-service-aliyun-drive@0.58.2		X														
-opendal-service-alluxio@0.58.2		X														
-opendal-service-azblob@0.58.2		X														
-opendal-service-azdls@0.58.2		X														
-opendal-service-azfile@0.58.2		X														
-opendal-service-azure-common@0.58.2		X														
-opendal-service-b2@0.58.2		X														
-opendal-service-cacache@0.58.2		X														
-opendal-service-cos@0.58.2		X														
-opendal-service-dashmap@0.58.2		X														
-opendal-service-dropbox@0.58.2		X														
-opendal-service-etcd@0.58.2		X														
-opendal-service-fs@0.58.2		X														
-opendal-service-gcs@0.58.2		X														
-opendal-service-gdrive@0.58.2		X														
-opendal-service-ghac@0.58.2		X														
-opendal-service-goosefs@0.58.2		X														
-opendal-service-gridfs@0.58.2		X														
-opendal-service-hf@0.58.2		X														
-opendal-service-http@0.58.2		X														
-opendal-service-ipfs@0.58.2		X														
-opendal-service-ipmfs@0.58.2		X														
-opendal-service-koofr@0.58.2		X														
-opendal-service-memcached@0.58.2		X														
-opendal-service-mini-moka@0.58.2		X														
-opendal-service-moka@0.58.2		X														
-opendal-service-mongodb@0.58.2		X														
-opendal-service-mysql@0.58.2		X														
-opendal-service-obs@0.58.2		X														
-opendal-service-onedrive@0.58.2		X														
-opendal-service-oss@0.58.2		X														
-opendal-service-persy@0.58.2		X														
-opendal-service-postgresql@0.58.2		X														
-opendal-service-redb@0.58.2		X														
-opendal-service-redis@0.58.2		X														
-opendal-service-s3@0.58.2		X														
-opendal-service-seafile@0.58.2		X														
-opendal-service-sftp@0.58.2		X														
-opendal-service-sled@0.58.2		X														
-opendal-service-sqlite@0.58.2		X														
-opendal-service-swift@0.58.2		X														
-opendal-service-tikv@0.58.2		X														
-opendal-service-tos@0.58.2		X														
-opendal-service-upyun@0.58.2		X														
-opendal-service-vercel-artifacts@0.58.2		X														
-opendal-service-webdav@0.58.2		X														
-opendal-service-webhdfs@0.58.2		X														
-opendal-service-yandex-disk@0.58.2		X														
+opendal-layer-concurrent-limit@0.59.0		X														
+opendal-layer-logging@0.59.0		X														
+opendal-layer-retry@0.59.0		X														
+opendal-layer-timeout@0.59.0		X														
+opendal-service-aliyun-drive@0.59.0		X														
+opendal-service-alluxio@0.59.0		X														
+opendal-service-azblob@0.59.0		X														
+opendal-service-azdls@0.59.0		X														
+opendal-service-azfile@0.59.0		X														
+opendal-service-azure-common@0.59.0		X														
+opendal-service-b2@0.59.0		X														
+opendal-service-cacache@0.59.0		X														
+opendal-service-cos@0.59.0		X														
+opendal-service-dashmap@0.59.0		X														
+opendal-service-dropbox@0.59.0		X														
+opendal-service-etcd@0.59.0		X														
+opendal-service-fs@0.59.0		X														
+opendal-service-gcs@0.59.0		X														
+opendal-service-gcs-grpc@0.59.0		X														
+opendal-service-gdrive@0.59.0		X														
+opendal-service-ghac@0.59.0		X														
+opendal-service-goosefs@0.59.0		X														
+opendal-service-gridfs@0.59.0		X														
+opendal-service-hf@0.59.0		X														
+opendal-service-http@0.59.0		X														
+opendal-service-ipfs@0.59.0		X														
+opendal-service-ipmfs@0.59.0		X														
+opendal-service-koofr@0.59.0		X														
+opendal-service-memcached@0.59.0		X														
+opendal-service-mini-moka@0.59.0		X														
+opendal-service-moka@0.59.0		X														
+opendal-service-mongodb@0.59.0		X														
+opendal-service-mysql@0.59.0		X														
+opendal-service-obs@0.59.0		X														
+opendal-service-onedrive@0.59.0		X														
+opendal-service-oss@0.59.0		X														
+opendal-service-persy@0.59.0		X														
+opendal-service-postgresql@0.59.0		X														
+opendal-service-redb@0.59.0		X														
+opendal-service-redis@0.59.0		X														
+opendal-service-s3@0.59.0		X														
+opendal-service-seafile@0.59.0		X														
+opendal-service-sftp@0.59.0		X														
+opendal-service-sled@0.59.0		X														
+opendal-service-sqlite@0.59.0		X														
+opendal-service-swift@0.59.0		X														
+opendal-service-tikv@0.59.0		X														
+opendal-service-tos@0.59.0		X														
+opendal-service-upyun@0.59.0		X														
+opendal-service-vercel-artifacts@0.59.0		X														
+opendal-service-webdav@0.59.0		X														
+opendal-service-webhdfs@0.59.0		X														
+opendal-service-yandex-disk@0.59.0		X														
 openssh@0.11.6		X									X					
-openssh-sftp-client@0.15.7											X					
+openssh-sftp-client@0.15.8											X					
 openssh-sftp-client-lowlevel@0.7.2											X					
 openssh-sftp-error@0.5.1											X					
 openssh-sftp-protocol@0.24.2											X					
@@ -391,7 +391,7 @@ r-efi@6.0.0		X								X	X
 radium@0.7.0											X					
 rand@0.10.2		X									X					
 rand@0.7.3		X									X					
-rand@0.8.7		X									X					
+rand@0.8.8		X									X					
 rand@0.9.5		X									X					
 rand_chacha@0.2.2		X									X					
 rand_chacha@0.3.1		X									X					
@@ -402,26 +402,25 @@ rand_core@0.6.4		X									X
 rand_core@0.9.5		X									X					
 rand_hc@0.2.0		X									X					
 redb@3.1.3		X									X					
-redb@4.1.0		X									X					
+redb@4.2.0		X									X					
 redis@1.6.0					X											
 redox_syscall@0.2.16											X					
 redox_syscall@0.5.18											X					
-redox_syscall@0.9.2											X					
 redox_users@0.5.2											X					
 reflink-copy@0.1.30		X									X					
 regex@1.13.1		X									X					
 regex-automata@0.4.18		X									X					
 regex-syntax@0.8.11		X									X					
-reqsign-aliyun-oss@3.1.4		X														
-reqsign-aws-core@3.1.0		X														
-reqsign-aws-v4@3.2.0		X														
-reqsign-azure-storage@3.2.0		X														
-reqsign-core@3.3.0		X														
-reqsign-file-read-tokio@3.0.5		X														
-reqsign-google@3.1.0		X														
-reqsign-huaweicloud-obs@3.0.5		X														
-reqsign-tencent-cos@3.0.5		X														
-reqsign-volcengine-tos@3.1.1		X														
+reqsign-aliyun-oss@3.1.5		X														
+reqsign-aws-core@3.1.1		X														
+reqsign-aws-v4@3.3.0		X														
+reqsign-azure-storage@3.2.1		X														
+reqsign-core@3.3.1		X														
+reqsign-file-read-tokio@3.0.6		X														
+reqsign-google@3.1.1		X														
+reqsign-huaweicloud-obs@3.0.6		X														
+reqsign-tencent-cos@3.0.6		X														
+reqsign-volcengine-tos@3.1.2		X														
 reqwest@0.12.28		X									X					
 reqwest@0.13.4		X									X					
 reqwest-middleware@0.5.2		X									X					
@@ -440,7 +439,7 @@ rustls-pki-types@1.15.1		X									X
 rustls-platform-verifier@0.7.0		X									X					
 rustls-platform-verifier-android@0.1.1		X									X					
 rustls-webpki@0.101.7									X							
-rustls-webpki@0.103.14									X							
+rustls-webpki@0.103.15									X							
 rustversion@1.0.23		X									X					
 ryu@1.0.23		X				X										
 safe-transmute@0.11.3											X					
@@ -505,7 +504,7 @@ subtle@2.6.1					X
 symlink@0.1.0		X									X					
 syn@1.0.109		X									X					
 syn@2.0.119		X									X					
-syn@3.0.3		X									X					
+syn@3.0.4		X									X					
 sync_wrapper@0.1.2		X														
 sync_wrapper@1.0.2		X														
 synstructure@0.13.2											X					
@@ -560,7 +559,7 @@ tracing-serde@0.2.0											X
 tracing-subscriber@0.3.23											X					
 triomphe@0.1.16		X									X					
 try-lock@0.2.5											X					
-twox-hash@2.1.3											X					
+twox-hash@2.1.4											X					
 typed-builder@0.22.0		X									X					
 typed-builder-macro@0.22.0		X									X					
 typenum@1.20.1		X									X					
@@ -578,7 +577,7 @@ untrusted@0.9.0									X
 url@2.5.8		X									X					
 urlencoding@2.1.3											X					
 utf8_iter@1.0.4		X									X					
-uuid@1.24.1		X									X					
+uuid@1.26.0		X									X					
 vcpkg@0.2.15		X									X					
 vec-strings@0.4.8											X					
 version_check@0.9.5		X									X					
@@ -656,7 +655,7 @@ zerofrom@0.1.8														X
 zerofrom-derive@0.1.7														X		
 zeroize@1.9.0		X									X					
 zerotrie@0.2.5														X		
-zerovec@0.11.7														X		
-zerovec-derive@0.11.4														X		
+zerovec@0.11.8														X		
+zerovec-derive@0.11.6														X		
 zigzag@0.1.0											X					
 zmij@1.0.23											X					

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal</artifactId>
-    <version>0.50.2</version> <!-- update version number -->
+    <version>0.50.3</version> <!-- update version number -->
 
     <name>Apache OpenDAL™</name>
     <description>

--- a/bindings/lua/DEPENDENCIES.rust.tsv
+++ b/bindings/lua/DEPENDENCIES.rust.tsv
@@ -20,12 +20,12 @@ bstr@1.13.1	X									X
 bumpalo@3.20.3	X									X			
 bytes@1.12.1										X			
 cbc@0.1.2	X									X			
-cc@1.4.3	X									X			
+cc@1.4.4	X									X			
 cfg-if@1.0.4	X									X			
 cipher@0.4.4	X									X			
 cmake@0.1.58	X									X			
 cmov@0.5.4	X									X			
-combine@4.6.7										X			
+combine@4.6.8										X			
 const-oid@0.10.2	X									X			
 const-oid@0.9.6	X									X			
 const-random@0.1.18	X									X			
@@ -33,7 +33,7 @@ const-random-macro@0.1.16	X									X
 core-foundation@0.10.1	X									X			
 core-foundation-sys@0.8.7	X									X			
 cpufeatures@0.2.17	X									X			
-cpufeatures@0.3.0	X									X			
+cpufeatures@0.3.1	X									X			
 crc-fast@1.10.0	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
@@ -46,7 +46,7 @@ digest@0.11.3	X									X
 displaydoc@0.2.7	X									X			
 dlv-list@0.5.2	X									X			
 dunce@1.0.5	X					X					X		
-either@1.17.0	X									X			
+either@1.18.0	X									X			
 errno@0.3.14	X									X			
 fastrand@2.5.0	X									X			
 find-msvc-tools@0.1.11	X									X			
@@ -76,7 +76,7 @@ http-body@1.1.0										X
 http-body-util@0.1.5										X			
 httparse@1.10.1	X									X			
 hybrid-array@0.4.14	X									X			
-hyper@1.11.0										X			
+hyper@1.11.1										X			
 hyper-rustls@0.27.9	X							X		X			
 hyper-util@0.1.20										X			
 icu_collections@2.3.0												X	
@@ -85,7 +85,7 @@ icu_normalizer@2.3.0												X
 icu_normalizer_data@2.3.0												X	
 icu_properties@2.3.0												X	
 icu_properties_data@2.3.0												X	
-icu_provider@2.3.0												X	
+icu_provider@2.3.1												X	
 idna@1.1.0	X									X			
 idna_adapter@1.2.2	X									X			
 inout@0.1.4	X									X			
@@ -110,8 +110,9 @@ linktime-proc-macro@0.2.3	X									X
 linux-raw-sys@0.12.1	X	X								X			
 litemap@0.8.3												X	
 lock_api@0.4.14	X									X			
-log@0.4.33	X									X			
+log@0.4.34	X									X			
 md-5@0.11.0	X									X			
+mea@0.6.7	X												
 memchr@2.8.3										X			X
 mio@1.2.2										X			
 mlua@0.11.6										X			
@@ -122,29 +123,29 @@ num-integer@0.1.47	X									X
 num-iter@0.1.46	X									X			
 num-traits@0.2.19	X									X			
 once_cell@1.21.4	X									X			
-opendal@0.58.2	X												
-opendal-core@0.58.2	X												
-opendal-http-transport-reqwest@0.58.2	X												
-opendal-layer-concurrent-limit@0.58.2	X												
-opendal-layer-logging@0.58.2	X												
-opendal-layer-retry@0.58.2	X												
-opendal-layer-timeout@0.58.2	X												
+opendal@0.59.0	X												
+opendal-core@0.59.0	X												
+opendal-http-transport-reqwest@0.59.0	X												
+opendal-layer-concurrent-limit@0.59.0	X												
+opendal-layer-logging@0.59.0	X												
+opendal-layer-retry@0.59.0	X												
+opendal-layer-timeout@0.59.0	X												
 opendal-lua@0.0.0	X												
-opendal-service-azblob@0.58.2	X												
-opendal-service-azdls@0.58.2	X												
-opendal-service-azfile@0.58.2	X												
-opendal-service-azure-common@0.58.2	X												
-opendal-service-cos@0.58.2	X												
-opendal-service-fs@0.58.2	X												
-opendal-service-gcs@0.58.2	X												
-opendal-service-ghac@0.58.2	X												
-opendal-service-http@0.58.2	X												
-opendal-service-ipmfs@0.58.2	X												
-opendal-service-obs@0.58.2	X												
-opendal-service-oss@0.58.2	X												
-opendal-service-s3@0.58.2	X												
-opendal-service-webdav@0.58.2	X												
-opendal-service-webhdfs@0.58.2	X												
+opendal-service-azblob@0.59.0	X												
+opendal-service-azdls@0.59.0	X												
+opendal-service-azfile@0.59.0	X												
+opendal-service-azure-common@0.59.0	X												
+opendal-service-cos@0.59.0	X												
+opendal-service-fs@0.59.0	X												
+opendal-service-gcs@0.59.0	X												
+opendal-service-ghac@0.59.0	X												
+opendal-service-http@0.59.0	X												
+opendal-service-ipmfs@0.59.0	X												
+opendal-service-obs@0.59.0	X												
+opendal-service-oss@0.59.0	X												
+opendal-service-s3@0.59.0	X												
+opendal-service-webdav@0.59.0	X												
+opendal-service-webhdfs@0.59.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-multimap@0.7.3										X			
 parking_lot@0.12.5	X									X			
@@ -170,22 +171,22 @@ prost-derive@0.14.4	X
 quick-xml@0.41.0										X			
 quote@1.0.47	X									X			
 r-efi@6.0.0	X								X	X			
-rand@0.8.7	X									X			
+rand@0.8.8	X									X			
 rand_chacha@0.3.1	X									X			
 rand_core@0.6.4	X									X			
 redox_syscall@0.5.18										X			
 regex@1.13.1	X									X			
 regex-automata@0.4.18	X									X			
 regex-syntax@0.8.11	X									X			
-reqsign-aliyun-oss@3.1.4	X												
-reqsign-aws-core@3.1.0	X												
-reqsign-aws-v4@3.2.0	X												
-reqsign-azure-storage@3.2.0	X												
-reqsign-core@3.3.0	X												
-reqsign-file-read-tokio@3.0.5	X												
-reqsign-google@3.1.0	X												
-reqsign-huaweicloud-obs@3.0.5	X												
-reqsign-tencent-cos@3.0.5	X												
+reqsign-aliyun-oss@3.1.5	X												
+reqsign-aws-core@3.1.1	X												
+reqsign-aws-v4@3.3.0	X												
+reqsign-azure-storage@3.2.1	X												
+reqsign-core@3.3.1	X												
+reqsign-file-read-tokio@3.0.6	X												
+reqsign-google@3.1.1	X												
+reqsign-huaweicloud-obs@3.0.6	X												
+reqsign-tencent-cos@3.0.6	X												
 reqwest@0.13.4	X									X			
 rsa@0.9.10	X									X			
 rust-ini@0.21.3										X			
@@ -197,7 +198,7 @@ rustls-native-certs@0.8.4	X							X		X
 rustls-pki-types@1.15.1	X									X			
 rustls-platform-verifier@0.7.0	X									X			
 rustls-platform-verifier-android@0.1.1	X									X			
-rustls-webpki@0.103.14								X					
+rustls-webpki@0.103.15								X					
 rustversion@1.0.23	X									X			
 ryu@1.0.23	X				X								
 salsa20@0.10.2	X									X			
@@ -230,7 +231,7 @@ spki@0.7.3	X									X
 stable_deref_trait@1.2.1	X									X			
 subtle@2.6.1				X									
 syn@2.0.119	X									X			
-syn@3.0.3	X									X			
+syn@3.0.4	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
 thiserror@2.0.20	X									X			
@@ -253,7 +254,7 @@ unicode-ident@1.0.24	X									X		X
 untrusted@0.9.0								X					
 url@2.5.8	X									X			
 utf8_iter@1.0.4	X									X			
-uuid@1.24.1	X									X			
+uuid@1.26.0	X									X			
 version_check@0.9.5	X									X			
 walkdir@2.5.0										X			X
 want@0.3.1										X			
@@ -279,6 +280,6 @@ zerofrom@0.1.8												X
 zerofrom-derive@0.1.7												X	
 zeroize@1.9.0	X									X			
 zerotrie@0.2.5												X	
-zerovec@0.11.7												X	
-zerovec-derive@0.11.4												X	
+zerovec@0.11.8												X	
+zerovec-derive@0.11.6												X	
 zmij@1.0.23										X			

--- a/bindings/nodejs/DEPENDENCIES.rust.tsv
+++ b/bindings/nodejs/DEPENDENCIES.rust.tsv
@@ -8,7 +8,6 @@ anyhow@1.0.104	X									X
 approx@0.5.1	X														
 arc-swap@1.9.2	X									X					
 arcstr@1.2.0	X									X					X
-arrayref@0.3.9			X												
 arrayvec@0.7.8	X									X					
 async-lock@3.4.2	X									X					
 async-trait@0.1.92	X									X					
@@ -26,7 +25,7 @@ base64ct@1.8.3	X									X
 bitflags@1.3.2	X									X					
 bitflags@2.13.1	X									X					
 bitvec@1.1.1										X					
-blake3@1.8.6	X	X				X									
+blake3@1.8.7	X	X				X									
 block-buffer@0.10.4	X									X					
 block-buffer@0.12.1	X									X					
 block-padding@0.3.3	X									X					
@@ -42,16 +41,16 @@ camino@1.2.5	X									X
 cargo-platform@0.1.9	X									X					
 cargo_metadata@0.14.2										X					
 cbc@0.1.2	X									X					
-cc@1.4.3	X									X					
+cc@1.4.4	X									X					
 cfg-if@0.1.10	X									X					
 cfg-if@1.0.4	X									X					
-chacha20@0.10.1	X									X					
+chacha20@0.10.2	X									X					
 chrono@0.4.45	X									X					
 cipher@0.4.4	X									X					
 cmake@0.1.58	X									X					
 cmov@0.5.4	X									X					
 colored@3.1.1												X			
-combine@4.6.7										X					
+combine@4.6.8										X					
 const-oid@0.10.2	X									X					
 const-oid@0.9.6	X									X					
 const-random@0.1.18	X									X					
@@ -66,12 +65,12 @@ core-foundation@0.9.4	X									X
 core-foundation-sys@0.8.7	X									X					
 countio@0.3.0										X					
 cpufeatures@0.2.17	X									X					
-cpufeatures@0.3.0	X									X					
+cpufeatures@0.3.1	X									X					
 crc@3.4.0	X									X					
 crc-catalog@2.5.0	X									X					
 crc-fast@1.10.0	X									X					
 crc16@0.4.0										X					
-crc32fast@1.5.0	X									X					
+crc32fast@1.5.1	X									X					
 critical-section@1.2.0	X									X					
 crossbeam-channel@0.5.16	X									X					
 crossbeam-epoch@0.9.20	X									X					
@@ -102,14 +101,14 @@ displaydoc@0.2.7	X									X
 dlv-list@0.5.2	X									X					
 dotenvy@0.15.7										X					
 dunce@1.0.5	X					X					X				
-either@1.17.0	X									X					
+either@1.18.0	X									X					
 equivalent@1.0.2	X									X					
 errno@0.3.14	X									X					
 error-chain@0.12.4	X									X					
 etcetera@0.8.0	X									X					
 event-listener@5.4.2	X									X					
 event-listener-strategy@0.5.4	X									X					
-fastpool@1.1.0	X														
+fastpool@1.1.1	X														
 fastrand@2.5.0	X									X					
 find-msvc-tools@0.1.11	X									X					
 flume@0.11.1	X									X					
@@ -144,7 +143,7 @@ glob@0.3.4	X									X
 gloo-timers@0.3.0	X									X					
 goosefs-sdk@0.1.9	X														
 governor@0.10.4										X					
-h2@0.4.15										X					
+h2@0.4.19										X					
 hashbrown@0.14.5	X									X					
 hashbrown@0.15.5	X									X					
 hashbrown@0.16.1	X									X					
@@ -169,7 +168,7 @@ httparse@1.10.1	X									X
 httpdate@1.0.3	X									X					
 humantime@2.4.0	X									X					
 hybrid-array@0.4.14	X									X					
-hyper@1.11.0										X					
+hyper@1.11.1										X					
 hyper-rustls@0.27.9	X							X		X					
 hyper-timeout@0.5.2	X									X					
 hyper-util@0.1.20										X					
@@ -181,11 +180,11 @@ icu_normalizer@2.3.0													X
 icu_normalizer_data@2.3.0													X		
 icu_properties@2.3.0													X		
 icu_properties_data@2.3.0													X		
-icu_provider@2.3.0													X		
+icu_provider@2.3.1													X		
 ident_case@1.0.1	X									X					
 idna@1.1.0	X									X					
 idna_adapter@1.2.2	X									X					
-indexmap@2.14.0	X									X					
+indexmap@2.14.1	X									X					
 inout@0.1.4	X									X					
 instant@0.1.13				X											
 io-uring@0.7.14	X									X					
@@ -209,7 +208,7 @@ lazy_static@1.5.0	X									X
 libc@0.2.189	X									X					
 libloading@0.9.0								X							
 libm@0.2.16										X					
-libredox@0.1.20										X					
+libredox@0.1.21										X					
 libsqlite3-sys@0.30.1										X					
 link-section@0.19.3	X									X					
 linked-hash-map@0.5.6	X									X					
@@ -217,8 +216,8 @@ linktime-proc-macro@0.2.3	X									X
 linux-raw-sys@0.12.1	X	X								X					
 litemap@0.8.3													X		
 lock_api@0.4.14	X									X					
-log@0.4.33	X									X					
-lru@0.18.2										X					
+log@0.4.34	X									X					
+lru@0.18.3										X					
 lz4_flex@0.13.1										X					
 macro_magic@0.5.1										X					
 macro_magic_core@0.5.1										X					
@@ -236,10 +235,10 @@ miette-derive@5.10.0	X
 mini-moka@0.10.3	X									X					
 mio@1.2.2										X					
 moka@0.12.16	X									X					
-mongodb@3.8.0	X														
-mongodb-internal-macros@3.8.0	X														
+mongodb@3.8.2	X														
+mongodb-internal-macros@3.8.2	X														
 more-asserts@0.3.1	X					X				X				X	
-napi@3.12.1										X					
+napi@3.12.2										X					
 napi-build@2.4.1										X					
 napi-derive@3.6.3										X					
 napi-derive-backend@6.1.2										X					
@@ -260,60 +259,61 @@ objc2-io-kit@0.3.2	X									X					X
 objc2-system-configuration@0.3.2	X									X					X
 once_cell@1.21.4	X									X					
 oneshot@0.1.13	X									X					
-opendal@0.58.2	X														
-opendal-core@0.58.2	X														
-opendal-http-transport-reqwest@0.58.2	X														
-opendal-layer-concurrent-limit@0.58.2	X														
-opendal-layer-logging@0.58.2	X														
-opendal-layer-retry@0.58.2	X														
-opendal-layer-throttle@0.58.2	X														
-opendal-layer-timeout@0.58.2	X														
+opendal@0.59.0	X														
+opendal-core@0.59.0	X														
+opendal-http-transport-reqwest@0.59.0	X														
+opendal-layer-concurrent-limit@0.59.0	X														
+opendal-layer-logging@0.59.0	X														
+opendal-layer-retry@0.59.0	X														
+opendal-layer-throttle@0.59.0	X														
+opendal-layer-timeout@0.59.0	X														
 opendal-nodejs@0.0.0	X														
-opendal-service-aliyun-drive@0.58.2	X														
-opendal-service-alluxio@0.58.2	X														
-opendal-service-azblob@0.58.2	X														
-opendal-service-azdls@0.58.2	X														
-opendal-service-azfile@0.58.2	X														
-opendal-service-azure-common@0.58.2	X														
-opendal-service-b2@0.58.2	X														
-opendal-service-cacache@0.58.2	X														
-opendal-service-cos@0.58.2	X														
-opendal-service-dashmap@0.58.2	X														
-opendal-service-dropbox@0.58.2	X														
-opendal-service-fs@0.58.2	X														
-opendal-service-gcs@0.58.2	X														
-opendal-service-gdrive@0.58.2	X														
-opendal-service-ghac@0.58.2	X														
-opendal-service-goosefs@0.58.2	X														
-opendal-service-gridfs@0.58.2	X														
-opendal-service-hf@0.58.2	X														
-opendal-service-http@0.58.2	X														
-opendal-service-ipfs@0.58.2	X														
-opendal-service-ipmfs@0.58.2	X														
-opendal-service-koofr@0.58.2	X														
-opendal-service-memcached@0.58.2	X														
-opendal-service-mini-moka@0.58.2	X														
-opendal-service-moka@0.58.2	X														
-opendal-service-mongodb@0.58.2	X														
-opendal-service-mysql@0.58.2	X														
-opendal-service-obs@0.58.2	X														
-opendal-service-onedrive@0.58.2	X														
-opendal-service-oss@0.58.2	X														
-opendal-service-persy@0.58.2	X														
-opendal-service-postgresql@0.58.2	X														
-opendal-service-redb@0.58.2	X														
-opendal-service-redis@0.58.2	X														
-opendal-service-s3@0.58.2	X														
-opendal-service-seafile@0.58.2	X														
-opendal-service-sled@0.58.2	X														
-opendal-service-sqlite@0.58.2	X														
-opendal-service-swift@0.58.2	X														
-opendal-service-tos@0.58.2	X														
-opendal-service-upyun@0.58.2	X														
-opendal-service-vercel-artifacts@0.58.2	X														
-opendal-service-webdav@0.58.2	X														
-opendal-service-webhdfs@0.58.2	X														
-opendal-service-yandex-disk@0.58.2	X														
+opendal-service-aliyun-drive@0.59.0	X														
+opendal-service-alluxio@0.59.0	X														
+opendal-service-azblob@0.59.0	X														
+opendal-service-azdls@0.59.0	X														
+opendal-service-azfile@0.59.0	X														
+opendal-service-azure-common@0.59.0	X														
+opendal-service-b2@0.59.0	X														
+opendal-service-cacache@0.59.0	X														
+opendal-service-cos@0.59.0	X														
+opendal-service-dashmap@0.59.0	X														
+opendal-service-dropbox@0.59.0	X														
+opendal-service-fs@0.59.0	X														
+opendal-service-gcs@0.59.0	X														
+opendal-service-gcs-grpc@0.59.0	X														
+opendal-service-gdrive@0.59.0	X														
+opendal-service-ghac@0.59.0	X														
+opendal-service-goosefs@0.59.0	X														
+opendal-service-gridfs@0.59.0	X														
+opendal-service-hf@0.59.0	X														
+opendal-service-http@0.59.0	X														
+opendal-service-ipfs@0.59.0	X														
+opendal-service-ipmfs@0.59.0	X														
+opendal-service-koofr@0.59.0	X														
+opendal-service-memcached@0.59.0	X														
+opendal-service-mini-moka@0.59.0	X														
+opendal-service-moka@0.59.0	X														
+opendal-service-mongodb@0.59.0	X														
+opendal-service-mysql@0.59.0	X														
+opendal-service-obs@0.59.0	X														
+opendal-service-onedrive@0.59.0	X														
+opendal-service-oss@0.59.0	X														
+opendal-service-persy@0.59.0	X														
+opendal-service-postgresql@0.59.0	X														
+opendal-service-redb@0.59.0	X														
+opendal-service-redis@0.59.0	X														
+opendal-service-s3@0.59.0	X														
+opendal-service-seafile@0.59.0	X														
+opendal-service-sled@0.59.0	X														
+opendal-service-sqlite@0.59.0	X														
+opendal-service-swift@0.59.0	X														
+opendal-service-tos@0.59.0	X														
+opendal-service-upyun@0.59.0	X														
+opendal-service-vercel-artifacts@0.59.0	X														
+opendal-service-webdav@0.59.0	X														
+opendal-service-webhdfs@0.59.0	X														
+opendal-service-yandex-disk@0.59.0	X														
 openssl-probe@0.2.1	X									X					
 option-ext@0.2.0												X			
 ordered-multimap@0.7.3										X					
@@ -355,7 +355,7 @@ r-efi@5.3.0	X								X	X
 r-efi@6.0.0	X								X	X					
 radium@0.7.0										X					
 rand@0.10.2	X									X					
-rand@0.8.7	X									X					
+rand@0.8.8	X									X					
 rand@0.9.5	X									X					
 rand_chacha@0.3.1	X									X					
 rand_chacha@0.9.0	X									X					
@@ -364,26 +364,25 @@ rand_core@0.6.4	X									X
 rand_core@0.9.5	X									X					
 raw-cpuid@11.6.0										X					
 redb@3.1.3	X									X					
-redb@4.1.0	X									X					
+redb@4.2.0	X									X					
 redis@1.6.0				X											
 redox_syscall@0.2.16										X					
 redox_syscall@0.5.18										X					
-redox_syscall@0.9.2										X					
 redox_users@0.5.2										X					
 reflink-copy@0.1.30	X									X					
 regex@1.13.1	X									X					
 regex-automata@0.4.18	X									X					
 regex-syntax@0.8.11	X									X					
-reqsign-aliyun-oss@3.1.4	X														
-reqsign-aws-core@3.1.0	X														
-reqsign-aws-v4@3.2.0	X														
-reqsign-azure-storage@3.2.0	X														
-reqsign-core@3.3.0	X														
-reqsign-file-read-tokio@3.0.5	X														
-reqsign-google@3.1.0	X														
-reqsign-huaweicloud-obs@3.0.5	X														
-reqsign-tencent-cos@3.0.5	X														
-reqsign-volcengine-tos@3.1.1	X														
+reqsign-aliyun-oss@3.1.5	X														
+reqsign-aws-core@3.1.1	X														
+reqsign-aws-v4@3.3.0	X														
+reqsign-azure-storage@3.2.1	X														
+reqsign-core@3.3.1	X														
+reqsign-file-read-tokio@3.0.6	X														
+reqsign-google@3.1.1	X														
+reqsign-huaweicloud-obs@3.0.6	X														
+reqsign-tencent-cos@3.0.6	X														
+reqsign-volcengine-tos@3.1.2	X														
 reqwest@0.12.28	X									X					
 reqwest@0.13.4	X									X					
 reqwest-middleware@0.5.2	X									X					
@@ -400,7 +399,7 @@ rustls-native-certs@0.8.4	X							X		X
 rustls-pki-types@1.15.1	X									X					
 rustls-platform-verifier@0.7.0	X									X					
 rustls-platform-verifier-android@0.1.1	X									X					
-rustls-webpki@0.103.14								X							
+rustls-webpki@0.103.15								X							
 rustversion@1.0.23	X									X					
 ryu@1.0.23	X				X										
 safe-transmute@0.11.3										X					
@@ -459,7 +458,7 @@ strsim@0.11.1										X
 subtle@2.6.1				X											
 symlink@0.1.0	X									X					
 syn@2.0.119	X									X					
-syn@3.0.3	X									X					
+syn@3.0.4	X									X					
 sync_wrapper@1.0.2	X														
 synstructure@0.13.2										X					
 sysinfo@0.38.4										X					
@@ -504,7 +503,7 @@ tracing-serde@0.2.0										X
 tracing-subscriber@0.3.23										X					
 triomphe@0.1.16	X									X					
 try-lock@0.2.5										X					
-twox-hash@2.1.3										X					
+twox-hash@2.1.4										X					
 typed-builder@0.22.0	X									X					
 typed-builder-macro@0.22.0	X									X					
 typenum@1.20.1	X									X					
@@ -522,7 +521,7 @@ untrusted@0.9.0								X
 url@2.5.8	X									X					
 urlencoding@2.1.3										X					
 utf8_iter@1.0.4	X									X					
-uuid@1.24.1	X									X					
+uuid@1.26.0	X									X					
 vcpkg@0.2.15	X									X					
 version_check@0.9.5	X									X					
 walkdir@2.5.0										X				X	
@@ -598,7 +597,7 @@ zerofrom@0.1.8													X
 zerofrom-derive@0.1.7													X		
 zeroize@1.9.0	X									X					
 zerotrie@0.2.5													X		
-zerovec@0.11.7													X		
-zerovec-derive@0.11.4													X		
+zerovec@0.11.8													X		
+zerovec-derive@0.11.6													X		
 zigzag@0.1.0										X					
 zmij@1.0.23										X					

--- a/bindings/nodejs/generated.js
+++ b/bindings/nodejs/generated.js
@@ -99,8 +99,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-android-arm64')
         const bindingPackageVersion = require('@opendal/lib-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -115,8 +115,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-android-arm-eabi')
         const bindingPackageVersion = require('@opendal/lib-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -135,8 +135,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-x64-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-ia32-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-arm64-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@opendal/lib-darwin-universal')
       const bindingPackageVersion = require('@opendal/lib-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-darwin-x64')
         const bindingPackageVersion = require('@opendal/lib-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-darwin-arm64')
         const bindingPackageVersion = require('@opendal/lib-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-freebsd-x64')
         const bindingPackageVersion = require('@opendal/lib-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-freebsd-arm64')
         const bindingPackageVersion = require('@opendal/lib-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-x64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-x64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm-musleabihf')
           const bindingPackageVersion = require('@opendal/lib-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@opendal/lib-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-riscv64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-riscv64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -410,8 +410,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-linux-ppc64-gnu')
         const bindingPackageVersion = require('@opendal/lib-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -426,8 +426,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-linux-s390x-gnu')
         const bindingPackageVersion = require('@opendal/lib-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -446,8 +446,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-arm64')
         const bindingPackageVersion = require('@opendal/lib-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -462,8 +462,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-x64')
         const bindingPackageVersion = require('@opendal/lib-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -478,8 +478,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-arm')
         const bindingPackageVersion = require('@opendal/lib-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.49.7' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.7 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-arm64",
-  "version": "0.49.7",
+  "version": "0.49.8",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-x64",
-  "version": "0.49.7",
+  "version": "0.49.8",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-gnu",
-  "version": "0.49.7",
+  "version": "0.49.8",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-musl",
-  "version": "0.49.7",
+  "version": "0.49.8",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.49.7",
+  "version": "0.49.8",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/linux-x64-musl/package.json
+++ b/bindings/nodejs/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-musl",
-  "version": "0.49.7",
+  "version": "0.49.8",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-arm64-msvc",
-  "version": "0.49.7",
+  "version": "0.49.8",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.49.7",
+  "version": "0.49.8",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "Apache OpenDAL <dev@opendal.apache.org>",
-  "version": "0.49.7",
+  "version": "0.49.8",
   "license": "Apache-2.0",
   "main": "index.cjs",
   "module": "index.mjs",

--- a/bindings/ocaml/DEPENDENCIES.rust.tsv
+++ b/bindings/ocaml/DEPENDENCIES.rust.tsv
@@ -18,12 +18,12 @@ block-padding@0.3.3	X									X
 bumpalo@3.20.3	X									X			
 bytes@1.12.1										X			
 cbc@0.1.2	X									X			
-cc@1.4.3	X									X			
+cc@1.4.4	X									X			
 cfg-if@1.0.4	X									X			
 cipher@0.4.4	X									X			
 cmake@0.1.58	X									X			
 cmov@0.5.4	X									X			
-combine@4.6.7										X			
+combine@4.6.8										X			
 const-oid@0.10.2	X									X			
 const-oid@0.9.6	X									X			
 const-random@0.1.18	X									X			
@@ -31,7 +31,7 @@ const-random-macro@0.1.16	X									X
 core-foundation@0.10.1	X									X			
 core-foundation-sys@0.8.7	X									X			
 cpufeatures@0.2.17	X									X			
-cpufeatures@0.3.0	X									X			
+cpufeatures@0.3.1	X									X			
 crc-fast@1.10.0	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
@@ -45,7 +45,7 @@ digest@0.11.3	X									X
 displaydoc@0.2.7	X									X			
 dlv-list@0.5.2	X									X			
 dunce@1.0.5	X					X					X		
-either@1.17.0	X									X			
+either@1.18.0	X									X			
 errno@0.3.14	X									X			
 fastrand@2.5.0	X									X			
 find-msvc-tools@0.1.11	X									X			
@@ -75,7 +75,7 @@ http-body@1.1.0										X
 http-body-util@0.1.5										X			
 httparse@1.10.1	X									X			
 hybrid-array@0.4.14	X									X			
-hyper@1.11.0										X			
+hyper@1.11.1										X			
 hyper-rustls@0.27.9	X							X		X			
 hyper-util@0.1.20										X			
 icu_collections@2.3.0												X	
@@ -84,7 +84,7 @@ icu_normalizer@2.3.0												X
 icu_normalizer_data@2.3.0												X	
 icu_properties@2.3.0												X	
 icu_properties_data@2.3.0												X	
-icu_provider@2.3.0												X	
+icu_provider@2.3.1												X	
 idna@1.1.0	X									X			
 idna_adapter@1.2.2	X									X			
 inout@0.1.4	X									X			
@@ -109,8 +109,9 @@ linktime-proc-macro@0.2.3	X									X
 linux-raw-sys@0.12.1	X	X								X			
 litemap@0.8.3												X	
 lock_api@0.4.14	X									X			
-log@0.4.33	X									X			
+log@0.4.34	X									X			
 md-5@0.11.0	X									X			
+mea@0.6.7	X												
 memchr@2.8.3										X			X
 mio@1.2.2										X			
 num-bigint-dig@0.8.6	X									X			
@@ -123,29 +124,29 @@ ocaml-build@1.0.0								X
 ocaml-derive@1.0.0								X					
 ocaml-sys@0.26.0								X					
 once_cell@1.21.4	X									X			
-opendal@0.58.2	X												
-opendal-core@0.58.2	X												
-opendal-http-transport-reqwest@0.58.2	X												
-opendal-layer-concurrent-limit@0.58.2	X												
-opendal-layer-logging@0.58.2	X												
-opendal-layer-retry@0.58.2	X												
-opendal-layer-timeout@0.58.2	X												
+opendal@0.59.0	X												
+opendal-core@0.59.0	X												
+opendal-http-transport-reqwest@0.59.0	X												
+opendal-layer-concurrent-limit@0.59.0	X												
+opendal-layer-logging@0.59.0	X												
+opendal-layer-retry@0.59.0	X												
+opendal-layer-timeout@0.59.0	X												
 opendal-ocaml@0.0.0	X												
-opendal-service-azblob@0.58.2	X												
-opendal-service-azdls@0.58.2	X												
-opendal-service-azfile@0.58.2	X												
-opendal-service-azure-common@0.58.2	X												
-opendal-service-cos@0.58.2	X												
-opendal-service-fs@0.58.2	X												
-opendal-service-gcs@0.58.2	X												
-opendal-service-ghac@0.58.2	X												
-opendal-service-http@0.58.2	X												
-opendal-service-ipmfs@0.58.2	X												
-opendal-service-obs@0.58.2	X												
-opendal-service-oss@0.58.2	X												
-opendal-service-s3@0.58.2	X												
-opendal-service-webdav@0.58.2	X												
-opendal-service-webhdfs@0.58.2	X												
+opendal-service-azblob@0.59.0	X												
+opendal-service-azdls@0.59.0	X												
+opendal-service-azfile@0.59.0	X												
+opendal-service-azure-common@0.59.0	X												
+opendal-service-cos@0.59.0	X												
+opendal-service-fs@0.59.0	X												
+opendal-service-gcs@0.59.0	X												
+opendal-service-ghac@0.59.0	X												
+opendal-service-http@0.59.0	X												
+opendal-service-ipmfs@0.59.0	X												
+opendal-service-obs@0.59.0	X												
+opendal-service-oss@0.59.0	X												
+opendal-service-s3@0.59.0	X												
+opendal-service-webdav@0.59.0	X												
+opendal-service-webhdfs@0.59.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-multimap@0.7.3										X			
 parking_lot@0.12.5	X									X			
@@ -169,19 +170,19 @@ prost-derive@0.14.4	X
 quick-xml@0.41.0										X			
 quote@1.0.47	X									X			
 r-efi@6.0.0	X								X	X			
-rand@0.8.7	X									X			
+rand@0.8.8	X									X			
 rand_chacha@0.3.1	X									X			
 rand_core@0.6.4	X									X			
 redox_syscall@0.5.18										X			
-reqsign-aliyun-oss@3.1.4	X												
-reqsign-aws-core@3.1.0	X												
-reqsign-aws-v4@3.2.0	X												
-reqsign-azure-storage@3.2.0	X												
-reqsign-core@3.3.0	X												
-reqsign-file-read-tokio@3.0.5	X												
-reqsign-google@3.1.0	X												
-reqsign-huaweicloud-obs@3.0.5	X												
-reqsign-tencent-cos@3.0.5	X												
+reqsign-aliyun-oss@3.1.5	X												
+reqsign-aws-core@3.1.1	X												
+reqsign-aws-v4@3.3.0	X												
+reqsign-azure-storage@3.2.1	X												
+reqsign-core@3.3.1	X												
+reqsign-file-read-tokio@3.0.6	X												
+reqsign-google@3.1.1	X												
+reqsign-huaweicloud-obs@3.0.6	X												
+reqsign-tencent-cos@3.0.6	X												
 reqwest@0.13.4	X									X			
 rsa@0.9.10	X									X			
 rust-ini@0.21.3										X			
@@ -192,7 +193,7 @@ rustls-native-certs@0.8.4	X							X		X
 rustls-pki-types@1.15.1	X									X			
 rustls-platform-verifier@0.7.0	X									X			
 rustls-platform-verifier-android@0.1.1	X									X			
-rustls-webpki@0.103.14								X					
+rustls-webpki@0.103.15								X					
 rustversion@1.0.23	X									X			
 ryu@1.0.23	X				X								
 salsa20@0.10.2	X									X			
@@ -225,7 +226,7 @@ spki@0.7.3	X									X
 stable_deref_trait@1.2.1	X									X			
 subtle@2.6.1				X									
 syn@2.0.119	X									X			
-syn@3.0.3	X									X			
+syn@3.0.4	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
 thiserror@2.0.20	X									X			
@@ -248,7 +249,7 @@ unicode-ident@1.0.24	X									X		X
 untrusted@0.9.0								X					
 url@2.5.8	X									X			
 utf8_iter@1.0.4	X									X			
-uuid@1.24.1	X									X			
+uuid@1.26.0	X									X			
 version_check@0.9.5	X									X			
 walkdir@2.5.0										X			X
 want@0.3.1										X			
@@ -274,6 +275,6 @@ zerofrom@0.1.8												X
 zerofrom-derive@0.1.7												X	
 zeroize@1.9.0	X									X			
 zerotrie@0.2.5												X	
-zerovec@0.11.7												X	
-zerovec-derive@0.11.4												X	
+zerovec@0.11.8												X	
+zerovec-derive@0.11.6												X	
 zmij@1.0.23										X			

--- a/bindings/php/DEPENDENCIES.rust.tsv
+++ b/bindings/php/DEPENDENCIES.rust.tsv
@@ -1,7 +1,7 @@
 crate	0BSD	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	Unicode-3.0	Unlicense	Zlib	bzip2-1.0.6
 adler2@2.0.1	X	X									X					
 aes@0.8.4		X									X					
-aes@0.9.2		X									X					
+aes@0.9.3		X									X					
 anyhow@1.0.104		X									X					
 async-trait@0.1.92		X									X					
 asyncband@0.6.7		X														
@@ -25,7 +25,7 @@ camino@1.2.5		X									X
 cargo-platform@0.1.9		X									X					
 cargo_metadata@0.14.2											X					
 cbc@0.1.2		X									X					
-cc@1.4.3		X									X					
+cc@1.4.4		X									X					
 cexpr@0.6.0		X									X					
 cfg-if@1.0.4		X									X					
 cipher@0.4.4		X									X					
@@ -33,7 +33,7 @@ cipher@0.5.2		X									X
 clang-sys@1.9.1		X														
 cmake@0.1.58		X									X					
 cmov@0.5.4		X									X					
-combine@4.6.7											X					
+combine@4.6.8											X					
 const-oid@0.10.2		X									X					
 const-oid@0.9.6		X									X					
 const-random@0.1.18		X									X					
@@ -44,9 +44,9 @@ core-foundation@0.10.1		X									X
 core-foundation-sys@0.8.7		X									X					
 cpubits@0.1.1		X									X					
 cpufeatures@0.2.17		X									X					
-cpufeatures@0.3.0		X									X					
+cpufeatures@0.3.1		X									X					
 crc-fast@1.10.0		X									X					
-crc32fast@1.5.0		X									X					
+crc32fast@1.5.1		X									X					
 crunchy@0.2.4											X					
 crypto-common@0.1.7		X									X					
 crypto-common@0.2.2		X									X					
@@ -64,7 +64,7 @@ digest@0.11.3		X									X
 displaydoc@0.2.7		X									X					
 dlv-list@0.5.2		X									X					
 dunce@1.0.5		X					X					X				
-either@1.17.0		X									X					
+either@1.18.0		X									X					
 equivalent@1.0.2		X									X					
 errno@0.3.14		X									X					
 error-chain@0.12.4		X									X					
@@ -74,7 +74,7 @@ ext-php-rs-build@0.1.1		X									X
 ext-php-rs-derive@0.11.14		X									X					
 fastrand@2.5.0		X									X					
 find-msvc-tools@0.1.11		X									X					
-flate2@1.1.9		X									X					
+flate2@1.1.10		X									X					
 foreign-types@0.3.2		X									X					
 foreign-types-shared@0.1.1		X									X					
 form_urlencoded@1.2.2		X									X					
@@ -104,7 +104,7 @@ http-body@1.1.0											X
 http-body-util@0.1.5											X					
 httparse@1.10.1		X									X					
 hybrid-array@0.4.14		X									X					
-hyper@1.11.0											X					
+hyper@1.11.1											X					
 hyper-rustls@0.27.9		X							X		X					
 hyper-util@0.1.20											X					
 icu_collections@2.3.0													X			
@@ -113,11 +113,11 @@ icu_normalizer@2.3.0													X
 icu_normalizer_data@2.3.0													X			
 icu_properties@2.3.0													X			
 icu_properties_data@2.3.0													X			
-icu_provider@2.3.0													X			
+icu_provider@2.3.1													X			
 ident_case@1.0.1		X									X					
 idna@1.1.0		X									X					
 idna_adapter@1.2.2		X									X					
-indexmap@2.14.0		X									X					
+indexmap@2.14.1		X									X					
 inout@0.1.4		X									X					
 inout@0.2.2		X									X					
 inventory@0.3.24		X									X					
@@ -137,19 +137,19 @@ js-sys@0.3.104		X									X
 lazy_static@1.5.0		X									X					
 libbz2-rs-sys@0.2.5																X
 libc@0.2.189		X									X					
-libloading@0.8.9									X							
 libm@0.2.16											X					
 link-section@0.19.3		X									X					
 linktime-proc-macro@0.2.3		X									X					
 linux-raw-sys@0.12.1		X	X								X					
 litemap@0.8.3													X			
 lock_api@0.4.14		X									X					
-log@0.4.33		X									X					
+log@0.4.34		X									X					
 lzma-rust2@0.16.5		X														
 md-5@0.11.0		X									X					
+mea@0.6.7		X														
 memchr@2.8.3											X			X		
 minimal-lexical@0.2.1		X									X					
-miniz_oxide@0.8.9		X									X				X	
+miniz_oxide@0.9.1		X									X				X	
 mio@1.2.2											X					
 native-tls@0.2.18		X									X					
 nom@7.1.3											X					
@@ -159,29 +159,29 @@ num-integer@0.1.47		X									X
 num-iter@0.1.46		X									X					
 num-traits@0.2.19		X									X					
 once_cell@1.21.4		X									X					
-opendal@0.58.2		X														
-opendal-core@0.58.2		X														
-opendal-http-transport-reqwest@0.58.2		X														
-opendal-layer-concurrent-limit@0.58.2		X														
-opendal-layer-logging@0.58.2		X														
-opendal-layer-retry@0.58.2		X														
-opendal-layer-timeout@0.58.2		X														
+opendal@0.59.0		X														
+opendal-core@0.59.0		X														
+opendal-http-transport-reqwest@0.59.0		X														
+opendal-layer-concurrent-limit@0.59.0		X														
+opendal-layer-logging@0.59.0		X														
+opendal-layer-retry@0.59.0		X														
+opendal-layer-timeout@0.59.0		X														
 opendal-php@0.0.0		X														
-opendal-service-azblob@0.58.2		X														
-opendal-service-azdls@0.58.2		X														
-opendal-service-azfile@0.58.2		X														
-opendal-service-azure-common@0.58.2		X														
-opendal-service-cos@0.58.2		X														
-opendal-service-fs@0.58.2		X														
-opendal-service-gcs@0.58.2		X														
-opendal-service-ghac@0.58.2		X														
-opendal-service-http@0.58.2		X														
-opendal-service-ipmfs@0.58.2		X														
-opendal-service-obs@0.58.2		X														
-opendal-service-oss@0.58.2		X														
-opendal-service-s3@0.58.2		X														
-opendal-service-webdav@0.58.2		X														
-opendal-service-webhdfs@0.58.2		X														
+opendal-service-azblob@0.59.0		X														
+opendal-service-azdls@0.59.0		X														
+opendal-service-azfile@0.59.0		X														
+opendal-service-azure-common@0.59.0		X														
+opendal-service-cos@0.59.0		X														
+opendal-service-fs@0.59.0		X														
+opendal-service-gcs@0.59.0		X														
+opendal-service-ghac@0.59.0		X														
+opendal-service-http@0.59.0		X														
+opendal-service-ipmfs@0.59.0		X														
+opendal-service-obs@0.59.0		X														
+opendal-service-oss@0.59.0		X														
+opendal-service-s3@0.59.0		X														
+opendal-service-webdav@0.59.0		X														
+opendal-service-webhdfs@0.59.0		X														
 openssl@0.10.81		X														
 openssl-macros@0.1.1		X									X					
 openssl-probe@0.2.1		X									X					
@@ -214,22 +214,22 @@ pulldown-cmark@0.9.6											X
 quick-xml@0.41.0											X					
 quote@1.0.47		X									X					
 r-efi@6.0.0		X								X	X					
-rand@0.8.7		X									X					
+rand@0.8.8		X									X					
 rand_chacha@0.3.1		X									X					
 rand_core@0.6.4		X									X					
 redox_syscall@0.5.18											X					
 regex@1.13.1		X									X					
 regex-automata@0.4.18		X									X					
 regex-syntax@0.8.11		X									X					
-reqsign-aliyun-oss@3.1.4		X														
-reqsign-aws-core@3.1.0		X														
-reqsign-aws-v4@3.2.0		X														
-reqsign-azure-storage@3.2.0		X														
-reqsign-core@3.3.0		X														
-reqsign-file-read-tokio@3.0.5		X														
-reqsign-google@3.1.0		X														
-reqsign-huaweicloud-obs@3.0.5		X														
-reqsign-tencent-cos@3.0.5		X														
+reqsign-aliyun-oss@3.1.5		X														
+reqsign-aws-core@3.1.1		X														
+reqsign-aws-v4@3.3.0		X														
+reqsign-azure-storage@3.2.1		X														
+reqsign-core@3.3.1		X														
+reqsign-file-read-tokio@3.0.6		X														
+reqsign-google@3.1.1		X														
+reqsign-huaweicloud-obs@3.0.6		X														
+reqsign-tencent-cos@3.0.6		X														
 reqwest@0.13.4		X									X					
 rsa@0.9.10		X									X					
 rust-ini@0.21.3											X					
@@ -241,7 +241,7 @@ rustls-native-certs@0.8.4		X							X		X
 rustls-pki-types@1.15.1		X									X					
 rustls-platform-verifier@0.7.0		X									X					
 rustls-platform-verifier-android@0.1.1		X									X					
-rustls-webpki@0.103.14									X							
+rustls-webpki@0.103.15									X							
 rustversion@1.0.23		X									X					
 ryu@1.0.23		X				X										
 salsa20@0.10.2		X									X					
@@ -278,7 +278,7 @@ stable_deref_trait@1.2.1		X									X
 strsim@0.11.1											X					
 subtle@2.6.1					X											
 syn@2.0.119		X									X					
-syn@3.0.3		X									X					
+syn@3.0.4		X									X					
 sync_wrapper@1.0.2		X														
 synstructure@0.13.2											X					
 tempfile@3.27.0		X									X					
@@ -310,7 +310,7 @@ ureq-proto@0.6.1		X									X
 url@2.5.8		X									X					
 utf8-zero@0.8.1		X									X					
 utf8_iter@1.0.4		X									X					
-uuid@1.24.1		X									X					
+uuid@1.26.0		X									X					
 vcpkg@0.2.15		X									X					
 version_check@0.9.5		X									X					
 walkdir@2.5.0											X			X		
@@ -337,8 +337,8 @@ zerofrom@0.1.8													X
 zerofrom-derive@0.1.7													X			
 zeroize@1.9.0		X									X					
 zerotrie@0.2.5													X			
-zerovec@0.11.7													X			
-zerovec-derive@0.11.4													X			
+zerovec@0.11.8													X			
+zerovec-derive@0.11.6													X			
 zip@8.6.0											X					
 zlib-rs@0.6.7															X	
 zmij@1.0.23											X					

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
 # Release candidate builds derive prerelease versions from tags in release_python.yml.
-version = "0.47.6"
+version = "0.47.7"
 
 [features]
 default = [

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -1,6 +1,6 @@
 crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.0	CC0-1.0	CDLA-Permissive-2.0	ISC	LGPL-2.1-or-later	MIT	MIT-0	MPL-2.0	Unicode-3.0	Unlicense	Zlib
 aes@0.8.4	X									X					
-aes@0.9.2	X									X					
+aes@0.9.3	X									X					
 ahash@0.8.12	X									X					
 aho-corasick@1.1.5										X				X	
 allocator-api2@0.2.21	X									X					
@@ -9,16 +9,8 @@ anyhow@1.0.104	X									X
 approx@0.5.1	X														
 arc-swap@1.9.2	X									X					
 arcstr@1.2.0	X									X					X
-arrayref@0.3.9			X												
 arrayvec@0.7.8	X									X					
-async-channel@1.9.0	X									X					
-async-channel@2.5.0	X									X					
-async-executor@1.14.0	X									X					
-async-global-executor@2.4.1	X									X					
-async-io@2.6.0	X									X					
 async-lock@3.4.2	X									X					
-async-std@1.13.2	X									X					
-async-task@4.7.1	X									X					
 async-trait@0.1.92	X									X					
 asyncband@0.6.7	X														
 atoi@2.0.0										X					
@@ -34,12 +26,11 @@ base64ct@1.8.3	X									X
 bitflags@1.3.2	X									X					
 bitflags@2.13.1	X									X					
 bitvec@1.1.1										X					
-blake3@1.8.6	X	X				X									
+blake3@1.8.7	X	X				X									
 block-buffer@0.10.4	X									X					
 block-buffer@0.12.1	X									X					
 block-padding@0.3.3	X									X					
 block-padding@0.4.2	X									X					
-blocking@1.6.2	X									X					
 bson@2.15.0										X					
 bstr@1.13.1	X									X					
 bumpalo@3.20.3	X									X					
@@ -53,18 +44,17 @@ cargo-platform@0.1.9	X									X
 cargo_metadata@0.14.2										X					
 cbc@0.1.2	X									X					
 cbc@0.2.1	X									X					
-cc@1.4.3	X									X					
+cc@1.4.4	X									X					
 cfg-if@0.1.10	X									X					
 cfg-if@1.0.4	X									X					
-chacha20@0.10.1	X									X					
+chacha20@0.10.2	X									X					
 chrono@0.4.45	X									X					
 cipher@0.4.4	X									X					
 cipher@0.5.2	X									X					
 cmake@0.1.58	X									X					
 cmov@0.5.4	X									X					
 colored@3.1.1												X			
-combine@4.6.7										X					
-concurrent-queue@2.5.0	X									X					
+combine@4.6.8										X					
 const-oid@0.10.2	X									X					
 const-oid@0.9.6	X									X					
 const-random@0.1.18	X									X					
@@ -79,12 +69,12 @@ core-foundation-sys@0.8.7	X									X
 countio@0.3.0										X					
 cpubits@0.1.1	X									X					
 cpufeatures@0.2.17	X									X					
-cpufeatures@0.3.0	X									X					
+cpufeatures@0.3.1	X									X					
 crc@3.4.0	X									X					
 crc-catalog@2.5.0	X									X					
 crc-fast@1.10.0	X									X					
 crc16@0.4.0										X					
-crc32fast@1.5.0	X									X					
+crc32fast@1.5.1	X									X					
 critical-section@1.2.0	X									X					
 crossbeam-channel@0.5.16	X									X					
 crossbeam-epoch@0.9.20	X									X					
@@ -118,18 +108,18 @@ dlv-list@0.5.2	X									X
 dns-lookup@3.0.1	X									X					
 dotenvy@0.15.7										X					
 dunce@1.0.5	X					X					X				
-either@1.17.0	X									X					
+either@1.18.0	X									X					
 equivalent@1.0.2	X									X					
 errno@0.3.14	X									X					
 error-chain@0.12.4	X									X					
 etcetera@0.8.0	X									X					
-event-listener@2.5.3	X									X					
 event-listener@5.4.2	X									X					
 event-listener-strategy@0.5.4	X									X					
-fastpool@1.1.0	X														
+fastpool@1.1.1	X														
 fastrand@2.5.0	X									X					
 find-msvc-tools@0.1.11	X									X					
 flume@0.11.1	X									X					
+fnv@1.0.7	X									X					
 foldhash@0.1.5															X
 form_urlencoded@1.2.2	X									X					
 fs2@0.4.3	X									X					
@@ -141,9 +131,7 @@ futures-core@0.3.34	X									X
 futures-executor@0.3.34	X									X					
 futures-intrusive@0.5.0	X									X					
 futures-io@0.3.34	X									X					
-futures-lite@2.6.1	X									X					
 futures-macro@0.3.34	X									X					
-futures-rustls@0.26.0	X									X					
 futures-sink@0.3.34	X									X					
 futures-task@0.3.34	X									X					
 futures-util@0.3.34	X									X					
@@ -161,14 +149,14 @@ git-version@0.3.9			X
 git-version-macro@0.3.9			X												
 glob@0.3.4	X									X					
 gloo-timers@0.3.0	X									X					
+h2@0.4.19										X					
 hashbrown@0.14.5	X									X					
 hashbrown@0.15.5	X									X					
 hashbrown@0.17.1	X									X					
 hashlink@0.10.0	X									X					
-hdfs-native@0.14.4	X														
+hdfs-native@0.14.5	X														
 heapify@0.2.0	X									X					
 heck@0.5.0	X									X					
-hermit-abi@0.5.2	X									X					
 hex@0.4.3	X									X					
 hf-xet@1.6.0	X														
 hickory-net@0.26.1	X									X					
@@ -184,8 +172,9 @@ http-body-util@0.1.5										X
 httparse@1.10.1	X									X					
 humantime@2.4.0	X									X					
 hybrid-array@0.4.14	X									X					
-hyper@1.11.0										X					
+hyper@1.11.1										X					
 hyper-rustls@0.27.9	X							X		X					
+hyper-timeout@0.5.2	X									X					
 hyper-util@0.1.20										X					
 iana-time-zone@0.1.65	X									X					
 iana-time-zone-haiku@0.1.2	X									X					
@@ -195,11 +184,11 @@ icu_normalizer@2.3.0													X
 icu_normalizer_data@2.3.0													X		
 icu_properties@2.3.0													X		
 icu_properties_data@2.3.0													X		
-icu_provider@2.3.0													X		
+icu_provider@2.3.1													X		
 ident_case@1.0.1	X									X					
 idna@1.1.0	X									X					
 idna_adapter@1.2.2	X									X					
-indexmap@2.14.0	X									X					
+indexmap@2.14.1	X									X					
 inout@0.1.4	X									X					
 inout@0.2.2	X									X					
 instant@0.1.13				X											
@@ -219,14 +208,13 @@ jobserver@0.1.35	X									X
 js-sys@0.3.104	X									X					
 konst@0.4.3															X
 konst_proc_macros@0.4.1															X
-kv-log-macro@1.0.7	X									X					
 lazy-regex@3.6.1										X					
 lazy-regex-proc_macros@3.6.1										X					
 lazy_static@1.5.0	X									X					
 libc@0.2.189	X									X					
 libloading@0.9.0								X							
 libm@0.2.16										X					
-libredox@0.1.20										X					
+libredox@0.1.21										X					
 libsqlite3-sys@0.30.1										X					
 link-section@0.19.3	X									X					
 linked-hash-map@0.5.6	X									X					
@@ -234,7 +222,7 @@ linktime-proc-macro@0.2.3	X									X
 linux-raw-sys@0.12.1	X	X								X					
 litemap@0.8.3													X		
 lock_api@0.4.14	X									X					
-log@0.4.33	X									X					
+log@0.4.34	X									X					
 lz4_flex@0.13.1										X					
 macro_magic@0.5.1										X					
 macro_magic_core@0.5.1										X					
@@ -253,8 +241,8 @@ mime_guess@2.0.5										X
 mini-moka@0.10.3	X									X					
 mio@1.2.2										X					
 moka@0.12.16	X									X					
-mongodb@3.8.0	X														
-mongodb-internal-macros@3.8.0	X														
+mongodb@3.8.2	X														
+mongodb-internal-macros@3.8.2	X														
 more-asserts@0.3.1	X					X				X				X	
 ndk-context@0.1.1	X									X					
 ntapi@0.4.3	X									X					
@@ -270,61 +258,62 @@ objc2-io-kit@0.3.2	X									X					X
 objc2-system-configuration@0.3.2	X									X					X
 once_cell@1.21.4	X									X					
 oneshot@0.1.13	X									X					
-opendal@0.58.2	X														
-opendal-core@0.58.2	X														
-opendal-http-transport-reqwest@0.58.2	X														
-opendal-layer-concurrent-limit@0.58.2	X														
-opendal-layer-logging@0.58.2	X														
-opendal-layer-mime-guess@0.58.2	X														
-opendal-layer-retry@0.58.2	X														
-opendal-layer-timeout@0.58.2	X														
-opendal-python@0.47.6	X														
-opendal-service-aliyun-drive@0.58.2	X														
-opendal-service-alluxio@0.58.2	X														
-opendal-service-azblob@0.58.2	X														
-opendal-service-azdls@0.58.2	X														
-opendal-service-azfile@0.58.2	X														
-opendal-service-azure-common@0.58.2	X														
-opendal-service-b2@0.58.2	X														
-opendal-service-cacache@0.58.2	X														
-opendal-service-cos@0.58.2	X														
-opendal-service-dashmap@0.58.2	X														
-opendal-service-dropbox@0.58.2	X														
-opendal-service-fs@0.58.2	X														
-opendal-service-ftp@0.58.2	X														
-opendal-service-gcs@0.58.2	X														
-opendal-service-gdrive@0.58.2	X														
-opendal-service-ghac@0.58.2	X														
-opendal-service-gridfs@0.58.2	X														
-opendal-service-hdfs-native@0.58.2	X														
-opendal-service-hf@0.58.2	X														
-opendal-service-http@0.58.2	X														
-opendal-service-ipfs@0.58.2	X														
-opendal-service-ipmfs@0.58.2	X														
-opendal-service-koofr@0.58.2	X														
-opendal-service-memcached@0.58.2	X														
-opendal-service-mini-moka@0.58.2	X														
-opendal-service-moka@0.58.2	X														
-opendal-service-mongodb@0.58.2	X														
-opendal-service-mysql@0.58.2	X														
-opendal-service-obs@0.58.2	X														
-opendal-service-onedrive@0.58.2	X														
-opendal-service-oss@0.58.2	X														
-opendal-service-persy@0.58.2	X														
-opendal-service-postgresql@0.58.2	X														
-opendal-service-redb@0.58.2	X														
-opendal-service-redis@0.58.2	X														
-opendal-service-s3@0.58.2	X														
-opendal-service-seafile@0.58.2	X														
-opendal-service-sled@0.58.2	X														
-opendal-service-sqlite@0.58.2	X														
-opendal-service-swift@0.58.2	X														
-opendal-service-tos@0.58.2	X														
-opendal-service-upyun@0.58.2	X														
-opendal-service-vercel-artifacts@0.58.2	X														
-opendal-service-webdav@0.58.2	X														
-opendal-service-webhdfs@0.58.2	X														
-opendal-service-yandex-disk@0.58.2	X														
+opendal@0.59.0	X														
+opendal-core@0.59.0	X														
+opendal-http-transport-reqwest@0.59.0	X														
+opendal-layer-concurrent-limit@0.59.0	X														
+opendal-layer-logging@0.59.0	X														
+opendal-layer-mime-guess@0.59.0	X														
+opendal-layer-retry@0.59.0	X														
+opendal-layer-timeout@0.59.0	X														
+opendal-python@0.47.7	X														
+opendal-service-aliyun-drive@0.59.0	X														
+opendal-service-alluxio@0.59.0	X														
+opendal-service-azblob@0.59.0	X														
+opendal-service-azdls@0.59.0	X														
+opendal-service-azfile@0.59.0	X														
+opendal-service-azure-common@0.59.0	X														
+opendal-service-b2@0.59.0	X														
+opendal-service-cacache@0.59.0	X														
+opendal-service-cos@0.59.0	X														
+opendal-service-dashmap@0.59.0	X														
+opendal-service-dropbox@0.59.0	X														
+opendal-service-fs@0.59.0	X														
+opendal-service-ftp@0.59.0	X														
+opendal-service-gcs@0.59.0	X														
+opendal-service-gcs-grpc@0.59.0	X														
+opendal-service-gdrive@0.59.0	X														
+opendal-service-ghac@0.59.0	X														
+opendal-service-gridfs@0.59.0	X														
+opendal-service-hdfs-native@0.59.0	X														
+opendal-service-hf@0.59.0	X														
+opendal-service-http@0.59.0	X														
+opendal-service-ipfs@0.59.0	X														
+opendal-service-ipmfs@0.59.0	X														
+opendal-service-koofr@0.59.0	X														
+opendal-service-memcached@0.59.0	X														
+opendal-service-mini-moka@0.59.0	X														
+opendal-service-moka@0.59.0	X														
+opendal-service-mongodb@0.59.0	X														
+opendal-service-mysql@0.59.0	X														
+opendal-service-obs@0.59.0	X														
+opendal-service-onedrive@0.59.0	X														
+opendal-service-oss@0.59.0	X														
+opendal-service-persy@0.59.0	X														
+opendal-service-postgresql@0.59.0	X														
+opendal-service-redb@0.59.0	X														
+opendal-service-redis@0.59.0	X														
+opendal-service-s3@0.59.0	X														
+opendal-service-seafile@0.59.0	X														
+opendal-service-sled@0.59.0	X														
+opendal-service-sqlite@0.59.0	X														
+opendal-service-swift@0.59.0	X														
+opendal-service-tos@0.59.0	X														
+opendal-service-upyun@0.59.0	X														
+opendal-service-vercel-artifacts@0.59.0	X														
+opendal-service-webdav@0.59.0	X														
+opendal-service-webhdfs@0.59.0	X														
+opendal-service-yandex-disk@0.59.0	X														
 openssl-probe@0.2.1	X									X					
 option-ext@0.2.0												X			
 ordered-multimap@0.7.3										X					
@@ -343,14 +332,11 @@ persy@1.8.1												X
 pin-project@1.1.13	X									X					
 pin-project-internal@1.1.13	X									X					
 pin-project-lite@0.2.17	X									X					
-pin-utils@0.1.0	X									X					
-piper@0.2.5	X									X					
 pkcs1@0.7.5	X									X					
 pkcs5@0.7.1	X									X					
 pkcs8@0.10.2	X									X					
 pkg-config@0.3.34	X									X					
 plain@0.2.3	X									X					
-polling@3.11.0	X									X					
 portable-atomic@1.15.0	X									X					
 portable-atomic-util@0.2.7	X									X					
 potential_utf@0.1.6													X		
@@ -374,7 +360,7 @@ r-efi@5.3.0	X								X	X
 r-efi@6.0.0	X								X	X					
 radium@0.7.0										X					
 rand@0.10.2	X									X					
-rand@0.8.7	X									X					
+rand@0.8.8	X									X					
 rand@0.9.5	X									X					
 rand_chacha@0.3.1	X									X					
 rand_chacha@0.9.0	X									X					
@@ -382,26 +368,25 @@ rand_core@0.10.1	X									X
 rand_core@0.6.4	X									X					
 rand_core@0.9.5	X									X					
 redb@3.1.3	X									X					
-redb@4.1.0	X									X					
+redb@4.2.0	X									X					
 redis@1.6.0				X											
 redox_syscall@0.2.16										X					
 redox_syscall@0.5.18										X					
-redox_syscall@0.9.2										X					
 redox_users@0.5.2										X					
 reflink-copy@0.1.30	X									X					
 regex@1.13.1	X									X					
 regex-automata@0.4.18	X									X					
 regex-syntax@0.8.11	X									X					
-reqsign-aliyun-oss@3.1.4	X														
-reqsign-aws-core@3.1.0	X														
-reqsign-aws-v4@3.2.0	X														
-reqsign-azure-storage@3.2.0	X														
-reqsign-core@3.3.0	X														
-reqsign-file-read-tokio@3.0.5	X														
-reqsign-google@3.1.0	X														
-reqsign-huaweicloud-obs@3.0.5	X														
-reqsign-tencent-cos@3.0.5	X														
-reqsign-volcengine-tos@3.1.1	X														
+reqsign-aliyun-oss@3.1.5	X														
+reqsign-aws-core@3.1.1	X														
+reqsign-aws-v4@3.3.0	X														
+reqsign-azure-storage@3.2.1	X														
+reqsign-core@3.3.1	X														
+reqsign-file-read-tokio@3.0.6	X														
+reqsign-google@3.1.1	X														
+reqsign-huaweicloud-obs@3.0.6	X														
+reqsign-tencent-cos@3.0.6	X														
+reqsign-volcengine-tos@3.1.2	X														
 reqwest@0.13.4	X									X					
 reqwest-middleware@0.5.2	X									X					
 resolv-conf@0.7.6	X									X					
@@ -417,7 +402,7 @@ rustls-native-certs@0.8.4	X							X		X
 rustls-pki-types@1.15.1	X									X					
 rustls-platform-verifier@0.7.0	X									X					
 rustls-platform-verifier-android@0.1.1	X									X					
-rustls-webpki@0.103.14								X							
+rustls-webpki@0.103.15								X							
 rustversion@1.0.23	X									X					
 ryu@1.0.23	X				X										
 safe-transmute@0.11.3										X					
@@ -473,10 +458,10 @@ statrs@0.18.0										X
 stringprep@0.1.5	X									X					
 strsim@0.11.1										X					
 subtle@2.6.1				X											
-suppaftp@8.0.5	X									X					
+suppaftp@10.0.2	X									X					
 symlink@0.1.0	X									X					
 syn@2.0.119	X									X					
-syn@3.0.3	X									X					
+syn@3.0.4	X									X					
 sync_wrapper@1.0.2	X														
 synstructure@0.13.2										X					
 sysinfo@0.38.4										X					
@@ -507,6 +492,8 @@ tokio-stream@0.1.19										X
 tokio-util@0.7.19										X					
 tokio_with_wasm@0.8.8										X					
 tokio_with_wasm_proc@0.8.8										X					
+tonic@0.14.6										X					
+tonic-prost@0.14.6										X					
 tower@0.5.3										X					
 tower-http@0.6.11										X					
 tower-layer@0.3.3										X					
@@ -520,7 +507,7 @@ tracing-serde@0.2.0										X
 tracing-subscriber@0.3.23										X					
 triomphe@0.1.16	X									X					
 try-lock@0.2.5										X					
-twox-hash@2.1.3										X					
+twox-hash@2.1.4										X					
 typed-builder@0.22.0	X									X					
 typed-builder-macro@0.22.0	X									X					
 typenum@1.20.1	X									X					
@@ -538,8 +525,7 @@ untrusted@0.9.0								X
 url@2.5.8	X									X					
 urlencoding@2.1.3										X					
 utf8_iter@1.0.4	X									X					
-uuid@1.24.1	X									X					
-value-bag@1.13.2	X									X					
+uuid@1.26.0	X									X					
 vcpkg@0.2.15	X									X					
 version_check@0.9.5	X									X					
 walkdir@2.5.0										X				X	
@@ -625,7 +611,7 @@ zerofrom@0.1.8													X
 zerofrom-derive@0.1.7													X		
 zeroize@1.9.0	X									X					
 zerotrie@0.2.5													X		
-zerovec@0.11.7													X		
-zerovec-derive@0.11.4													X		
+zerovec@0.11.8													X		
+zerovec-derive@0.11.6													X		
 zigzag@0.1.0										X					
 zmij@1.0.23										X					

--- a/bindings/ruby/Cargo.lock
+++ b/bindings/ruby/Cargo.lock
@@ -1391,7 +1391,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "opendal"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "ctor",
  "opendal-core",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-core"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "asyncband",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-http-transport-reqwest"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "futures",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-concurrent-limit"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "futures",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-logging"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "log",
  "opendal-core",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-retry"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "backon",
  "log",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-throttle"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "governor",
  "opendal-core",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-timeout"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-ruby"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "bytes",
  "magnus",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azblob"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azdls"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "base64 0.23.0",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azfile"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azure-common"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "http",
  "opendal-core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cos"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-fs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "log",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ghac"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "ghac",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-http"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "http",
  "log",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ipmfs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http",
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-obs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http",
@@ -1674,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-oss"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-s3"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webdav"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "asyncband",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webhdfs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "asyncband",

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.1.10"
+version = "0.1.11"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -127,6 +127,7 @@ log@0.4.33	X									X
 magnus@0.8.2										X				
 magnus-macros@0.8.0										X				
 md-5@0.11.0	X									X				
+mea@0.6.7	X													
 memchr@2.8.3										X			X	
 minimal-lexical@0.2.1	X									X				
 mio@1.2.1										X				
@@ -137,30 +138,30 @@ num-integer@0.1.46	X									X
 num-iter@0.1.46	X									X				
 num-traits@0.2.19	X									X				
 once_cell@1.21.4	X									X				
-opendal@0.58.2	X													
-opendal-core@0.58.2	X													
-opendal-http-transport-reqwest@0.58.2	X													
-opendal-layer-concurrent-limit@0.58.2	X													
-opendal-layer-logging@0.58.2	X													
-opendal-layer-retry@0.58.2	X													
-opendal-layer-throttle@0.58.2	X													
-opendal-layer-timeout@0.58.2	X													
-opendal-ruby@0.1.10	X													
-opendal-service-azblob@0.58.2	X													
-opendal-service-azdls@0.58.2	X													
-opendal-service-azfile@0.58.2	X													
-opendal-service-azure-common@0.58.2	X													
-opendal-service-cos@0.58.2	X													
-opendal-service-fs@0.58.2	X													
-opendal-service-gcs@0.58.2	X													
-opendal-service-ghac@0.58.2	X													
-opendal-service-http@0.58.2	X													
-opendal-service-ipmfs@0.58.2	X													
-opendal-service-obs@0.58.2	X													
-opendal-service-oss@0.58.2	X													
-opendal-service-s3@0.58.2	X													
-opendal-service-webdav@0.58.2	X													
-opendal-service-webhdfs@0.58.2	X													
+opendal@0.59.0	X													
+opendal-core@0.59.0	X													
+opendal-http-transport-reqwest@0.59.0	X													
+opendal-layer-concurrent-limit@0.59.0	X													
+opendal-layer-logging@0.59.0	X													
+opendal-layer-retry@0.59.0	X													
+opendal-layer-throttle@0.59.0	X													
+opendal-layer-timeout@0.59.0	X													
+opendal-ruby@0.1.11	X													
+opendal-service-azblob@0.59.0	X													
+opendal-service-azdls@0.59.0	X													
+opendal-service-azfile@0.59.0	X													
+opendal-service-azure-common@0.59.0	X													
+opendal-service-cos@0.59.0	X													
+opendal-service-fs@0.59.0	X													
+opendal-service-gcs@0.59.0	X													
+opendal-service-ghac@0.59.0	X													
+opendal-service-http@0.59.0	X													
+opendal-service-ipmfs@0.59.0	X													
+opendal-service-obs@0.59.0	X													
+opendal-service-oss@0.59.0	X													
+opendal-service-s3@0.59.0	X													
+opendal-service-webdav@0.59.0	X													
+opendal-service-webhdfs@0.59.0	X													
 openssl-probe@0.2.1	X									X				
 ordered-multimap@0.7.3										X				
 parking_lot@0.12.5	X									X				
@@ -201,11 +202,11 @@ regex@1.12.4	X									X
 regex-automata@0.4.14	X									X				
 regex-syntax@0.8.11	X									X				
 reqsign-aliyun-oss@3.1.3	X													
-reqsign-aws-core@3.1.0	X													
-reqsign-aws-v4@3.2.0	X													
+reqsign-aws-core@3.1.1	X													
+reqsign-aws-v4@3.3.0	X													
 reqsign-azure-storage@3.1.2	X													
-reqsign-core@3.3.0	X													
-reqsign-file-read-tokio@3.0.5	X													
+reqsign-core@3.3.1	X													
+reqsign-file-read-tokio@3.0.6	X													
 reqsign-google@3.0.4	X													
 reqsign-huaweicloud-obs@3.0.4	X													
 reqsign-tencent-cos@3.0.4	X													
@@ -300,7 +301,17 @@ winapi-i686-pc-windows-gnu@0.4.0	X									X
 winapi-util@0.1.11										X			X	
 winapi-x86_64-pc-windows-gnu@0.4.0	X									X				
 windows-link@0.2.1	X									X				
+windows-sys@0.52.0	X									X				
 windows-sys@0.61.2	X									X				
+windows-targets@0.52.6	X									X				
+windows_aarch64_gnullvm@0.52.6	X									X				
+windows_aarch64_msvc@0.52.6	X									X				
+windows_i686_gnu@0.52.6	X									X				
+windows_i686_gnullvm@0.52.6	X									X				
+windows_i686_msvc@0.52.6	X									X				
+windows_x86_64_gnu@0.52.6	X									X				
+windows_x86_64_gnullvm@0.52.6	X									X				
+windows_x86_64_msvc@0.52.6	X									X				
 wit-bindgen@0.57.1	X	X								X				
 writeable@0.6.3												X		
 xattr@1.6.1	X									X				

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_aws_s3_assume_role_with_web_identity"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "logforth",
  "opendal",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_file_write_on_full_disk"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal",
  "rand 0.10.1",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_opfs_wasm32"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "futures",
  "opendal",
@@ -2833,7 +2833,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_s3_read_on_wasm"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal",
  "wasm-bindgen",
@@ -6203,7 +6203,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opendal"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6317,7 +6317,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-benchmark-vs-fs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "criterion",
  "opendal",
@@ -6328,7 +6328,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-benchmark-vs-s3"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -6343,7 +6343,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-core"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "asyncband",
@@ -6371,7 +6371,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-basic"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6379,7 +6379,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-concurrent-upload"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6387,7 +6387,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-getting-started"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6395,7 +6395,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-multipart-upload"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal",
  "tokio",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-fuzz"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -6415,7 +6415,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-http-transport-reqwest"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "futures",
@@ -6427,7 +6427,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-async-backtrace"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "async-backtrace",
  "opendal-core",
@@ -6435,7 +6435,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-await-tree"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "await-tree",
  "futures",
@@ -6444,7 +6444,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-capability-check"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-chaos"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal-core",
  "rand 0.10.1",
@@ -6460,7 +6460,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-concurrent-limit"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "futures",
@@ -6471,7 +6471,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-dtrace"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "opendal-core",
@@ -6481,7 +6481,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-fastmetrics"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "fastmetrics",
  "log",
@@ -6492,7 +6492,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-fastrace"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6504,7 +6504,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-foyer"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "foyer",
  "opendal-core",
@@ -6515,7 +6515,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-hotpath"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "futures",
  "hotpath",
@@ -6526,7 +6526,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-immutable-index"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "futures",
  "log",
@@ -6537,7 +6537,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-logging"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "log",
  "opendal-core",
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-metrics"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "metrics",
  "opendal-core",
@@ -6554,7 +6554,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-mime-guess"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "futures",
  "mime_guess",
@@ -6564,7 +6564,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-observe-metrics-common"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "futures",
  "http 1.4.2",
@@ -6574,7 +6574,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-otelmetrics"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal-core",
  "opendal-layer-observe-metrics-common",
@@ -6583,7 +6583,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-oteltrace"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal-core",
  "opentelemetry",
@@ -6591,7 +6591,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-prometheus"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "log",
  "opendal-core",
@@ -6602,7 +6602,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-prometheus-client"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "log",
  "opendal-core",
@@ -6613,7 +6613,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-retry"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "backon",
  "bytes",
@@ -6628,7 +6628,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-route"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "futures",
  "globset",
@@ -6639,7 +6639,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-tail-cut"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -6647,7 +6647,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-throttle"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "governor",
  "opendal-core",
@@ -6655,7 +6655,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-timeout"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "futures",
  "opendal-core",
@@ -6665,7 +6665,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-tracing"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6683,7 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-aliyun-drive"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "bytes",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-alluxio"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azblob"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -6732,7 +6732,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azdls"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "base64 0.23.0",
@@ -6752,7 +6752,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azfile"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6769,7 +6769,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azure-common"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "http 1.4.2",
  "opendal-core",
@@ -6777,7 +6777,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-b2"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "bytes",
@@ -6791,7 +6791,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cacache"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "cacache",
@@ -6802,7 +6802,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cloudflare-kv"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6813,7 +6813,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-compfs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "compio",
@@ -6824,7 +6824,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cos"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6840,7 +6840,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-d1"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6852,7 +6852,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dashmap"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "dashmap 6.2.1",
  "log",
@@ -6863,7 +6863,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dbfs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -6877,7 +6877,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dropbox"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "bytes",
@@ -6890,7 +6890,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-etcd"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "etcd-client",
  "fastpool",
@@ -6901,7 +6901,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-foundationdb"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "foundationdb",
  "opendal-core",
@@ -6911,7 +6911,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-foyer"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "foyer",
  "log",
@@ -6925,7 +6925,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-fs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "log",
@@ -6938,7 +6938,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ftp"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "fastpool",
@@ -6953,7 +6953,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6974,7 +6974,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs-grpc"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "futures",
@@ -6995,7 +6995,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gdrive"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "bytes",
@@ -7009,7 +7009,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ghac"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "ghac",
@@ -7028,7 +7028,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-github"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -7042,7 +7042,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-goosefs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "goosefs-sdk",
@@ -7055,7 +7055,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gridfs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "futures",
@@ -7067,7 +7067,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hdfs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "futures",
@@ -7080,7 +7080,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hdfs-native"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "futures",
@@ -7092,7 +7092,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hf"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "base64 0.23.0",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-http"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "http 1.4.2",
  "log",
@@ -7122,7 +7122,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ipfs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7135,7 +7135,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ipmfs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7148,7 +7148,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-koofr"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "bytes",
@@ -7162,7 +7162,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-lakefs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-memcached"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "fastpool",
  "opendal-core",
@@ -7186,7 +7186,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mini-moka"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "log",
  "mini-moka",
@@ -7196,7 +7196,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-moka"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "log",
  "moka",
@@ -7207,7 +7207,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mongodb"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "asyncband",
@@ -7219,7 +7219,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-monoiofs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "bytes",
@@ -7232,7 +7232,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mysql"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "opendal-core",
@@ -7243,7 +7243,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-obs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7259,7 +7259,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-onedrive"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "bytes",
@@ -7274,7 +7274,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-opfs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "js-sys",
  "opendal-core",
@@ -7287,7 +7287,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-oss"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7304,7 +7304,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-pcloud"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7317,7 +7317,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-persy"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal-core",
  "persy",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-postgresql"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "opendal-core",
@@ -7338,7 +7338,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-redb"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal-core",
  "redb 4.1.0",
@@ -7348,7 +7348,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-redis"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "fastpool",
@@ -7361,7 +7361,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-rocksdb"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal-core",
  "rocksdb",
@@ -7371,7 +7371,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-s3"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -7394,7 +7394,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-seafile"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "bytes",
@@ -7408,7 +7408,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sftp"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7424,7 +7424,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sled"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "opendal-core",
  "serde",
@@ -7434,7 +7434,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sqlite"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "opendal-core",
@@ -7445,7 +7445,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-surrealdb"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "opendal-core",
@@ -7456,7 +7456,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-swift"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -7476,7 +7476,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-tikv"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "asyncband",
  "opendal-core",
@@ -7487,7 +7487,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-tos"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7502,7 +7502,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-upyun"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -7520,7 +7520,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-vercel-artifacts"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7534,7 +7534,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-vercel-blob"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7548,7 +7548,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webdav"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "asyncband",
@@ -7563,7 +7563,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webhdfs"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "anyhow",
  "asyncband",
@@ -7579,7 +7579,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-yandex-disk"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7593,7 +7593,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-testkit"
-version = "0.58.2"
+version = "0.59.0"
 dependencies = [
  "bytes",
  "dotenvy",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,7 +39,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.58.2"
+version = "0.59.0"
 
 [workspace.dependencies]
 asyncband = { version = "0.6" }
@@ -246,103 +246,103 @@ required-features = ["tests"]
 
 [dependencies]
 ctor = { workspace = true, optional = true }
-opendal-core = { path = "core", version = "0.58.2", default-features = false }
-opendal-http-transport-reqwest = { path = "http-transports/reqwest", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-async-backtrace = { path = "layers/async-backtrace", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-await-tree = { path = "layers/await-tree", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-capability-check = { path = "layers/capability-check", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-chaos = { path = "layers/chaos", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-concurrent-limit = { path = "layers/concurrent-limit", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-fastmetrics = { path = "layers/fastmetrics", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-fastrace = { path = "layers/fastrace", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-foyer = { path = "layers/foyer", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-hotpath = { path = "layers/hotpath", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-immutable-index = { path = "layers/immutable-index", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-logging = { path = "layers/logging", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-metrics = { path = "layers/metrics", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-mime-guess = { path = "layers/mime-guess", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-observe-metrics-common = { path = "layers/observe-metrics-common", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-otelmetrics = { path = "layers/otelmetrics", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-oteltrace = { path = "layers/oteltrace", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-prometheus = { path = "layers/prometheus", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-prometheus-client = { path = "layers/prometheus-client", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-retry = { path = "layers/retry", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-route = { path = "layers/route", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-tail-cut = { path = "layers/tail-cut", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-throttle = { path = "layers/throttle", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-timeout = { path = "layers/timeout", version = "0.58.2", optional = true, default-features = false }
-opendal-layer-tracing = { path = "layers/tracing", version = "0.58.2", optional = true, default-features = false }
-opendal-service-aliyun-drive = { path = "services/aliyun-drive", version = "0.58.2", optional = true, default-features = false }
-opendal-service-alluxio = { path = "services/alluxio", version = "0.58.2", optional = true, default-features = false }
-opendal-service-azblob = { path = "services/azblob", version = "0.58.2", optional = true, default-features = false }
-opendal-service-azdls = { path = "services/azdls", version = "0.58.2", optional = true, default-features = false }
-opendal-service-azfile = { path = "services/azfile", version = "0.58.2", optional = true, default-features = false }
-opendal-service-b2 = { path = "services/b2", version = "0.58.2", optional = true, default-features = false }
-opendal-service-cacache = { path = "services/cacache", version = "0.58.2", optional = true, default-features = false }
-opendal-service-cloudflare-kv = { path = "services/cloudflare-kv", version = "0.58.2", optional = true, default-features = false }
-opendal-service-compfs = { path = "services/compfs", version = "0.58.2", optional = true, default-features = false }
-opendal-service-cos = { path = "services/cos", version = "0.58.2", optional = true, default-features = false }
-opendal-service-d1 = { path = "services/d1", version = "0.58.2", optional = true, default-features = false }
-opendal-service-dashmap = { path = "services/dashmap", version = "0.58.2", optional = true, default-features = false }
-opendal-service-dbfs = { path = "services/dbfs", version = "0.58.2", optional = true, default-features = false }
-opendal-service-dropbox = { path = "services/dropbox", version = "0.58.2", optional = true, default-features = false }
-opendal-service-etcd = { path = "services/etcd", version = "0.58.2", optional = true, default-features = false }
-opendal-service-foundationdb = { path = "services/foundationdb", version = "0.58.2", optional = true, default-features = false }
-opendal-service-foyer = { path = "services/foyer", version = "0.58.2", optional = true, default-features = false }
-opendal-service-fs = { path = "services/fs", version = "0.58.2", optional = true, default-features = false }
-opendal-service-ftp = { path = "services/ftp", version = "0.58.2", optional = true, default-features = false }
-opendal-service-gcs = { path = "services/gcs", version = "0.58.2", optional = true, default-features = false }
-opendal-service-gcs-grpc = { path = "services/gcs-grpc", version = "0.58.2", optional = true, default-features = false }
-opendal-service-gdrive = { path = "services/gdrive", version = "0.58.2", optional = true, default-features = false }
-opendal-service-ghac = { path = "services/ghac", version = "0.58.2", optional = true, default-features = false }
-opendal-service-github = { path = "services/github", version = "0.58.2", optional = true, default-features = false }
-opendal-service-goosefs = { path = "services/goosefs", version = "0.58.2", optional = true, default-features = false }
-opendal-service-gridfs = { path = "services/gridfs", version = "0.58.2", optional = true, default-features = false }
-opendal-service-hdfs = { path = "services/hdfs", version = "0.58.2", optional = true, default-features = false }
-opendal-service-hdfs-native = { path = "services/hdfs-native", version = "0.58.2", optional = true, default-features = false }
-opendal-service-hf = { path = "services/hf", version = "0.58.2", optional = true, default-features = false }
-opendal-service-http = { path = "services/http", version = "0.58.2", optional = true, default-features = false }
-opendal-service-ipfs = { path = "services/ipfs", version = "0.58.2", optional = true, default-features = false }
-opendal-service-ipmfs = { path = "services/ipmfs", version = "0.58.2", optional = true, default-features = false }
-opendal-service-koofr = { path = "services/koofr", version = "0.58.2", optional = true, default-features = false }
-opendal-service-lakefs = { path = "services/lakefs", version = "0.58.2", optional = true, default-features = false }
-opendal-service-memcached = { path = "services/memcached", version = "0.58.2", optional = true, default-features = false }
-opendal-service-mini-moka = { path = "services/mini_moka", version = "0.58.2", optional = true, default-features = false }
-opendal-service-moka = { path = "services/moka", version = "0.58.2", optional = true, default-features = false }
-opendal-service-mongodb = { path = "services/mongodb", version = "0.58.2", optional = true, default-features = false }
-opendal-service-monoiofs = { path = "services/monoiofs", version = "0.58.2", optional = true, default-features = false }
-opendal-service-mysql = { path = "services/mysql", version = "0.58.2", optional = true, default-features = false }
-opendal-service-obs = { path = "services/obs", version = "0.58.2", optional = true, default-features = false }
-opendal-service-onedrive = { path = "services/onedrive", version = "0.58.2", optional = true, default-features = false }
-opendal-service-oss = { path = "services/oss", version = "0.58.2", optional = true, default-features = false }
-opendal-service-pcloud = { path = "services/pcloud", version = "0.58.2", optional = true, default-features = false }
-opendal-service-persy = { path = "services/persy", version = "0.58.2", optional = true, default-features = false }
-opendal-service-postgresql = { path = "services/postgresql", version = "0.58.2", optional = true, default-features = false }
-opendal-service-redb = { path = "services/redb", version = "0.58.2", optional = true, default-features = false }
-opendal-service-redis = { path = "services/redis", version = "0.58.2", optional = true, default-features = false }
-opendal-service-rocksdb = { path = "services/rocksdb", version = "0.58.2", optional = true, default-features = false }
-opendal-service-s3 = { path = "services/s3", version = "0.58.2", optional = true, default-features = false }
-opendal-service-seafile = { path = "services/seafile", version = "0.58.2", optional = true, default-features = false }
-opendal-service-sftp = { path = "services/sftp", version = "0.58.2", optional = true, default-features = false }
-opendal-service-sled = { path = "services/sled", version = "0.58.2", optional = true, default-features = false }
-opendal-service-sqlite = { path = "services/sqlite", version = "0.58.2", optional = true, default-features = false }
-opendal-service-surrealdb = { path = "services/surrealdb", version = "0.58.2", optional = true, default-features = false }
-opendal-service-swift = { path = "services/swift", version = "0.58.2", optional = true, default-features = false }
-opendal-service-tikv = { path = "services/tikv", version = "0.58.2", optional = true, default-features = false }
-opendal-service-tos = { path = "services/tos", version = "0.58.2", optional = true, default-features = false }
-opendal-service-upyun = { path = "services/upyun", version = "0.58.2", optional = true, default-features = false }
-opendal-service-vercel-artifacts = { path = "services/vercel-artifacts", version = "0.58.2", optional = true, default-features = false }
-opendal-service-vercel-blob = { path = "services/vercel-blob", version = "0.58.2", optional = true, default-features = false }
-opendal-service-webdav = { path = "services/webdav", version = "0.58.2", optional = true, default-features = false }
-opendal-service-webhdfs = { path = "services/webhdfs", version = "0.58.2", optional = true, default-features = false }
-opendal-service-yandex-disk = { path = "services/yandex-disk", version = "0.58.2", optional = true, default-features = false }
-opendal-testkit = { path = "testkit", version = "0.58.2", optional = true }
+opendal-core = { path = "core", version = "0.59.0", default-features = false }
+opendal-http-transport-reqwest = { path = "http-transports/reqwest", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-async-backtrace = { path = "layers/async-backtrace", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-await-tree = { path = "layers/await-tree", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-capability-check = { path = "layers/capability-check", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-chaos = { path = "layers/chaos", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-concurrent-limit = { path = "layers/concurrent-limit", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-fastmetrics = { path = "layers/fastmetrics", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-fastrace = { path = "layers/fastrace", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-foyer = { path = "layers/foyer", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-hotpath = { path = "layers/hotpath", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-immutable-index = { path = "layers/immutable-index", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-logging = { path = "layers/logging", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-metrics = { path = "layers/metrics", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-mime-guess = { path = "layers/mime-guess", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-observe-metrics-common = { path = "layers/observe-metrics-common", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-otelmetrics = { path = "layers/otelmetrics", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-oteltrace = { path = "layers/oteltrace", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-prometheus = { path = "layers/prometheus", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-prometheus-client = { path = "layers/prometheus-client", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-retry = { path = "layers/retry", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-route = { path = "layers/route", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-tail-cut = { path = "layers/tail-cut", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-throttle = { path = "layers/throttle", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-timeout = { path = "layers/timeout", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-tracing = { path = "layers/tracing", version = "0.59.0", optional = true, default-features = false }
+opendal-service-aliyun-drive = { path = "services/aliyun-drive", version = "0.59.0", optional = true, default-features = false }
+opendal-service-alluxio = { path = "services/alluxio", version = "0.59.0", optional = true, default-features = false }
+opendal-service-azblob = { path = "services/azblob", version = "0.59.0", optional = true, default-features = false }
+opendal-service-azdls = { path = "services/azdls", version = "0.59.0", optional = true, default-features = false }
+opendal-service-azfile = { path = "services/azfile", version = "0.59.0", optional = true, default-features = false }
+opendal-service-b2 = { path = "services/b2", version = "0.59.0", optional = true, default-features = false }
+opendal-service-cacache = { path = "services/cacache", version = "0.59.0", optional = true, default-features = false }
+opendal-service-cloudflare-kv = { path = "services/cloudflare-kv", version = "0.59.0", optional = true, default-features = false }
+opendal-service-compfs = { path = "services/compfs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-cos = { path = "services/cos", version = "0.59.0", optional = true, default-features = false }
+opendal-service-d1 = { path = "services/d1", version = "0.59.0", optional = true, default-features = false }
+opendal-service-dashmap = { path = "services/dashmap", version = "0.59.0", optional = true, default-features = false }
+opendal-service-dbfs = { path = "services/dbfs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-dropbox = { path = "services/dropbox", version = "0.59.0", optional = true, default-features = false }
+opendal-service-etcd = { path = "services/etcd", version = "0.59.0", optional = true, default-features = false }
+opendal-service-foundationdb = { path = "services/foundationdb", version = "0.59.0", optional = true, default-features = false }
+opendal-service-foyer = { path = "services/foyer", version = "0.59.0", optional = true, default-features = false }
+opendal-service-fs = { path = "services/fs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-ftp = { path = "services/ftp", version = "0.59.0", optional = true, default-features = false }
+opendal-service-gcs = { path = "services/gcs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-gcs-grpc = { path = "services/gcs-grpc", version = "0.59.0", optional = true, default-features = false }
+opendal-service-gdrive = { path = "services/gdrive", version = "0.59.0", optional = true, default-features = false }
+opendal-service-ghac = { path = "services/ghac", version = "0.59.0", optional = true, default-features = false }
+opendal-service-github = { path = "services/github", version = "0.59.0", optional = true, default-features = false }
+opendal-service-goosefs = { path = "services/goosefs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-gridfs = { path = "services/gridfs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-hdfs = { path = "services/hdfs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-hdfs-native = { path = "services/hdfs-native", version = "0.59.0", optional = true, default-features = false }
+opendal-service-hf = { path = "services/hf", version = "0.59.0", optional = true, default-features = false }
+opendal-service-http = { path = "services/http", version = "0.59.0", optional = true, default-features = false }
+opendal-service-ipfs = { path = "services/ipfs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-ipmfs = { path = "services/ipmfs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-koofr = { path = "services/koofr", version = "0.59.0", optional = true, default-features = false }
+opendal-service-lakefs = { path = "services/lakefs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-memcached = { path = "services/memcached", version = "0.59.0", optional = true, default-features = false }
+opendal-service-mini-moka = { path = "services/mini_moka", version = "0.59.0", optional = true, default-features = false }
+opendal-service-moka = { path = "services/moka", version = "0.59.0", optional = true, default-features = false }
+opendal-service-mongodb = { path = "services/mongodb", version = "0.59.0", optional = true, default-features = false }
+opendal-service-monoiofs = { path = "services/monoiofs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-mysql = { path = "services/mysql", version = "0.59.0", optional = true, default-features = false }
+opendal-service-obs = { path = "services/obs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-onedrive = { path = "services/onedrive", version = "0.59.0", optional = true, default-features = false }
+opendal-service-oss = { path = "services/oss", version = "0.59.0", optional = true, default-features = false }
+opendal-service-pcloud = { path = "services/pcloud", version = "0.59.0", optional = true, default-features = false }
+opendal-service-persy = { path = "services/persy", version = "0.59.0", optional = true, default-features = false }
+opendal-service-postgresql = { path = "services/postgresql", version = "0.59.0", optional = true, default-features = false }
+opendal-service-redb = { path = "services/redb", version = "0.59.0", optional = true, default-features = false }
+opendal-service-redis = { path = "services/redis", version = "0.59.0", optional = true, default-features = false }
+opendal-service-rocksdb = { path = "services/rocksdb", version = "0.59.0", optional = true, default-features = false }
+opendal-service-s3 = { path = "services/s3", version = "0.59.0", optional = true, default-features = false }
+opendal-service-seafile = { path = "services/seafile", version = "0.59.0", optional = true, default-features = false }
+opendal-service-sftp = { path = "services/sftp", version = "0.59.0", optional = true, default-features = false }
+opendal-service-sled = { path = "services/sled", version = "0.59.0", optional = true, default-features = false }
+opendal-service-sqlite = { path = "services/sqlite", version = "0.59.0", optional = true, default-features = false }
+opendal-service-surrealdb = { path = "services/surrealdb", version = "0.59.0", optional = true, default-features = false }
+opendal-service-swift = { path = "services/swift", version = "0.59.0", optional = true, default-features = false }
+opendal-service-tikv = { path = "services/tikv", version = "0.59.0", optional = true, default-features = false }
+opendal-service-tos = { path = "services/tos", version = "0.59.0", optional = true, default-features = false }
+opendal-service-upyun = { path = "services/upyun", version = "0.59.0", optional = true, default-features = false }
+opendal-service-vercel-artifacts = { path = "services/vercel-artifacts", version = "0.59.0", optional = true, default-features = false }
+opendal-service-vercel-blob = { path = "services/vercel-blob", version = "0.59.0", optional = true, default-features = false }
+opendal-service-webdav = { path = "services/webdav", version = "0.59.0", optional = true, default-features = false }
+opendal-service-webhdfs = { path = "services/webhdfs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-yandex-disk = { path = "services/yandex-disk", version = "0.59.0", optional = true, default-features = false }
+opendal-testkit = { path = "testkit", version = "0.59.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-opendal-layer-dtrace = { path = "layers/dtrace", version = "0.58.2", optional = true, default-features = false }
+opendal-layer-dtrace = { path = "layers/dtrace", version = "0.59.0", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-opendal-service-opfs = { path = "services/opfs", version = "0.58.2", optional = true, default-features = false }
+opendal-service-opfs = { path = "services/opfs", version = "0.59.0", optional = true, default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -122,24 +122,25 @@ lock_api@0.4.14	X									X
 log@0.4.33	X									X				
 lru@0.12.5										X				
 md-5@0.11.0	X									X				
+mea@0.6.4	X													
 memchr@2.8.2										X			X	
 memmap2@0.9.11	X									X				
 mime@0.3.17	X									X				
 mio@1.2.0										X				
 moka@0.12.15	X									X				
 once_cell@1.21.4	X									X				
-opendal@0.58.2	X													
-opendal-core@0.58.2	X													
-opendal-http-transport-reqwest@0.58.2	X													
-opendal-layer-concurrent-limit@0.58.2	X													
-opendal-layer-logging@0.58.2	X													
-opendal-layer-retry@0.58.2	X													
-opendal-layer-timeout@0.58.2	X													
-opendal-service-fs@0.58.2	X													
-opendal-service-goosefs@0.58.2	X													
-opendal-service-opfs@0.58.2	X													
-opendal-service-s3@0.58.2	X													
-opendal-testkit@0.58.2	X													
+opendal@0.59.0	X													
+opendal-core@0.59.0	X													
+opendal-http-transport-reqwest@0.59.0	X													
+opendal-layer-concurrent-limit@0.59.0	X													
+opendal-layer-logging@0.59.0	X													
+opendal-layer-retry@0.59.0	X													
+opendal-layer-timeout@0.59.0	X													
+opendal-service-fs@0.59.0	X													
+opendal-service-goosefs@0.59.0	X													
+opendal-service-opfs@0.59.0	X													
+opendal-service-s3@0.59.0	X													
+opendal-testkit@0.59.0	X													
 openssl-probe@0.2.1	X									X				
 ordered-multimap@0.7.3										X				
 parking@2.2.1	X									X				
@@ -167,10 +168,10 @@ rand_chacha@0.9.0	X									X
 rand_core@0.10.1	X									X				
 rand_core@0.9.5	X									X				
 redox_syscall@0.5.18										X				
-reqsign-aws-core@3.1.0	X													
-reqsign-aws-v4@3.2.0	X													
-reqsign-core@3.3.0	X													
-reqsign-file-read-tokio@3.0.5	X													
+reqsign-aws-core@3.1.1	X													
+reqsign-aws-v4@3.3.0	X													
+reqsign-core@3.3.1	X													
+reqsign-file-read-tokio@3.0.6	X													
 reqwest@0.12.28	X									X				
 reqwest@0.13.4	X									X				
 ring@0.17.14	X							X						

--- a/core/benches/vs_fs/Cargo.toml
+++ b/core/benches/vs_fs/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "opendal-benchmark-vs-fs"
 publish = false
 rust-version = "1.86"
-version = "0.58.2"
+version = "0.59.0"
 
 [dependencies]
 criterion = { version = "0.8.2", features = ["async", "async_tokio"] }

--- a/core/benches/vs_s3/Cargo.toml
+++ b/core/benches/vs_s3/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "opendal-benchmark-vs-s3"
 publish = false
 rust-version = "1.86"
-version = "0.58.2"
+version = "0.59.0"
 
 [dependencies]
 aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }

--- a/core/core/src/docs/upgrade.md
+++ b/core/core/src/docs/upgrade.md
@@ -1,3 +1,31 @@
+# Upgrade to v0.59
+
+## Public API
+
+### `Metadata` uses immutable builder-based construction
+
+`Metadata::new`, `Metadata::builder`, `Default`, direct metadata setters, and `with_*` have been removed. Construct metadata with `MetadataBuilder::file(content_length)`, `MetadataBuilder::dir()`, or `MetadataBuilder::unknown()`, then call `build()` after setting optional fields. Consume existing metadata with `into_builder()` when creating a modified value; use `set_file(content_length)`, `set_dir()`, or `set_unknown()` to change its mode.
+
+`Metadata::user_metadata()` now returns a borrowed `UserMetadata` view instead of `&HashMap<String, String>`. The view supports `get`, `len`, `is_empty`, and `IntoIterator`; collect owned string pairs at boundaries that require a map.
+
+Every file `Metadata` contains an explicit full-object content length by construction. Raw services use `Unknown` for incomplete metadata and promote it with `set_file(content_length)` only when the full length is authoritative.
+
+Compact metadata and finalized raw-operation value blocks are limited to `u16::MAX` encoded bytes, including indexes. `MetadataBuilder::build`, raw option freezing, and raw listed-entry construction panic when a block exceeds this bound.
+
+### Delete inputs use `DeleteOptions`
+
+`DeleteInput` has been removed. Pass `(String, DeleteOptions)` to `Deleter`, delete iterators, streams, and sinks when an entry needs options. Plain paths and `Entry` values remain supported through `IntoDeleteInput`. `(String, OpDelete)` is no longer accepted by the public delete APIs because raw arguments are already capability-resolved.
+
+## Raw API
+
+### `OpCopier` merged into `OpCopy`
+
+`OpCopier` has been removed. `Service::copy` now receives a single `OpCopy` argument, and raw services read `chunk`, `concurrent`, and `source_content_length_hint` from `OpCopy`.
+
+### Raw operation arguments are frozen from public options
+
+Public `with_*` mutation methods have been removed from `OpRead`, `OpStat`, `OpWrite`, `OpDelete`, `OpCopy`, `OpList`, and `OpRestore`. Construct non-empty read, stat, list, and restore arguments by converting the corresponding public `*Options`. Use `OpWrite::from_options`, `OpDelete::from_options`, or `OpCopy::from_options` with the composed `Capability`; `new` and `Default` remain available for empty arguments. These constructors lower `if_not_changed` before freezing, so raw arguments contain only service-ready primitive conditions. `OpWrite::user_metadata()` returns the same borrowed `UserMetadata` view as `Metadata`.
+
 # Upgrade to v0.58
 
 ## Public API
@@ -29,27 +57,11 @@ Operator runtime resources now live in `OperationContext`, which is exported fro
 
 `BytesRange` is now part of the public type layer. Reader APIs accept values convertible into `BytesRange`, and suffix reads can be requested with `BytesRange::suffix(size)`. Code that imported raw HTTP range helpers should use `opendal::BytesRange` instead.
 
-### `Metadata` uses immutable builder-based construction
-
-`Metadata::new`, `Metadata::builder`, `Default`, direct metadata setters, and `with_*` have been removed. Construct metadata with `MetadataBuilder::file(content_length)`, `MetadataBuilder::dir()`, or `MetadataBuilder::unknown()`, then call `build()` after setting optional fields. Consume existing metadata with `into_builder()` when creating a modified value; use `set_file(content_length)`, `set_dir()`, or `set_unknown()` to change its mode.
-
-`Metadata::user_metadata()` now returns a borrowed `UserMetadata` view instead of `&HashMap<String, String>`. The view supports `get`, `len`, `is_empty`, and `IntoIterator`; collect owned string pairs at boundaries that require a map.
-
-Every file `Metadata` contains an explicit full-object content length by construction. Raw services use `Unknown` for incomplete metadata and promote it with `set_file(content_length)` only when the full length is authoritative.
-
-Compact metadata and finalized raw-operation value blocks are limited to `u16::MAX` encoded bytes, including indexes. `MetadataBuilder::build`, raw option freezing, and raw listed-entry construction panic when a block exceeds this bound.
-
-### Delete inputs use `DeleteOptions`
-
-`DeleteInput` has been removed. Pass `(String, DeleteOptions)` to `Deleter`, delete iterators, streams, and sinks when an entry needs options. Plain paths and `Entry` values remain supported through `IntoDeleteInput`. `(String, OpDelete)` is no longer accepted by the public delete APIs because raw arguments are already capability-resolved.
-
 ## Raw API
 
 ### Services and layers use the new composition boundary
 
 Out-of-tree services must implement `raw::Service` instead of the old accessor pipeline. Services now return immutable identity through `ServiceInfo`, report availability through `capability()`, and receive `&OperationContext` at each operation boundary.
-
-`WriteOptions`, `DeleteOptions`, and `CopyOptions` no longer implement direct conversion into their raw operation arguments. Use `OpWrite::from_options`, `OpDelete::from_options`, or `OpCopy::from_options` with the composed `Capability`. These constructors lower `if_not_changed` before freezing, so raw arguments contain only service-ready primitive conditions.
 
 Out-of-tree layers must implement `Layer::apply_service` and, when they replace runtime resources, `Layer::apply_context`. The old typed layer pipeline, including `TypedLayer`, `RuntimeResourceLayer`, `TypeEraseLayer`, `OperatorBuilder<S>`, and `typed_layer`, has been removed.
 
@@ -60,10 +72,6 @@ Out-of-tree layers must implement `Layer::apply_service` and, when they replace 
 ### Removed raw helpers
 
 The unused `raw::AtomicContentLength`, `raw::PathCacher`, and `raw::PathQuery` helpers have been removed. The `internal-path-cache` feature has also been removed.
-
-### Raw operation arguments are frozen from public options
-
-Public `with_*` mutation methods have been removed from `OpRead`, `OpStat`, `OpWrite`, `OpDelete`, `OpCopy`, `OpList`, and `OpRestore`. Construct non-empty read, stat, list, and restore arguments by converting the corresponding public `*Options`. Use the capability-aware `from_options` constructors described above for write, delete, and copy; `new` and `Default` remain available for empty arguments. `OpWrite::user_metadata()` returns the same borrowed `UserMetadata` view as `Metadata`.
 
 # Upgrade to v0.57
 

--- a/core/core/src/docs/upgrade.md
+++ b/core/core/src/docs/upgrade.md
@@ -2,9 +2,20 @@
 
 ## Public API
 
-### `Metadata` uses immutable builder-based construction
+### Construct `Metadata` with `MetadataBuilder`
 
-`Metadata::new`, `Metadata::builder`, `Default`, direct metadata setters, and `with_*` have been removed. Construct metadata with `MetadataBuilder::file(content_length)`, `MetadataBuilder::dir()`, or `MetadataBuilder::unknown()`, then call `build()` after setting optional fields. Consume existing metadata with `into_builder()` when creating a modified value; use `set_file(content_length)`, `set_dir()`, or `set_unknown()` to change its mode.
+`Metadata::new`, `Default`, direct metadata setters, and `with_*` methods have been removed. Construct metadata with `MetadataBuilder::file(content_length)`, `MetadataBuilder::dir()`, or `MetadataBuilder::unknown()`, set optional fields on the builder, then call `build()`:
+
+```diff
+-let mut metadata = Metadata::new(EntryMode::FILE);
+-metadata.set_content_length(size);
+-metadata.set_content_type("text/plain");
++let mut builder = MetadataBuilder::file(size);
++builder.content_type("text/plain");
++let metadata = builder.build();
+```
+
+Consume existing metadata with `into_builder()` when creating a modified value. Use `set_file(content_length)`, `set_dir()`, or `set_unknown()` on the builder to change its mode.
 
 `Metadata::user_metadata()` now returns a borrowed `UserMetadata` view instead of `&HashMap<String, String>`. The view supports `get`, `len`, `is_empty`, and `IntoIterator`; collect owned string pairs at boundaries that require a map.
 
@@ -14,17 +25,91 @@ Compact metadata and finalized raw-operation value blocks are limited to `u16::M
 
 ### Delete inputs use `DeleteOptions`
 
-`DeleteInput` has been removed. Pass `(String, DeleteOptions)` to `Deleter`, delete iterators, streams, and sinks when an entry needs options. Plain paths and `Entry` values remain supported through `IntoDeleteInput`. `(String, OpDelete)` is no longer accepted by the public delete APIs because raw arguments are already capability-resolved.
+`DeleteInput` has been removed. Pass `(String, DeleteOptions)` to `Deleter`, delete iterators, streams, and sinks when an entry needs options. Plain paths and `Entry` values remain supported through `IntoDeleteInput`. Custom `IntoDeleteInput` implementations must now return `(String, DeleteOptions)` from `into_delete_input`. `(String, OpDelete)` is no longer accepted by the public delete APIs because raw arguments are already capability-resolved.
+
+```diff
+-deleter.delete(DeleteInput {
+-    path,
+-    version,
+-    recursive: false,
+-});
++deleter.delete((
++    path,
++    DeleteOptions {
++        version,
++        ..Default::default()
++    },
++));
+```
+
+### Existing option and capability literals require defaults
+
+OpenDAL added fields to `Capability`, `ReadOptions`, `ReaderOptions`, `StatOptions`, `WriteOptions`, `DeleteOptions`, and `CopyOptions`. Code that constructs any of these types with an exhaustive struct literal must initialize the new fields. Prefer update syntax so later additions remain source-compatible:
+
+```rust
+use opendal_core::Capability;
+use opendal_core::options::DeleteOptions;
+
+let options = DeleteOptions {
+    recursive: true,
+    ..Default::default()
+};
+
+let capability = Capability {
+    read: true,
+    ..Default::default()
+};
+```
+
+### Conditional errors distinguish conflicts
+
+Failed conditions supplied through operation options return `ErrorKind::ConditionNotMatch`. Conflicts reported independently by a service return the new `ErrorKind::Conflict`; inspect `Error::is_temporary()` to decide whether the receiving OpenDAL layer can replay the same operation. Unsupported conditions return `ErrorKind::Unsupported`, and a missing target observed by `stat` or `read` remains `ErrorKind::NotFound` even when the request was conditional. Update error recovery code that previously treated every service conflict as `ConditionNotMatch` or `Unexpected`.
 
 ## Raw API
 
 ### `OpCopier` merged into `OpCopy`
 
-`OpCopier` has been removed. `Service::copy` now receives a single `OpCopy` argument, and raw services read `chunk`, `concurrent`, and `source_content_length_hint` from `OpCopy`.
+`OpCopier` has been removed. `Service::copy` and `ServiceDyn::copy_dyn` now receive a single `OpCopy` argument, and raw services read `chunk`, `concurrent`, and `source_content_length_hint` from `OpCopy`.
 
 ### Raw operation arguments are frozen from public options
 
-Public `with_*` mutation methods have been removed from `OpRead`, `OpStat`, `OpWrite`, `OpDelete`, `OpCopy`, `OpList`, and `OpRestore`. Construct non-empty read, stat, list, and restore arguments by converting the corresponding public `*Options`. Use `OpWrite::from_options`, `OpDelete::from_options`, or `OpCopy::from_options` with the composed `Capability`; `new` and `Default` remain available for empty arguments. These constructors lower `if_not_changed` before freezing, so raw arguments contain only service-ready primitive conditions. `OpWrite::user_metadata()` returns the same borrowed `UserMetadata` view as `Metadata`.
+Public `with_*` mutation methods have been removed from `OpRead`, `OpStat`, `OpWrite`, `OpDelete`, `OpCopy`, and `OpList`. Construct non-empty read, stat, list, and restore arguments by converting the corresponding public `*Options`. Use the capability-aware `from_options(&capability, options)` constructors for `OpWrite`, `OpDelete`, `OpCopy`, and `OpCompose`; `new` and `Default` remain available for empty arguments.
+
+The direct `From<WriteOptions>`, `From<DeleteOptions>`, and `From<CopyOptions>` conversions have been removed. The capability-aware constructors lower `if_not_changed` before freezing, so raw arguments contain only service-ready primitive conditions. `OpWrite::from_options` still returns `(OpWrite, OpWriter)`, while copy execution settings now live directly in `OpCopy`. `OpWrite::user_metadata()` returns the same borrowed `UserMetadata` view as `Metadata`.
+
+### Listed entries contain finalized metadata
+
+`raw::oio::Entry::set_mode` and `metadata_mut` have been removed. Build the final `Metadata` first and pass it to `raw::oio::Entry::new` or `with`. To modify an existing raw entry, consume it with `into_parts`, rebuild its metadata, and construct a replacement entry:
+
+```rust
+use opendal_core::MetadataBuilder;
+use opendal_core::raw;
+
+let entry = raw::oio::Entry::new("path", MetadataBuilder::file(0).build());
+let (path, metadata) = entry.into_parts();
+let mut builder = metadata.into_builder();
+builder.content_type("text/plain");
+let entry = raw::oio::Entry::new(&path, builder.build());
+```
+
+The metadata mode must continue to match the path: directory paths end in `/`, while file paths do not.
+
+### Do not use numeric `Operation` discriminants
+
+The new `Compose` and `Restore` variants changed the implicit numeric discriminants of later `Operation` variants. Code that casts `Operation` with `as usize` must migrate to `Operation::into_static()` or `Display` for stable operation names. `Operation` has no numeric representation contract.
+
+## Services
+
+### Duration config fields use `SignedDuration`
+
+The public `default_ttl` fields on `CloudflareKvConfig`, `MemcachedConfig`, and `RedisConfig` now use `Option<raw::SignedDuration>` instead of `Option<std::time::Duration>`. This allows configuration maps and serialized configuration to parse duration strings. Direct config construction can use the re-exported duration type:
+
+```diff
+-default_ttl: Some(std::time::Duration::from_secs(30)),
++default_ttl: Some(opendal::raw::SignedDuration::from_secs(30)),
+```
+
+The corresponding builder methods continue to accept `std::time::Duration`.
 
 # Upgrade to v0.58
 

--- a/core/http-transports/reqwest/Cargo.toml
+++ b/core/http-transports/reqwest/Cargo.toml
@@ -53,7 +53,7 @@ bytes = { workspace = true }
 futures = { workspace = true, features = ["std"] }
 http = { workspace = true }
 http-body = "1"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 reqwest = { version = "0.13.4", features = [
   "stream",
 ], default-features = false }

--- a/core/layers/async-backtrace/Cargo.toml
+++ b/core/layers/async-backtrace/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 async-backtrace = "0.2.6"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }

--- a/core/layers/await-tree/Cargo.toml
+++ b/core/layers/await-tree/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 await-tree = "0.3"
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }

--- a/core/layers/capability-check/Cargo.toml
+++ b/core/layers/capability-check/Cargo.toml
@@ -32,8 +32,8 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/chaos/Cargo.toml
+++ b/core/layers/chaos/Cargo.toml
@@ -32,8 +32,8 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 rand = { workspace = true }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }

--- a/core/layers/concurrent-limit/Cargo.toml
+++ b/core/layers/concurrent-limit/Cargo.toml
@@ -35,8 +35,8 @@ all-features = true
 asyncband = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/core/layers/dtrace/Cargo.toml
+++ b/core/layers/dtrace/Cargo.toml
@@ -33,9 +33,9 @@ all-features = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 bytes = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 probe = "0.5.1"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/fastmetrics/Cargo.toml
+++ b/core/layers/fastmetrics/Cargo.toml
@@ -33,10 +33,10 @@ all-features = true
 
 [dependencies]
 fastmetrics = "0.7"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/fastrace/Cargo.toml
+++ b/core/layers/fastrace/Cargo.toml
@@ -33,12 +33,12 @@ all-features = true
 
 [dependencies]
 fastrace = { version = "0.7.18" }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0"
 dotenvy = "0.15"
 fastrace = { version = "0.7", features = ["enable"] }
 fastrace-jaeger = "0.7"
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/foyer/Cargo.toml
+++ b/core/layers/foyer/Cargo.toml
@@ -33,10 +33,10 @@ all-features = true
 
 [dependencies]
 foyer = { version = "0.22.3" }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", features = [
+opendal-core = { path = "../../core", version = "0.59.0", features = [
   "services-memory",
 ] }
 size = "0.5"

--- a/core/layers/hotpath/Cargo.toml
+++ b/core/layers/hotpath/Cargo.toml
@@ -35,8 +35,8 @@ all-features = true
 futures = { workspace = true }
 hotpath = "0.22.0"
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/immutable-index/Cargo.toml
+++ b/core/layers/immutable-index/Cargo.toml
@@ -32,11 +32,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
 log = { workspace = true }
 logforth = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/logging/Cargo.toml
+++ b/core/layers/logging/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }

--- a/core/layers/metrics/Cargo.toml
+++ b/core/layers/metrics/Cargo.toml
@@ -33,8 +33,8 @@ all-features = true
 
 [dependencies]
 metrics = "0.24"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }

--- a/core/layers/mime-guess/Cargo.toml
+++ b/core/layers/mime-guess/Cargo.toml
@@ -33,9 +33,9 @@ all-features = true
 
 [dependencies]
 mime_guess = "2.0.5"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/observe-metrics-common/Cargo.toml
+++ b/core/layers/observe-metrics-common/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 futures = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/otelmetrics/Cargo.toml
+++ b/core/layers/otelmetrics/Cargo.toml
@@ -32,11 +32,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.0" }
 opentelemetry = { version = "0.32.0", default-features = false, features = [
   "metrics",
 ] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }

--- a/core/layers/oteltrace/Cargo.toml
+++ b/core/layers/oteltrace/Cargo.toml
@@ -32,10 +32,10 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 opentelemetry = { version = "0.32.0", default-features = false, features = [
   "trace",
 ] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }

--- a/core/layers/prometheus-client/Cargo.toml
+++ b/core/layers/prometheus-client/Cargo.toml
@@ -32,11 +32,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.0" }
 prometheus-client = { version = "0.25" }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/prometheus/Cargo.toml
+++ b/core/layers/prometheus/Cargo.toml
@@ -32,11 +32,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.0" }
 prometheus = { version = "0.14", features = ["process"] }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/retry/Cargo.toml
+++ b/core/layers/retry/Cargo.toml
@@ -34,13 +34,13 @@ all-features = true
 [dependencies]
 backon = { version = "1.6", features = ["tokio-sleep"] }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
 bytes = { workspace = true }
 futures = { workspace = true }
 logforth = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2" }
-opendal-layer-logging = { path = "../logging", version = "0.58.2" }
-opendal-layer-timeout = { path = "../timeout", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-layer-logging = { path = "../logging", version = "0.59.0" }
+opendal-layer-timeout = { path = "../timeout", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/route/Cargo.toml
+++ b/core/layers/route/Cargo.toml
@@ -33,10 +33,10 @@ all-features = true
 
 [dependencies]
 globset = "0.4.15"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2" }
-opendal-service-fs = { path = "../../services/fs", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-service-fs = { path = "../../services/fs", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/tail-cut/Cargo.toml
+++ b/core/layers/tail-cut/Cargo.toml
@@ -32,9 +32,9 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/throttle/Cargo.toml
+++ b/core/layers/throttle/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 governor = "0.10.4"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }

--- a/core/layers/timeout/Cargo.toml
+++ b/core/layers/timeout/Cargo.toml
@@ -32,11 +32,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2" }
-opendal-layer-retry = { path = "../retry", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-layer-retry = { path = "../retry", version = "0.59.0" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/tracing/Cargo.toml
+++ b/core/layers/tracing/Cargo.toml
@@ -34,13 +34,13 @@ all-features = true
 [dependencies]
 futures = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 tracing = "0.1"
 
 [dev-dependencies]
 anyhow = "1.0"
 dotenvy = "0.15"
-opendal-core = { path = "../../core", version = "0.58.2" }
+opendal-core = { path = "../../core", version = "0.59.0" }
 opentelemetry = { version = "0.32.0", default-features = false, features = [
   "trace",
 ] }

--- a/core/services/aliyun-drive/Cargo.toml
+++ b/core/services/aliyun-drive/Cargo.toml
@@ -36,7 +36,7 @@ asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/alluxio/Cargo.toml
+++ b/core/services/alluxio/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/azblob/Cargo.toml
+++ b/core/services/azblob/Cargo.toml
@@ -36,10 +36,10 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
   "reqsign",
 ] }
-opendal-service-azure-common = { path = "../azure-common", version = "0.58.2" }
+opendal-service-azure-common = { path = "../azure-common", version = "0.59.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.1.1", default-features = false }
 reqsign-core = { version = "3.2.0", default-features = false }

--- a/core/services/azdls/Cargo.toml
+++ b/core/services/azdls/Cargo.toml
@@ -37,10 +37,10 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
   "reqsign",
 ] }
-opendal-service-azure-common = { path = "../azure-common", version = "0.58.2" }
+opendal-service-azure-common = { path = "../azure-common", version = "0.59.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.1.1", default-features = false }
 reqsign-core = { version = "3.2.0", default-features = false }

--- a/core/services/azfile/Cargo.toml
+++ b/core/services/azfile/Cargo.toml
@@ -35,10 +35,10 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
   "reqsign",
 ] }
-opendal-service-azure-common = { path = "../azure-common", version = "0.58.2" }
+opendal-service-azure-common = { path = "../azure-common", version = "0.59.0" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.1.1", default-features = false }
 reqsign-core = { version = "3.2.0", default-features = false }

--- a/core/services/azure-common/Cargo.toml
+++ b/core/services/azure-common/Cargo.toml
@@ -33,4 +33,4 @@ all-features = true
 
 [dependencies]
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }

--- a/core/services/b2/Cargo.toml
+++ b/core/services/b2/Cargo.toml
@@ -36,7 +36,7 @@ asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/cacache/Cargo.toml
+++ b/core/services/cacache/Cargo.toml
@@ -37,7 +37,7 @@ cacache = { version = "13.0", default-features = false, features = [
   "tokio-runtime",
   "mmap",
 ] }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/cloudflare-kv/Cargo.toml
+++ b/core/services/cloudflare-kv/Cargo.toml
@@ -34,6 +34,6 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/compfs/Cargo.toml
+++ b/core/services/compfs/Cargo.toml
@@ -41,7 +41,7 @@ compio = { version = "0.19.0", features = [
   "runtime",
   "sync",
 ] }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/cos/Cargo.toml
+++ b/core/services/cos/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/d1/Cargo.toml
+++ b/core/services/d1/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/dashmap/Cargo.toml
+++ b/core/services/dashmap/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 dashmap = "6"
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/dbfs/Cargo.toml
+++ b/core/services/dbfs/Cargo.toml
@@ -36,7 +36,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/dropbox/Cargo.toml
+++ b/core/services/dropbox/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/etcd/Cargo.toml
+++ b/core/services/etcd/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 etcd-client = { version = "0.19.0", features = ["tls"] }
 fastpool = "1.0.2"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["time"] }
 

--- a/core/services/foundationdb/Cargo.toml
+++ b/core/services/foundationdb/Cargo.toml
@@ -36,7 +36,7 @@ foundationdb = { version = "0.11.0", features = [
   "embedded-fdb-include",
   "fdb-7_3",
 ] }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/foyer/Cargo.toml
+++ b/core/services/foyer/Cargo.toml
@@ -34,12 +34,12 @@ all-features = true
 [dependencies]
 foyer = { version = "0.22.3" }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-opendal = { path = "../..", version = "0.58.2", features = ["services-memory"] }
-opendal-core = { path = "../../core", version = "0.58.2", features = [
+opendal = { path = "../..", version = "0.59.0", features = ["services-memory"] }
+opendal-core = { path = "../../core", version = "0.59.0", features = [
   "services-memory",
 ] }
 size = "0.5"

--- a/core/services/fs/Cargo.toml
+++ b/core/services/fs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
   "internal-tokio-rt",
 ] }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/ftp/Cargo.toml
+++ b/core/services/ftp/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 fastpool = "1.0.2"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 rustls-native-certs = "0.8"
 serde = { workspace = true, features = ["derive"] }
 suppaftp = { version = "10.0.2", default-features = false, features = [

--- a/core/services/gcs-grpc/Cargo.toml
+++ b/core/services/gcs-grpc/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 futures = { workspace = true, features = ["async-await", "std"] }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
   "reqsign",
 ] }
 percent-encoding = "2"

--- a/core/services/gcs/Cargo.toml
+++ b/core/services/gcs/Cargo.toml
@@ -36,7 +36,7 @@ async-trait = "0.1"
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
   "reqsign",
 ] }
 percent-encoding = "2.3"

--- a/core/services/gdrive/Cargo.toml
+++ b/core/services/gdrive/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 asyncband = { workspace = true }
 bytes = { workspace = true }

--- a/core/services/ghac/Cargo.toml
+++ b/core/services/ghac/Cargo.toml
@@ -36,8 +36,8 @@ bytes = { workspace = true }
 ghac = { version = "0.3.0", default-features = false }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
-opendal-service-azblob = { path = "../azblob", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-service-azblob = { path = "../azblob", version = "0.59.0", default-features = false }
 prost = { version = "0.14.3", default-features = false }
 reqsign-azure-storage = { version = "3.1.1", default-features = false }
 reqsign-core = { version = "3.2.0", default-features = false }

--- a/core/services/github/Cargo.toml
+++ b/core/services/github/Cargo.toml
@@ -36,7 +36,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/goosefs/Cargo.toml
+++ b/core/services/goosefs/Cargo.toml
@@ -35,12 +35,12 @@ all-features = true
 bytes = { workspace = true }
 goosefs-sdk = "0.1.8"
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true }
 
 [dev-dependencies]
-opendal = { path = "../..", version = "0.58.2", features = [
+opendal = { path = "../..", version = "0.59.0", features = [
   "services-goosefs",
 ] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/gridfs/Cargo.toml
+++ b/core/services/gridfs/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 asyncband = { workspace = true }
 futures = { workspace = true }
 mongodb = "3.3.0"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/hdfs-native/Cargo.toml
+++ b/core/services/hdfs-native/Cargo.toml
@@ -36,5 +36,5 @@ bytes = { workspace = true }
 futures = { workspace = true }
 hdfs-native = { version = "0.14" }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/hdfs/Cargo.toml
+++ b/core/services/hdfs/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 bytes = { workspace = true }
 futures = { workspace = true }

--- a/core/services/hf/Cargo.toml
+++ b/core/services/hf/Cargo.toml
@@ -37,7 +37,7 @@ bytes = { workspace = true }
 hf-xet = "1.6.0"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 percent-encoding = "2"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -45,6 +45,6 @@ serde_json = { workspace = true }
 [dev-dependencies]
 base64 = { workspace = true }
 futures = { workspace = true }
-opendal-http-transport-reqwest = { path = "../../http-transports/reqwest", version = "0.58.2" }
+opendal-http-transport-reqwest = { path = "../../http-transports/reqwest", version = "0.59.0" }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/http/Cargo.toml
+++ b/core/services/http/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "opendal-service-http"
 readme = "README.md"
 repository = "https://github.com/apache/opendal"
-version = "0.58.2"
+version = "0.59.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -30,9 +30,9 @@ all-features = true
 [dependencies]
 http = "1.4"
 log = "0.4"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }

--- a/core/services/ipfs/Cargo.toml
+++ b/core/services/ipfs/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 prost = "0.14.3"
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/ipmfs/Cargo.toml
+++ b/core/services/ipmfs/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/koofr/Cargo.toml
+++ b/core/services/koofr/Cargo.toml
@@ -36,7 +36,7 @@ asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/lakefs/Cargo.toml
+++ b/core/services/lakefs/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/memcached/Cargo.toml
+++ b/core/services/memcached/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 fastpool = "1.0.2"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "time"] }
 url = { workspace = true }

--- a/core/services/mini_moka/Cargo.toml
+++ b/core/services/mini_moka/Cargo.toml
@@ -34,5 +34,5 @@ all-features = true
 [dependencies]
 log = { workspace = true }
 mini-moka = "0.10"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/moka/Cargo.toml
+++ b/core/services/moka/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 log = { workspace = true }
 moka = { version = "0.12", features = ["future", "sync"] }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/mongodb/Cargo.toml
+++ b/core/services/mongodb/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 asyncband = { workspace = true }
 mongodb = { version = "3.3.0" }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/monoiofs/Cargo.toml
+++ b/core/services/monoiofs/Cargo.toml
@@ -41,7 +41,7 @@ monoio = { version = "0.2.4", features = [
   "unlinkat",
   "renameat",
 ] }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/mysql/Cargo.toml
+++ b/core/services/mysql/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 asyncband = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "mysql"] }
 

--- a/core/services/obs/Cargo.toml
+++ b/core/services/obs/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/onedrive/Cargo.toml
+++ b/core/services/onedrive/Cargo.toml
@@ -36,7 +36,7 @@ asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time"] }

--- a/core/services/opfs/Cargo.toml
+++ b/core/services/opfs/Cargo.toml
@@ -35,7 +35,7 @@ targets = ["wasm32-unknown-unknown"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.77"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 send_wrapper = "0.6"
 serde = { workspace = true, features = ["derive"] }
 wasm-bindgen = "0.2.100"

--- a/core/services/oss/Cargo.toml
+++ b/core/services/oss/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/pcloud/Cargo.toml
+++ b/core/services/pcloud/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/persy/Cargo.toml
+++ b/core/services/persy/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 persy = "1.7.1"
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/postgresql/Cargo.toml
+++ b/core/services/postgresql/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 asyncband = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "postgres"] }
 

--- a/core/services/redb/Cargo.toml
+++ b/core/services/redb/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 redb = { version = "4" }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/redis/Cargo.toml
+++ b/core/services/redis/Cargo.toml
@@ -40,7 +40,7 @@ rustls = ["redis/tokio-rustls-comp"]
 bytes = { workspace = true }
 fastpool = "1.0.2"
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 redis = { version = "1.2", features = [
   "cluster-async",
   "tokio-comp",

--- a/core/services/rocksdb/Cargo.toml
+++ b/core/services/rocksdb/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 rocksdb = { version = "0.24.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/s3/Cargo.toml
+++ b/core/services/s3/Cargo.toml
@@ -38,7 +38,7 @@ crc-fast = "1.9.0"
 http = { workspace = true }
 log = { workspace = true }
 md-5 = "0.11.0"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/seafile/Cargo.toml
+++ b/core/services/seafile/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 asyncband = { workspace = true }
 bytes = { workspace = true }

--- a/core/services/sftp/Cargo.toml
+++ b/core/services/sftp/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 bytes = { workspace = true }
 fastpool = "1.0.2"

--- a/core/services/sled/Cargo.toml
+++ b/core/services/sled/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sled = "0.34.7"
 

--- a/core/services/sqlite/Cargo.toml
+++ b/core/services/sqlite/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 asyncband = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "sqlite"] }
 

--- a/core/services/surrealdb/Cargo.toml
+++ b/core/services/surrealdb/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 asyncband = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 surrealdb = { version = "3", features = ["protocol-http"] }
 

--- a/core/services/swift/Cargo.toml
+++ b/core/services/swift/Cargo.toml
@@ -37,7 +37,7 @@ bytes = { workspace = true }
 hmac = "0.13.0"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 percent-encoding = "2"
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/tikv/Cargo.toml
+++ b/core/services/tikv/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 asyncband = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tikv-client = { version = "0.4.0", default-features = false }
 

--- a/core/services/tos/Cargo.toml
+++ b/core/services/tos/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/upyun/Cargo.toml
+++ b/core/services/upyun/Cargo.toml
@@ -38,7 +38,7 @@ hmac = "0.13.0"
 http = { workspace = true }
 log = { workspace = true }
 md-5 = "0.11.0"
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/vercel-artifacts/Cargo.toml
+++ b/core/services/vercel-artifacts/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/vercel-blob/Cargo.toml
+++ b/core/services/vercel-blob/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/webdav/Cargo.toml
+++ b/core/services/webdav/Cargo.toml
@@ -37,7 +37,7 @@ asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/webhdfs/Cargo.toml
+++ b/core/services/webhdfs/Cargo.toml
@@ -37,7 +37,7 @@ asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/core/services/yandex-disk/Cargo.toml
+++ b/core/services/yandex-disk/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.58.2", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/testkit/Cargo.toml
+++ b/core/testkit/Cargo.toml
@@ -34,10 +34,10 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 dotenvy = "0.15"
-opendal-core = { path = "../core", version = "0.58.2", default-features = false }
-opendal-layer-logging = { path = "../layers/logging", version = "0.58.2", default-features = false }
-opendal-layer-retry = { path = "../layers/retry", version = "0.58.2", default-features = false }
-opendal-layer-timeout = { path = "../layers/timeout", version = "0.58.2", default-features = false }
+opendal-core = { path = "../core", version = "0.59.0", default-features = false }
+opendal-layer-logging = { path = "../layers/logging", version = "0.59.0", default-features = false }
+opendal-layer-retry = { path = "../layers/retry", version = "0.59.0", default-features = false }
+opendal-layer-timeout = { path = "../layers/timeout", version = "0.59.0", default-features = false }
 rand = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/dev/src/release/package.rs
+++ b/dev/src/release/package.rs
@@ -87,26 +87,26 @@ fn make_package(path: &str, version: &str, dependencies: Vec<Package>) -> Packag
 
 /// List all packages that are ready for release.
 pub fn all_packages() -> Vec<Package> {
-    let core = make_package("core", "0.58.2", vec![]);
+    let core = make_package("core", "0.59.0", vec![]);
 
     // Integrations
-    let dav_server = make_package("integrations/dav-server", "0.7.5", vec![core.clone()]);
-    let object_store = make_package("integrations/object_store", "0.59.0", vec![core.clone()])
+    let dav_server = make_package("integrations/dav-server", "0.7.6", vec![core.clone()]);
+    let object_store = make_package("integrations/object_store", "0.60.0", vec![core.clone()])
         .with_public_compat_dependencies(&["opendal", "object_store"]);
-    let parquet = make_package("integrations/parquet", "0.9.1", vec![core.clone()])
+    let parquet = make_package("integrations/parquet", "0.10.0", vec![core.clone()])
         .with_public_compat_dependencies(&["opendal", "parquet"]);
-    let unftp_sbe = make_package("integrations/unftp-sbe", "0.4.5", vec![core.clone()]);
+    let unftp_sbe = make_package("integrations/unftp-sbe", "0.4.6", vec![core.clone()]);
 
     // Binaries moved to separate repositories; no longer released from this repo
 
     // Bindings
-    let c = make_package("bindings/c", "0.47.2", vec![core.clone()]);
-    let cpp = make_package("bindings/cpp", "0.45.29", vec![core.clone()]);
-    let java = make_package("bindings/java", "0.50.2", vec![core.clone()]);
-    let nodejs = make_package("bindings/nodejs", "0.49.7", vec![core.clone()]);
-    let python = make_package("bindings/python", "0.47.6", vec![core.clone()]);
-    let ruby = make_package("bindings/ruby", "0.1.10", vec![core.clone()]);
-    let dotnet = make_package("bindings/dotnet", "0.1.2", vec![core.clone()]);
+    let c = make_package("bindings/c", "0.47.3", vec![core.clone()]);
+    let cpp = make_package("bindings/cpp", "0.45.30", vec![core.clone()]);
+    let java = make_package("bindings/java", "0.50.3", vec![core.clone()]);
+    let nodejs = make_package("bindings/nodejs", "0.49.8", vec![core.clone()]);
+    let python = make_package("bindings/python", "0.47.7", vec![core.clone()]);
+    let ruby = make_package("bindings/ruby", "0.1.11", vec![core.clone()]);
+    let dotnet = make_package("bindings/dotnet", "0.2.0", vec![core.clone()]);
 
     vec![
         core,
@@ -226,22 +226,12 @@ fn update_dependency_version(
     manifest_dir: &Path,
     dependency: &Package,
 ) -> bool {
-    let Some(crate_name) = dependency.crate_name() else {
-        return false;
-    };
-
-    update_dependency_version_in_table(
-        manifest.as_table_mut(),
-        manifest_dir,
-        crate_name,
-        dependency,
-    )
+    update_dependency_version_in_table(manifest.as_table_mut(), manifest_dir, dependency)
 }
 
 fn update_dependency_version_in_table(
     table: &mut dyn TableLike,
     manifest_dir: &Path,
-    crate_name: &str,
     dependency: &Package,
 ) -> bool {
     let mut updated = false;
@@ -251,12 +241,8 @@ fn update_dependency_version_in_table(
             continue;
         };
 
-        updated |= update_dependency_version_in_dependencies(
-            dependencies,
-            manifest_dir,
-            crate_name,
-            dependency,
-        );
+        updated |=
+            update_dependency_version_in_dependencies(dependencies, manifest_dir, dependency);
     }
 
     let Some(targets) = table.get_mut("target").and_then(Item::as_table_like_mut) else {
@@ -267,7 +253,7 @@ fn update_dependency_version_in_table(
         let Some(target) = target.as_table_like_mut() else {
             continue;
         };
-        updated |= update_dependency_version_in_table(target, manifest_dir, crate_name, dependency);
+        updated |= update_dependency_version_in_table(target, manifest_dir, dependency);
     }
 
     updated
@@ -276,43 +262,42 @@ fn update_dependency_version_in_table(
 fn update_dependency_version_in_dependencies(
     dependencies: &mut dyn TableLike,
     manifest_dir: &Path,
-    crate_name: &str,
     dependency: &Package,
 ) -> bool {
-    let Some(entry) = dependencies.get_mut(crate_name) else {
-        return false;
-    };
-    let Some(entry) = entry.as_table_like_mut() else {
-        return false;
-    };
-    let Some(path) = entry.get("path").and_then(Item::as_str) else {
-        return false;
-    };
-    if !path_points_to(manifest_dir, path, &dependency.path) {
-        return false;
+    let mut updated = false;
+
+    for (crate_name, entry) in dependencies.iter_mut() {
+        let Some(entry) = entry.as_table_like_mut() else {
+            continue;
+        };
+        let Some(path) = entry.get("path").and_then(Item::as_str) else {
+            continue;
+        };
+        if !path_points_into(manifest_dir, path, &dependency.path) {
+            continue;
+        }
+        let Some(value) = entry.get_mut("version") else {
+            continue;
+        };
+
+        let old_version = match value.as_str().map(Version::parse) {
+            Some(Ok(version)) => version,
+            _ => continue,
+        };
+
+        if old_version == dependency.version {
+            continue;
+        }
+
+        *value = toml_edit::value(dependency.version.to_string());
+        println!(
+            "updating dependency version for crate: {} from {} to {}",
+            crate_name, old_version, dependency.version
+        );
+        updated = true;
     }
-    let Some(value) = entry.get_mut("version") else {
-        return false;
-    };
 
-    let old_version = match value.as_str() {
-        Some(version) => match Version::parse(version) {
-            Ok(version) => version,
-            Err(_) => return false,
-        },
-        None => panic!("missing dependency version for crate: {crate_name}"),
-    };
-
-    if old_version == dependency.version {
-        return false;
-    }
-
-    *value = toml_edit::value(dependency.version.to_string());
-    println!(
-        "updating dependency version for crate: {} from {} to {}",
-        crate_name, old_version, dependency.version
-    );
-    true
+    updated
 }
 
 fn is_core_workspace_root(path: &Path) -> bool {
@@ -457,12 +442,8 @@ fn sync_workspace_internal_dependency_versions_in_dependencies(
     updated
 }
 
-fn path_points_to(manifest_dir: &Path, raw_path: &str, expected: &Path) -> bool {
-    normalize_path(&manifest_dir.join(raw_path)) == normalize_path(expected)
-}
-
 fn path_points_into(manifest_dir: &Path, raw_path: &str, workspace_root: &Path) -> bool {
-    normalize_path(&manifest_dir.join(raw_path)).starts_with(workspace_root)
+    normalize_path(&manifest_dir.join(raw_path)).starts_with(normalize_path(workspace_root))
 }
 
 fn normalize_path(path: &Path) -> PathBuf {
@@ -706,6 +687,7 @@ version = "0.8.0"
 
 [dependencies]
 opendal = { version = "0.55.0", path = "../../core" }
+opendal-core = { version = "0.55.0", path = "../../core/core" }
 serde = "1"
 
 [dev-dependencies]
@@ -730,6 +712,11 @@ opendal = { version = "0.55.0", path = "../core" }
             dependencies: vec![],
             public_compat_dependencies: &[],
         };
+        assert!(path_points_into(
+            dir.as_path(),
+            "../../core",
+            &dependency.path
+        ));
 
         let updated = update_cargo_version(
             dir.as_path(),
@@ -743,6 +730,10 @@ opendal = { version = "0.55.0", path = "../core" }
 
         assert_eq!(
             manifest["dependencies"]["opendal"]["version"].as_str(),
+            Some("0.56.0")
+        );
+        assert_eq!(
+            manifest["dependencies"]["opendal-core"]["version"].as_str(),
             Some("0.56.0")
         );
         assert_eq!(

--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 description = "Use OpenDAL as a backend to access data in various service with WebDAV protocol"
 name = "dav-server-opendalfs"
-version = "0.7.5"
+version = "0.7.6"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2024"
@@ -32,10 +32,10 @@ anyhow = "1"
 bytes = { version = "1.4.0" }
 dav-server = { version = "0.11.0" }
 futures = "0.3"
-opendal-core = { version = "0.58.1", path = "../../core/core", default-features = false }
+opendal-core = { version = "0.59.0", path = "../../core/core", default-features = false }
 
 [dev-dependencies]
-opendal = { version = "0.58.2", path = "../../core", features = [
+opendal = { version = "0.59.0", path = "../../core", features = [
   "services-fs",
 ] }
 tokio = { version = "1.27", features = ["macros", "rt-multi-thread", "io-std"] }

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -11,7 +11,7 @@ block-buffer@0.10.4	X			X
 block-buffer@0.12.1	X			X				
 bumpalo@3.20.3	X			X				
 bytes@1.12.1				X				
-cc@1.4.3	X			X				
+cc@1.4.4	X			X				
 cfg-if@1.0.4	X			X				
 chrono@0.4.45	X			X				
 const-oid@0.10.2	X			X				
@@ -20,7 +20,7 @@ cpufeatures@0.2.17	X			X
 crypto-common@0.1.7	X			X				
 crypto-common@0.2.2	X			X				
 dav-server@0.11.0	X							
-dav-server-opendalfs@0.7.5	X							
+dav-server-opendalfs@0.7.6	X							
 derive-where@1.6.1	X			X				
 digest@0.10.7	X			X				
 digest@0.11.3	X			X				
@@ -60,7 +60,7 @@ icu_normalizer@2.3.0						X
 icu_normalizer_data@2.3.0						X		
 icu_properties@2.3.0						X		
 icu_properties_data@2.3.0						X		
-icu_provider@2.3.0						X		
+icu_provider@2.3.1						X		
 idna@1.1.0	X			X				
 idna_adapter@1.2.2	X			X				
 itoa@1.0.18	X			X				
@@ -74,7 +74,7 @@ libc@0.2.189	X			X
 linux-raw-sys@0.12.1	X	X		X				
 litemap@0.8.3						X		
 lock_api@0.4.14	X			X				
-log@0.4.33	X			X				
+log@0.4.34	X			X				
 lru@0.16.4				X				
 md-5@0.11.0	X			X				
 memchr@2.8.3				X			X	
@@ -83,7 +83,7 @@ mime_guess@2.0.5				X
 mio@1.2.2				X				
 num-traits@0.2.19	X			X				
 once_cell@1.21.4	X			X				
-opendal-core@0.58.2	X							
+opendal-core@0.59.0	X							
 parking_lot@0.12.5	X			X				
 parking_lot_core@0.9.12	X			X				
 percent-encoding@2.3.2	X			X				
@@ -111,7 +111,7 @@ smallvec@1.15.2	X			X
 socket2@0.6.5	X			X				
 stable_deref_trait@1.2.1	X			X				
 syn@2.0.119	X			X				
-syn@3.0.3	X			X				
+syn@3.0.4	X			X				
 synstructure@0.13.2				X				
 tinystr@0.8.4						X		
 tokio@1.53.1				X				
@@ -121,7 +121,7 @@ unicase@2.9.0	X			X
 unicode-ident@1.0.24	X			X		X		
 url@2.5.8	X			X				
 utf8_iter@1.0.4	X			X				
-uuid@1.24.1	X			X				
+uuid@1.26.0	X			X				
 version_check@0.9.5	X			X				
 wasi@0.11.1+wasi-snapshot-preview1	X	X		X				
 wasm-bindgen@0.2.127	X			X				
@@ -150,6 +150,6 @@ yoke-derive@0.8.2						X
 zerofrom@0.1.8						X		
 zerofrom-derive@0.1.7						X		
 zerotrie@0.2.5						X		
-zerovec@0.11.7						X		
-zerovec-derive@0.11.4						X		
+zerovec@0.11.8						X		
+zerovec-derive@0.11.6						X		
 zmij@1.0.23				X				

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.59.0"
+version = "0.60.0"
 
 [features]
 send_wrapper = ["dep:send_wrapper"]
@@ -43,7 +43,7 @@ bytes = "1"
 chrono = { version = "0.4.42", features = ["std", "clock"] }
 futures = "0.3"
 object_store = "0.14.1"
-opendal = { version = "0.58.2", path = "../../core", default-features = false }
+opendal = { version = "0.59.0", path = "../../core", default-features = false }
 pin-project = "1.1"
 send_wrapper = { version = "0.6", features = ["futures"], optional = true }
 tokio = { version = "1", default-features = false }
@@ -51,7 +51,7 @@ tokio = { version = "1", default-features = false }
 [dev-dependencies]
 anyhow = "1.0.86"
 libtest-mimic = "0.8.1"
-opendal = { version = "0.58.2", path = "../../core", features = [
+opendal = { version = "0.59.0", path = "../../core", features = [
   "services-fs",
   "services-memory",
   "services-s3",

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -14,20 +14,20 @@ bitflags@2.13.1	X								X
 block-buffer@0.12.1	X								X			
 bumpalo@3.20.3	X								X			
 bytes@1.12.1									X			
-cc@1.4.3	X								X			
+cc@1.4.4	X								X			
 cfg-if@1.0.4	X								X			
 cfg_aliases@0.2.2									X			
-chacha20@0.10.1	X								X			
+chacha20@0.10.2	X								X			
 chrono@0.4.45	X								X			
 cmake@0.1.58	X								X			
 cmov@0.5.4	X								X			
-combine@4.6.7									X			
+combine@4.6.8									X			
 const-oid@0.10.2	X								X			
 const-random@0.1.18	X								X			
 const-random-macro@0.1.16	X								X			
 core-foundation@0.10.1	X								X			
 core-foundation-sys@0.8.7	X								X			
-cpufeatures@0.3.0	X								X			
+cpufeatures@0.3.1	X								X			
 crc-fast@1.10.0	X								X			
 crunchy@0.2.4									X			
 crypto-common@0.1.7	X								X			
@@ -40,7 +40,7 @@ displaydoc@0.2.7	X								X
 dlv-list@0.5.2	X								X			
 dotenvy@0.15.7									X			
 dunce@1.0.5	X				X					X		
-either@1.17.0	X								X			
+either@1.18.0	X								X			
 errno@0.3.14	X								X			
 fastrand@2.5.0	X								X			
 find-msvc-tools@0.1.11	X								X			
@@ -69,7 +69,7 @@ http-body-util@0.1.5									X
 httparse@1.10.1	X								X			
 humantime@2.4.0	X								X			
 hybrid-array@0.4.14	X								X			
-hyper@1.11.0									X			
+hyper@1.11.1									X			
 hyper-rustls@0.27.9	X						X		X			
 hyper-util@0.1.20									X			
 iana-time-zone@0.1.65	X								X			
@@ -80,7 +80,7 @@ icu_normalizer@2.3.0											X
 icu_normalizer_data@2.3.0											X	
 icu_properties@2.3.0											X	
 icu_properties_data@2.3.0											X	
-icu_provider@2.3.0											X	
+icu_provider@2.3.1											X	
 idna@1.1.0	X								X			
 idna_adapter@1.2.2	X								X			
 ipnet@2.12.1	X								X			
@@ -102,25 +102,26 @@ linktime-proc-macro@0.2.3	X								X
 linux-raw-sys@0.12.1	X	X							X			
 litemap@0.8.3											X	
 lock_api@0.4.14	X								X			
-log@0.4.33	X								X			
+log@0.4.34	X								X			
 md-5@0.11.0	X								X			
+mea@0.6.7	X											
 memchr@2.8.3									X			X
 mio@1.2.2									X			
 nix@0.31.3									X			
 num-traits@0.2.19	X								X			
 object_store@0.14.1	X								X			
-object_store_opendal@0.59.0	X											
+object_store_opendal@0.60.0	X											
 once_cell@1.21.4	X								X			
-opendal@0.58.2	X											
-opendal-core@0.58.2	X											
-opendal-http-transport-reqwest@0.58.2	X											
-opendal-layer-concurrent-limit@0.58.2	X											
-opendal-layer-logging@0.58.2	X											
-opendal-layer-retry@0.58.2	X											
-opendal-layer-timeout@0.58.2	X											
-opendal-service-fs@0.58.2	X											
-opendal-service-s3@0.58.2	X											
-opendal-testkit@0.58.2	X											
+opendal@0.59.0	X											
+opendal-core@0.59.0	X											
+opendal-http-transport-reqwest@0.59.0	X											
+opendal-layer-concurrent-limit@0.59.0	X											
+opendal-layer-logging@0.59.0	X											
+opendal-layer-retry@0.59.0	X											
+opendal-layer-timeout@0.59.0	X											
+opendal-service-fs@0.59.0	X											
+opendal-service-s3@0.59.0	X											
+opendal-testkit@0.59.0	X											
 openssl-probe@0.2.1	X								X			
 ordered-multimap@0.7.3									X			
 parking_lot@0.12.5	X								X			
@@ -140,10 +141,10 @@ r-efi@6.0.0	X							X	X
 rand@0.10.2	X								X			
 rand_core@0.10.1	X								X			
 redox_syscall@0.5.18									X			
-reqsign-aws-core@3.1.0	X											
-reqsign-aws-v4@3.2.0	X											
-reqsign-core@3.3.0	X											
-reqsign-file-read-tokio@3.0.5	X											
+reqsign-aws-core@3.1.1	X											
+reqsign-aws-v4@3.3.0	X											
+reqsign-core@3.3.1	X											
+reqsign-file-read-tokio@3.0.6	X											
 reqwest@0.13.4	X								X			
 rust-ini@0.21.3									X			
 rustc_version@0.4.1	X								X			
@@ -153,7 +154,7 @@ rustls-native-certs@0.8.4	X						X		X
 rustls-pki-types@1.15.1	X								X			
 rustls-platform-verifier@0.7.0	X								X			
 rustls-platform-verifier-android@0.1.1	X								X			
-rustls-webpki@0.103.14							X					
+rustls-webpki@0.103.15							X					
 rustversion@1.0.23	X								X			
 ryu@1.0.23	X			X								
 same-file@1.0.6									X			X
@@ -179,7 +180,7 @@ spin@0.10.1									X
 stable_deref_trait@1.2.1	X								X			
 subtle@2.6.1			X									
 syn@2.0.119	X								X			
-syn@3.0.3	X								X			
+syn@3.0.4	X								X			
 sync_wrapper@1.0.2	X											
 synstructure@0.13.2									X			
 thiserror@2.0.20	X								X			
@@ -203,7 +204,7 @@ unicode-ident@1.0.24	X								X		X
 untrusted@0.9.0							X					
 url@2.5.8	X								X			
 utf8_iter@1.0.4	X								X			
-uuid@1.24.1	X								X			
+uuid@1.26.0	X								X			
 version_check@0.9.5	X								X			
 walkdir@2.5.0									X			X
 want@0.3.1									X			
@@ -233,6 +234,6 @@ zerofrom@0.1.8											X
 zerofrom-derive@0.1.7											X	
 zeroize@1.9.0	X								X			
 zerotrie@0.2.5											X	
-zerovec@0.11.7											X	
-zerovec-derive@0.11.4											X	
+zerovec@0.11.8											X	
+zerovec-derive@0.11.6											X	
 zmij@1.0.23									X			

--- a/integrations/object_store/upgrade.md
+++ b/integrations/object_store/upgrade.md
@@ -1,3 +1,16 @@
+# Upgrade to v0.60
+
+## Upgrade OpenDAL to v0.59
+
+`object_store_opendal` 0.60 uses `opendal` 0.59 while continuing to implement the `object_store` 0.14 API. Update both OpenDAL dependencies together when they appear in the same dependency graph:
+
+```diff
+-opendal = "0.58"
+-object_store_opendal = "0.59"
++opendal = "0.59"
++object_store_opendal = "0.60"
+```
+
 # Upgrade to v0.59
 
 ## Upgrade `object_store` to v0.14

--- a/integrations/parquet/Cargo.toml
+++ b/integrations/parquet/Cargo.toml
@@ -25,13 +25,13 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.9.1"
+version = "0.10.0"
 
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
-opendal = { version = "0.58.2", path = "../../core" }
+opendal = { version = "0.59.0", path = "../../core" }
 parquet = { version = "59.0", default-features = false, features = [
   "async",
   "arrow",
@@ -39,7 +39,7 @@ parquet = { version = "59.0", default-features = false, features = [
 
 [dev-dependencies]
 arrow = { version = "59.0" }
-opendal = { version = "0.58.2", path = "../../core", features = [
+opendal = { version = "0.59.0", path = "../../core", features = [
   "services-memory",
   "services-s3",
 ] }

--- a/integrations/parquet/DEPENDENCIES.rust.tsv
+++ b/integrations/parquet/DEPENDENCIES.rust.tsv
@@ -21,18 +21,18 @@ bitflags@2.13.1	X									X
 block-buffer@0.12.1	X									X			
 bumpalo@3.20.3	X									X			
 bytes@1.12.1										X			
-cc@1.4.3	X									X			
+cc@1.4.4	X									X			
 cfg-if@1.0.4	X									X			
 chrono@0.4.45	X									X			
 cmake@0.1.58	X									X			
 cmov@0.5.4	X									X			
-combine@4.6.7										X			
+combine@4.6.8										X			
 const-oid@0.10.2	X									X			
 const-random@0.1.18	X									X			
 const-random-macro@0.1.16	X									X			
 core-foundation@0.10.1	X									X			
 core-foundation-sys@0.8.7	X									X			
-cpufeatures@0.3.0	X									X			
+cpufeatures@0.3.1	X									X			
 crc-fast@1.10.0	X									X			
 crunchy@0.2.4										X			
 crypto-common@0.1.7	X									X			
@@ -73,7 +73,7 @@ http-body@1.1.0										X
 http-body-util@0.1.5										X			
 httparse@1.10.1	X									X			
 hybrid-array@0.4.14	X									X			
-hyper@1.11.0										X			
+hyper@1.11.1										X			
 hyper-rustls@0.27.9	X							X		X			
 hyper-util@0.1.20										X			
 iana-time-zone@0.1.65	X									X			
@@ -84,7 +84,7 @@ icu_normalizer@2.3.0												X
 icu_normalizer_data@2.3.0												X	
 icu_properties@2.3.0												X	
 icu_properties_data@2.3.0												X	
-icu_provider@2.3.0												X	
+icu_provider@2.3.1												X	
 idna@1.1.0	X									X			
 idna_adapter@1.2.2	X									X			
 ipnet@2.12.1	X									X			
@@ -104,8 +104,9 @@ libm@0.2.16										X
 link-section@0.19.3	X									X			
 linktime-proc-macro@0.2.3	X									X			
 litemap@0.8.3												X	
-log@0.4.33	X									X			
+log@0.4.34	X									X			
 md-5@0.11.0	X									X			
+mea@0.6.7	X												
 memchr@2.8.3										X			X
 mio@1.2.2										X			
 num-bigint@0.5.1	X									X			
@@ -113,18 +114,18 @@ num-complex@0.4.6	X									X
 num-integer@0.1.47	X									X			
 num-traits@0.2.19	X									X			
 once_cell@1.21.4	X									X			
-opendal@0.58.2	X												
-opendal-core@0.58.2	X												
-opendal-http-transport-reqwest@0.58.2	X												
-opendal-layer-concurrent-limit@0.58.2	X												
-opendal-layer-logging@0.58.2	X												
-opendal-layer-retry@0.58.2	X												
-opendal-layer-timeout@0.58.2	X												
-opendal-service-s3@0.58.2	X												
+opendal@0.59.0	X												
+opendal-core@0.59.0	X												
+opendal-http-transport-reqwest@0.59.0	X												
+opendal-layer-concurrent-limit@0.59.0	X												
+opendal-layer-logging@0.59.0	X												
+opendal-layer-retry@0.59.0	X												
+opendal-layer-timeout@0.59.0	X												
+opendal-service-s3@0.59.0	X												
 openssl-probe@0.2.1	X									X			
 ordered-multimap@0.7.3										X			
 parquet@59.2.0	X												
-parquet_opendal@0.9.1	X												
+parquet_opendal@0.10.0	X												
 percent-encoding@2.3.2	X									X			
 pin-project-lite@0.2.17	X									X			
 pkg-config@0.3.34	X									X			
@@ -137,10 +138,10 @@ quote@1.0.47	X									X
 r-efi@5.3.0	X								X	X			
 r-efi@6.0.0	X								X	X			
 rand_core@0.10.1	X									X			
-reqsign-aws-core@3.1.0	X												
-reqsign-aws-v4@3.2.0	X												
-reqsign-core@3.3.0	X												
-reqsign-file-read-tokio@3.0.5	X												
+reqsign-aws-core@3.1.1	X												
+reqsign-aws-v4@3.3.0	X												
+reqsign-core@3.3.1	X												
+reqsign-file-read-tokio@3.0.6	X												
 reqwest@0.13.4	X									X			
 rust-ini@0.21.3										X			
 rustc_version@0.4.1	X									X			
@@ -149,7 +150,7 @@ rustls-native-certs@0.8.4	X							X		X
 rustls-pki-types@1.15.1	X									X			
 rustls-platform-verifier@0.7.0	X									X			
 rustls-platform-verifier-android@0.1.1	X									X			
-rustls-webpki@0.103.14								X					
+rustls-webpki@0.103.15								X					
 rustversion@1.0.23	X									X			
 ryu@1.0.23	X				X								
 same-file@1.0.6										X			X
@@ -175,7 +176,7 @@ spin@0.10.1										X
 stable_deref_trait@1.2.1	X									X			
 subtle@2.6.1				X									
 syn@2.0.119	X									X			
-syn@3.0.3	X									X			
+syn@3.0.4	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
 thiserror@2.0.20	X									X			
@@ -193,13 +194,13 @@ tower-service@0.3.3										X
 tracing@0.1.44										X			
 tracing-core@0.1.36										X			
 try-lock@0.2.5										X			
-twox-hash@2.1.3										X			
+twox-hash@2.1.4										X			
 typenum@1.20.1	X									X			
 unicode-ident@1.0.24	X									X		X	
 untrusted@0.9.0								X					
 url@2.5.8	X									X			
 utf8_iter@1.0.4	X									X			
-uuid@1.24.1	X									X			
+uuid@1.26.0	X									X			
 version_check@0.9.5	X									X			
 walkdir@2.5.0										X			X
 want@0.3.1										X			
@@ -232,6 +233,6 @@ zerofrom@0.1.8												X
 zerofrom-derive@0.1.7												X	
 zeroize@1.9.0	X									X			
 zerotrie@0.2.5												X	
-zerovec@0.11.7												X	
-zerovec-derive@0.11.4												X	
+zerovec@0.11.8												X	
+zerovec-derive@0.11.6												X	
 zmij@1.0.23										X			

--- a/integrations/parquet/upgrade.md
+++ b/integrations/parquet/upgrade.md
@@ -1,3 +1,16 @@
+# Upgrade to v0.10
+
+## Upgrade OpenDAL to v0.59
+
+`parquet_opendal` 0.10 uses `opendal` 0.59. Update both dependencies together when they appear in the same dependency graph:
+
+```diff
+-opendal = "0.58"
+-parquet_opendal = "0.9"
++opendal = "0.59"
++parquet_opendal = "0.10"
+```
+
 # Upgrade to v0.9
 
 ## Bump Arrow and Parquet versions to v59

--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -24,11 +24,11 @@ license = "Apache-2.0"
 name = "unftp-sbe-opendal"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.4.5"
+version = "0.4.6"
 
 [dependencies]
 async-trait = "0.1.88"
-opendal = { version = "0.58.2", path = "../../core" }
+opendal = { version = "0.59.0", path = "../../core" }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.7.11", features = ["compat"] }
 unftp-core = "0.1.0"
@@ -36,7 +36,7 @@ unftp-core = "0.1.0"
 [dev-dependencies]
 anyhow = "1"
 libunftp = "0.23.0"
-opendal = { version = "0.58.2", path = "../../core", features = [
+opendal = { version = "0.59.0", path = "../../core", features = [
   "services-s3",
 ] }
 tokio = { version = "1.38.0", default-features = false, features = [

--- a/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
+++ b/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
@@ -18,19 +18,19 @@ block-buffer@0.10.4	X								X
 block-buffer@0.12.1	X								X			
 bumpalo@3.20.3	X								X			
 bytes@1.12.1									X			
-cc@1.4.3	X								X			
+cc@1.4.4	X								X			
 cfg-if@1.0.4	X								X			
 chrono@0.4.45	X								X			
 cmake@0.1.58	X								X			
 cmov@0.5.4	X								X			
-combine@4.6.7									X			
+combine@4.6.8									X			
 const-oid@0.10.2	X								X			
 const-random@0.1.18	X								X			
 const-random-macro@0.1.16	X								X			
 convert_case@0.10.0									X			
 core-foundation@0.10.1	X								X			
 core-foundation-sys@0.8.7	X								X			
-cpufeatures@0.3.0	X								X			
+cpufeatures@0.3.1	X								X			
 crc-fast@1.10.0	X								X			
 crunchy@0.2.4									X			
 crypto-common@0.1.7	X								X			
@@ -74,7 +74,7 @@ http-body@1.1.0									X
 http-body-util@0.1.5									X			
 httparse@1.10.1	X								X			
 hybrid-array@0.4.14	X								X			
-hyper@1.11.0									X			
+hyper@1.11.1									X			
 hyper-rustls@0.27.9	X						X		X			
 hyper-util@0.1.20									X			
 iana-time-zone@0.1.65	X								X			
@@ -85,7 +85,7 @@ icu_normalizer@2.3.0											X
 icu_normalizer_data@2.3.0											X	
 icu_properties@2.3.0											X	
 icu_properties_data@2.3.0											X	
-icu_provider@2.3.0											X	
+icu_provider@2.3.1											X	
 idna@1.1.0	X								X			
 idna_adapter@1.2.2	X								X			
 ipnet@2.12.1	X								X			
@@ -105,9 +105,10 @@ libc@0.2.189	X								X
 link-section@0.19.3	X								X			
 linktime-proc-macro@0.2.3	X								X			
 litemap@0.8.3											X	
-log@0.4.33	X								X			
+log@0.4.34	X								X			
 md-5@0.10.6	X								X			
 md-5@0.11.0	X								X			
+mea@0.6.7	X											
 memchr@2.8.3									X			X
 minimal-lexical@0.2.1	X								X			
 mio@1.2.2									X			
@@ -118,14 +119,14 @@ num-integer@0.1.47	X								X
 num-traits@0.2.19	X								X			
 oid-registry@0.8.1	X								X			
 once_cell@1.21.4	X								X			
-opendal@0.58.2	X											
-opendal-core@0.58.2	X											
-opendal-http-transport-reqwest@0.58.2	X											
-opendal-layer-concurrent-limit@0.58.2	X											
-opendal-layer-logging@0.58.2	X											
-opendal-layer-retry@0.58.2	X											
-opendal-layer-timeout@0.58.2	X											
-opendal-service-s3@0.58.2	X											
+opendal@0.59.0	X											
+opendal-core@0.59.0	X											
+opendal-http-transport-reqwest@0.59.0	X											
+opendal-layer-concurrent-limit@0.59.0	X											
+opendal-layer-logging@0.59.0	X											
+opendal-layer-retry@0.59.0	X											
+opendal-layer-timeout@0.59.0	X											
+opendal-service-s3@0.59.0	X											
 openssl-probe@0.2.1	X								X			
 ordered-multimap@0.7.3									X			
 percent-encoding@2.3.2	X								X			
@@ -139,10 +140,10 @@ proc-macro2@1.0.107	X								X
 quick-xml@0.41.0									X			
 quote@1.0.47	X								X			
 r-efi@6.0.0	X							X	X			
-reqsign-aws-core@3.1.0	X											
-reqsign-aws-v4@3.2.0	X											
-reqsign-core@3.3.0	X											
-reqsign-file-read-tokio@3.0.5	X											
+reqsign-aws-core@3.1.1	X											
+reqsign-aws-v4@3.3.0	X											
+reqsign-core@3.3.1	X											
+reqsign-file-read-tokio@3.0.6	X											
 reqwest@0.13.4	X								X			
 rust-ini@0.21.3									X			
 rustc_version@0.4.1	X								X			
@@ -152,7 +153,7 @@ rustls-native-certs@0.8.4	X						X		X
 rustls-pki-types@1.15.1	X								X			
 rustls-platform-verifier@0.7.0	X								X			
 rustls-platform-verifier-android@0.1.1	X								X			
-rustls-webpki@0.103.14							X					
+rustls-webpki@0.103.15							X					
 rustversion@1.0.23	X								X			
 ryu@1.0.23	X			X								
 same-file@1.0.6									X			X
@@ -178,7 +179,7 @@ spin@0.10.1									X
 stable_deref_trait@1.2.1	X								X			
 subtle@2.6.1			X									
 syn@2.0.119	X								X			
-syn@3.0.3	X								X			
+syn@3.0.4	X								X			
 sync_wrapper@1.0.2	X											
 synstructure@0.13.2									X			
 thiserror@2.0.20	X								X			
@@ -201,14 +202,14 @@ tracing-core@0.1.36									X
 try-lock@0.2.5									X			
 typenum@1.20.1	X								X			
 unftp-core@0.1.0	X											
-unftp-sbe-opendal@0.4.5	X											
+unftp-sbe-opendal@0.4.6	X											
 unicode-ident@1.0.24	X								X		X	
 unicode-segmentation@1.13.3	X								X			
 unicode-xid@0.2.6	X								X			
 untrusted@0.9.0							X					
 url@2.5.8	X								X			
 utf8_iter@1.0.4	X								X			
-uuid@1.24.1	X								X			
+uuid@1.26.0	X								X			
 version_check@0.9.5	X								X			
 walkdir@2.5.0									X			X
 want@0.3.1									X			
@@ -238,6 +239,6 @@ zerofrom@0.1.8											X
 zerofrom-derive@0.1.7											X	
 zeroize@1.9.0	X								X			
 zerotrie@0.2.5											X	
-zerovec@0.11.7											X	
-zerovec-derive@0.11.4											X	
+zerovec@0.11.8											X	
+zerovec-derive@0.11.6											X	
 zmij@1.0.23									X			


### PR DESCRIPTION
# Which issue does this PR close?

N/A.

# Rationale for this change

Prepare the Apache OpenDAL 0.59.0 source release and its independently versioned bindings and integrations.

# What changes are included in this PR?

This PR updates package versions, dependency manifests, generated Node.js metadata, and the changelog. It also documents core breaking changes since v0.58.2 and adds package-specific upgrade guidance for `object_store_opendal` 0.60 and `parquet_opendal` 0.10.

# Are there any user-facing changes?

Yes. Users upgrading the Rust core should follow the v0.59 migration guidance for metadata construction, delete inputs, conditional error semantics, raw operation arguments, and service duration configuration. The integration upgrade guides describe the corresponding OpenDAL dependency updates.

# AI Usage Statement

AI materially assisted with auditing the public API changes since v0.58.2 and drafting the upgrade guidance. The release scope, package versions, and documented migration requirements were reviewed by the release manager.
