### PR TITLE
chore(bindings/dotnet): fix license headers and third-party license accounting

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,19 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+------------------------------------------------------------------------------------
+This product bundles third-party components under other open source licenses.
+This section summarizes those components and their licenses. See the referenced
+license files for text of these licenses.
+
+
+Creative Commons Zero v1.0 Universal
+------------------------------------
+
+bindings/dotnet/.gitignore
+
+The above file is derived from VisualStudio.gitignore in
+https://github.com/github/gitignore. Its license text is in
+bindings/dotnet/LICENSE-CC0-1.0.txt.

--- a/bindings/dotnet/LICENSE
+++ b/bindings/dotnet/LICENSE
@@ -199,3 +199,31 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+------------------------------------------------------------------------------------
+This product bundles third-party components under other open source licenses.
+This section summarizes those components and their licenses. See the referenced
+license files for text of these licenses.
+
+
+Creative Commons Zero v1.0 Universal
+------------------------------------
+
+.gitignore
+
+The above file is part of the source distribution only. It is derived from
+VisualStudio.gitignore in https://github.com/github/gitignore. Its license
+text is in LICENSE-CC0-1.0.txt.
+
+
+Mozilla Public License 2.0
+--------------------------
+
+colored 3.1.1        https://crates.io/crates/colored/3.1.1
+option-ext 0.2.0     https://crates.io/crates/option-ext/0.2.0
+persy 1.8.1          https://crates.io/crates/persy/1.8.1
+
+The above Rust crates are statically linked into the native library bundled in
+the NuGet package. Their source code is available from the listed pages. Their
+license text is in LICENSE-MPL-2.0.txt.

--- a/bindings/dotnet/LICENSE-CC0-1.0.txt
+++ b/bindings/dotnet/LICENSE-CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/bindings/dotnet/OpenDAL.Tests/OpenDAL.Tests.csproj
+++ b/bindings/dotnet/OpenDAL.Tests/OpenDAL.Tests.csproj
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>

--- a/bindings/dotnet/OpenDAL/OpenDAL.csproj
+++ b/bindings/dotnet/OpenDAL/OpenDAL.csproj
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>

--- a/bindings/dotnet/OpenDAL/OpenDAL.csproj
+++ b/bindings/dotnet/OpenDAL/OpenDAL.csproj
@@ -45,6 +45,7 @@
         <None Include="../README.md" Pack="true" PackagePath="" />
         <None Include="../LICENSE" Pack="true" PackagePath="" />
         <None Include="../LICENSE-MPL-2.0.txt" Pack="true" PackagePath="" />
+        <None Include="../LICENSE-CC0-1.0.txt" Pack="true" PackagePath="" />
         <None Include="../NOTICE" Pack="true" PackagePath="" />
         <None Include="runtimes\win-x64\native\opendal_dotnet.dll"
             Pack="true"

--- a/bindings/dotnet/README.md
+++ b/bindings/dotnet/README.md
@@ -89,3 +89,8 @@ components. Their source code is available from the linked project pages:
 - `persy` 1.8.1 ([source](https://crates.io/crates/persy/1.8.1), [homepage](https://persy.rs)), licensed under MPL-2.0.
 
 The distribution includes the MPL-2.0 text in `LICENSE-MPL-2.0.txt`.
+
+The source distribution includes `.gitignore`, derived from
+[`VisualStudio.gitignore`](https://github.com/github/gitignore) and dedicated to
+the public domain under CC0-1.0. The distribution includes the CC0-1.0 text in
+`LICENSE-CC0-1.0.txt`.

--- a/bindings/dotnet/examples/GettingStarted/GettingStarted.csproj
+++ b/bindings/dotnet/examples/GettingStarted/GettingStarted.csproj
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>

--- a/bindings/dotnet/opendal.slnx
+++ b/bindings/dotnet/opendal.slnx
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <Solution>
   <Project Path="OpenDAL.Tests/OpenDAL.Tests.csproj" />
   <Project Path="OpenDAL/OpenDAL.csproj" />

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -44,3 +44,8 @@ excludes = [
   "bindings/dart/opendal_api.dart",
   "*generated*",
 ]
+
+# HawkEye's default mapping does not cover .NET project and solution files,
+# which are XML documents and accept XML comments.
+[mapping.XML_STYLE]
+extensions = ["csproj", "slnx"]


### PR DESCRIPTION
# Which issue does this PR close?

No issue. This addresses the .NET items from the 0.59.0-rc.1 release-verification findings in https://github.com/apache/opendal/discussions/8211 — the *Source package licensing* and *Source headers* sections.

# Rationale for this change

`bindings/dotnet/.gitignore` is derived from `VisualStudio.gitignore` in github/gitignore (CC0-1.0) and its header says so, but no LICENSE in the distribution accounted for it. github/gitignore keeps its license at the repository root, so nothing travelled with the copied template.

The report asks for this in the *root* LICENSE. Source archives are assembled by `git ls-files LICENSE NOTICE <package> <deps>` in `dev/src/release/mod.rs`, so the file that lands at the archive root is the repository root LICENSE — that is the one this PR edits. (That is also why `.gitattributes`' `bindings/dotnet export-ignore`
does not keep the binding out of the release: it only affects `git archive`.)

Separately, the three `.csproj` files carried no ASF header. HawkEye's default mapping has no entry for `.csproj`, so its check reported them as unknown and exited successfully — adding headers alone would not prevent a repeat.

# What changes are included in this PR?

**`chore(bindings/dotnet): add ASF license headers to project files`**

- ASF header added to the three `.csproj` files and `opendal.slnx`.
- `licenserc.toml` maps `csproj` and `slnx` to `XML_STYLE` so HawkEye checks them.
  These are the only tracked files with those extensions.

**`chore(bindings/dotnet): account for bundled third-party licenses`**

- Root `LICENSE` gains a subcomponents section listing `bindings/dotnet/.gitignore` under CC0-1.0, formatted after `apache/spark`'s root LICENSE.
- `bindings/dotnet/LICENSE` (packed into the NuGet package) gains the same entry, marked source-distribution-only since `.gitignore` is not in the package, plus an MPL-2.0 section for the three crates statically linked into the native library. Those were listed only in `README.md`, although `LICENSE-MPL-2.0.txt` was already being packed.
- `LICENSE-CC0-1.0.txt` added (text from SPDX license-list-data) and packed.
- `README.md` notes the CC0 subcomponent.

CC0 requires nothing — no attribution, no license text. This is release-audit hygiene so the archive's LICENSE accounts for what the archive contains.

# Are there any user-facing changes?

No API or behaviour changes. The NuGet package gains `LICENSE-CC0-1.0.txt`, and its `LICENSE` now describes the bundled third-party components.

# AI Usage Statement

Claude Code (Opus 5) assisted throughout: locating the affected files, reading HawkEye v6.5.1's source to establish how an extension is mapped to a style and that its check requires byte-exact `XML_STYLE` output, drafting the LICENSE sections, and running the license check, the .NET builds and a `dotnet pack` locally. The packaging behaviour described above was read out of the release code rather than assumed.

Two decisions here are mine rather than derived, and reviewers may reasonably disagree: putting the CC0 entry in the shared root LICENSE over-declares for the other source archives, which do not contain that file; and bundling the CC0 text costs 7KB for something CC0 does not require. I am responsible for both.