### PR TITLE
fix(services/hf): follow case redirects instead of resolving the canonical repo id

### DIFF
--- a/core/services/hf/src/backend.rs
+++ b/core/services/hf/src/backend.rs
@@ -146,12 +146,18 @@ impl HfBuilder {
         self
     }
 
+    /// Resolve the Hub base URL: an explicit config value wins, then
+    /// `HF_ENDPOINT`, then the public Hub. A trailing slash is trimmed
+    /// because every URL is built by appending `/api/...` to this, and HF
+    /// answers the resulting `//api/...` with a 404.
     fn hf_endpoint(&self) -> String {
         self.config
             .endpoint
             .clone()
             .or_else(|| std::env::var("HF_ENDPOINT").ok())
             .unwrap_or_else(|| "https://huggingface.co".to_string())
+            .trim_end_matches('/')
+            .to_string()
     }
 
     /// Resolve the download mode: an explicit config value wins; otherwise a set,
@@ -435,6 +441,19 @@ pub(super) mod test_utils {
         finish_operator(op)
     }
 
+    /// Same public dataset as [`mbpp_operator`], but with the repo id cased
+    /// differently from the canonical `google-research-datasets/mbpp`. HF
+    /// answers every request for it with a `307` to the canonical URL.
+    pub fn miscased_mbpp_operator() -> Operator {
+        let op = Operator::new(
+            HfBuilder::default()
+                .repo_type("dataset")
+                .repo_id("Google-Research-Datasets/MBPP"),
+        )
+        .unwrap();
+        finish_operator(op)
+    }
+
     pub fn testing_dataset_core() -> Arc<HfCore> {
         let repo_id = std::env::var("HF_OPENDAL_DATASET").expect("HF_OPENDAL_DATASET must be set");
         let token = std::env::var("HF_OPENDAL_TOKEN").expect("HF_OPENDAL_TOKEN must be set");
@@ -536,6 +555,18 @@ mod tests {
         unsafe { std::env::remove_var("HF_TOKEN_PATH") };
         std::fs::remove_file(&token_file).ok();
         assert_eq!(result.as_deref(), Some("file-token"));
+    }
+
+    #[test]
+    fn hf_endpoint_trims_trailing_slash() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("HF_ENDPOINT") };
+        assert_eq!(
+            HfBuilder::default()
+                .endpoint("https://hub.example.com/")
+                .hf_endpoint(),
+            "https://hub.example.com"
+        );
     }
 
     #[test]

--- a/core/services/hf/src/core.rs
+++ b/core/services/hf/src/core.rs
@@ -16,11 +16,11 @@
 // under the License.
 
 use asyncband::mutex::Mutex;
-use asyncband::once::OnceCell;
 use bytes::Buf;
 use bytes::Bytes;
 use http::Request;
 use http::Response;
+use http::StatusCode;
 use http::header;
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -165,11 +165,6 @@ pub(super) struct XetFileResponse {
     pub size: u64,
 }
 
-#[derive(Deserialize)]
-pub(super) struct RepoInfoResponse {
-    pub id: String,
-}
-
 /// Response shape of HF's `xet-{read,write}-token` endpoint. Matches
 /// `CasJWTInfo` in the vendored `xet` crate (`xet_client::hub_client::types`)
 /// — the same three fields regardless of read or write token.
@@ -215,10 +210,9 @@ impl XetTokenScope {
         }
     }
 
-    /// The `Operation` a fetch for this scope's token should be tagged
-    /// with, so a token-less writer hits `request()`'s local
-    /// `PermissionDenied` fast-path instead of an unauthenticated network
-    /// call.
+    /// `Operation` to tag this scope's token fetch with, so a token-less
+    /// writer is rejected locally by `request()` instead of hitting the
+    /// network.
     fn operation(self) -> Operation {
         match self {
             Self::Read => Operation::Read,
@@ -314,7 +308,6 @@ pub struct HfCore {
     pub endpoint: String,
     pub xet_session: XetSession,
     pub download_mode: HfDownloadMode,
-    canonical_repo: OnceCell<HfRepo>,
     /// Cached CAS read token, shared by every `XetDownloadStreamGroup` this
     /// core creates, so at most one `xet-read-token` request happens per
     /// token lifetime instead of one per group (one per file read).
@@ -355,7 +348,6 @@ impl HfCore {
             endpoint,
             xet_session,
             download_mode,
-            canonical_repo: OnceCell::new(),
             xet_read_token: Arc::new(Mutex::new(None)),
             xet_write_token: Arc::new(Mutex::new(None)),
         }
@@ -404,8 +396,7 @@ impl HfCore {
         &self,
         ctx: &OperationContext,
     ) -> Result<XetUploadCommit> {
-        let (token, refresh_url, refresh_headers) =
-            self.xet_auth(ctx, XetTokenScope::Write).await?;
+        let token = self.cached_xet_token(ctx, XetTokenScope::Write).await?;
         self.xet_session
             .new_upload_commit()
             .map_err(|err| {
@@ -414,7 +405,11 @@ impl HfCore {
             })?
             .with_endpoint(token.cas_url)
             .with_token_info(token.access_token, token.expires_at)
-            .with_token_refresh_url(refresh_url, refresh_headers)
+            .with_token_refresh_url(
+                self.repo
+                    .xet_token_url(&self.endpoint, XetTokenScope::Write),
+                self.xet_token_refresh_headers(),
+            )
             .build()
             .await
             .map_err(|err| {
@@ -423,32 +418,9 @@ impl HfCore {
             })
     }
 
-    /// A cached token for `scope`, plus the URL/headers to configure
-    /// automatic refresh on a builder that outlives this call. Shared by
-    /// [`Self::xet_upload_commit`] and [`Self::xet_download_group`], which
-    /// otherwise differ only in which builder they seed with it. Uses the
-    /// canonical repo id so the refresh URL doesn't depend on redirect
-    /// behavior (see [`Self::canonical_repo`]). Resolves the repo once and
-    /// hands it to [`Self::cached_xet_token`] so the token lookup doesn't
-    /// resolve it again.
-    async fn xet_auth(
-        &self,
-        ctx: &OperationContext,
-        scope: XetTokenScope,
-    ) -> Result<(XetToken, String, http::HeaderMap)> {
-        let repo = self.canonical_repo(ctx).await?;
-        let token = self.cached_xet_token(ctx, &repo, scope).await?;
-        let refresh_url = repo.xet_token_url(&self.endpoint, scope);
-        let refresh_headers = self.xet_token_refresh_headers();
-        Ok((token, refresh_url, refresh_headers))
-    }
-
-    /// Get a still-valid cached token for `scope` against the already
-    /// resolved `repo`, fetching and caching a fresh one if missing or
-    /// close to expiry. The lock is held across the refresh request so
-    /// concurrent callers single-flight onto one fetch; `repo` is resolved
-    /// by the caller beforehand so that lookup doesn't extend this
-    /// critical section.
+    /// Get a still-valid cached token for `scope`, fetching and caching a
+    /// fresh one if missing or close to expiry. The lock is held across the
+    /// refresh request so concurrent callers single-flight onto one fetch.
     ///
     /// On a clock failure, `now` falls back to `u64::MAX` so the token is
     /// treated as stale (extra `/api` traffic) rather than `0`, which would
@@ -456,7 +428,6 @@ impl HfCore {
     async fn cached_xet_token(
         &self,
         ctx: &OperationContext,
-        repo: &HfRepo,
         scope: XetTokenScope,
     ) -> Result<XetToken> {
         let cache = match scope {
@@ -475,12 +446,12 @@ impl HfCore {
             return Ok(token.clone());
         }
 
-        let url = repo.xet_token_url(&self.endpoint, scope);
+        let url = self.repo.xet_token_url(&self.endpoint, scope);
         let req = self
             .request(http::Method::GET, &url, scope.operation(), "XetToken")?
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
-        let resp = ctx.http_transport().fetch(req).await?;
+        let resp = self.send(ctx, req).await?;
         if !resp.status().is_success() {
             let (parts, _) = resp.into_parts();
             return Err(parse_error(
@@ -513,7 +484,7 @@ impl HfCore {
         &self,
         ctx: &OperationContext,
     ) -> Result<XetDownloadStreamGroup> {
-        let (token, refresh_url, refresh_headers) = self.xet_auth(ctx, XetTokenScope::Read).await?;
+        let token = self.cached_xet_token(ctx, XetTokenScope::Read).await?;
         self.xet_session
             .new_download_stream_group()
             .map_err(|err| {
@@ -525,7 +496,10 @@ impl HfCore {
             })?
             .with_endpoint(token.cas_url)
             .with_token_info(token.access_token, token.expires_at)
-            .with_token_refresh_url(refresh_url, refresh_headers)
+            .with_token_refresh_url(
+                self.repo.xet_token_url(&self.endpoint, XetTokenScope::Read),
+                self.xet_token_refresh_headers(),
+            )
             .build()
             .await
             .map_err(|err| {
@@ -548,9 +522,8 @@ impl HfCore {
         op: Operation,
         service_operation: &'static str,
     ) -> Result<http::request::Builder> {
-        // Every outbound HF/CAS request is built here, so this is the one
-        // place that can show what's actually being queried -- enable with
-        // `RUST_LOG=opendal_service_hf::core=debug`.
+        // Every outbound HF/CAS request passes through here -- enable with
+        // `RUST_LOG=opendal_service_hf::core=debug` to see what's queried.
         debug!(
             "hf request: service_operation={service_operation} operation={op} method={method} url={url}"
         );
@@ -576,58 +549,61 @@ impl HfCore {
         Ok(req)
     }
 
-    /// Return the repo handle with the server's canonical repo id, resolving
-    /// and caching it on first use.
+    /// Send `req`, following one same-endpoint `307`/`308` redirect.
     ///
-    /// HF resolves repo ids case-insensitively but replies 307 to any request
-    /// for a non-canonically-cased id (e.g. `user/repo` for `user/Repo`).
-    /// The transport cannot replay bodied requests (commit, paths-info)
-    /// through a redirect. Building every URL from the canonical id avoids
-    /// depending on redirect behavior entirely, removing the inconsistency across
-    /// operations.
-    pub(super) async fn canonical_repo(&self, ctx: &OperationContext) -> Result<HfRepo> {
-        // Buckets are addressed by opaque ids
-        if self.repo.is_bucket() {
-            return Ok(self.repo.clone());
-        }
+    /// HF resolves repo ids case-insensitively but answers any request for
+    /// a non-canonically cased id (`user/repo` for `user/Repo`) with a 307
+    /// to the canonical URL. Transports follow that for `GET`s but hand a
+    /// bodied `POST` (commit, paths-info) back as the bare 307, which would
+    /// otherwise surface as an error while reads silently succeed.
+    /// Re-issuing the request here makes the outcome independent of the
+    /// transport's redirect policy. `send` returns a redirect to any other
+    /// host as-is, so it never sends the bearer token off the configured
+    /// endpoint itself; the caller then reports it via [`parse_error`].
+    pub(super) async fn send(
+        &self,
+        ctx: &OperationContext,
+        req: Request<Buffer>,
+    ) -> Result<Response<HttpBody>> {
+        let retry = req.clone();
 
-        self.canonical_repo
-            .get_or_try_init(|| async {
-                let url = format!(
-                    "{}/api/{}/{}",
-                    self.endpoint,
-                    self.repo.repo_type.as_plural_str(),
-                    self.repo.repo_id,
-                );
-                let req = self
-                    .request(http::Method::GET, &url, Operation::Stat, "RepoInfo")?
-                    .body(Buffer::new())
-                    .map_err(new_request_build_error)?;
-                let resp = ctx.http_transport().fetch(req).await?;
-                if !resp.status().is_success() {
-                    let (parts, _) = resp.into_parts();
-                    return Err(parse_error(
-                        ErrorContext::new(ServiceOperation("RepoInfo")),
-                        parts,
-                    ));
-                }
-                let (_, mut body) = resp.into_parts();
-                let buffer = body.to_buffer().await?;
-                let info: RepoInfoResponse =
-                    serde_json::from_reader(buffer.reader()).map_err(new_json_deserialize_error)?;
+        // The response is confined to this block so it is gone before the
+        // retry runs: its body is never read, so the connection cannot be
+        // pooled and is better closed than held across another round trip.
+        let target = {
+            let resp = ctx.http_transport().fetch(req).await?;
+            if !matches!(
+                resp.status(),
+                StatusCode::TEMPORARY_REDIRECT | StatusCode::PERMANENT_REDIRECT
+            ) {
+                return Ok(resp);
+            }
 
-                let mut repo = self.repo.clone();
-                repo.repo_id = info.id;
-                Ok(repo)
-            })
+            // Accept a path-only `Location`, which is what HF sends, or one
+            // already on the endpoint (a bare origin, normalized by
+            // `HfBuilder`). What remains after dropping the endpoint must be
+            // a single-slash path, which also refuses a protocol-relative
+            // `//host/...` naming another host.
+            let Some(location) = parse_location(resp.headers())? else {
+                return Ok(resp);
+            };
+            let path = location
+                .strip_prefix(self.endpoint.as_str())
+                .unwrap_or(location);
+            if !path.starts_with('/') || path.starts_with("//") {
+                return Ok(resp);
+            }
+            format!("{}{path}", self.endpoint)
+        };
+
+        debug!("hf request redirected: url={} -> {target}", retry.uri());
+        let (mut parts, body) = retry.into_parts();
+        parts.uri = target
+            .parse()
+            .map_err(|err| new_http_uri_invalid_error(err).with_context("location", &target))?;
+        ctx.http_transport()
+            .fetch(Request::from_parts(parts, body))
             .await
-            .cloned()
-    }
-
-    /// Build an [`HfUri`] for the given operator-relative path, using the
-    /// canonical repo id.
-    pub(super) async fn canonical_uri(&self, ctx: &OperationContext, path: &str) -> Result<HfUri> {
-        Ok(self.canonical_repo(ctx).await?.uri(&self.root, path))
     }
 
     /// Convert an operator-relative path to a repo-absolute path
@@ -639,7 +615,7 @@ impl HfCore {
     }
 
     pub(super) async fn path_info(&self, ctx: &OperationContext, path: &str) -> Result<PathInfo> {
-        let uri = self.canonical_uri(ctx, path).await?;
+        let uri = self.repo.uri(&self.root, path);
         let url = uri.paths_info_url(&self.endpoint);
         let form_body = format!("paths={}&expand=True", percent_encode_path(&uri.path));
 
@@ -648,7 +624,7 @@ impl HfCore {
             .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
             .body(Buffer::from(Bytes::from(form_body)))
             .map_err(new_request_build_error)?;
-        let resp = ctx.http_transport().fetch(req).await?;
+        let resp = self.send(ctx, req).await?;
         if !resp.status().is_success() {
             let (parts, _) = resp.into_parts();
             return Err(parse_error(
@@ -683,7 +659,7 @@ impl HfCore {
         range: BytesRange,
         mode: HfDownloadMode,
     ) -> Result<Response<HttpBody>> {
-        let uri = self.canonical_uri(ctx, path).await?;
+        let uri = self.repo.uri(&self.root, path);
         let url = uri.resolve_url(&self.endpoint, self.repo.revision());
 
         let mut req = self.request(http::Method::GET, &url, Operation::Read, "Resolve")?;
@@ -697,7 +673,7 @@ impl HfCore {
         }
 
         let req = req.body(Buffer::new()).map_err(new_request_build_error)?;
-        let resp = ctx.http_transport().fetch(req).await?;
+        let resp = self.send(ctx, req).await?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -726,10 +702,7 @@ impl HfCore {
         deleted_files: Vec<DeletedFile>,
         deleted_folders: Vec<DeletedFolder>,
     ) -> Result<CommitResponse> {
-        let url = self
-            .canonical_repo(ctx)
-            .await?
-            .git_commit_url(&self.endpoint);
+        let url = self.repo.git_commit_url(&self.endpoint);
 
         let payload = MixedCommitPayload {
             summary: "Commit via OpenDAL".to_string(),
@@ -748,7 +721,7 @@ impl HfCore {
             .body(Buffer::from(json_body))
             .map_err(new_request_build_error)?;
 
-        let resp = ctx.http_transport().fetch(req).await?;
+        let resp = self.send(ctx, req).await?;
         if !resp.status().is_success() {
             let (parts, _) = resp.into_parts();
             return Err(parse_error(
@@ -792,7 +765,7 @@ impl HfCore {
             .body(Buffer::from(Bytes::from(body)))
             .map_err(new_request_build_error)?;
 
-        let resp = ctx.http_transport().fetch(req).await?;
+        let resp = self.send(ctx, req).await?;
         if !resp.status().is_success() {
             let (parts, _) = resp.into_parts();
             return Err(parse_error(
@@ -806,7 +779,7 @@ impl HfCore {
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use http::{Request, Response, StatusCode};
+    use http::{Request, Response};
     use std::sync::{Arc, Mutex};
 
     use super::super::core::HfRepoType;
@@ -973,16 +946,6 @@ pub(crate) mod test_utils {
                     HttpBody::new(futures::stream::iter(vec![Ok(buffer)]), Some(size)),
                     size,
                 )
-            } else if let Some(rest) = req.uri().path().strip_prefix("/api/") {
-                // Repo-info: echo the requested id back as the canonical id.
-                let id = rest.split_once('/').map(|(_, id)| id).unwrap_or(rest);
-                let data = Bytes::from(format!(r#"{{"id":"{id}"}}"#));
-                let size = data.len() as u64;
-                let buffer = Buffer::from(data);
-                (
-                    HttpBody::new(futures::stream::iter(vec![Ok(buffer)]), Some(size)),
-                    size,
-                )
             } else {
                 let data = Bytes::from_static(b"hello");
                 let size = data.len() as u64;
@@ -1007,8 +970,25 @@ pub(crate) mod test_utils {
         revision: &str,
         endpoint: &str,
     ) -> (HfCore, OperationContext, MockHttpTransport) {
-        let mock_client = MockHttpTransport::new();
-        let http_transport = HttpTransporter::new(mock_client.clone());
+        create_test_core_with(
+            MockHttpTransport::new(),
+            repo_type,
+            repo_id,
+            revision,
+            endpoint,
+        )
+    }
+
+    /// Like [`create_test_core`] but with a caller-supplied transport, for
+    /// tests that need to script responses the shared mock doesn't.
+    pub(crate) fn create_test_core_with<T: HttpTransport + Clone>(
+        transport: T,
+        repo_type: HfRepoType,
+        repo_id: &str,
+        revision: &str,
+        endpoint: &str,
+    ) -> (HfCore, OperationContext, T) {
+        let http_transport = HttpTransporter::new(transport.clone());
         let ctx = OperationContext::from_parts(http_transport, Executor::default());
 
         let info = ServiceInfo::new("hf", "", "");
@@ -1028,7 +1008,7 @@ pub(crate) mod test_utils {
             HfDownloadMode::Xet,
         );
 
-        (core, ctx, mock_client)
+        (core, ctx, transport)
     }
 }
 
@@ -1037,10 +1017,9 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use http::Response;
-    use http::StatusCode;
 
     use super::super::core::HfRepoType;
-    use super::test_utils::create_test_core;
+    use super::test_utils::{create_test_core, create_test_core_with};
     use super::*;
 
     #[tokio::test]
@@ -1123,15 +1102,26 @@ mod tests {
         Ok(())
     }
 
-    /// A scripted transport mirroring how HF serves a repo whose configured id
-    /// is not canonically cased: repo-info returns the canonical id, and only
-    /// the canonical commit URL accepts the commit.
-    #[derive(Clone, Default)]
-    struct CanonicalCaseTransport {
-        requests: Arc<Mutex<Vec<(String, String, String)>>>,
+    struct SeenRequest {
+        method: String,
+        uri: String,
+        auth: String,
+        body: String,
     }
 
-    impl HttpTransport for CanonicalCaseTransport {
+    /// A scripted transport mirroring how HF serves a repo whose configured
+    /// id is not canonically cased: it answers that URL with `status` and a
+    /// `Location` of `location`, and only the canonically cased URL accepts
+    /// the commit. Tests set both, so one transport covers
+    /// a followed redirect, a refused one, and a non-307 status.
+    #[derive(Clone)]
+    struct RedirectingTransport {
+        status: StatusCode,
+        location: &'static str,
+        requests: Arc<Mutex<Vec<SeenRequest>>>,
+    }
+
+    impl HttpTransport for RedirectingTransport {
         async fn fetch(&self, req: Request<Buffer>) -> Result<Response<HttpBody>> {
             let uri = req.uri().to_string();
             let auth = req
@@ -1140,91 +1130,200 @@ mod tests {
                 .and_then(|v| v.to_str().ok())
                 .unwrap_or_default()
                 .to_string();
-            self.requests
-                .lock()
-                .unwrap()
-                .push((req.method().to_string(), uri.clone(), auth));
+            let body = String::from_utf8(req.body().to_bytes().to_vec()).unwrap();
+            self.requests.lock().unwrap().push(SeenRequest {
+                method: req.method().to_string(),
+                uri: uri.clone(),
+                auth,
+                body,
+            });
 
-            let body = match uri.as_str() {
-                "https://huggingface.co/api/models/test-user/uppercase-repo" => {
-                    Bytes::from_static(br#"{"id":"test-user/Uppercase-Repo"}"#)
+            let resp = match uri.as_str() {
+                "https://huggingface.co/api/models/test-user/uppercase-repo/commit/main" => {
+                    Response::builder()
+                        .status(self.status)
+                        .header(header::LOCATION, self.location)
+                        .header(header::CONTENT_LENGTH, 0)
+                        .body(HttpBody::new(futures::stream::empty(), Some(0)))
                 }
                 "https://huggingface.co/api/models/test-user/Uppercase-Repo/commit/main" => {
-                    Bytes::from_static(b"{}")
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .header(header::CONTENT_LENGTH, 2)
+                        .body(HttpBody::new(
+                            futures::stream::iter(vec![Ok(Buffer::from(Bytes::from_static(
+                                b"{}",
+                            )))]),
+                            Some(2),
+                        ))
                 }
                 other => panic!("unexpected request to {other}"),
             };
-            let len = body.len() as u64;
-            Ok(Response::builder()
-                .status(http::StatusCode::OK)
-                .header(header::CONTENT_LENGTH, len)
-                .body(HttpBody::new(
-                    futures::stream::iter(vec![Ok(Buffer::from(body))]),
-                    Some(len),
-                ))
-                .unwrap())
+            Ok(resp.unwrap())
         }
     }
 
-    #[tokio::test]
-    async fn test_commit_uses_canonical_repo_id() -> Result<()> {
-        let transport = CanonicalCaseTransport::default();
-        let ctx = OperationContext::from_parts(
-            HttpTransporter::new(transport.clone()),
-            Executor::default(),
+    fn redirecting_core(
+        status: StatusCode,
+        location: &'static str,
+    ) -> (HfCore, OperationContext, RedirectingTransport) {
+        let (mut core, ctx, transport) = create_test_core_with(
+            RedirectingTransport {
+                status,
+                location,
+                requests: Arc::default(),
+            },
+            HfRepoType::Model,
+            "test-user/uppercase-repo",
+            "main",
+            "https://huggingface.co",
         );
+        core.token = Some("hf_dummy".to_string());
+        (core, ctx, transport)
+    }
 
-        let xet_session = XetSessionBuilder::new()
-            .build()
-            .expect("failed to create xet session");
-        let core = HfCore::new(
-            ServiceInfo::new("hf", "", ""),
-            Capability::default(),
-            HfRepo::new(
-                HfRepoType::Model,
-                "test-user/uppercase-repo".to_string(),
-                Some("main".to_string()),
-            ),
-            "/".to_string(),
-            Some("hf_dummy".to_string()),
-            "https://huggingface.co".to_string(),
-            xet_session,
-            HfDownloadMode::Xet,
-        );
-
-        let lfs_file = |path: &str| LfsFile {
+    fn lfs_file(path: &str) -> LfsFile {
+        LfsFile {
             path: path.to_string(),
             oid: "deadbeef".to_string(),
             algo: "sha256".to_string(),
             size: 2812,
-        };
+        }
+    }
+
+    /// `send` re-issues a bodied `POST` answered with a 307 to the
+    /// canonically cased URL with the same method, headers and body,
+    /// regardless of whether the transport replays redirects itself. HF
+    /// sends the `Location` as an absolute path, as in the report for #8107.
+    #[tokio::test]
+    async fn test_commit_follows_case_redirect() -> Result<()> {
+        let (core, ctx, transport) = redirecting_core(
+            StatusCode::TEMPORARY_REDIRECT,
+            "/api/models/test-user/Uppercase-Repo/commit/main",
+        );
+
         core.commit_git(&ctx, vec![], vec![lfs_file("a.md")], vec![], vec![])
-            .await?;
-        core.commit_git(&ctx, vec![], vec![lfs_file("b.md")], vec![], vec![])
             .await?;
 
         let requests = transport.requests.lock().unwrap();
-        let expected = [
-            (
-                "GET",
-                "https://huggingface.co/api/models/test-user/uppercase-repo",
+        assert_eq!(requests.len(), 2);
+        let (first, redirected) = (&requests[0], &requests[1]);
+        assert_eq!(first.method, "POST");
+        assert_eq!(
+            first.uri,
+            "https://huggingface.co/api/models/test-user/uppercase-repo/commit/main"
+        );
+        assert_eq!(first.auth, "Bearer hf_dummy");
+        assert_eq!(redirected.method, "POST");
+        assert_eq!(
+            redirected.uri,
+            "https://huggingface.co/api/models/test-user/Uppercase-Repo/commit/main"
+        );
+        assert_eq!(redirected.auth, "Bearer hf_dummy");
+        assert_eq!(redirected.body, first.body);
+        assert!(first.body.contains("a.md"));
+
+        Ok(())
+    }
+
+    /// `send` also follows an absolute `Location` on the configured endpoint,
+    /// and a 308 like a 307.
+    #[tokio::test]
+    async fn test_commit_follows_absolute_same_endpoint_redirect() -> Result<()> {
+        let (core, ctx, transport) = redirecting_core(
+            StatusCode::PERMANENT_REDIRECT,
+            "https://huggingface.co/api/models/test-user/Uppercase-Repo/commit/main",
+        );
+
+        core.commit_git(&ctx, vec![], vec![lfs_file("a.md")], vec![], vec![])
+            .await?;
+
+        assert_eq!(transport.requests.lock().unwrap().len(), 2);
+        Ok(())
+    }
+
+    /// `send` must not follow a redirect off the configured endpoint: the
+    /// re-issued request would carry the bearer token to a foreign host.
+    /// The 307 surfaces as an error instead.
+    #[tokio::test]
+    async fn test_commit_does_not_follow_foreign_redirect() -> Result<()> {
+        let (core, ctx, transport) = redirecting_core(
+            StatusCode::TEMPORARY_REDIRECT,
+            "https://evil.example.com/api/models/test-user/Uppercase-Repo/commit/main",
+        );
+
+        let err = core
+            .commit_git(&ctx, vec![], vec![lfs_file("a.md")], vec![], vec![])
+            .await
+            .expect_err("a foreign redirect must not be followed");
+        assert_eq!(err.kind(), ErrorKind::Unexpected);
+        assert!(
+            err.to_string()
+                .contains("redirect to https://evil.example.com/api/models/test-user/Uppercase-Repo/commit/main not followed"),
+            "the refused redirect must be named in the error: {err}"
+        );
+        assert_eq!(transport.requests.lock().unwrap().len(), 1);
+
+        Ok(())
+    }
+
+    /// A protocol-relative `Location` names another host, so it is refused
+    /// rather than treated as a path on ours.
+    #[tokio::test]
+    async fn test_commit_does_not_follow_protocol_relative_redirect() -> Result<()> {
+        let (core, ctx, transport) =
+            redirecting_core(StatusCode::TEMPORARY_REDIRECT, "//evil.example.com/api/x");
+
+        let err = core
+            .commit_git(&ctx, vec![], vec![lfs_file("a.md")], vec![], vec![])
+            .await
+            .expect_err("a protocol-relative redirect must not be followed");
+        assert!(err.to_string().contains("not followed"), "{err}");
+        assert_eq!(transport.requests.lock().unwrap().len(), 1);
+
+        Ok(())
+    }
+
+    /// A `Location` without a leading slash is a relative reference this
+    /// service does not resolve; it is refused rather than guessed at.
+    #[tokio::test]
+    async fn test_commit_does_not_follow_relative_redirect() -> Result<()> {
+        let (core, ctx, transport) = redirecting_core(
+            StatusCode::TEMPORARY_REDIRECT,
+            "api/models/test-user/Uppercase-Repo/commit/main",
+        );
+
+        let err = core
+            .commit_git(&ctx, vec![], vec![lfs_file("a.md")], vec![], vec![])
+            .await
+            .expect_err("a relative redirect must not be followed");
+        assert!(err.to_string().contains("not followed"), "{err}");
+        assert_eq!(transport.requests.lock().unwrap().len(), 1);
+
+        Ok(())
+    }
+
+    /// `send` only replays 307/308. A 302 is passed through untouched: in
+    /// http download mode the transport follows the resolve 302 to the CDN
+    /// itself, and `send` must not re-issue it on the API host.
+    #[tokio::test]
+    async fn test_send_leaves_302_to_the_transport() -> Result<()> {
+        let (core, ctx, transport) = redirecting_core(
+            StatusCode::FOUND,
+            "/api/models/test-user/Uppercase-Repo/commit/main",
+        );
+
+        let err = core
+            .commit_git(&ctx, vec![], vec![lfs_file("a.md")], vec![], vec![])
+            .await
+            .expect_err("an unfollowed 302 must surface as an error");
+        assert!(
+            err.to_string().contains(
+                "redirect to /api/models/test-user/Uppercase-Repo/commit/main not followed"
             ),
-            (
-                "POST",
-                "https://huggingface.co/api/models/test-user/Uppercase-Repo/commit/main",
-            ),
-            // The canonical id is cached: no second repo-info request.
-            (
-                "POST",
-                "https://huggingface.co/api/models/test-user/Uppercase-Repo/commit/main",
-            ),
-        ];
-        assert_eq!(requests.len(), expected.len());
-        for ((method, uri, auth), (exp_method, exp_uri)) in requests.iter().zip(expected) {
-            assert_eq!(method, exp_method);
-            assert_eq!(uri, exp_uri);
-            assert_eq!(auth, "Bearer hf_dummy");
-        }
+            "{err}"
+        );
+        assert_eq!(transport.requests.lock().unwrap().len(), 1);
 
         Ok(())
     }
@@ -1239,22 +1338,15 @@ mod tests {
         );
         mock_client.set_xet_token_expires_at(u64::MAX);
 
-        // 2 requests: one to resolve the canonical repo id, one for the
-        // token itself.
-        let repo = core.canonical_repo(&ctx).await?;
-        let first = core
-            .cached_xet_token(&ctx, &repo, XetTokenScope::Read)
-            .await?;
-        assert_eq!(mock_client.request_count(), 2);
+        let first = core.cached_xet_token(&ctx, XetTokenScope::Read).await?;
+        assert_eq!(mock_client.request_count(), 1);
         assert_eq!(first.access_token, "mock-token");
         assert_eq!(first.cas_url, "https://cas.example.com");
 
         // A second call with the cached token nowhere near expiry must not
-        // hit the network again -- the canonical repo id is cached too.
-        let second = core
-            .cached_xet_token(&ctx, &repo, XetTokenScope::Read)
-            .await?;
-        assert_eq!(mock_client.request_count(), 2);
+        // hit the network again.
+        let second = core.cached_xet_token(&ctx, XetTokenScope::Read).await?;
+        assert_eq!(mock_client.request_count(), 1);
         assert_eq!(second.access_token, first.access_token);
 
         Ok(())
@@ -1271,19 +1363,13 @@ mod tests {
         // Already within the refresh buffer of "now" -- immediately stale.
         mock_client.set_xet_token_expires_at(0);
 
-        // 2 requests: one to resolve the canonical repo id, one for the
-        // token itself.
-        let repo = core.canonical_repo(&ctx).await?;
-        core.cached_xet_token(&ctx, &repo, XetTokenScope::Read)
-            .await?;
-        assert_eq!(mock_client.request_count(), 2);
+        core.cached_xet_token(&ctx, XetTokenScope::Read).await?;
+        assert_eq!(mock_client.request_count(), 1);
 
-        // The canonical repo id is cached, so only the token is re-fetched.
-        core.cached_xet_token(&ctx, &repo, XetTokenScope::Read)
-            .await?;
+        core.cached_xet_token(&ctx, XetTokenScope::Read).await?;
         assert_eq!(
             mock_client.request_count(),
-            3,
+            2,
             "a token that's always stale must be refreshed on every call, not cached"
         );
 
@@ -1304,21 +1390,15 @@ mod tests {
         mock_client.set_xet_token_expires_at(u64::MAX);
         mock_client.fail_next_requests(1);
 
-        // The injected failure hits the canonical repo id lookup, the first
-        // request resolving it makes.
-        match core.canonical_repo(&ctx).await {
+        match core.cached_xet_token(&ctx, XetTokenScope::Read).await {
             Err(err) => assert!(err.to_string().contains("mock injected failure")),
-            Ok(_) => panic!("a failed canonical repo lookup must surface as an error"),
+            Ok(_) => panic!("a failed token fetch must surface as an error"),
         }
         assert_eq!(mock_client.request_count(), 1);
 
-        // Retry: canonical repo id lookup succeeds, then the token itself.
-        let repo = core.canonical_repo(&ctx).await?;
-        let token = core
-            .cached_xet_token(&ctx, &repo, XetTokenScope::Read)
-            .await?;
+        let token = core.cached_xet_token(&ctx, XetTokenScope::Read).await?;
         assert_eq!(token.access_token, "mock-token");
-        assert_eq!(mock_client.request_count(), 3);
+        assert_eq!(mock_client.request_count(), 2);
 
         Ok(())
     }
@@ -1331,32 +1411,24 @@ mod tests {
             "main",
             "https://huggingface.co",
         );
-        // A write-scope token fetch now goes through `request()` tagged as
-        // `Operation::Write`, which requires a token to be configured.
+        // Write-scope token fetches are tagged `Operation::Write`, which
+        // requires a token.
         core.token = Some("hf_dummy".to_string());
         mock_client.set_xet_token_expires_at(u64::MAX);
 
-        // 2 requests: one to resolve the canonical repo id, one for the
-        // read token itself.
-        let repo = core.canonical_repo(&ctx).await?;
-        core.cached_xet_token(&ctx, &repo, XetTokenScope::Read)
-            .await?;
-        assert_eq!(mock_client.request_count(), 2);
+        core.cached_xet_token(&ctx, XetTokenScope::Read).await?;
+        assert_eq!(mock_client.request_count(), 1);
 
         // A write token request must not be satisfied by the read token's
-        // cache slot -- read and write are distinct HF API scopes. The
-        // canonical repo id is already cached, so only the token is fetched.
-        core.cached_xet_token(&ctx, &repo, XetTokenScope::Write)
-            .await?;
-        assert_eq!(mock_client.request_count(), 3);
+        // cache slot -- read and write are distinct HF API scopes.
+        core.cached_xet_token(&ctx, XetTokenScope::Write).await?;
+        assert_eq!(mock_client.request_count(), 2);
         assert!(mock_client.get_captured_url().contains("write"));
 
         // Both are now warm; neither call should hit the network again.
-        core.cached_xet_token(&ctx, &repo, XetTokenScope::Read)
-            .await?;
-        core.cached_xet_token(&ctx, &repo, XetTokenScope::Write)
-            .await?;
-        assert_eq!(mock_client.request_count(), 3);
+        core.cached_xet_token(&ctx, XetTokenScope::Read).await?;
+        core.cached_xet_token(&ctx, XetTokenScope::Write).await?;
+        assert_eq!(mock_client.request_count(), 2);
 
         Ok(())
     }
@@ -1375,15 +1447,13 @@ mod tests {
         );
         mock_client.set_xet_token_expires_at(u64::MAX);
 
-        // 2 requests: one to resolve the canonical repo id, one for the
-        // read token itself.
         core.xet_download_group(&ctx).await?;
-        assert_eq!(mock_client.request_count(), 2);
+        assert_eq!(mock_client.request_count(), 1);
 
-        // A second group build must reuse the cached read token (and
-        // canonical repo id) rather than fetching its own.
+        // A second group build must reuse the cached read token rather than
+        // fetching its own.
         core.xet_download_group(&ctx).await?;
-        assert_eq!(mock_client.request_count(), 2);
+        assert_eq!(mock_client.request_count(), 1);
 
         Ok(())
     }
@@ -1399,23 +1469,20 @@ mod tests {
         core.token = Some("hf_dummy".to_string());
         mock_client.set_xet_token_expires_at(u64::MAX);
 
-        // 2 requests: one to resolve the canonical repo id, one for the
-        // write token itself.
         core.xet_upload_commit(&ctx).await?;
-        assert_eq!(mock_client.request_count(), 2);
+        assert_eq!(mock_client.request_count(), 1);
         assert!(mock_client.get_captured_url().contains("write"));
 
-        // A second commit build must reuse the cached write token (and
-        // canonical repo id) rather than fetching its own.
+        // A second commit build must reuse the cached write token rather
+        // than fetching its own.
         core.xet_upload_commit(&ctx).await?;
-        assert_eq!(mock_client.request_count(), 2);
+        assert_eq!(mock_client.request_count(), 1);
 
         Ok(())
     }
 
-    /// A write-token fetch must be tagged `Operation::Write`, not `Read`, so
-    /// a token-less writer hits `request()`'s local `PermissionDenied`
-    /// fast-path instead of firing a real unauthenticated network call.
+    /// A write-token fetch must be tagged `Operation::Write` so a
+    /// token-less writer is rejected locally instead of hitting the network.
     #[tokio::test]
     async fn test_xet_upload_commit_without_token_fails_locally() -> Result<()> {
         let (core, ctx, mock_client) = create_test_core(
@@ -1430,10 +1497,7 @@ mod tests {
             Err(err) => assert_eq!(err.kind(), ErrorKind::PermissionDenied),
             Ok(_) => panic!("an upload commit without a token must fail locally"),
         }
-        // The canonical repo id lookup doesn't require a token, but the
-        // write-token fetch itself must be rejected before it reaches the
-        // network.
-        assert_eq!(mock_client.request_count(), 1);
+        assert_eq!(mock_client.request_count(), 0);
 
         Ok(())
     }
@@ -1456,31 +1520,25 @@ mod tests {
             .as_secs();
 
         // Exactly at the buffer boundary: `expires_at > now + BUFFER` is
-        // false, so this must be treated as stale. The first call also pays
-        // for the one-time canonical repo id lookup.
+        // false, so this must be treated as stale.
         mock_client.set_xet_token_expires_at(now + XET_TOKEN_REFRESH_BUFFER_SECS);
-        let repo = core.canonical_repo(&ctx).await?;
-        core.cached_xet_token(&ctx, &repo, XetTokenScope::Read)
-            .await?;
-        assert_eq!(mock_client.request_count(), 2);
-        core.cached_xet_token(&ctx, &repo, XetTokenScope::Read)
-            .await?;
+        core.cached_xet_token(&ctx, XetTokenScope::Read).await?;
+        assert_eq!(mock_client.request_count(), 1);
+        core.cached_xet_token(&ctx, XetTokenScope::Read).await?;
         assert_eq!(
             mock_client.request_count(),
-            3,
+            2,
             "a token expiring exactly at the refresh buffer must be refetched, not reused"
         );
 
         // One second past the boundary: now fresh, so cached and reused.
         mock_client.set_xet_token_expires_at(now + XET_TOKEN_REFRESH_BUFFER_SECS + 1);
-        core.cached_xet_token(&ctx, &repo, XetTokenScope::Read)
-            .await?;
-        assert_eq!(mock_client.request_count(), 4);
-        core.cached_xet_token(&ctx, &repo, XetTokenScope::Read)
-            .await?;
+        core.cached_xet_token(&ctx, XetTokenScope::Read).await?;
+        assert_eq!(mock_client.request_count(), 3);
+        core.cached_xet_token(&ctx, XetTokenScope::Read).await?;
         assert_eq!(
             mock_client.request_count(),
-            4,
+            3,
             "a token expiring past the refresh buffer must be cached and reused"
         );
 
@@ -1500,11 +1558,10 @@ mod tests {
         );
         mock_client.set_xet_token_expires_at(u64::MAX);
 
-        let repo = core.canonical_repo(&ctx).await?;
         let (r1, r2, r3) = futures::join!(
-            core.cached_xet_token(&ctx, &repo, XetTokenScope::Read),
-            core.cached_xet_token(&ctx, &repo, XetTokenScope::Read),
-            core.cached_xet_token(&ctx, &repo, XetTokenScope::Read),
+            core.cached_xet_token(&ctx, XetTokenScope::Read),
+            core.cached_xet_token(&ctx, XetTokenScope::Read),
+            core.cached_xet_token(&ctx, XetTokenScope::Read),
         );
         r1?;
         r2?;
@@ -1512,9 +1569,8 @@ mod tests {
 
         assert_eq!(
             mock_client.request_count(),
-            2,
-            "concurrent callers racing on a cold/stale token must share one refresh \
-             (plus the one-time canonical repo id lookup)"
+            1,
+            "concurrent callers racing on a cold/stale token must share one refresh"
         );
 
         Ok(())
@@ -1554,8 +1610,6 @@ mod tests {
     }
 }
 
-use http::StatusCode;
-
 /// Context needed to classify an error from this service.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct ErrorContext {
@@ -1573,12 +1627,23 @@ pub(crate) fn parse_error(ctx: ErrorContext, parts: http::response::Parts) -> Er
     // HF sets x-error-message on every error response with a short human-readable
     // description. Using the header avoids reading the response body, which can be
     // a large HTML error page (e.g. 52 KB on 404s from the /resolve/ endpoint).
-    let message = parts
+    let error_message = parts
         .headers
         .get("x-error-message")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("unknown error")
-        .to_string();
+        .and_then(|v| v.to_str().ok());
+    let location = parts
+        .headers
+        .get(header::LOCATION)
+        .and_then(|v| v.to_str().ok());
+    let message = match (error_message, location) {
+        (Some(message), _) => message.to_string(),
+        // A 3xx only reaches here when `HfCore::send` refused to follow it,
+        // so name the destination instead of "unknown error".
+        (None, Some(location)) if parts.status.is_redirection() => {
+            format!("redirect to {location} not followed")
+        }
+        _ => "unknown error".to_string(),
+    };
 
     // HF git-style commit APIs reject stale branch snapshots with 412.
     // Treat this specific conflict as temporary so RetryLayer can replay

--- a/core/services/hf/src/lister.rs
+++ b/core/services/hf/src/lister.rs
@@ -86,7 +86,7 @@ impl HfLister {
         recursive: bool,
         cursor: Option<&str>,
     ) -> Result<FileTree> {
-        let uri = self.core.canonical_uri(&self.ctx, path).await?;
+        let uri = self.core.repo.uri(&self.core.root, path);
         let url = uri.file_tree_url(&self.core.endpoint, recursive, cursor);
 
         let req = self
@@ -94,7 +94,7 @@ impl HfLister {
             .request(http::Method::GET, &url, Operation::List, "FileTree")?
             .body(Buffer::new())
             .map_err(new_request_build_error)?;
-        let resp = self.ctx.http_transport().fetch(req).await?;
+        let resp = self.core.send(&self.ctx, req).await?;
         if !resp.status().is_success() {
             let (parts, _) = resp.into_parts();
             return Err(parse_error(

--- a/core/services/hf/src/reader.rs
+++ b/core/services/hf/src/reader.rs
@@ -232,7 +232,9 @@ impl oio::StreamRead for HfReader {
 
 #[cfg(test)]
 mod tests {
-    use super::super::backend::test_utils::{mbpp_operator, testing_dataset_core};
+    use super::super::backend::test_utils::{
+        mbpp_operator, miscased_mbpp_operator, testing_dataset_core,
+    };
     use super::super::core::HfRepoType;
     use super::super::core::test_utils::create_test_core;
     use super::super::core::{CommitFile, DeletedFile, HfCore};
@@ -308,9 +310,8 @@ mod tests {
     /// file has no separate metadata step to skip for its actual bytes: the
     /// classifying resolve's body is discarded and every open, including the
     /// first, fetches its own bytes with its own resolve. So the first open
-    /// costs 3 (canonical repo id + classify + fetch) and every later one
-    /// costs 1 (fetch only, classification and the canonical repo id already
-    /// cached).
+    /// costs 2 (classify + fetch) and every later one costs 1 (fetch only,
+    /// classification already cached).
     #[tokio::test]
     async fn test_non_xet_reads_cache_classification_but_still_fetch_each_range() -> Result<()> {
         let (core, ctx, mock_client) = create_test_core(
@@ -323,11 +324,11 @@ mod tests {
 
         let (_, mut s1) = reader.open(BytesRange::new(0, Some(1))).await?;
         s1.read().await?;
-        assert_eq!(mock_client.request_count(), 3);
+        assert_eq!(mock_client.request_count(), 2);
 
         let (_, mut s2) = reader.open(BytesRange::new(1, Some(1))).await?;
         s2.read().await?;
-        assert_eq!(mock_client.request_count(), 4);
+        assert_eq!(mock_client.request_count(), 3);
 
         Ok(())
     }
@@ -346,8 +347,6 @@ mod tests {
         let reader = hf_reader(core, ctx, "plain.txt");
         mock_client.fail_next_requests(1);
 
-        // The injected failure hits the canonical repo id lookup, the first
-        // request a classifying resolve makes.
         let result = reader.open(BytesRange::new(0, Some(1))).await;
         assert!(
             result.is_err(),
@@ -359,8 +358,8 @@ mod tests {
         stream.read().await?;
         assert_eq!(
             mock_client.request_count(),
-            4,
-            "classification must retry (canonical repo id + resolve) then fetch the range (1 more)"
+            3,
+            "classification must retry (1 resolve) then fetch the range (1 more)"
         );
 
         Ok(())
@@ -392,11 +391,10 @@ mod tests {
         r2?;
         r3?;
 
-        // 1 shared canonical repo id lookup + 1 shared classifying resolve +
-        // 1 shared xet-read-token fetch for the shared group build. Fetching
-        // actual bytes from the group would need a real CAS server, so this
-        // test only covers open().
-        assert_eq!(mock_client.request_count(), 3);
+        // 1 shared classifying resolve + 1 shared xet-read-token fetch for
+        // the shared group build. Fetching actual bytes from the group would
+        // need a real CAS server, so this test only covers open().
+        assert_eq!(mock_client.request_count(), 2);
 
         Ok(())
     }
@@ -476,10 +474,41 @@ mod tests {
         r2?.1.read().await?;
         r3?.1.read().await?;
 
-        // 1 canonical repo id lookup + 1 shared classifying resolve + 3 individual fetches.
-        assert_eq!(mock_client.request_count(), 5);
+        // 1 shared classifying resolve + 3 individual fetches.
+        assert_eq!(mock_client.request_count(), 4);
 
         Ok(())
+    }
+
+    /// Regression test for #8107 against the live API: a repo id whose case
+    /// differs from the canonical one.
+    ///
+    /// `stat` is the operation that matters here. It posts to `paths-info`,
+    /// and HF answers a miscased id with a `307` carrying a path-only
+    /// `Location`. A transport will follow that for a `GET` but hands a
+    /// bodied `POST` back unfollowed, which is exactly the failure #8107
+    /// reported, so this only passes if `HfCore::send` re-issues the request.
+    /// The read then covers the `resolve` path through the same repo. Both
+    /// use a public dataset, so no token is needed.
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn test_miscased_repo_id_follows_redirects() {
+        let path = "full/train-00000-of-00001.parquet";
+        let op = miscased_mbpp_operator();
+
+        let meta = op
+            .stat(path)
+            .await
+            .expect("stat must follow the case redirect on its paths-info POST");
+        assert!(meta.content_length() > 0);
+
+        let bytes = op
+            .read_with(path)
+            .range(0..4)
+            .await
+            .expect("read must succeed against a miscased repo id")
+            .to_vec();
+        assert_eq!(bytes, PARQUET_MAGIC);
     }
 
     /// Exercises the XET download code path against a public dataset known to


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up to #8108 (which closed #8107).

# Rationale for this change

#8108 resolves the canonical repo id via an extra repo-info request per `Operator` and builds every URL from it. HF answers a mis-cased id with a `307` and a path-only `Location`; the reqwest transport follows that for GETs but returns bodied POSTs (commit, paths-info) as the bare `307`. Following that one redirect where it happens fixes #8107 with no cost for correctly cased ids.

After some extra work to enable logging in the tests:

```
❯ RUST_LOG=opendal_service_hf::core=debug cargo test -p opendal-service-hf test_miscased_repo_id_follows_redirects -- --ignored --nocapture

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running unittests src/lib.rs (target/debug/deps/opendal_service_hf-d55de3598e88cd7f)

running 1 test
2026-09-07T18:43:21.741385+02:00  DEBUG opendal_service_hf::core: core.rs:527 hf request: service_operation=PathInfo operation=stat method=POST url=https://huggingface.co/api/datasets/Google-Research-Datasets/MBPP/paths-info/main
2026-09-07T18:43:22.046166+02:00  DEBUG opendal_service_hf::core: core.rs:599 hf request redirected: url=https://huggingface.co/api/datasets/Google-Research-Datasets/MBPP/paths-info/main -> https://huggingface.co/api/datasets/google-research-datasets/mbpp/paths-info/main
2026-09-07T18:43:22.313634+02:00  DEBUG opendal_service_hf::core: core.rs:527 hf request: service_operation=Resolve operation=read method=GET url=https://huggingface.co/datasets/Google-Research-Datasets/MBPP/resolve/main/full/train-00000-of-00001.parquet
2026-09-07T18:43:22.580211+02:00  DEBUG opendal_service_hf::core: core.rs:527 hf request: service_operation=XetToken operation=read method=GET url=https://huggingface.co/api/datasets/Google-Research-Datasets/MBPP/xet-read-token/main
test reader::tests::test_miscased_repo_id_follows_redirects ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 84 filtered out; finished in 2.14s
```

# What changes are included in this PR?

- `HfCore::send` re-issues a request once when HF answers `307`/`308` with a `Location` on the configured origin. Other hosts are not followed, and the refused redirect is named in the error.
- `canonical_repo`, `canonical_uri`, `RepoInfoResponse` and `xet_auth` are removed; URL construction is synchronous again.
- Tests script the redirect directly (path-only, absolute same-origin, foreign host, `302` pass-through, prefixed endpoint) and drop the repo-info request from the existing counts.

Verified live against huggingface.co with an upper-cased dataset id: write, stat, read and delete succeed in both download modes.

# Are there any user-facing changes?

No API change. Correctly cased repo ids no longer issue a repo-info request; mis-cased ids pay one redirect per request instead of one lookup per `Operator`.

# AI Usage Statement

Claude drafted the implementation, tests and live verification. 
