### PR TITLE
chore(release): remove the source release environment

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -63,21 +63,9 @@ github:
           - name: main
             type: branch
     source-release:
-      required_reviewers:
-        - id: Xuanwo
-          type: User
-        - id: dentiny
-          type: User
-        - id: erickguan
-          type: User
-        - id: tisonkun
-          type: User
-        - id: koushiro
-          type: User
-        - id: PsiACE
-          type: User
+      required_reviewers: []
       wait_timer: 0
-      prevent_self_review: true
+      prevent_self_review: false
       deployment_branch_policy:
         protected_branches: false
         policies:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -62,15 +62,6 @@ github:
         policies:
           - name: main
             type: branch
-    source-release:
-      required_reviewers: []
-      wait_timer: 0
-      prevent_self_review: false
-      deployment_branch_policy:
-        protected_branches: false
-        policies:
-          - name: main
-            type: branch
   custom_subjects:
     new_discussion: "{title}"
     edit_discussion: "Re: {title}"

--- a/.github/workflows/release-compose.yml
+++ b/.github/workflows/release-compose.yml
@@ -86,9 +86,6 @@ jobs:
       contents: read
     outputs:
       artifact-id: ${{ steps.signed.outputs.artifact-id }}
-    environment:
-      name: source-release
-      url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/website/community/release/ci-signing-proposal.md
+++ b/website/community/release/ci-signing-proposal.md
@@ -23,7 +23,7 @@ Three jobs separate credentials and responsibilities:
 1. The build job runs the reproduction tool on the candidate in two independent
    checkouts. It retains the complete unsigned source bundle and report as an
    immutable Actions artifact. It has neither signing secrets nor OIDC permission.
-2. The protected `source-release` job downloads that artifact by ID, validates its
+2. The `source-release` job downloads that artifact by ID, validates its
    commit, reproduction report, package inventory and SHA-512 checksums, and signs
    only the expected `.tar.gz` files. Trusted tooling comes from the workflow's
    `main` checkout; candidate scripts are not executed with the key. The public
@@ -71,7 +71,8 @@ reviewed again before upgrading.
    | Finish workflows | Leave empty |
 
 5. Confirm that the `source-release` environment protection from `.asf.yaml` is
-   active, including main-only deployment and required reviewers. A YAML change
+   active with main-only deployment and no required reviewers or waiting period.
+   A maintainer dispatch starts the pipeline without another human approval. A YAML change
    alone is not evidence that GitHub applied the protection. The signing key is a
    repository secret under the documented Infra procedure, so also restrict and
    review changes to workflows that could access repository secrets.

--- a/website/community/release/ci-signing-proposal.md
+++ b/website/community/release/ci-signing-proposal.md
@@ -23,7 +23,7 @@ Three jobs separate credentials and responsibilities:
 1. The build job runs the reproduction tool on the candidate in two independent
    checkouts. It retains the complete unsigned source bundle and report as an
    immutable Actions artifact. It has neither signing secrets nor OIDC permission.
-2. The `source-release` job downloads that artifact by ID, validates its
+2. The signing job downloads that artifact by ID, validates its
    commit, reproduction report, package inventory and SHA-512 checksums, and signs
    only the expected `.tar.gz` files. Trusted tooling comes from the workflow's
    `main` checkout; candidate scripts are not executed with the key. The public
@@ -70,13 +70,7 @@ reviewed again before upgrading.
    | Vote workflows | Leave empty |
    | Finish workflows | Leave empty |
 
-5. Confirm that the `source-release` environment protection from `.asf.yaml` is
-   active with main-only deployment and no required reviewers or waiting period.
-   A maintainer dispatch starts the pipeline without another human approval. A YAML change
-   alone is not evidence that GitHub applied the protection. The signing key is a
-   repository secret under the documented Infra procedure, so also restrict and
-   review changes to workflows that could access repository secrets.
-6. Set the repository variable `SOURCE_RELEASE_ENABLED=true` only after these
+5. Set the repository variable `SOURCE_RELEASE_ENABLED=true` only after these
    prerequisites are verified. Leave it unset to keep compose disabled.
 
 The repository secret's existence and the public key in KEYS have been verified.


### PR DESCRIPTION
# Which issue does this PR close?

Follow-up to #8232.

# Rationale for this change

The source signing job uses a repository secret and already runs only from main. Its GitHub Environment adds a redundant approval step to candidate preparation.

# What changes are included in this PR?

Remove the source-release environment definition, the signing job's environment reference, and the corresponding setup instructions. Retain the workflow's main-only dispatch check, activation variable, and ATR compose authorization.

# Are there any user-facing changes?

A maintainer dispatch can proceed through building, signing and ATR upload without an environment approval. Release verification and PMC voting are unchanged.

# AI Usage Statement

AI assisted the configuration and documentation change. The existing remote environment could not be modified with the current account's repository permissions. Removing the workflow reference eliminates its role in this pipeline once merged, regardless of whether the unused remote environment is retained.
