### PR TITLE
fix(core): release successful task inputs before collecting results

### DIFF
--- a/core/core/src/docs/upgrade.md
+++ b/core/core/src/docs/upgrade.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Raw API
+
+### Submit tasks through `ConcurrentTasks::execute`
+
+`raw::ConcurrentTasks::create_task` has been removed. Submit inputs with `execute()` and collect outputs in submission order with `next()`. These methods keep task ownership, completion accounting, and retry handling inside the queue. If code needs input data after successful completion, include that data in the factory's output type.
+
 # Upgrade to v0.59
 
 ## Public API

--- a/core/core/src/raw/futures_util.rs
+++ b/core/core/src/raw/futures_util.rs
@@ -75,20 +75,20 @@ impl<T> MaybeSend for T {}
 /// The code patterns below are intentional; please do not modify them unless you fully understand these notes.
 ///
 /// ```skip
-///  let (i, o) = self
+///  let result = self
 ///     .tasks
 ///     .front_mut()                                        // Use `front_mut` instead of `pop_front`
 ///     .expect("tasks must be available")
 ///     .await;
 /// ...
-/// match o {
+/// match result {
 ///     Ok(o) => {
 ///         let _ = self.tasks.pop_front();                 // `pop_front` after got `Ok(o)`
 ///         self.results.push_back(o)
 ///     }
-///     Err(err) => {
+///     Err((i, err)) => {
 ///         if err.is_temporary() {
-///             let task = self.create_task(i);
+///             let task = self.spawn_task(i);
 ///             self.tasks
 ///                 .front_mut()
 ///                 .expect("tasks must be available")
@@ -128,7 +128,7 @@ pub struct ConcurrentTasks<I, O> {
     /// to poll the tasks to see if they are ready.
     ///
     /// Dropping task without `await` it will cancel the task.
-    tasks: VecDeque<Task<(I, Result<O>)>>,
+    tasks: VecDeque<Task<Result<O, (I, Error)>>>,
     /// `results` stores the successful results.
     results: VecDeque<O>,
 
@@ -213,6 +213,19 @@ impl<I: Send + 'static, O: Send + 'static> ConcurrentTasks<I, O> {
         self.executor.execute(fut)
     }
 
+    fn spawn_task(&self, input: I) -> Task<Result<O, (I, Error)>> {
+        let completed = self.completed_but_unretrieved.clone();
+        let fut = (self.factory)(input)
+            // Completed tasks can remain queued while the caller produces more work.
+            // Only failures need to retain their input for a retry.
+            .map(|(input, result)| result.map_err(|err| (input, err)))
+            .inspect(move |_| {
+                completed.fetch_add(1, Ordering::Relaxed);
+            });
+
+        self.executor.execute(fut)
+    }
+
     /// Execute the task with given input.
     ///
     /// - Execute the task in the current thread if is not concurrent.
@@ -240,22 +253,22 @@ impl<I: Send + 'static, O: Send + 'static> ConcurrentTasks<I, O> {
         }
 
         if !self.has_remaining() {
-            let (i, o) = self
+            let result = self
                 .tasks
                 .front_mut()
                 .expect("tasks must be available")
                 .await;
             self.completed_but_unretrieved
                 .fetch_sub(1, Ordering::Relaxed);
-            match o {
+            match result {
                 Ok(o) => {
                     let _ = self.tasks.pop_front();
                     self.results.push_back(o)
                 }
-                Err(err) => {
+                Err((i, err)) => {
                     // Retry this task if the error is temporary
                     if err.is_temporary() {
-                        let task = self.create_task(i);
+                        let task = self.spawn_task(i);
                         self.tasks
                             .front_mut()
                             .expect("tasks must be available")
@@ -269,7 +282,7 @@ impl<I: Send + 'static, O: Send + 'static> ConcurrentTasks<I, O> {
             }
         }
 
-        self.tasks.push_back(self.create_task(input));
+        self.tasks.push_back(self.spawn_task(input));
         Ok(())
     }
 
@@ -287,18 +300,18 @@ impl<I: Send + 'static, O: Send + 'static> ConcurrentTasks<I, O> {
         }
 
         if let Some(task) = self.tasks.front_mut() {
-            let (i, o) = task.await;
+            let result = task.await;
             self.completed_but_unretrieved
                 .fetch_sub(1, Ordering::Relaxed);
-            return match o {
+            return match result {
                 Ok(o) => {
                     let _ = self.tasks.pop_front();
                     Some(Ok(o))
                 }
-                Err(err) => {
+                Err((i, err)) => {
                     // Retry this task if the error is temporary
                     if err.is_temporary() {
-                        let task = self.create_task(i);
+                        let task = self.spawn_task(i);
                         self.tasks
                             .front_mut()
                             .expect("tasks must be available")

--- a/core/core/src/raw/futures_util.rs
+++ b/core/core/src/raw/futures_util.rs
@@ -63,7 +63,10 @@ impl<T: Send> MaybeSend for T {}
 #[cfg(target_arch = "wasm32")]
 impl<T> MaybeSend for T {}
 
-/// ConcurrentTasks is used to execute tasks concurrently.
+/// ConcurrentTasks executes tasks concurrently and collects outputs in submission order.
+///
+/// Submit inputs with [`Self::execute`] and collect outputs with [`Self::next`].
+/// The queue owns the task handles and tracks their completion for concurrency control.
 ///
 /// ConcurrentTasks has two generic types:
 ///
@@ -200,17 +203,6 @@ impl<I: Send + 'static, O: Send + 'static> ConcurrentTasks<I, O> {
     #[inline]
     pub fn has_result(&self) -> bool {
         !self.results.is_empty()
-    }
-
-    /// Create a task with given input.
-    pub fn create_task(&self, input: I) -> Task<(I, Result<O>)> {
-        let completed = self.completed_but_unretrieved.clone();
-
-        let fut = (self.factory)(input).inspect(move |_| {
-            completed.fetch_add(1, Ordering::Relaxed);
-        });
-
-        self.executor.execute(fut)
     }
 
     fn spawn_task(&self, input: I) -> Task<Result<O, (I, Error)>> {


### PR DESCRIPTION
# Which issue does this PR close?

No linked issue.

# Rationale for this change

Concurrent multipart uploads can retain payloads from already successful parts while the producer continues writing. `ConcurrentTasks` queues completed results to preserve output order, but each successful result previously retained its original retry input. Prefetch therefore allowed completed payloads to accumulate until result collection.

The public `create_task` method also allowed tasks to update the queue's completion counter without entering its task queue. Task creation and completion accounting need to remain inside `ConcurrentTasks`.

This retention was reproduced against AWS S3 with the released Python binding. A wheel built at `64c32fac26` passed ordinary and paced 512 MiB S3 uploads with full readback SHA-256 validation; completed payloads no longer accumulated until close. Subsequent changes remove the unused public method and update documentation without changing the tested upload path.

# What changes are included in this PR?

Successful queued tasks retain only their output; failed tasks retain their input for retry. Private `spawn_task` handles background task creation for submission and retries. Remove public `create_task` and document migration to `execute` and `next`.

The factory signature, result ordering, concurrency controls, and retry policy remain unchanged.

# Are there any user-facing changes?

Concurrent writers release successfully uploaded payloads before result collection.

**Breaking raw API change:** `raw::ConcurrentTasks::create_task` is removed. Submit inputs with `execute()` and collect outputs with `next()`. Callers that need input data after success should include it in the factory's output type. There are no in-repository callers of the removed method.

# AI Usage Statement

AI assisted with the investigation, implementation, and validation. Deterministic lifecycle checks cover successful completion and temporary-error retries. The earlier full-workspace test run was blocked locally by the missing Java runtime required by HDFS-linked binaries.
