### PR TITLE
docs: add conda-forge installation instructions

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -24,8 +24,16 @@ version.
 
 ## Installation
 
+Install from PyPI:
+
 ```bash
 pip install opendal
+```
+
+Or install from [conda-forge](https://anaconda.org/conda-forge/opendal):
+
+```bash
+conda install conda-forge::opendal
 ```
 
 ## Quickstart

--- a/bindings/python/docs/index.md
+++ b/bindings/python/docs/index.md
@@ -2,8 +2,16 @@
 
 ## Installation
 
+Install from PyPI:
+
 ```bash
 pip install opendal
+```
+
+Or install from [conda-forge](https://anaconda.org/conda-forge/opendal):
+
+```bash
+conda install conda-forge::opendal
 ```
 
 ## Local Usage

--- a/website/docs/20-bindings/python/01-overview.md
+++ b/website/docs/20-bindings/python/01-overview.md
@@ -22,7 +22,8 @@ compatibility against the binding's version, not the core's.
 
 ## Status
 
-Released and stable, published to [PyPI](https://pypi.org/project/opendal/).
+Released and stable, published to [PyPI](https://pypi.org/project/opendal/) and
+[conda-forge](https://anaconda.org/conda-forge/opendal).
 
 ## Capabilities
 
@@ -35,8 +36,16 @@ Released and stable, published to [PyPI](https://pypi.org/project/opendal/).
 
 ## Installation
 
+Install from PyPI:
+
 ```shell
 pip install opendal
+```
+
+Or install from conda-forge:
+
+```shell
+conda install conda-forge::opendal
 ```
 
 ## Useful Links

--- a/website/docs/20-bindings/python/02-getting-started.md
+++ b/website/docs/20-bindings/python/02-getting-started.md
@@ -12,8 +12,16 @@ This program builds an operator, writes a file, reads it back, inspects its
 metadata, and deletes it. It runs against the in-memory service with no
 credentials, so you can run it right after installing.
 
+Install from PyPI:
+
 ```shell
 pip install opendal
+```
+
+Or install from conda-forge:
+
+```shell
+conda install conda-forge::opendal
 ```
 
 ```python file=bindings/python/examples/getting_started.py region=quickstart


### PR DESCRIPTION
# Which issue does this PR close?

Related to #8170.

# Rationale for this change

The OpenDAL Python binding is available from conda-forge, while the user-facing installation documentation currently mentions only PyPI.

# What changes are included in this PR?

Document `conda install conda-forge::opendal` in the Python README, API documentation overview, website overview, and getting-started guide. Link the website status and installation sections to the published conda-forge package.

The Python documentation build passes. The website build rendered both changed pages locally, but its existing external-image post-build step did not complete because downloading `https://opendal.apache.org/img/architectural.png` timed out repeatedly.

# Are there any user-facing changes?

Yes. Python users can now discover and copy the conda-forge installation command from each primary documentation entry point. This does not change package or API behavior.

# AI Usage Statement

Codex drafted and applied the documentation changes. The author reviewed the scope and wording. The Anaconda Defaults request is still in progress, so this PR documents only the currently available conda-forge package.
