### PR TITLE
fix(ci/goosefs): switch the fixture image to GHCR v2.0.0

### DIFF
--- a/.github/services/goosefs/goosefs/action.yml
+++ b/.github/services/goosefs/goosefs/action.yml
@@ -24,10 +24,12 @@ description: "Behavior test for GooseFS (single-container / local profile)"
 # `{service=goosefs, setup=goosefs, feature=services-goosefs}`. No changes
 # to workflow YAMLs are required.
 #
-# The fixture image `goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0` is
-# public (no authentication required), so this action does NOT pull any
+# The fixture image `ghcr.io/tencent/tencent-goosefs-rust-sdk/goosefs:v2.0.0`
+# is public (no authentication required), so this action does NOT pull any
 # 1Password secret and therefore runs on every PR (plan.py filters out
 # actions that reference `op:` URLs when GITHUB_HAS_SECRETS is not set).
+# Override with GOOSEFS_IMAGE (for example TCR
+# goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1).
 runs:
   using: "composite"
   steps:
@@ -35,7 +37,14 @@ runs:
       shell: bash
       working-directory: fixtures/goosefs
       run: |
-        docker compose -f docker-compose-goosefs.yml up -d --wait
+        set -euo pipefail
+        IMAGE="${GOOSEFS_IMAGE:-ghcr.io/tencent/tencent-goosefs-rust-sdk/goosefs:v2.0.0}"
+        export GOOSEFS_IMAGE="${IMAGE}"
+        echo "GOOSEFS_IMAGE=${IMAGE}"
+        # Bound the wait so an unhealthy fixture fails fast instead of
+        # hanging the job indefinitely.
+        docker compose -f docker-compose-goosefs.yml up -d --wait \
+          --wait-timeout "${GOOSEFS_WAIT_TIMEOUT:-300}"
     - name: Set environment variables
       shell: bash
       run: |

--- a/core/services/goosefs/src/docs.md
+++ b/core/services/goosefs/src/docs.md
@@ -140,8 +140,7 @@ This service is covered by all three OpenDAL test layers:
    `create_dir`). Start the fixture and point the harness at it:
 
    ```shell
-   # Start a single-container GooseFS (master + worker + job_master +
-   # job_worker + table_master)
+   # Start a single-container GooseFS (master + worker; see start-default.sh)
    docker compose -f fixtures/goosefs/docker-compose-goosefs.yml up -d --wait
 
    OPENDAL_TEST=goosefs \
@@ -158,7 +157,7 @@ This service is covered by all three OpenDAL test layers:
 3. **GitHub CI** — `.github/services/goosefs/goosefs/action.yml` is picked up
    automatically by `.github/scripts/test_behavior/plan.py::provided_cases()`
    and runs the fixture + behavior suite on every PR. The fixture image
-   (`goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0`) is public so no secrets
+   (`ghcr.io/tencent/tencent-goosefs-rust-sdk/goosefs:v2.0.0`) is public so no secrets
    are needed.
 
 The fixture also exposes a `distributed` compose profile (separate master /

--- a/fixtures/goosefs/bin/start-default.sh
+++ b/fixtures/goosefs/bin/start-default.sh
@@ -19,8 +19,8 @@
 # ---------------------------------------------------------------------------
 # Default GooseFS launcher for OpenDAL CI / local dev.
 #
-# The stock `goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0` entrypoint
-# (`goosefs-start.sh local`) starts *five* JVMs: master, worker,
+# The stock GooseFS image entrypoint (`goosefs-start.sh local`) starts
+# *five* JVMs: master, worker,
 # job_master, job_worker and table_master. On the GitHub Actions
 # ubuntu-latest runner, the three processes OpenDAL does NOT use
 # (job_master + job_worker + table_master) still consume ~1.1 GiB RSS
@@ -49,10 +49,10 @@
 #   2. Create the runtime directories the image expects to exist.
 #   3. Format the journal on first boot (journal dir empty) -- exactly
 #      what `docker-entrypoint.sh format_if_needed` does.
-#   4. Launch `goosefs-start.sh -a master` and
-#      `goosefs-start.sh -a worker NoMount` (the `-a` flag tells the
-#      launcher to return asynchronously; each component is started as
-#      a detached daemon writing to /opt/goosefs/logs/).
+#   4. Launch `goosefs-start.sh -aN master` and
+#      `goosefs-start.sh -aN worker NoMount` (`-a` returns asynchronously;
+#      `-N` skips kill-before-start. Each component is a detached daemon
+#      writing to /opt/goosefs/logs/).
 #   5. `exec tail -F` on the two log files so the container stays alive
 #      and `docker logs` shows the running state. When either JVM dies,
 #      its log tail surfaces in `docker logs` and the compose healthcheck
@@ -166,22 +166,46 @@ format_if_needed() {
   fi
 }
 
+# Some GooseFS images (Alpine + musl) ship a glibc jemalloc and
+# goosefs-config.sh LD_PRELOADs it. That makes musl tools (`ps`,
+# `hostname`, `nohup`) abort with "Error relocating ... symbol not
+# found", so `goosefs-start.sh` dies at the pre-start stop step.
+# Java (glibc) does not need the preload. Probe with a musl binary
+# and only disable the .so when the preload is actually incompatible,
+# so glibc-based images keep jemalloc.
+disable_incompatible_jemalloc() {
+  local jemalloc="${GOOSEFS_HOME}/lib/native/libjemalloc.so"
+  [[ -f "${jemalloc}" ]] || return 0
+  if LD_PRELOAD="${jemalloc}" /bin/true >/dev/null 2>&1; then
+    return 0
+  fi
+  if mv "${jemalloc}" "${jemalloc}.disabled" 2>/dev/null; then
+    echo "[start-default] disabled libjemalloc.so (LD_PRELOAD incompatible with this libc)"
+  else
+    echo "[start-default] WARN: libjemalloc.so is incompatible with this libc but could not be renamed" >&2
+  fi
+  unset LD_PRELOAD || true
+}
+
 main() {
   echo "[start-default] applying runtime config ..."
   apply_runtime_config
   ensure_dirs
+  disable_incompatible_jemalloc
   format_if_needed
 
   # goosefs-start.sh parses flags with getopts *before* the ACTION
-  # positional arg, so `-a master` is the correct order. `-a master`
-  # with no trailing keyword means "start a single local master and
-  # return asynchronously". `worker NoMount` tells the worker not to
-  # try to mount a RamFS (the image doesn't ship with `sudo`); the
-  # worker uses /dev/shm directly instead.
+  # positional arg, so `-aN master` is the correct order. `-a` starts
+  # the daemon and returns; `-N` skips kill-before-start (Alpine
+  # BusyBox `ps` does not support the GNU `ps -Aww` that `killAll`
+  # uses, so the pre-start stop is a no-op or a hard failure).
+  # `worker NoMount` tells the worker not to try to mount a RamFS
+  # (the image doesn't ship with `sudo`); the worker uses /dev/shm
+  # directly instead.
   echo "[start-default] launching master ..."
-  "${GOOSEFS_HOME}/bin/goosefs-start.sh" -a master
+  "${GOOSEFS_HOME}/bin/goosefs-start.sh" -aN master
   echo "[start-default] launching worker ..."
-  "${GOOSEFS_HOME}/bin/goosefs-start.sh" -a worker NoMount
+  "${GOOSEFS_HOME}/bin/goosefs-start.sh" -aN worker NoMount
 
   # Give both JVMs a moment to create their log files so `tail -F`
   # doesn't print a confusing "No such file" warning. `tail -F`

--- a/fixtures/goosefs/docker-compose-goosefs.yml
+++ b/fixtures/goosefs/docker-compose-goosefs.yml
@@ -42,20 +42,14 @@ services:
   # Ports (host:container) are mapped on 127.0.0.1 so the fixture can
   # coexist with other fixtures on a dev machine.
   #
-  # Image source: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1
+  # Image source: ghcr.io/tencent/tencent-goosefs-rust-sdk/goosefs:v2.0.0
+  # linux/amd64, public, no auth required. Override with GOOSEFS_IMAGE
+  # (TCR fallback: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1).
   #
-  # The image is built from the official GooseFS 2.1.0 release tarball
-  # (goosefs-2.1.0-SNAPSHOT.tar.gz) and published to Tencent Cloud
-  # Container Registry (public, no auth required) so that GitHub Actions
-  # runners can pull it without credentials. The tag is intentionally
-  # pinned to `v2.1.0.1` (never `latest`) so behavior tests stay
-  # reproducible and cannot silently break when a new image is published.
-  #
-  # The image is published as a multi-arch manifest list covering both
-  # linux/amd64 and linux/arm64, so Docker auto-selects the right variant
-  # on GitHub Actions amd64 runners and on Apple Silicon dev machines
-  # without any `platform:` override. The manifest was built with
-  # `docker buildx build --platform linux/amd64,linux/arm64 --push ...`.
+  # The tag is intentionally pinned (never `latest`) so behavior tests
+  # stay reproducible and cannot silently break when a new image is
+  # published. GitHub-hosted runners can pull GHCR without credentials
+  # and without hitting TCR timeouts.
   # ==========================================================================
 
   # --------------------------------------------------------------------------
@@ -79,7 +73,7 @@ services:
   # `--profile local-full`.
   # --------------------------------------------------------------------------
   goosefs:
-    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1
+    image: ${GOOSEFS_IMAGE:-ghcr.io/tencent/tencent-goosefs-rust-sdk/goosefs:v2.0.0}
     container_name: opendal-goosefs
     profiles: ["", "local"]
     # Bypass the image's stock `docker-entrypoint.sh` and run the
@@ -220,7 +214,7 @@ services:
   # Opt-in via `--profile distributed`.
   # --------------------------------------------------------------------------
   goosefs-master:
-    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1
+    image: ${GOOSEFS_IMAGE:-ghcr.io/tencent/tencent-goosefs-rust-sdk/goosefs:v2.0.0}
     container_name: opendal-goosefs-master
     profiles: ["distributed"]
     command: master
@@ -246,7 +240,7 @@ services:
       start_period: 60s
 
   goosefs-job-master:
-    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1
+    image: ${GOOSEFS_IMAGE:-ghcr.io/tencent/tencent-goosefs-rust-sdk/goosefs:v2.0.0}
     container_name: opendal-goosefs-job-master
     profiles: ["distributed"]
     command: job_master
@@ -259,7 +253,7 @@ services:
         condition: service_healthy
 
   goosefs-worker:
-    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1
+    image: ${GOOSEFS_IMAGE:-ghcr.io/tencent/tencent-goosefs-rust-sdk/goosefs:v2.0.0}
     container_name: opendal-goosefs-worker
     profiles: ["distributed"]
     command: worker
@@ -277,7 +271,7 @@ services:
         condition: service_healthy
 
   goosefs-job-worker:
-    image: goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1
+    image: ${GOOSEFS_IMAGE:-ghcr.io/tencent/tencent-goosefs-rust-sdk/goosefs:v2.0.0}
     container_name: opendal-goosefs-job-worker
     profiles: ["distributed"]
     command: job_worker


### PR DESCRIPTION
# Which issue does this PR close?

N/A (no tracking issue).

# Rationale for this change

GitHub-hosted runners often time out pulling `goosefs.tencentcloudcr.com`. The GooseFS behavior-test fixture now uses the public GHCR image:

`ghcr.io/tencent/tencent-goosefs-rust-sdk/goosefs:v2.0.0`

That image is Alpine + musl and `LD_PRELOAD`s a glibc `libjemalloc.so`. `ps` / `hostname` / `nohup` then exit 127 (`Error relocating ... symbol not found`), so `goosefs-start.sh` dies at the pre-start stop step and master never comes up. Alpine BusyBox `ps` also lacks GNU `ps -Aww` used by `killAll`. Switching the tag without hardening `start-default.sh` would break `services-goosefs` behavior tests.

# What changes are included in this PR?

- Default image is `${GOOSEFS_IMAGE:-ghcr.io/tencent/tencent-goosefs-rust-sdk/goosefs:v2.0.0}` for all compose services; the behavior-test action exports the same default.
- TCR `goosefs.tencentcloudcr.com/goosefs/repo:v2.1.0.1` remains available via `GOOSEFS_IMAGE`.
- `start-default.sh` probes jemalloc and disables it only when preload is incompatible; start with `-aN`.
- Behavior-test action uses `compose up --wait --wait-timeout 300`.
- Docs/comments point at GHCR `v2.0.0`; default profile starts master + worker only.

# Are there any user-facing changes?

No public API changes. Local `docker compose -f fixtures/goosefs/docker-compose-goosefs.yml up` now defaults to GHCR `v2.0.0` (linux/amd64). Override with `GOOSEFS_IMAGE` to stay on TCR.

# AI Usage Statement

AI assisted with the fixture image switch, jemalloc workaround, CI wiring, and this PR text. The author remains responsible for the submitted claims and code.