### PR TITLE
fix(ci): make release docs deployment recoverable

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,12 @@ on:
     branches:
       - main
     paths: *paths
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Release tag to deploy to nightlies"
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
@@ -632,11 +638,11 @@ jobs:
           cp ${{ github.workspace }}/.asf.yaml ./build/.asf.yaml
         env:
           # Keep this same with the remote_path below
-          OPENDAL_WEBSITE_BASE_URL: /opendal/opendal-docs-release-${{ github.ref_name }}/
+          OPENDAL_WEBSITE_BASE_URL: /opendal/opendal-docs-release-${{ inputs.release_version || github.ref_name }}/
           OPENDAL_WEBSITE_NOT_LATEST: true
 
       - name: Deploy to nightlies for tagged version
-        if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}
+        if: ${{ (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc')) || github.event_name == 'workflow_dispatch' }}
         shell: bash
         env:
           NIGHTLIES_RSYNC_HOST: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
@@ -646,12 +652,12 @@ jobs:
           NIGHTLIES_RSYNC_USER: ${{ secrets.NIGHTLIES_RSYNC_USER }}
         run: |
           mkdir -p "${HOME}/.ssh"
-          printf '%s' "${NIGHTLIES_RSYNC_KEY}" > "${HOME}/.ssh/nightlies_rsync"
+          printf '%s\n' "${NIGHTLIES_RSYNC_KEY}" > "${HOME}/.ssh/nightlies_rsync"
           chmod 0600 "${HOME}/.ssh/nightlies_rsync"
           rsync -avzr \
             -e "ssh -i ${HOME}/.ssh/nightlies_rsync -p ${NIGHTLIES_RSYNC_PORT} -o StrictHostKeyChecking=no" \
             build/ \
-            "${NIGHTLIES_RSYNC_USER}@${NIGHTLIES_RSYNC_HOST}:${NIGHTLIES_RSYNC_PATH}/opendal/opendal-docs-release-${{ github.ref_name }}/"
+            "${NIGHTLIES_RSYNC_USER}@${NIGHTLIES_RSYNC_HOST}:${NIGHTLIES_RSYNC_PATH}/opendal/opendal-docs-release-${{ inputs.release_version || github.ref_name }}/"
 
       - name: Clear build
         run: rm -rf ./build
@@ -664,7 +670,7 @@ jobs:
           OPENDAL_WEBSITE_BASE_URL: /opendal/opendal-docs-stable/
 
       - name: Deploy to nightlies for stable version
-        if: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc') }}
+        if: ${{ (startsWith(github.ref, 'refs/tags/') && !contains(github.ref, 'rc')) || github.event_name == 'workflow_dispatch' }}
         shell: bash
         env:
           NIGHTLIES_RSYNC_HOST: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
@@ -674,7 +680,7 @@ jobs:
           NIGHTLIES_RSYNC_USER: ${{ secrets.NIGHTLIES_RSYNC_USER }}
         run: |
           mkdir -p "${HOME}/.ssh"
-          printf '%s' "${NIGHTLIES_RSYNC_KEY}" > "${HOME}/.ssh/nightlies_rsync"
+          printf '%s\n' "${NIGHTLIES_RSYNC_KEY}" > "${HOME}/.ssh/nightlies_rsync"
           chmod 0600 "${HOME}/.ssh/nightlies_rsync"
           rsync -avzr --delete \
             -e "ssh -i ${HOME}/.ssh/nightlies_rsync -p ${NIGHTLIES_RSYNC_PORT} -o StrictHostKeyChecking=no" \


### PR DESCRIPTION
# Which issue does this PR close?

None. Filed directly as a release CI fix.

# Rationale for this change

The v0.59.0 documentation build succeeded, but the nightlies deployment failed because the SSH private key was written without a terminating newline and OpenSSL rejected it with `error in libcrypto`.

A release-tag workflow also cannot pick up a workflow fix without moving the signed tag. A manual recovery path is needed so release managers can run corrected workflow code from a recovery branch while preserving the intended release directory name.

# What changes are included in this PR?

The docs workflow now:

- appends a newline when writing the nightlies SSH private key;
- accepts a required `release_version` for manual dispatches;
- uses that version for the release documentation base URL and destination; and
- deploys both versioned and stable documentation during an explicit manual recovery run.

The equivalent recovery workflow successfully deployed the v0.59.0 versioned and stable documentation in https://github.com/apache/opendal/actions/runs/33837397746.

# Are there any user-facing changes?

No. This only makes release documentation deployment recoverable.

# AI Usage Statement

AI assisted in diagnosing the v0.59.0 deployment failure, implementing the workflow changes, and drafting this description. The recovery path assumes the release manager dispatches a branch based on the intended release tag and supplies the matching `release_version`.
