### PR TITLE
chore: prepare release v0.59.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 <!-- Release notes generated with: gh release create v_draft --generate-notes --draft -->
 
+## [v0.59.1] - 2026-09-05
+
+### Fixed
+* Include the changelog in the `opendal-core` crate so packages downloaded from crates.io compile. https://github.com/apache/opendal/pull/8223
+* Resolve GooseFS master addresses from `goosefs-site.properties`. https://github.com/apache/opendal/pull/8216
+
+### Added
+* Support response header overrides in GCS presigned XML requests. https://github.com/apache/opendal/pull/8206
+
+### Docs
+* Add conda-forge installation instructions for Python. https://github.com/apache/opendal/pull/8213
+
+### CI
+* Refresh the APT package index before installing dependencies. https://github.com/apache/opendal/pull/8215
+* Use the GHCR v2.0.0 GooseFS fixture image. https://github.com/apache/opendal/pull/8214
+
+**Full Changelog**: https://github.com/apache/opendal/compare/v0.59.0...v0.59.1
+
 ## [v0.59.0] - 2026-08-31
 
 ### Breaking Changes

--- a/bindings/c/DEPENDENCIES.rust.tsv
+++ b/bindings/c/DEPENDENCIES.rust.tsv
@@ -7,8 +7,8 @@ anstyle-wincon@3.0.11	X							X
 anyhow@1.0.104	X							X				
 asyncband@0.6.7	X											
 atomic-waker@1.1.2	X							X				
-aws-lc-rs@1.18.0	X					X						
-aws-lc-sys@0.44.0	X		X			X		X	X			
+aws-lc-rs@1.18.1	X					X						
+aws-lc-sys@0.45.0	X		X			X		X	X			
 backon@1.6.0	X											
 base64@0.22.1	X							X				
 base64@0.23.1	X							X				
@@ -17,7 +17,7 @@ block-buffer@0.12.1	X							X
 bumpalo@3.20.3	X							X				
 bytes@1.12.1								X				
 cbindgen@0.29.4										X		
-cc@1.4.4	X							X				
+cc@1.4.5	X							X				
 cfg-if@1.0.4	X							X				
 clap@4.6.6	X							X				
 clap_builder@4.6.6	X							X				
@@ -36,7 +36,7 @@ dunce@1.0.5	X			X					X
 equivalent@1.0.2	X							X				
 errno@0.3.14	X							X				
 fastrand@2.5.0	X							X				
-find-msvc-tools@0.1.11	X							X				
+find-msvc-tools@0.1.12	X							X				
 form_urlencoded@1.2.2	X							X				
 fs_extra@1.3.0								X				
 futures@0.3.34	X							X				
@@ -68,7 +68,7 @@ icu_properties_data@2.3.0											X
 icu_provider@2.3.1											X	
 idna@1.1.0	X							X				
 idna_adapter@1.2.2	X							X				
-indexmap@2.14.1	X							X				
+indexmap@2.14.2	X							X				
 ipnet@2.12.1	X							X				
 is_terminal_polyfill@1.70.2	X							X				
 itoa@1.0.18	X							X				
@@ -81,7 +81,7 @@ jni-macros@0.22.4	X							X
 jni-sys@0.4.1	X							X				
 jni-sys-macros@0.4.1	X							X				
 jobserver@0.1.35	X							X				
-js-sys@0.3.104	X							X				
+js-sys@0.3.105	X							X				
 libc@0.2.189	X							X				
 link-section@0.19.3	X							X				
 linktime-proc-macro@0.2.3	X							X				
@@ -90,23 +90,23 @@ litemap@0.8.3											X
 log@0.4.34	X							X				
 md-5@0.11.0	X							X				
 memchr@2.8.3								X				X
-mio@1.2.2								X				
+mio@1.2.3								X				
 once_cell@1.21.4	X							X				
 once_cell_polyfill@1.70.2	X							X				
-opendal@0.59.0	X											
+opendal@0.59.1	X											
 opendal-c@0.0.0	X											
-opendal-core@0.59.0	X											
-opendal-http-transport-reqwest@0.59.0	X											
-opendal-layer-concurrent-limit@0.59.0	X											
-opendal-layer-logging@0.59.0	X											
-opendal-layer-retry@0.59.0	X											
-opendal-layer-timeout@0.59.0	X											
+opendal-core@0.59.1	X											
+opendal-http-transport-reqwest@0.59.1	X											
+opendal-layer-concurrent-limit@0.59.1	X											
+opendal-layer-logging@0.59.1	X											
+opendal-layer-retry@0.59.1	X											
+opendal-layer-timeout@0.59.1	X											
 openssl-probe@0.2.1	X							X				
 percent-encoding@2.3.2	X							X				
 pin-project-lite@0.2.17	X							X				
 pkg-config@0.3.34	X							X				
 portable-atomic@1.15.0	X							X				
-portable-atomic-util@0.2.7	X							X				
+portable-atomic-util@0.2.8	X							X				
 potential_utf@0.1.6											X	
 proc-macro2@1.0.107	X							X				
 quick-xml@0.41.0								X				
@@ -136,13 +136,13 @@ shlex@2.0.1	X							X
 simd_cesu8@1.2.0	X							X				
 simdutf8@0.1.5	X							X				
 slab@0.4.12								X				
-smallvec@1.15.2	X							X				
+smallvec@1.16.0	X							X				
 socket2@0.6.5	X							X				
 stable_deref_trait@1.2.1	X							X				
 strsim@0.11.1								X				
 subtle@2.6.1			X									
 syn@2.0.119	X							X				
-syn@3.0.4	X							X				
+syn@3.0.5	X							X				
 sync_wrapper@1.0.2	X											
 synstructure@0.13.2								X				
 tempfile@3.27.0	X							X				
@@ -151,7 +151,7 @@ thiserror-impl@2.0.20	X							X
 tinystr@0.8.4											X	
 tokio@1.53.1								X				
 tokio-macros@2.7.2								X				
-tokio-rustls@0.26.4	X							X				
+tokio-rustls@0.26.5	X							X				
 tokio-util@0.7.19								X				
 toml@0.9.12+spec-1.1.0	X							X				
 toml_datetime@0.7.5+spec-1.1.0	X							X				
@@ -173,13 +173,13 @@ uuid@1.26.0	X							X
 walkdir@2.5.0								X				X
 want@0.3.1								X				
 wasi@0.11.1+wasi-snapshot-preview1	X	X						X				
-wasm-bindgen@0.2.127	X							X				
-wasm-bindgen-futures@0.4.77	X							X				
-wasm-bindgen-macro@0.2.127	X							X				
-wasm-bindgen-macro-support@0.2.127	X							X				
-wasm-bindgen-shared@0.2.127	X							X				
+wasm-bindgen@0.2.128	X							X				
+wasm-bindgen-futures@0.4.78	X							X				
+wasm-bindgen-macro@0.2.128	X							X				
+wasm-bindgen-macro-support@0.2.128	X							X				
+wasm-bindgen-shared@0.2.128	X							X				
 wasm-streams@0.5.0	X							X				
-web-sys@0.3.104	X							X				
+web-sys@0.3.105	X							X				
 web-time@1.1.0	X							X				
 webpki-root-certs@1.0.9					X							
 winapi-util@0.1.11								X				X

--- a/bindings/cpp/DEPENDENCIES.rust.tsv
+++ b/bindings/cpp/DEPENDENCIES.rust.tsv
@@ -2,8 +2,8 @@ crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-3-Clause	CC0-1.0	CDLA-Permis
 anyhow@1.0.104	X							X				
 asyncband@0.6.7	X											
 atomic-waker@1.1.2	X							X				
-aws-lc-rs@1.18.0	X					X						
-aws-lc-sys@0.44.0	X		X			X		X	X			
+aws-lc-rs@1.18.1	X					X						
+aws-lc-sys@0.45.0	X		X			X		X	X			
 backon@1.6.0	X											
 base64@0.22.1	X							X				
 base64@0.23.1	X							X				
@@ -11,7 +11,7 @@ bitflags@2.13.1	X							X
 block-buffer@0.12.1	X							X				
 bumpalo@3.20.3	X							X				
 bytes@1.12.1								X				
-cc@1.4.4	X							X				
+cc@1.4.5	X							X				
 cfg-if@1.0.4	X							X				
 cmake@0.1.58	X							X				
 codespan-reporting@0.13.1	X											
@@ -21,16 +21,16 @@ core-foundation@0.10.1	X							X
 core-foundation-sys@0.8.7	X							X				
 crypto-common@0.2.2	X							X				
 ctor@1.0.13	X							X				
-cxx@1.0.199	X							X				
-cxx-build@1.0.199	X							X				
-cxxbridge-flags@1.0.199	X							X				
-cxxbridge-macro@1.0.199	X							X				
+cxx@1.0.200	X							X				
+cxx-build@1.0.200	X							X				
+cxxbridge-flags@1.0.200	X							X				
+cxxbridge-macro@1.0.200	X							X				
 digest@0.11.3	X							X				
 displaydoc@0.2.7	X							X				
 dunce@1.0.5	X			X					X			
 equivalent@1.0.2	X							X				
 fastrand@2.5.0	X							X				
-find-msvc-tools@0.1.11	X							X				
+find-msvc-tools@0.1.12	X							X				
 foldhash@0.2.0												X
 form_urlencoded@1.2.2	X							X				
 fs_extra@1.3.0								X				
@@ -63,7 +63,7 @@ icu_properties_data@2.3.0										X
 icu_provider@2.3.1										X		
 idna@1.1.0	X							X				
 idna_adapter@1.2.2	X							X				
-indexmap@2.14.1	X							X				
+indexmap@2.14.2	X							X				
 ipnet@2.12.1	X							X				
 itoa@1.0.18	X							X				
 jiff@0.2.35								X			X	
@@ -75,7 +75,7 @@ jni-macros@0.22.4	X							X
 jni-sys@0.4.1	X							X				
 jni-sys-macros@0.4.1	X							X				
 jobserver@0.1.35	X							X				
-js-sys@0.3.104	X							X				
+js-sys@0.3.105	X							X				
 libc@0.2.189	X							X				
 link-cplusplus@1.0.12	X							X				
 link-section@0.19.3	X							X				
@@ -84,22 +84,22 @@ litemap@0.8.3										X
 log@0.4.34	X							X				
 md-5@0.11.0	X							X				
 memchr@2.8.3								X			X	
-mio@1.2.2								X				
+mio@1.2.3								X				
 once_cell@1.21.4	X							X				
-opendal@0.59.0	X											
-opendal-core@0.59.0	X											
+opendal@0.59.1	X											
+opendal-core@0.59.1	X											
 opendal-cpp@0.0.0	X											
-opendal-http-transport-reqwest@0.59.0	X											
-opendal-layer-concurrent-limit@0.59.0	X											
-opendal-layer-logging@0.59.0	X											
-opendal-layer-retry@0.59.0	X											
-opendal-layer-timeout@0.59.0	X											
+opendal-http-transport-reqwest@0.59.1	X											
+opendal-layer-concurrent-limit@0.59.1	X											
+opendal-layer-logging@0.59.1	X											
+opendal-layer-retry@0.59.1	X											
+opendal-layer-timeout@0.59.1	X											
 openssl-probe@0.2.1	X							X				
 percent-encoding@2.3.2	X							X				
 pin-project-lite@0.2.17	X							X				
 pkg-config@0.3.34	X							X				
 portable-atomic@1.15.0	X							X				
-portable-atomic-util@0.2.7	X							X				
+portable-atomic-util@0.2.8	X							X				
 potential_utf@0.1.6										X		
 proc-macro2@1.0.107	X							X				
 quick-xml@0.41.0								X				
@@ -128,12 +128,12 @@ shlex@2.0.1	X							X
 simd_cesu8@1.2.0	X							X				
 simdutf8@0.1.5	X							X				
 slab@0.4.12								X				
-smallvec@1.15.2	X							X				
+smallvec@1.16.0	X							X				
 socket2@0.6.5	X							X				
 stable_deref_trait@1.2.1	X							X				
 subtle@2.6.1			X									
 syn@2.0.119	X							X				
-syn@3.0.4	X							X				
+syn@3.0.5	X							X				
 sync_wrapper@1.0.2	X											
 synstructure@0.13.2								X				
 termcolor@1.4.1								X			X	
@@ -142,7 +142,7 @@ thiserror-impl@2.0.20	X							X
 tinystr@0.8.4										X		
 tokio@1.53.1								X				
 tokio-macros@2.7.2								X				
-tokio-rustls@0.26.4	X							X				
+tokio-rustls@0.26.5	X							X				
 tokio-util@0.7.19								X				
 tower@0.5.3								X				
 tower-http@0.6.11								X				
@@ -161,13 +161,13 @@ uuid@1.26.0	X							X
 walkdir@2.5.0								X			X	
 want@0.3.1								X				
 wasi@0.11.1+wasi-snapshot-preview1	X	X						X				
-wasm-bindgen@0.2.127	X							X				
-wasm-bindgen-futures@0.4.77	X							X				
-wasm-bindgen-macro@0.2.127	X							X				
-wasm-bindgen-macro-support@0.2.127	X							X				
-wasm-bindgen-shared@0.2.127	X							X				
+wasm-bindgen@0.2.128	X							X				
+wasm-bindgen-futures@0.4.78	X							X				
+wasm-bindgen-macro@0.2.128	X							X				
+wasm-bindgen-macro-support@0.2.128	X							X				
+wasm-bindgen-shared@0.2.128	X							X				
 wasm-streams@0.5.0	X							X				
-web-sys@0.3.104	X							X				
+web-sys@0.3.105	X							X				
 web-time@1.1.0	X							X				
 webpki-root-certs@1.0.9					X							
 winapi-util@0.1.11								X			X	

--- a/bindings/dotnet/DEPENDENCIES.rust.tsv
+++ b/bindings/dotnet/DEPENDENCIES.rust.tsv
@@ -22,8 +22,8 @@ auto-const-array@0.2.2		X									X
 autocfg@1.5.1		X									X					
 awaitable@0.4.0											X					
 awaitable-error@0.1.0											X					
-aws-lc-rs@1.18.0		X							X							
-aws-lc-sys@0.44.0		X			X				X		X	X				
+aws-lc-rs@1.18.1		X							X							
+aws-lc-sys@0.45.0		X			X				X		X	X				
 axum@0.6.20											X					
 axum@0.8.9											X					
 axum-core@0.3.4											X					
@@ -52,7 +52,7 @@ camino@1.2.5		X									X
 cargo-platform@0.1.9		X									X					
 cargo_metadata@0.14.2											X					
 cbc@0.1.2		X									X					
-cc@1.4.4		X									X					
+cc@1.4.5		X									X					
 cfg-if@0.1.10		X									X					
 cfg-if@1.0.4		X									X					
 cfg_aliases@0.2.2											X					
@@ -136,9 +136,9 @@ etcetera@0.8.0		X									X
 event-listener@5.4.2		X									X					
 event-listener-strategy@0.5.4		X									X					
 fail@0.4.0		X														
-fastpool@1.1.1		X														
+fastpool@1.1.2		X														
 fastrand@2.5.0		X									X					
-find-msvc-tools@0.1.11		X									X					
+find-msvc-tools@0.1.12		X									X					
 fixedbitset@0.5.7		X									X					
 flate2@1.1.10		X									X					
 flume@0.11.1		X									X					
@@ -189,9 +189,9 @@ heck@0.5.0		X									X
 hermit-abi@0.5.3		X									X					
 hex@0.4.3		X									X					
 hf-xet@1.6.0		X														
-hickory-net@0.26.1		X									X					
-hickory-proto@0.26.1		X									X					
-hickory-resolver@0.26.1		X									X					
+hickory-net@0.26.2		X									X					
+hickory-proto@0.26.2		X									X					
+hickory-resolver@0.26.2		X									X					
 hkdf@0.12.4		X									X					
 hmac@0.12.1		X									X					
 hmac@0.13.0		X									X					
@@ -225,7 +225,7 @@ ident_case@1.0.1		X									X
 idna@1.1.0		X									X					
 idna_adapter@1.2.2		X									X					
 indexmap@1.9.3		X									X					
-indexmap@2.14.1		X									X					
+indexmap@2.14.2		X									X					
 inout@0.1.4		X									X					
 instant@0.1.13					X											
 io-uring@0.6.4		X									X					
@@ -244,13 +244,13 @@ jni-macros@0.22.4		X									X
 jni-sys@0.4.1		X									X					
 jni-sys-macros@0.4.1		X									X					
 jobserver@0.1.35		X									X					
-js-sys@0.3.104		X									X					
+js-sys@0.3.105		X									X					
 konst@0.4.3																X
 konst_proc_macros@0.4.1																X
 lazy_static@1.5.0		X									X					
 libc@0.2.189		X									X					
 libm@0.2.16											X					
-libredox@0.1.21											X					
+libredox@0.1.23											X					
 libsqlite3-sys@0.30.1											X					
 link-section@0.19.3		X									X					
 linked-hash-map@0.5.6		X									X					
@@ -261,7 +261,7 @@ local-event@0.1.3											X
 lock_api@0.4.14		X									X					
 log@0.4.34		X									X					
 loom@0.7.2											X					
-lru@0.18.3											X					
+lru@0.18.4											X					
 lz4_flex@0.13.1											X					
 macro_magic@0.5.1											X					
 macro_magic_core@0.5.1											X					
@@ -284,11 +284,11 @@ mime_guess@2.0.5											X
 mini-moka@0.10.3		X									X					
 miniz_oxide@0.9.1		X									X					X
 mio@0.8.11											X					
-mio@1.2.2											X					
+mio@1.2.3											X					
 mod_use@0.2.3											X					
 moka@0.12.16		X									X					
-mongodb@3.8.2		X														
-mongodb-internal-macros@3.8.2		X														
+mongodb@3.9.0		X														
+mongodb-internal-macros@3.9.0		X														
 monoio@0.2.4		X									X					
 monoio-macros@0.1.0		X									X					
 more-asserts@0.3.1		X					X				X				X	
@@ -312,67 +312,67 @@ objc2-io-kit@0.3.2		X									X					X
 objc2-system-configuration@0.3.2		X									X					X
 once_cell@1.21.4		X									X					
 oneshot@0.1.13		X									X					
-opendal@0.59.0		X														
-opendal-core@0.59.0		X														
+opendal@0.59.1		X														
+opendal-core@0.59.1		X														
 opendal-dotnet@0.0.0		X														
-opendal-http-transport-reqwest@0.59.0		X														
-opendal-layer-concurrent-limit@0.59.0		X														
-opendal-layer-logging@0.59.0		X														
-opendal-layer-mime-guess@0.59.0		X														
-opendal-layer-retry@0.59.0		X														
-opendal-layer-throttle@0.59.0		X														
-opendal-layer-timeout@0.59.0		X														
-opendal-service-aliyun-drive@0.59.0		X														
-opendal-service-alluxio@0.59.0		X														
-opendal-service-azblob@0.59.0		X														
-opendal-service-azdls@0.59.0		X														
-opendal-service-azfile@0.59.0		X														
-opendal-service-azure-common@0.59.0		X														
-opendal-service-b2@0.59.0		X														
-opendal-service-cacache@0.59.0		X														
-opendal-service-compfs@0.59.0		X														
-opendal-service-cos@0.59.0		X														
-opendal-service-dashmap@0.59.0		X														
-opendal-service-dropbox@0.59.0		X														
-opendal-service-etcd@0.59.0		X														
-opendal-service-fs@0.59.0		X														
-opendal-service-gcs@0.59.0		X														
-opendal-service-gcs-grpc@0.59.0		X														
-opendal-service-gdrive@0.59.0		X														
-opendal-service-ghac@0.59.0		X														
-opendal-service-goosefs@0.59.0		X														
-opendal-service-gridfs@0.59.0		X														
-opendal-service-hf@0.59.0		X														
-opendal-service-http@0.59.0		X														
-opendal-service-ipfs@0.59.0		X														
-opendal-service-ipmfs@0.59.0		X														
-opendal-service-koofr@0.59.0		X														
-opendal-service-memcached@0.59.0		X														
-opendal-service-mini-moka@0.59.0		X														
-opendal-service-moka@0.59.0		X														
-opendal-service-mongodb@0.59.0		X														
-opendal-service-monoiofs@0.59.0		X														
-opendal-service-mysql@0.59.0		X														
-opendal-service-obs@0.59.0		X														
-opendal-service-onedrive@0.59.0		X														
-opendal-service-oss@0.59.0		X														
-opendal-service-persy@0.59.0		X														
-opendal-service-postgresql@0.59.0		X														
-opendal-service-redb@0.59.0		X														
-opendal-service-redis@0.59.0		X														
-opendal-service-s3@0.59.0		X														
-opendal-service-seafile@0.59.0		X														
-opendal-service-sftp@0.59.0		X														
-opendal-service-sled@0.59.0		X														
-opendal-service-sqlite@0.59.0		X														
-opendal-service-swift@0.59.0		X														
-opendal-service-tikv@0.59.0		X														
-opendal-service-tos@0.59.0		X														
-opendal-service-upyun@0.59.0		X														
-opendal-service-vercel-artifacts@0.59.0		X														
-opendal-service-webdav@0.59.0		X														
-opendal-service-webhdfs@0.59.0		X														
-opendal-service-yandex-disk@0.59.0		X														
+opendal-http-transport-reqwest@0.59.1		X														
+opendal-layer-concurrent-limit@0.59.1		X														
+opendal-layer-logging@0.59.1		X														
+opendal-layer-mime-guess@0.59.1		X														
+opendal-layer-retry@0.59.1		X														
+opendal-layer-throttle@0.59.1		X														
+opendal-layer-timeout@0.59.1		X														
+opendal-service-aliyun-drive@0.59.1		X														
+opendal-service-alluxio@0.59.1		X														
+opendal-service-azblob@0.59.1		X														
+opendal-service-azdls@0.59.1		X														
+opendal-service-azfile@0.59.1		X														
+opendal-service-azure-common@0.59.1		X														
+opendal-service-b2@0.59.1		X														
+opendal-service-cacache@0.59.1		X														
+opendal-service-compfs@0.59.1		X														
+opendal-service-cos@0.59.1		X														
+opendal-service-dashmap@0.59.1		X														
+opendal-service-dropbox@0.59.1		X														
+opendal-service-etcd@0.59.1		X														
+opendal-service-fs@0.59.1		X														
+opendal-service-gcs@0.59.1		X														
+opendal-service-gcs-grpc@0.59.1		X														
+opendal-service-gdrive@0.59.1		X														
+opendal-service-ghac@0.59.1		X														
+opendal-service-goosefs@0.59.1		X														
+opendal-service-gridfs@0.59.1		X														
+opendal-service-hf@0.59.1		X														
+opendal-service-http@0.59.1		X														
+opendal-service-ipfs@0.59.1		X														
+opendal-service-ipmfs@0.59.1		X														
+opendal-service-koofr@0.59.1		X														
+opendal-service-memcached@0.59.1		X														
+opendal-service-mini-moka@0.59.1		X														
+opendal-service-moka@0.59.1		X														
+opendal-service-mongodb@0.59.1		X														
+opendal-service-monoiofs@0.59.1		X														
+opendal-service-mysql@0.59.1		X														
+opendal-service-obs@0.59.1		X														
+opendal-service-onedrive@0.59.1		X														
+opendal-service-oss@0.59.1		X														
+opendal-service-persy@0.59.1		X														
+opendal-service-postgresql@0.59.1		X														
+opendal-service-redb@0.59.1		X														
+opendal-service-redis@0.59.1		X														
+opendal-service-s3@0.59.1		X														
+opendal-service-seafile@0.59.1		X														
+opendal-service-sftp@0.59.1		X														
+opendal-service-sled@0.59.1		X														
+opendal-service-sqlite@0.59.1		X														
+opendal-service-swift@0.59.1		X														
+opendal-service-tikv@0.59.1		X														
+opendal-service-tos@0.59.1		X														
+opendal-service-upyun@0.59.1		X														
+opendal-service-vercel-artifacts@0.59.1		X														
+opendal-service-webdav@0.59.1		X														
+opendal-service-webhdfs@0.59.1		X														
+opendal-service-yandex-disk@0.59.1		X														
 openssh@0.11.6		X									X					
 openssh-sftp-client@0.15.8											X					
 openssh-sftp-client-lowlevel@0.7.2											X					
@@ -407,7 +407,7 @@ pkg-config@0.3.34		X									X
 plain@0.2.3		X									X					
 polling@3.11.0		X									X					
 portable-atomic@1.15.0		X									X					
-portable-atomic-util@0.2.7		X									X					
+portable-atomic-util@0.2.8		X									X					
 potential_utf@0.1.6														X		
 powerfmt@0.2.0		X									X					
 ppv-lite86@0.2.21		X									X					
@@ -523,7 +523,7 @@ skeptic@0.13.7		X									X
 slab@0.4.12											X					
 sled@0.34.7		X									X					
 slotmap@1.1.1																X
-smallvec@1.15.2		X									X					
+smallvec@1.16.0		X									X					
 socket2@0.5.10		X									X					
 socket2@0.6.5		X									X					
 spin@0.10.1											X					
@@ -549,7 +549,7 @@ subtle@2.6.1					X
 symlink@0.1.0		X									X					
 syn@1.0.109		X									X					
 syn@2.0.119		X									X					
-syn@3.0.4		X									X					
+syn@3.0.5		X									X					
 sync_wrapper@0.1.2		X														
 sync_wrapper@1.0.2		X														
 synchrony@0.1.9											X					
@@ -575,7 +575,7 @@ time-core@0.1.9		X									X
 time-macros@0.2.32		X									X					
 tiny-keccak@2.0.2							X									
 tinystr@0.8.4														X		
-tinyvec@1.12.0		X									X					X
+tinyvec@1.13.2		X									X					X
 tinyvec_macros@0.1.1		X									X					X
 tokio@1.53.1											X					
 tokio-io-timeout@1.2.1		X									X					
@@ -583,7 +583,7 @@ tokio-io-utility@0.7.6											X
 tokio-macros@2.7.2											X					
 tokio-retry@0.3.2											X					
 tokio-rustls@0.24.1		X									X					
-tokio-rustls@0.26.4		X									X					
+tokio-rustls@0.26.5		X									X					
 tokio-stream@0.1.19											X					
 tokio-util@0.7.19											X					
 tokio_with_wasm@0.8.8											X					
@@ -637,13 +637,13 @@ wasi@0.9.0+wasi-snapshot-preview1		X	X								X
 wasip2@1.0.4+wasi-0.2.12		X	X								X					
 wasite@0.1.0		X				X					X					
 wasite@1.0.2		X				X					X					
-wasm-bindgen@0.2.127		X									X					
-wasm-bindgen-futures@0.4.77		X									X					
-wasm-bindgen-macro@0.2.127		X									X					
-wasm-bindgen-macro-support@0.2.127		X									X					
-wasm-bindgen-shared@0.2.127		X									X					
+wasm-bindgen@0.2.128		X									X					
+wasm-bindgen-futures@0.4.78		X									X					
+wasm-bindgen-macro@0.2.128		X									X					
+wasm-bindgen-macro-support@0.2.128		X									X					
+wasm-bindgen-shared@0.2.128		X									X					
 wasm-streams@0.5.0		X									X					
-web-sys@0.3.104		X									X					
+web-sys@0.3.105		X									X					
 web-time@1.1.0		X									X					
 webpki-root-certs@1.0.9								X								
 webpki-roots@0.26.11								X								

--- a/bindings/dotnet/OpenDAL/OpenDAL.csproj
+++ b/bindings/dotnet/OpenDAL/OpenDAL.csproj
@@ -4,7 +4,7 @@
         <Title>Apache OpenDAL .NET</Title>
         <PackageId>Apache.OpenDAL</PackageId>
         <Description>The official .NET binding for Apache OpenDAL™</Description>
-        <VersionPrefix>0.2.0</VersionPrefix>
+        <VersionPrefix>0.2.1</VersionPrefix>
         <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
         <FileVersion>$(VersionPrefix)</FileVersion>
         <Authors>Apache OpenDAL™</Authors>

--- a/bindings/java/DEPENDENCIES.rust.tsv
+++ b/bindings/java/DEPENDENCIES.rust.tsv
@@ -21,8 +21,8 @@ atomic-waker@1.1.2		X									X
 autocfg@1.5.1		X									X					
 awaitable@0.4.0											X					
 awaitable-error@0.1.0											X					
-aws-lc-rs@1.18.0		X							X							
-aws-lc-sys@0.44.0		X			X				X		X	X				
+aws-lc-rs@1.18.1		X							X							
+aws-lc-sys@0.45.0		X			X				X		X	X				
 axum@0.6.20											X					
 axum@0.8.9											X					
 axum-core@0.3.4											X					
@@ -51,7 +51,7 @@ camino@1.2.5		X									X
 cargo-platform@0.1.9		X									X					
 cargo_metadata@0.14.2											X					
 cbc@0.1.2		X									X					
-cc@1.4.4		X									X					
+cc@1.4.5		X									X					
 cfg-if@0.1.10		X									X					
 cfg-if@1.0.4		X									X					
 chacha20@0.10.2		X									X					
@@ -122,9 +122,9 @@ etcetera@0.8.0		X									X
 event-listener@5.4.2		X									X					
 event-listener-strategy@0.5.4		X									X					
 fail@0.4.0		X														
-fastpool@1.1.1		X														
+fastpool@1.1.2		X														
 fastrand@2.5.0		X									X					
-find-msvc-tools@0.1.11		X									X					
+find-msvc-tools@0.1.12		X									X					
 fixedbitset@0.5.7		X									X					
 flate2@1.1.10		X									X					
 flume@0.11.1		X									X					
@@ -169,9 +169,9 @@ heapify@0.2.0		X									X
 heck@0.5.0		X									X					
 hex@0.4.3		X									X					
 hf-xet@1.6.0		X														
-hickory-net@0.26.1		X									X					
-hickory-proto@0.26.1		X									X					
-hickory-resolver@0.26.1		X									X					
+hickory-net@0.26.2		X									X					
+hickory-proto@0.26.2		X									X					
+hickory-resolver@0.26.2		X									X					
 hkdf@0.12.4		X									X					
 hmac@0.12.1		X									X					
 hmac@0.13.0		X									X					
@@ -205,7 +205,7 @@ ident_case@1.0.1		X									X
 idna@1.1.0		X									X					
 idna_adapter@1.2.2		X									X					
 indexmap@1.9.3		X									X					
-indexmap@2.14.1		X									X					
+indexmap@2.14.2		X									X					
 inout@0.1.4		X									X					
 instant@0.1.13					X											
 io-uring@0.7.14		X									X					
@@ -223,13 +223,13 @@ jni-macros@0.22.4		X									X
 jni-sys@0.4.1		X									X					
 jni-sys-macros@0.4.1		X									X					
 jobserver@0.1.35		X									X					
-js-sys@0.3.104		X									X					
+js-sys@0.3.105		X									X					
 konst@0.4.3																X
 konst_proc_macros@0.4.1																X
 lazy_static@1.5.0		X									X					
 libc@0.2.189		X									X					
 libm@0.2.16											X					
-libredox@0.1.21											X					
+libredox@0.1.23											X					
 libsqlite3-sys@0.30.1											X					
 link-section@0.19.3		X									X					
 linked-hash-map@0.5.6		X									X					
@@ -238,7 +238,7 @@ linux-raw-sys@0.12.1		X	X								X
 litemap@0.8.3														X		
 lock_api@0.4.14		X									X					
 log@0.4.34		X									X					
-lru@0.18.3											X					
+lru@0.18.4											X					
 lz4_flex@0.13.1											X					
 macro_magic@0.5.1											X					
 macro_magic_core@0.5.1											X					
@@ -258,10 +258,10 @@ miette-derive@5.10.0		X
 mime@0.3.17		X									X					
 mini-moka@0.10.3		X									X					
 miniz_oxide@0.9.1		X									X					X
-mio@1.2.2											X					
+mio@1.2.3											X					
 moka@0.12.16		X									X					
-mongodb@3.8.2		X														
-mongodb-internal-macros@3.8.2		X														
+mongodb@3.9.0		X														
+mongodb-internal-macros@3.9.0		X														
 more-asserts@0.3.1		X					X				X				X	
 multimap@0.10.1		X									X					
 ndk-context@0.1.1		X									X					
@@ -279,63 +279,63 @@ objc2-io-kit@0.3.2		X									X					X
 objc2-system-configuration@0.3.2		X									X					X
 once_cell@1.21.4		X									X					
 oneshot@0.1.13		X									X					
-opendal@0.59.0		X														
-opendal-core@0.59.0		X														
-opendal-http-transport-reqwest@0.59.0		X														
+opendal@0.59.1		X														
+opendal-core@0.59.1		X														
+opendal-http-transport-reqwest@0.59.1		X														
 opendal-java@0.0.0		X														
-opendal-layer-concurrent-limit@0.59.0		X														
-opendal-layer-logging@0.59.0		X														
-opendal-layer-retry@0.59.0		X														
-opendal-layer-timeout@0.59.0		X														
-opendal-service-aliyun-drive@0.59.0		X														
-opendal-service-alluxio@0.59.0		X														
-opendal-service-azblob@0.59.0		X														
-opendal-service-azdls@0.59.0		X														
-opendal-service-azfile@0.59.0		X														
-opendal-service-azure-common@0.59.0		X														
-opendal-service-b2@0.59.0		X														
-opendal-service-cacache@0.59.0		X														
-opendal-service-cos@0.59.0		X														
-opendal-service-dashmap@0.59.0		X														
-opendal-service-dropbox@0.59.0		X														
-opendal-service-etcd@0.59.0		X														
-opendal-service-fs@0.59.0		X														
-opendal-service-gcs@0.59.0		X														
-opendal-service-gcs-grpc@0.59.0		X														
-opendal-service-gdrive@0.59.0		X														
-opendal-service-ghac@0.59.0		X														
-opendal-service-goosefs@0.59.0		X														
-opendal-service-gridfs@0.59.0		X														
-opendal-service-hf@0.59.0		X														
-opendal-service-http@0.59.0		X														
-opendal-service-ipfs@0.59.0		X														
-opendal-service-ipmfs@0.59.0		X														
-opendal-service-koofr@0.59.0		X														
-opendal-service-memcached@0.59.0		X														
-opendal-service-mini-moka@0.59.0		X														
-opendal-service-moka@0.59.0		X														
-opendal-service-mongodb@0.59.0		X														
-opendal-service-mysql@0.59.0		X														
-opendal-service-obs@0.59.0		X														
-opendal-service-onedrive@0.59.0		X														
-opendal-service-oss@0.59.0		X														
-opendal-service-persy@0.59.0		X														
-opendal-service-postgresql@0.59.0		X														
-opendal-service-redb@0.59.0		X														
-opendal-service-redis@0.59.0		X														
-opendal-service-s3@0.59.0		X														
-opendal-service-seafile@0.59.0		X														
-opendal-service-sftp@0.59.0		X														
-opendal-service-sled@0.59.0		X														
-opendal-service-sqlite@0.59.0		X														
-opendal-service-swift@0.59.0		X														
-opendal-service-tikv@0.59.0		X														
-opendal-service-tos@0.59.0		X														
-opendal-service-upyun@0.59.0		X														
-opendal-service-vercel-artifacts@0.59.0		X														
-opendal-service-webdav@0.59.0		X														
-opendal-service-webhdfs@0.59.0		X														
-opendal-service-yandex-disk@0.59.0		X														
+opendal-layer-concurrent-limit@0.59.1		X														
+opendal-layer-logging@0.59.1		X														
+opendal-layer-retry@0.59.1		X														
+opendal-layer-timeout@0.59.1		X														
+opendal-service-aliyun-drive@0.59.1		X														
+opendal-service-alluxio@0.59.1		X														
+opendal-service-azblob@0.59.1		X														
+opendal-service-azdls@0.59.1		X														
+opendal-service-azfile@0.59.1		X														
+opendal-service-azure-common@0.59.1		X														
+opendal-service-b2@0.59.1		X														
+opendal-service-cacache@0.59.1		X														
+opendal-service-cos@0.59.1		X														
+opendal-service-dashmap@0.59.1		X														
+opendal-service-dropbox@0.59.1		X														
+opendal-service-etcd@0.59.1		X														
+opendal-service-fs@0.59.1		X														
+opendal-service-gcs@0.59.1		X														
+opendal-service-gcs-grpc@0.59.1		X														
+opendal-service-gdrive@0.59.1		X														
+opendal-service-ghac@0.59.1		X														
+opendal-service-goosefs@0.59.1		X														
+opendal-service-gridfs@0.59.1		X														
+opendal-service-hf@0.59.1		X														
+opendal-service-http@0.59.1		X														
+opendal-service-ipfs@0.59.1		X														
+opendal-service-ipmfs@0.59.1		X														
+opendal-service-koofr@0.59.1		X														
+opendal-service-memcached@0.59.1		X														
+opendal-service-mini-moka@0.59.1		X														
+opendal-service-moka@0.59.1		X														
+opendal-service-mongodb@0.59.1		X														
+opendal-service-mysql@0.59.1		X														
+opendal-service-obs@0.59.1		X														
+opendal-service-onedrive@0.59.1		X														
+opendal-service-oss@0.59.1		X														
+opendal-service-persy@0.59.1		X														
+opendal-service-postgresql@0.59.1		X														
+opendal-service-redb@0.59.1		X														
+opendal-service-redis@0.59.1		X														
+opendal-service-s3@0.59.1		X														
+opendal-service-seafile@0.59.1		X														
+opendal-service-sftp@0.59.1		X														
+opendal-service-sled@0.59.1		X														
+opendal-service-sqlite@0.59.1		X														
+opendal-service-swift@0.59.1		X														
+opendal-service-tikv@0.59.1		X														
+opendal-service-tos@0.59.1		X														
+opendal-service-upyun@0.59.1		X														
+opendal-service-vercel-artifacts@0.59.1		X														
+opendal-service-webdav@0.59.1		X														
+opendal-service-webhdfs@0.59.1		X														
+opendal-service-yandex-disk@0.59.1		X														
 openssh@0.11.6		X									X					
 openssh-sftp-client@0.15.8											X					
 openssh-sftp-client-lowlevel@0.7.2											X					
@@ -367,7 +367,7 @@ pkcs8@0.10.2		X									X
 pkg-config@0.3.34		X									X					
 plain@0.2.3		X									X					
 portable-atomic@1.15.0		X									X					
-portable-atomic-util@0.2.7		X									X					
+portable-atomic-util@0.2.8		X									X					
 potential_utf@0.1.6														X		
 powerfmt@0.2.0		X									X					
 ppv-lite86@0.2.21		X									X					
@@ -479,7 +479,7 @@ simdutf8@0.1.5		X									X
 skeptic@0.13.7		X									X					
 slab@0.4.12											X					
 sled@0.34.7		X									X					
-smallvec@1.15.2		X									X					
+smallvec@1.16.0		X									X					
 socket2@0.5.10		X									X					
 socket2@0.6.5		X									X					
 spin@0.10.1											X					
@@ -504,7 +504,7 @@ subtle@2.6.1					X
 symlink@0.1.0		X									X					
 syn@1.0.109		X									X					
 syn@2.0.119		X									X					
-syn@3.0.4		X									X					
+syn@3.0.5		X									X					
 sync_wrapper@0.1.2		X														
 sync_wrapper@1.0.2		X														
 synstructure@0.13.2											X					
@@ -527,7 +527,7 @@ time-core@0.1.9		X									X
 time-macros@0.2.32		X									X					
 tiny-keccak@2.0.2							X									
 tinystr@0.8.4														X		
-tinyvec@1.12.0		X									X					X
+tinyvec@1.13.2		X									X					X
 tinyvec_macros@0.1.1		X									X					X
 tokio@1.53.1											X					
 tokio-io-timeout@1.2.1		X									X					
@@ -535,7 +535,7 @@ tokio-io-utility@0.7.6											X
 tokio-macros@2.7.2											X					
 tokio-retry@0.3.2											X					
 tokio-rustls@0.24.1		X									X					
-tokio-rustls@0.26.4		X									X					
+tokio-rustls@0.26.5		X									X					
 tokio-stream@0.1.19											X					
 tokio-util@0.7.19											X					
 tokio_with_wasm@0.8.8											X					
@@ -589,13 +589,13 @@ wasi@0.9.0+wasi-snapshot-preview1		X	X								X
 wasip2@1.0.4+wasi-0.2.12		X	X								X					
 wasite@0.1.0		X				X					X					
 wasite@1.0.2		X				X					X					
-wasm-bindgen@0.2.127		X									X					
-wasm-bindgen-futures@0.4.77		X									X					
-wasm-bindgen-macro@0.2.127		X									X					
-wasm-bindgen-macro-support@0.2.127		X									X					
-wasm-bindgen-shared@0.2.127		X									X					
+wasm-bindgen@0.2.128		X									X					
+wasm-bindgen-futures@0.4.78		X									X					
+wasm-bindgen-macro@0.2.128		X									X					
+wasm-bindgen-macro-support@0.2.128		X									X					
+wasm-bindgen-shared@0.2.128		X									X					
 wasm-streams@0.5.0		X									X					
-web-sys@0.3.104		X									X					
+web-sys@0.3.105		X									X					
 web-time@1.1.0		X									X					
 webpki-root-certs@1.0.9								X								
 webpki-roots@0.26.11								X								

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>org.apache.opendal</groupId>
     <artifactId>opendal</artifactId>
-    <version>0.50.3</version> <!-- update version number -->
+    <version>0.50.4</version> <!-- update version number -->
 
     <name>Apache OpenDAL™</name>
     <description>

--- a/bindings/nodejs/DEPENDENCIES.rust.tsv
+++ b/bindings/nodejs/DEPENDENCIES.rust.tsv
@@ -15,8 +15,8 @@ asyncband@0.6.7	X
 atoi@2.0.0										X					
 atomic-waker@1.1.2	X									X					
 autocfg@1.5.1	X									X					
-aws-lc-rs@1.18.0	X							X							
-aws-lc-sys@0.44.0	X			X				X		X	X				
+aws-lc-rs@1.18.1	X							X							
+aws-lc-sys@0.45.0	X			X				X		X	X				
 backon@1.6.0	X														
 base64@0.21.7	X									X					
 base64@0.22.1	X									X					
@@ -41,7 +41,7 @@ camino@1.2.5	X									X
 cargo-platform@0.1.9	X									X					
 cargo_metadata@0.14.2										X					
 cbc@0.1.2	X									X					
-cc@1.4.4	X									X					
+cc@1.4.5	X									X					
 cfg-if@0.1.10	X									X					
 cfg-if@1.0.4	X									X					
 chacha20@0.10.2	X									X					
@@ -108,9 +108,9 @@ error-chain@0.12.4	X									X
 etcetera@0.8.0	X									X					
 event-listener@5.4.2	X									X					
 event-listener-strategy@0.5.4	X									X					
-fastpool@1.1.1	X														
+fastpool@1.1.2	X														
 fastrand@2.5.0	X									X					
-find-msvc-tools@0.1.11	X									X					
+find-msvc-tools@0.1.12	X									X					
 flume@0.11.1	X									X					
 fnv@1.0.7	X									X					
 foldhash@0.1.5															X
@@ -153,9 +153,9 @@ heapify@0.2.0	X									X
 heck@0.5.0	X									X					
 hex@0.4.3	X									X					
 hf-xet@1.6.0	X														
-hickory-net@0.26.1	X									X					
-hickory-proto@0.26.1	X									X					
-hickory-resolver@0.26.1	X									X					
+hickory-net@0.26.2	X									X					
+hickory-proto@0.26.2	X									X					
+hickory-resolver@0.26.2	X									X					
 hkdf@0.12.4	X									X					
 hmac@0.12.1	X									X					
 hmac@0.13.0	X									X					
@@ -184,7 +184,7 @@ icu_provider@2.3.1													X
 ident_case@1.0.1	X									X					
 idna@1.1.0	X									X					
 idna_adapter@1.2.2	X									X					
-indexmap@2.14.1	X									X					
+indexmap@2.14.2	X									X					
 inout@0.1.4	X									X					
 instant@0.1.13				X											
 io-uring@0.7.14	X									X					
@@ -201,14 +201,14 @@ jni-macros@0.22.4	X									X
 jni-sys@0.4.1	X									X					
 jni-sys-macros@0.4.1	X									X					
 jobserver@0.1.35	X									X					
-js-sys@0.3.104	X									X					
+js-sys@0.3.105	X									X					
 konst@0.4.3															X
 konst_proc_macros@0.4.1															X
 lazy_static@1.5.0	X									X					
 libc@0.2.189	X									X					
 libloading@0.9.0								X							
 libm@0.2.16										X					
-libredox@0.1.21										X					
+libredox@0.1.23										X					
 libsqlite3-sys@0.30.1										X					
 link-section@0.19.3	X									X					
 linked-hash-map@0.5.6	X									X					
@@ -217,7 +217,7 @@ linux-raw-sys@0.12.1	X	X								X
 litemap@0.8.3													X		
 lock_api@0.4.14	X									X					
 log@0.4.34	X									X					
-lru@0.18.3										X					
+lru@0.18.4										X					
 lz4_flex@0.13.1										X					
 macro_magic@0.5.1										X					
 macro_magic_core@0.5.1										X					
@@ -233,10 +233,10 @@ memmap2@0.9.11	X									X
 miette@5.10.0	X														
 miette-derive@5.10.0	X														
 mini-moka@0.10.3	X									X					
-mio@1.2.2										X					
+mio@1.2.3										X					
 moka@0.12.16	X									X					
-mongodb@3.8.2	X														
-mongodb-internal-macros@3.8.2	X														
+mongodb@3.9.0	X														
+mongodb-internal-macros@3.9.0	X														
 more-asserts@0.3.1	X					X				X				X	
 napi@3.12.2										X					
 napi-build@2.4.1										X					
@@ -259,61 +259,61 @@ objc2-io-kit@0.3.2	X									X					X
 objc2-system-configuration@0.3.2	X									X					X
 once_cell@1.21.4	X									X					
 oneshot@0.1.13	X									X					
-opendal@0.59.0	X														
-opendal-core@0.59.0	X														
-opendal-http-transport-reqwest@0.59.0	X														
-opendal-layer-concurrent-limit@0.59.0	X														
-opendal-layer-logging@0.59.0	X														
-opendal-layer-retry@0.59.0	X														
-opendal-layer-throttle@0.59.0	X														
-opendal-layer-timeout@0.59.0	X														
+opendal@0.59.1	X														
+opendal-core@0.59.1	X														
+opendal-http-transport-reqwest@0.59.1	X														
+opendal-layer-concurrent-limit@0.59.1	X														
+opendal-layer-logging@0.59.1	X														
+opendal-layer-retry@0.59.1	X														
+opendal-layer-throttle@0.59.1	X														
+opendal-layer-timeout@0.59.1	X														
 opendal-nodejs@0.0.0	X														
-opendal-service-aliyun-drive@0.59.0	X														
-opendal-service-alluxio@0.59.0	X														
-opendal-service-azblob@0.59.0	X														
-opendal-service-azdls@0.59.0	X														
-opendal-service-azfile@0.59.0	X														
-opendal-service-azure-common@0.59.0	X														
-opendal-service-b2@0.59.0	X														
-opendal-service-cacache@0.59.0	X														
-opendal-service-cos@0.59.0	X														
-opendal-service-dashmap@0.59.0	X														
-opendal-service-dropbox@0.59.0	X														
-opendal-service-fs@0.59.0	X														
-opendal-service-gcs@0.59.0	X														
-opendal-service-gcs-grpc@0.59.0	X														
-opendal-service-gdrive@0.59.0	X														
-opendal-service-ghac@0.59.0	X														
-opendal-service-goosefs@0.59.0	X														
-opendal-service-gridfs@0.59.0	X														
-opendal-service-hf@0.59.0	X														
-opendal-service-http@0.59.0	X														
-opendal-service-ipfs@0.59.0	X														
-opendal-service-ipmfs@0.59.0	X														
-opendal-service-koofr@0.59.0	X														
-opendal-service-memcached@0.59.0	X														
-opendal-service-mini-moka@0.59.0	X														
-opendal-service-moka@0.59.0	X														
-opendal-service-mongodb@0.59.0	X														
-opendal-service-mysql@0.59.0	X														
-opendal-service-obs@0.59.0	X														
-opendal-service-onedrive@0.59.0	X														
-opendal-service-oss@0.59.0	X														
-opendal-service-persy@0.59.0	X														
-opendal-service-postgresql@0.59.0	X														
-opendal-service-redb@0.59.0	X														
-opendal-service-redis@0.59.0	X														
-opendal-service-s3@0.59.0	X														
-opendal-service-seafile@0.59.0	X														
-opendal-service-sled@0.59.0	X														
-opendal-service-sqlite@0.59.0	X														
-opendal-service-swift@0.59.0	X														
-opendal-service-tos@0.59.0	X														
-opendal-service-upyun@0.59.0	X														
-opendal-service-vercel-artifacts@0.59.0	X														
-opendal-service-webdav@0.59.0	X														
-opendal-service-webhdfs@0.59.0	X														
-opendal-service-yandex-disk@0.59.0	X														
+opendal-service-aliyun-drive@0.59.1	X														
+opendal-service-alluxio@0.59.1	X														
+opendal-service-azblob@0.59.1	X														
+opendal-service-azdls@0.59.1	X														
+opendal-service-azfile@0.59.1	X														
+opendal-service-azure-common@0.59.1	X														
+opendal-service-b2@0.59.1	X														
+opendal-service-cacache@0.59.1	X														
+opendal-service-cos@0.59.1	X														
+opendal-service-dashmap@0.59.1	X														
+opendal-service-dropbox@0.59.1	X														
+opendal-service-fs@0.59.1	X														
+opendal-service-gcs@0.59.1	X														
+opendal-service-gcs-grpc@0.59.1	X														
+opendal-service-gdrive@0.59.1	X														
+opendal-service-ghac@0.59.1	X														
+opendal-service-goosefs@0.59.1	X														
+opendal-service-gridfs@0.59.1	X														
+opendal-service-hf@0.59.1	X														
+opendal-service-http@0.59.1	X														
+opendal-service-ipfs@0.59.1	X														
+opendal-service-ipmfs@0.59.1	X														
+opendal-service-koofr@0.59.1	X														
+opendal-service-memcached@0.59.1	X														
+opendal-service-mini-moka@0.59.1	X														
+opendal-service-moka@0.59.1	X														
+opendal-service-mongodb@0.59.1	X														
+opendal-service-mysql@0.59.1	X														
+opendal-service-obs@0.59.1	X														
+opendal-service-onedrive@0.59.1	X														
+opendal-service-oss@0.59.1	X														
+opendal-service-persy@0.59.1	X														
+opendal-service-postgresql@0.59.1	X														
+opendal-service-redb@0.59.1	X														
+opendal-service-redis@0.59.1	X														
+opendal-service-s3@0.59.1	X														
+opendal-service-seafile@0.59.1	X														
+opendal-service-sled@0.59.1	X														
+opendal-service-sqlite@0.59.1	X														
+opendal-service-swift@0.59.1	X														
+opendal-service-tos@0.59.1	X														
+opendal-service-upyun@0.59.1	X														
+opendal-service-vercel-artifacts@0.59.1	X														
+opendal-service-webdav@0.59.1	X														
+opendal-service-webhdfs@0.59.1	X														
+opendal-service-yandex-disk@0.59.1	X														
 openssl-probe@0.2.1	X									X					
 option-ext@0.2.0												X			
 ordered-multimap@0.7.3										X					
@@ -338,7 +338,7 @@ pkcs8@0.10.2	X									X
 pkg-config@0.3.34	X									X					
 plain@0.2.3	X									X					
 portable-atomic@1.15.0	X									X					
-portable-atomic-util@0.2.7	X									X					
+portable-atomic-util@0.2.8	X									X					
 potential_utf@0.1.6													X		
 powerfmt@0.2.0	X									X					
 ppv-lite86@0.2.21	X									X					
@@ -436,7 +436,7 @@ simdutf8@0.1.5	X									X
 skeptic@0.13.7	X									X					
 slab@0.4.12										X					
 sled@0.34.7	X									X					
-smallvec@1.15.2	X									X					
+smallvec@1.16.0	X									X					
 socket2@0.6.5	X									X					
 spin@0.10.1										X					
 spin@0.9.9										X					
@@ -458,7 +458,7 @@ strsim@0.11.1										X
 subtle@2.6.1				X											
 symlink@0.1.0	X									X					
 syn@2.0.119	X									X					
-syn@3.0.4	X									X					
+syn@3.0.5	X									X					
 sync_wrapper@1.0.2	X														
 synstructure@0.13.2										X					
 sysinfo@0.38.4										X					
@@ -478,12 +478,12 @@ time-core@0.1.9	X									X
 time-macros@0.2.32	X									X					
 tiny-keccak@2.0.2						X									
 tinystr@0.8.4													X		
-tinyvec@1.12.0	X									X					X
+tinyvec@1.13.2	X									X					X
 tinyvec_macros@0.1.1	X									X					X
 tokio@1.53.1										X					
 tokio-macros@2.7.2										X					
 tokio-retry@0.3.2										X					
-tokio-rustls@0.26.4	X									X					
+tokio-rustls@0.26.5	X									X					
 tokio-stream@0.1.19										X					
 tokio-util@0.7.19										X					
 tokio_with_wasm@0.8.8										X					
@@ -531,13 +531,13 @@ wasi@0.14.7+wasi-0.2.4	X	X								X
 wasip2@1.0.4+wasi-0.2.12	X	X								X					
 wasite@0.1.0	X				X					X					
 wasite@1.0.2	X				X					X					
-wasm-bindgen@0.2.127	X									X					
-wasm-bindgen-futures@0.4.77	X									X					
-wasm-bindgen-macro@0.2.127	X									X					
-wasm-bindgen-macro-support@0.2.127	X									X					
-wasm-bindgen-shared@0.2.127	X									X					
+wasm-bindgen@0.2.128	X									X					
+wasm-bindgen-futures@0.4.78	X									X					
+wasm-bindgen-macro@0.2.128	X									X					
+wasm-bindgen-macro-support@0.2.128	X									X					
+wasm-bindgen-shared@0.2.128	X									X					
 wasm-streams@0.5.0	X									X					
-web-sys@0.3.104	X									X					
+web-sys@0.3.105	X									X					
 web-time@1.1.0	X									X					
 webpki-root-certs@1.0.9							X								
 webpki-roots@0.26.11							X								

--- a/bindings/nodejs/generated.js
+++ b/bindings/nodejs/generated.js
@@ -99,8 +99,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-android-arm64')
         const bindingPackageVersion = require('@opendal/lib-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -115,8 +115,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-android-arm-eabi')
         const bindingPackageVersion = require('@opendal/lib-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -135,8 +135,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-x64-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -151,8 +151,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-ia32-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -167,8 +167,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-win32-arm64-msvc')
         const bindingPackageVersion = require('@opendal/lib-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -186,8 +186,8 @@ function requireNative() {
     try {
       const binding = require('@opendal/lib-darwin-universal')
       const bindingPackageVersion = require('@opendal/lib-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -202,8 +202,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-darwin-x64')
         const bindingPackageVersion = require('@opendal/lib-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -218,8 +218,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-darwin-arm64')
         const bindingPackageVersion = require('@opendal/lib-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -238,8 +238,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-freebsd-x64')
         const bindingPackageVersion = require('@opendal/lib-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -254,8 +254,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-freebsd-arm64')
         const bindingPackageVersion = require('@opendal/lib-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -275,8 +275,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-x64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -291,8 +291,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-x64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -309,8 +309,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -325,8 +325,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -343,8 +343,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm-musleabihf')
           const bindingPackageVersion = require('@opendal/lib-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -359,8 +359,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@opendal/lib-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -377,8 +377,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-riscv64-musl')
           const bindingPackageVersion = require('@opendal/lib-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -393,8 +393,8 @@ function requireNative() {
         try {
           const binding = require('@opendal/lib-linux-riscv64-gnu')
           const bindingPackageVersion = require('@opendal/lib-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -410,8 +410,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-linux-ppc64-gnu')
         const bindingPackageVersion = require('@opendal/lib-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -426,8 +426,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-linux-s390x-gnu')
         const bindingPackageVersion = require('@opendal/lib-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -446,8 +446,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-arm64')
         const bindingPackageVersion = require('@opendal/lib-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -462,8 +462,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-x64')
         const bindingPackageVersion = require('@opendal/lib-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -478,8 +478,8 @@ function requireNative() {
       try {
         const binding = require('@opendal/lib-openharmony-arm')
         const bindingPackageVersion = require('@opendal/lib-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.49.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.49.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '0.49.9' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 0.49.9 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-arm64",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-darwin-x64",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-gnu",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-arm64-musl",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-gnu",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/linux-x64-musl/package.json
+++ b/bindings/nodejs/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-linux-x64-musl",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-arm64-msvc",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "cpu": [
     "arm64"
   ],

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendal/lib-win32-x64-msvc",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "cpu": [
     "x64"
   ],

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opendal",
   "author": "Apache OpenDAL <dev@opendal.apache.org>",
-  "version": "0.49.8",
+  "version": "0.49.9",
   "license": "Apache-2.0",
   "main": "index.cjs",
   "module": "index.mjs",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -26,7 +26,7 @@ license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
 # Release candidate builds derive prerelease versions from tags in release_python.yml.
-version = "0.47.7"
+version = "0.47.8"
 
 [features]
 default = [

--- a/bindings/python/DEPENDENCIES.rust.tsv
+++ b/bindings/python/DEPENDENCIES.rust.tsv
@@ -16,8 +16,8 @@ asyncband@0.6.7	X
 atoi@2.0.0										X					
 atomic-waker@1.1.2	X									X					
 autocfg@1.5.1	X									X					
-aws-lc-rs@1.18.0	X							X							
-aws-lc-sys@0.44.0	X			X				X		X	X				
+aws-lc-rs@1.18.1	X							X							
+aws-lc-sys@0.45.0	X			X				X		X	X				
 backon@1.6.0	X														
 base64@0.21.7	X									X					
 base64@0.22.1	X									X					
@@ -44,7 +44,7 @@ cargo-platform@0.1.9	X									X
 cargo_metadata@0.14.2										X					
 cbc@0.1.2	X									X					
 cbc@0.2.1	X									X					
-cc@1.4.4	X									X					
+cc@1.4.5	X									X					
 cfg-if@0.1.10	X									X					
 cfg-if@1.0.4	X									X					
 chacha20@0.10.2	X									X					
@@ -115,9 +115,9 @@ error-chain@0.12.4	X									X
 etcetera@0.8.0	X									X					
 event-listener@5.4.2	X									X					
 event-listener-strategy@0.5.4	X									X					
-fastpool@1.1.1	X														
+fastpool@1.1.2	X														
 fastrand@2.5.0	X									X					
-find-msvc-tools@0.1.11	X									X					
+find-msvc-tools@0.1.12	X									X					
 flume@0.11.1	X									X					
 fnv@1.0.7	X									X					
 foldhash@0.1.5															X
@@ -159,9 +159,9 @@ heapify@0.2.0	X									X
 heck@0.5.0	X									X					
 hex@0.4.3	X									X					
 hf-xet@1.6.0	X														
-hickory-net@0.26.1	X									X					
-hickory-proto@0.26.1	X									X					
-hickory-resolver@0.26.1	X									X					
+hickory-net@0.26.2	X									X					
+hickory-proto@0.26.2	X									X					
+hickory-resolver@0.26.2	X									X					
 hkdf@0.12.4	X									X					
 hmac@0.12.1	X									X					
 hmac@0.13.0	X									X					
@@ -188,7 +188,7 @@ icu_provider@2.3.1													X
 ident_case@1.0.1	X									X					
 idna@1.1.0	X									X					
 idna_adapter@1.2.2	X									X					
-indexmap@2.14.1	X									X					
+indexmap@2.14.2	X									X					
 inout@0.1.4	X									X					
 inout@0.2.2	X									X					
 instant@0.1.13				X											
@@ -205,7 +205,7 @@ jni-macros@0.22.4	X									X
 jni-sys@0.4.1	X									X					
 jni-sys-macros@0.4.1	X									X					
 jobserver@0.1.35	X									X					
-js-sys@0.3.104	X									X					
+js-sys@0.3.105	X									X					
 konst@0.4.3															X
 konst_proc_macros@0.4.1															X
 lazy-regex@3.6.1										X					
@@ -214,7 +214,7 @@ lazy_static@1.5.0	X									X
 libc@0.2.189	X									X					
 libloading@0.9.0								X							
 libm@0.2.16										X					
-libredox@0.1.21										X					
+libredox@0.1.23										X					
 libsqlite3-sys@0.30.1										X					
 link-section@0.19.3	X									X					
 linked-hash-map@0.5.6	X									X					
@@ -239,10 +239,10 @@ miette-derive@5.10.0	X
 mime@0.3.17	X									X					
 mime_guess@2.0.5										X					
 mini-moka@0.10.3	X									X					
-mio@1.2.2										X					
+mio@1.2.3										X					
 moka@0.12.16	X									X					
-mongodb@3.8.2	X														
-mongodb-internal-macros@3.8.2	X														
+mongodb@3.9.0	X														
+mongodb-internal-macros@3.9.0	X														
 more-asserts@0.3.1	X					X				X				X	
 ndk-context@0.1.1	X									X					
 ntapi@0.4.3	X									X					
@@ -258,62 +258,62 @@ objc2-io-kit@0.3.2	X									X					X
 objc2-system-configuration@0.3.2	X									X					X
 once_cell@1.21.4	X									X					
 oneshot@0.1.13	X									X					
-opendal@0.59.0	X														
-opendal-core@0.59.0	X														
-opendal-http-transport-reqwest@0.59.0	X														
-opendal-layer-concurrent-limit@0.59.0	X														
-opendal-layer-logging@0.59.0	X														
-opendal-layer-mime-guess@0.59.0	X														
-opendal-layer-retry@0.59.0	X														
-opendal-layer-timeout@0.59.0	X														
-opendal-python@0.47.7	X														
-opendal-service-aliyun-drive@0.59.0	X														
-opendal-service-alluxio@0.59.0	X														
-opendal-service-azblob@0.59.0	X														
-opendal-service-azdls@0.59.0	X														
-opendal-service-azfile@0.59.0	X														
-opendal-service-azure-common@0.59.0	X														
-opendal-service-b2@0.59.0	X														
-opendal-service-cacache@0.59.0	X														
-opendal-service-cos@0.59.0	X														
-opendal-service-dashmap@0.59.0	X														
-opendal-service-dropbox@0.59.0	X														
-opendal-service-fs@0.59.0	X														
-opendal-service-ftp@0.59.0	X														
-opendal-service-gcs@0.59.0	X														
-opendal-service-gcs-grpc@0.59.0	X														
-opendal-service-gdrive@0.59.0	X														
-opendal-service-ghac@0.59.0	X														
-opendal-service-gridfs@0.59.0	X														
-opendal-service-hdfs-native@0.59.0	X														
-opendal-service-hf@0.59.0	X														
-opendal-service-http@0.59.0	X														
-opendal-service-ipfs@0.59.0	X														
-opendal-service-ipmfs@0.59.0	X														
-opendal-service-koofr@0.59.0	X														
-opendal-service-memcached@0.59.0	X														
-opendal-service-mini-moka@0.59.0	X														
-opendal-service-moka@0.59.0	X														
-opendal-service-mongodb@0.59.0	X														
-opendal-service-mysql@0.59.0	X														
-opendal-service-obs@0.59.0	X														
-opendal-service-onedrive@0.59.0	X														
-opendal-service-oss@0.59.0	X														
-opendal-service-persy@0.59.0	X														
-opendal-service-postgresql@0.59.0	X														
-opendal-service-redb@0.59.0	X														
-opendal-service-redis@0.59.0	X														
-opendal-service-s3@0.59.0	X														
-opendal-service-seafile@0.59.0	X														
-opendal-service-sled@0.59.0	X														
-opendal-service-sqlite@0.59.0	X														
-opendal-service-swift@0.59.0	X														
-opendal-service-tos@0.59.0	X														
-opendal-service-upyun@0.59.0	X														
-opendal-service-vercel-artifacts@0.59.0	X														
-opendal-service-webdav@0.59.0	X														
-opendal-service-webhdfs@0.59.0	X														
-opendal-service-yandex-disk@0.59.0	X														
+opendal@0.59.1	X														
+opendal-core@0.59.1	X														
+opendal-http-transport-reqwest@0.59.1	X														
+opendal-layer-concurrent-limit@0.59.1	X														
+opendal-layer-logging@0.59.1	X														
+opendal-layer-mime-guess@0.59.1	X														
+opendal-layer-retry@0.59.1	X														
+opendal-layer-timeout@0.59.1	X														
+opendal-python@0.47.8	X														
+opendal-service-aliyun-drive@0.59.1	X														
+opendal-service-alluxio@0.59.1	X														
+opendal-service-azblob@0.59.1	X														
+opendal-service-azdls@0.59.1	X														
+opendal-service-azfile@0.59.1	X														
+opendal-service-azure-common@0.59.1	X														
+opendal-service-b2@0.59.1	X														
+opendal-service-cacache@0.59.1	X														
+opendal-service-cos@0.59.1	X														
+opendal-service-dashmap@0.59.1	X														
+opendal-service-dropbox@0.59.1	X														
+opendal-service-fs@0.59.1	X														
+opendal-service-ftp@0.59.1	X														
+opendal-service-gcs@0.59.1	X														
+opendal-service-gcs-grpc@0.59.1	X														
+opendal-service-gdrive@0.59.1	X														
+opendal-service-ghac@0.59.1	X														
+opendal-service-gridfs@0.59.1	X														
+opendal-service-hdfs-native@0.59.1	X														
+opendal-service-hf@0.59.1	X														
+opendal-service-http@0.59.1	X														
+opendal-service-ipfs@0.59.1	X														
+opendal-service-ipmfs@0.59.1	X														
+opendal-service-koofr@0.59.1	X														
+opendal-service-memcached@0.59.1	X														
+opendal-service-mini-moka@0.59.1	X														
+opendal-service-moka@0.59.1	X														
+opendal-service-mongodb@0.59.1	X														
+opendal-service-mysql@0.59.1	X														
+opendal-service-obs@0.59.1	X														
+opendal-service-onedrive@0.59.1	X														
+opendal-service-oss@0.59.1	X														
+opendal-service-persy@0.59.1	X														
+opendal-service-postgresql@0.59.1	X														
+opendal-service-redb@0.59.1	X														
+opendal-service-redis@0.59.1	X														
+opendal-service-s3@0.59.1	X														
+opendal-service-seafile@0.59.1	X														
+opendal-service-sled@0.59.1	X														
+opendal-service-sqlite@0.59.1	X														
+opendal-service-swift@0.59.1	X														
+opendal-service-tos@0.59.1	X														
+opendal-service-upyun@0.59.1	X														
+opendal-service-vercel-artifacts@0.59.1	X														
+opendal-service-webdav@0.59.1	X														
+opendal-service-webhdfs@0.59.1	X														
+opendal-service-yandex-disk@0.59.1	X														
 openssl-probe@0.2.1	X									X					
 option-ext@0.2.0												X			
 ordered-multimap@0.7.3										X					
@@ -338,7 +338,7 @@ pkcs8@0.10.2	X									X
 pkg-config@0.3.34	X									X					
 plain@0.2.3	X									X					
 portable-atomic@1.15.0	X									X					
-portable-atomic-util@0.2.7	X									X					
+portable-atomic-util@0.2.8	X									X					
 potential_utf@0.1.6													X		
 powerfmt@0.2.0	X									X					
 ppv-lite86@0.2.21	X									X					
@@ -439,7 +439,7 @@ simdutf8@0.1.5	X									X
 skeptic@0.13.7	X									X					
 slab@0.4.12										X					
 sled@0.34.7	X									X					
-smallvec@1.15.2	X									X					
+smallvec@1.16.0	X									X					
 socket2@0.6.5	X									X					
 spin@0.10.1										X					
 spin@0.9.9										X					
@@ -461,7 +461,7 @@ subtle@2.6.1				X
 suppaftp@10.0.2	X									X					
 symlink@0.1.0	X									X					
 syn@2.0.119	X									X					
-syn@3.0.4	X									X					
+syn@3.0.5	X									X					
 sync_wrapper@1.0.2	X														
 synstructure@0.13.2										X					
 sysinfo@0.38.4										X					
@@ -482,12 +482,12 @@ time-core@0.1.9	X									X
 time-macros@0.2.32	X									X					
 tiny-keccak@2.0.2						X									
 tinystr@0.8.4													X		
-tinyvec@1.12.0	X									X					X
+tinyvec@1.13.2	X									X					X
 tinyvec_macros@0.1.1	X									X					X
 tokio@1.53.1										X					
 tokio-macros@2.7.2										X					
 tokio-retry@0.3.2										X					
-tokio-rustls@0.26.4	X									X					
+tokio-rustls@0.26.5	X									X					
 tokio-stream@0.1.19										X					
 tokio-util@0.7.19										X					
 tokio_with_wasm@0.8.8										X					
@@ -535,13 +535,13 @@ wasi@0.14.7+wasi-0.2.4	X	X								X
 wasip2@1.0.4+wasi-0.2.12	X	X								X					
 wasite@0.1.0	X				X					X					
 wasite@1.0.2	X				X					X					
-wasm-bindgen@0.2.127	X									X					
-wasm-bindgen-futures@0.4.77	X									X					
-wasm-bindgen-macro@0.2.127	X									X					
-wasm-bindgen-macro-support@0.2.127	X									X					
-wasm-bindgen-shared@0.2.127	X									X					
+wasm-bindgen@0.2.128	X									X					
+wasm-bindgen-futures@0.4.78	X									X					
+wasm-bindgen-macro@0.2.128	X									X					
+wasm-bindgen-macro-support@0.2.128	X									X					
+wasm-bindgen-shared@0.2.128	X									X					
 wasm-streams@0.5.0	X									X					
-web-sys@0.3.104	X									X					
+web-sys@0.3.105	X									X					
 web-time@1.1.0	X									X					
 webpki-root-certs@1.0.9							X								
 webpki-roots@0.26.11							X								

--- a/bindings/ruby/Cargo.lock
+++ b/bindings/ruby/Cargo.lock
@@ -1391,7 +1391,7 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "opendal"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "ctor",
  "opendal-core",
@@ -1419,7 +1419,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-core"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "asyncband",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-http-transport-reqwest"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "futures",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-concurrent-limit"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "futures",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-logging"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "log",
  "opendal-core",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-retry"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "backon",
  "log",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-throttle"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "governor",
  "opendal-core",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-timeout"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-ruby"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "bytes",
  "magnus",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azblob"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azdls"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "base64 0.23.0",
@@ -1548,7 +1548,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azfile"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http",
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azure-common"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "http",
  "opendal-core",
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cos"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-fs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "log",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ghac"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "ghac",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-http"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "http",
  "log",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ipmfs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http",
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-obs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http",
@@ -1674,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-oss"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http",
@@ -1689,7 +1689,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-s3"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webdav"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "asyncband",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webhdfs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "asyncband",

--- a/bindings/ruby/Cargo.toml
+++ b/bindings/ruby/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.1.11"
+version = "0.1.12"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/ruby/DEPENDENCIES.rust.tsv
+++ b/bindings/ruby/DEPENDENCIES.rust.tsv
@@ -138,30 +138,30 @@ num-integer@0.1.46	X									X
 num-iter@0.1.46	X									X				
 num-traits@0.2.19	X									X				
 once_cell@1.21.4	X									X				
-opendal@0.59.0	X													
-opendal-core@0.59.0	X													
-opendal-http-transport-reqwest@0.59.0	X													
-opendal-layer-concurrent-limit@0.59.0	X													
-opendal-layer-logging@0.59.0	X													
-opendal-layer-retry@0.59.0	X													
-opendal-layer-throttle@0.59.0	X													
-opendal-layer-timeout@0.59.0	X													
-opendal-ruby@0.1.11	X													
-opendal-service-azblob@0.59.0	X													
-opendal-service-azdls@0.59.0	X													
-opendal-service-azfile@0.59.0	X													
-opendal-service-azure-common@0.59.0	X													
-opendal-service-cos@0.59.0	X													
-opendal-service-fs@0.59.0	X													
-opendal-service-gcs@0.59.0	X													
-opendal-service-ghac@0.59.0	X													
-opendal-service-http@0.59.0	X													
-opendal-service-ipmfs@0.59.0	X													
-opendal-service-obs@0.59.0	X													
-opendal-service-oss@0.59.0	X													
-opendal-service-s3@0.59.0	X													
-opendal-service-webdav@0.59.0	X													
-opendal-service-webhdfs@0.59.0	X													
+opendal@0.59.1	X													
+opendal-core@0.59.1	X													
+opendal-http-transport-reqwest@0.59.1	X													
+opendal-layer-concurrent-limit@0.59.1	X													
+opendal-layer-logging@0.59.1	X													
+opendal-layer-retry@0.59.1	X													
+opendal-layer-throttle@0.59.1	X													
+opendal-layer-timeout@0.59.1	X													
+opendal-ruby@0.1.12	X													
+opendal-service-azblob@0.59.1	X													
+opendal-service-azdls@0.59.1	X													
+opendal-service-azfile@0.59.1	X													
+opendal-service-azure-common@0.59.1	X													
+opendal-service-cos@0.59.1	X													
+opendal-service-fs@0.59.1	X													
+opendal-service-gcs@0.59.1	X													
+opendal-service-ghac@0.59.1	X													
+opendal-service-http@0.59.1	X													
+opendal-service-ipmfs@0.59.1	X													
+opendal-service-obs@0.59.1	X													
+opendal-service-oss@0.59.1	X													
+opendal-service-s3@0.59.1	X													
+opendal-service-webdav@0.59.1	X													
+opendal-service-webhdfs@0.59.1	X													
 openssl-probe@0.2.1	X									X				
 ordered-multimap@0.7.3										X				
 parking_lot@0.12.5	X									X				

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_aws_s3_assume_role_with_web_identity"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "logforth",
  "opendal",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_file_write_on_full_disk"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal",
  "rand 0.10.1",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_opfs_wasm32"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "futures",
  "opendal",
@@ -2833,7 +2833,7 @@ dependencies = [
 
 [[package]]
 name = "edge_test_s3_read_on_wasm"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal",
  "wasm-bindgen",
@@ -6218,7 +6218,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opendal"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6332,7 +6332,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-benchmark-vs-fs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "criterion",
  "opendal",
@@ -6343,7 +6343,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-benchmark-vs-s3"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -6358,7 +6358,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-core"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "asyncband",
@@ -6386,7 +6386,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-basic"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal",
  "tokio",
@@ -6394,7 +6394,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-concurrent-upload"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal",
  "tokio",
@@ -6402,7 +6402,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-getting-started"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal",
  "tokio",
@@ -6410,7 +6410,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-examples-multipart-upload"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal",
  "tokio",
@@ -6418,7 +6418,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-fuzz"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -6430,7 +6430,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-http-transport-reqwest"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "futures",
@@ -6442,7 +6442,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-async-backtrace"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "async-backtrace",
  "opendal-core",
@@ -6450,7 +6450,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-await-tree"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "await-tree",
  "futures",
@@ -6459,7 +6459,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-capability-check"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -6467,7 +6467,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-chaos"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal-core",
  "rand 0.10.1",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-concurrent-limit"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "futures",
@@ -6486,7 +6486,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-dtrace"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "opendal-core",
@@ -6496,7 +6496,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-fastmetrics"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "fastmetrics",
  "log",
@@ -6507,7 +6507,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-fastrace"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6519,7 +6519,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-foyer"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "foyer",
  "opendal-core",
@@ -6530,7 +6530,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-hotpath"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "futures",
  "hotpath",
@@ -6541,7 +6541,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-immutable-index"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "futures",
  "log",
@@ -6552,7 +6552,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-logging"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "log",
  "opendal-core",
@@ -6560,7 +6560,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-metrics"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "metrics",
  "opendal-core",
@@ -6569,7 +6569,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-mime-guess"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "futures",
  "mime_guess",
@@ -6579,7 +6579,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-observe-metrics-common"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "futures",
  "http 1.4.2",
@@ -6589,7 +6589,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-otelmetrics"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal-core",
  "opendal-layer-observe-metrics-common",
@@ -6598,7 +6598,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-oteltrace"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal-core",
  "opentelemetry",
@@ -6606,7 +6606,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-prometheus"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "log",
  "opendal-core",
@@ -6617,7 +6617,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-prometheus-client"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "log",
  "opendal-core",
@@ -6628,7 +6628,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-retry"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "backon",
  "bytes",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-route"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "futures",
  "globset",
@@ -6654,7 +6654,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-tail-cut"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal-core",
  "tokio",
@@ -6662,7 +6662,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-throttle"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "governor",
  "opendal-core",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-timeout"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "futures",
  "opendal-core",
@@ -6680,7 +6680,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-layer-tracing"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -6698,7 +6698,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-aliyun-drive"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "bytes",
@@ -6712,7 +6712,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-alluxio"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6725,7 +6725,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azblob"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -6747,7 +6747,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azdls"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "base64 0.23.0",
@@ -6767,7 +6767,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azfile"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6784,7 +6784,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-azure-common"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "http 1.4.2",
  "opendal-core",
@@ -6792,7 +6792,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-b2"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "bytes",
@@ -6806,7 +6806,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cacache"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "cacache",
@@ -6817,7 +6817,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cloudflare-kv"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6828,7 +6828,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-compfs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "compio",
@@ -6839,7 +6839,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-cos"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6855,7 +6855,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-d1"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -6867,7 +6867,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dashmap"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "dashmap 6.2.1",
  "log",
@@ -6878,7 +6878,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dbfs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -6892,7 +6892,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-dropbox"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "bytes",
@@ -6905,7 +6905,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-etcd"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "etcd-client",
  "fastpool",
@@ -6916,7 +6916,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-foundationdb"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "foundationdb",
  "opendal-core",
@@ -6926,7 +6926,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-foyer"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "foyer",
  "log",
@@ -6940,7 +6940,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-fs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "log",
@@ -6953,7 +6953,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ftp"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "fastpool",
@@ -6968,7 +6968,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6989,7 +6989,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gcs-grpc"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "futures",
@@ -7010,7 +7010,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gdrive"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "bytes",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ghac"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "ghac",
@@ -7043,7 +7043,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-github"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -7057,7 +7057,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-goosefs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "goosefs-sdk",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-gridfs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "futures",
@@ -7082,7 +7082,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hdfs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "futures",
@@ -7095,7 +7095,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hdfs-native"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "futures",
@@ -7107,7 +7107,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-hf"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "base64 0.23.0",
@@ -7126,7 +7126,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-http"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "http 1.4.2",
  "log",
@@ -7137,7 +7137,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ipfs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7150,7 +7150,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-ipmfs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7163,7 +7163,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-koofr"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "bytes",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-lakefs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7190,7 +7190,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-memcached"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "fastpool",
  "opendal-core",
@@ -7201,7 +7201,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mini-moka"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "log",
  "mini-moka",
@@ -7211,7 +7211,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-moka"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "log",
  "moka",
@@ -7222,7 +7222,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mongodb"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "asyncband",
@@ -7234,7 +7234,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-monoiofs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "bytes",
@@ -7247,7 +7247,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-mysql"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "opendal-core",
@@ -7258,7 +7258,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-obs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7274,7 +7274,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-onedrive"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-opfs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "js-sys",
  "opendal-core",
@@ -7302,7 +7302,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-oss"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7319,7 +7319,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-pcloud"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7332,7 +7332,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-persy"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal-core",
  "persy",
@@ -7342,7 +7342,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-postgresql"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "opendal-core",
@@ -7353,7 +7353,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-redb"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal-core",
  "redb 4.1.0",
@@ -7363,7 +7363,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-redis"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "fastpool",
@@ -7376,7 +7376,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-rocksdb"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal-core",
  "rocksdb",
@@ -7386,7 +7386,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-s3"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -7409,7 +7409,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-seafile"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "bytes",
@@ -7423,7 +7423,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sftp"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7439,7 +7439,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sled"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "opendal-core",
  "serde",
@@ -7449,7 +7449,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-sqlite"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "opendal-core",
@@ -7460,7 +7460,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-surrealdb"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "opendal-core",
@@ -7471,7 +7471,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-swift"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -7491,7 +7491,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-tikv"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "asyncband",
  "opendal-core",
@@ -7502,7 +7502,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-tos"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7517,7 +7517,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-upyun"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "base64 0.23.0",
  "bytes",
@@ -7535,7 +7535,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-vercel-artifacts"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7549,7 +7549,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-vercel-blob"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7563,7 +7563,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webdav"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "asyncband",
@@ -7578,7 +7578,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-webhdfs"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "anyhow",
  "asyncband",
@@ -7594,7 +7594,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-service-yandex-disk"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "http 1.4.2",
@@ -7608,7 +7608,7 @@ dependencies = [
 
 [[package]]
 name = "opendal-testkit"
-version = "0.59.0"
+version = "0.59.1"
 dependencies = [
  "bytes",
  "dotenvy",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -39,7 +39,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.59.0"
+version = "0.59.1"
 
 [workspace.dependencies]
 asyncband = { version = "0.6" }
@@ -246,103 +246,103 @@ required-features = ["tests"]
 
 [dependencies]
 ctor = { workspace = true, optional = true }
-opendal-core = { path = "core", version = "0.59.0", default-features = false }
-opendal-http-transport-reqwest = { path = "http-transports/reqwest", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-async-backtrace = { path = "layers/async-backtrace", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-await-tree = { path = "layers/await-tree", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-capability-check = { path = "layers/capability-check", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-chaos = { path = "layers/chaos", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-concurrent-limit = { path = "layers/concurrent-limit", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-fastmetrics = { path = "layers/fastmetrics", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-fastrace = { path = "layers/fastrace", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-foyer = { path = "layers/foyer", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-hotpath = { path = "layers/hotpath", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-immutable-index = { path = "layers/immutable-index", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-logging = { path = "layers/logging", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-metrics = { path = "layers/metrics", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-mime-guess = { path = "layers/mime-guess", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-observe-metrics-common = { path = "layers/observe-metrics-common", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-otelmetrics = { path = "layers/otelmetrics", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-oteltrace = { path = "layers/oteltrace", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-prometheus = { path = "layers/prometheus", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-prometheus-client = { path = "layers/prometheus-client", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-retry = { path = "layers/retry", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-route = { path = "layers/route", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-tail-cut = { path = "layers/tail-cut", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-throttle = { path = "layers/throttle", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-timeout = { path = "layers/timeout", version = "0.59.0", optional = true, default-features = false }
-opendal-layer-tracing = { path = "layers/tracing", version = "0.59.0", optional = true, default-features = false }
-opendal-service-aliyun-drive = { path = "services/aliyun-drive", version = "0.59.0", optional = true, default-features = false }
-opendal-service-alluxio = { path = "services/alluxio", version = "0.59.0", optional = true, default-features = false }
-opendal-service-azblob = { path = "services/azblob", version = "0.59.0", optional = true, default-features = false }
-opendal-service-azdls = { path = "services/azdls", version = "0.59.0", optional = true, default-features = false }
-opendal-service-azfile = { path = "services/azfile", version = "0.59.0", optional = true, default-features = false }
-opendal-service-b2 = { path = "services/b2", version = "0.59.0", optional = true, default-features = false }
-opendal-service-cacache = { path = "services/cacache", version = "0.59.0", optional = true, default-features = false }
-opendal-service-cloudflare-kv = { path = "services/cloudflare-kv", version = "0.59.0", optional = true, default-features = false }
-opendal-service-compfs = { path = "services/compfs", version = "0.59.0", optional = true, default-features = false }
-opendal-service-cos = { path = "services/cos", version = "0.59.0", optional = true, default-features = false }
-opendal-service-d1 = { path = "services/d1", version = "0.59.0", optional = true, default-features = false }
-opendal-service-dashmap = { path = "services/dashmap", version = "0.59.0", optional = true, default-features = false }
-opendal-service-dbfs = { path = "services/dbfs", version = "0.59.0", optional = true, default-features = false }
-opendal-service-dropbox = { path = "services/dropbox", version = "0.59.0", optional = true, default-features = false }
-opendal-service-etcd = { path = "services/etcd", version = "0.59.0", optional = true, default-features = false }
-opendal-service-foundationdb = { path = "services/foundationdb", version = "0.59.0", optional = true, default-features = false }
-opendal-service-foyer = { path = "services/foyer", version = "0.59.0", optional = true, default-features = false }
-opendal-service-fs = { path = "services/fs", version = "0.59.0", optional = true, default-features = false }
-opendal-service-ftp = { path = "services/ftp", version = "0.59.0", optional = true, default-features = false }
-opendal-service-gcs = { path = "services/gcs", version = "0.59.0", optional = true, default-features = false }
-opendal-service-gcs-grpc = { path = "services/gcs-grpc", version = "0.59.0", optional = true, default-features = false }
-opendal-service-gdrive = { path = "services/gdrive", version = "0.59.0", optional = true, default-features = false }
-opendal-service-ghac = { path = "services/ghac", version = "0.59.0", optional = true, default-features = false }
-opendal-service-github = { path = "services/github", version = "0.59.0", optional = true, default-features = false }
-opendal-service-goosefs = { path = "services/goosefs", version = "0.59.0", optional = true, default-features = false }
-opendal-service-gridfs = { path = "services/gridfs", version = "0.59.0", optional = true, default-features = false }
-opendal-service-hdfs = { path = "services/hdfs", version = "0.59.0", optional = true, default-features = false }
-opendal-service-hdfs-native = { path = "services/hdfs-native", version = "0.59.0", optional = true, default-features = false }
-opendal-service-hf = { path = "services/hf", version = "0.59.0", optional = true, default-features = false }
-opendal-service-http = { path = "services/http", version = "0.59.0", optional = true, default-features = false }
-opendal-service-ipfs = { path = "services/ipfs", version = "0.59.0", optional = true, default-features = false }
-opendal-service-ipmfs = { path = "services/ipmfs", version = "0.59.0", optional = true, default-features = false }
-opendal-service-koofr = { path = "services/koofr", version = "0.59.0", optional = true, default-features = false }
-opendal-service-lakefs = { path = "services/lakefs", version = "0.59.0", optional = true, default-features = false }
-opendal-service-memcached = { path = "services/memcached", version = "0.59.0", optional = true, default-features = false }
-opendal-service-mini-moka = { path = "services/mini_moka", version = "0.59.0", optional = true, default-features = false }
-opendal-service-moka = { path = "services/moka", version = "0.59.0", optional = true, default-features = false }
-opendal-service-mongodb = { path = "services/mongodb", version = "0.59.0", optional = true, default-features = false }
-opendal-service-monoiofs = { path = "services/monoiofs", version = "0.59.0", optional = true, default-features = false }
-opendal-service-mysql = { path = "services/mysql", version = "0.59.0", optional = true, default-features = false }
-opendal-service-obs = { path = "services/obs", version = "0.59.0", optional = true, default-features = false }
-opendal-service-onedrive = { path = "services/onedrive", version = "0.59.0", optional = true, default-features = false }
-opendal-service-oss = { path = "services/oss", version = "0.59.0", optional = true, default-features = false }
-opendal-service-pcloud = { path = "services/pcloud", version = "0.59.0", optional = true, default-features = false }
-opendal-service-persy = { path = "services/persy", version = "0.59.0", optional = true, default-features = false }
-opendal-service-postgresql = { path = "services/postgresql", version = "0.59.0", optional = true, default-features = false }
-opendal-service-redb = { path = "services/redb", version = "0.59.0", optional = true, default-features = false }
-opendal-service-redis = { path = "services/redis", version = "0.59.0", optional = true, default-features = false }
-opendal-service-rocksdb = { path = "services/rocksdb", version = "0.59.0", optional = true, default-features = false }
-opendal-service-s3 = { path = "services/s3", version = "0.59.0", optional = true, default-features = false }
-opendal-service-seafile = { path = "services/seafile", version = "0.59.0", optional = true, default-features = false }
-opendal-service-sftp = { path = "services/sftp", version = "0.59.0", optional = true, default-features = false }
-opendal-service-sled = { path = "services/sled", version = "0.59.0", optional = true, default-features = false }
-opendal-service-sqlite = { path = "services/sqlite", version = "0.59.0", optional = true, default-features = false }
-opendal-service-surrealdb = { path = "services/surrealdb", version = "0.59.0", optional = true, default-features = false }
-opendal-service-swift = { path = "services/swift", version = "0.59.0", optional = true, default-features = false }
-opendal-service-tikv = { path = "services/tikv", version = "0.59.0", optional = true, default-features = false }
-opendal-service-tos = { path = "services/tos", version = "0.59.0", optional = true, default-features = false }
-opendal-service-upyun = { path = "services/upyun", version = "0.59.0", optional = true, default-features = false }
-opendal-service-vercel-artifacts = { path = "services/vercel-artifacts", version = "0.59.0", optional = true, default-features = false }
-opendal-service-vercel-blob = { path = "services/vercel-blob", version = "0.59.0", optional = true, default-features = false }
-opendal-service-webdav = { path = "services/webdav", version = "0.59.0", optional = true, default-features = false }
-opendal-service-webhdfs = { path = "services/webhdfs", version = "0.59.0", optional = true, default-features = false }
-opendal-service-yandex-disk = { path = "services/yandex-disk", version = "0.59.0", optional = true, default-features = false }
-opendal-testkit = { path = "testkit", version = "0.59.0", optional = true }
+opendal-core = { path = "core", version = "0.59.1", default-features = false }
+opendal-http-transport-reqwest = { path = "http-transports/reqwest", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-async-backtrace = { path = "layers/async-backtrace", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-await-tree = { path = "layers/await-tree", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-capability-check = { path = "layers/capability-check", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-chaos = { path = "layers/chaos", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-concurrent-limit = { path = "layers/concurrent-limit", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-fastmetrics = { path = "layers/fastmetrics", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-fastrace = { path = "layers/fastrace", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-foyer = { path = "layers/foyer", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-hotpath = { path = "layers/hotpath", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-immutable-index = { path = "layers/immutable-index", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-logging = { path = "layers/logging", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-metrics = { path = "layers/metrics", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-mime-guess = { path = "layers/mime-guess", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-observe-metrics-common = { path = "layers/observe-metrics-common", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-otelmetrics = { path = "layers/otelmetrics", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-oteltrace = { path = "layers/oteltrace", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-prometheus = { path = "layers/prometheus", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-prometheus-client = { path = "layers/prometheus-client", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-retry = { path = "layers/retry", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-route = { path = "layers/route", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-tail-cut = { path = "layers/tail-cut", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-throttle = { path = "layers/throttle", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-timeout = { path = "layers/timeout", version = "0.59.1", optional = true, default-features = false }
+opendal-layer-tracing = { path = "layers/tracing", version = "0.59.1", optional = true, default-features = false }
+opendal-service-aliyun-drive = { path = "services/aliyun-drive", version = "0.59.1", optional = true, default-features = false }
+opendal-service-alluxio = { path = "services/alluxio", version = "0.59.1", optional = true, default-features = false }
+opendal-service-azblob = { path = "services/azblob", version = "0.59.1", optional = true, default-features = false }
+opendal-service-azdls = { path = "services/azdls", version = "0.59.1", optional = true, default-features = false }
+opendal-service-azfile = { path = "services/azfile", version = "0.59.1", optional = true, default-features = false }
+opendal-service-b2 = { path = "services/b2", version = "0.59.1", optional = true, default-features = false }
+opendal-service-cacache = { path = "services/cacache", version = "0.59.1", optional = true, default-features = false }
+opendal-service-cloudflare-kv = { path = "services/cloudflare-kv", version = "0.59.1", optional = true, default-features = false }
+opendal-service-compfs = { path = "services/compfs", version = "0.59.1", optional = true, default-features = false }
+opendal-service-cos = { path = "services/cos", version = "0.59.1", optional = true, default-features = false }
+opendal-service-d1 = { path = "services/d1", version = "0.59.1", optional = true, default-features = false }
+opendal-service-dashmap = { path = "services/dashmap", version = "0.59.1", optional = true, default-features = false }
+opendal-service-dbfs = { path = "services/dbfs", version = "0.59.1", optional = true, default-features = false }
+opendal-service-dropbox = { path = "services/dropbox", version = "0.59.1", optional = true, default-features = false }
+opendal-service-etcd = { path = "services/etcd", version = "0.59.1", optional = true, default-features = false }
+opendal-service-foundationdb = { path = "services/foundationdb", version = "0.59.1", optional = true, default-features = false }
+opendal-service-foyer = { path = "services/foyer", version = "0.59.1", optional = true, default-features = false }
+opendal-service-fs = { path = "services/fs", version = "0.59.1", optional = true, default-features = false }
+opendal-service-ftp = { path = "services/ftp", version = "0.59.1", optional = true, default-features = false }
+opendal-service-gcs = { path = "services/gcs", version = "0.59.1", optional = true, default-features = false }
+opendal-service-gcs-grpc = { path = "services/gcs-grpc", version = "0.59.1", optional = true, default-features = false }
+opendal-service-gdrive = { path = "services/gdrive", version = "0.59.1", optional = true, default-features = false }
+opendal-service-ghac = { path = "services/ghac", version = "0.59.1", optional = true, default-features = false }
+opendal-service-github = { path = "services/github", version = "0.59.1", optional = true, default-features = false }
+opendal-service-goosefs = { path = "services/goosefs", version = "0.59.1", optional = true, default-features = false }
+opendal-service-gridfs = { path = "services/gridfs", version = "0.59.1", optional = true, default-features = false }
+opendal-service-hdfs = { path = "services/hdfs", version = "0.59.1", optional = true, default-features = false }
+opendal-service-hdfs-native = { path = "services/hdfs-native", version = "0.59.1", optional = true, default-features = false }
+opendal-service-hf = { path = "services/hf", version = "0.59.1", optional = true, default-features = false }
+opendal-service-http = { path = "services/http", version = "0.59.1", optional = true, default-features = false }
+opendal-service-ipfs = { path = "services/ipfs", version = "0.59.1", optional = true, default-features = false }
+opendal-service-ipmfs = { path = "services/ipmfs", version = "0.59.1", optional = true, default-features = false }
+opendal-service-koofr = { path = "services/koofr", version = "0.59.1", optional = true, default-features = false }
+opendal-service-lakefs = { path = "services/lakefs", version = "0.59.1", optional = true, default-features = false }
+opendal-service-memcached = { path = "services/memcached", version = "0.59.1", optional = true, default-features = false }
+opendal-service-mini-moka = { path = "services/mini_moka", version = "0.59.1", optional = true, default-features = false }
+opendal-service-moka = { path = "services/moka", version = "0.59.1", optional = true, default-features = false }
+opendal-service-mongodb = { path = "services/mongodb", version = "0.59.1", optional = true, default-features = false }
+opendal-service-monoiofs = { path = "services/monoiofs", version = "0.59.1", optional = true, default-features = false }
+opendal-service-mysql = { path = "services/mysql", version = "0.59.1", optional = true, default-features = false }
+opendal-service-obs = { path = "services/obs", version = "0.59.1", optional = true, default-features = false }
+opendal-service-onedrive = { path = "services/onedrive", version = "0.59.1", optional = true, default-features = false }
+opendal-service-oss = { path = "services/oss", version = "0.59.1", optional = true, default-features = false }
+opendal-service-pcloud = { path = "services/pcloud", version = "0.59.1", optional = true, default-features = false }
+opendal-service-persy = { path = "services/persy", version = "0.59.1", optional = true, default-features = false }
+opendal-service-postgresql = { path = "services/postgresql", version = "0.59.1", optional = true, default-features = false }
+opendal-service-redb = { path = "services/redb", version = "0.59.1", optional = true, default-features = false }
+opendal-service-redis = { path = "services/redis", version = "0.59.1", optional = true, default-features = false }
+opendal-service-rocksdb = { path = "services/rocksdb", version = "0.59.1", optional = true, default-features = false }
+opendal-service-s3 = { path = "services/s3", version = "0.59.1", optional = true, default-features = false }
+opendal-service-seafile = { path = "services/seafile", version = "0.59.1", optional = true, default-features = false }
+opendal-service-sftp = { path = "services/sftp", version = "0.59.1", optional = true, default-features = false }
+opendal-service-sled = { path = "services/sled", version = "0.59.1", optional = true, default-features = false }
+opendal-service-sqlite = { path = "services/sqlite", version = "0.59.1", optional = true, default-features = false }
+opendal-service-surrealdb = { path = "services/surrealdb", version = "0.59.1", optional = true, default-features = false }
+opendal-service-swift = { path = "services/swift", version = "0.59.1", optional = true, default-features = false }
+opendal-service-tikv = { path = "services/tikv", version = "0.59.1", optional = true, default-features = false }
+opendal-service-tos = { path = "services/tos", version = "0.59.1", optional = true, default-features = false }
+opendal-service-upyun = { path = "services/upyun", version = "0.59.1", optional = true, default-features = false }
+opendal-service-vercel-artifacts = { path = "services/vercel-artifacts", version = "0.59.1", optional = true, default-features = false }
+opendal-service-vercel-blob = { path = "services/vercel-blob", version = "0.59.1", optional = true, default-features = false }
+opendal-service-webdav = { path = "services/webdav", version = "0.59.1", optional = true, default-features = false }
+opendal-service-webhdfs = { path = "services/webhdfs", version = "0.59.1", optional = true, default-features = false }
+opendal-service-yandex-disk = { path = "services/yandex-disk", version = "0.59.1", optional = true, default-features = false }
+opendal-testkit = { path = "testkit", version = "0.59.1", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-opendal-layer-dtrace = { path = "layers/dtrace", version = "0.59.0", optional = true, default-features = false }
+opendal-layer-dtrace = { path = "layers/dtrace", version = "0.59.1", optional = true, default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-opendal-service-opfs = { path = "services/opfs", version = "0.59.0", optional = true, default-features = false }
+opendal-service-opfs = { path = "services/opfs", version = "0.59.1", optional = true, default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/core/DEPENDENCIES.rust.tsv
+++ b/core/DEPENDENCIES.rust.tsv
@@ -128,18 +128,18 @@ mime@0.3.17	X									X
 mio@1.2.0										X				
 moka@0.12.15	X									X				
 once_cell@1.21.4	X									X				
-opendal@0.59.0	X													
-opendal-core@0.59.0	X													
-opendal-http-transport-reqwest@0.59.0	X													
-opendal-layer-concurrent-limit@0.59.0	X													
-opendal-layer-logging@0.59.0	X													
-opendal-layer-retry@0.59.0	X													
-opendal-layer-timeout@0.59.0	X													
-opendal-service-fs@0.59.0	X													
-opendal-service-goosefs@0.59.0	X													
-opendal-service-opfs@0.59.0	X													
-opendal-service-s3@0.59.0	X													
-opendal-testkit@0.59.0	X													
+opendal@0.59.1	X													
+opendal-core@0.59.1	X													
+opendal-http-transport-reqwest@0.59.1	X													
+opendal-layer-concurrent-limit@0.59.1	X													
+opendal-layer-logging@0.59.1	X													
+opendal-layer-retry@0.59.1	X													
+opendal-layer-timeout@0.59.1	X													
+opendal-service-fs@0.59.1	X													
+opendal-service-goosefs@0.59.1	X													
+opendal-service-opfs@0.59.1	X													
+opendal-service-s3@0.59.1	X													
+opendal-testkit@0.59.1	X													
 openssl-probe@0.2.1	X									X				
 ordered-multimap@0.7.3										X				
 parking@2.2.1	X									X				

--- a/core/benches/vs_fs/Cargo.toml
+++ b/core/benches/vs_fs/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "opendal-benchmark-vs-fs"
 publish = false
 rust-version = "1.86"
-version = "0.59.0"
+version = "0.59.1"
 
 [dependencies]
 criterion = { version = "0.8.2", features = ["async", "async_tokio"] }

--- a/core/benches/vs_s3/Cargo.toml
+++ b/core/benches/vs_s3/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "opendal-benchmark-vs-s3"
 publish = false
 rust-version = "1.86"
-version = "0.59.0"
+version = "0.59.1"
 
 [dependencies]
 aws-config = { version = "1.0.1", features = ["behavior-version-latest"] }

--- a/core/http-transports/reqwest/Cargo.toml
+++ b/core/http-transports/reqwest/Cargo.toml
@@ -53,7 +53,7 @@ bytes = { workspace = true }
 futures = { workspace = true, features = ["std"] }
 http = { workspace = true }
 http-body = "1"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 reqwest = { version = "0.13.4", features = [
   "stream",
 ], default-features = false }

--- a/core/layers/async-backtrace/Cargo.toml
+++ b/core/layers/async-backtrace/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 async-backtrace = "0.2.6"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }

--- a/core/layers/await-tree/Cargo.toml
+++ b/core/layers/await-tree/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 await-tree = "0.3"
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }

--- a/core/layers/capability-check/Cargo.toml
+++ b/core/layers/capability-check/Cargo.toml
@@ -32,8 +32,8 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/chaos/Cargo.toml
+++ b/core/layers/chaos/Cargo.toml
@@ -32,8 +32,8 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 rand = { workspace = true }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }

--- a/core/layers/concurrent-limit/Cargo.toml
+++ b/core/layers/concurrent-limit/Cargo.toml
@@ -35,8 +35,8 @@ all-features = true
 asyncband = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/core/layers/dtrace/Cargo.toml
+++ b/core/layers/dtrace/Cargo.toml
@@ -33,9 +33,9 @@ all-features = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 bytes = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 probe = "0.5.1"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/fastmetrics/Cargo.toml
+++ b/core/layers/fastmetrics/Cargo.toml
@@ -33,10 +33,10 @@ all-features = true
 
 [dependencies]
 fastmetrics = "0.7"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/fastrace/Cargo.toml
+++ b/core/layers/fastrace/Cargo.toml
@@ -33,12 +33,12 @@ all-features = true
 
 [dependencies]
 fastrace = { version = "0.7.18" }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0"
 dotenvy = "0.15"
 fastrace = { version = "0.7", features = ["enable"] }
 fastrace-jaeger = "0.7"
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/foyer/Cargo.toml
+++ b/core/layers/foyer/Cargo.toml
@@ -33,10 +33,10 @@ all-features = true
 
 [dependencies]
 foyer = { version = "0.22.3" }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", features = [
+opendal-core = { path = "../../core", version = "0.59.1", features = [
   "services-memory",
 ] }
 size = "0.5"

--- a/core/layers/hotpath/Cargo.toml
+++ b/core/layers/hotpath/Cargo.toml
@@ -35,8 +35,8 @@ all-features = true
 futures = { workspace = true }
 hotpath = "0.22.0"
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/immutable-index/Cargo.toml
+++ b/core/layers/immutable-index/Cargo.toml
@@ -32,11 +32,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
 log = { workspace = true }
 logforth = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/logging/Cargo.toml
+++ b/core/layers/logging/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }

--- a/core/layers/metrics/Cargo.toml
+++ b/core/layers/metrics/Cargo.toml
@@ -33,8 +33,8 @@ all-features = true
 
 [dependencies]
 metrics = "0.24"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }

--- a/core/layers/mime-guess/Cargo.toml
+++ b/core/layers/mime-guess/Cargo.toml
@@ -33,9 +33,9 @@ all-features = true
 
 [dependencies]
 mime_guess = "2.0.5"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/observe-metrics-common/Cargo.toml
+++ b/core/layers/observe-metrics-common/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 futures = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/otelmetrics/Cargo.toml
+++ b/core/layers/otelmetrics/Cargo.toml
@@ -32,11 +32,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.1" }
 opentelemetry = { version = "0.32.0", default-features = false, features = [
   "metrics",
 ] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }

--- a/core/layers/oteltrace/Cargo.toml
+++ b/core/layers/oteltrace/Cargo.toml
@@ -32,10 +32,10 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 opentelemetry = { version = "0.32.0", default-features = false, features = [
   "trace",
 ] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }

--- a/core/layers/prometheus-client/Cargo.toml
+++ b/core/layers/prometheus-client/Cargo.toml
@@ -32,11 +32,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.1" }
 prometheus-client = { version = "0.25" }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/prometheus/Cargo.toml
+++ b/core/layers/prometheus/Cargo.toml
@@ -32,11 +32,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
-opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
+opendal-layer-observe-metrics-common = { path = "../observe-metrics-common", version = "0.59.1" }
 prometheus = { version = "0.14", features = ["process"] }
 
 [dev-dependencies]
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/retry/Cargo.toml
+++ b/core/layers/retry/Cargo.toml
@@ -34,13 +34,13 @@ all-features = true
 [dependencies]
 backon = { version = "1.6", features = ["tokio-sleep"] }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
 bytes = { workspace = true }
 futures = { workspace = true }
 logforth = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0" }
-opendal-layer-logging = { path = "../logging", version = "0.59.0" }
-opendal-layer-timeout = { path = "../timeout", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
+opendal-layer-logging = { path = "../logging", version = "0.59.1" }
+opendal-layer-timeout = { path = "../timeout", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/route/Cargo.toml
+++ b/core/layers/route/Cargo.toml
@@ -33,10 +33,10 @@ all-features = true
 
 [dependencies]
 globset = "0.4.15"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0" }
-opendal-service-fs = { path = "../../services/fs", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
+opendal-service-fs = { path = "../../services/fs", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/tail-cut/Cargo.toml
+++ b/core/layers/tail-cut/Cargo.toml
@@ -32,9 +32,9 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/throttle/Cargo.toml
+++ b/core/layers/throttle/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 governor = "0.10.4"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }

--- a/core/layers/timeout/Cargo.toml
+++ b/core/layers/timeout/Cargo.toml
@@ -32,11 +32,11 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 tokio = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 futures = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0" }
-opendal-layer-retry = { path = "../retry", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
+opendal-layer-retry = { path = "../retry", version = "0.59.1" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/layers/tracing/Cargo.toml
+++ b/core/layers/tracing/Cargo.toml
@@ -34,13 +34,13 @@ all-features = true
 [dependencies]
 futures = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 tracing = "0.1"
 
 [dev-dependencies]
 anyhow = "1.0"
 dotenvy = "0.15"
-opendal-core = { path = "../../core", version = "0.59.0" }
+opendal-core = { path = "../../core", version = "0.59.1" }
 opentelemetry = { version = "0.32.0", default-features = false, features = [
   "trace",
 ] }

--- a/core/services/aliyun-drive/Cargo.toml
+++ b/core/services/aliyun-drive/Cargo.toml
@@ -36,7 +36,7 @@ asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/alluxio/Cargo.toml
+++ b/core/services/alluxio/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/azblob/Cargo.toml
+++ b/core/services/azblob/Cargo.toml
@@ -36,10 +36,10 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false, features = [
   "reqsign",
 ] }
-opendal-service-azure-common = { path = "../azure-common", version = "0.59.0" }
+opendal-service-azure-common = { path = "../azure-common", version = "0.59.1" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.1.1", default-features = false }
 reqsign-core = { version = "3.2.0", default-features = false }

--- a/core/services/azdls/Cargo.toml
+++ b/core/services/azdls/Cargo.toml
@@ -37,10 +37,10 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false, features = [
   "reqsign",
 ] }
-opendal-service-azure-common = { path = "../azure-common", version = "0.59.0" }
+opendal-service-azure-common = { path = "../azure-common", version = "0.59.1" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.1.1", default-features = false }
 reqsign-core = { version = "3.2.0", default-features = false }

--- a/core/services/azfile/Cargo.toml
+++ b/core/services/azfile/Cargo.toml
@@ -35,10 +35,10 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false, features = [
   "reqsign",
 ] }
-opendal-service-azure-common = { path = "../azure-common", version = "0.59.0" }
+opendal-service-azure-common = { path = "../azure-common", version = "0.59.1" }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 reqsign-azure-storage = { version = "3.1.1", default-features = false }
 reqsign-core = { version = "3.2.0", default-features = false }

--- a/core/services/azure-common/Cargo.toml
+++ b/core/services/azure-common/Cargo.toml
@@ -33,4 +33,4 @@ all-features = true
 
 [dependencies]
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }

--- a/core/services/b2/Cargo.toml
+++ b/core/services/b2/Cargo.toml
@@ -36,7 +36,7 @@ asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/cacache/Cargo.toml
+++ b/core/services/cacache/Cargo.toml
@@ -37,7 +37,7 @@ cacache = { version = "13.0", default-features = false, features = [
   "tokio-runtime",
   "mmap",
 ] }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/cloudflare-kv/Cargo.toml
+++ b/core/services/cloudflare-kv/Cargo.toml
@@ -34,6 +34,6 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/compfs/Cargo.toml
+++ b/core/services/compfs/Cargo.toml
@@ -41,7 +41,7 @@ compio = { version = "0.19.0", features = [
   "runtime",
   "sync",
 ] }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/cos/Cargo.toml
+++ b/core/services/cos/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/d1/Cargo.toml
+++ b/core/services/d1/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/dashmap/Cargo.toml
+++ b/core/services/dashmap/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 dashmap = "6"
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/dbfs/Cargo.toml
+++ b/core/services/dbfs/Cargo.toml
@@ -36,7 +36,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/dropbox/Cargo.toml
+++ b/core/services/dropbox/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/etcd/Cargo.toml
+++ b/core/services/etcd/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 etcd-client = { version = "0.19.0", features = ["tls"] }
 fastpool = "1.0.2"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["time"] }
 

--- a/core/services/foundationdb/Cargo.toml
+++ b/core/services/foundationdb/Cargo.toml
@@ -36,7 +36,7 @@ foundationdb = { version = "0.11.0", features = [
   "embedded-fdb-include",
   "fdb-7_3",
 ] }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/foyer/Cargo.toml
+++ b/core/services/foyer/Cargo.toml
@@ -34,12 +34,12 @@ all-features = true
 [dependencies]
 foyer = { version = "0.22.3" }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-opendal = { path = "../..", version = "0.59.0", features = ["services-memory"] }
-opendal-core = { path = "../../core", version = "0.59.0", features = [
+opendal = { path = "../..", version = "0.59.1", features = ["services-memory"] }
+opendal-core = { path = "../../core", version = "0.59.1", features = [
   "services-memory",
 ] }
 size = "0.5"

--- a/core/services/fs/Cargo.toml
+++ b/core/services/fs/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false, features = [
   "internal-tokio-rt",
 ] }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/ftp/Cargo.toml
+++ b/core/services/ftp/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 fastpool = "1.0.2"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 rustls-native-certs = "0.8"
 serde = { workspace = true, features = ["derive"] }
 suppaftp = { version = "10.0.2", default-features = false, features = [

--- a/core/services/gcs-grpc/Cargo.toml
+++ b/core/services/gcs-grpc/Cargo.toml
@@ -36,7 +36,7 @@ bytes = { workspace = true }
 futures = { workspace = true, features = ["async-await", "std"] }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false, features = [
   "reqsign",
 ] }
 percent-encoding = "2"

--- a/core/services/gcs/Cargo.toml
+++ b/core/services/gcs/Cargo.toml
@@ -36,7 +36,7 @@ async-trait = "0.1"
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false, features = [
   "reqsign",
 ] }
 percent-encoding = "2.3"

--- a/core/services/gdrive/Cargo.toml
+++ b/core/services/gdrive/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 asyncband = { workspace = true }
 bytes = { workspace = true }

--- a/core/services/ghac/Cargo.toml
+++ b/core/services/ghac/Cargo.toml
@@ -36,8 +36,8 @@ bytes = { workspace = true }
 ghac = { version = "0.3.0", default-features = false }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
-opendal-service-azblob = { path = "../azblob", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
+opendal-service-azblob = { path = "../azblob", version = "0.59.1", default-features = false }
 prost = { version = "0.14.3", default-features = false }
 reqsign-azure-storage = { version = "3.1.1", default-features = false }
 reqsign-core = { version = "3.2.0", default-features = false }

--- a/core/services/github/Cargo.toml
+++ b/core/services/github/Cargo.toml
@@ -36,7 +36,7 @@ base64 = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/goosefs/Cargo.toml
+++ b/core/services/goosefs/Cargo.toml
@@ -35,12 +35,12 @@ all-features = true
 bytes = { workspace = true }
 goosefs-sdk = "0.1.9"
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true }
 
 [dev-dependencies]
-opendal = { path = "../..", version = "0.59.0", features = [
+opendal = { path = "../..", version = "0.59.1", features = [
   "services-goosefs",
 ] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/gridfs/Cargo.toml
+++ b/core/services/gridfs/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 asyncband = { workspace = true }
 futures = { workspace = true }
 mongodb = "3.3.0"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/hdfs-native/Cargo.toml
+++ b/core/services/hdfs-native/Cargo.toml
@@ -36,5 +36,5 @@ bytes = { workspace = true }
 futures = { workspace = true }
 hdfs-native = { version = "0.14" }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/hdfs/Cargo.toml
+++ b/core/services/hdfs/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 bytes = { workspace = true }
 futures = { workspace = true }

--- a/core/services/hf/Cargo.toml
+++ b/core/services/hf/Cargo.toml
@@ -37,7 +37,7 @@ bytes = { workspace = true }
 hf-xet = "1.6.0"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 percent-encoding = "2"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -45,6 +45,6 @@ serde_json = { workspace = true }
 [dev-dependencies]
 base64 = { workspace = true }
 futures = { workspace = true }
-opendal-http-transport-reqwest = { path = "../../http-transports/reqwest", version = "0.59.0" }
+opendal-http-transport-reqwest = { path = "../../http-transports/reqwest", version = "0.59.1" }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/core/services/http/Cargo.toml
+++ b/core/services/http/Cargo.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 name = "opendal-service-http"
 readme = "README.md"
 repository = "https://github.com/apache/opendal"
-version = "0.59.0"
+version = "0.59.1"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -30,9 +30,9 @@ all-features = true
 [dependencies]
 http = "1.4"
 log = "0.4"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 tokio = { version = "1.52", features = ["macros", "rt-multi-thread"] }

--- a/core/services/ipfs/Cargo.toml
+++ b/core/services/ipfs/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 prost = "0.14.3"
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/ipmfs/Cargo.toml
+++ b/core/services/ipmfs/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/koofr/Cargo.toml
+++ b/core/services/koofr/Cargo.toml
@@ -36,7 +36,7 @@ asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/lakefs/Cargo.toml
+++ b/core/services/lakefs/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/memcached/Cargo.toml
+++ b/core/services/memcached/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 fastpool = "1.0.2"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "time"] }
 url = { workspace = true }

--- a/core/services/mini_moka/Cargo.toml
+++ b/core/services/mini_moka/Cargo.toml
@@ -34,5 +34,5 @@ all-features = true
 [dependencies]
 log = { workspace = true }
 mini-moka = "0.10"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/moka/Cargo.toml
+++ b/core/services/moka/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 log = { workspace = true }
 moka = { version = "0.12", features = ["future", "sync"] }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/mongodb/Cargo.toml
+++ b/core/services/mongodb/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 asyncband = { workspace = true }
 mongodb = { version = "3.3.0" }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/monoiofs/Cargo.toml
+++ b/core/services/monoiofs/Cargo.toml
@@ -41,7 +41,7 @@ monoio = { version = "0.2.4", features = [
   "unlinkat",
   "renameat",
 ] }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]

--- a/core/services/mysql/Cargo.toml
+++ b/core/services/mysql/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 asyncband = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "mysql"] }
 

--- a/core/services/obs/Cargo.toml
+++ b/core/services/obs/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/onedrive/Cargo.toml
+++ b/core/services/onedrive/Cargo.toml
@@ -36,7 +36,7 @@ asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["time"] }

--- a/core/services/opfs/Cargo.toml
+++ b/core/services/opfs/Cargo.toml
@@ -35,7 +35,7 @@ targets = ["wasm32-unknown-unknown"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.77"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 send_wrapper = "0.6"
 serde = { workspace = true, features = ["derive"] }
 wasm-bindgen = "0.2.100"

--- a/core/services/oss/Cargo.toml
+++ b/core/services/oss/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/pcloud/Cargo.toml
+++ b/core/services/pcloud/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/core/services/persy/Cargo.toml
+++ b/core/services/persy/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 persy = "1.7.1"
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/postgresql/Cargo.toml
+++ b/core/services/postgresql/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 asyncband = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "postgres"] }
 

--- a/core/services/redb/Cargo.toml
+++ b/core/services/redb/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 redb = { version = "4" }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/redis/Cargo.toml
+++ b/core/services/redis/Cargo.toml
@@ -40,7 +40,7 @@ rustls = ["redis/tokio-rustls-comp"]
 bytes = { workspace = true }
 fastpool = "1.0.2"
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 redis = { version = "1.2", features = [
   "cluster-async",
   "tokio-comp",

--- a/core/services/rocksdb/Cargo.toml
+++ b/core/services/rocksdb/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 rocksdb = { version = "0.24.0", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/s3/Cargo.toml
+++ b/core/services/s3/Cargo.toml
@@ -38,7 +38,7 @@ crc-fast = "1.9.0"
 http = { workspace = true }
 log = { workspace = true }
 md-5 = "0.11.0"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/seafile/Cargo.toml
+++ b/core/services/seafile/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 asyncband = { workspace = true }
 bytes = { workspace = true }

--- a/core/services/sftp/Cargo.toml
+++ b/core/services/sftp/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 bytes = { workspace = true }
 fastpool = "1.0.2"

--- a/core/services/sled/Cargo.toml
+++ b/core/services/sled/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sled = "0.34.7"
 

--- a/core/services/sqlite/Cargo.toml
+++ b/core/services/sqlite/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 asyncband = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 sqlx = { version = "0.8.0", features = ["runtime-tokio-rustls", "sqlite"] }
 

--- a/core/services/surrealdb/Cargo.toml
+++ b/core/services/surrealdb/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 asyncband = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 surrealdb = { version = "3", features = ["protocol-http"] }
 

--- a/core/services/swift/Cargo.toml
+++ b/core/services/swift/Cargo.toml
@@ -37,7 +37,7 @@ bytes = { workspace = true }
 hmac = "0.13.0"
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 percent-encoding = "2"
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }

--- a/core/services/tikv/Cargo.toml
+++ b/core/services/tikv/Cargo.toml
@@ -33,7 +33,7 @@ all-features = true
 
 [dependencies]
 asyncband = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 tikv-client = { version = "0.4.0", default-features = false }
 

--- a/core/services/tos/Cargo.toml
+++ b/core/services/tos/Cargo.toml
@@ -34,7 +34,7 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 http = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false, features = [
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false, features = [
   "reqsign",
 ] }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }

--- a/core/services/upyun/Cargo.toml
+++ b/core/services/upyun/Cargo.toml
@@ -38,7 +38,7 @@ hmac = "0.13.0"
 http = { workspace = true }
 log = { workspace = true }
 md-5 = "0.11.0"
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/vercel-artifacts/Cargo.toml
+++ b/core/services/vercel-artifacts/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/services/vercel-blob/Cargo.toml
+++ b/core/services/vercel-blob/Cargo.toml
@@ -35,7 +35,7 @@ all-features = true
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/core/services/webdav/Cargo.toml
+++ b/core/services/webdav/Cargo.toml
@@ -37,7 +37,7 @@ asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 quick-xml = { workspace = true, features = ["serialize", "overlapped-lists"] }
 serde = { workspace = true, features = ["derive"] }
 

--- a/core/services/webhdfs/Cargo.toml
+++ b/core/services/webhdfs/Cargo.toml
@@ -37,7 +37,7 @@ asyncband = { workspace = true }
 bytes = { workspace = true }
 http = { workspace = true }
 log = { workspace = true }
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/core/services/yandex-disk/Cargo.toml
+++ b/core/services/yandex-disk/Cargo.toml
@@ -32,7 +32,7 @@ version = { workspace = true }
 all-features = true
 
 [dependencies]
-opendal-core = { path = "../../core", version = "0.59.0", default-features = false }
+opendal-core = { path = "../../core", version = "0.59.1", default-features = false }
 
 bytes = { workspace = true }
 http = { workspace = true }

--- a/core/testkit/Cargo.toml
+++ b/core/testkit/Cargo.toml
@@ -34,10 +34,10 @@ all-features = true
 [dependencies]
 bytes = { workspace = true }
 dotenvy = "0.15"
-opendal-core = { path = "../core", version = "0.59.0", default-features = false }
-opendal-layer-logging = { path = "../layers/logging", version = "0.59.0", default-features = false }
-opendal-layer-retry = { path = "../layers/retry", version = "0.59.0", default-features = false }
-opendal-layer-timeout = { path = "../layers/timeout", version = "0.59.0", default-features = false }
+opendal-core = { path = "../core", version = "0.59.1", default-features = false }
+opendal-layer-logging = { path = "../layers/logging", version = "0.59.1", default-features = false }
+opendal-layer-retry = { path = "../layers/retry", version = "0.59.1", default-features = false }
+opendal-layer-timeout = { path = "../layers/timeout", version = "0.59.1", default-features = false }
 rand = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/dev/src/release/package.rs
+++ b/dev/src/release/package.rs
@@ -87,26 +87,26 @@ fn make_package(path: &str, version: &str, dependencies: Vec<Package>) -> Packag
 
 /// List all packages that are ready for release.
 pub fn all_packages() -> Vec<Package> {
-    let core = make_package("core", "0.59.0", vec![]);
+    let core = make_package("core", "0.59.1", vec![]);
 
     // Integrations
-    let dav_server = make_package("integrations/dav-server", "0.7.6", vec![core.clone()]);
-    let object_store = make_package("integrations/object_store", "0.60.0", vec![core.clone()])
+    let dav_server = make_package("integrations/dav-server", "0.7.7", vec![core.clone()]);
+    let object_store = make_package("integrations/object_store", "0.60.1", vec![core.clone()])
         .with_public_compat_dependencies(&["opendal", "object_store"]);
-    let parquet = make_package("integrations/parquet", "0.10.0", vec![core.clone()])
+    let parquet = make_package("integrations/parquet", "0.10.1", vec![core.clone()])
         .with_public_compat_dependencies(&["opendal", "parquet"]);
-    let unftp_sbe = make_package("integrations/unftp-sbe", "0.4.6", vec![core.clone()]);
+    let unftp_sbe = make_package("integrations/unftp-sbe", "0.4.7", vec![core.clone()]);
 
     // Binaries moved to separate repositories; no longer released from this repo
 
     // Bindings
-    let c = make_package("bindings/c", "0.47.3", vec![core.clone()]);
-    let cpp = make_package("bindings/cpp", "0.45.30", vec![core.clone()]);
-    let java = make_package("bindings/java", "0.50.3", vec![core.clone()]);
-    let nodejs = make_package("bindings/nodejs", "0.49.8", vec![core.clone()]);
-    let python = make_package("bindings/python", "0.47.7", vec![core.clone()]);
-    let ruby = make_package("bindings/ruby", "0.1.11", vec![core.clone()]);
-    let dotnet = make_package("bindings/dotnet", "0.2.0", vec![core.clone()]);
+    let c = make_package("bindings/c", "0.47.4", vec![core.clone()]);
+    let cpp = make_package("bindings/cpp", "0.45.31", vec![core.clone()]);
+    let java = make_package("bindings/java", "0.50.4", vec![core.clone()]);
+    let nodejs = make_package("bindings/nodejs", "0.49.9", vec![core.clone()]);
+    let python = make_package("bindings/python", "0.47.8", vec![core.clone()]);
+    let ruby = make_package("bindings/ruby", "0.1.12", vec![core.clone()]);
+    let dotnet = make_package("bindings/dotnet", "0.2.1", vec![core.clone()]);
 
     vec![
         core,

--- a/integrations/dav-server/Cargo.toml
+++ b/integrations/dav-server/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 description = "Use OpenDAL as a backend to access data in various service with WebDAV protocol"
 name = "dav-server-opendalfs"
-version = "0.7.6"
+version = "0.7.7"
 
 authors = ["Apache OpenDAL <dev@opendal.apache.org>"]
 edition = "2024"
@@ -32,10 +32,10 @@ anyhow = "1"
 bytes = { version = "1.4.0" }
 dav-server = { version = "0.11.0" }
 futures = "0.3"
-opendal-core = { version = "0.59.0", path = "../../core/core", default-features = false }
+opendal-core = { version = "0.59.1", path = "../../core/core", default-features = false }
 
 [dev-dependencies]
-opendal = { version = "0.59.0", path = "../../core", features = [
+opendal = { version = "0.59.1", path = "../../core", features = [
   "services-fs",
 ] }
 tokio = { version = "1.27", features = ["macros", "rt-multi-thread", "io-std"] }

--- a/integrations/dav-server/DEPENDENCIES.rust.tsv
+++ b/integrations/dav-server/DEPENDENCIES.rust.tsv
@@ -11,7 +11,7 @@ block-buffer@0.10.4	X			X
 block-buffer@0.12.1	X			X				
 bumpalo@3.20.3	X			X				
 bytes@1.12.1				X				
-cc@1.4.4	X			X				
+cc@1.4.5	X			X				
 cfg-if@1.0.4	X			X				
 chrono@0.4.45	X			X				
 const-oid@0.10.2	X			X				
@@ -20,7 +20,7 @@ cpufeatures@0.2.17	X			X
 crypto-common@0.1.7	X			X				
 crypto-common@0.2.2	X			X				
 dav-server@0.11.0	X							
-dav-server-opendalfs@0.7.6	X							
+dav-server-opendalfs@0.7.7	X							
 derive-where@1.6.1	X			X				
 digest@0.10.7	X			X				
 digest@0.11.3	X			X				
@@ -28,7 +28,7 @@ displaydoc@0.2.7	X			X
 dyn-clone@1.0.20	X			X				
 equivalent@1.0.2	X			X				
 errno@0.3.14	X			X				
-find-msvc-tools@0.1.11	X			X				
+find-msvc-tools@0.1.12	X			X				
 foldhash@0.2.0								X
 form_urlencoded@1.2.2	X			X				
 futures@0.3.34	X			X				
@@ -69,7 +69,7 @@ jiff-core@0.1.0				X			X
 jiff-tzdb@0.1.8				X			X	
 jiff-tzdb-platform@0.1.3				X			X	
 jobserver@0.1.35	X			X				
-js-sys@0.3.104	X			X				
+js-sys@0.3.105	X			X				
 libc@0.2.189	X			X				
 linux-raw-sys@0.12.1	X	X		X				
 litemap@0.8.3						X		
@@ -80,16 +80,16 @@ md-5@0.11.0	X			X
 memchr@2.8.3				X			X	
 mime@0.3.17	X			X				
 mime_guess@2.0.5				X				
-mio@1.2.2				X				
+mio@1.2.3				X				
 num-traits@0.2.19	X			X				
 once_cell@1.21.4	X			X				
-opendal-core@0.59.0	X							
+opendal-core@0.59.1	X							
 parking_lot@0.12.5	X			X				
 parking_lot_core@0.9.12	X			X				
 percent-encoding@2.3.2	X			X				
 pin-project-lite@0.2.17	X			X				
 portable-atomic@1.15.0	X			X				
-portable-atomic-util@0.2.7	X			X				
+portable-atomic-util@0.2.8	X			X				
 potential_utf@0.1.6						X		
 proc-macro2@1.0.107	X			X				
 quick-xml@0.41.0				X				
@@ -107,11 +107,11 @@ serde_json@1.0.151	X			X
 sha1@0.10.7	X			X				
 shlex@2.0.1	X			X				
 slab@0.4.12				X				
-smallvec@1.15.2	X			X				
+smallvec@1.16.0	X			X				
 socket2@0.6.5	X			X				
 stable_deref_trait@1.2.1	X			X				
 syn@2.0.119	X			X				
-syn@3.0.4	X			X				
+syn@3.0.5	X			X				
 synstructure@0.13.2				X				
 tinystr@0.8.4						X		
 tokio@1.53.1				X				
@@ -124,10 +124,10 @@ utf8_iter@1.0.4	X			X
 uuid@1.26.0	X			X				
 version_check@0.9.5	X			X				
 wasi@0.11.1+wasi-snapshot-preview1	X	X		X				
-wasm-bindgen@0.2.127	X			X				
-wasm-bindgen-macro@0.2.127	X			X				
-wasm-bindgen-macro-support@0.2.127	X			X				
-wasm-bindgen-shared@0.2.127	X			X				
+wasm-bindgen@0.2.128	X			X				
+wasm-bindgen-macro@0.2.128	X			X				
+wasm-bindgen-macro-support@0.2.128	X			X				
+wasm-bindgen-shared@0.2.128	X			X				
 web-time@1.1.0	X			X				
 windows@0.62.2	X			X				
 windows-collections@0.3.2	X			X				

--- a/integrations/object_store/Cargo.toml
+++ b/integrations/object_store/Cargo.toml
@@ -25,7 +25,7 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.60.0"
+version = "0.60.1"
 
 [features]
 send_wrapper = ["dep:send_wrapper"]
@@ -43,7 +43,7 @@ bytes = "1"
 chrono = { version = "0.4.42", features = ["std", "clock"] }
 futures = "0.3"
 object_store = "0.14.1"
-opendal = { version = "0.59.0", path = "../../core", default-features = false }
+opendal = { version = "0.59.1", path = "../../core", default-features = false }
 pin-project = "1.1"
 send_wrapper = { version = "0.6", features = ["futures"], optional = true }
 tokio = { version = "1", default-features = false }
@@ -51,7 +51,7 @@ tokio = { version = "1", default-features = false }
 [dev-dependencies]
 anyhow = "1.0.86"
 libtest-mimic = "0.8.1"
-opendal = { version = "0.59.0", path = "../../core", features = [
+opendal = { version = "0.59.1", path = "../../core", features = [
   "services-fs",
   "services-memory",
   "services-s3",

--- a/integrations/object_store/DEPENDENCIES.rust.tsv
+++ b/integrations/object_store/DEPENDENCIES.rust.tsv
@@ -5,8 +5,8 @@ async-trait@0.1.92	X								X
 asyncband@0.6.7	X											
 atomic-waker@1.1.2	X								X			
 autocfg@1.5.1	X								X			
-aws-lc-rs@1.18.0	X						X					
-aws-lc-sys@0.44.0	X		X				X		X	X		
+aws-lc-rs@1.18.1	X						X					
+aws-lc-sys@0.45.0	X		X				X		X	X		
 backon@1.6.0	X											
 base64@0.22.1	X								X			
 base64@0.23.1	X								X			
@@ -14,7 +14,7 @@ bitflags@2.13.1	X								X
 block-buffer@0.12.1	X								X			
 bumpalo@3.20.3	X								X			
 bytes@1.12.1									X			
-cc@1.4.4	X								X			
+cc@1.4.5	X								X			
 cfg-if@1.0.4	X								X			
 cfg_aliases@0.2.2									X			
 chacha20@0.10.2	X								X			
@@ -43,7 +43,7 @@ dunce@1.0.5	X				X					X
 either@1.18.0	X								X			
 errno@0.3.14	X								X			
 fastrand@2.5.0	X								X			
-find-msvc-tools@0.1.11	X								X			
+find-msvc-tools@0.1.12	X								X			
 form_urlencoded@1.2.2	X								X			
 fs_extra@1.3.0									X			
 futures@0.3.34	X								X			
@@ -95,7 +95,7 @@ jni-macros@0.22.4	X								X
 jni-sys@0.4.1	X								X			
 jni-sys-macros@0.4.1	X								X			
 jobserver@0.1.35	X								X			
-js-sys@0.3.104	X								X			
+js-sys@0.3.105	X								X			
 libc@0.2.189	X								X			
 link-section@0.19.3	X								X			
 linktime-proc-macro@0.2.3	X								X			
@@ -106,22 +106,22 @@ log@0.4.34	X								X
 md-5@0.11.0	X								X			
 mea@0.6.7	X											
 memchr@2.8.3									X			X
-mio@1.2.2									X			
+mio@1.2.3									X			
 nix@0.31.3									X			
 num-traits@0.2.19	X								X			
 object_store@0.14.1	X								X			
-object_store_opendal@0.60.0	X											
+object_store_opendal@0.60.1	X											
 once_cell@1.21.4	X								X			
-opendal@0.59.0	X											
-opendal-core@0.59.0	X											
-opendal-http-transport-reqwest@0.59.0	X											
-opendal-layer-concurrent-limit@0.59.0	X											
-opendal-layer-logging@0.59.0	X											
-opendal-layer-retry@0.59.0	X											
-opendal-layer-timeout@0.59.0	X											
-opendal-service-fs@0.59.0	X											
-opendal-service-s3@0.59.0	X											
-opendal-testkit@0.59.0	X											
+opendal@0.59.1	X											
+opendal-core@0.59.1	X											
+opendal-http-transport-reqwest@0.59.1	X											
+opendal-layer-concurrent-limit@0.59.1	X											
+opendal-layer-logging@0.59.1	X											
+opendal-layer-retry@0.59.1	X											
+opendal-layer-timeout@0.59.1	X											
+opendal-service-fs@0.59.1	X											
+opendal-service-s3@0.59.1	X											
+opendal-testkit@0.59.1	X											
 openssl-probe@0.2.1	X								X			
 ordered-multimap@0.7.3									X			
 parking_lot@0.12.5	X								X			
@@ -132,7 +132,7 @@ pin-project-internal@1.1.13	X								X
 pin-project-lite@0.2.17	X								X			
 pkg-config@0.3.34	X								X			
 portable-atomic@1.15.0	X								X			
-portable-atomic-util@0.2.7	X								X			
+portable-atomic-util@0.2.8	X								X			
 potential_utf@0.1.6											X	
 proc-macro2@1.0.107	X								X			
 quick-xml@0.41.0									X			
@@ -174,13 +174,13 @@ shlex@2.0.1	X								X
 simd_cesu8@1.2.0	X								X			
 simdutf8@0.1.5	X								X			
 slab@0.4.12									X			
-smallvec@1.15.2	X								X			
+smallvec@1.16.0	X								X			
 socket2@0.6.5	X								X			
 spin@0.10.1									X			
 stable_deref_trait@1.2.1	X								X			
 subtle@2.6.1			X									
 syn@2.0.119	X								X			
-syn@3.0.4	X								X			
+syn@3.0.5	X								X			
 sync_wrapper@1.0.2	X											
 synstructure@0.13.2									X			
 thiserror@2.0.20	X								X			
@@ -189,7 +189,7 @@ tiny-keccak@2.0.2					X
 tinystr@0.8.4											X	
 tokio@1.53.1									X			
 tokio-macros@2.7.2									X			
-tokio-rustls@0.26.4	X								X			
+tokio-rustls@0.26.5	X								X			
 tokio-util@0.7.19									X			
 tower@0.5.3									X			
 tower-http@0.6.11									X			
@@ -209,13 +209,13 @@ version_check@0.9.5	X								X
 walkdir@2.5.0									X			X
 want@0.3.1									X			
 wasi@0.11.1+wasi-snapshot-preview1	X	X							X			
-wasm-bindgen@0.2.127	X								X			
-wasm-bindgen-futures@0.4.77	X								X			
-wasm-bindgen-macro@0.2.127	X								X			
-wasm-bindgen-macro-support@0.2.127	X								X			
-wasm-bindgen-shared@0.2.127	X								X			
+wasm-bindgen@0.2.128	X								X			
+wasm-bindgen-futures@0.4.78	X								X			
+wasm-bindgen-macro@0.2.128	X								X			
+wasm-bindgen-macro-support@0.2.128	X								X			
+wasm-bindgen-shared@0.2.128	X								X			
 wasm-streams@0.5.0	X								X			
-web-sys@0.3.104	X								X			
+web-sys@0.3.105	X								X			
 web-time@1.1.0	X								X			
 webpki-root-certs@1.0.9						X						
 winapi-util@0.1.11									X			X

--- a/integrations/parquet/Cargo.toml
+++ b/integrations/parquet/Cargo.toml
@@ -25,13 +25,13 @@ homepage = "https://opendal.apache.org/"
 license = "Apache-2.0"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.10.0"
+version = "0.10.1"
 
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
 futures = "0.3"
-opendal = { version = "0.59.0", path = "../../core" }
+opendal = { version = "0.59.1", path = "../../core" }
 parquet = { version = "59.0", default-features = false, features = [
   "async",
   "arrow",
@@ -39,7 +39,7 @@ parquet = { version = "59.0", default-features = false, features = [
 
 [dev-dependencies]
 arrow = { version = "59.0" }
-opendal = { version = "0.59.0", path = "../../core", features = [
+opendal = { version = "0.59.1", path = "../../core", features = [
   "services-memory",
   "services-s3",
 ] }

--- a/integrations/parquet/DEPENDENCIES.rust.tsv
+++ b/integrations/parquet/DEPENDENCIES.rust.tsv
@@ -2,18 +2,18 @@ crate	Apache-2.0	Apache-2.0 WITH LLVM-exception	BSD-2-Clause	BSD-3-Clause	BSL-1.
 ahash@0.8.12	X									X			
 android_system_properties@0.1.6	X									X			
 anyhow@1.0.104	X									X			
-arrow-array@59.2.0	X									X			
-arrow-buffer@59.2.0	X												
-arrow-data@59.2.0	X												
-arrow-ipc@59.2.0	X												
-arrow-schema@59.2.0	X												
-arrow-select@59.2.0	X												
+arrow-array@59.3.0	X									X			
+arrow-buffer@59.3.0	X												
+arrow-data@59.3.0	X												
+arrow-ipc@59.3.0	X												
+arrow-schema@59.3.0	X												
+arrow-select@59.3.0	X												
 async-trait@0.1.92	X									X			
 asyncband@0.6.7	X												
 atomic-waker@1.1.2	X									X			
 autocfg@1.5.1	X									X			
-aws-lc-rs@1.18.0	X							X					
-aws-lc-sys@0.44.0	X			X				X		X	X		
+aws-lc-rs@1.18.1	X							X					
+aws-lc-sys@0.45.0	X			X				X		X	X		
 backon@1.6.0	X												
 base64@0.22.1	X									X			
 base64@0.23.1	X									X			
@@ -21,7 +21,7 @@ bitflags@2.13.1	X									X
 block-buffer@0.12.1	X									X			
 bumpalo@3.20.3	X									X			
 bytes@1.12.1										X			
-cc@1.4.4	X									X			
+cc@1.4.5	X									X			
 cfg-if@1.0.4	X									X			
 chrono@0.4.45	X									X			
 cmake@0.1.58	X									X			
@@ -45,7 +45,7 @@ displaydoc@0.2.7	X									X
 dlv-list@0.5.2	X									X			
 dunce@1.0.5	X					X					X		
 fastrand@2.5.0	X									X			
-find-msvc-tools@0.1.11	X									X			
+find-msvc-tools@0.1.12	X									X			
 flatbuffers@25.12.19	X												
 form_urlencoded@1.2.2	X									X			
 fs_extra@1.3.0										X			
@@ -98,7 +98,7 @@ jni-macros@0.22.4	X									X
 jni-sys@0.4.1	X									X			
 jni-sys-macros@0.4.1	X									X			
 jobserver@0.1.35	X									X			
-js-sys@0.3.104	X									X			
+js-sys@0.3.105	X									X			
 libc@0.2.189	X									X			
 libm@0.2.16										X			
 link-section@0.19.3	X									X			
@@ -108,29 +108,29 @@ log@0.4.34	X									X
 md-5@0.11.0	X									X			
 mea@0.6.7	X												
 memchr@2.8.3										X			X
-mio@1.2.2										X			
+mio@1.2.3										X			
 num-bigint@0.5.1	X									X			
 num-complex@0.4.6	X									X			
 num-integer@0.1.47	X									X			
 num-traits@0.2.19	X									X			
 once_cell@1.21.4	X									X			
-opendal@0.59.0	X												
-opendal-core@0.59.0	X												
-opendal-http-transport-reqwest@0.59.0	X												
-opendal-layer-concurrent-limit@0.59.0	X												
-opendal-layer-logging@0.59.0	X												
-opendal-layer-retry@0.59.0	X												
-opendal-layer-timeout@0.59.0	X												
-opendal-service-s3@0.59.0	X												
+opendal@0.59.1	X												
+opendal-core@0.59.1	X												
+opendal-http-transport-reqwest@0.59.1	X												
+opendal-layer-concurrent-limit@0.59.1	X												
+opendal-layer-logging@0.59.1	X												
+opendal-layer-retry@0.59.1	X												
+opendal-layer-timeout@0.59.1	X												
+opendal-service-s3@0.59.1	X												
 openssl-probe@0.2.1	X									X			
 ordered-multimap@0.7.3										X			
-parquet@59.2.0	X												
-parquet_opendal@0.10.0	X												
+parquet@59.3.0	X												
+parquet_opendal@0.10.1	X												
 percent-encoding@2.3.2	X									X			
 pin-project-lite@0.2.17	X									X			
 pkg-config@0.3.34	X									X			
 portable-atomic@1.15.0	X									X			
-portable-atomic-util@0.2.7	X									X			
+portable-atomic-util@0.2.8	X									X			
 potential_utf@0.1.6												X	
 proc-macro2@1.0.107	X									X			
 quick-xml@0.41.0										X			
@@ -170,13 +170,13 @@ shlex@2.0.1	X									X
 simd_cesu8@1.2.0	X									X			
 simdutf8@0.1.5	X									X			
 slab@0.4.12										X			
-smallvec@1.15.2	X									X			
+smallvec@1.16.0	X									X			
 socket2@0.6.5	X									X			
 spin@0.10.1										X			
 stable_deref_trait@1.2.1	X									X			
 subtle@2.6.1				X									
 syn@2.0.119	X									X			
-syn@3.0.4	X									X			
+syn@3.0.5	X									X			
 sync_wrapper@1.0.2	X												
 synstructure@0.13.2										X			
 thiserror@2.0.20	X									X			
@@ -185,7 +185,7 @@ tiny-keccak@2.0.2						X
 tinystr@0.8.4												X	
 tokio@1.53.1										X			
 tokio-macros@2.7.2										X			
-tokio-rustls@0.26.4	X									X			
+tokio-rustls@0.26.5	X									X			
 tokio-util@0.7.19										X			
 tower@0.5.3										X			
 tower-http@0.6.11										X			
@@ -206,13 +206,13 @@ walkdir@2.5.0										X			X
 want@0.3.1										X			
 wasi@0.11.1+wasi-snapshot-preview1	X	X								X			
 wasip2@1.0.4+wasi-0.2.12	X	X								X			
-wasm-bindgen@0.2.127	X									X			
-wasm-bindgen-futures@0.4.77	X									X			
-wasm-bindgen-macro@0.2.127	X									X			
-wasm-bindgen-macro-support@0.2.127	X									X			
-wasm-bindgen-shared@0.2.127	X									X			
+wasm-bindgen@0.2.128	X									X			
+wasm-bindgen-futures@0.4.78	X									X			
+wasm-bindgen-macro@0.2.128	X									X			
+wasm-bindgen-macro-support@0.2.128	X									X			
+wasm-bindgen-shared@0.2.128	X									X			
 wasm-streams@0.5.0	X									X			
-web-sys@0.3.104	X									X			
+web-sys@0.3.105	X									X			
 web-time@1.1.0	X									X			
 webpki-root-certs@1.0.9							X						
 winapi-util@0.1.11										X			X

--- a/integrations/unftp-sbe/Cargo.toml
+++ b/integrations/unftp-sbe/Cargo.toml
@@ -24,11 +24,11 @@ license = "Apache-2.0"
 name = "unftp-sbe-opendal"
 repository = "https://github.com/apache/opendal"
 rust-version = "1.91"
-version = "0.4.6"
+version = "0.4.7"
 
 [dependencies]
 async-trait = "0.1.88"
-opendal = { version = "0.59.0", path = "../../core" }
+opendal = { version = "0.59.1", path = "../../core" }
 tokio = { version = "1.38.0", default-features = false, features = ["io-util"] }
 tokio-util = { version = "0.7.11", features = ["compat"] }
 unftp-core = "0.1.0"
@@ -36,7 +36,7 @@ unftp-core = "0.1.0"
 [dev-dependencies]
 anyhow = "1"
 libunftp = "0.23.0"
-opendal = { version = "0.59.0", path = "../../core", features = [
+opendal = { version = "0.59.1", path = "../../core", features = [
   "services-s3",
 ] }
 tokio = { version = "1.38.0", default-features = false, features = [

--- a/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
+++ b/integrations/unftp-sbe/DEPENDENCIES.rust.tsv
@@ -8,8 +8,8 @@ async-trait@0.1.92	X								X
 asyncband@0.6.7	X											
 atomic-waker@1.1.2	X								X			
 autocfg@1.5.1	X								X			
-aws-lc-rs@1.18.0	X						X					
-aws-lc-sys@0.44.0	X		X				X		X	X		
+aws-lc-rs@1.18.1	X						X					
+aws-lc-sys@0.45.0	X		X				X		X	X		
 backon@1.6.0	X											
 base64@0.22.1	X								X			
 base64@0.23.1	X								X			
@@ -18,7 +18,7 @@ block-buffer@0.10.4	X								X
 block-buffer@0.12.1	X								X			
 bumpalo@3.20.3	X								X			
 bytes@1.12.1									X			
-cc@1.4.4	X								X			
+cc@1.4.5	X								X			
 cfg-if@1.0.4	X								X			
 chrono@0.4.45	X								X			
 cmake@0.1.58	X								X			
@@ -49,7 +49,7 @@ dlv-list@0.5.2	X								X
 dunce@1.0.5	X				X					X		
 errno@0.3.14	X								X			
 fastrand@2.5.0	X								X			
-find-msvc-tools@0.1.11	X								X			
+find-msvc-tools@0.1.12	X								X			
 form_urlencoded@1.2.2	X								X			
 fs_extra@1.3.0									X			
 futures@0.3.34	X								X			
@@ -99,7 +99,7 @@ jni-macros@0.22.4	X								X
 jni-sys@0.4.1	X								X			
 jni-sys-macros@0.4.1	X								X			
 jobserver@0.1.35	X								X			
-js-sys@0.3.104	X								X			
+js-sys@0.3.105	X								X			
 lazy_static@1.5.0	X								X			
 libc@0.2.189	X								X			
 link-section@0.19.3	X								X			
@@ -111,7 +111,7 @@ md-5@0.11.0	X								X
 mea@0.6.7	X											
 memchr@2.8.3									X			X
 minimal-lexical@0.2.1	X								X			
-mio@1.2.2									X			
+mio@1.2.3									X			
 nom@7.1.3									X			
 num-bigint@0.4.8	X								X			
 num-conv@0.2.2	X								X			
@@ -119,21 +119,21 @@ num-integer@0.1.47	X								X
 num-traits@0.2.19	X								X			
 oid-registry@0.8.1	X								X			
 once_cell@1.21.4	X								X			
-opendal@0.59.0	X											
-opendal-core@0.59.0	X											
-opendal-http-transport-reqwest@0.59.0	X											
-opendal-layer-concurrent-limit@0.59.0	X											
-opendal-layer-logging@0.59.0	X											
-opendal-layer-retry@0.59.0	X											
-opendal-layer-timeout@0.59.0	X											
-opendal-service-s3@0.59.0	X											
+opendal@0.59.1	X											
+opendal-core@0.59.1	X											
+opendal-http-transport-reqwest@0.59.1	X											
+opendal-layer-concurrent-limit@0.59.1	X											
+opendal-layer-logging@0.59.1	X											
+opendal-layer-retry@0.59.1	X											
+opendal-layer-timeout@0.59.1	X											
+opendal-service-s3@0.59.1	X											
 openssl-probe@0.2.1	X								X			
 ordered-multimap@0.7.3									X			
 percent-encoding@2.3.2	X								X			
 pin-project-lite@0.2.17	X								X			
 pkg-config@0.3.34	X								X			
 portable-atomic@1.15.0	X								X			
-portable-atomic-util@0.2.7	X								X			
+portable-atomic-util@0.2.8	X								X			
 potential_utf@0.1.6											X	
 powerfmt@0.2.0	X								X			
 proc-macro2@1.0.107	X								X			
@@ -173,13 +173,13 @@ signal-hook-registry@1.4.8	X								X
 simd_cesu8@1.2.0	X								X			
 simdutf8@0.1.5	X								X			
 slab@0.4.12									X			
-smallvec@1.15.2	X								X			
+smallvec@1.16.0	X								X			
 socket2@0.6.5	X								X			
 spin@0.10.1									X			
 stable_deref_trait@1.2.1	X								X			
 subtle@2.6.1			X									
 syn@2.0.119	X								X			
-syn@3.0.4	X								X			
+syn@3.0.5	X								X			
 sync_wrapper@1.0.2	X											
 synstructure@0.13.2									X			
 thiserror@2.0.20	X								X			
@@ -191,7 +191,7 @@ tiny-keccak@2.0.2					X
 tinystr@0.8.4											X	
 tokio@1.53.1									X			
 tokio-macros@2.7.2									X			
-tokio-rustls@0.26.4	X								X			
+tokio-rustls@0.26.5	X								X			
 tokio-util@0.7.19									X			
 tower@0.5.3									X			
 tower-http@0.6.11									X			
@@ -202,7 +202,7 @@ tracing-core@0.1.36									X
 try-lock@0.2.5									X			
 typenum@1.20.1	X								X			
 unftp-core@0.1.0	X											
-unftp-sbe-opendal@0.4.6	X											
+unftp-sbe-opendal@0.4.7	X											
 unicode-ident@1.0.24	X								X		X	
 unicode-segmentation@1.13.3	X								X			
 unicode-xid@0.2.6	X								X			
@@ -214,13 +214,13 @@ version_check@0.9.5	X								X
 walkdir@2.5.0									X			X
 want@0.3.1									X			
 wasi@0.11.1+wasi-snapshot-preview1	X	X							X			
-wasm-bindgen@0.2.127	X								X			
-wasm-bindgen-futures@0.4.77	X								X			
-wasm-bindgen-macro@0.2.127	X								X			
-wasm-bindgen-macro-support@0.2.127	X								X			
-wasm-bindgen-shared@0.2.127	X								X			
+wasm-bindgen@0.2.128	X								X			
+wasm-bindgen-futures@0.4.78	X								X			
+wasm-bindgen-macro@0.2.128	X								X			
+wasm-bindgen-macro-support@0.2.128	X								X			
+wasm-bindgen-shared@0.2.128	X								X			
 wasm-streams@0.5.0	X								X			
-web-sys@0.3.104	X								X			
+web-sys@0.3.105	X								X			
 web-time@1.1.0	X								X			
 webpki-root-certs@1.0.9						X						
 winapi-util@0.1.11									X			X


### PR DESCRIPTION
# Which issue does this PR close?

Release preparation for Apache OpenDAL 0.59.1, tracked in #8227; related to #8222 and #8223.

Release discussion: https://github.com/apache/opendal/discussions/8226

# Rationale for this change

The published `opendal-core` 0.59.0 crate cannot compile because the changelog include points outside the package. Prepare the next patch release containing the merged packaging fix.

# What changes are included in this PR?

Bump core to 0.59.1 and every binding and integration in the source release list to its next patch version. Synchronize package versions, internal Rust dependency requirements, the core lockfile, dependency inventories, and the changelog.

# Are there any user-facing changes?

The release includes the changelog packaging fix, GooseFS master address resolution, and GCS presigned response header overrides already merged on main. This preparation introduces no public API changes.

The packaged `opendal-core` 0.59.1 compiles independently, and its `CHANGELOG.md` is a regular file matching the repository changelog.

# AI Usage Statement

AI assisted with version updates, release notes, and package validation. The release manager reviews the changes and public release text before submission. Cross-platform release workflows and RC verification remain pending.
