### PR TITLE
fix(ci): refresh apt index before installing packages

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -55,7 +55,9 @@ runs:
     - name: Setup Linux
       if: runner.os == 'Linux'
       shell: bash
-      run: sudo apt-get install libclang-dev libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libclang-dev libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
 
     - name: Setup Protoc
       if: inputs.need-protoc == 'true'

--- a/.github/workflows/ci_bindings_cpp.yml
+++ b/.github/workflows/ci_bindings_cpp.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install ninja-build valgrind doxygen
+          sudo apt-get install -y ninja-build valgrind doxygen
 
       - name: Setup Rust toolchain
         uses: ./.github/actions/setup

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -225,7 +225,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup doxygen
-        run: sudo apt-get install doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen
 
       - name: Build Docs
         working-directory: bindings/c
@@ -244,7 +246,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Setup lua-ldoc
-        run: sudo apt-get install lua-ldoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lua-ldoc
 
       - name: Build Docs
         working-directory: "bindings/lua"
@@ -334,7 +338,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install doxygen graphviz ninja-build
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz ninja-build
 
       - name: Build Cpp docs
         working-directory: "bindings/cpp"

--- a/.github/workflows/test_fuzz.yml
+++ b/.github/workflows/test_fuzz.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Set Rust Fuzz
         shell: bash
         run: |
+          sudo apt-get update
           sudo apt-get install -y libfuzzer-14-dev
           rustup install ${{ env.RUST_TOOLCHAIN }}
           cargo +${{ env.RUST_TOOLCHAIN }} install cargo-fuzz


### PR DESCRIPTION
# Which issue does this PR close?

None. Filed directly as a CI fix.

# Rationale for this change

Linux jobs fail during dependency installation with a 404:

```
Err:3 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libbz2-dev amd64 1.0.8-5.1build0.1
  404  Not Found
E: Failed to fetch .../libbz2-dev_1.0.8-5.1build0.1_amd64.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

GitHub-hosted runner images ship a pre-baked apt package index. When the archive
publishes a newer package revision, the old `.deb` disappears from the pool while
the stale index still points at it, so `apt-get install` resolves a version that
is no longer downloadable and exits with code 100. The installed package set is
correct; the index is simply out of date.

Several steps already ran `apt-get update` before installing, but the shared
setup action and a few workflow steps did not, so they broke whenever an upstream
package was revised.

# What changes are included in this PR?

- `.github/actions/setup/action.yaml`: run `apt-get update` before installing the
  Linux build dependencies. This is the failing step and it runs in nearly every
  Linux job.
- `.github/workflows/docs.yml`: same fix for the doxygen, lua-ldoc, and C++ docs
  dependency steps.
- `.github/workflows/test_fuzz.yml`: same fix for the `libfuzzer-14-dev` step.
- `.github/workflows/ci_bindings_cpp.yml`: already refreshed the index; only adds
  `-y`.

Every `apt-get install` in the repository now runs after `apt-get update` and
passes `-y` so it never blocks on a confirmation prompt.

# Are there any user-facing changes?

No. The change only touches CI workflow configuration.

# AI Usage Statement

AI assisted in locating every `apt-get install` step that lacked a preceding
`apt-get update` and in drafting the changes and this description.

The failure mode was diagnosed from the CI log rather than reproduced locally,
since it depends on the runner image's index being older than the archive. The
transient nature of that skew means a green run does not by itself prove the fix;
the argument is that refreshing the index removes the stale-version resolution
that caused the 404. Reviewers may want to confirm that no step depends on a
pinned package version that `apt-get update` would change.